### PR TITLE
feat(scheduling): single-surface schedules workbench (redesign PR-4, final)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -125,7 +125,7 @@ rows.
 | `/` | Focus the filter box |
 | `n` | Create — opens the Reminder / Recurring question chooser |
 | `p` | Pause or resume (a reminder's enable state, an automation's lifecycle) |
-| `m` | Open the highlighted row's **Runs on** dropdown — the move-between-owners flow |
+| `m` | Open the highlighted row's **Runs on** dropdown — the move-between-owners flow. Below 84 columns this opens the row's full-screen detail first, since the docked pane is hidden there |
 | `r` | Mark the highlighted automation's unread results read |
 | `e` | Edit in full — opens the row's own edit form |
 | `space` | Enable or disable (reminders) |
@@ -158,7 +158,9 @@ The screen has a floor of **80×24** and degrades in two steps:
   place behind it. **Escape** closes it (and, while a row editor is
   open, Escape closes *the editor* first). The four filter chips
   collapse into one **Filter: …** button that cycles them, and the rail
-  keeps Create ▾, Mark all read and Results on a single row.
+  keeps its buttons on a single row — Create ▾ and Results, plus
+  **Mark all read** whenever there is anything unread to mark (that
+  button is hidden otherwise, at every width).
 
 At the floor every operation is still reachable: create through **n** or
 **Create ▾**; edit, pause/resume, run now and transfer inside the pushed
@@ -748,7 +750,14 @@ hosted-editor `Esc` rule, every operation reachable at 80x24, and the
 `Tests/UI/test_schedules_keyboard_map.py`,
 `Tests/UI/test_schedules_unified_list.py`,
 `Tests/UI/test_schedules_results_tab.py` and
-`Tests/UI/test_schedules_workbench.py`.)*
+`Tests/UI/test_schedules_workbench.py`. Final fix wave (2026-09-04): `m`
+below 84 columns now pushes the detail and opens the Runs-on dropdown
+inside it instead of activating the hidden pane, a pushed detail is
+pinned to the row it was opened for (and closes with a notice if that row
+leaves the queue), and resolving a conflict reloads the queue while the
+conflicts view is still open — all four pinned in
+`Tests/UI/test_schedules_responsive_floor.py`. The `m` row above and the
+rail sentence in "Narrow terminals" were corrected in the same pass.)*
 
 *Verified against the schedules redesign PR-3 final fix wave —
 2026-09-03 (docs pass against shipped code/tests, live check pending the

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -19,24 +19,23 @@ no briefing model call is attempted until a persisted route is available.
 
 If creation is accepted but no completed briefing appears, inspect the exact briefing receipt before editing or duplicating the schedule.
 
-> 🚧 **This page is a stub.** The full write-up is planned; the sections
-> below cover orientation only. See the [guide index](index.md).
-
 ## What this screen is for
 
-Schedules controls when jobs, watchlists, and workflows run. The screen
-has no single on-screen title; a one-line scheduler-liveness indicator
-sits above **Queue**, **Automations**, **Conflicts**, and **Results**
-tabs, with panels for the Schedule Queue, Task Detail, and Inspector. A
-status strip (sync bar + Conflicts count) runs along the bottom of the
-whole screen, shared across every tab — see "Status strip", below.
+Schedules controls when jobs, watchlists, and workflows run. It is a
+**single surface**: one list of everything scheduled, a detail pane for
+whatever is highlighted, and an inspector — no tabs. A one-line
+scheduler-liveness indicator sits above them, and a status strip (sync
+bar + Conflicts count) runs along the bottom — see "Status strip",
+below. Views that are not about one selected row — results, a
+definition's run history, sync conflicts — open **over** the list and
+close with **Escape**, rather than living in a tab bar you have to
+remember to visit.
 
-## The unified Queue list
+## The unified list
 
-The Queue tab's Schedule Queue lists **both** reminders and recurring-
-question automation definitions in one table, spanning both owners
-(this device and any connected server) — no need to check the
-Automations tab separately just to see whether something is scheduled.
+The Schedule Queue lists **both** reminders and recurring-question
+automations in one table, spanning both owners (this device and any
+connected server) — one place to see whether something is scheduled.
 A chip row above the table (**All · Active · Paused · Completed**)
 narrows it: **Active** is everything still armed to run (an enabled
 reminder or a `configured` automation, including one mid-transfer to the
@@ -53,16 +52,14 @@ a subtitle line (the schedule summary plus a relative next-run time, or
 "— (paused)"/"— (disabled)" when nothing will fire). An automation row
 with unread results carries a bold unread dot after its title.
 
-Automation-definition rows are **view-only from the Queue tab** —
-highlighting one opens the same read-only detail pane the Automations
-tab uses, but editing, running, transferring, or deleting a recurring
-question still happens from the **Automations** tab. Pressing a
-reminder key (**e**, **r**, **x**, **space**, **d**) on a definition row
-says so ("This automation is managed on the Automations tab for now")
-rather than doing nothing. Every reminder
-action described in the rest of this page (edit, run now, delete, mark,
-enable/disable, move between owners) is unchanged and still reachable
-from the Queue tab exactly as before.
+Highlighting a row opens its detail pane beside the list — a reminder's
+or an automation's, routed by the row you are on. **Both kinds are
+fully actionable from here**: edit, run now, pause/resume and move
+between owners all work on an automation row exactly as they do on a
+reminder. The few genuinely reminder-only verbs (delete, mark, enable/
+disable) say so when pressed on an automation row ("Automations don't
+support delete — use the actions in this automation's own detail pane")
+rather than doing nothing.
 
 Watchlist checks and briefings are not in this list — they have their
 own home in Watchlists' **Sources** pane, whose **Next check** column
@@ -73,40 +70,99 @@ Every row's relative next-run text ("in 25m", "overdue 2h") stays
 current on its own: the visible Queue rows repaint once a minute
 without reloading the list, so a bucket a row was in a minute ago
 ("in 1h") reads correctly once it crosses into the next one ("in 59m")
-even if you never touch the screen. Switching away to another tab in
-the app pauses that repaint; coming back refreshes it immediately so
-nothing is left stale from the time it was hidden.
+even if you never touch the screen. Switching away to another screen
+pauses that repaint; coming back refreshes it immediately so nothing is
+left stale from the time it was hidden — and re-reads the automations if
+anything changed them while you were gone.
 
-## Queue rail
+## The rail
 
-The Queue tab's pane header is a rail: **Create ▾** opens the chooser
-described below; **Mark all read** appears only once an automation
-result somewhere in the queue is unread, and clears every one of them
-in one press (the same action as pressing **a**, without needing to be
-on the Results tab first). It — and the per-row unread dots — track
-results as they change: a result arriving from the server makes them
-appear without switching tabs, and marking everything read from the
-Results tab clears them here too. Below the chip row, the filter box
-narrows the list by title or question/body text as you type — not by
-status words like `missed`, which the unified list dropped along with
-the Status/Type columns.
+The list pane's header is a rail:
+
+- **Create ▾** opens the chooser described below (also **n**).
+- **Mark all read** appears only once an automation result somewhere in
+  the queue is unread, and clears every one of them in one press (also
+  **a**).
+- **Results** opens the results inbox over the list — always available,
+  since browsing already-read results is useful too. Its label carries
+  the unread count ("Results (3)").
+
+The rail and the per-row unread dots track results as they change: a
+result arriving from the server makes them appear on their own, and
+marking everything read inside the results view clears them here too.
+Below the chip row, the filter box narrows the list by title or
+question/body text as you type (**/** focuses it) — not by status words
+like `missed`, which the unified list dropped along with the Status/Type
+columns.
 
 ## Status strip
 
-A status strip runs along the bottom of the screen, below the tabs and
-shared by all of them: the sync bar (Local/Server, last pull/push —
-see "Sync bar honesty", below) on the left, and a **Conflicts** button
-on the right showing the current owner's scheduled-task conflict count
-("Conflicts (2)", or plain "Conflicts" with none). Clicking it switches
-to the Conflicts tab. At narrow terminal widths the sync bar's
-timestamps drop to save space, the same compacting the side panes
-already do; the owner buttons and any sync error stay visible either
-way.
+A status strip runs along the bottom of the screen: the sync bar
+(Local/Server, last pull/push — see "Sync bar honesty", below) on the
+left, and a **Conflicts** button on the right showing the current
+owner's scheduled-task conflict count ("Conflicts (2)", or plain
+"Conflicts" with none). Clicking it opens the conflicts view over the
+list; **Escape** returns, and the count re-reads itself in case you
+resolved something. At narrow terminal widths the sync bar's timestamps
+drop to save space; the owner buttons, any sync error, and the
+Conflicts button stay visible either way.
 
 ## Getting there
 
 - Press **Ctrl+7**, click **⌃7 Schedules** in the nav bar, or press
   **Ctrl+P** → "Tab Navigation: Switch to Schedules".
+
+## Keyboard map
+
+Every key acts on the highlighted row unless noted. Up/Down move the
+list cursor; inside a detail pane, Up/Down move between its editable
+rows.
+
+| Key | Action |
+| --- | --- |
+| `1` `2` `3` `4` | Show **All** / **Active** / **Paused** / **Completed** |
+| `f` | Cycle those four filters in order |
+| `/` | Focus the filter box |
+| `n` | Create — opens the Reminder / Recurring question chooser |
+| `p` | Pause or resume (a reminder's enable state, an automation's lifecycle) |
+| `m` | Open the highlighted row's **Runs on** dropdown — the move-between-owners flow |
+| `r` | Mark the highlighted automation's unread results read |
+| `e` | Edit in full — opens the row's own edit form |
+| `space` | Enable or disable (reminders) |
+| `d` | Delete (reminders) |
+| `x` | Mark or unmark the row for a bulk action |
+| `Esc` | Clear marks — or, in a view opened over the list, close it |
+| `s` | Sync now |
+| `a` | Mark every unread automation result read |
+
+**Run now is not a key.** It is a button in the detail pane of the row
+it belongs to, so a dispatch always names what it is about to run. The
+same is true of the results, run-history and conflicts views: they are
+opened from the affordance that describes them, not from a global
+shortcut.
+
+Keys that only make sense for one row kind say so when pressed on the
+other, rather than silently doing nothing.
+
+## Narrow terminals
+
+The screen has a floor of **80×24** and degrades in two steps:
+
+- **Below ~118 columns** the inspector yields (it summarises what the
+  detail pane already shows). A one-line notice under the queue says so.
+- **Below 84 columns** the detail pane yields too, and the list takes the
+  whole width. **Enter on a row opens that row's detail full-screen**,
+  with everything it normally offers — the in-pane row editors, the
+  Runs-on transfer dropdown, Pause/Resume, Run now, Edit in full. It is
+  a fresh view of the same pane, not a moved one, so the list keeps its
+  place behind it. **Escape** closes it (and, while a row editor is
+  open, Escape closes *the editor* first). The four filter chips
+  collapse into one **Filter: …** button that cycles them, and the rail
+  keeps Create ▾, Mark all read and Results on a single row.
+
+At the floor every operation is still reachable: create through **n** or
+**Create ▾**; edit, pause/resume, run now and transfer inside the pushed
+detail; results from the rail; conflicts from the status strip.
 
 ## Sync bar honesty
 
@@ -164,9 +220,9 @@ recoverable rather than overwritten. History is capped per task (the newest
 keep their history server-authoritative (per ADR-077) rather than
 duplicating it locally. The existing missed-fire accounting is unchanged.
 
-## Task Detail — grouped fields
+## The reminder detail pane — grouped fields
 
-A reminder's Task Detail pane shows its body text in a card, then its
+A reminder's detail pane shows its body text in a card, then its
 fields as three labeled groups instead of a flat list, matching the same
 label-left/value-right row style used throughout the pane (a reminder with
 no body text shows no card):
@@ -174,8 +230,8 @@ no body text shows no card):
 - **Details** — `Runs on` (the owner: "This device" for a reminder this
   device runs, or the server's own id for one the server runs, with the
   transfer badge text appended while a move is in flight, e.g.
-  "This device (Moving to server…)"). The Automations tab's detail pane
-  words this row exactly the same way.
+  "This device (Moving to server…)"). The automation detail pane words
+  this row exactly the same way.
 - **Frequency** — `Repeat`, `At`, `Timezone`, and `Notifications` (always
   "Inbox + toast" — every reminder dispatch writes an inbox row and
   attempts a toast; there is no per-reminder channel setting).
@@ -229,25 +285,24 @@ target and only changes through **Edit in full…** or the create form.
   **Resume** does *not* refuse an edit — lifecycle changes queue
   separately, so you can pause an automation while offline, edit it, and
   have both land on the next sync.
-- `Runs on`'s dropdown is the same transfer flow described under
-  "Moving a task between this device and the server", below — picking
-  the other owner runs the same refusal check and confirmation dialog,
-  just from the row itself rather than a button. Once a move is queued or
-  failed, its own **Cancel transfer** / **Retry transfer** buttons appear
-  directly under the row (the dropdown is unavailable while a move is in
-  flight — that is the locked state above). The pane's older Move/Cancel/
-  Retry buttons documented there keep working side by side with all of
-  this.
+- `Runs on`'s dropdown is the transfer flow described under "Moving a
+  task between this device and the server", below — picking the other
+  owner runs the refusal check and confirmation dialog. Once a move is
+  queued or failed, its own **Cancel transfer** / **Retry transfer**
+  buttons appear directly under the row (the dropdown is unavailable
+  while a move is in flight — that is the locked state above). This row
+  is the **only** transfer surface: the pane's older Move/Cancel/Retry
+  buttons, and the automation-only transfer keys that went with them,
+  are retired.
 
 ## Creating a scheduled task
 
-Press **c**, or click **Create ▾** in the Queue tab's rail header, to
-open the create form. Clicking **Create ▾** first asks which kind of
-task you want — **Reminder…** or **Recurring question…** — since a
-recurring question is a different kind of definition, not just another
-schedule shape; **c** always opens the reminder form directly. The form
-scrolls when the terminal is short; the live "Runs: …" preview,
-validation, and Save/Cancel stay pinned at the bottom while you edit.
+Press **n**, or click **Create ▾** in the rail header. Both ask which
+kind of task you want — **Reminder…** or **Recurring question…** —
+since a recurring question is a different kind of definition, not just
+another schedule shape. The form scrolls when the terminal is short; the
+live "Runs: …" preview, validation, and Save/Cancel stay pinned at the
+bottom while you edit.
 
 Every create/edit form also has a **Runs on** selector — **This device**
 or **Server (\<id\>)** when a scheduling server is connected — defaulting
@@ -255,10 +310,9 @@ to whatever owner the Schedules screen is currently showing. Choosing the
 server writes the task there directly when the server is reachable, or
 authors it locally and queues it to sync up on the next successful sync
 when it is not (the sync bar and the task's own state say which
-happened -- a recurring question in that state is listed on the
-Automations tab as *\[\<server id\> · pending sync\]*, and Run now/run
-history say so rather than asking the server about a task it has never
-seen). If the server refuses the save outright rather than being
+happened -- a recurring question in that state is listed as
+*\[\<server id\> · pending sync\]*, and Run now/run history say so
+rather than asking the server about a task it has never seen). If the server refuses the save outright rather than being
 unreachable, the form says so and nothing is queued -- retrying it later
 would only hit the same refusal. An existing reminder's owner is fixed
 once created — the selector shows it but is not editable — moving a task
@@ -337,7 +391,7 @@ not running at the scheduled time.
   time, not from where it left off. Skipped occurrences are counted and
   surfaced, never re-run.
 - **The queue marks late tasks with a ◇ glyph** before the title, so a
-  glance at the Queue tab shows what fell behind. The queue filter
+  glance at the queue shows what fell behind. The queue filter
   searches title and body text only (it no longer matches status words
   like `missed` — the unified list dropped the old status/type keyword
   search along with the Status/Type columns); search for the task's own
@@ -369,12 +423,13 @@ scheduler queue immediately — they do not wait for the periodic reload,
 and creating one for a time that already passed reports as missed-while-
 away only if it genuinely outruns the grace window.
 
-## Run now — dispatch a reminder immediately
+## Run now — dispatch immediately
 
-Press **r** on a highlighted reminder (or its **Run now** button in the
-task detail pane) to dispatch it right away, without waiting for its
-schedule. This is a **real dispatch** through the same path the scheduler
-uses — not a preview:
+Click **Run now** in the highlighted row's detail pane to dispatch it
+right away, without waiting for its schedule. (There is no Run-now key:
+the button names what it is about to run, a global shortcut would not.)
+This is a **real dispatch** through the same path the scheduler uses —
+not a preview:
 
 - A **recurring** reminder's next occurrence is computed from the moment
   you run it, exactly as a scheduled firing would.
@@ -397,28 +452,24 @@ firing twice.
 owner is a connected server, reminders synced to it carry a server scope:
 the **server** executes them on schedule and delivers the notification
 through the server feed, and the local scheduler never fires them (no
-double execution — one owner, one executor). Pressing **r** on one refuses
-with a toast saying so. This is the single-owner execution rule the
+double execution — one owner, one executor). Run now on one refuses with
+a toast saying so. This is the single-owner execution rule the
 server-offload design is built on; local-owner reminders are unaffected.
 
 ## Moving a task between this device and the server
 
-A reminder's detail pane offers **Move to server** (on a local task) or
-**Move to local** (on a server-owned mirror), plus **Cancel transfer**
-once a move is in flight and **Retry transfer** after one fails. Each
-button is visible whenever it could apply and disabled with a stated
-reason otherwise — no server connection, no server identity, a transfer
-already running, or, moving a `recurring_question` mirror to this
-device, the same local-health reason the Automations tab already
-surfaces.
+Every move — reminder or automation, either direction — goes through the
+**`Runs on`** row in that row's detail pane. Open its dropdown (click it,
+press Enter on it, or press **m** with the row highlighted) and pick the
+other owner. One surface, one flow: the older Move/Cancel/Retry buttons
+and the automation-only `M`/`m`/`y`/`k` transfer keys are retired.
 
-The `Runs on` row itself is a second way into the same flow: opening its
-dropdown and picking the other owner runs the same refusal check and
-confirmation dialog described below, with a refusal shown inline under
-the row instead of as a toast. Both surfaces drive the same transfer —
-use whichever is at hand.
+A move that cannot proceed is refused inline under the row with the
+reason — no server connection, no server identity, a transfer already
+running, or, moving a `recurring_question` mirror to this device, the
+same local-health reason the automation's own pane reports.
 
-Clicking Move opens a confirmation listing anything worth knowing before
+Picking the other owner opens a confirmation listing anything worth knowing before
 you commit: an imminent or already-passed one-time run time ("server
 behavior this close to run time is unverified"), and, for a reminder,
 that its per-run timeout is local-only and will not transfer.
@@ -443,14 +494,14 @@ until the server's release is acknowledged, at which point it arms and
 starts running here.
 
 When Schedules is showing a server owner's queue, each row's title also
-carries a "(server: \<id\>)" owner suffix — the same wording the Results
-tab uses for its own rows. It is hidden whenever the window is narrow
-enough to trigger the compact layout (side panes already hidden), so a
-squeezed terminal never truncates a title to make room for it.
+carries a "(server: \<id\>)" owner suffix — the same wording the results
+view uses for its own rows. It is hidden whenever the window is narrow
+enough to trigger the compact layout, so a squeezed terminal never
+truncates a title to make room for it.
 
 **While a move is in flight the task is read-only.** Edit, Delete and
-Enable/Disable are disabled with the reason stated, on the buttons and
-as text, for a queued local → server move, one already sent, and a
+Enable/Disable are refused with the reason stated for a queued
+local → server move, one already sent, and a
 dormant server → local copy. This is not fussiness: the move takes a
 snapshot of the task when you start it, so an edit made afterwards would
 be sent nowhere and then overwritten by the first sync. Cancel the
@@ -476,32 +527,12 @@ button, and retrying resubmits the same task.
 **A disabled server reminder stays disabled** when it is released to this
 device — the release moves the task, not its on/off state.
 
-### Moving an automation (Automations tab)
-
-Automations use keys instead of buttons, because that tab has no
-per-row detail pane:
-
-| Key | Action |
-| --- | --- |
-| `M` | Move the selected local automation **to the server** |
-| `m` | Move the selected server-owned automation **to this device** |
-| `y` | Retry a local → server move the server rejected |
-| `k` | Cancel the selected automation's in-progress move |
-
-These four are **Automations-tab only**, even though the footer
-advertises them on every tab: pressing them elsewhere answers with a
-"Switch to the Automations tab…" notice rather than acting on whatever
-the Queue tab happens to have selected. They run the same confirmation,
-warnings and honest toasts as the reminder buttons above, and a refusal
-appears inline in the Automations pane's notice line rather than as a
-toast.
-
 ## Creating a recurring question
 
 A recurring question runs a scoped search on a schedule and reports what
 it finds — a different kind of task than a reminder. Open its create
-form from the Queue tab's **Create ▾** chooser ("Recurring question…")
-or the Automations tab's own **+ New** button. Its v1 fields: a name, the
+form from the **Create ▾** chooser ("Recurring question…"). Its v1
+fields: a name, the
 question itself, which sources to search (all readable library sources,
 or a specific choice of Media / Notes / Chats — collections, tags, and
 saved searches are not offered yet), the schedule (the same one-time/
@@ -516,20 +547,18 @@ previews first — an invalid definition is never written. Only the
 `recurring_question` family can be authored here; agent-task automations
 are not yet supported from this form.
 
-## Automations tab — local and server automations
+## Automations in the list
 
-The **Automations** tab lists automation definitions from **both**
-owners: this device's own local `recurring_question` automations and
-whatever a connected server reports — the server ones execute there,
-which is why they do not appear in the local Queue. Each row's Name cell
-is prefixed with its owner (`[This device] …` or `[<server id>] …`) so
-the two are never ambiguous side by side; saving a new "Runs on: This
-device" automation shows up here immediately (the tab refreshes after
-every save). With no server connected the tab shows local automations
-alone instead of an empty list.
+Automation definitions from **both** owners share the one list: this
+device's own local `recurring_question` automations and whatever a
+connected server reports. Each row carries its owner suffix so the two
+are never ambiguous side by side; saving a new "Runs on: This device"
+automation appears immediately. With no server connected you see the
+local ones alone rather than an empty list.
 
-Press **r** on a highlighted definition to run it immediately — a real
-dispatch, not a preview, routed by that row's own owner. A local
+Click **Run now** in a highlighted definition's detail pane to run it
+immediately — a real dispatch, not a preview, routed by that row's own
+owner. A local
 automation runs through the same claim/spawn machinery the scheduler's
 own tick uses (no risk of it double-firing against a scheduled run) and
 refuses honestly when it is missing, paused/archived, mid-transfer, or
@@ -540,38 +569,38 @@ collapsed it into an already-queued run), and the result arrives through
 the server's notification feed, not the local queue. A paused or
 archived server definition refuses with the server's own reason.
 
-Press **e** on a highlighted `recurring_question` definition (either
-owner) to edit it — the same form Save opens, pre-filled from the row.
-Editing a server automation that has never synced to this device mirrors
-it locally first (automatic, no extra step); agent-task automations are
-not yet editable here.
+Press **e** (or **Edit in full…** in the pane) on a highlighted
+`recurring_question` definition, either owner, to edit it — the same
+form Save opens, pre-filled from the row. Editing a server automation
+that has never synced to this device mirrors it locally first
+(automatic, no extra step); agent-task automations are not yet editable
+here.
 
-The **Model** column shows each automation's pinned execution target —
-`provider/model` when the definition carries its own selection (the
+The pane's **Model** row shows the automation's pinned execution target
+— `provider/model` when the definition carries its own selection (the
 executor honors it per run), or `auto` when it pins nothing and the
-executor resolves the target itself (config defaults, then the
-provider default). Per-task selection rides the definition payload, so
-one automation can run on a different model than the default without
+executor resolves the target itself (config defaults, then the provider
+default). Per-task selection rides the definition payload, so one
+automation can run on a different model than the default without
 touching config.
 
-The right half of the tab is that definition's **Run history**. For a
-server automation this is the server's durable audit trail, newest first
-(time, event, summary) — it loads when you highlight the row and
-refreshes right after a Run-now dispatch, so the run you just triggered
-appears without re-selecting it. **Local automations do not have a
-durable run history yet** — the pane says so honestly rather than
-showing an empty server-shaped trail; every execution still leaves its
-trail here for server automations: queued, succeeded, failed, timed out,
-skipped, the same events the server records for reconciliation.
+Activating the pane's **Last run** row opens that definition's **run
+history** over the list ("Run history — \<name\>"). For a server
+automation this is the server's durable audit trail, newest first (time,
+event, summary), fetched when the view opens: queued, succeeded, failed,
+timed out, skipped — the same events the server records for
+reconciliation. **Local automations do not have a durable run history
+yet**, and the view says so rather than showing an empty server-shaped
+trail. **Escape** closes it.
 
-### Automations tab — definition detail pane
+### The automation detail pane
 
-Highlighting a definition row opens a detail pane alongside the list and
-its run history — the Automations tab's first per-row detail view. A
-**Pause**/**Resume** button sits above the body, toggling the
-definition's lifecycle (Archive stays a kebab/list action, not this
-button); the pane shows the question text in a card next, then the same
-grouped-row layout as the reminder detail pane:
+Highlighting a definition row opens its detail pane beside the list.
+**Pause**/**Resume** and **Run now** buttons sit above the body
+(Pause/Resume toggles the definition's lifecycle; Archive stays a list
+action, not this button), and **p** does the same as the Pause/Resume
+button from the list. The pane shows the question text in a card next,
+then the same grouped-row layout as the reminder detail pane:
 
 - **Details** — `Runs on` (owner + transfer badge, same wording as the
   reminder pane; its dropdown is the same transfer flow described under
@@ -586,12 +615,13 @@ grouped-row layout as the reminder detail pane:
 - **Frequency** — the schedule summary (repeat/at/timezone, or the raw
   cron expression for a custom schedule) and `Notifications` (a real
   On/Off toggle here, unlike a reminder's fixed "Inbox + toast" label).
-- **History** (collapsed by default) — the last run's outcome, total run
-  count, unread results count, and a pointer to the Results tab. Those
+- **History** (collapsed by default) — `Last run` (activate it to open
+  the run history described above), total run count, and `Unread
+  results` (activate it to open the results view scoped to just this
+  automation; **r** marks them all read without opening anything). Those
   counts are this device's own execution record, so a server-owned
   definition reads "Kept on the server — see Run history" instead: only
-  the server holds that definition's execution history, and the run
-  history pane beside it is already showing it.
+  the server holds that definition's execution history.
 
 Every Details/Frequency row except the schedule-kind mismatch (Repeat on
 a one-time definition, or At on a recurring one — same rule the reminder
@@ -604,16 +634,23 @@ selection, not "all searchable library" — pick **Edit in full…** if you
 want the scope to keep resolving to whatever sources are readable at
 each run rather than freezing today's three.
 
-The detail pane hides at narrow terminal widths, the same responsive rule
-the Queue tab's own detail pane already uses.
+At narrow widths this pane opens full-screen over the list instead of
+beside it — see "Narrow terminals", above. Everything described here
+works there unchanged.
 
-## Results tab — the automation findings inbox
+## The results view — the automation findings inbox
 
-The **Results** tab lists the `automation_results` rows a recurring
-question has produced, across **both** owners (this device and any
-connected server) in one inbox, newest first. Its tab label carries an
-unread badge — "Results (3)" — updating after every sync and after every
-action below, and reading plain "Results" with nothing unread.
+The **Results** button in the rail opens the `automation_results` rows a
+recurring question has produced, across **both** owners (this device and
+any connected server) in one inbox over the list, newest first.
+**Escape** closes it and re-syncs the rail. The button carries an unread
+badge — "Results (3)" — updating after every sync and after every action
+below, and reading plain "Results" with nothing unread.
+
+An automation's own **Unread results** row opens the same view scoped to
+just that automation (both of its id spaces, so a definition that has
+moved between owners keeps its earlier results), with the heading naming
+it.
 
 The table holds the newest 200 results: the same window a sync pull
 mirrors down, so it shows everything a sync could have fetched. Past
@@ -632,17 +669,15 @@ its answer, evidence (the stored source references), and review
 metadata (who reviewed it and when, plus any review note) in the detail
 pane below the table.
 
-While connected to a server, this tab also refreshes on its own the
-moment the server reports that an automation run finished — no need to
-press **s**. A short pause (well under a second) absorbs a burst of
-several finish notifications arriving close together into a single
-pull, so opening a chatty automation's run history does not fire one
-network round trip per event. Opening the screen pulls once as well, so
-results announced while you were on another screen are picked up rather
-than waiting for the next notification.
+While connected to a server, results refresh on their own the moment the
+server reports that an automation run finished — no need to press **s**.
+A short pause (well under a second) absorbs a burst of several finish
+notifications arriving close together into a single pull, so a chatty
+automation does not fire one network round trip per event. Opening the
+screen pulls once as well, so results announced while you were elsewhere
+are picked up rather than waiting for the next notification.
 
-Actions are keys, not buttons — the tab has no per-row detail widget
-here either:
+Actions inside the view are keys:
 
 | Key | Action |
 | --- | --- |
@@ -651,14 +686,10 @@ here either:
 | `o` | Mark the selected finding's automation **solved** |
 | `a` | Mark **every** currently-listed unread result read |
 
-`r`/`d` are the same keys the Queue tab uses for Run now/Delete —
-reused here because Read/Dismiss are the natural reading of those same
-letters on this tab. A server-owned row's read/dismiss writes locally
-and automatically queues the matching pushback to the server; nothing
-extra to do. `o`/`a` are Results-tab only, the same way the Automations
-tab's `m`/`M`/`y`/`k` are: pressed elsewhere they answer with a "Switch
-to the Results tab…" notice instead of acting on another tab's
-selection.
+These four belong to the results view itself — it is a screen of its
+own, so its keys never collide with the list's behind it. A server-owned
+row's read/dismiss writes locally and automatically queues the matching
+pushback to the server; nothing extra to do.
 
 **Mark solved** only applies to a `finding` whose automation is not
 already solved — a `failure` row, or a finding whose automation was
@@ -690,6 +721,34 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules redesign PR-4 — 2026-09-04 (docs pass
+against shipped code/tests, live check pending the redesign program's
+own §14 gate). This page was REWRITTEN for the single surface: the tab
+bar is gone, and with it the Automations, Conflicts and Results tabs and
+every instruction that named one. What replaced them, all documented
+above: automation rows are fully actionable from the one list (run now,
+edit in full, pause/resume, move owner, mark read) instead of
+view-only; the spec §12 keyboard map (`1`-`4`/`f` chips, `/` search, `n`
+create, `p` pause/resume, `m` move owner, `r` mark read, `e` edit,
+`space`/`d`/`x`, `s`, `a`, `Esc`) replaces the old `c`/`r`-run-now/
+`o`/`M`/`m`/`y`/`k` set; the `Runs on` row's dropdown is the ONE
+transfer surface (the Move/Cancel/Retry buttons and the four
+automation-only transfer keys are deleted); Run now is a detail-pane
+button, not a key; the results inbox, a definition's run history, and
+the conflicts view open OVER the list and close with `Esc`, reached from
+the rail's `Results` button, the pane's `Last run`/`Unread results` rows,
+and the status strip's `Conflicts` badge; and the 80x24 floor now pushes
+the same detail pane full-screen on `Enter` (chips collapsing to one
+cycling control, the rail to a single row) instead of hiding the detail
+region behind a "widen the window" notice. Pinned by
+`Tests/UI/test_schedules_responsive_floor.py` (the floor, the push, the
+hosted-editor `Esc` rule, every operation reachable at 80x24, and the
+~110/full-width layouts), `Tests/UI/test_workbench_host_screen.py`,
+`Tests/UI/test_schedules_keyboard_map.py`,
+`Tests/UI/test_schedules_unified_list.py`,
+`Tests/UI/test_schedules_results_tab.py` and
+`Tests/UI/test_schedules_workbench.py`.)*
 
 *Verified against the schedules redesign PR-3 final fix wave —
 2026-09-03 (docs pass against shipped code/tests, live check pending the

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2897,6 +2897,13 @@
     },
     {
       "call_count": 1,
+      "diagnostic_digest": "7c97480f99ca94c6e4d4",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
       "diagnostic_digest": "6abd5e2a330f548a189a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/definition_detail.py",
@@ -2910,8 +2917,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 34,
-      "diagnostic_digest": "b7e7388dbb41c5b41a6f",
+      "call_count": 27,
+      "diagnostic_digest": "c85dd7c9863c11936c42",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11342,10 +11349,10 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 572,
+    "owner_files": 573,
     "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
     "task_492_calls": 1337,
-    "task_494_calls": 7599
+    "task_494_calls": 7593
   }
 }

--- a/Tests/Scheduling/test_unified_rows.py
+++ b/Tests/Scheduling/test_unified_rows.py
@@ -59,9 +59,8 @@ def _definition(**overrides) -> dict:
         server_id=None,
         owner_id="local",
         name="A Definition",
-        # Qodo MEDIUM: `build_unified_rows` now filters definitions to
-        # `family == "recurring_question"` (unknown/agent_task families
-        # must not render as pseudo-recurring rows) -- every real
+        # PR-4 ruling 1: `build_unified_rows` lists every definition
+        # family now (not just `recurring_question`) -- every real
         # definition row carries a family, so the helper must too.
         family="recurring_question",
         lifecycle="configured",
@@ -324,21 +323,55 @@ def test_archived_lifecycle_definition_is_completed():
     assert rows[0].bucket == "completed"
 
 
-def test_agent_task_definition_yields_no_unified_row():
-    """Qodo MEDIUM: `definitions` is never family-filtered upstream (the
-    server can return `agent_task` rows too), so `build_unified_rows`
-    itself must drop anything that is not `recurring_question` -- an
-    `agent_task` row has no recurring semantics behind it and would
-    otherwise render as a pseudo-recurring Queue entry. It stays visible
-    on the Automations tab, which is family-agnostic and unaffected by
-    this filter."""
+def test_agent_task_definition_is_included_and_bucketed_honestly():
+    """PR-4 ruling 1 (was: Qodo MEDIUM dropping non-`recurring_question`
+    rows entirely): the Automations tab -- the only other all-families
+    surface -- is retired by PR-4, so `build_unified_rows` must list
+    every definition family or an `agent_task` row loses its only
+    remaining home. Bucket/glyph read the SAME `lifecycle`/`schedule`
+    fields every family shares (verified against the real server
+    fixture, `Tests/Scheduling/fixtures/server_responses/
+    automation_definition_list.json`, whose `agent_task` entry carries
+    the identical `schedule`/`lifecycle` shape a `recurring_question`
+    row does) -- an `agent_task` row therefore buckets/glyphs exactly
+    like any other `configured`+`cron` definition, no special-casing."""
     rows = build_unified_rows([], [_definition(family="agent_task")], [])
-    assert rows == []
+    assert len(rows) == 1
+    assert rows[0].kind == "definition"
+    assert rows[0].bucket == "active"
+    assert rows[0].glyph == "○"
 
 
-def test_unknown_family_definition_yields_no_unified_row():
+def test_unknown_family_definition_is_also_included():
     rows = build_unified_rows([], [_definition(family="something_new")], [])
-    assert rows == []
+    assert len(rows) == 1
+    assert rows[0].bucket == "active"
+
+
+def test_agent_task_definition_with_no_recurring_question_shape_degrades_honestly():
+    """Bucket sanity for the shape an `agent_task` row is MORE likely to
+    carry than a full cron schedule: no `input.question` (recurring-
+    question's own field) and an absent/minimal `schedule`. Every
+    formatter already degrades to an honest placeholder for a shape it
+    doesn't recognize (`unified_rows.py`'s own defensive-read rule) --
+    pinned here so a future family-specific field never needs a
+    `unified_rows.py` change to stay crash-free."""
+    definition = _definition(
+        family="agent_task",
+        schedule={},
+        input={"source_collection": "library://default"},
+    )
+    rows = build_unified_rows([], [definition], [])
+    assert len(rows) == 1
+    row = rows[0]
+    # No recognized `schedule.kind` -> the honest "-" fallbacks, not a
+    # crash or a guessed cadence.
+    assert row.schedule_summary == "-"
+    assert row.bucket == "active"
+    assert row.glyph == "▶"
+    # No `input.question` -> falls back through description/name, never
+    # raises on the missing key.
+    assert "A Definition" in row.search_blob
 
 
 # ---------------------------------------------------------------------------

--- a/Tests/UI/schedules_test_helpers.py
+++ b/Tests/UI/schedules_test_helpers.py
@@ -353,3 +353,41 @@ def rendered_row_cells(table, row_index: int = 0) -> list[str]:
     whenever the point of the test is that content renders literally.
     """
     return [str(cell) for cell in table._get_row_renderables(row_index).cells]
+
+
+# --- settling the workbench --------------------------------------------------
+
+
+async def settle_schedules_workbench(pilot, workbench=None) -> None:
+    """Drain the workbench's background work, debounce timer included.
+
+    ``pilot.app.workers.wait_for_complete()`` does NOT cover a pending
+    ``set_timer`` callback, and `SchedulesWorkbench.on_mount` arms one: the
+    catch-up results pull (`_schedule_catch_up_results_pull`, 0.3 s). Its
+    worker ends in `_request_tasks_refresh`, which re-feeds the detail
+    pane -- so a test that has painted or pushed a detail pane can have it
+    cleared out from under an assertion by a reload landing after the test
+    believed the screen was settled.
+
+    redesign PR-4 task 5 hit this in `test_runs_on_dropdown_refusal_
+    renders_inline_with_health_reason` and fixed it inline; task 6's
+    pushed-pane tests are the second occurrence, which is where a shared
+    helper earns its keep (task-5 review's own ruling). Only the
+    results-pull timer is stopped -- the queue filter's debounce is
+    deliberately driven by the tests that use it.
+
+    Args:
+        pilot: The running `Pilot`.
+        workbench: The workbench screen; defaults to the app's current
+            screen.
+    """
+    app = pilot.app
+    target = workbench if workbench is not None else app.screen
+    await app.workers.wait_for_complete()
+    timer = getattr(target, "_results_pull_debounce_timer", None)
+    if timer is not None:
+        timer.stop()
+        target._results_pull_debounce_timer = None
+    await pilot.pause()
+    await app.workers.wait_for_complete()
+    await pilot.pause()

--- a/Tests/UI/test_detail_value_row.py
+++ b/Tests/UI/test_detail_value_row.py
@@ -519,3 +519,137 @@ async def test_a_select_editor_mounted_via_begin_edit_still_opens_on_enter():
             "Select's own Enter-to-open binding must still fire while it "
             "is the row's open editor"
         )
+
+
+# ---------------------------------------------------------------------------
+# redesign PR-4, task 4: spec §12 Up/Down detail-row traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_down_up_move_focus_between_focusable_rows():
+    first = DetailValueRow("Repeat", "Weekly", can_focus=True, id="first")
+    second = DetailValueRow("At", "9:00 AM", can_focus=True, id="second")
+    app = _RowHarness(first, second)
+    async with app.run_test(size=(40, 8)) as pilot:
+        first.focus()
+        await pilot.pause()
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is second
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is first
+
+
+@pytest.mark.asyncio
+async def test_traversal_skips_non_focusable_rows():
+    """`can_focus=False` rows (every read-only row) are not in the focus
+    chain at all -- Down from a focusable row lands on the NEXT
+    focusable one, skipping any read-only rows in between."""
+    top = DetailValueRow("Repeat", "Weekly", can_focus=True, id="top")
+    middle = DetailValueRow("Status", "Waiting", id="middle")  # can_focus=False
+    bottom = DetailValueRow("At", "9:00 AM", can_focus=True, id="bottom")
+    app = _RowHarness(top, middle, bottom)
+    async with app.run_test(size=(40, 10)) as pilot:
+        top.focus()
+        await pilot.pause()
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is bottom, "must skip the non-focusable middle row"
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is top
+
+
+@pytest.mark.asyncio
+async def test_traversal_wraps_at_the_ends():
+    """Textual's own `focus_chain` wrap-around (`_move_focus`'s modulo),
+    reused rather than a hand-rolled row registry -- picked over
+    stopping at the ends (task-4 brief: "pick, document")."""
+    first = DetailValueRow("Repeat", "Weekly", can_focus=True, id="first")
+    last = DetailValueRow("At", "9:00 AM", can_focus=True, id="last")
+    app = _RowHarness(first, last)
+    async with app.run_test(size=(40, 8)) as pilot:
+        first.focus()
+        await pilot.pause()
+
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is last, "Up from the first row must wrap to the last"
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is first, "Down from the last row must wrap to the first"
+
+
+@pytest.mark.asyncio
+async def test_traversal_skips_rows_inside_a_hidden_pane():
+    """A row inside a `display:none` container (the pane-hidden sibling
+    detail pane, or a collapsed `DetailGroup`) is excluded from Textual's
+    own `focus_chain` -- traversal never needs to know about the other
+    pane at all."""
+    from textual.containers import Vertical
+
+    visible = DetailValueRow("Repeat", "Weekly", can_focus=True, id="visible")
+    hidden = DetailValueRow("At", "9:00 AM", can_focus=True, id="hidden")
+
+    class _TwoPaneHarness(ConsolidatedCSSApp):
+        CSS_PATH = str(BUNDLED_STYLESHEET)
+
+        def compose(self) -> ComposeResult:
+            yield visible
+            pane = Vertical(hidden, id="hidden-pane")
+            pane.styles.display = "none"
+            yield pane
+
+    app = _TwoPaneHarness()
+    async with app.run_test(size=(40, 8)) as pilot:
+        visible.focus()
+        await pilot.pause()
+
+        await pilot.press("down")
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.focused is visible, (
+            "the only focusable row is the one in the visible pane -- "
+            "traversal must stay on it, never touch the hidden row"
+        )
+
+
+@pytest.mark.asyncio
+async def test_up_down_belongs_to_an_open_editor_not_the_row():
+    """PR-3's editor-open input-ownership rule, extended to arrows
+    (task-4 brief): `Select` binds up/down itself (`show_overlay`) --
+    while an editor is open, the row must NOT intercept them (same
+    `self._editor is None` guard Enter/Escape already use), or the
+    mounted `Select` could never be opened with the keyboard."""
+    row = DetailValueRow(
+        "Repeat", "Weekly", affordance=True, can_focus=True, id="row"
+    )
+    other = DetailValueRow("At", "9:00 AM", can_focus=True, id="other")
+    app = _RowHarness(row, other)
+    async with app.run_test(size=(40, 8)) as pilot:
+        select: Select[str] = Select(
+            [("Weekly", "weekly"), ("Daily", "daily")], id="editor"
+        )
+        row.begin_edit(select)
+        await pilot.pause()
+        assert app.focused is select
+        assert select.expanded is False
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert select.expanded is True, (
+            "Select's own up/down-to-open binding must fire while it is "
+            "the row's open editor"
+        )
+        # Opening moves focus to Select's own overlay popup (expected
+        # Textual behavior) -- the important thing is it did NOT move to
+        # the OTHER row, which is what the row's own traversal handler
+        # would have done had it wrongly intercepted the key.
+        assert app.focused is not other

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -12,7 +12,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from textual.widgets import DataTable, Input, Select, Static, TabbedContent
+from textual.widgets import Button, DataTable, Input, Select, Static, TabbedContent
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import (
@@ -26,9 +26,15 @@ from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientValidationError,
 )
 from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
+from tldw_chatbook.UI.Screens.scheduling.definition_audit_view import (
+    DefinitionAuditView,
+)
 from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
 from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
     AutomationDefinitionForm,
+)
+from tldw_chatbook.UI.Screens.scheduling.workbench_host_screen import (
+    WorkbenchHostScreen,
 )
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 
@@ -352,7 +358,15 @@ async def test_run_now_refusal_surfaces_without_raising():
 
 
 @pytest.mark.asyncio
-async def test_run_now_on_queue_tab_never_reaches_server_client():
+async def test_run_now_on_queue_tab_routes_a_definition_row_to_its_owner():
+    """redesign PR-4, task 3 (supersedes this test's old pin): Queue
+    definition rows now have their own run-now -- PR-2 ruling 1 made them
+    action-less, but PR-4 ruling 1 gives every family a home on the Queue
+    and task 3 wires run-now/edit onto those rows. `r` on the Queue's
+    first row (the server-owned "Morning brief" definition, `def-1`)
+    reaches the SAME server-run seam the Automations tab's own `r`
+    uses, routed by owner exactly like `_run_automation_now` already
+    routes there."""
     server_client = AutomationsServerClient()
     app = AutomationsTestApp(AutomationsMockService(server_client))
     async with app.run_test() as pilot:
@@ -360,10 +374,11 @@ async def test_run_now_on_queue_tab_never_reaches_server_client():
         await pilot.pause()
         workbench = pilot.app.screen
 
-        # Queue tab is active by default; r must not reach the server client.
+        # Queue tab is active by default; its first row is the
+        # server-owned "Morning brief" definition (def-1).
         workbench.action_run_task_now()
         await pilot.pause()
-        server_client.run_automation_definition_now.assert_not_awaited()
+        server_client.run_automation_definition_now.assert_awaited_once_with("def-1")
 
 
 @pytest.mark.asyncio
@@ -1572,3 +1587,221 @@ async def test_automations_panes_stay_on_screen_across_the_detail_hide_boundary(
                     f"W={width}: {pane.id} runs off-screen "
                     f"(x={pane.region.x}, width={pane.region.width})"
                 )
+
+
+# --- redesign PR-4, task 3: Queue definition-row actions + all-families
+# listing + audit-view relocation ------------------------------------------
+
+
+def _isolated_local_service(definitions):
+    """An `AutomationsMockService` whose server side returns NO
+    definitions -- isolates the Queue's first row to a single LOCAL
+    definition so a test can assert on a deterministic cursor position
+    without also contending with the server fixture's own two rows."""
+    server_client = AutomationsServerClient()
+    server_client.list_automation_definitions = AsyncMock(
+        return_value={"items": [], "total": 0}
+    )
+    return AutomationsMockService(server_client, local_definitions=definitions), server_client
+
+
+@pytest.mark.asyncio
+async def test_run_now_on_queue_tab_dispatches_a_local_definition_locally():
+    """PR-4 task 3: the Queue's own run-now routes a LOCAL definition
+    through `SchedulingService.run_automation_now` (never the server
+    client) -- the same owner routing `_run_automation_now` already
+    applies for the Automations tab's own `r`."""
+    service, server_client = _isolated_local_service([_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_run_task_now()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service.run_automation_now.assert_awaited_once_with("local-def-1")
+        server_client.run_automation_definition_now.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_edit_on_queue_tab_opens_the_form_for_a_recurring_question_row():
+    """PR-4 task 3: `e` on a Queue definition row opens the SAME
+    `AutomationDefinitionForm` the Automations tab's own `e` opens,
+    prefilled for that row."""
+    service, _server_client = _isolated_local_service([_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_edit_task()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
+
+
+@pytest.mark.asyncio
+async def test_edit_on_queue_tab_refuses_a_non_recurring_question_row():
+    """PR-4 task 3: an `agent_task` Queue row's `e` refuses honestly
+    (the SAME copy the Automations tab's own family gate already gives)
+    instead of opening a form that only knows how to author `recurring_
+    question`."""
+    agent_def = _local_definition(
+        id="local-agent-1", family="agent_task", name="Nightly agent run"
+    )
+    service, _server_client = _isolated_local_service([agent_def])
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        workbench.action_edit_task()
+        await pilot.pause()
+
+        assert pilot.app.screen is workbench
+        notifications = list(pilot.app._notifications)
+        assert any("recurring-question" in n.message for n in notifications), [
+            n.message for n in notifications
+        ]
+
+
+@pytest.mark.asyncio
+async def test_agent_task_queue_row_is_visible_and_read_only_with_honest_note():
+    """PR-4 ruling 1 + task 3: an `agent_task` definition now has a home
+    on the Queue (it was invisible there entirely before PR-4) and
+    renders with `DefinitionDetail`'s existing `_UNSUPPORTED_FAMILY_NOTE`
+    fallback -- no editable row lights up for it, the same as on the
+    Automations tab (`test_non_recurring_question_definition_exposes_no_
+    editors`)."""
+    agent_def = _local_definition(
+        id="local-agent-1", family="agent_task", name="Nightly agent run"
+    )
+    service, _server_client = _isolated_local_service([agent_def])
+    app = AutomationsTestApp(service)
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        # Column 0 is the glyph, column 1 is "Title" (`add_columns("",
+        # "Title", "Details")`) -- prefixed with the owner label
+        # (`automation_name_cell`).
+        assert "Nightly agent run" in rendered_row_cells(table, 0)[1]
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        detail = workbench.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        )
+        assert detail._definition["family"] == "agent_task"
+        assert [
+            row.row_key for row in detail._editable_rows() if row.affordance
+        ] == []
+        why = detail.query_one("#scheduling-automation-detail-why", Static)
+        assert "isn't a recurring question" in why.render_line(0).text
+
+
+@pytest.mark.asyncio
+async def test_last_run_row_activation_pushes_audit_view_with_painted_events():
+    """PR-4 task 3 (audit-view relocation): the Queue's own
+    `DefinitionDetail` sibling's `Last run` row activation pushes a
+    `DefinitionAuditView` scoped to the highlighted (server-owned)
+    definition, reusing the SAME `list_automation_definition_audit` seam
+    the retiring Automations-tab pane already calls."""
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        detail = workbench.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        )
+        row = detail._last_run_row
+        assert row.affordance is True
+        row.post_message(DetailValueRow.Activated(row))
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, WorkbenchHostScreen)
+        assert str(pilot.app.screen.title).startswith("Run history — Morning brief")
+        overlay = pilot.app.screen.query_one(DefinitionAuditView)
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        audit_table = overlay.query_one("#scheduling-audit-view-table", DataTable)
+        assert audit_table.row_count == 2
+        assert rendered_row_cells(audit_table, 0)[2] == "Run succeeded."
+
+
+@pytest.mark.asyncio
+async def test_run_now_button_on_queue_definition_pane_dispatches_locally():
+    """PR-4 task 3, ruling 2: the retired Automations-tab `r` key
+    relocates to a `Run now` button beside Pause/Resume on the pane
+    itself -- pressing it on the Queue's own `DefinitionDetail` sibling
+    reaches the SAME local dispatch seam the key used to."""
+    service, _server_client = _isolated_local_service([_local_definition()])
+    app = AutomationsTestApp(service)
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        detail = workbench.query_one(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        )
+        run_now = detail.query_one("#scheduling-automation-run-now", Button)
+        detail.on_button_pressed(Button.Pressed(run_now))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        service.run_automation_now.assert_awaited_once_with("local-def-1")

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -1,10 +1,21 @@
-"""Automations tab behavior on the Schedules workbench (task-18940 slice 2).
+"""Automation-definition behavior on the Schedules workbench (task-18940
+slice 2).
 
-The tab surfaces both the server's automation definitions (ADR-077, ``r``
-dispatches through the server control plane) and, since task-5's fix
-round, this device's own local-owned `recurring_question` definitions
-(``r`` routes those through `SchedulingService.run_automation_now`
-instead -- never the server client, and never both).
+Definitions come from two halves -- the server's (ADR-077, dispatched
+through the server control plane) and this device's own local-owned
+`recurring_question` rows (dispatched through `SchedulingService.run_
+automation_now`; never the server client, and never both).
+
+redesign PR-4 task 5 (the retirement): the file keeps its `automations_
+tab` name -- the same judgment the plan applied to `results_tab.py`/
+`conflicts_tab.py`, renaming buys churn, not clarity -- but the TAB it
+was written against is gone. Its listing, its per-definition detail pane
+and its run-now/edit actions all relocated onto the unified queue
+(`#scheduling-task-table` + `#scheduling-queue-definition-detail`), and
+its audit-trail pane relocated to the pushed `DefinitionAuditView`
+(task 3). Every test below is re-pointed at whichever of those now owns
+the behaviour, with the exceptions individually cited where a surface
+(and its behaviour) genuinely went away rather than moved.
 """
 
 import asyncio
@@ -12,7 +23,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from textual.widgets import Button, DataTable, Input, Select, Static, TabbedContent
+from textual.widgets import Button, DataTable, Input, Select, Static
 
 from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import (
@@ -184,34 +195,91 @@ class LocalOnlyTestApp(ConsolidatedCSSApp):
     scheduling_service = None
 
 
-async def _mounted_workbench(app):
-    """Run the app and return (pilot context, screen) with the workbench up."""
-    return app
+# -- queue-list readers (redesign PR-4 task 5) -------------------------------
+#
+# The retired Automations table was a flat, definitions-only listing whose
+# row order matched the loader's own merge order, so tests indexed it
+# directly. The unified queue mixes reminders in and SORTS (`sort_rows`),
+# so a definition is found by id, never by a hard-coded position. Its
+# columns are (glyph, Title, Details), so the Name cell the old table put
+# at index 0 is index 1 here.
+
+
+def _queue_table(workbench) -> DataTable:
+    return workbench.query_one("#scheduling-task-table", DataTable)
+
+
+def _queue_titles(workbench) -> list[str]:
+    table = _queue_table(workbench)
+    return [rendered_row_cells(table, i)[1] for i in range(table.row_count)]
+
+
+def _queue_definitions(workbench) -> list[dict]:
+    return [
+        row.source_row for row in workbench._visible_rows if row.kind == "definition"
+    ]
+
+
+def _queue_row_index(workbench, definition_id: str) -> int:
+    return next(
+        index
+        for index, row in enumerate(workbench._visible_rows)
+        if row.kind == "definition"
+        and str(row.source_row.get("id")) == definition_id
+    )
+
+
+async def _select_queue_definition(pilot, workbench, definition_id: str):
+    """Put the queue cursor on `definition_id` and let its detail load."""
+    table = _queue_table(workbench)
+    table.cursor_coordinate = (_queue_row_index(workbench, definition_id), 0)
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return workbench.query_one(
+        "#scheduling-queue-definition-detail", DefinitionDetail
+    )
+
+
+async def _settled_workbench(pilot):
+    """Push the workbench and let its mount-time loads finish."""
+    await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen
 
 
 @pytest.mark.asyncio
-async def test_automations_tab_loads_server_definitions():
+async def test_server_definitions_load_into_the_queue():
+    """redesign PR-4 task 5: the server fetch lands in the unified queue.
+
+    Two things changed with the retirement. The fetch count drops 2 -> 1:
+    PR-2 noted that `load_tasks` had started fetching both definition
+    halves ALONGSIDE the tab's own loader, on its own cadence -- with the
+    tab's loader deleted, one fetch per mount is all that is left. And
+    the selection the run-now/edit actions read is the unified row's
+    (`_selected_row_id`), not the retired table's `_selected_automation_
+    id`.
+
+    The pane notice this used to assert ("2 automations on the server")
+    is DELETED with `_automations_notice_text`: the queue's own notice
+    (`#scheduling-pane-notice`) reports hidden panes/marks/glyphs, not a
+    per-owner definition census, and inventing one here would be new
+    copy, not a relocation.
+    """
     server_client = AutomationsServerClient()
     app = AutomationsTestApp(AutomationsMockService(server_client))
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        notice = workbench.query_one("#scheduling-automations-notice")
+        workbench = await _settled_workbench(pilot)
 
-        # redesign PR-2, Task 2: `load_tasks` (the Queue tab's own unified
-        # loader) now ALSO fetches both definition halves on every mount
-        # (its own separate cadence, per the brief -- not a shared cache
-        # with this tab's `load_automations`), so the server fetch is
-        # awaited twice, not once, at mount.
-        assert server_client.list_automation_definitions.await_count == 2
-        assert table.row_count == 2
-        assert "2 automations on the server" in str(notice.content)
-        # Highlighting a row records the selection Run-now will act on.
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
-        assert workbench._selected_automation_id == "def-1"
+        assert server_client.list_automation_definitions.await_count == 1
+        assert _queue_table(workbench).row_count == 2
+
+        # Highlighting a row records the selection the actions act on.
+        await _select_queue_definition(pilot, workbench, "def-1")
+        assert workbench._selected_row_id == "definition:def-1"
+        assert workbench._selected_queue_definition()["id"] == "def-1"
 
 
 @pytest.mark.asyncio
@@ -226,17 +294,15 @@ async def test_server_rows_are_rebound_to_the_connection_owner_scope():
     server_client = AutomationsServerClient()
     app = AutomationsTestApp(AutomationsMockService(server_client))
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
+        workbench = await _settled_workbench(pilot)
 
-        assert [row["owner_id"] for row in workbench._automations] == [
-            "server:server-1",
-            "server:server-1",
+        assert [
+            row["owner_id"] for row in _queue_definitions(workbench)
+        ] == ["server:server-1", "server:server-1"]
+
+        first_cell = _queue_titles(workbench)[
+            _queue_row_index(workbench, "def-1")
         ]
-
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        first_cell = rendered_row_cells(table, 0)[0]
         assert first_cell == "[server-1] Morning brief"
         assert "This device" not in first_cell
 
@@ -286,75 +352,68 @@ async def test_owner_prefix_and_bracket_name_render_literally():
     app.runtime_policy = SimpleNamespace(
         state=SimpleNamespace(active_server_id="http://127.0.0.1:8020")
     )
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        table = pilot.app.screen.query_one(
-            "#scheduling-automations-table", DataTable
+    async with app.run_test(size=(200, 50)) as pilot:
+        workbench = await _settled_workbench(pilot)
+
+        assert _queue_titles(workbench) == [
+            "[http://127.0.0.1:8020] Nightly [bold] digest"
+        ]
+        # redesign PR-4 task 5: the retired table's Model COLUMN carried
+        # server-derived text too, and its escaping had to be pinned for
+        # the same reason. That reading now lives on the definition pane's
+        # Model row, so the second half of this claim follows it there
+        # rather than being dropped.
+        detail = await _select_queue_definition(pilot, workbench, "def-1")
+        assert (
+            _detail_text(detail, "scheduling-automation-detail-model")
+            == "custom-openai-api/[deprecated] Qwen2.5"
         )
 
-        cells = rendered_row_cells(table, 0)
-        assert cells[0] == "[http://127.0.0.1:8020] Nightly [bold] digest"
-        # The Model column carries server-derived text too.
-        assert cells[4] == "custom-openai-api/[deprecated] Qwen2.5"
+
+# redesign PR-4 task 5, two DELETIONS in this block, each because the
+# surface under test is gone rather than moved:
+#
+# `test_automations_tab_shows_notice_without_server` pinned the retired
+# pane notice's no-server wording ("Server automations need a connected
+# server"), composed by `_automations_notice_text`. Both are deleted --
+# the queue's own `#scheduling-pane-notice` is about hidden panes, marks
+# and the glyph legend, and giving it a definitions census would be new
+# copy rather than a relocation. The behaviour that mattered underneath
+# (no server -> no server rows, local rows still listed) is still pinned
+# by `test_local_automation_appears_with_recomputed_health` below, which
+# runs with `notifications_service=None`.
+#
+# `test_run_now_on_automations_tab_dispatches_server_side` pinned `r` on
+# the Automations tab dispatching server-side. Its claim is now covered
+# verbatim by `test_run_now_on_queue_tab_routes_a_definition_row_to_its_
+# owner` below -- same fixture, same `def-1`, same
+# `run_automation_definition_now` assertion, reached through the surface
+# that survived. Keeping both would be one test twice.
 
 
 @pytest.mark.asyncio
-async def test_automations_tab_shows_notice_without_server():
-    app = LocalOnlyTestApp()
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        notice = workbench.query_one("#scheduling-automations-notice")
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        assert table.row_count == 0
-        assert "need a connected server" in str(notice.content)
-
-
-@pytest.mark.asyncio
-async def test_run_now_on_automations_tab_dispatches_server_side():
-    server_client = AutomationsServerClient()
-    app = AutomationsTestApp(AutomationsMockService(server_client))
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
-
-        workbench.action_run_task_now()
-        await pilot.pause()
-
-        server_client.run_automation_definition_now.assert_awaited_once_with("def-1")
-
-
-@pytest.mark.asyncio
-async def test_run_now_refusal_surfaces_without_raising():
+async def test_server_run_now_refusal_surfaces_without_raising():
+    """A `ServerClientValidationError` refusal is surfaced, not raised out
+    of the action. (redesign PR-4 task 5: driven from the queue row --
+    the Automations tab's own selection state is retired, so the
+    still-selected assertion reads the unified row id.)"""
     server_client = AutomationsServerClient()
     server_client.run_automation_definition_now = AsyncMock(
         side_effect=ServerClientValidationError("definition_paused")
     )
     app = AutomationsTestApp(AutomationsMockService(server_client))
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        await _select_queue_definition(pilot, workbench, "def-1")
 
         workbench.action_run_task_now()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         server_client.run_automation_definition_now.assert_awaited_once()
         # The refusal path must not raise out of the action handler.
-        assert workbench._selected_automation_id == "def-1"
+        assert workbench._selected_row_id == "definition:def-1"
 
 
 @pytest.mark.asyncio
@@ -381,101 +440,113 @@ async def test_run_now_on_queue_tab_routes_a_definition_row_to_its_owner():
         server_client.run_automation_definition_now.assert_awaited_once_with("def-1")
 
 
-@pytest.mark.asyncio
-async def test_selecting_a_definition_loads_its_audit_trail():
-    server_client = AutomationsServerClient()
-    app = AutomationsTestApp(AutomationsMockService(server_client))
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        history = workbench.query_one(
-            "#scheduling-automation-history-table", DataTable
-        )
-        notice = workbench.query_one("#scheduling-automation-history-notice")
-        title = workbench.query_one("#scheduling-automation-history-title")
+# redesign PR-4 task 5: the audit trail's three states move from the
+# retired Automations-tab third pane (a DataTable + notice + title that
+# reloaded on every row selection) to the pushed `DefinitionAuditView`
+# (task 3), which fetches once on mount. The states themselves --
+# events + count line, an honest empty state, and the no-server refusal
+# -- are unchanged: both surfaces always shared `fetch_definition_audit`
+# and `audit_notice_text`. The three tests below carry them over.
+#
+# `test_successful_run_now_refreshes_the_audit_trail` is DELETED, not
+# carried over: it pinned the server run-now's immediate + 5s-delayed
+# re-fetch INTO the always-mounted history pane, and that pane is what
+# made the re-fetch necessary. A pushed view fetches on mount, so it can
+# never be showing a trail that a just-dispatched run has outdated --
+# there is nothing left to poke, and the workbench no longer calls the
+# audit seam at all outside a push. What the run-now path does now
+# instead (refresh the definitions) is pinned by
+# `test_server_run_now_marks_definitions_stale` in
+# `test_schedules_unified_list.py`.
 
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+
+async def _push_audit_view(pilot, service, definition):
+    """Push a `DefinitionAuditView` the way `_push_definition_audit_
+    overlay` does, and let its on-mount fetch finish."""
+    await pilot.app.push_screen(
+        WorkbenchHostScreen(
+            lambda: DefinitionAuditView(service, dict(definition)),
+            title="Run history",
+        )
+    )
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen.query_one(DefinitionAuditView)
+
+
+@pytest.mark.asyncio
+async def test_audit_view_lists_the_events_and_counts_them():
+    server_client = AutomationsServerClient()
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await _settled_workbench(pilot)
+        server_client.list_automation_definition_audit.reset_mock()
+
+        overlay = await _push_audit_view(
+            pilot,
+            service,
+            {"id": "def-1", "name": "Morning brief", "owner_id": "server:server-1"},
+        )
 
         server_client.list_automation_definition_audit.assert_awaited_once_with(
             "def-1"
         )
-        assert history.row_count == 2
-        assert "Run history — Morning brief" in str(title.content)
+        table = overlay.query_one("#scheduling-audit-view-table", DataTable)
+        notice = overlay.query_one("#scheduling-audit-view-notice")
+        assert table.row_count == 2
         assert "2 events" in str(notice.content)
 
 
 @pytest.mark.asyncio
-async def test_audit_trail_shows_empty_state_without_events():
+async def test_audit_view_shows_empty_state_without_events():
     server_client = AutomationsServerClient()
     server_client.list_automation_definition_audit = AsyncMock(
         return_value={"items": [], "total": 0}
     )
-    app = AutomationsTestApp(AutomationsMockService(server_client))
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        history = workbench.query_one(
-            "#scheduling-automation-history-table", DataTable
+        await _settled_workbench(pilot)
+
+        overlay = await _push_audit_view(
+            pilot,
+            service,
+            {"id": "def-2", "name": "Paused one", "owner_id": "server:server-1"},
         )
-        notice = workbench.query_one("#scheduling-automation-history-notice")
 
-        table.cursor_coordinate = (1, 0)
-        await pilot.pause()
-
-        assert history.row_count == 0
+        table = overlay.query_one("#scheduling-audit-view-table", DataTable)
+        notice = overlay.query_one("#scheduling-audit-view-notice")
+        assert table.row_count == 0
         assert "No recorded events" in str(notice.content)
 
 
 @pytest.mark.asyncio
-async def test_audit_trail_without_server_shows_notice():
+async def test_audit_view_without_server_shows_notice():
     app = LocalOnlyTestApp()
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        history = workbench.query_one(
-            "#scheduling-automation-history-table", DataTable
+        overlay = await _push_audit_view(
+            pilot,
+            None,
+            {"id": "def-1", "name": "Morning brief", "owner_id": "server:server-1"},
         )
-        notice = workbench.query_one("#scheduling-automation-history-notice")
 
-        assert history.row_count == 0
+        table = overlay.query_one("#scheduling-audit-view-table", DataTable)
+        notice = overlay.query_one("#scheduling-audit-view-notice")
+        assert table.row_count == 0
         assert "needs a connected server" in str(notice.content)
 
 
-@pytest.mark.asyncio
-async def test_successful_run_now_refreshes_the_audit_trail():
-    server_client = AutomationsServerClient()
-    app = AutomationsTestApp(AutomationsMockService(server_client))
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
-        assert server_client.list_automation_definition_audit.await_count == 1
-
-        workbench.action_run_task_now()
-        await pilot.pause()
-        await pilot.pause()
-
-        # Selection load + post-dispatch refresh.
-        assert server_client.list_automation_definition_audit.await_count == 2
-        assert (
-            server_client.list_automation_definition_audit.await_args.args[-1]
-            == "def-1"
-        )
-
-
 def test_execution_target_label_matrix():
-    from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+    # redesign PR-4 task 5: imported from `definition_detail`, this
+    # helper's real home. `schedules_workbench` used to re-export it
+    # purely so this test's original import kept working, and that
+    # re-export was the last consumer of the name there once the retired
+    # Automations table (its only real caller) went -- so the import
+    # moves and the re-export is deleted rather than kept alive with a
+    # `noqa`.
+    from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
         automation_execution_target_label,
     )
 
@@ -497,47 +568,18 @@ def test_execution_target_label_matrix():
     assert automation_execution_target_label({"input": "redacted"}) == "auto"
 
 
-@pytest.mark.asyncio
-async def test_definitions_table_shows_the_model_column():
-    server_client = AutomationsServerClient()
-    server_client.list_automation_definitions = AsyncMock(
-        return_value={
-            "items": [
-                {
-                    "id": "def-1",
-                    "name": "Pinned",
-                    "family": "recurring_question",
-                    "lifecycle": "configured",
-                    "health": "ready",
-                    "input": {"provider": "anthropic", "model": "claude-x"},
-                },
-                {
-                    "id": "def-2",
-                    "name": "Default",
-                    "family": "recurring_question",
-                    "lifecycle": "configured",
-                    "health": "ready",
-                },
-            ],
-            "total": 2,
-        }
-    )
-    app = AutomationsTestApp(AutomationsMockService(server_client))
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-
-        assert [c.label.plain for c in table.columns.values()] == [
-            "Name",
-            "Family",
-            "Lifecycle",
-            "Health",
-            "Model",
-        ]
-        assert rendered_row_cells(table, 0)[4] == "anthropic/claude-x"
-        assert rendered_row_cells(table, 1)[4] == "auto"
+# redesign PR-4 task 5: `test_definitions_table_shows_the_model_column`
+# is DELETED. It pinned the retired table's five-column shape
+# (Name/Family/Lifecycle/Health/Model) and the Model cell's
+# provider/model vs "auto" rendering. The unified queue is deliberately
+# (glyph, Title, Details) -- PR-2 spec S4, "a single primitive's column
+# set no longer fits a mixed reminder+definition list" -- so the columns
+# themselves have no successor to assert. The READING survives in two
+# places that already cover it: `automation_execution_target_label`'s own
+# matrix (`test_execution_target_label_matrix` above, including the
+# "auto" fallback) and the definition pane's Model row (asserted by
+# `test_selecting_a_local_definition_paints_its_details_and_counts` and
+# `test_owner_prefix_and_bracket_name_render_literally`).
 
 
 # --- task-5 fix round: merged local + server listing ------------------------
@@ -552,18 +594,19 @@ async def test_local_automation_appears_with_recomputed_health():
     service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        notice = workbench.query_one("#scheduling-automations-notice")
+        workbench = await _settled_workbench(pilot)
 
-        assert table.row_count == 1
-        assert rendered_row_cells(table, 0)[0] == "[This device] Local digest"
-        # No `library_rag_search_service` on the bare test app -> capability_unavailable,
-        # NOT the DB row's stored "execution_unavailable" placeholder.
-        assert rendered_row_cells(table, 0)[3] == "capability_unavailable"
-        assert "1 on this device" in str(notice.content)
+        assert _queue_titles(workbench) == ["[This device] Local digest"]
+        # No `library_rag_search_service` on the bare test app ->
+        # capability_unavailable, NOT the DB row's stored
+        # "execution_unavailable" placeholder. redesign PR-4 task 5: the
+        # retired table had a Health COLUMN to read this from; the queue
+        # does not, so the recomputed value is read off the row the queue
+        # actually built (`_device_only_automations` stamps it, and that
+        # stamping is what this test is about).
+        assert _queue_definitions(workbench)[0]["health"] == (
+            "capability_unavailable"
+        )
 
 
 @pytest.mark.asyncio
@@ -574,16 +617,18 @@ async def test_merged_list_shows_both_local_and_server_rows_with_owner_prefix():
     )
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        workbench = await _settled_workbench(pilot)
 
-        assert table.row_count == 3
-        names = [rendered_row_cells(table, i)[0] for i in range(3)]
-        assert names[0] == "[This device] Local one"
-        assert names[1] == "[server-1] Morning brief"
-        assert names[2] == "[server-1] Paused one"
+        # redesign PR-4 task 5: the queue SORTS its rows (`sort_rows`)
+        # rather than preserving the loader's merge order, so the merge is
+        # asserted as a set of painted titles rather than by position.
+        assert sorted(_queue_titles(workbench)) == sorted(
+            [
+                "[This device] Local one",
+                "[server-1] Morning brief",
+                "[server-1] Paused one",
+            ]
+        )
 
 
 @pytest.mark.asyncio
@@ -602,16 +647,18 @@ async def test_offline_server_owned_row_is_listed_as_pending_sync():
     service = AutomationsMockService(server_client, local_definitions=[pending_row])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
+        workbench = await _settled_workbench(pilot)
 
-        names = [rendered_row_cells(table, i)[0] for i in range(table.row_count)]
-        assert names[0] == "[server-1 · pending sync] Queued digest"
+        assert "[server-1 · pending sync] Queued digest" in _queue_titles(
+            workbench
+        )
         # Its `id` is the LOCAL one; editing must not treat it as a server
         # id and mirror it back as a second row.
-        listed = workbench._automations[0]
+        listed = next(
+            row
+            for row in _queue_definitions(workbench)
+            if row["id"] == "local-def-pending"
+        )
         assert (
             await workbench._resolve_local_definition_id(service, listed)
             == "local-def-pending"
@@ -626,19 +673,13 @@ async def test_run_now_routes_local_automation_through_the_service_seam():
     service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        assert table.row_count == 3  # local row first, then the 2 server rows
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
-        assert workbench._selected_automation_id == "local-def-1"
+        workbench = await _settled_workbench(pilot)
+        assert _queue_table(workbench).row_count == 3  # 1 local + 2 server
+        await _select_queue_definition(pilot, workbench, "local-def-1")
 
         workbench.action_run_task_now()
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         service.run_automation_now.assert_awaited_once_with("local-def-1")
@@ -652,38 +693,32 @@ async def test_local_run_now_refusal_surfaces_without_raising():
     service.run_automation_now = AsyncMock(return_value=None)
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        await _select_queue_definition(pilot, workbench, "local-def-1")
 
         workbench.action_run_task_now()
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         service.run_automation_now.assert_awaited_once()
-        assert workbench._selected_automation_id == "local-def-1"
+        assert workbench._selected_row_id == "definition:local-def-1"
 
 
 @pytest.mark.asyncio
 async def test_local_automation_history_says_not_available_yet():
+    """Local dispatch keeps no durable audit trail, and the view says so
+    rather than showing an empty table. (redesign PR-4 task 5: read off
+    the pushed `DefinitionAuditView`, which owns this notice now.)"""
     server_client = MockServerClient(notifications_service=None)
     service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        notice = workbench.query_one("#scheduling-automation-history-notice")
+        await _settled_workbench(pilot)
 
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+        overlay = await _push_audit_view(pilot, service, _local_definition())
 
+        notice = overlay.query_one("#scheduling-audit-view-notice")
         assert "isn't available yet" in str(notice.content)
 
 
@@ -694,11 +729,8 @@ async def test_refresh_after_local_save_shows_the_new_row():
     service = AutomationsMockService(server_client, local_definitions=[])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        assert table.row_count == 0
+        workbench = await _settled_workbench(pilot)
+        assert _queue_table(workbench).row_count == 0
 
         # Simulate what save_definition("local") just wrote to the DB.
         service.db._automation_definitions.append(_local_definition(name="Just saved"))
@@ -709,10 +741,10 @@ async def test_refresh_after_local_save_shows_the_new_row():
             SimpleNamespace(status="saved", definition_id="local-def-1")
         )
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
-        assert table.row_count == 1
-        assert rendered_row_cells(table, 0)[0] == "[This device] Just saved"
+        assert _queue_titles(workbench) == ["[This device] Just saved"]
 
 
 # --- task-5 fix round: edit affordance ---------------------------------------
@@ -724,17 +756,12 @@ async def test_edit_action_opens_form_prefilled_for_a_local_row():
     service = AutomationsMockService(server_client, local_definitions=[_local_definition()])
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        await _select_queue_definition(pilot, workbench, "local-def-1")
 
         workbench.action_edit_task()
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, AutomationDefinitionForm)
@@ -767,14 +794,8 @@ async def test_edit_action_refuses_agent_task_rows():
     service = AutomationsMockService(server_client)
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        await _select_queue_definition(pilot, workbench, "def-agent")
 
         workbench.action_edit_task()
         await pilot.pause()
@@ -793,19 +814,14 @@ async def test_edit_action_mirrors_a_server_only_row_on_demand():
     service = AutomationsMockService(server_client)  # no local rows yet
     app = AutomationsTestApp(service)
     async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table.cursor_coordinate = (0, 0)  # def-1, "Morning brief"
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        await _select_queue_definition(pilot, workbench, "def-1")
 
         assert service.db._automation_definitions == []
 
         workbench.action_edit_task()
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, AutomationDefinitionForm)
@@ -1162,30 +1178,19 @@ async def test_selecting_a_local_definition_paints_its_details_and_counts():
             ],
         )
     )
-    # Wide terminal (task-4 fix round): an inactive `TabPane`'s content
-    # paints at a zero region -- `render_line(0)` legitimately blanks
-    # there (proven empty, not a stored-attribute false pass: `.content`
-    # still reads correctly, only the PAINT is absent -- see
-    # `test_detail_value_row.py`'s own painted-not-stored discipline), so
-    # this switches to the Automations tab before asserting, same as
-    # `test_run_now_on_automations_tab_dispatches_server_side` above.
+    # Wide terminal (task-4 fix round): a pane that paints at a zero
+    # region legitimately blanks `render_line(0)` (proven empty, not a
+    # stored-attribute false pass: `.content` still reads correctly, only
+    # the PAINT is absent -- see `test_detail_value_row.py`'s own
+    # painted-not-stored discipline). redesign PR-4 task 5: the tab
+    # activation that used to give the pane a region is retired; the
+    # queue's detail pane is on screen from mount, so selecting the row
+    # is enough.
     async with app.run_test(size=(200, 50)) as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
-
-        row_index = next(
-            i
-            for i, row in enumerate(workbench._automations)
-            if row["id"] == "local-def-freq"
+        workbench = await _settled_workbench(pilot)
+        detail = await _select_queue_definition(
+            pilot, workbench, "local-def-freq"
         )
-        table.cursor_coordinate = (row_index, 0)
-        await pilot.pause()
-        await pilot.pause()
 
         assert _detail_text(detail, "scheduling-automation-detail-runs-on") == "This device"
         assert _detail_text(detail, "scheduling-automation-detail-model") == "openai/gpt-5"
@@ -1241,19 +1246,12 @@ async def test_selecting_a_server_definition_shows_its_server_owner_label():
         }
     )
     app = AutomationsTestApp(AutomationsMockService(server_client))
-    # Wide terminal + active tab -- see the local-definition test above.
+    # Wide terminal -- see the local-definition test above.
     async with app.run_test(size=(200, 50)) as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
-
-        table.cursor_coordinate = (0, 0)
-        await pilot.pause()
-        await pilot.pause()
+        workbench = await _settled_workbench(pilot)
+        detail = await _select_queue_definition(
+            pilot, workbench, "def-server-freq"
+        )
 
         assert _detail_text(detail, "scheduling-automation-detail-runs-on") == "server-1"
         assert (
@@ -1456,7 +1454,9 @@ async def test_definition_detail_says_so_when_the_history_read_failed():
 @pytest.mark.asyncio
 async def test_a_failed_count_read_paints_the_error_not_zeros():
     """Same as above, driven through `SchedulesWorkbench`'s own read path
-    (the `except` branch of `_load_automation_detail`)."""
+    (the `except` branch of `_fetch_definition_detail_counts`, reached via
+    `_load_queue_definition_detail` -- redesign PR-4 task 5 retired the
+    Automations-tab loader that was the other caller)."""
     server_client = AutomationsServerClient()
     definition = _frequency_definition(id="local-def-freq")
     service = AutomationsMockService(server_client, local_definitions=[definition])
@@ -1467,22 +1467,10 @@ async def test_a_failed_count_read_paints_the_error_not_zeros():
     service.db.count_automation_runs = _boom
     app = AutomationsTestApp(service)
     async with app.run_test(size=(200, 50)) as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-            "scheduling-automations-tab"
+        workbench = await _settled_workbench(pilot)
+        detail = await _select_queue_definition(
+            pilot, workbench, "local-def-freq"
         )
-        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        row_index = next(
-            i
-            for i, row in enumerate(workbench._automations)
-            if row["id"] == "local-def-freq"
-        )
-        table.cursor_coordinate = (row_index, 0)
-        await pilot.pause()
-        await pilot.pause()
 
         history_group = detail.query_one("#scheduling-automation-detail-group-history")
         history_group.collapsed = False
@@ -1507,22 +1495,10 @@ async def test_editing_the_selected_definition_refreshes_the_detail_pane():
     service = AutomationsMockService(server_client, local_definitions=[definition])
     app = AutomationsTestApp(service)
     async with app.run_test(size=(200, 50)) as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-            "scheduling-automations-tab"
+        workbench = await _settled_workbench(pilot)
+        detail = await _select_queue_definition(
+            pilot, workbench, "local-def-freq"
         )
-        detail = workbench.query_one("#scheduling-automation-detail", DefinitionDetail)
-        table = workbench.query_one("#scheduling-automations-table", DataTable)
-        row_index = next(
-            i
-            for i, row in enumerate(workbench._automations)
-            if row["id"] == "local-def-freq"
-        )
-        table.cursor_coordinate = (row_index, 0)
-        await pilot.pause()
-        await pilot.pause()
         assert _detail_text(detail, "scheduling-automation-detail-model") == "openai/gpt-5"
 
         # Edit-and-save shape: the stored row changes, the id does not.
@@ -1531,8 +1507,15 @@ async def test_editing_the_selected_definition_refreshes_the_detail_pane():
             "provider": "anthropic",
             "model": "claude-x",
         }
-        await workbench.load_automations()
+        # redesign PR-4 task 5: `load_automations()` (the retired tab's
+        # own reloader) is deleted; the equivalent authoritative repaint
+        # is the queue's own detail re-feed, which is what every
+        # definition mutation path now calls after a successful save.
+        await workbench._repaint_queue_definition_detail(
+            service, "local-def-freq", service.db._automation_definitions[0]
+        )
         await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         assert (
@@ -1541,52 +1524,16 @@ async def test_editing_the_selected_definition_refreshes_the_detail_pane():
         )
 
 
-@pytest.mark.asyncio
-async def test_automations_panes_stay_on_screen_across_the_detail_hide_boundary():
-    """Final review F5: three panes x min-width 30 could not fit the 84-89
-    band, and Textual's fr layout then laid the detail and history panes
-    out entirely off-screen (the split has `overflow: hidden`, so nothing
-    hinted at it).
-
-    84 is the width at which the detail pane is still shown -- the same
-    `hide_detail` threshold the Queue tab uses.
-    """
-
-    class _CssApp(AutomationsTestApp):
-        # The default harness does not load `_scheduling.tcss`, so
-        # geometry assertions there measure NOTHING (this exact trap made
-        # the reviewer's first probe read clean when it was not).
-        CSS_PATH = str(BUNDLED_STYLESHEET)
-
-    app = _CssApp(AutomationsMockService(AutomationsServerClient()))
-    async with app.run_test(size=(120, 40)) as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen
-        workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-            "scheduling-automations-tab"
-        )
-        await pilot.pause()
-
-        for width in (84, 90):
-            await pilot.resize_terminal(width, 40)
-            await pilot.pause()
-            await pilot.pause()
-            panes = [
-                workbench.query_one(f"#{pane_id}")
-                for pane_id in (
-                    "scheduling-automations-pane",
-                    "scheduling-automations-detail-pane",
-                    "scheduling-automation-history-pane",
-                )
-            ]
-            for pane in panes:
-                assert not pane.has_class("pane-hidden"), (width, pane.id)
-                assert pane.region.width > 0, (width, pane.id)
-                assert pane.region.right <= width, (
-                    f"W={width}: {pane.id} runs off-screen "
-                    f"(x={pane.region.x}, width={pane.region.width})"
-                )
+# redesign PR-4 task 5: `test_automations_panes_stay_on_screen_across_
+# the_detail_hide_boundary` is DELETED. It pinned final review F5 -- the
+# Automations tab's own THREE-pane split (list | definition detail | run
+# history) laying panes off-screen in the 84-89 band because 3 x
+# min-width 30 could not fit. All three panes are retired: the list
+# merged into the queue, the detail pane is the queue's own sibling, and
+# the history pane became the pushed `DefinitionAuditView`. The geometry
+# claim has no subject left here -- the queue's own three-pane fit at
+# that boundary is separately pinned (its `hide_detail`/`hide_inspector`
+# thresholds), and the responsive floor as a whole is Task 6's brief.
 
 
 # --- redesign PR-4, task 3: Queue definition-row actions + all-families

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -21,9 +21,11 @@ from Tests.UI.schedules_test_helpers import (
     MockServerClient,
     rendered_row_cells,
 )
+from tldw_chatbook.Scheduling.events import ViewDefinitionResultsRequested
 from tldw_chatbook.Scheduling.services.server_client import (
     ServerClientValidationError,
 )
+from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
 from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
 from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
     AutomationDefinitionForm,
@@ -1041,10 +1043,51 @@ async def test_definition_detail_shows_counts_and_last_run_outcome():
         last_run_text = _detail_text(detail, "scheduling-automation-detail-last-run")
         assert "failed" in last_run_text
         assert "2026-08-20 09:00" in last_run_text
-        assert (
-            _detail_text(detail, "scheduling-automation-detail-view-results")
-            == "See Results tab"
-        )
+        # redesign PR-4, task 2: the separate "Results -- See Results
+        # tab" row (a dangling pointer once the tab bar retires) is gone
+        # -- the unread-results row itself is now the live activation
+        # (see test_unread_row_activation_requests_definition_results
+        # below).
+        assert detail._unread_row.affordance is True
+
+
+class _CapturingDefinitionDetailApp(_BareDefinitionDetailApp):
+    """`_BareDefinitionDetailApp` + captures `ViewDefinitionResultsRequested`
+    messages bubbled up to the App (redesign PR-4, task 2) -- there is no
+    `SchedulesWorkbench` mounted here to route them further, this only
+    proves `DefinitionDetail` posts the right message."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.captured: list[ViewDefinitionResultsRequested] = []
+
+    def on_view_definition_results_requested(
+        self, event: ViewDefinitionResultsRequested
+    ) -> None:
+        self.captured.append(event)
+
+
+@pytest.mark.asyncio
+async def test_unread_row_activation_requests_definition_results():
+    """redesign PR-4, task 2: activating the `Unread results` row posts
+    `ViewDefinitionResultsRequested` carrying the currently-painted
+    definition -- the live replacement for the retired "See Results tab"
+    pointer."""
+    app = _CapturingDefinitionDetailApp()
+    async with app.run_test() as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        definition = _frequency_definition()
+        detail.set_definition(definition, unread_count=2)
+        await pilot.pause()
+
+        row = detail._unread_row
+        assert row.affordance is True
+        assert row.can_focus is True
+        row.post_message(DetailValueRow.Activated(row))
+        await pilot.pause()
+
+        assert len(pilot.app.captured) == 1
+        assert pilot.app.captured[0].definition["id"] == definition["id"]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_keyboard_map.py
+++ b/Tests/UI/test_schedules_keyboard_map.py
@@ -1,0 +1,505 @@
+"""Tests for the redesign PR-4, task 4 spec §12 keyboard map on
+`SchedulesWorkbench`: `1`-`4`/`f` chips, `/` search, `n` create, `p`
+pause/resume, `m` move owner, `r` mark read.
+
+Real `SchedulingService` + a tmp_path `ScheduledTasksDB` throughout (same
+rationale `test_schedules_transfer_actions.py`/`test_schedules_workbench.py`
+give: routing/refusal correctness is proven against the real facade, not a
+hand-rolled stub of it). Each test file in this package duplicates its own
+small harness rather than importing another test file's (established
+no-cross-file-test-coupling precedent).
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, DataTable, Input, Select
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
+from tldw_chatbook.UI.Screens.scheduling.forms.new_task_choice_modal import (
+    NewTaskChoiceModal,
+)
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
+from tldw_chatbook.UI.Screens.scheduling.task_detail import TaskDetail
+
+
+class WorkbenchTestApp(ConsolidatedCSSApp):
+    """Minimal test app; `scheduling_service` is set by `_real_service`."""
+
+    scheduling_service = None
+
+
+def _real_service(tmp_path, app):
+    """A real (tmp_path-file) `ScheduledTasksDB` + `SchedulingService`, no
+    server -- these tests exercise LOCAL-only routing (reminder enable/
+    disable, definition lifecycle, mark-read); the owner-row dropdown's
+    OWN server-offered-option behavior is already covered by `test_
+    schedules_workbench.py`'s `test_runs_on_dropdown_*` suite."""
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    service = SchedulingService(db=db, runtime_source="local", app_getter=lambda: app)
+    app.scheduling_service = service
+    return db, service
+
+
+async def _select_row(pilot, index: int = 0) -> None:
+    table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+    table.cursor_coordinate = (index, 0)
+    await pilot.pause()
+
+
+# ---------------------------------------------------------------------------
+# 1-4 / f: chip switching, incl. at a width where the chip row is hidden
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_digit_keys_switch_the_chip_and_paint_the_selected_button():
+    app = WorkbenchTestApp()
+    async with app.run_test(size=(220, 60)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        assert workbench._chip == "all"
+
+        await pilot.press("2")
+        await pilot.pause()
+        assert workbench._chip == "active"
+        assert (
+            workbench.query_one("#scheduling-chip-active", Button).variant == "primary"
+        )
+        assert workbench.query_one("#scheduling-chip-all", Button).variant == "default"
+
+        await pilot.press("3")
+        await pilot.pause()
+        assert workbench._chip == "paused"
+
+        await pilot.press("4")
+        await pilot.pause()
+        assert workbench._chip == "completed"
+
+        await pilot.press("1")
+        await pilot.pause()
+        assert workbench._chip == "all"
+
+
+@pytest.mark.asyncio
+async def test_f_key_cycles_through_every_chip_and_wraps():
+    app = WorkbenchTestApp()
+    async with app.run_test(size=(220, 60)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        seen = [workbench._chip]
+        for _ in range(4):
+            await pilot.press("f")
+            await pilot.pause()
+            seen.append(workbench._chip)
+
+        assert seen == ["all", "active", "paused", "completed", "all"], (
+            "f must cycle all -> active -> paused -> completed and wrap"
+        )
+
+
+@pytest.mark.asyncio
+async def test_chip_keys_work_even_when_the_chip_row_is_hidden():
+    """task-4 brief: chip keys must work "at every width (incl.
+    collapsed-chip mode later -- don't couple to chip visibility)".
+
+    The chip row hides below 84 cols today via `#scheduling-workbench
+    .compact` (`on_resize`'s `hide_detail` class, `_scheduling.tcss`) --
+    that CSS rule lives in the app bundle, which this bare harness (no
+    `CSS_PATH` override) does not load, so `.display` is forced directly
+    here instead of via the class, to isolate what this test actually
+    claims: `_set_queue_chip`/`action_cycle_chip` only ever touch
+    `self._chip` and the still-MOUNTED buttons' `.variant`, never
+    `.display`, so a key press works identically whether or not the row
+    is visible.
+    """
+    app = WorkbenchTestApp()
+    async with app.run_test(size=(220, 60)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        chips = workbench.query_one("#scheduling-queue-chips")
+        chips.styles.display = "none"
+        await pilot.pause()
+        assert chips.display is False
+
+        await pilot.press("2")
+        await pilot.pause()
+        assert workbench._chip == "active"
+
+        await pilot.press("f")
+        await pilot.pause()
+        assert workbench._chip == "paused"
+
+
+# ---------------------------------------------------------------------------
+# /: focus search
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_slash_key_focuses_the_filter_input():
+    app = WorkbenchTestApp()
+    async with app.run_test(size=(220, 60)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        await pilot.press("/")
+        await pilot.pause()
+        assert isinstance(pilot.app.focused, Input)
+        assert pilot.app.focused.id == "scheduling-queue-filter"
+
+
+# ---------------------------------------------------------------------------
+# n: create chooser
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_n_key_opens_the_create_chooser():
+    app = WorkbenchTestApp()
+    async with app.run_test(size=(220, 60)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        await pilot.press("n")
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, NewTaskChoiceModal)
+
+
+# ---------------------------------------------------------------------------
+# p: pause/resume, routed by kind
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_p_key_toggles_a_reminder_enabled_state(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+            enabled=True,
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("p")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_reminder_task(task_id)["enabled"] is False
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_p_key_on_a_locked_reminder_refuses_honestly(tmp_path):
+    """The reminder branch reuses `action_toggle_enabled` verbatim, which
+    already refuses via `_refuse_if_transfer_locked` -- pinned here via
+    the actual `p` KEY (not a direct method call), end to end."""
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Moving",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+            enabled=True,
+        )
+        db.set_transfer_state(
+            "reminder_task", task_id, "to_server_pending", expected=(None,)
+        )
+        notifications: list[str] = []
+        async with app.run_test(size=(220, 60)) as pilot:
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("p")
+            await pilot.pause()
+
+            assert notifications
+            assert "read-only" in notifications[0]
+            assert db.get_reminder_task(task_id)["enabled"] is True
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_p_key_toggles_a_definition_lifecycle(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("p")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+
+            await pilot.press("p")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert (
+                db.get_automation_definition(definition_id)["lifecycle"]
+                == "configured"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_p_key_on_a_locked_definition_refuses_honestly(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        db.set_transfer_state(
+            "automation_definition", definition_id, "to_server_pending",
+            expected=(None,),
+        )
+        notifications: list[str] = []
+        async with app.run_test(size=(220, 60)) as pilot:
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("p")
+            await pilot.pause()
+
+            assert notifications, "a locked row must refuse with a reason, not go silent"
+            assert (
+                db.get_automation_definition(definition_id)["lifecycle"] == "configured"
+            ), "the lifecycle must be untouched by a refused toggle"
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# m: open the selected row's Runs-on dropdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m_key_opens_the_runs_on_dropdown_for_a_reminder_row(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await _select_row(pilot)
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            assert len(detail._runs_on_row.query(Select)) == 0
+
+            await pilot.press("m")
+            await pilot.pause()
+
+            assert len(detail._runs_on_row.query(Select)) > 0, (
+                "m must activate the row's own editor, same as Enter/click"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_m_key_opens_the_runs_on_dropdown_for_a_definition_row(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            await _select_row(pilot)
+
+            detail = pilot.app.screen.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            )
+            assert len(detail._runs_on_row.query(Select)) == 0
+
+            await pilot.press("m")
+            await pilot.pause()
+
+            assert len(detail._runs_on_row.query(Select)) > 0
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_m_key_with_nothing_selected_refuses_honestly():
+    app = WorkbenchTestApp()
+    notifications: list[str] = []
+    async with app.run_test(size=(220, 60)) as pilot:
+        pilot.app.notify = lambda message, **kw: notifications.append(message)
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        await pilot.press("m")
+        await pilot.pause()
+
+        assert notifications
+
+
+# ---------------------------------------------------------------------------
+# r: mark a definition row's unread results read
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_r_key_marks_a_definitions_unread_results_read(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        result_id = db.create_automation_result(
+            owner_id="local",
+            definition_id=definition_id,
+            run_id="run-1",
+            kind="finding",
+            title="Daily stand-up summary",
+            summary="Two blockers reported.",
+            dedupe_key="d1",
+            answer="The team is blocked on CI flakiness.",
+            source_refs=[{"source_type": "message", "source_id": "msg-1"}],
+            review_state="unread",
+        )
+        assert result_id is not None
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("r")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_result(result_id)["review_state"] == "read"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_r_key_on_a_definition_with_nothing_unread_refuses_honestly(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Nightly digest",
+            schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+            input={"question": "What shipped?"},
+            config={},
+        )
+        notifications: list[str] = []
+        async with app.run_test(size=(220, 60)) as pilot:
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("r")
+            await pilot.pause()
+
+            assert notifications
+            assert "unread" in notifications[0].lower()
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_r_key_on_a_reminder_row_is_an_honest_no_op(tmp_path):
+    app = WorkbenchTestApp()
+    db, service = _real_service(tmp_path, app)
+    try:
+        task_id = db.create_reminder_task(
+            owner_id="local",
+            title="Nightly check",
+            schedule_kind="one_time",
+            run_at="2030-01-01T00:00:00+00:00",
+        )
+        notifications: list[str] = []
+        async with app.run_test(size=(220, 60)) as pilot:
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await _select_row(pilot)
+
+            await pilot.press("r")
+            await pilot.pause()
+
+            assert notifications
+            assert "no results" in notifications[0].lower()
+            # Nothing about the task itself changes.
+            assert db.get_reminder_task(task_id)["enabled"] is True
+    finally:
+        db.close()

--- a/Tests/UI/test_schedules_marks_legend.py
+++ b/Tests/UI/test_schedules_marks_legend.py
@@ -193,11 +193,17 @@ class _MixedService(MockSchedulingServiceMixin):
 
 @pytest.mark.asyncio
 async def test_definition_rows_are_not_markable():
-    """redesign PR-2, Task 2: definition rows expose no actions in this
-    PR (plan ruling 1) -- marking one must not-op, same as the
-    since-retired projection-row case this test used to cover (a
-    watchlist projection can no longer even enter the Queue list, spec
-    S2 locked decision 2)."""
+    """redesign PR-2, Task 2: marking is reminder-only (plan ruling 1) --
+    marking a definition row must no-op, same as the since-retired
+    projection-row case this test used to cover (a watchlist projection
+    can no longer even enter the Queue list, spec S2 locked decision 2).
+
+    redesign PR-4 task 5: the refusal copy no longer points at the
+    Automations tab, which is retired -- and by task 3 that pointer was
+    already wrong for the verbs definition rows DO have (run/edit/pause/
+    move/mark-read are routed by kind before this copy is reached). It
+    names the limit instead. The claim -- `x` refuses, and says so --
+    is unchanged."""
     app = _App(_MixedService())
     async with app.run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
@@ -214,7 +220,8 @@ async def test_definition_rows_are_not_markable():
         messages = [n.message for n in pilot.app._notifications]
         # Final review F8: a definition row IS selected, so the refusal
         # says where the action lives instead of "select a task first".
-        assert any("Automations tab" in m for m in messages), messages
+        assert any("Automations don't support mark" in m for m in messages), messages
+        assert not any("Automations tab" in m for m in messages), messages
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_new_button.py
+++ b/Tests/UI/test_schedules_new_button.py
@@ -127,12 +127,20 @@ async def test_new_button_chooser_recurring_choice_opens_automation_form():
 
 
 @pytest.mark.asyncio
-async def test_new_button_row_hidden_in_compact_mode():
-    """Compact mode (see on_resize) reclaims the header's row for the table.
+async def test_new_button_row_flattens_to_one_line_in_compact_mode():
+    """Compact mode (see on_resize) reclaims the header's ROWS, not its
+    buttons.
 
-    Hiding the whole header -- not just the title -- keeps the pre-change
-    row budget: the New button stays reachable via the `c` key, which the
-    footer advertises, instead of eating the one spare row at 80x24.
+    Redesign PR-4, task 6 (ruling 6: "the rail degrades readably at 80")
+    DELIBERATELY replaces this test's previous claim -- that the whole
+    header hid below 84 columns. It hid `Create ▾`, `Mark all read` and
+    `Results` with it, which are the only routes to those operations that
+    need no selected row, and the row it bought back came from the
+    3-row bordered Button box rather than from the buttons themselves.
+    The header now flattens to a single row: the title yields (the screen
+    header already names the pane) and the buttons lose their border.
+    The narrow-width floor's own reachability claims are pinned in
+    `test_schedules_responsive_floor.py`.
     """
     app = LocalOnlyBundledCSSTestApp()
     async with app.run_test() as pilot:
@@ -146,4 +154,10 @@ async def test_new_button_row_hidden_in_compact_mode():
         await pilot.pause()
 
         header = workbench.query_one("#scheduling-list-header")
-        assert header.display is False
+        assert header.display is True
+        assert header.region.height == 1
+        assert workbench.query_one("#scheduling-list-title").display is False
+        for button_id in ("#scheduling-new-task", "#scheduling-results-badge"):
+            button = workbench.query_one(button_id, Button)
+            assert button.display is True
+            assert button.region.height == 1

--- a/Tests/UI/test_schedules_responsive_floor.py
+++ b/Tests/UI/test_schedules_responsive_floor.py
@@ -603,3 +603,217 @@ async def test_the_pushed_pane_repaints_from_the_same_refresh_as_the_docked_one(
             assert pushed._current_task.title == "Renamed check"
     finally:
         db.close()
+
+
+# ---------------------------------------------------------------------------
+# Final-review fix wave: the floor's remaining traps
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_m_at_the_floor_opens_the_dropdown_in_the_pane_the_user_can_see(
+    tmp_path,
+):
+    """F1: `m` below the threshold must not activate the HIDDEN pane.
+
+    It used to mount a `Select` inside `#scheduling-detail-pane` while that
+    pane was `display: none` -- a zero-region editor that painted nothing,
+    stole focus off the queue table (so Up/Down stopped moving the list) and
+    said nothing. `m` now takes the same push route `Enter` does and
+    activates the Runs-on row of the pane that is actually on screen.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            await _select_row(pilot)
+            assert workbench._detail_hidden(), "the floor must hide the docked pane"
+
+            await pilot.press("m")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            host = pilot.app.screen
+            assert isinstance(host, WorkbenchHostScreen), (
+                "`m` at the floor must push the detail, not activate a hidden pane"
+            )
+            row = host.query_one(TaskDetail).runs_on_row
+            editors = row.query(Select)
+            assert editors, "no owner picker opened in the pushed pane"
+            region = editors.first().region
+            assert region.width > 0 and region.height > 0, (
+                f"the dropdown is unpainted ({region}) -- the zero-region trap"
+            )
+            # The invisible docked pane was left alone.
+            docked = workbench.query_one("#scheduling-task-detail", TaskDetail)
+            assert not docked.query(Select)
+
+            # Escape closes the editor, Escape again returns to a WORKING queue
+            # (the old trap left the list unresponsive with nothing painted).
+            await pilot.press("escape")
+            await pilot.pause()
+            assert pilot.app.screen is host
+            await pilot.press("escape")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert pilot.app.screen is workbench
+            table = workbench.query_one("#scheduling-task-table", DataTable)
+            table.focus()
+            await pilot.press("down")
+            await pilot.pause()
+            assert workbench.focused is table, "the queue never got its keys back"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_m_at_the_floor_on_an_empty_queue_refuses_out_loud(tmp_path):
+    """F1's other half: no row under the cursor still says why."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            notifications: list[str] = []
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+
+            await pilot.press("m")
+            await pilot.pause()
+
+            assert not isinstance(pilot.app.screen, WorkbenchHostScreen)
+            assert notifications, "`m` with nothing to move must not go silent"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_pushed_detail_never_repaints_from_another_rows_data(tmp_path):
+    """F2: the pushed pane is pinned to the row it was pushed FOR.
+
+    `_render_table`'s restore falls back to `target_index = 0` whenever the
+    selected row is gone, and every re-feed used to reach the pushed instance
+    too -- so a pane headed "ZZZ Second reminder" could end up painting (and
+    wiring its Delete button to) "AAA First reminder". The identity gate in
+    `_detail_panes` makes that frame impossible.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "AAA First reminder")
+        _reminder(db, "ZZZ Second reminder")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            rows = workbench._visible_rows
+            zzz_index = next(
+                index
+                for index, row in enumerate(rows)
+                if row.title == "ZZZ Second reminder"
+            )
+            await _select_row(pilot, zzz_index)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+            assert pushed._current_task.title == "ZZZ Second reminder"
+            assert host.title == "ZZZ Second reminder"
+
+            # The seam every refresh goes through, aimed at the OTHER row.
+            other_index = 1 - zzz_index
+            workbench._update_detail_for_index(other_index)
+            await pilot.pause()
+
+            docked = workbench.query_one("#scheduling-task-detail", TaskDetail)
+            assert docked._current_task.title == "AAA First reminder"
+            assert pushed._current_task.title == "ZZZ Second reminder", (
+                "the pushed pane retargeted while its Header still named ZZZ"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_a_pushed_detail_closes_with_a_notice_when_its_row_is_gone(tmp_path):
+    """F2's honest gone-state (the documented choice: auto-pop + notice).
+
+    A background refresh that drops the open row leaves the pane nothing true
+    to show -- and its Delete / Disable / Run-now controls pointed at a
+    reminder that no longer exists. Popping removes both problems.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "AAA First reminder")
+        zzz_id = _reminder(db, "ZZZ Second reminder")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            zzz_index = next(
+                index
+                for index, row in enumerate(workbench._visible_rows)
+                if row.title == "ZZZ Second reminder"
+            )
+            await _select_row(pilot, zzz_index)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+
+            notifications: list[str] = []
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+
+            db.delete_reminder_task(zzz_id)
+            workbench._request_tasks_refresh(refresh_definitions=False)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert pilot.app.screen is workbench, "the stale pane stayed open"
+            assert workbench._pushed_detail is None
+            assert workbench._pushed_row_id is None
+            assert any("ZZZ Second reminder" in text for text in notifications), (
+                "the pane vanished without saying why"
+            )
+            assert pushed._current_task.title == "ZZZ Second reminder", (
+                "the pane took another row's data on its way out"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_resolving_a_conflict_in_the_pushed_view_reloads_the_queue(tmp_path):
+    """F3: `ConflictsTab.ConflictResolved` reaches the workbench LIVE.
+
+    Task 5 moved the only `ConflictsTab` instance onto a pushed screen, and
+    that push carried no `route_message` -- so the message bubbled tab -> host
+    -> App and `@on(ConflictsTab.ConflictResolved)` never ran. The badge count
+    still updated on pop, which is why the loss looked like nothing.
+
+    Asserted through the REAL message path (post from the hosted tab), never a
+    direct `_on_conflict_resolved(...)` call -- a direct call is exactly what
+    could not observe this break.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        task_id = _reminder(db, "Losing side")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            assert await pilot.click("#scheduling-conflicts-badge")
+            await pilot.pause()
+            host = pilot.app.screen
+            tab = host.query_one(ConflictsTab)
+
+            # What "the winning side" looks like to the queue behind.
+            db.update_reminder_task(task_id, title="Winning side")
+            tab.post_message(ConflictsTab.ConflictResolved("conflict-1", "local"))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert pilot.app.screen is host, "the overlay must still be open"
+            assert [task.title for task in workbench._tasks] == ["Winning side"], (
+                "resolving a conflict did not reload the queue behind the overlay"
+            )
+    finally:
+        db.close()

--- a/Tests/UI/test_schedules_responsive_floor.py
+++ b/Tests/UI/test_schedules_responsive_floor.py
@@ -1,0 +1,605 @@
+"""The 80x24 responsive floor for the single-surface Schedules workbench.
+
+redesign PR-4, task 6 (spec S11, ruling 6). Below 84 columns the docked
+detail region no longer blank-hides with a "widen the window" notice --
+`Enter` on a queue row PUSHES the same pane class (`TaskDetail` /
+`DefinitionDetail`) as a fresh instance inside Task 1's
+`WorkbenchHostScreen`, fed by the same service-backed loads the docked
+panes use. The four filter chips collapse to a single cycling control,
+and the rail header degrades to a one-row button strip instead of
+vanishing, so every spec-named operation stays reachable at 80x24.
+
+Real `ScheduledTasksDB` + `SchedulingService` throughout (the same
+rationale `test_schedules_keyboard_map.py` gives: routing correctness is
+proven against the real facade, not a stub of it), and
+`CSS_PATH = BUNDLED_STYLESHEET` so the width-driven `display` rules this
+file asserts on actually resolve -- without the app tier every `.compact`
+rule is absent and the geometry claims measure nothing.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, DataTable, Input, Select
+
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET, ConsolidatedCSSApp
+from Tests.UI.schedules_test_helpers import settle_schedules_workbench
+from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+from tldw_chatbook.UI.Screens.scheduling.conflicts_tab import ConflictsTab
+from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
+from tldw_chatbook.UI.Screens.scheduling.forms.new_task_choice_modal import (
+    NewTaskChoiceModal,
+)
+from tldw_chatbook.UI.Screens.scheduling.results_tab import ResultsTab
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+    ReminderForm,
+    SchedulesWorkbench,
+)
+from tldw_chatbook.UI.Screens.scheduling.task_detail import TaskDetail
+from tldw_chatbook.UI.Screens.scheduling.workbench_host_screen import (
+    WorkbenchHostScreen,
+)
+from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
+
+#: The floor the spec pins (S14) and the two wider layouts that must keep
+#: their docked panes.
+FLOOR = (80, 24)
+MID = (110, 40)
+WIDE = (220, 60)
+
+
+class BundledCSSWorkbenchApp(ConsolidatedCSSApp):
+    """Harness with the app CSS tier, where the `.compact` rules live."""
+
+    CSS_PATH = BUNDLED_STYLESHEET
+    scheduling_service = None
+
+
+def _real_service(tmp_path, app: App) -> tuple[ScheduledTasksDB, SchedulingService]:
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    service = SchedulingService(db=db, runtime_source="local", app_getter=lambda: app)
+    app.scheduling_service = service
+    return db, service
+
+
+def _reminder(db: ScheduledTasksDB, title: str = "Nightly check") -> str:
+    return db.create_reminder_task(
+        owner_id="local",
+        title=title,
+        schedule_kind="one_time",
+        run_at="2030-01-01T00:00:00+00:00",
+        enabled=True,
+    )
+
+
+def _definition(db: ScheduledTasksDB, name: str = "Nightly digest") -> str:
+    return db.create_automation_definition(
+        "local",
+        "recurring_question",
+        name,
+        schedule={"kind": "one_time", "run_at": "2030-01-01T00:00:00+00:00"},
+        input={"question": "What shipped?"},
+        config={},
+    )
+
+
+def _painted(app: App) -> str:
+    """Every glyph the compositor actually paints, newline-joined.
+
+    Textual 8.2.8 has no `App.export_text()`, so `Screen._compositor.
+    render_strips()` is the only honest read of a painted frame (post-CSS,
+    post-clip) -- the same idiom `test_compact_focus_outline_render.py`
+    uses. `Widget.region` alone would happily report a plausible region for
+    something the terminal never draws.
+    """
+    strips = app.screen._compositor.render_strips()
+    return "\n".join("".join(seg.text for seg in strip) for strip in strips)
+
+
+async def _open_workbench(pilot, size_note: str = "") -> SchedulesWorkbench:
+    await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+    await pilot.pause()
+    workbench = pilot.app.screen
+    await settle_schedules_workbench(pilot, workbench)
+    return workbench
+
+
+async def _select_row(pilot, index: int = 0) -> None:
+    table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
+    table.focus()
+    table.cursor_coordinate = (index, 0)
+    await pilot.pause()
+
+
+async def _push_detail(pilot) -> WorkbenchHostScreen:
+    """Enter on the highlighted row, the way a user reaches the detail at
+    the floor width."""
+    await pilot.press("enter")
+    await pilot.pause()
+    await pilot.app.workers.wait_for_complete()
+    await pilot.pause()
+    return pilot.app.screen
+
+
+# ---------------------------------------------------------------------------
+# The floor itself: what 80x24 paints
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_the_queue_is_full_width_and_the_rows_paint(tmp_path):
+    """The rail owned 24 of 80 columns while the two hidden panes owned the
+    rest, so the queue wrapped into a 20-column gutter and no row was
+    painted at all. With the detail region hidden the queue takes the full
+    width."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            list_pane = workbench.query_one("#scheduling-list-pane")
+            table = workbench.query_one("#scheduling-task-table", DataTable)
+            assert workbench.query_one("#scheduling-detail-pane").display is False
+            assert list_pane.region.width >= 70, (
+                f"the queue rail is {list_pane.region.width} columns wide at "
+                "80x24 while it is the only visible pane"
+            )
+            assert table.region.height >= 2, (
+                f"the queue table gets {table.region.height} row(s) at 80x24"
+            )
+            assert "Nightly check" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_the_chips_collapse_to_the_cycling_control(tmp_path):
+    """Spec S11: the four chips collapse into one cycling control rather
+    than disappearing outright -- a mouse user keeps a filter affordance."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            cycle = workbench.query_one("#scheduling-chip-cycle", Button)
+            assert cycle.display is True
+            for chip_id in (
+                "scheduling-chip-all",
+                "scheduling-chip-active",
+                "scheduling-chip-paused",
+                "scheduling-chip-completed",
+            ):
+                assert workbench.query_one(f"#{chip_id}", Button).display is False
+            assert "All" in str(cycle.label)
+
+            assert await pilot.click("#scheduling-chip-cycle")
+            await pilot.pause()
+            await pilot.pause()
+            assert workbench._chip == "active"
+            assert "Active" in str(cycle.label)
+            assert "Filter: Active" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_the_chip_keys_are_independent_of_chip_visibility(tmp_path):
+    """Task 4's `1`-`4`/`f` bindings never read chip visibility; this pins
+    that at the width where the four chips are actually hidden (the earlier
+    pin forced `display` by hand at a wide size)."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            assert workbench.query_one("#scheduling-chip-all", Button).display is False
+
+            await pilot.press("3")
+            await pilot.pause()
+            assert workbench._chip == "paused"
+            assert "Paused" in str(
+                workbench.query_one("#scheduling-chip-cycle", Button).label
+            )
+
+            await pilot.press("f")
+            await pilot.pause()
+            assert workbench._chip == "completed"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_the_rail_and_status_strip_stay_readable(tmp_path):
+    """The rail header used to hide entirely below 84, taking `Create ▾`,
+    `Mark all read` and `Results` with it. It degrades to a one-row button
+    strip instead, and the status strip keeps its conflicts badge."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            header = workbench.query_one("#scheduling-list-header")
+            assert header.display is True
+            assert header.region.height == 1, (
+                f"the rail header costs {header.region.height} rows at the "
+                "floor; it must degrade to a single row"
+            )
+            painted = _painted(pilot.app)
+            assert "Create" in painted
+            assert "Results" in painted
+            assert "Conflicts" in painted
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Enter pushes the hosted detail (ruling 6)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_enter_pushes_the_hosted_reminder_detail(tmp_path):
+    """A FRESH `TaskDetail` instance -- never the docked pane reparented --
+    painted with the row's own data."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            docked = workbench.query_one("#scheduling-task-detail", TaskDetail)
+            await _select_row(pilot)
+
+            host = await _push_detail(pilot)
+
+            assert isinstance(host, WorkbenchHostScreen)
+            pushed = host.query_one(TaskDetail)
+            assert pushed is not docked, "the docked pane was reparented"
+            assert docked.is_mounted, "the docked pane must stay put"
+            assert pushed._current_task is not None
+            assert pushed._current_task.title == "Nightly check"
+            assert "Nightly check" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_at_the_floor_enter_pushes_the_hosted_definition_detail(tmp_path):
+    """Same push for a definition row, and the pushed pane gets the same
+    service-fed counts the docked pane's own loader reads."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        definition_id = _definition(db, "Nightly digest")
+        db.create_automation_run(
+            "local",
+            definition_id,
+            1,
+            "manual",
+            status="succeeded",
+        )
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            docked = workbench.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            )
+            await _select_row(pilot)
+
+            host = await _push_detail(pilot)
+
+            assert isinstance(host, WorkbenchHostScreen)
+            pushed = host.query_one(DefinitionDetail)
+            assert pushed is not docked
+            assert pushed._definition is not None
+            assert pushed._definition.get("name") == "Nightly digest"
+            assert "Nightly digest" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_escape_pops_the_pushed_detail_back_to_the_queue(tmp_path):
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            await _select_row(pilot)
+            await _push_detail(pilot)
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert pilot.app.screen is workbench
+            assert workbench._pushed_detail is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_escape_with_a_hosted_editor_open_closes_the_editor_not_the_screen(
+    tmp_path,
+):
+    """Task 1's review rider, landed at its first editor-bearing consumer.
+
+    `WorkbenchHostScreen` binds `escape` to dismiss, and the hosted pane's
+    rows bind `escape` to close an open in-pane editor. `DetailValueRow.
+    _on_key` stops the key while an editor is open, so it never reaches the
+    screen binding -- source-traced in task 1, PINNED here.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+
+            row = pushed.runs_on_row
+            row.focus()
+            await pilot.pause()
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            assert row.query(Select), "the Runs-on editor did not open"
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert pilot.app.screen is host, (
+                "escape popped the host screen instead of closing the editor"
+            )
+            assert not row.query(Select), "the editor stayed open"
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert pilot.app.screen is not host, (
+                "escape with no editor open must still pop the host"
+            )
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Every operation, at the floor
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_is_reachable_at_the_floor(tmp_path):
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+
+            assert await pilot.click("#scheduling-new-task")
+            await pilot.pause()
+            assert isinstance(pilot.app.screen, NewTaskChoiceModal)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_edit_in_full_is_reachable_from_the_pushed_detail(tmp_path):
+    """The pushed pane's `Edit` button posts `EditTaskRequested`, which
+    bubbles to the HOST screen -- the workbench underneath never sees a
+    pushed screen's messages unless they are routed there."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+
+            host.query_one("#scheduling-edit-task", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ReminderForm)
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_pause_resume_is_reachable_from_the_pushed_detail(tmp_path):
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        definition_id = _definition(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+
+            host.query_one("#scheduling-automation-pause-resume", Button).press()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_definition(definition_id)["lifecycle"] == "paused"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_an_in_pane_edit_inside_the_pushed_detail_persists(tmp_path):
+    """The in-pane row editors work inside the pushed pane: the commit
+    message routes to the workbench's own persistence bridge."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        task_id = _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+
+            row = pushed._at_row
+            row.focus()
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+            editor = row.query_one(Input)
+            editor.focus()
+            editor.value = "2031-02-03 04:05"
+            await pilot.press("enter")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert "2031-02-03" in str(db.get_reminder_task(task_id)["run_at"])
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_transfer_dropdown_opens_inside_the_pushed_detail(tmp_path):
+    """Ruling 2's one transfer surface -- the Runs-on row's dropdown --
+    reachable at the floor from inside the pushed pane."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+
+            row = pushed.runs_on_row
+            row.focus()
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+
+            assert row.query(Select), "no owner picker opened on the Runs-on row"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_results_and_conflicts_are_reachable_at_the_floor(tmp_path):
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db)
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+
+            assert await pilot.click("#scheduling-results-badge")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            assert pilot.app.screen.query(ResultsTab)
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert await pilot.click("#scheduling-conflicts-badge")
+            await pilot.pause()
+            assert pilot.app.screen.query(ConflictsTab)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# The wider layouts stay docked
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_mid_width_layout_keeps_the_docked_detail_and_does_not_push(tmp_path):
+    """~110 columns: the detail pane is docked (only the inspector yields),
+    so Enter must NOT push a second copy of it."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=MID) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            assert workbench.query_one("#scheduling-detail-pane").display is True
+            assert workbench.query_one("#scheduling-inspector-pane").display is False
+            assert workbench.query_one("#scheduling-chip-cycle", Button).display is False
+            assert workbench.query_one("#scheduling-chip-all", Button).display is True
+            table = workbench.query_one("#scheduling-task-table", DataTable)
+            assert table.region.height >= 2
+
+            await _select_row(pilot)
+            await pilot.press("enter")
+            await pilot.pause()
+            assert pilot.app.screen is workbench
+            assert workbench._pushed_detail is None
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_full_width_layout_keeps_all_three_panes(tmp_path):
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=WIDE) as pilot:
+            workbench = await _open_workbench(pilot)
+
+            for pane_id in (
+                "#scheduling-list-pane",
+                "#scheduling-detail-pane",
+                "#scheduling-inspector-pane",
+            ):
+                assert workbench.query_one(pane_id).display is True
+            assert not workbench.query_one("#scheduling-workbench").has_class("compact")
+            assert workbench.query_one("#scheduling-list-header").region.height == 3
+            assert workbench.query_one("#scheduling-chip-cycle", Button).display is False
+            assert "Nightly check" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Pushed-detail data correctness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_pushed_pane_repaints_from_the_same_refresh_as_the_docked_one(
+    tmp_path,
+):
+    """A mutation refreshes the queue and re-feeds the detail; the pushed
+    instance is fed by that SAME seam, so it never shows a value the
+    docked pane has already moved past."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        task_id = _reminder(db, "Nightly check")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            await _select_row(pilot)
+            host = await _push_detail(pilot)
+            pushed = host.query_one(TaskDetail)
+
+            db.update_reminder_task(task_id, title="Renamed check")
+            workbench._request_tasks_refresh(refresh_definitions=False)
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert pushed._current_task is not None
+            assert pushed._current_task.title == "Renamed check"
+    finally:
+        db.close()

--- a/Tests/UI/test_schedules_responsive_floor.py
+++ b/Tests/UI/test_schedules_responsive_floor.py
@@ -780,6 +780,80 @@ async def test_a_pushed_detail_closes_with_a_notice_when_its_row_is_gone(tmp_pat
 
 
 @pytest.mark.asyncio
+async def test_a_row_removed_while_the_initial_push_mounts_closes_with_a_notice(
+    tmp_path,
+):
+    """Fix wave finding 7: `_push_row_detail`'s INITIAL paint used to
+    replay the POSITIONAL `index` captured before the screen-mount
+    `await`, rather than resolving the pushed row by identity the way F2
+    already does for re-feeds (`_pushed_row_id` + the `_detail_panes`
+    gate) -- an index-after-an-await bug in the one path F2 had not yet
+    touched. A row that vanishes from `_all_rows` WHILE the screen mounts
+    (`widget_factory` runs from `compose()`, inside the awaited push)
+    must take the same auto-pop-with-notice path as a background refresh
+    that drops it after the fact -- never paint whatever row now happens
+    to sit at that stale position.
+    """
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "AAA First reminder")
+        _reminder(db, "ZZZ Second reminder")
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            aaa_index = next(
+                index
+                for index, row in enumerate(workbench._visible_rows)
+                if row.title == "AAA First reminder"
+            )
+            await _select_row(pilot, aaa_index)
+
+            notifications: list[str] = []
+            pilot.app.notify = lambda message, **kw: notifications.append(message)
+
+            # `TaskDetail(...)` is built inside `compose()`, i.e. WHILE
+            # `_push_row_detail` is suspended on `await self.app.push_
+            # screen(host)` -- the exact window between the `Enter` press
+            # and the mount completing. Dropping the row from `_all_rows`
+            # here (not through a DB delete + worker round trip, which
+            # would race the very continuation this test pins) is the
+            # deterministic way to land in that window.
+            original_init = TaskDetail.__init__
+
+            def _vanish_during_mount(self, *args, **kwargs):
+                TaskDetail.__init__ = original_init
+                workbench._all_rows = [
+                    row
+                    for row in workbench._all_rows
+                    if row.title != "AAA First reminder"
+                ]
+                workbench._visible_rows = [
+                    row
+                    for row in workbench._visible_rows
+                    if row.title != "AAA First reminder"
+                ]
+                original_init(self, *args, **kwargs)
+
+            TaskDetail.__init__ = _vanish_during_mount
+            try:
+                await pilot.press("enter")
+                await pilot.pause()
+                await pilot.app.workers.wait_for_complete()
+                await pilot.pause()
+            finally:
+                TaskDetail.__init__ = original_init
+
+            assert pilot.app.screen is workbench, "the stale pane stayed open"
+            assert workbench._pushed_detail is None
+            assert workbench._pushed_row_id is None
+            assert any("AAA First reminder" in text for text in notifications), (
+                "the pane vanished without saying why"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
 async def test_resolving_a_conflict_in_the_pushed_view_reloads_the_queue(tmp_path):
     """F3: `ConflictsTab.ConflictResolved` reaches the workbench LIVE.
 

--- a/Tests/UI/test_schedules_results_tab.py
+++ b/Tests/UI/test_schedules_results_tab.py
@@ -30,11 +30,13 @@ from tldw_chatbook.Scheduling.services import SchedulingService
 from tldw_chatbook.Scheduling.services.server_client import SchedulingServerClient
 from tldw_chatbook.UI.Screens.scheduling.results_tab import (
     RESULTS_HEADING,
+    ResultsHostScreen,
     ResultsTab,
     _format_result_created,
     _result_kind_cell,
     _result_owner_suffix,
     _review_state_cell,
+    index_definitions_by_id,
     solved_eligibility,
 )
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
@@ -982,3 +984,248 @@ async def test_inbox_heading_stays_plain_when_everything_fits(results_db):
 
         heading = workbench.query_one("#scheduling-results-heading")
         assert str(heading.render()).strip() == RESULTS_HEADING
+
+
+# ---------------------------------------------------------------------------
+# redesign PR-4, task 2: Results relocation onto the pushed surface
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_initial_results_self_populate_with_custom_heading():
+    """`ConflictsTab.initial_conflicts`'s own self-populate-on-mount idiom
+    (task 1), plus the optional `heading` override a definition-filtered
+    pushed view uses -- the SAME "showing newest N of TOTAL" cap-line math
+    renders under whatever heading text it is given."""
+
+    class _App(ConsolidatedCSSApp):
+        def compose(self):
+            yield ResultsTab(
+                id="scheduling-results-overlay",
+                initial_results=[_base_result()],
+                initial_total=5,
+                heading="Automation results — Weekly digest",
+            )
+
+    app = _App()
+    async with app.run_test() as pilot:
+        tab = pilot.app.query_one(ResultsTab)
+        await pilot.pause()
+
+        table = tab.query_one("#scheduling-results-table", DataTable)
+        assert table.row_count == 1
+        heading = str(tab.query_one("#scheduling-results-heading").render()).strip()
+        assert heading == "Automation results — Weekly digest — showing newest 1 of 5"
+
+
+def _push_results_host_closures(service, *, definition_id: str | None = None):
+    """`(query, unread_ids)` closures matching `SchedulesWorkbench._push_
+    results_overlay`'s own shape, scoped to a single `definition_id`
+    string when given. These tests never mix local/server id spaces for
+    one definition -- that merge is `_definition_results_query`'s own
+    concern, exercised directly below."""
+
+    def query():
+        results = service.db.list_automation_results(
+            owner_id=None, definition_id=definition_id, limit=RESULTS_INBOX_LIMIT
+        )
+        total = service.db.count_automation_results(
+            owner_id=None, definition_id=definition_id
+        )
+        definitions_by_id = index_definitions_by_id(
+            service.db.list_automation_definitions(owner_id=None)
+        )
+        return results, definitions_by_id, total
+
+    def unread_ids():
+        total_unread = service.db.count_unread_results(
+            owner_id=None, definition_id=definition_id
+        )
+        if not total_unread:
+            return []
+        rows = service.db.list_automation_results(
+            owner_id=None,
+            definition_id=definition_id,
+            review_state="unread",
+            limit=total_unread,
+        )
+        return [row["id"] for row in rows]
+
+    return query, unread_ids
+
+
+async def _push_results_host_screen(pilot, service, *, definition_id: str | None = None):
+    """Push a `ResultsHostScreen` directly (no `SchedulesWorkbench`
+    involved) -- exercises the pushed view's own r/d/o/a binding surface
+    and the shared service orchestration in isolation."""
+    query, unread_ids = _push_results_host_closures(service, definition_id=definition_id)
+    results, definitions_by_id, total = query()
+
+    def _factory() -> ResultsTab:
+        return ResultsTab(
+            id="scheduling-results-overlay",
+            initial_results=results,
+            initial_definitions_by_id=definitions_by_id,
+            initial_total=total,
+        )
+
+    await pilot.app.push_screen(
+        ResultsHostScreen(
+            _factory, title="Results", service=service, query=query, unread_ids=unread_ids
+        )
+    )
+    await pilot.pause()
+    return pilot.app.screen
+
+
+@pytest.mark.asyncio
+async def test_hosted_read_action_updates_the_selected_result(results_db):
+    db = results_db
+    definition_id = _seed_definition(db)
+    result_id = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        service = pilot.app.scheduling_service
+        screen = await _push_results_host_screen(pilot, service)
+        table = screen.query_one("#scheduling-results-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        await pilot.press("r")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert db.get_automation_result(result_id)["review_state"] == "read"
+
+
+@pytest.mark.asyncio
+async def test_hosted_dismiss_action_updates_the_selected_result(results_db):
+    db = results_db
+    definition_id = _seed_definition(db)
+    result_id = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        service = pilot.app.scheduling_service
+        screen = await _push_results_host_screen(pilot, service)
+        table = screen.query_one("#scheduling-results-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        await pilot.press("d")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert db.get_automation_result(result_id)["review_state"] == "dismissed"
+
+
+@pytest.mark.asyncio
+async def test_hosted_mark_solved_action_resolves_the_definition(results_db):
+    db = results_db
+    definition_id = _seed_definition(db)
+    result_id = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        service = pilot.app.scheduling_service
+        screen = await _push_results_host_screen(pilot, service)
+        table = screen.query_one("#scheduling-results-table", DataTable)
+        table.cursor_coordinate = (0, 0)
+        await pilot.pause()
+
+        await pilot.press("o")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        definition = db.get_automation_definition(definition_id)
+        assert definition["resolution_state"] == "solved"
+        assert definition["resolved_result_id"] == result_id
+
+
+@pytest.mark.asyncio
+async def test_hosted_mark_all_read_action_fans_out(results_db):
+    db = results_db
+    definition_id = _seed_definition(db)
+    r1 = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
+    r2 = _seed_result(db, definition_id=definition_id, dedupe_key="d2")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        service = pilot.app.scheduling_service
+        await _push_results_host_screen(pilot, service)
+
+        await pilot.press("a")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert db.get_automation_result(r1)["review_state"] == "read"
+        assert db.get_automation_result(r2)["review_state"] == "read"
+
+
+@pytest.mark.asyncio
+async def test_definition_results_query_merges_local_and_server_id_spaces(results_db):
+    """redesign PR-4 task 2: a definition mirrored from the server can
+    carry results in BOTH id spaces -- a locally-created one
+    (`definition_id` = the local row id) and a server-mirrored one
+    (`definition_id` = the server's id, `index_definitions_by_id`'s own
+    documented split). `_definition_results_query` must see both, and
+    count both toward its cap-line total -- neither single-id-space DB
+    query alone sees more than half. A result belonging to a different
+    definition must not leak in."""
+    db = results_db
+    definition_id = _seed_definition(db, owner_id="server:1", server_id="srv-def-1")
+    local_result_id = _seed_result(db, definition_id=definition_id, dedupe_key="local-1")
+    server_result_id = _seed_result(
+        db, definition_id="srv-def-1", server_id="srv-res-1", dedupe_key="server-1"
+    )
+    other_definition_id = _seed_definition(db, name="Other")
+    _seed_result(db, definition_id=other_definition_id, dedupe_key="other-1")
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        service = pilot.app.scheduling_service
+
+        definition = db.get_automation_definition(definition_id)
+        results, total = workbench._definition_results_query(service, definition)
+
+        assert total == 2
+        assert {row["id"] for row in results} == {local_result_id, server_result_id}
+
+
+@pytest.mark.asyncio
+async def test_definition_unread_result_ids_merges_both_id_spaces(results_db):
+    """`_definition_unread_result_ids` counterpart of the query merge test
+    above -- the `a` action inside a definition-filtered pushed view must
+    reach unread results in BOTH id spaces, and none belonging to another
+    definition."""
+    db = results_db
+    definition_id = _seed_definition(db, owner_id="server:1", server_id="srv-def-1")
+    local_result_id = _seed_result(db, definition_id=definition_id, dedupe_key="local-1")
+    server_result_id = _seed_result(
+        db, definition_id="srv-def-1", server_id="srv-res-1", dedupe_key="server-1"
+    )
+    other_definition_id = _seed_definition(db, name="Other")
+    other_result_id = _seed_result(
+        db, definition_id=other_definition_id, dedupe_key="other-1"
+    )
+
+    app = ResultsWorkbenchTestApp(db)
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        workbench = pilot.app.screen
+        service = pilot.app.scheduling_service
+
+        definition = db.get_automation_definition(definition_id)
+        ids = workbench._definition_unread_result_ids(service, definition)
+
+        assert set(ids) == {local_result_id, server_result_id}
+        assert other_result_id not in ids

--- a/Tests/UI/test_schedules_results_tab.py
+++ b/Tests/UI/test_schedules_results_tab.py
@@ -21,7 +21,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import Button, DataTable, TabbedContent
+from textual.widgets import Button, DataTable
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import rendered_row_cells
@@ -443,27 +443,44 @@ def _seed_result(
     return result_id
 
 
-def _rendered_tab_title(workbench, pane_id: str) -> str:
-    """The text the tab bar actually shows for one pane.
+def _rendered_badge_label(workbench, button_id: str) -> str:
+    """The text a status/rail badge Button actually shows.
 
-    Goes through `TabbedContent.get_tab()` -> the `Tab` widget's own
-    rendered visual, so it can only pass if the label really reached the
-    widget that paints the tab bar.
+    redesign PR-4 task 5 replaces `_rendered_tab_title`, which read the
+    same counts off the retired `TabbedContent`'s own `Tab` widgets. The
+    reason that helper went through the rendered widget rather than an
+    attribute survives verbatim and is why this one does too: the
+    previous assertion read back `TabPane.label`, an attribute Textual
+    8.x's `TabPane` does not have, so the badge was invisible on screen
+    while the test confirmed itself (live verification task 6, D2). A
+    `Button`'s `label` IS its rendered content, so reading it is reading
+    the paint.
     """
-    tab = workbench.query_one("#scheduling-tabs", TabbedContent).get_tab(pane_id)
-    return str(tab.render())
+    return str(workbench.query_one(button_id, Button).label)
 
 
-async def _open_results_tab(pilot, *, row: int = 0):
+async def _open_results_overlay(pilot, *, row: int = 0):
+    """Open the results view the way a user does -- the rail's
+    `Results (N)` button -- and select `row`.
+
+    redesign PR-4 task 5 replaces `_open_results_tab`, which flipped
+    `TabbedContent.active` to the retired Results tab. Every scenario
+    that used it is re-pointed here rather than deleted: the listing, the
+    detail rendering and the read/dismiss/mark-solved verbs all still
+    exist, on the pushed surface (task 2) instead of the tab. Returns
+    `(workbench, screen)` because several of those scenarios assert on
+    BOTH -- the pushed view's effect, and the rail badge behind it.
+    """
     workbench = pilot.app.screen
-    tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-    tabs.active = "scheduling-results-tab"
+    workbench.query_one("#scheduling-results-badge", Button).press()
     await pilot.pause()
-    table = workbench.query_one("#scheduling-results-table", DataTable)
+    screen = pilot.app.screen
+    assert isinstance(screen, ResultsHostScreen), screen
+    table = screen.query_one("#scheduling-results-table", DataTable)
     if table.row_count:
         table.cursor_coordinate = (row, 0)
         await pilot.pause()
-    return workbench
+    return workbench, screen
 
 
 @pytest.mark.asyncio
@@ -495,25 +512,31 @@ async def test_badge_and_table_span_every_owner(results_db):
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
-        # Assert the RENDERED tab title through the real widget tree, not
-        # an attribute the code just set. The previous assertion read back
-        # `TabPane.label` -- an attribute Textual 8.x's TabPane does not
-        # have (it stores `_title`), so the assignment created an inert
-        # Python attribute, this test confirmed itself, and the badge was
-        # invisible on screen (live verification task 6, D2).
-        assert _rendered_tab_title(pilot.app.screen, "scheduling-results-tab") == (
-            "Results (2)"
-        )
+        # redesign PR-4 task 5: the unread count is read off the rail's
+        # `Results (N)` button, the badge that survived the retirement --
+        # `_refresh_results_badge` mirrors the same single
+        # `count_unread_results` the tab label used to.
+        assert _rendered_badge_label(
+            pilot.app.screen, "#scheduling-results-badge"
+        ) == "Results (2)"
 
-        table = pilot.app.screen.query_one("#scheduling-results-table", DataTable)
+        # ...and the all-owners listing is the pushed view's, opened from
+        # that same button.
+        _workbench, screen = await _open_results_overlay(pilot)
+        table = screen.query_one("#scheduling-results-table", DataTable)
         assert table.row_count == 3
 
 
 @pytest.mark.asyncio
 async def test_conflicts_badge_renders_too(results_db):
     """The Conflicts badge is the one PR-6's Results badge was copied from
-    and was equally inert (live verification task 6, D2). Both go through
-    the same `_set_tab_label` seam now, so both are pinned on the render.
+    and was equally inert (live verification task 6, D2), so both are
+    pinned on the render.
+
+    redesign PR-4 task 5: both counts used to be mirrored onto a tab
+    label AND a badge Button; `_set_tab_label` is deleted with the
+    `TabbedContent` and the Buttons are the only home left. Same two
+    counts, same two `service.db` reads.
     """
     db = results_db
     db.record_conflict(
@@ -529,21 +552,29 @@ async def test_conflicts_badge_renders_too(results_db):
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
-        assert _rendered_tab_title(
-            pilot.app.screen, "scheduling-conflicts-tab"
+        assert _rendered_badge_label(
+            pilot.app.screen, "#scheduling-conflicts-badge"
         ) == "Conflicts (1)"
         # No results seeded -> the Results badge stays a bare label.
-        assert _rendered_tab_title(
-            pilot.app.screen, "scheduling-results-tab"
+        assert _rendered_badge_label(
+            pilot.app.screen, "#scheduling-results-badge"
         ) == "Results"
 
 
 @pytest.mark.asyncio
 async def test_mark_solved_resolves_a_server_keyed_result(results_db):
     """Live verification task 6, D3: a synced result's `definition_id` is
-    the SERVER's id, but the tab indexed definitions by their LOCAL id and
-    `resolve_definition` takes a LOCAL id -- so `o` refused ("definition
-    could not be found") on exactly the rows the feature exists for.
+    the SERVER's id, but the view indexed definitions by their LOCAL id
+    and `resolve_definition` takes a LOCAL id -- so `o` refused
+    ("definition could not be found") on exactly the rows the feature
+    exists for.
+
+    redesign PR-4 task 5: driven through the pushed view's own `o`
+    (`ResultsHostScreen.action_mark_solved`) now that the tab and its
+    tab-gated `action_mark_result_solved` are retired. Both always shared
+    the same `solved_eligibility` gate and `mark_selected_result_solved`
+    orchestration (task 2 factored them out for exactly this), so the D3
+    regression this pins is unmoved -- only its caller is.
     """
     db = results_db
     local_definition_id = _seed_definition(
@@ -561,10 +592,10 @@ async def test_mark_solved_resolves_a_server_keyed_result(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
         # The eligibility gate resolves through the server id space...
-        results_tab = workbench.query_one("#scheduling-results", ResultsTab)
+        results_tab = screen.query_one(ResultsTab)
         detail_text = str(
             results_tab.query_one("#scheduling-results-detail").render()
         )
@@ -572,7 +603,7 @@ async def test_mark_solved_resolves_a_server_keyed_result(results_db):
 
         # ...and so does the action, which must hand `resolve_definition`
         # the LOCAL id it contracts for.
-        workbench.action_mark_result_solved()
+        screen.action_mark_solved()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
@@ -583,6 +614,13 @@ async def test_mark_solved_resolves_a_server_keyed_result(results_db):
 
 @pytest.mark.asyncio
 async def test_read_action_marks_local_result_read(results_db):
+    """redesign PR-4 task 5: `r` used to be `action_run_task_now` routed
+    by active tab; the routing and the tab are retired, so this drives
+    the pushed view's own `r` (`ResultsHostScreen.action_review_read`),
+    which has always called the same `review_selected_result`. The badge
+    half of the claim -- the count clears once nothing is unread -- is
+    re-asserted on the rail button, and now also proves the pop-time
+    `dismissed` refresh actually runs."""
     db = results_db
     definition_id = _seed_definition(db)
     result_id = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
@@ -591,23 +629,38 @@ async def test_read_action_marks_local_result_read(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        workbench, screen = await _open_results_overlay(pilot)
+        assert _rendered_badge_label(
+            workbench, "#scheduling-results-badge"
+        ) == "Results (1)"
 
-        # r reuses action_run_task_now, routed to "read" on this tab.
-        workbench.action_run_task_now()
+        screen.action_review_read()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
         row = db.get_automation_result(result_id)
         assert row["review_state"] == "read"
-        # Badge clears once nothing is unread -- asserted on the render,
-        # same reason as the badge test above (task 6, D2).
-        assert _rendered_tab_title(workbench, "scheduling-results-tab") == "Results"
+
+        # Closing the view runs its `dismissed` hook, which re-counts the
+        # rail badge: it clears once nothing is unread.
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert pilot.app.screen is workbench
+        assert _rendered_badge_label(
+            workbench, "#scheduling-results-badge"
+        ) == "Results"
 
 
 @pytest.mark.asyncio
 async def test_dismiss_action_queues_server_pushback_mutation(results_db):
+    """redesign PR-4 task 5: `d` used to be `action_delete` routed by
+    active tab; driven through the pushed view's own `d` now (same
+    `review_selected_result` orchestration). The claim -- a server-owned
+    result's dismissal queues its pushback mutation with the SERVER's
+    result id -- is untouched and has no other home."""
     db = results_db
     definition_id = _seed_definition(
         db, owner_id="server:1", server_id="srv-def-1"
@@ -624,10 +677,9 @@ async def test_dismiss_action_queues_server_pushback_mutation(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        # d reuses action_delete, routed to "dismissed" on this tab.
-        workbench.action_delete()
+        screen.action_review_dismiss()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
@@ -645,6 +697,11 @@ async def test_dismiss_action_queues_server_pushback_mutation(results_db):
 
 @pytest.mark.asyncio
 async def test_mark_all_read_fans_out_per_row(results_db):
+    """redesign PR-4 task 5: no tab to activate first --
+    `action_mark_all_results_read` is ungated now (it was Results-tab-only,
+    with a byte-identical ungated twin behind the rail button; the two
+    collapsed into one when the gate went). The fan-out claim is
+    unchanged."""
     db = results_db
     definition_id = _seed_definition(db)
     r1 = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
@@ -657,7 +714,7 @@ async def test_mark_all_read_fans_out_per_row(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        workbench = pilot.app.screen
 
         workbench.action_mark_all_results_read()
         await pilot.pause()
@@ -675,7 +732,7 @@ async def test_mark_all_read_fans_out_per_row(results_db):
 async def test_mark_all_read_reaches_unread_rows_beyond_the_inbox_window(
     results_db,
 ):
-    """HIGH (Qodo): `_unread_result_ids` used to read the Results tab's
+    """HIGH (Qodo): `_unread_result_ids` used to read the results view's
     own CAPPED listing (`RESULTS_INBOX_LIMIT`, 200 newest rows) instead
     of querying the DB directly, so an older unread result outside that
     window survived a mark-all-read -- while the rail button's
@@ -708,13 +765,17 @@ async def test_mark_all_read_reaches_unread_rows_beyond_the_inbox_window(
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        workbench, screen = await _open_results_overlay(pilot)
 
         # Sanity: the loaded table window is capped, so the old result is
         # not among the currently-rendered rows -- this is the exact
-        # shape that used to leave it unreached.
-        table = workbench.query_one("#scheduling-results-table", DataTable)
+        # shape that used to leave it unreached. (redesign PR-4 task 5:
+        # that capped listing is the PUSHED view's now; the fan-out under
+        # test still reads the DB, which is the whole point.)
+        table = screen.query_one("#scheduling-results-table", DataTable)
         assert table.row_count == RESULTS_INBOX_LIMIT
+        await pilot.press("escape")
+        await pilot.pause()
 
         workbench.action_mark_all_results_read()
         await pilot.pause()
@@ -739,13 +800,16 @@ async def test_mark_all_read_reaches_unread_rows_beyond_the_inbox_window(
 
 
 @pytest.mark.asyncio
-async def test_rail_mark_all_read_button_fans_out_without_switching_tabs(results_db):
-    """redesign PR-2, Task 3: unlike the `a` keybinding (Results-tab-only,
-    see `test_results_actions_refuse_off_the_results_tab`), the rail's
-    `Mark all read` button on the Queue tab reuses the SAME per-row
-    fan-out (`_dispatch_mark_all_results_read`) without a tab switch
-    first, then refreshes the Queue's own unread dots so the button hides
-    itself again once nothing is unread."""
+async def test_rail_mark_all_read_button_fans_out_and_hides_itself(results_db):
+    """redesign PR-2, Task 3: the rail's `Mark all read` button reuses the
+    per-row fan-out (`_dispatch_mark_all_results_read`), then refreshes
+    the Queue's own unread dots so the button hides itself again once
+    nothing is unread.
+
+    redesign PR-4 task 5 (renamed): "without switching tabs" was the
+    point of the button when `a` was Results-tab-only -- there are no
+    tabs and no gate now, so the button and `a` are one path and the
+    name says what is still true."""
     db = results_db
     definition_id = _seed_definition(db)
     r1 = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
@@ -758,10 +822,6 @@ async def test_rail_mark_all_read_button_fans_out_without_switching_tabs(results
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
         workbench = pilot.app.screen
-
-        # Still on the Queue tab -- the `a` keybinding would refuse here.
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        assert tabs.active == "scheduling-queue-tab"
 
         button = workbench.query_one("#scheduling-mark-all-read", Button)
         assert button.display is True
@@ -781,6 +841,10 @@ async def test_rail_mark_all_read_button_fans_out_without_switching_tabs(results
 
 @pytest.mark.asyncio
 async def test_mark_solved_local_round_trip(results_db):
+    """redesign PR-4 task 5: driven through the pushed view's `o`
+    (`ResultsHostScreen.action_mark_solved`) -- same
+    `mark_selected_result_solved` orchestration the retired tab-gated
+    `action_mark_result_solved` called."""
     db = results_db
     definition_id = _seed_definition(db)
     result_id = _seed_result(db, definition_id=definition_id, dedupe_key="d1")
@@ -789,9 +853,9 @@ async def test_mark_solved_local_round_trip(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        workbench.action_mark_result_solved()
+        screen.action_mark_solved()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
@@ -806,6 +870,11 @@ async def test_mark_solved_local_round_trip(results_db):
 async def test_mark_solved_refuses_failure_row_without_reaching_the_service(
     results_db,
 ):
+    """redesign PR-4 task 5: the SYNCHRONOUS eligibility refusal (no
+    worker round-trip) that `solved_eligibility` owns, re-pinned on the
+    pushed view's `o` -- `ResultsHostScreen.action_mark_solved` keeps the
+    same caller-side gate the retired tab action had (results_tab.py's
+    own docstring: the gates stay in each CALLER)."""
     db = results_db
     definition_id = _seed_definition(db)
     _seed_result(
@@ -816,9 +885,9 @@ async def test_mark_solved_refuses_failure_row_without_reaching_the_service(
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        workbench.action_mark_result_solved()
+        screen.action_mark_solved()
         await pilot.pause()
 
         definition = db.get_automation_definition(definition_id)
@@ -832,6 +901,8 @@ async def test_mark_solved_refuses_failure_row_without_reaching_the_service(
 
 @pytest.mark.asyncio
 async def test_mark_solved_server_round_trip(results_db):
+    """redesign PR-4 task 5: driven through the pushed view's `o`; the
+    local->server id translation under test is unchanged."""
     db = results_db
     definition_id = _seed_definition(
         db, owner_id="server:1", server_id="srv-def-1"
@@ -855,9 +926,9 @@ async def test_mark_solved_server_round_trip(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        workbench.action_mark_result_solved()
+        screen.action_mark_solved()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
@@ -872,6 +943,8 @@ async def test_mark_solved_server_round_trip(results_db):
 
 @pytest.mark.asyncio
 async def test_mark_solved_refused_offline_surfaces_the_reason(results_db):
+    """redesign PR-4 task 5: driven through the pushed view's `o`; the
+    real `ServerUnavailableError` refusal under test is unchanged."""
     db = results_db
     definition_id = _seed_definition(
         db, owner_id="server:1", server_id="srv-def-1"
@@ -891,9 +964,9 @@ async def test_mark_solved_refused_offline_surfaces_the_reason(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        workbench.action_mark_result_solved()
+        screen.action_mark_solved()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
@@ -906,39 +979,36 @@ async def test_mark_solved_refused_offline_surfaces_the_reason(results_db):
         )
 
 
-@pytest.mark.asyncio
-async def test_results_actions_refuse_off_the_results_tab(results_db):
-    db = results_db
-    definition_id = _seed_definition(db)
-    _seed_result(db, definition_id=definition_id, dedupe_key="d1")
-
-    app = ResultsWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        workbench = pilot.app.screen  # Queue tab is active by default
-
-        workbench.action_mark_result_solved()
-        workbench.action_mark_all_results_read()
-        await pilot.pause()
-
-        definition = db.get_automation_definition(definition_id)
-        assert definition["resolution_state"] == "open"
-        notifications = list(pilot.app._notifications)
-        assert len(notifications) == 2
-        assert all("Results tab" in n.message for n in notifications)
+# redesign PR-4 task 5: `test_results_actions_refuse_off_the_results_tab`
+# is DELETED, not relocated. It pinned `_is_results_tab_active`'s two
+# refusals ("Switch to the Results tab to ...") -- the behaviour of a
+# gate whose only purpose was to stop tab-scoped keys acting on a tab the
+# user was not looking at. With one surface there is no tab to be off of:
+# `o` lives only on the pushed view (a screen underneath never receives
+# the key at all -- structural, not gated), and `a` is deliberately
+# ungated because its target, the rail's `Mark all read` button, is
+# always on screen. There is no behaviour left to assert; keeping the
+# test would mean re-introducing the gate to satisfy it. The half that
+# survives -- `a` doing the right thing from the rail -- is
+# `test_rail_mark_all_read_button_fans_out_and_hides_itself` above.
 
 
 @pytest.mark.asyncio
 async def test_inbox_lists_the_sync_window_and_says_what_it_hides(results_db):
     """HIGH (Qodo): the refresh took the DB's default `limit=50` while the
-    badge counted EVERY unread result, so the tab could read "Results
+    badge counted EVERY unread result, so the badge could read "Results
     (201)" over 50 rows with nothing saying the rest existed.
 
-    The listing is now the sync-mirrored window -- `RESULTS_INBOX_LIMIT`,
+    The listing is the sync-mirrored window -- `RESULTS_INBOX_LIMIT`,
     i.e. exactly the newest-pages walk `SyncEngine._pull_results` does --
     and once it bites, the heading says so. Deliberately no pagination:
     saying what is hidden is the fix.
+
+    redesign PR-4 task 5: the listing and its cap line moved to the
+    pushed view with the retirement (`_push_results_overlay` runs the
+    same `RESULTS_INBOX_LIMIT` query the tab refresh used to). Both
+    halves of the honesty claim are still asserted together, which is the
+    point of the test: the capped listing AND the uncapped badge count.
     """
     db = results_db
     definition_id = _seed_definition(db)
@@ -950,27 +1020,28 @@ async def test_inbox_lists_the_sync_window_and_says_what_it_hides(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        workbench, screen = await _open_results_overlay(pilot)
 
-        table = workbench.query_one("#scheduling-results-table", DataTable)
+        table = screen.query_one("#scheduling-results-table", DataTable)
         assert table.row_count == RESULTS_INBOX_LIMIT
 
-        heading = workbench.query_one("#scheduling-results-heading")
+        heading = screen.query_one("#scheduling-results-heading")
         assert (
             f"showing newest {RESULTS_INBOX_LIMIT} of {total}"
             in str(heading.render())
         )
         # The badge still counts every unread result -- that honesty is
         # the whole reason the truncation has to be stated.
-        assert f"Results ({total})" in _rendered_tab_title(
-            workbench, "scheduling-results-tab"
+        assert f"Results ({total})" in _rendered_badge_label(
+            workbench, "#scheduling-results-badge"
         )
 
 
 @pytest.mark.asyncio
 async def test_inbox_heading_stays_plain_when_everything_fits(results_db):
     """The count line is truncation-only -- an inbox that fits must not
-    grow a permanent "showing newest 2 of 2" tail."""
+    grow a permanent "showing newest 2 of 2" tail. (redesign PR-4 task 5:
+    read off the pushed view, which owns the listing now.)"""
     db = results_db
     definition_id = _seed_definition(db)
     for index in range(2):
@@ -980,9 +1051,9 @@ async def test_inbox_heading_stays_plain_when_everything_fits(results_db):
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
-        workbench = await _open_results_tab(pilot)
+        _workbench, screen = await _open_results_overlay(pilot)
 
-        heading = workbench.query_one("#scheduling-results-heading")
+        heading = screen.query_one("#scheduling-results-heading")
         assert str(heading.render()).strip() == RESULTS_HEADING
 
 

--- a/Tests/UI/test_schedules_terminology.py
+++ b/Tests/UI/test_schedules_terminology.py
@@ -95,13 +95,17 @@ async def _mounted_workbench(pilot):
 # `_managed_elsewhere_notice` guard FROM this table with a projection.
 # The guard's own copy generation stays covered by
 # `test_managed_elsewhere_notice_names_the_owning_screen` above (a
-# direct, workbench-free unit test of `_managed_elsewhere_notice` itself);
-# `TaskDetail.set_task`'s "#scheduling-task-detail-managed" ownership-line
-# RENDERING for a `ScheduledTask` has no dedicated test anywhere else in
-# the suite and genuinely loses coverage here -- the code path is now
-# unreachable from this screen (a `ScheduledTask` is never fed to
-# `TaskDetail` from the Queue table any more) but is left in place,
-# unmodified, in case another future caller needs it.
+# direct, workbench-free unit test of `_managed_elsewhere_notice` itself).
+#
+# redesign PR-4 task 5 (ruling 5) closes the loose end this note left
+# open: `TaskDetail.set_task`'s "#scheduling-task-detail-managed"
+# ownership-line rendering was kept "in case another future caller needs
+# it", and no such caller ever appeared. It is now DELETED as provably
+# dead -- `TaskDetail(` is constructed exactly once in the repo, fed only
+# by `list_tasks(include_projections=False)` filtered to `ReminderTask`,
+# so the `else` branch that painted it could never run. The copy
+# GENERATOR (`_managed_elsewhere_notice`) stays: the workbench's own
+# edit/mark/enable refusals still call it, and the test above covers it.
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_transfer_actions.py
+++ b/Tests/UI/test_schedules_transfer_actions.py
@@ -1,21 +1,36 @@
-"""Detail-pane Move/Cancel transfer UI tests (schedules-handoff spec §6,
-PR-5 task 7).
+"""Detail-pane transfer-lock + toast-copy tests (schedules-handoff spec §6,
+PR-5 task 7; narrowed by redesign PR-4 task 4).
 
-Two layers, matching `test_schedules_missed_notice.py`'s split:
+redesign PR-4 task 4 (ruling 2) retired the legacy button-driven transfer
+surface this file used to cover in depth (`TaskDetail`'s Move/Retry/Cancel
+buttons, `set_transfer_reasons`, and the Automations-tab-only `m`/`M`/`y`/`k`
+keybindings driving `_begin_automation_transfer`/`_cancel_automation_
+transfer`) -- the Runs-on row's dropdown + mini-bar (PR-3 task 5,
+`test_schedules_workbench.py`'s `test_runs_on_dropdown_*`/`test_definition_
+runs_on_*`/`test_runs_on_*_button_*` tests) is now the ONE transfer surface,
+and already carries equivalent coverage for the routing/confirm-dialog/
+begin/cancel/retry behaviors those deleted tests pinned. What survives here:
 
-- Widget-level (`_DetailHarnessApp`, a bare `TaskDetail`): pins the
-  disabled-with-reason rendering pipeline itself -- button show/hide per
-  row structure, and `set_transfer_reasons` quoting whatever reason
-  string it is given verbatim (including a health-shaped one), without
-  needing a real scheduling service.
-- Workbench-level (`TransferWorkbenchTestApp`, a REAL `SchedulingService`
-  over a tmp_path `ScheduledTasksDB`): pins the UI's *routing* --
-  `transfer_refusal`/`transfer_warnings` run for real (Task 6 owns their
-  correctness; this file only proves the UI calls them and acts on what
-  they say), confirm-dialog wiring, honest toast copy, and that cancel
-  is called with the right row id per state (the dormant-copy case in
-  particular -- Task 6's handoff note: the release leg's `cancel_
-  transfer` row_id is the COPY's own id, never the mirror's).
+- Widget-level (`_DetailHarnessApp`, a bare `TaskDetail`): `set_lifecycle_
+  lock`'s Edit/Enable/Disable/Delete read-only-with-reason rendering --
+  unaffected by the legacy button deletion (a SEPARATE lock surface from
+  the retired `set_transfer_reasons`).
+- Workbench-level (`TransferWorkbenchTestApp`, a REAL `SchedulingService`):
+  the same lock, sourced from the real facade's `transfer_lock_reason`, and
+  the `e`/`space` key-bound refusal it drives.
+- The DataTable row's own transfer-badge suffix rendering (never routed
+  through the legacy buttons at all).
+- `_transfer_confirm_dialog`'s literal-bracket escaping (a shared helper,
+  still used by the Runs-on dropdown flow).
+- Direct unit tests for `_cancel_toast_text`/`_transfer_pending_toast_text`
+  (shared, unchanged pure functions -- the dropdown flow's `_run_owner_
+  transfer`/`_run_owner_cancel` already called them before this task) --
+  the deleted tests' honest-copy assertions, preserved as a cheap direct-
+  call belt rather than re-adding a full integration round-trip that
+  `test_runs_on_dropdown_confirm_begins_to_server_transfer`/`test_runs_on_
+  cancel_button_cancels_the_dormant_copy_using_its_own_id`
+  (`test_schedules_workbench.py`) already exercise for the surrounding
+  DB-state behavior.
 """
 
 from __future__ import annotations
@@ -24,18 +39,18 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 
 import pytest
-from textual.widgets import Button, DataTable, Static, TabbedContent
+from textual.widgets import Button, DataTable, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
 from tldw_chatbook.Scheduling.services import SchedulingService
-from tldw_chatbook.Scheduling.services import (
-    scheduling_service as scheduling_service_module,
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+    SchedulesWorkbench,
+    _cancel_toast_text,
 )
-from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.task_detail import TaskDetail
-from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
+
 
 def _reminder(**kwargs) -> ReminderTask:
     defaults = dict(
@@ -50,7 +65,9 @@ def _reminder(**kwargs) -> ReminderTask:
 
 
 # ---------------------------------------------------------------------------
-# Widget-level: TaskDetail's own show/hide + disabled-with-reason rendering
+# Widget-level: TaskDetail's lifecycle-lock rendering (the legacy button
+# show/hide + `set_transfer_reasons` disabled-with-reason tests that used to
+# live here were deleted with the buttons -- redesign PR-4 task 4)
 # ---------------------------------------------------------------------------
 
 
@@ -61,163 +78,51 @@ class _DetailHarnessApp(ConsolidatedCSSApp):
         yield TaskDetail()
 
 
-def _buttons(detail: TaskDetail) -> dict[str, Button]:
-    return {
-        "to_server": detail.query_one("#scheduling-transfer-to-server", Button),
-        "to_local": detail.query_one("#scheduling-transfer-to-local", Button),
-        "retry": detail.query_one("#scheduling-retry-transfer", Button),
-        "cancel": detail.query_one("#scheduling-cancel-transfer", Button),
-    }
-
-
 @pytest.mark.asyncio
-async def test_local_row_shows_only_move_to_server():
-    """A plain local row (never transferred) offers only Move to server."""
+@pytest.mark.parametrize(
+    "state", ["to_server_pending", "to_server_sent", "from_server_pending"]
+)
+async def test_in_flight_row_disables_lifecycle_actions_with_a_reason(state):
+    """Final review I7 / spec §6.3: an in-flight row is read-only except
+    cancel. The reason must be in TEXT, not only a tooltip (UX-073)."""
     async with _DetailHarnessApp().run_test() as pilot:
         detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(owner_id="local", transfer_state=None))
-        buttons = _buttons(detail)
-        assert buttons["to_server"].display
-        assert not buttons["to_local"].display
-        assert not buttons["retry"].display
-        assert not buttons["cancel"].display
+        detail.set_task(_reminder(owner_id="local", transfer_state=state))
+        detail.set_lifecycle_lock("This row is moving -- read-only.")
 
-
-@pytest.mark.asyncio
-async def test_server_mirror_shows_only_move_to_local():
-    """A server-owned mirror (never transferring) offers only Move to local."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(
-            _reminder(owner_id="server:1", server_id="srv-1", transfer_state=None)
-        )
-        buttons = _buttons(detail)
-        assert not buttons["to_server"].display
-        assert buttons["to_local"].display
-        assert not buttons["retry"].display
-        assert not buttons["cancel"].display
-
-
-@pytest.mark.asyncio
-async def test_to_server_failed_shows_retry_alongside_move_to_server():
-    """spec §6.1.5: a definitively-failed transfer offers Retry (plus the
-    Cancel escape hatch) alongside the still-shown Move to server."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(
-            _reminder(owner_id="local", transfer_state="to_server_failed")
-        )
-        buttons = _buttons(detail)
-        assert buttons["to_server"].display
-        assert not buttons["to_local"].display
-        assert buttons["retry"].display
-        assert buttons["cancel"].display
-
-
-@pytest.mark.asyncio
-async def test_dormant_local_copy_shows_cancel_only():
-    """A `from_server_pending` copy (owner_id local) can only be cancelled."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(
-            _reminder(owner_id="local", transfer_state="from_server_pending")
-        )
-        buttons = _buttons(detail)
-        assert buttons["to_server"].display
-        assert not buttons["retry"].display
-        assert buttons["cancel"].display
-
-
-@pytest.mark.asyncio
-async def test_selecting_a_projection_hides_the_whole_transfer_row():
-    """A ScheduledTask projection (watchlist/briefing) has no transfer_state
-    at all -- the row must not appear (or error querying it)."""
-    from tldw_chatbook.Scheduling.models import ScheduledTask, TaskStatus
-
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(
-            ScheduledTask(
-                id="watchlist:1",
-                title="Watchlist",
-                type="watchlist_job",
-                status=TaskStatus.WAITING,
-            )
-        )
-        transfer_row = detail.query_one("#scheduling-task-detail-transfer")
-        assert not transfer_row.display
-
-
-@pytest.mark.asyncio
-async def test_set_transfer_reasons_renders_disabled_with_reason():
-    """A refusal reason (health-quoted, verbatim) disables the button AND
-    appears in the always-visible Static (UX-073 -- tooltip alone is not
-    enough for keyboard users)."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(owner_id="server:1", server_id="srv-1"))
-        health_reason = (
-            "Local health is not ready: RAG dependencies are not installed."
-        )
-        detail.set_transfer_reasons(
-            to_server_reason=None,
-            to_local_reason=health_reason,
-            retry_reason=None,
-            cancel_reason=None,
-            retry_errors=[],
-        )
-        buttons = _buttons(detail)
-        assert buttons["to_local"].disabled
-        assert str(buttons["to_local"].tooltip) == health_reason
+        for button_id in (
+            "scheduling-edit-task",
+            "scheduling-delete-task",
+            "scheduling-enable-task",
+            "scheduling-disable-task",
+        ):
+            assert detail.query_one(f"#{button_id}", Button).disabled, button_id
         why = detail.query_one("#scheduling-transfer-why", Static)
-        assert f"Move to local: {health_reason}" in why.visual.plain
+        assert "read-only" in why.visual.plain
 
 
 @pytest.mark.asyncio
-async def test_set_transfer_reasons_shows_retry_errors():
-    """The stored `transfer_errors` render beside Retry (Task 6's ruling 3)."""
+async def test_clearing_the_lifecycle_lock_restores_the_buttons():
+    """An editable row keeps its normal enable/disable logic, and the lock
+    line is removed from the shared reason Static."""
     async with _DetailHarnessApp().run_test() as pilot:
         detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(transfer_state="to_server_failed"))
-        detail.set_transfer_reasons(
-            to_server_reason=None,
-            to_local_reason=None,
-            retry_reason=None,
-            cancel_reason=None,
-            retry_errors=["schedule_invalid: cron field out of range"],
-        )
-        why = detail.query_one("#scheduling-transfer-why", Static)
-        assert "schedule_invalid: cron field out of range" in why.visual.plain
+        detail.set_task(_reminder(owner_id="local", transfer_state="to_server_sent"))
+        detail.set_lifecycle_lock("locked for now")
+        detail.set_task(_reminder(owner_id="local", transfer_state=None, enabled=True))
+        detail.set_lifecycle_lock(None)
 
-
-@pytest.mark.asyncio
-async def test_allowed_action_clears_disabled_and_reason():
-    """`None` reasons re-enable and clear any stale reason text."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(owner_id="local"))
-        detail.set_transfer_reasons(
-            to_server_reason="blocked",
-            to_local_reason=None,
-            retry_reason=None,
-            cancel_reason=None,
-            retry_errors=[],
-        )
-        detail.set_transfer_reasons(
-            to_server_reason=None,
-            to_local_reason=None,
-            retry_reason=None,
-            cancel_reason=None,
-            retry_errors=[],
-        )
-        buttons = _buttons(detail)
-        assert not buttons["to_server"].disabled
+        assert not detail.query_one("#scheduling-edit-task", Button).disabled
+        assert not detail.query_one("#scheduling-delete-task", Button).disabled
+        # set_task's own UX-059 rule still owns these two.
+        assert detail.query_one("#scheduling-enable-task", Button).disabled
+        assert not detail.query_one("#scheduling-disable-task", Button).disabled
         why = detail.query_one("#scheduling-transfer-why", Static)
-        assert why.visual.plain == ""
+        assert "locked for now" not in why.visual.plain
 
 
 # ---------------------------------------------------------------------------
-# Workbench-level: routing, confirm dialog, toasts, cancel row-id correctness
+# Workbench-level: routing, confirm dialog, and cancel/toast copy units
 # ---------------------------------------------------------------------------
 
 
@@ -274,271 +179,11 @@ async def _select_row(pilot, index: int = 0) -> None:
 
 
 @pytest.mark.asyncio
-async def test_move_to_server_button_opens_confirm_dialog_with_warnings(
-    transfer_db,
-):
-    """An imminent one-time run_at surfaces in the confirm dialog (spec §6.4)."""
-    db = transfer_db
-    imminent = (datetime.now(timezone.utc) + timedelta(minutes=2)).isoformat()
-    db.create_reminder_task(
-        owner_id="local",
-        title="Almost due",
-        schedule_kind="one_time",
-        run_at=imminent,
-        timeout_seconds=30,
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_row(pilot)
-
-        button = pilot.app.screen.query_one(
-            "#scheduling-transfer-to-server", Button
-        )
-        assert not button.disabled
-        button.focus()
-        await pilot.press("enter")
-        await pilot.pause()
-
-        assert isinstance(pilot.app.screen, ConfirmationDialog)
-        message = pilot.app.screen.message
-        assert "Almost due" in message
-        assert "unverified" in message  # imminent run_at warning
-        assert "timeout_seconds" in message  # non-transferring field
-
-
-@pytest.mark.asyncio
-async def test_confirming_move_to_server_queues_transfer_with_honest_toast(
-    transfer_db, monkeypatch
-):
-    """Confirming starts the transfer, and the toast says the task still
-    runs locally while only queued (spec §6.1.1)."""
-    db = transfer_db
-    reminder_id = db.create_reminder_task(
-        owner_id="local",
-        title="Nightly check",
-        schedule_kind="one_time",
-        run_at="2030-01-01T00:00:00+00:00",
-    )
-    app = TransferWorkbenchTestApp(db)
-    notifications: list[tuple[str, str]] = []
-    monkeypatch.setattr(
-        app,
-        "notify",
-        lambda message, severity="information", **kw: notifications.append(
-            (message, severity)
-        ),
-    )
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_row(pilot)
-
-        pilot.app.screen.query_one(
-            "#scheduling-transfer-to-server", Button
-        ).press()
-        await pilot.pause()
-        assert isinstance(pilot.app.screen, ConfirmationDialog)
-        pilot.app.screen.dismiss(True)
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        row = db.get_reminder_task(reminder_id)
-        assert row["transfer_state"] == "to_server_pending"
-        assert row["owner_id"] == "local"  # still executes locally while queued
-
-        toast_messages = [message for message, _ in notifications]
-        assert any(
-            "still runs on this device" in message for message in toast_messages
-        )
-
-
-@pytest.mark.asyncio
-async def test_cancelling_declines_when_dialog_dismissed(transfer_db):
-    """Dismissing the confirm dialog leaves the row untouched."""
-    db = transfer_db
-    reminder_id = db.create_reminder_task(
-        owner_id="local",
-        title="Nightly check",
-        schedule_kind="one_time",
-        run_at="2030-01-01T00:00:00+00:00",
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_row(pilot)
-
-        pilot.app.screen.query_one(
-            "#scheduling-transfer-to-server", Button
-        ).press()
-        await pilot.pause()
-        pilot.app.screen.dismiss(False)
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        row = db.get_reminder_task(reminder_id)
-        assert row["transfer_state"] is None
-
-
-@pytest.mark.asyncio
-async def test_cancel_on_dormant_copy_uses_the_copys_own_id(transfer_db):
-    """Task 6 handoff note: the release leg's `cancel_transfer` row_id is
-    the DORMANT COPY's own id, never the mirror's. Selecting the copy row
-    (which is what the UI actually shows -- the mirror never carries
-    `from_server_pending` itself) and pressing Cancel must delete exactly
-    that copy and leave the mirror alone.
-    """
-    db = transfer_db
-    mirror_id = db.create_reminder_task(
-        owner_id="server:1",
-        server_id="srv-9",
-        title="Server task",
-        schedule_kind="one_time",
-        run_at="2030-01-01T00:00:00+00:00",
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-
-        # Start the release for real through the facade so the dormant
-        # copy is created exactly the way begin_transfer_to_local does.
-        service = app.scheduling_service
-        outcome = await service.begin_transfer_to_local("reminder_task", mirror_id)
-        assert outcome.status == "pending"
-        copy_id = outcome.row_id
-        assert copy_id is not None
-        assert copy_id != mirror_id
-
-        # redesign PR-2, Task 2: the Queue list is now spans-owners, so
-        # BOTH the local dormant copy AND the server-owned mirror show up
-        # (was 1 -- only the current-owner-scoped reminder listing --
-        # before the unified list). Select the copy row explicitly by id
-        # rather than assuming it lands at index 0.
-        await pilot.app.screen.load_tasks()
-        await pilot.pause()
-        table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
-        assert table.row_count == 2
-        workbench = pilot.app.screen
-        copy_index = next(
-            index
-            for index, row in enumerate(workbench._visible_rows)
-            if row.kind == "reminder" and row.source_row.id == copy_id
-        )
-        await _select_row(pilot, copy_index)
-
-        cancel_button = pilot.app.screen.query_one(
-            "#scheduling-cancel-transfer", Button
-        )
-        assert not cancel_button.disabled
-        cancel_button.press()
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        assert db.get_reminder_task(copy_id) is None  # the copy is gone
-        mirror_row = db.get_reminder_task(mirror_id)
-        assert mirror_row is not None  # the mirror is untouched
-        assert mirror_row["transfer_state"] is None
-
-
-@pytest.mark.asyncio
-async def test_retry_button_only_appears_after_definitive_failure(transfer_db):
-    """Retry is invisible on a healthy local row and appears once the row
-    is `to_server_failed`, carrying the stored transfer_errors."""
-    db = transfer_db
-    reminder_id = db.create_reminder_task(
-        owner_id="local",
-        title="Flaky sync",
-        schedule_kind="one_time",
-        run_at="2030-01-01T00:00:00+00:00",
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_row(pilot)
-
-        retry_button = pilot.app.screen.query_one(
-            "#scheduling-retry-transfer", Button
-        )
-        assert not retry_button.display
-
-        db.set_transfer_state(
-            "reminder_task", reminder_id, "to_server_pending", expected=(None,)
-        )
-        db.set_transfer_state(
-            "reminder_task",
-            reminder_id,
-            "to_server_sent",
-            expected=("to_server_pending",),
-        )
-        db.set_transfer_state(
-            "reminder_task",
-            reminder_id,
-            "to_server_failed",
-            expected=("to_server_sent",),
-        )
-        db.record_pending_mutation(
-            reminder_id,
-            "reminder_task",
-            "server:1",
-            {
-                "action": "transfer_to_server",
-                "task_payload": {"title": "Flaky sync"},
-                "transfer_errors": ["schedule_invalid: bad cron"],
-            },
-        )
-        await pilot.app.screen.load_tasks()
-        await pilot.pause()
-        await _select_row(pilot)
-
-        retry_button = pilot.app.screen.query_one(
-            "#scheduling-retry-transfer", Button
-        )
-        assert retry_button.display
-        assert not retry_button.disabled
-
-        why = pilot.app.screen.query_one("#scheduling-transfer-why", Static)
-        assert "schedule_invalid: bad cron" in why.visual.plain
-
-
-@pytest.mark.asyncio
-async def test_no_server_connection_disables_move_to_server_with_reason(
-    transfer_db,
-):
-    """spec §6.4: no server connection is the first refusal reason."""
-    db = transfer_db
-    db.create_reminder_task(
-        owner_id="local",
-        title="Solo task",
-        schedule_kind="one_time",
-        run_at="2030-01-01T00:00:00+00:00",
-    )
-    app = TransferWorkbenchTestApp(db, connected=False)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_row(pilot)
-
-        button = pilot.app.screen.query_one(
-            "#scheduling-transfer-to-server", Button
-        )
-        assert button.disabled
-        assert "No server connection" in str(button.tooltip)
-        why = pilot.app.screen.query_one("#scheduling-transfer-why", Static)
-        assert "No server connection" in why.visual.plain
-
-
-@pytest.mark.asyncio
 async def test_queue_row_shows_transfer_badge_suffix(transfer_db):
     """A minimal, always-on signal that the state machine is doing
     something -- spec §9's badge language, pulled forward just far enough
-    (plan ruling 1 keeps full badge/owner-column polish PR-6 scope)."""
+    (plan ruling 1 keeps full badge/owner-column polish PR-6 scope).
+    Never routed through the (now-retired) legacy transfer buttons."""
     db = transfer_db
     reminder_id = db.create_reminder_task(
         owner_id="local",
@@ -559,327 +204,6 @@ async def test_queue_row_shows_transfer_badge_suffix(transfer_db):
         # redesign PR-2, Task 2: column 0 is now the glyph, column 1 the
         # title (old single-primitive shape was Title/Type/Status/Next Run).
         assert "Moving to server" in str(row[1])
-
-
-# ---------------------------------------------------------------------------
-# Automations-tab transfer actions (Task 7 fix round item 1)
-#
-# The tab has no per-row detail widget -- Move-to-local/Retry/Cancel are
-# keybindings routed by active tab (`m`/`y`/`k`), same idiom as the tab's
-# existing Run-now/Edit (`r`/`e`). A REAL `SchedulingService` + tmp_path DB
-# throughout, same rationale as the reminder-side tests above.
-# ---------------------------------------------------------------------------
-
-
-def _stub_ready_health(monkeypatch) -> None:
-    """A `recurring_question` `to_local` refusal also gates on local
-    health (spec §6.4/§7.4) -- irrelevant to what THIS file tests (Task
-    6 owns health-quoting correctness), so stubbed ready, mirroring Task
-    6's own `_stub_health` test helper exactly."""
-    monkeypatch.setattr(
-        scheduling_service_module,
-        "compute_local_health",
-        lambda app, row: ("ready", ""),
-    )
-
-
-def _local_definition(db, **overrides):
-    """A local `automation_definitions` row, mirroring Task 6's own
-    `_make_definition` test helper exactly (same required fields)."""
-    kwargs = dict(
-        owner_id="local",
-        family="recurring_question",
-        name="Daily digest",
-        schedule={"kind": "interval", "every_seconds": 3600},
-        input={"question": "What happened today?"},
-        config={},
-    )
-    kwargs.update(overrides)
-    return db.create_automation_definition(**kwargs)
-
-
-class _FakeAutomationsServerClient(_FakeServerClient):
-    """Adds a minimal `list_automation_definitions` server-fetch stub on
-    top of the reminder-transfer fake -- the Automations tab's server
-    half is a live fetch (`_load_server_automations`), never read off a
-    local mirror row directly, so a server-owned row reaches the UI
-    exactly this way in real usage too."""
-
-    def __init__(self, items: list[dict]) -> None:
-        super().__init__()
-        self._items = items
-
-    async def list_automation_definitions(self, limit: int, offset: int):
-        page = self._items[offset : offset + limit]
-        return {"items": page, "total": len(self._items), "has_more": False}
-
-    async def list_automation_definition_audit(self, definition_id: str):
-        # Selecting a row fires the run-history fetch; empty is a valid,
-        # honest response and keeps this fake minimal.
-        return {"items": [], "total": 0}
-
-
-async def _select_automations_tab_row(pilot, index: int = 0) -> None:
-    workbench = pilot.app.screen
-    tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-    tabs.active = "scheduling-automations-tab"
-    table = workbench.query_one("#scheduling-automations-table", DataTable)
-    table.cursor_coordinate = (index, 0)
-    await pilot.pause()
-
-
-@pytest.mark.asyncio
-async def test_begin_to_local_from_a_server_mirror_row(transfer_db, monkeypatch):
-    """Selecting a live server-fetched definition and pressing `m` mirrors
-    it locally (same seam `_edit_selected_automation` already uses), then
-    starts a real `begin_transfer_to_local`: a dormant local copy is
-    created and the mirror itself stays untouched (spec §6.2)."""
-    _stub_ready_health(monkeypatch)
-    db = transfer_db
-    server_client = _FakeAutomationsServerClient(
-        [{"id": "srv-9", "name": "Nightly digest", "family": "recurring_question"}]
-    )
-    app = TransferWorkbenchTestApp(db, server_client=server_client)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_automations_tab_row(pilot)
-        assert pilot.app.screen._selected_automation_id == "srv-9"
-
-        pilot.app.screen.action_move_automation_to_local()
-        await pilot.pause()
-
-        assert isinstance(pilot.app.screen, ConfirmationDialog)
-        assert "Nightly digest" in pilot.app.screen.message
-        pilot.app.screen.dismiss(True)
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        rows = db.list_automation_definitions(owner_id="server:1")
-        assert len(rows) == 1
-        mirror = rows[0]
-        assert mirror["server_id"] == "srv-9"
-        assert mirror["transfer_state"] is None  # untouched by the release
-
-        local_rows = db.list_automation_definitions(owner_id="local")
-        assert len(local_rows) == 1
-        copy = local_rows[0]
-        assert copy["server_id"] is None
-        assert copy["transfer_state"] == "from_server_pending"
-
-
-@pytest.mark.asyncio
-async def test_automation_move_to_local_refusal_renders_inline(transfer_db):
-    """A row that isn't server-owned refuses `to_local` -- the reason
-    renders inline in the tab's notice Static (fix round item 1's
-    "refusal -> inline reason" flow; the tab has no per-row Static)."""
-    db = transfer_db
-    _local_definition(db, name="Local only")
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_automations_tab_row(pilot)
-
-        pilot.app.screen.action_move_automation_to_local()
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        notice = pilot.app.screen.query_one("#scheduling-automations-notice", Static)
-        assert "not server-owned" in notice.visual.plain
-        # No dialog opened -- refused before ever confirming.
-        assert not isinstance(pilot.app.screen, ConfirmationDialog)
-
-
-@pytest.mark.asyncio
-async def test_cancel_automation_transfer_routes_to_dormant_copy(
-    transfer_db, monkeypatch
-):
-    """Cancel on the selected (dormant-copy) row deletes exactly that
-    copy and leaves the mirror's transfer_state untouched -- same
-    critical case as the reminder side's cancel-row-id test, driven
-    through the Automations tab's own keybinding this time."""
-    _stub_ready_health(monkeypatch)
-    db = transfer_db
-    mirror_id = db.create_automation_definition(
-        owner_id="server:1",
-        server_id="srv-7",
-        family="recurring_question",
-        name="Weekly roundup",
-        schedule={"kind": "interval", "every_seconds": 604800},
-        input={"question": "What happened this week?"},
-        config={},
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-
-        service = app.scheduling_service
-        outcome = await service.begin_transfer_to_local(
-            "automation_definition", mirror_id
-        )
-        assert outcome.status == "pending"
-        copy_id = outcome.row_id
-        assert copy_id is not None and copy_id != mirror_id
-
-        await pilot.app.screen.load_automations()
-        await pilot.pause()
-        await _select_automations_tab_row(pilot)
-        assert pilot.app.screen._selected_automation_id == copy_id
-
-        pilot.app.screen.action_cancel_automation_transfer()
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        assert db.get_automation_definition(copy_id) is None
-        mirror_row = db.get_automation_definition(mirror_id)
-        assert mirror_row is not None
-        assert mirror_row["transfer_state"] is None
-
-
-@pytest.mark.asyncio
-async def test_retry_automation_transfer_only_on_failed(transfer_db):
-    """Retry re-arms a definitively-failed local -> server transfer
-    (spec §6.1.5) -- same retry leg Task 6 built for reminders, exercised
-    here through the Automations tab's `y` keybinding."""
-    db = transfer_db
-    definition_id = _local_definition(db, name="Flaky automation")
-    db.set_transfer_state(
-        "automation_definition", definition_id, "to_server_pending", expected=(None,)
-    )
-    db.set_transfer_state(
-        "automation_definition",
-        definition_id,
-        "to_server_sent",
-        expected=("to_server_pending",),
-    )
-    db.set_transfer_state(
-        "automation_definition",
-        definition_id,
-        "to_server_failed",
-        expected=("to_server_sent",),
-    )
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_automations_tab_row(pilot)
-        assert pilot.app.screen._selected_automation_id == definition_id
-
-        pilot.app.screen.action_retry_automation_transfer()
-        await pilot.pause()
-        assert isinstance(pilot.app.screen, ConfirmationDialog)
-        pilot.app.screen.dismiss(True)
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        row = db.get_automation_definition(definition_id)
-        assert row["transfer_state"] == "to_server_pending"
-
-
-@pytest.mark.asyncio
-async def test_automation_transfer_actions_no_op_outside_automations_tab(
-    transfer_db,
-):
-    """Pressing m/y/k while the Queue tab is active refuses with a
-    switch-tabs notice rather than acting on a stale selection."""
-    db = transfer_db
-    _local_definition(db)
-    app = TransferWorkbenchTestApp(db)
-    notifications: list[str] = []
-    async with app.run_test() as pilot:
-        pilot.app.notify = lambda message, **kw: notifications.append(message)
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        # Queue tab is active by default -- never switched.
-
-        pilot.app.screen.action_move_automation_to_local()
-        pilot.app.screen.action_retry_automation_transfer()
-        pilot.app.screen.action_cancel_automation_transfer()
-        await pilot.pause()
-
-        assert len(notifications) == 3
-        assert all("Automations tab" in message for message in notifications)
-
-
-# ---------------------------------------------------------------------------
-# Final whole-branch review fixes (2026-09-02)
-# ---------------------------------------------------------------------------
-
-
-@pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "state", ["to_server_pending", "to_server_sent", "from_server_pending"]
-)
-async def test_in_flight_row_disables_lifecycle_actions_with_a_reason(state):
-    """Final review I7 / spec §6.3: an in-flight row is read-only except
-    cancel. The reason must be in TEXT, not only a tooltip (UX-073)."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(owner_id="local", transfer_state=state))
-        detail.set_lifecycle_lock("This row is moving -- read-only.")
-
-        for button_id in (
-            "scheduling-edit-task",
-            "scheduling-delete-task",
-            "scheduling-enable-task",
-            "scheduling-disable-task",
-        ):
-            assert detail.query_one(f"#{button_id}", Button).disabled, button_id
-        why = detail.query_one("#scheduling-transfer-why", Static)
-        assert "read-only" in why.visual.plain
-
-
-@pytest.mark.asyncio
-async def test_clearing_the_lifecycle_lock_restores_the_buttons():
-    """An editable row keeps its normal enable/disable logic, and the lock
-    line is removed from the shared reason Static."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(_reminder(owner_id="local", transfer_state="to_server_sent"))
-        detail.set_lifecycle_lock("locked for now")
-        detail.set_task(_reminder(owner_id="local", transfer_state=None, enabled=True))
-        detail.set_lifecycle_lock(None)
-
-        assert not detail.query_one("#scheduling-edit-task", Button).disabled
-        assert not detail.query_one("#scheduling-delete-task", Button).disabled
-        # set_task's own UX-059 rule still owns these two.
-        assert detail.query_one("#scheduling-enable-task", Button).disabled
-        assert not detail.query_one("#scheduling-disable-task", Button).disabled
-        why = detail.query_one("#scheduling-transfer-why", Static)
-        assert "locked for now" not in why.visual.plain
-
-
-@pytest.mark.asyncio
-async def test_lifecycle_lock_shares_the_reason_static_without_clobbering_it():
-    """`set_transfer_reasons` and `set_lifecycle_lock` both write the one
-    reason Static (the workbench calls them in that order): the lock line
-    is appended and later removed on its own, leaving the transfer
-    reasons intact."""
-    async with _DetailHarnessApp().run_test() as pilot:
-        detail = pilot.app.query_one(TaskDetail)
-        detail.set_task(
-            _reminder(owner_id="local", transfer_state="to_server_pending")
-        )
-        detail.set_transfer_reasons(
-            to_server_reason="already moving",
-            to_local_reason=None,
-            retry_reason=None,
-            cancel_reason=None,
-            retry_errors=[],
-        )
-        detail.set_lifecycle_lock("read-only while moving")
-        why = detail.query_one("#scheduling-transfer-why", Static)
-        assert "Move to server: already moving" in why.visual.plain
-        assert "read-only while moving" in why.visual.plain
-
-        detail.set_lifecycle_lock(None)
-        assert why.visual.plain == "Move to server: already moving"
 
 
 @pytest.mark.asyncio
@@ -939,78 +263,6 @@ async def test_key_bound_edit_refuses_on_a_transferring_row(transfer_db):
 
 
 @pytest.mark.asyncio
-async def test_automation_move_to_server_has_its_own_trigger(transfer_db):
-    """Final review M8: a plain LOCAL definition had no way to start a
-    move -- `y`/Retry only ever appeared as a retry. `M` is that trigger,
-    on the same facade call."""
-    db = transfer_db
-    definition_id = _local_definition(db, name="Nightly digest")
-    app = TransferWorkbenchTestApp(db)
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        await _select_automations_tab_row(pilot)
-
-        pilot.app.screen.action_move_automation_to_server()
-        await pilot.pause()
-        assert isinstance(pilot.app.screen, ConfirmationDialog)
-        pilot.app.screen.dismiss(True)
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        row = db.get_automation_definition(definition_id)
-        assert row["transfer_state"] == "to_server_pending"
-        mutations = db.get_pending_mutations(
-            "server:1", primitive="automation_definition"
-        )
-        assert [m["payload"]["action"] for m in mutations] == ["transfer_to_server"]
-
-
-@pytest.mark.asyncio
-async def test_move_to_server_is_advertised_in_the_footer_hints(transfer_db):
-    """ADR-031: footer hints stay 1:1 with BINDINGS."""
-    binding_keys = {binding.key for binding in SchedulesWorkbench.BINDINGS}
-    hint_keys = {key for key, _label in SchedulesWorkbench.SCHEDULES_SHORTCUTS}
-    assert "M" in binding_keys and "M" in hint_keys
-    assert hint_keys <= binding_keys
-
-
-@pytest.mark.asyncio
-async def test_cancel_toast_does_not_promise_no_server_effect(transfer_db):
-    """Final review L13: `from_server_pending` also covers a release whose
-    delete already landed but whose ack was lost, so the toast may not
-    claim nothing happened -- only that nothing further will be sent."""
-    db = transfer_db
-    mirror_id = db.create_reminder_task(
-        owner_id="server:1",
-        server_id="srv-1",
-        title="Standup",
-        schedule_kind="one_time",
-        run_at=(datetime.now(timezone.utc) + timedelta(days=1)).isoformat(),
-    )
-    copy_id = db.create_local_copy_from_mirror("reminder_task", mirror_id)
-    app = TransferWorkbenchTestApp(db)
-    notifications: list[str] = []
-    async with app.run_test() as pilot:
-        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
-        await pilot.pause()
-        rows = pilot.app.screen._visible_tasks
-        index = next(i for i, task in enumerate(rows) if task.id == copy_id)
-        await _select_row(pilot, index)
-        pilot.app.notify = lambda message, **kw: notifications.append(message)
-
-        pilot.app.screen.query_one("#scheduling-cancel-transfer", Button).press()
-        await pilot.pause()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        assert notifications, "cancel must report its outcome"
-        assert "nothing further will be sent" in notifications[0]
-        assert "no server-side effect" not in notifications[0]
-
-
-@pytest.mark.asyncio
 async def test_transfer_confirm_dialog_renders_brackets_literally():
     """Task 6's escaping saga, fourth surface.
 
@@ -1037,3 +289,43 @@ async def test_transfer_confirm_dialog_renders_brackets_literally():
         rendered = str(pilot.app.screen.query_one(".dialog-message").render())
         assert "Nightly [PR-6] digest" in rendered
         assert "Field [bold] does not transfer" in rendered
+
+
+def test_cancel_toast_does_not_promise_no_server_effect():
+    """Final review L13: `from_server_pending` also covers a release whose
+    delete already landed but whose ack was lost, so the toast may not
+    claim nothing happened -- only that nothing further will be sent.
+
+    redesign PR-4 task 4: was an integration test driven through the now-
+    retired legacy Cancel button; `_cancel_toast_text` is unchanged and
+    still the SAME function the Runs-on row's own Cancel now drives
+    (`_run_owner_cancel`, also pinned end-to-end in `test_schedules_
+    workbench.py::test_runs_on_cancel_button_cancels_the_dormant_copy_
+    using_its_own_id`) -- a direct call is the cheapest belt for the copy
+    itself.
+    """
+    message = _cancel_toast_text("Standup")
+    assert "nothing further will be sent" in message
+    assert "no server-side effect" not in message
+
+
+def test_transfer_pending_toast_is_honest_about_still_running_locally():
+    """spec §6.1.1: a queued-not-sent `to_server` transfer must not claim
+    the task stopped running here -- it still executes locally until the
+    server accepts it. redesign PR-4 task 4: was an integration test
+    driven through the now-retired legacy Move-to-server button; `_
+    transfer_pending_toast_text` is unchanged and still the SAME
+    `@staticmethod` the Runs-on row's own dropdown now drives
+    (`_run_owner_transfer`, also pinned end-to-end in `test_schedules_
+    workbench.py::test_runs_on_dropdown_confirm_begins_to_server_
+    transfer`) -- a direct call is the cheapest belt for the copy
+    itself."""
+    to_server = SchedulesWorkbench._transfer_pending_toast_text(
+        "Standup", "to_server"
+    )
+    assert "still runs on this device" in to_server
+
+    to_local = SchedulesWorkbench._transfer_pending_toast_text(
+        "Standup", "to_local"
+    )
+    assert "dormant copy" in to_local

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from textual.widgets import Button, DataTable, Input, Static, TabbedContent
+from textual.widgets import Button, DataTable, Input, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.schedules_test_helpers import MockSchedulingDB, MockSchedulingServiceMixin
@@ -528,10 +528,17 @@ async def test_search_narrows_a_mixed_reminder_and_definition_list():
 
 
 # ---------------------------------------------------------------------------
-# Fix round 2 (task-2 review addendum): an Automations-tab definition
-# mutation must not leave the Queue's cached definitions stale for the
-# rest of the session -- a reminder-only refresh upgrades to one full
-# fetch, and so does switching to the Queue tab while stale.
+# Fix round 2 (task-2 review addendum): a definition mutation must not
+# leave the Queue's cached definitions stale for the rest of the session
+# -- a reminder-only refresh upgrades to one full fetch, and so does
+# returning to the screen while stale.
+#
+# redesign PR-4 task 5 (the retirement): "switching to the Queue tab
+# while stale" was the original trigger and it no longer exists -- there
+# is one surface and no `TabbedContent`. The staleness MACHINE is
+# unchanged (every set-site kept), only its consumer moved: onto
+# `on_screen_resume` -> `_consume_definitions_stale`, which covers every
+# pushed view and modal this screen opens. Pinned below.
 # ---------------------------------------------------------------------------
 
 
@@ -555,9 +562,16 @@ async def test_automations_edit_save_refetches_definitions_immediately():
     """Round 2 pinned that a save marks the cache stale and the NEXT
     reminder-only refresh upgrades to one full fetch. Final review F1
     moved that fetch forward: the save's own path refreshes the Queue
-    (its create entry point is the Queue rail, which never fires
-    `TabActivated`), so the flag is consumed at the save -- exactly one
-    definitions fetch then, and none owed to the next reminder action."""
+    (its create entry point is the Queue rail, which never left the
+    surface), so the flag is consumed at the save -- exactly one
+    definitions fetch then, and none owed to the next reminder action.
+
+    redesign PR-4 task 5: the count drops 2 -> 1. The save used to fire
+    the Queue refresh AND a second, separate Automations-tab list reload
+    (`_request_automations_refresh`), each with its own definitions
+    fetch. That tab is retired and the Queue IS the definitions list, so
+    the duplicate fetch went with it -- same visible outcome, half the
+    DB work."""
     service, calls = _counting_definitions_service()
 
     class _CountingApp(ConsolidatedCSSApp):
@@ -576,9 +590,8 @@ async def test_automations_edit_save_refetches_definitions_immediately():
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
         assert workbench._definitions_stale is False
-        assert len(calls) == calls_before_save + 2, (
-            "the save refreshes the Automations list AND the Queue, one "
-            "definitions fetch each"
+        assert len(calls) == calls_before_save + 1, (
+            "the save refreshes the one definitions surface exactly once"
         )
         calls_after_save = len(calls)
 
@@ -599,10 +612,22 @@ async def test_automations_edit_save_refetches_definitions_immediately():
 
 
 @pytest.mark.asyncio
-async def test_automations_run_now_then_tab_switch_to_queue_refreshes():
-    """An Automations-tab run-now marks the cache stale; switching to
-    the Queue tab while stale upgrades the next refresh to a full one,
-    even with no reminder action in between."""
+async def test_local_run_now_refetches_the_queue_definitions():
+    """A local run-now is an Automations-era mutation path: it must still
+    upgrade the Queue's definitions snapshot.
+
+    redesign PR-4 task 5 rewrite (retirement citation). This used to be
+    `test_automations_run_now_then_tab_switch_to_queue_refreshes`: run
+    now, assert the stale FLAG, then flip to the Automations tab and back
+    to the Queue and assert the arrival consumed it. The tabs are retired,
+    so the flip half of that scenario cannot be staged at all -- and the
+    run-now path no longer parks the refresh behind a lazy consumer: the
+    reload it used to ask the Automations tab for is now the Queue's own
+    reload, so the fetch happens at the mutation. The claim under test is
+    unchanged (`run-now leaves the definitions rows current`); only the
+    trigger it is observed through moved. The lazy consumer's own
+    re-home is pinned separately, below.
+    """
     service, calls = _counting_definitions_service()
     service.run_automation_now = AsyncMock(
         return_value={"run_id": "run-1", "deduped": False}
@@ -615,6 +640,7 @@ async def test_automations_run_now_then_tab_switch_to_queue_refreshes():
 
     async with _CountingApp().run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
+        calls_before_run = len(calls)
         definition = next(
             row.source_row
             for row in workbench._visible_rows
@@ -624,21 +650,91 @@ async def test_automations_run_now_then_tab_switch_to_queue_refreshes():
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
-        assert workbench._definitions_stale is True
-        calls_after_run = len(calls)
 
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-automations-tab"
+        assert service.run_automation_now.await_count == 1
+        assert workbench._definitions_stale is False, (
+            "the run's own refresh consumed the staleness it marked"
+        )
+        assert len(calls) == calls_before_run + 1, (
+            "run-now refetches the definitions exactly once"
+        )
+
+
+@pytest.mark.asyncio
+async def test_returning_to_the_screen_while_stale_refetches_definitions():
+    """The staleness consumer's NEW home (redesign PR-4 task 5).
+
+    The retired `TabbedContent.TabActivated` handler fired when the user
+    arrived back on the Queue tab. With one surface, the equivalent
+    moment is the push/pop lifecycle (plan ruling 6): pushing any hosted
+    view or modal suspends this screen, popping resumes it. This drives
+    exactly that -- a mutation path that does NOT self-refresh (the flag
+    is set here directly, as `_definition_owner_action` does before it
+    can know whether its transfer will even resolve), then a real push
+    and pop of the conflicts overlay -- and pins that the arrival back
+    fetches definitions exactly once and clears the flag.
+    """
+    service, calls = _counting_definitions_service()
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        workbench._definitions_stale = True
+        calls_before_push = len(calls)
+
+        workbench._push_conflicts_overlay()
         await pilot.pause()
-        tabs.active = "scheduling-queue-tab"
+        assert pilot.app.screen is not workbench
+        assert len(calls) == calls_before_push, (
+            "opening the view must not itself refetch"
+        )
+
+        await pilot.press("escape")
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()
 
+        assert pilot.app.screen is workbench
         assert workbench._definitions_stale is False
-        assert len(calls) == calls_after_run + 1, (
-            "arriving on the Queue tab while stale must fetch definitions"
-            " exactly once"
+        assert len(calls) == calls_before_push + 1, (
+            "returning to the screen while stale fetches definitions once"
+        )
+
+
+@pytest.mark.asyncio
+async def test_returning_to_the_screen_when_nothing_is_stale_refetches_nothing():
+    """The re-homed consumer's own no-op half: `ScreenResume` fires on
+    every pop (and when this screen first becomes active), so it must
+    stay free when no definition mutation is pending. This is the
+    regression the retired handler had to be taught -- its own docstring
+    recorded a mount-time double-reload -- restated against the new
+    trigger."""
+    service, calls = _counting_definitions_service()
+
+    class _CountingApp(ConsolidatedCSSApp):
+        def __init__(self, *args, **kwargs) -> None:
+            super().__init__(*args, **kwargs)
+            self.scheduling_service = service
+
+    async with _CountingApp().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        assert workbench._definitions_stale is False
+        calls_before_push = len(calls)
+
+        workbench._push_conflicts_overlay()
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert pilot.app.screen is workbench
+        assert len(calls) == calls_before_push, (
+            "a pop with nothing stale must not fetch definitions"
         )
 
 
@@ -803,20 +899,22 @@ class _TransferredService(MockSchedulingServiceMixin):
 
 @pytest.mark.asyncio
 async def test_transferred_definition_unread_matches_the_results_badge():
-    """Final review F2, the review's own repro: the Results tab badge read
-    2 while the Queue counted 0 (and hid the rail button) for the same DB,
+    """Final review F2, the review's own repro: the results badge read 2
+    while the Queue counted 0 (and hid the rail button) for the same DB,
     because the Queue indexed the DISPLAY merge -- which drops every local
-    row carrying a `server_id`."""
+    row carrying a `server_id`.
+
+    redesign PR-4 task 5: the badge is read off the rail's `Results (N)`
+    button instead of the retired Results TAB's label. Same number, same
+    single `count_unread_results` source (`_refresh_results_badge`) -- the
+    tab label was always a mirror of it, and it is the mirror that was
+    retired, not the count."""
     service = _TransferredService()
     async with _app_for(service, with_server=True).run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
 
         queue_unread = sum(row.unread_count for row in workbench._all_rows)
-        badge = str(
-            workbench.query_one("#scheduling-tabs", TabbedContent)
-            .get_tab("scheduling-results-tab")
-            .label
-        )
+        badge = str(workbench.query_one("#scheduling-results-badge", Button).label)
         assert "Results (2)" in badge
         assert queue_unread == 2, (
             "the Queue's unread count must equal the Results badge for the "
@@ -1013,8 +1111,15 @@ async def test_results_pull_reveals_the_rail_mark_all_read_button():
 
 @pytest.mark.asyncio
 async def test_marking_all_read_from_the_results_tab_clears_the_queue_dots():
-    """The inverse half of F5: `a` on the Results tab shares the fan-out,
-    so the Queue's dots and the rail button must drop with it."""
+    """The inverse half of F5: mark-all-read shares the fan-out, so the
+    Queue's dots and the rail button must drop with it.
+
+    redesign PR-4 task 5: the tab flip this used to stage first
+    (`tabs.active = "scheduling-results-tab"`, satisfying the retired
+    `_is_results_tab_active` gate) is gone -- `action_mark_all_results_
+    read` is ungated now and IS the rail button's own handler, so the
+    action is simply invoked. The claim -- one fan-out clears both the
+    results state and the Queue's derived dots -- is unchanged."""
     service = _MixedService()
     async with _app_for(service).run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
@@ -1028,9 +1133,6 @@ async def test_marking_all_read_from_the_results_tab_clears_the_queue_dots():
             return True
 
         service.review_automation_result = _review
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        tabs.active = "scheduling-results-tab"
-        await pilot.pause()
         workbench.action_mark_all_results_read()
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
@@ -1066,14 +1168,20 @@ async def test_filter_placeholder_names_title_and_question():
 async def test_definition_row_keys_answer_honestly_by_kind():
     """Final review F8, superseded by redesign PR-4 ruling 1 + task 3:
     `x`/`space`/`d` (mark/toggle/delete) are UNCHANGED -- still not wired
-    to definition rows -- and keep answering "managed on the Automations
-    tab" rather than doing nothing. `r`/`e` are ROUTED now: `r` attempts
-    a real dispatch for ANY family (`_run_automation_now` is owner-routed
-    only, never family-gated); `e` opens `AutomationDefinitionForm` for
-    this fixture's `recurring_question` row (see `test_definition_row_
-    edit_refuses_honestly_for_a_non_recurring_question_row` for the
-    family-gated refusal, which reads differently from the "Automations
-    tab" copy below)."""
+    to definition rows -- and must still ANSWER rather than do nothing.
+    `r`/`e` are ROUTED now: `r` attempts a real dispatch for ANY family
+    (`_run_automation_now` is owner-routed only, never family-gated); `e`
+    opens `AutomationDefinitionForm` for this fixture's
+    `recurring_question` row (see `test_definition_row_edit_refuses_
+    honestly_for_a_non_recurring_question_row` for the family-gated
+    refusal).
+
+    redesign PR-4 task 5: the refusal copy no longer says "managed on the
+    Automations tab" -- there is no such tab to send anyone to, and by
+    task 3 the pointer was already wrong (the verbs that DO work on a
+    definition row are routed before this copy is ever reached). It names
+    the limit instead. What is pinned is unchanged: these three keys
+    answer, and they do not act."""
     async with _App().run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
         table = workbench.query_one("#scheduling-task-table", DataTable)
@@ -1095,8 +1203,12 @@ async def test_definition_row_keys_answer_honestly_by_kind():
             await pilot.pause()
             new = _toasts(pilot.app)[before:]
             assert new, f"{action.__name__} answered nothing at all"
-            assert any("Automations tab" in message for message in new), (
-                f"{action.__name__} said {new!r}"
+            assert any(
+                "Automations don't support" in message for message in new
+            ), f"{action.__name__} said {new!r}"
+            assert not any("Automations tab" in message for message in new), (
+                "the retired tab must not be named as a place to go: "
+                f"{new!r}"
             )
 
         # `d` must not reach TaskDetail.request_delete, which would open
@@ -1229,11 +1341,29 @@ class _ServerRunNowService(MockSchedulingServiceMixin):
 @pytest.mark.asyncio
 async def test_server_run_now_marks_definitions_stale():
     """Final review F11: the branch's own rule is "mark staleness at each
-    genuine mutation call site"; only the local twin did."""
+    genuine mutation call site"; only the local twin did.
+
+    redesign PR-4 task 5: the server twin now also REFRESHES, like the
+    local twin always has -- the audit-pane re-fetches it used to do
+    instead retired with the Automations tab's history pane. So the flag
+    is set and then immediately consumed, and the observable claim
+    becomes the one that always mattered: after a server run-now the
+    Queue's definitions have been refetched. (The set-site itself is
+    unchanged, per the brief's "the staleness machine keeps every
+    set-site" -- `_definitions_stale = True` still runs before the
+    refresh, so a concurrent reminder-only reload upgrades itself.)"""
     service = _ServerRunNowService()
     async with _app_for(service, with_server=True).run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
         assert workbench._definitions_stale is False
+        definition_fetches: list[tuple] = []
+        _listing = service.server_client.list_automation_definitions
+
+        async def _counting_listing(*args, **kwargs):
+            definition_fetches.append((args, kwargs))
+            return await _listing(*args, **kwargs)
+
+        service.server_client.list_automation_definitions = _counting_listing
 
         workbench._run_automation_now(
             {
@@ -1249,7 +1379,12 @@ async def test_server_run_now_marks_definitions_stale():
         await pilot.pause()
 
         service.server_client.run_automation_definition_now.assert_awaited_once()
-        assert workbench._definitions_stale is True
+        assert workbench._definitions_stale is False, (
+            "the run's own refresh consumed the staleness it marked"
+        )
+        assert definition_fetches, (
+            "a server run-now must refetch the definitions listing"
+        )
 
 
 # --- F12: the ticker does not re-read the definition detail ---------------
@@ -1280,6 +1415,63 @@ async def test_tick_skips_the_definition_detail_read_for_an_unchanged_row():
             if row.kind == "definition"
         )
         table.move_cursor(row=definition_index)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        after_selection = len(reads)
+        assert after_selection > 0
+
+        workbench._refresh_next_run_rendering()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(reads) == after_selection, "a tick must not re-read the DB"
+
+        # A refresh-driven render still re-feeds the pane.
+        workbench._render_table()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert len(reads) == after_selection + 1
+
+
+@pytest.mark.asyncio
+async def test_tick_skips_the_reminder_detail_reads_for_an_unchanged_row():
+    """redesign PR-4 task 5 (ruling 5's rider): F12's guard was applied to
+    ONE of `_update_detail_for_index`'s two branches.
+
+    A selected REMINDER row re-ran `_run_history_for` + `_incidents_for`
+    on every tick -- `list_task_runs` once and `list_task_incidents`
+    twice (both id spellings), three synchronous `service.db` reads a
+    minute for a row that had not moved, against the ticker's own "no
+    reload/DB on tick" contract (PR-2 plan Task 4). This mirrors the
+    definition branch's guard and its exception: a refresh-driven render
+    still re-feeds, because the DATA can change while the selection
+    stands still.
+    """
+    service = _MixedService()
+    reads: list[tuple] = []
+
+    # `MockSchedulingDB` implements neither reader, and `_run_history_for`/
+    # `_incidents_for` are both fail-safe (`callable(...)`-gated), so the
+    # unguarded branch silently made ZERO reads against the plain mock --
+    # a real DB is what pays the cost. Install a real-shaped
+    # `list_task_runs` so the tick either does or does not call it.
+    def _counting(*args, **kwargs):
+        reads.append((args, kwargs))
+        return []
+
+    service.db.list_task_runs = _counting
+
+    async with _app_for(service).run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        reminder_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "reminder"
+        )
+        table.move_cursor(row=reminder_index)
         await pilot.pause()
         await pilot.app.workers.wait_for_complete()
         await pilot.pause()

--- a/Tests/UI/test_schedules_unified_list.py
+++ b/Tests/UI/test_schedules_unified_list.py
@@ -26,6 +26,9 @@ from tldw_chatbook.Scheduling.events import (
 )
 from tldw_chatbook.Scheduling.models import ReminderTask, ScheduleKind
 from tldw_chatbook.UI.Screens.scheduling.definition_detail import DefinitionDetail
+from tldw_chatbook.UI.Screens.scheduling.forms.automation_definition_form import (
+    AutomationDefinitionForm,
+)
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.task_detail import TaskDetail
 
@@ -53,17 +56,22 @@ def _reminder(
     )
 
 
-def _definition(def_id: str, name: str, *, lifecycle: str = "configured") -> dict:
+def _definition(
+    def_id: str,
+    name: str,
+    *,
+    lifecycle: str = "configured",
+    family: str = "recurring_question",
+) -> dict:
     return {
         "id": def_id,
         "server_id": None,
         "owner_id": "local",
         "name": name,
-        # Qodo MEDIUM (schedules-redesign PR-2): `build_unified_rows`
-        # filters definitions to `family == "recurring_question"` --
-        # every real definition row carries a family, so this fixture
-        # must too.
-        "family": "recurring_question",
+        # `build_unified_rows` lists every family now (PR-4 ruling 1) --
+        # every real definition row carries a family regardless, so this
+        # fixture always sets one.
+        "family": family,
         "lifecycle": lifecycle,
         "schedule": {"kind": "one_time", "run_at": "2099-01-01T00:00:00+00:00"},
         "input": {"question": f"Question for {name}?"},
@@ -367,14 +375,20 @@ async def test_reminder_actions_still_fire_amid_a_mixed_list():
 
 
 # ---------------------------------------------------------------------------
-# Definition rows: no actions in this PR
+# Definition rows: mark/toggle still no-op; run-now/edit are routed
+# (redesign PR-4, task 3 -- supersedes the original "no actions until
+# PR-4" pin from plan ruling 1).
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_definition_rows_expose_no_actions():
-    """Edit/mark/toggle/delete on a definition row must no-op -- plan
-    ruling 1: definition rows are viewable + detail only until PR-4."""
+async def test_definition_row_mark_and_toggle_still_no_op():
+    """Mark/toggle-enabled on a definition row still no-op -- PR-4 task 3
+    only wired run-now (`r`) and edit-in-full (`e`) onto Queue definition
+    rows; `x`/`space` remain unrouted (see `test_definition_row_edit_
+    opens_the_form_for_a_recurring_question_row` for the two that now
+    act, and `test_definition_row_keys_answer_honestly_by_kind` for the
+    full per-key picture)."""
     async with _App().run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
         table = workbench.query_one("#scheduling-task-table", DataTable)
@@ -393,13 +407,35 @@ async def test_definition_rows_expose_no_actions():
         await pilot.pause()
         assert not workbench._marked_ids
 
-        workbench.action_edit_task()
-        await pilot.pause()
-        assert isinstance(pilot.app.screen, SchedulesWorkbench)  # no form pushed
-
         workbench.action_toggle_enabled()
         await pilot.pause()
         assert workbench._scheduling_service.updated == []
+
+
+@pytest.mark.asyncio
+async def test_definition_row_edit_opens_the_form_for_a_recurring_question_row():
+    """redesign PR-4, task 3: `e` on a Queue definition row now opens the
+    SAME `AutomationDefinitionForm` the Automations tab's own `e` opens
+    (`_edit_selected_automation` reused via `_selected_queue_definition`)
+    -- this fixture's rows are all `recurring_question`, so the family
+    gate never refuses here."""
+    async with _App().run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        definition_index = next(
+            i
+            for i, row in enumerate(workbench._visible_rows)
+            if row.kind == "definition"
+        )
+        table.move_cursor(row=definition_index)
+        await pilot.pause()
+
+        workbench.action_edit_task()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
 
 
 # ---------------------------------------------------------------------------
@@ -1020,13 +1056,24 @@ async def test_filter_placeholder_names_title_and_question():
         assert "type" not in placeholder.lower()
 
 
-# --- F8: definition rows answer the reminder keys honestly ----------------
+# --- F8: definition rows answer the reminder keys honestly -----------------
+# (redesign PR-4, task 3 supersedes part of this: `r`/`e` are ROUTED now,
+# not refused -- see the class/test docstrings below for the current
+# per-key picture.)
 
 
 @pytest.mark.asyncio
-async def test_definition_row_keys_say_where_the_action_lives():
-    """Final review F8: `r` was swallowed in silence and the other keys
-    answered "select a task first" while a row was plainly selected."""
+async def test_definition_row_keys_answer_honestly_by_kind():
+    """Final review F8, superseded by redesign PR-4 ruling 1 + task 3:
+    `x`/`space`/`d` (mark/toggle/delete) are UNCHANGED -- still not wired
+    to definition rows -- and keep answering "managed on the Automations
+    tab" rather than doing nothing. `r`/`e` are ROUTED now: `r` attempts
+    a real dispatch for ANY family (`_run_automation_now` is owner-routed
+    only, never family-gated); `e` opens `AutomationDefinitionForm` for
+    this fixture's `recurring_question` row (see `test_definition_row_
+    edit_refuses_honestly_for_a_non_recurring_question_row` for the
+    family-gated refusal, which reads differently from the "Automations
+    tab" copy below)."""
     async with _App().run_test(size=(160, 48)) as pilot:
         workbench = await _mounted(pilot)
         table = workbench.query_one("#scheduling-task-table", DataTable)
@@ -1039,8 +1086,6 @@ async def test_definition_row_keys_say_where_the_action_lives():
         await pilot.pause()
 
         for action in (
-            workbench.action_run_task_now,
-            workbench.action_edit_task,
             workbench.action_mark_task,
             workbench.action_toggle_enabled,
             workbench.action_delete,
@@ -1054,9 +1099,71 @@ async def test_definition_row_keys_say_where_the_action_lives():
                 f"{action.__name__} said {new!r}"
             )
 
-        # d must not reach TaskDetail.request_delete, which would open a
-        # confirmation for whatever reminder the pane last held.
+        # `d` must not reach TaskDetail.request_delete, which would open
+        # a confirmation for whatever reminder the pane last held.
         assert isinstance(pilot.app.screen, SchedulesWorkbench)
+
+        # `r`: routed now (task 3) -- a real dispatch attempt, not the
+        # old refusal. The stub service has no `run_automation_now`, so
+        # the attempt fails honestly rather than silently.
+        before = len(_toasts(pilot.app))
+        workbench.action_run_task_now()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        run_toasts = _toasts(pilot.app)[before:]
+        assert any("Failed to run" in message for message in run_toasts), run_toasts
+
+        # `e`: routed now too -- opens the SAME AutomationDefinitionForm
+        # the Automations tab's own `e` opens (this row is `recurring_
+        # question`).
+        workbench.action_edit_task()
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, AutomationDefinitionForm)
+
+
+class _AgentTaskOnlyService(MockSchedulingServiceMixin):
+    """One `agent_task` definition, no reminders -- isolates the Queue's
+    only row so `e`'s family-gated refusal can be pinned deterministically
+    (redesign PR-4 ruling 1: a non-`recurring_question` definition now
+    has a home on the Queue too)."""
+
+    def __init__(self) -> None:
+        self.db = MockSchedulingDB(
+            automation_definitions=[
+                _definition("def-agent", "Nightly agent run", family="agent_task"),
+            ]
+        )
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_definition_row_edit_refuses_honestly_for_a_non_recurring_question_row():
+    """redesign PR-4, task 3: `e` on an `agent_task` Queue row refuses --
+    the SAME family-gate copy the Automations tab's own `e` already gives
+    (`_edit_selected_automation`'s existing refusal, reused verbatim) --
+    which is NOT the "managed on the Automations tab" copy the other
+    (still-unrouted) keys use."""
+    app = _App()
+    app.scheduling_service = _AgentTaskOnlyService()
+    async with app.run_test(size=(160, 48)) as pilot:
+        workbench = await _mounted(pilot)
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        table.move_cursor(row=0)
+        await pilot.pause()
+
+        before = len(_toasts(pilot.app))
+        workbench.action_edit_task()
+        await pilot.pause()
+        new = _toasts(pilot.app)[before:]
+
+        assert isinstance(pilot.app.screen, SchedulesWorkbench)  # no form pushed
+        assert any("recurring-question" in message for message in new), new
+        assert not any("Automations tab" in message for message in new), new
 
 
 # --- F10: empty-state copy at widths where the chips are hidden -----------

--- a/Tests/UI/test_schedules_ux_fixes.py
+++ b/Tests/UI/test_schedules_ux_fixes.py
@@ -45,8 +45,10 @@ def test_schedules_bindings_avoid_terminal_conventions() -> None:
 
 
 def test_schedules_bindings_use_single_letters() -> None:
+    # redesign PR-4 task 4: `c` (create) renamed to `n` (spec §12, survey
+    # §3 "straight rename/rebind").
     bound = {binding.key for binding in SchedulesWorkbench.BINDINGS}
-    assert {"c", "d", "s"} <= bound
+    assert {"n", "d", "s"} <= bound
 
 
 def test_every_binding_has_an_implemented_action() -> None:
@@ -69,8 +71,15 @@ def test_footer_shortcuts_match_bindings_exactly() -> None:
 
 
 def test_stub_actions_removed() -> None:
+    # redesign PR-4 task 4: `action_pause_resume` used to be forbidden
+    # here because only a never-wired stub of that name had ever existed
+    # -- spec §12's `p` key now gives it a real, tested implementation
+    # (routes reminders to `action_toggle_enabled`, definitions to
+    # `_toggle_definition_lifecycle`), so the assertion inverts for that
+    # one name. `action_run_now` (never a real binding's action string --
+    # the run-now key was always `action_run_task_now`) stays forbidden.
     assert not hasattr(SchedulesWorkbench, "action_run_now")
-    assert not hasattr(SchedulesWorkbench, "action_pause_resume")
+    assert hasattr(SchedulesWorkbench, "action_pause_resume")
 
 
 def test_conflict_type_labels_are_plain_language() -> None:

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -2777,7 +2777,8 @@ async def test_empty_queue_shows_friendly_empty_state():
             "#scheduling-task-detail-empty-state", Static
         )
         assert "No scheduled tasks yet" in empty_state.visual.plain
-        assert "Press c" in empty_state.visual.plain
+        # redesign PR-4 task 4: create rebound from c to n (spec §12).
+        assert "Press n" in empty_state.visual.plain
 
 
 @pytest.mark.asyncio
@@ -2791,7 +2792,8 @@ async def test_no_task_selected_shows_friendly_copy():
             "#scheduling-task-detail-empty-state", Static
         )
         assert "Select a task" in empty_state.visual.plain
-        assert "press c" in empty_state.visual.plain
+        # redesign PR-4 task 4: create rebound from c to n (spec §12).
+        assert "press n" in empty_state.visual.plain
 
 
 @pytest.mark.asyncio
@@ -4765,14 +4767,20 @@ async def test_runs_on_retry_button_rebegins_a_failed_transfer(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_runs_on_dropdown_and_legacy_transfer_buttons_coexist(tmp_path):
-    """Coexistence (task-5 brief, pinned): the PR-5 buttons stay
-    untouched until PR-4 -- both surfaces read/write the SAME underlying
-    transfer state and stay in sync with each other, side by side."""
+async def test_legacy_transfer_buttons_are_retired(tmp_path):
+    """redesign PR-4 task 4 (ruling 2): supersedes `test_runs_on_dropdown_
+    and_legacy_transfer_buttons_coexist` -- the PR-3 task 5 "coexistence
+    pinned" window (task-5 brief) is over, and the legacy Move/Retry/
+    Cancel buttons this test used to exercise ALONGSIDE the dropdown are
+    deleted. Begin/cancel via the dropdown itself stays pinned by `test_
+    runs_on_dropdown_confirm_begins_to_server_transfer`/`test_runs_on_
+    cancel_button_cancels_the_dormant_copy_using_its_own_id` (this file);
+    this only pins that the retired ids are actually gone and the
+    dropdown's own affordance is unaffected."""
     app = WorkbenchTestApp()
     db, service = _connected_service(tmp_path, app)
     try:
-        task_id = db.create_reminder_task(
+        db.create_reminder_task(
             owner_id="local",
             title="Nightly check",
             schedule_kind="one_time",
@@ -4786,44 +4794,15 @@ async def test_runs_on_dropdown_and_legacy_transfer_buttons_coexist(tmp_path):
             await pilot.pause()
 
             detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
-
-            # Legacy surface: begin via the EXISTING button, untouched.
-            legacy_to_server = pilot.app.screen.query_one(
-                "#scheduling-transfer-to-server", Button
-            )
-            assert not legacy_to_server.disabled
-            legacy_to_server.press()
-            await pilot.pause()
-            assert isinstance(pilot.app.screen, ConfirmationDialog)
-            pilot.app.screen.dismiss(True)
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
-
-            assert db.get_reminder_task(task_id)["transfer_state"] == "to_server_pending"
-            # BOTH surfaces now reflect the in-flight state.
-            legacy_cancel = pilot.app.screen.query_one(
-                "#scheduling-cancel-transfer", Button
-            )
-            assert not legacy_cancel.disabled
-            assert detail._runs_on_cancel_button.display is True
-            # Affordance stays ON (fix round 1 finding 2) -- activation
-            # would show the lock reason instead of opening a dropdown.
-            assert detail._runs_on_row.affordance is True
-
-            # NEW surface: cancel via the row's own affordance.
-            detail._runs_on_cancel_button.press()
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
-
-            assert db.get_reminder_task(task_id)["transfer_state"] is None
-            # The LEGACY button reflects the SAME underlying state,
-            # refreshed via the SAME `_request_tasks_refresh` seam.
-            legacy_cancel_after = pilot.app.screen.query_one(
-                "#scheduling-cancel-transfer", Button
-            )
-            assert legacy_cancel_after.disabled
+            for legacy_id in (
+                "scheduling-transfer-to-server",
+                "scheduling-transfer-to-local",
+                "scheduling-retry-transfer",
+                "scheduling-cancel-transfer",
+            ):
+                assert not detail.query(f"#{legacy_id}")
+            # The Runs-on row's own affordance is the one transfer
+            # surface now, unaffected by the legacy buttons' removal.
             assert detail._runs_on_row.affordance is True
     finally:
         db.close()
@@ -5230,19 +5209,32 @@ async def test_definition_runs_on_retry_button_rebegins_a_failed_transfer(tmp_pa
 
 
 @pytest.mark.asyncio
-async def test_definition_runs_on_dropdown_and_automations_tab_keybindings_coexist(
-    tmp_path,
-):
-    """Definition-pane twin of the reminder-side coexistence test -- the
-    Automations tab has no per-row transfer BUTTONS (spec §6, PR-5 task
-    7's own design: `m`/`M`/`y`/`k` keybindings instead), so "coexistence"
-    here means the keybinding-driven legacy flow
-    (`action_move_automation_to_server`/`_cancel_automation_transfer`)
-    and the NEW Runs-on row read/write the SAME underlying state."""
+async def test_automations_tab_transfer_keybindings_are_retired(tmp_path):
+    """redesign PR-4 task 4 (ruling 2): supersedes `test_definition_runs_
+    on_dropdown_and_automations_tab_keybindings_coexist` -- the
+    Automations-tab-only `m`/`M`/`y`/`k` keybindings and their `action_
+    move_automation_to_local`/`_to_server`/`action_retry_automation_
+    transfer`/`action_cancel_automation_transfer`/`_begin_automation_
+    transfer`/`_cancel_automation_transfer` flow are genuinely gone --
+    the Runs-on dropdown (already exercised end-to-end by `test_
+    definition_runs_on_dropdown_confirm_begins_to_server_transfer`/`test_
+    definition_runs_on_cancel_button_cancels_the_dormant_copy_using_its_
+    own_id` above, including on this SAME Automations-tab `DefinitionDetail`
+    instance) is the one transfer surface now."""
+    for legacy_action in (
+        "action_move_automation_to_local",
+        "action_move_automation_to_server",
+        "action_retry_automation_transfer",
+        "action_cancel_automation_transfer",
+    ):
+        assert not hasattr(SchedulesWorkbench, legacy_action)
+    bound_keys = {binding.key for binding in SchedulesWorkbench.BINDINGS}
+    assert bound_keys.isdisjoint({"M", "y", "k"})
+
     app = WorkbenchTestApp()
     db, service = _connected_service(tmp_path, app)
     try:
-        definition_id = db.create_automation_definition(
+        db.create_automation_definition(
             "local",
             "recurring_question",
             "Nightly digest automation",
@@ -5262,49 +5254,18 @@ async def test_definition_runs_on_dropdown_and_automations_tab_keybindings_coexi
             )
             await pilot.pause()
             table = workbench.query_one("#scheduling-automations-table", DataTable)
-            assert table.row_count == 1
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
-            # Legacy surface: begin via the EXISTING keybinding, untouched.
-            workbench.action_move_automation_to_server()
-            await pilot.pause()
-            assert isinstance(pilot.app.screen, ConfirmationDialog)
-            pilot.app.screen.dismiss(True)
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
-
-            assert (
-                db.get_automation_definition(definition_id)["transfer_state"]
-                == "to_server_pending"
-            )
-            # NEW surface reflects the state the LEGACY keybinding wrote.
+            # The Runs-on dropdown still activates fine on the
+            # Automations tab's own DefinitionDetail instance -- the
+            # retired keybindings' removal did not touch it.
             detail = workbench.query_one(
                 "#scheduling-automation-detail", DefinitionDetail
             )
-            assert detail._runs_on_cancel_button.display is True
             assert detail._runs_on_row.affordance is True
-
-            # NEW surface: cancel via the row's own affordance.
-            detail._runs_on_cancel_button.press()
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
-
-            fresh_row = db.get_automation_definition(definition_id)
-            assert fresh_row["transfer_state"] is None
-            # The LEGACY surface's own refusal check (`cancel_refusal`,
-            # what `_cancel_automation_transfer`'s keybinding path itself
-            # calls) sees the SAME state -- no drift between the two
-            # surfaces. Read directly rather than firing a second
-            # keybinding action: that action's own success/refusal notice
-            # is transient and gets overwritten by the very refresh it
-            # triggers (`_show_automations_inline_reason`'s own documented
-            # behavior), racy to assert on here.
-            assert service.cancel_refusal(fresh_row) is not None
     finally:
         db.close()
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -21,12 +21,16 @@ from textual.widgets import (
 )
 from textual.widgets._collapsible import CollapsibleTitle
 
+from textual import on
+
 from tldw_chatbook.Scheduling.events import (
+    DefinitionRunNowRequested,
     DeleteTaskRequested,
     ReminderFieldEditRequested,
     ReminderOwnerActionRequested,
     SyncCompleted,
     SyncFailed,
+    ViewDefinitionAuditRequested,
     ViewDefinitionResultsRequested,
 )
 from tldw_chatbook.Scheduling.models import (
@@ -925,6 +929,90 @@ def _editable_definition(**overrides) -> dict:
     }
     base.update(overrides)
     return base
+
+
+class _CapturingDefinitionDetailApp(ConsolidatedCSSApp):
+    """`_BareDefinitionDetailApp`'s twin with its own message capture
+    (redesign PR-4, task 3): a plain bare harness cannot observe a
+    posted `Message` bubbling past it -- an `@on` handler on the App
+    itself records what `DefinitionDetail` posts, no workbench needed."""
+
+    CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.run_now_events: list = []
+        self.audit_events: list = []
+
+    def compose(self):
+        yield DefinitionDetail()
+
+    @on(DefinitionRunNowRequested)
+    def _capture_run_now(self, event: DefinitionRunNowRequested) -> None:
+        self.run_now_events.append(event.definition)
+
+    @on(ViewDefinitionAuditRequested)
+    def _capture_audit(self, event: ViewDefinitionAuditRequested) -> None:
+        self.audit_events.append(event.definition)
+
+
+@pytest.mark.asyncio
+async def test_run_now_button_posts_definition_run_now_requested():
+    """redesign PR-4, task 3, ruling 2: the header `Run now` button
+    (the retired Automations-tab `r` key's live replacement) posts
+    `DefinitionRunNowRequested` carrying the painted definition -- never
+    gated on the lifecycle lock or family note, same as the tab's own
+    `r` key never was."""
+    async with _CapturingDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        definition = _editable_definition()
+        detail.set_definition(definition)
+        await pilot.pause()
+
+        run_now = detail.query_one("#scheduling-automation-run-now", Button)
+        assert run_now.disabled is False
+        detail.on_button_pressed(Button.Pressed(run_now))
+        await pilot.pause()
+
+        assert pilot.app.run_now_events == [definition]
+
+
+@pytest.mark.asyncio
+async def test_run_now_button_is_a_no_op_with_nothing_painted():
+    async with _CapturingDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail._request_run_now()
+        await pilot.pause()
+        assert pilot.app.run_now_events == []
+
+
+@pytest.mark.asyncio
+async def test_last_run_row_activation_posts_view_definition_audit_requested():
+    """redesign PR-4, task 3 (audit-view relocation): the `Last run` row
+    -- whose own copy already says "...see Run history" for a
+    server-owned definition -- is a live activation now, posting
+    `ViewDefinitionAuditRequested` rather than opening an editor.
+    Unconditionally activatable regardless of family/lifecycle lock,
+    same as `Unread results` (task 2's own precedent): viewing history
+    is not an edit."""
+    async with _CapturingDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        # A non-`recurring_question` row -- editors are gated for this
+        # family, but the audit activation must still fire.
+        definition = _editable_definition(family="agent_task")
+        detail.set_definition(definition)
+        await pilot.pause()
+
+        row = detail._last_run_row
+        assert row.affordance is True
+        assert row.can_focus is True
+        row.post_message(DetailValueRow.Activated(row))
+        await pilot.pause()
+
+        assert pilot.app.audit_events == [definition]
+        # Never opened an in-place editor for this row.
+        assert not row.query(Input)
+        assert not row.query(Select)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -2478,9 +2478,12 @@ async def test_edit_on_server_owned_row_with_unreachable_seam_queues_a_mutation(
         async with app.run_test(size=(220, 60)) as pilot:
             workbench = SchedulesWorkbench(app_instance=pilot.app)
             await pilot.app.push_screen(workbench)
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
+            # Fix wave F4: `settle_schedules_workbench` (not a bare
+            # pause + wait) -- the mount-time catch-up results pull is a
+            # `set_timer` callback `wait_for_complete` does not cover, and
+            # its `_request_tasks_refresh` wipes a hand-set definition off
+            # the live `#scheduling-queue-definition-detail` pane.
+            await settle_schedules_workbench(pilot, workbench)
 
             detail = pilot.app.screen.query_one(
                 "#scheduling-queue-definition-detail", DefinitionDetail
@@ -2604,9 +2607,12 @@ async def test_lifecycle_toggle_on_server_owned_row_survives_a_racing_pull(tmp_p
         async with app.run_test(size=(220, 60)) as pilot:
             workbench = SchedulesWorkbench(app_instance=pilot.app)
             await pilot.app.push_screen(workbench)
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
+            # Fix wave F4: `settle_schedules_workbench` (not a bare
+            # pause + wait) -- the mount-time catch-up results pull is a
+            # `set_timer` callback `wait_for_complete` does not cover, and
+            # its `_request_tasks_refresh` wipes a hand-set definition off
+            # the live `#scheduling-queue-definition-detail` pane.
+            await settle_schedules_workbench(pilot, workbench)
 
             detail = pilot.app.screen.query_one(
                 "#scheduling-queue-definition-detail", DefinitionDetail
@@ -3197,8 +3203,12 @@ async def test_delete_mutation_refresh_cannot_repaint_after_newer_user_refresh()
             await service.mutation_refresh_started.wait()
 
             # Resolving a conflict is a user action whose production handler
-            # requests a grouped task-list refresh.
-            workbench._on_conflict_resolved(
+            # requests a grouped task-list refresh. Fix wave F3: POSTED, not
+            # called -- a direct `_on_conflict_resolved(...)` call is what let
+            # the DISPATCH itself break unnoticed when task 5 moved the
+            # `ConflictsTab` onto a pushed screen (the live-path pin now lives
+            # in `test_schedules_responsive_floor.py`).
+            workbench.post_message(
                 ConflictsTab.ConflictResolved("conflict-1", "local")
             )
             await service.user_refresh_started.wait()
@@ -4075,9 +4085,13 @@ async def test_unread_row_activation_pushes_definition_filtered_results_overlay(
         async with app.run_test(size=(220, 60)) as pilot:
             await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
             await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
             workbench = pilot.app.screen
+            # Fix wave F4: `settle_schedules_workbench` (not a bare
+            # pause + wait) -- the mount-time catch-up results pull is a
+            # `set_timer` callback `wait_for_complete` does not cover, and
+            # its `_request_tasks_refresh` wipes a hand-set definition off
+            # the live `#scheduling-queue-definition-detail` pane.
+            await settle_schedules_workbench(pilot, workbench)
 
             detail = workbench.query_one(
                 "#scheduling-queue-definition-detail", DefinitionDetail
@@ -4917,7 +4931,9 @@ async def test_definition_owner_action_marks_stale_before_resolving(
 ):
     """Fix round 1 finding 1, pinned via ORDERING, not a post-hoc flag
     read: a real mounted workbench has its own background refreshes
-    (mount-time, `TabActivated` on the initial tab) that legitimately
+    (mount-time `load_tasks`, the catch-up results pull, `on_screen_
+    resume`'s `_consume_definitions_stale` -- redesign PR-4 task 5 retired
+    the `TabActivated` refresh this used to name) that legitimately
     consume/clear `_definitions_stale` too, so asserting the flag's
     value some time AFTER the action is racy against those -- this pins
     the actual claim instead: `self._definitions_stale` is ALREADY
@@ -5073,6 +5089,16 @@ async def test_definition_runs_on_dropdown_confirm_begins_to_local_transfer_with
         async with app.run_test(size=(220, 60)) as pilot:
             await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
             await pilot.pause()
+            # Fix wave F4: this body was repointed onto the LIVE
+            # `#scheduling-queue-definition-detail` pane in task 5, which
+            # the workbench's own mount-time `load_tasks` repaints -- with
+            # an empty queue that means `set_definition(None)`, wiping the
+            # definition set below (and its editable rows) before the test
+            # activates the Runs-on row. The final review measured this
+            # body at 7 failed / 3 passed over 10 solo runs without this
+            # line (10 passed at BASE, where it still pointed at the
+            # retired pane); 10/10 green with it.
+            await settle_schedules_workbench(pilot, pilot.app.screen)
 
             mirror = db.get_automation_definition(mirror_id)
             detail = pilot.app.screen.query_one(
@@ -5564,9 +5590,12 @@ async def test_queue_definition_pane_repaints_after_a_successful_in_pane_edit(tm
         async with app.run_test(size=(220, 60)) as pilot:
             workbench = SchedulesWorkbench(app_instance=pilot.app)
             await pilot.app.push_screen(workbench)
-            await pilot.pause()
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
+            # Fix wave F4: `settle_schedules_workbench` (not a bare
+            # pause + wait) -- the mount-time catch-up results pull is a
+            # `set_timer` callback `wait_for_complete` does not cover, and
+            # its `_request_tasks_refresh` wipes a hand-set definition off
+            # the live `#scheduling-queue-definition-detail` pane.
+            await settle_schedules_workbench(pilot, workbench)
 
             queue_detail = pilot.app.screen.query_one(
                 "#scheduling-queue-definition-detail", DefinitionDetail

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -69,6 +69,7 @@ from Tests.UI.schedules_test_helpers import (
     MockSchedulingServiceMixin as _MockSchedulingServiceMixin,
     MockServerClient as _MockServerClient,
     rendered_row_cells,
+    settle_schedules_workbench,
 )
 
 
@@ -4564,15 +4565,14 @@ async def test_runs_on_dropdown_refusal_renders_inline_with_health_reason(tmp_pa
             # the hand-painted definition and closing the open editor
             # mid-test. The mount-time catch-up results pull is exactly
             # such a reload (a 0.3s debounce timer, so `wait_for_complete`
-            # does not cover it), and it is stopped here. The retired
-            # Automations-tab `DefinitionDetail` sat outside that loader's
-            # reach, which is why none of this was needed before.
-            await pilot.app.workers.wait_for_complete()
+            # does not cover it). The retired Automations-tab
+            # `DefinitionDetail` sat outside that loader's reach, which is
+            # why none of this was needed before. redesign PR-4 task 6 hit
+            # the same race with its pushed panes, which is where the
+            # inline fix this test used to carry graduated into the shared
+            # `settle_schedules_workbench` helper.
             workbench = pilot.app.screen
-            if workbench._results_pull_debounce_timer is not None:
-                workbench._results_pull_debounce_timer.stop()
-                workbench._results_pull_debounce_timer = None
-            await pilot.pause()
+            await settle_schedules_workbench(pilot, workbench)
 
             # A server-fetch-shaped dict (Task 4's own documented trap,
             # its report's "trap hit while writing the lifecycle/offline

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -17,7 +17,6 @@ from textual.widgets import (
     Input,
     Select,
     Static,
-    TabbedContent,
 )
 from textual.widgets._collapsible import CollapsibleTitle
 
@@ -31,7 +30,6 @@ from tldw_chatbook.Scheduling.events import (
     SyncCompleted,
     SyncFailed,
     ViewDefinitionAuditRequested,
-    ViewDefinitionResultsRequested,
 )
 from tldw_chatbook.Scheduling.models import (
     ReminderTask,
@@ -1434,14 +1432,23 @@ async def test_pause_resume_button_disabled_and_reason_shown_when_locked():
 
 
 @pytest.mark.asyncio
-async def test_committing_generation_edit_persists_and_repaints_automations_pane(
+async def test_committing_generation_edit_persists_and_repaints_the_definition_pane(
     tmp_path,
 ):
     """Commit persists via `save_definition`; success repaints the
-    Automations-tab pane from a fresh read AND arms the unified Queue
-    list's own (lazy, tab-activation-gated) refresh -- the same
-    `_definitions_stale` seam every other definition mutation in this
-    file uses (run-now, transfer begin/cancel)."""
+    definition pane from a fresh read AND refreshes the unified list --
+    the same `_definitions_stale` seam every other definition mutation in
+    this file uses (run-now, transfer begin/cancel).
+
+    redesign PR-4 task 5: the refresh used to be LAZY (marked stale, then
+    picked up whenever the user next arrived on the Queue tab) because
+    the eager half went to the Automations tab's own list. That tab is
+    retired and the unified list is the only definitions surface, so the
+    mutation refreshes it directly and the flag it sets is consumed in
+    the same beat -- which is what the last assertion now reads. The
+    set-site itself is unchanged (brief: "the staleness machine keeps
+    every set-site"), so a concurrent reminder-only reload still upgrades
+    itself."""
     db, service = _real_scheduling_service(tmp_path)
     try:
         definition_id = db.create_automation_definition(
@@ -1468,12 +1475,12 @@ async def test_committing_generation_edit_persists_and_repaints_automations_pane
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             assert table.row_count == 1
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
@@ -1481,7 +1488,7 @@ async def test_committing_generation_edit_persists_and_repaints_automations_pane
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._generation_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1505,8 +1512,8 @@ async def test_committing_generation_edit_persists_and_repaints_automations_pane
                 generation_static.render_line(0).text.strip()
                 == "Always generate a draft"
             )
-            # The unified Queue list's own next (lazy) refresh is armed.
-            assert workbench._definitions_stale is True
+            # The unified list's own refresh ran and consumed the flag.
+            assert workbench._definitions_stale is False
     finally:
         db.close()
 
@@ -1540,18 +1547,19 @@ async def test_committing_repeat_edit_resends_whole_schedule_preserving_timezone
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._repeat_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1595,18 +1603,19 @@ async def test_committing_timezone_edit_preserves_cron(tmp_path):
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._timezone_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1625,7 +1634,7 @@ async def test_committing_timezone_edit_preserves_cron(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_committing_model_edit_persists_and_repaints_automations_pane(
+async def test_committing_model_edit_persists_and_repaints_the_definition_pane(
     tmp_path,
 ):
     """Model row commit persists `input.provider`/`model` and repaints the
@@ -1654,19 +1663,19 @@ async def test_committing_model_edit_persists_and_repaints_automations_pane(
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._model_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1691,7 +1700,7 @@ async def test_committing_model_edit_persists_and_repaints_automations_pane(
 
 
 @pytest.mark.asyncio
-async def test_committing_finding_policy_edit_persists_and_repaints_automations_pane(
+async def test_committing_finding_policy_edit_persists_and_repaints_the_definition_pane(
     tmp_path,
 ):
     """Finding-policy row commit writes `config.finding_policy.preset`
@@ -1721,19 +1730,19 @@ async def test_committing_finding_policy_edit_persists_and_repaints_automations_
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._finding_policy_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1762,7 +1771,7 @@ async def test_committing_finding_policy_edit_persists_and_repaints_automations_
 
 
 @pytest.mark.asyncio
-async def test_committing_sources_edit_persists_and_repaints_automations_pane(
+async def test_committing_sources_edit_persists_and_repaints_the_definition_pane(
     tmp_path,
 ):
     """Sources editor Apply persists the explicit `{"mode": "sources", ...}`
@@ -1790,19 +1799,19 @@ async def test_committing_sources_edit_persists_and_repaints_automations_pane(
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._sources_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1840,7 +1849,7 @@ async def test_committing_sources_edit_persists_and_repaints_automations_pane(
 
 
 @pytest.mark.asyncio
-async def test_committing_notifications_edit_persists_and_repaints_automations_pane(
+async def test_committing_notifications_edit_persists_and_repaints_the_definition_pane(
     tmp_path,
 ):
     """Notifications row commit writes the boolean on/off shape for BOTH
@@ -1869,19 +1878,19 @@ async def test_committing_notifications_edit_persists_and_repaints_automations_p
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._notifications_row
             row.post_message(DetailValueRow.Activated(row))
@@ -1906,7 +1915,7 @@ async def test_committing_notifications_edit_persists_and_repaints_automations_p
 
 
 @pytest.mark.asyncio
-async def test_committing_at_edit_persists_and_repaints_automations_pane(tmp_path):
+async def test_committing_at_edit_persists_and_repaints_the_definition_pane(tmp_path):
     """At row commit persists `run_at` on a one-time definition and
     repaints the pane (task-4 review Finding 2)."""
     db, service = _real_scheduling_service(tmp_path)
@@ -1928,19 +1937,19 @@ async def test_committing_at_edit_persists_and_repaints_automations_pane(tmp_pat
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._at_row
             row.post_message(DetailValueRow.Activated(row))
@@ -2001,19 +2010,19 @@ async def test_at_edit_on_a_daily_automation_edits_time_of_day_not_run_at(tmp_pa
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._at_row
             assert row.affordance is True, "a weekly schedule has a time target"
@@ -2048,15 +2057,12 @@ async def test_at_edit_on_a_daily_automation_edits_time_of_day_not_run_at(tmp_pa
                 == "Weekly on Wednesday at 07:30 UTC"
             )
 
-            # SECOND surface: `_definition_at_label` also feeds the Queue
-            # tab's unified-row subtitle (`build_unified_rows`'s
+            # SECOND surface: `_definition_at_label` also feeds the
+            # unified-row subtitle (`build_unified_rows`'s
             # `schedule_summary` -> `_row_subtitle`). Painted, so the
             # shared-helper change is verified where it actually lands
-            # rather than assumed.
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-queue-tab"
-            )
-            await pilot.pause()
+            # rather than assumed. (redesign PR-4 task 5: no tab flip back
+            # -- the row and the pane are on the same surface now.)
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             queue_table = workbench.query_one("#scheduling-task-table", DataTable)
@@ -2094,19 +2100,19 @@ async def test_at_row_is_read_only_for_an_interval_automation(tmp_path):
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             assert detail._at_row.affordance is False
             assert detail._at_row.can_focus is False
@@ -2150,19 +2156,19 @@ async def test_two_fields_of_one_definition_both_land_without_a_lost_update(tmp_
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             definition = dict(detail._definition)
 
@@ -2220,19 +2226,19 @@ async def test_model_only_target_round_trips_through_an_unchanged_submit(tmp_pat
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             # The row still READS as a bare model -- the display label is
             # unchanged, only the editor's seed is the parse's inverse.
@@ -2283,19 +2289,19 @@ async def test_non_recurring_question_definition_exposes_no_editors(tmp_path):
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             assert detail._definition["family"] == "agent_task"
             assert [row.row_key for row in detail._editable_rows() if row.affordance] == []
@@ -2371,18 +2377,19 @@ async def test_not_set_model_preserved_across_an_unrelated_edit(tmp_path):
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             model_static = detail.query_one(
                 "#scheduling-automation-detail-model", Static
@@ -2475,7 +2482,7 @@ async def test_edit_on_server_owned_row_with_unreachable_seam_queues_a_mutation(
             await pilot.pause()
 
             detail = pilot.app.screen.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             detail.set_definition(server_item)
             await pilot.pause()
@@ -2532,18 +2539,19 @@ async def test_lifecycle_toggle_pauses_a_local_automation_and_the_button_flips(
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             button = detail.query_one("#scheduling-automation-pause-resume", Button)
             assert button.label.plain == "Pause"
@@ -2600,7 +2608,7 @@ async def test_lifecycle_toggle_on_server_owned_row_survives_a_racing_pull(tmp_p
             await pilot.pause()
 
             detail = pilot.app.screen.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             detail.set_definition(server_item)
             await pilot.pause()
@@ -3810,6 +3818,69 @@ class _RailTestApp(ConsolidatedCSSApp):
         self.scheduling_service = service
 
 
+# --- redesign PR-4, task 5: the retirement -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_workbench_composes_one_surface_with_no_tab_chrome():
+    """The retirement's headline claim, asserted on the real widget tree.
+
+    The Automations/Conflicts/Results `TabPane`s and the `TabbedContent`
+    that held them are gone -- and with only the Queue pane left there
+    was no reason to keep the container either, so the queue's three
+    panes now hang directly off `#schedules-shell`. That structural
+    simplification is the point of the task, so it is pinned rather than
+    inferred from the absence of failures: a future edit re-wrapping the
+    content in tab chrome would put every one of the retired surfaces'
+    problems back.
+
+    Painted, not merely present (`region.width`): a container mounted
+    inside a dead `TabPane` would still answer `query_one` while
+    rendering at a zero region -- the exact false pass
+    `test_schedules_automations_tab.py`'s own detail assertions had to be
+    taught about.
+    """
+    from textual.widgets import TabbedContent, TabPane
+
+    app = _RailTestApp(_RailService())
+    async with app.run_test(size=(200, 50)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        assert list(workbench.query(TabbedContent)) == []
+        assert list(workbench.query(TabPane)) == []
+
+        shell = workbench.query_one("#schedules-shell")
+        row = workbench.query_one("#scheduling-workbench")
+        assert row.parent is shell, (
+            "the queue row hangs directly off the shell, not off tab chrome"
+        )
+        for pane_id in (
+            "scheduling-list-pane",
+            "scheduling-detail-pane",
+            "scheduling-inspector-pane",
+        ):
+            pane = workbench.query_one(f"#{pane_id}")
+            assert pane.region.width > 0, pane_id
+
+        # The retired surfaces' own mounted widgets are gone with them --
+        # both views exist only as fresh instances inside a pushed screen.
+        assert list(workbench.query(ConflictsTab)) == []
+        assert list(workbench.query(ResultsTab)) == []
+        # ...and only ONE DefinitionDetail is left (the Automations tab's
+        # sibling instance retired with its pane).
+        assert [d.id for d in workbench.query(DefinitionDetail)] == [
+            "scheduling-queue-definition-detail"
+        ]
+
+        # The badges that reach the pushed views are on the surface.
+        assert workbench.query_one("#scheduling-conflicts-badge", Button).region.width
+        assert workbench.query_one("#scheduling-results-badge", Button).region.width
+
+
 @pytest.mark.asyncio
 async def test_mark_all_read_hidden_when_nothing_unread():
     app = _RailTestApp(_RailService(unread=False))
@@ -3844,9 +3915,11 @@ async def test_conflicts_badge_pushes_conflicts_overlay_with_painted_content():
     """redesign PR-4, Task 1: the status strip's conflicts badge mirrors
     `_refresh_conflicts_tab`'s own existing count (no new query) and
     pushes a fresh `ConflictsTab` overlay via `WorkbenchHostScreen` on
-    click -- the tab-flip this replaced cannot work once the tab bar is
-    retired (Task 5). The Conflicts TAB itself stays untouched by the
-    push (it is retired separately, in Task 5)."""
+    click -- the tab-flip this replaced could not survive the tab bar,
+    which Task 5 has now retired. With no tab bar there is nothing left
+    to assert a non-flip against; what remains is the claim that always
+    mattered: the badge pushes a screen carrying PAINTED conflict rows,
+    and Esc returns to the same workbench instance."""
     app = _RailTestApp(
         _RailService(
             conflicts=[{"id": "c1", "local_state": {"title": "Digest"}}]
@@ -3861,14 +3934,10 @@ async def test_conflicts_badge_pushes_conflicts_overlay_with_painted_content():
         assert str(badge.label) == "Conflicts (1)"
         assert "scheduled task" in str(badge.tooltip).lower()
 
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        original_active = tabs.active
-
         badge.press()
         await pilot.pause()
 
-        # No tab flip -- a fresh screen is pushed on top instead.
-        assert tabs.active == original_active
+        # A fresh screen is pushed on top of the workbench.
         assert pilot.app.screen is not workbench
         assert isinstance(pilot.app.screen, WorkbenchHostScreen)
 
@@ -3903,10 +3972,12 @@ async def test_conflicts_badge_defaults_to_no_count():
 @pytest.mark.asyncio
 async def test_results_badge_shows_unread_count_and_pushes_global_overlay():
     """redesign PR-4, task 2: the rail's `Results (N)` affordance mirrors
-    `_refresh_results_tab`'s own existing unread count (no new query,
+    `_refresh_results_badge`'s own existing unread count (no new query,
     the status strip's Conflicts badge's own idiom) and pushes a fresh
-    `ResultsHostScreen` overlay -- the Results TAB itself stays reachable
-    until Task 5 retires it (both paths coexist this task)."""
+    `ResultsHostScreen` overlay. redesign PR-4 task 5 retired the Results
+    tab, so this button (and a definition pane's unread row) is the only
+    route to the view -- and with no tab bar there is nothing left to
+    assert a non-flip against."""
     app = _RailTestApp(_RailService(unread=True))
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
@@ -3918,14 +3989,10 @@ async def test_results_badge_shows_unread_count_and_pushes_global_overlay():
         badge = workbench.query_one("#scheduling-results-badge", Button)
         assert str(badge.label) == "Results (1)"
 
-        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        original_active = tabs.active
-
         badge.press()
         await pilot.pause()
 
-        # No tab flip -- a fresh screen is pushed on top instead.
-        assert tabs.active == original_active
+        # A fresh screen is pushed on top of the workbench.
         assert pilot.app.screen is not workbench
         assert isinstance(pilot.app.screen, ResultsHostScreen)
 
@@ -4460,8 +4527,8 @@ async def test_definition_runs_on_activation_on_failed_row_shows_stored_transfer
 @pytest.mark.asyncio
 async def test_runs_on_dropdown_refusal_renders_inline_with_health_reason(tmp_path):
     """A refused target renders via `row.show_error` (this row's OWN
-    surface, never the Automations tab's shared inline notice) -- health-
-    quoting preserved verbatim (spec §6.4/§7), and nothing is written.
+    surface, never a pane-level shared notice) -- health-quoting
+    preserved verbatim (spec §6.4/§7), and nothing is written.
 
     `transfer_refusal`'s FIRST gate ("No server connection is
     configured.") applies to EVERY direction, not only `to_server` --
@@ -4488,17 +4555,35 @@ async def test_runs_on_dropdown_refusal_renders_inline_with_health_reason(tmp_pa
             await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
             await pilot.pause()
 
+            # redesign PR-4 task 5: this dict is painted onto the pane by
+            # HAND, and that pane is now the same instance the QUEUE's own
+            # loader repaints. This fixture's queue is empty (a
+            # `server_id`-carrying row belongs to the server half, which
+            # `_FakeConnectedServerClient` cannot list), so any background
+            # reload lands `set_definition(None)` on the pane -- clearing
+            # the hand-painted definition and closing the open editor
+            # mid-test. The mount-time catch-up results pull is exactly
+            # such a reload (a 0.3s debounce timer, so `wait_for_complete`
+            # does not cover it), and it is stopped here. The retired
+            # Automations-tab `DefinitionDetail` sat outside that loader's
+            # reach, which is why none of this was needed before.
+            await pilot.app.workers.wait_for_complete()
+            workbench = pilot.app.screen
+            if workbench._results_pull_debounce_timer is not None:
+                workbench._results_pull_debounce_timer.stop()
+                workbench._results_pull_debounce_timer = None
+            await pilot.pause()
+
             # A server-fetch-shaped dict (Task 4's own documented trap,
             # its report's "trap hit while writing the lifecycle/offline
             # tests": `id` IS the server's own id) -- painted directly
-            # onto the Automations-tab `DefinitionDetail` instance rather
-            # than driving a real server-list fetch (out of this test's
-            # scope), matching what `_selected_automation()` would hand
-            # this pane for a pure server row.
+            # onto the `DefinitionDetail` instance rather than driving a
+            # real server-list fetch (out of this test's scope), matching
+            # what a pure server row hands this pane.
             server_item = dict(db.get_automation_definition(definition_id) or {})
             server_item["id"] = "srv-1"
             detail = pilot.app.screen.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             detail.set_definition(
                 server_item, runs_on_options=[("This device", "local")]
@@ -4881,7 +4966,7 @@ async def test_definition_owner_action_marks_stale_before_resolving(
                 "config": {"scope": {"mode": "all_searchable_library"}},
             }
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._runs_on_row
 
@@ -4932,11 +5017,12 @@ async def test_definition_runs_on_dropdown_confirm_dialog_lists_warnings(tmp_pat
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             assert table.row_count == 1
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
@@ -4944,7 +5030,7 @@ async def test_definition_runs_on_dropdown_confirm_dialog_lists_warnings(tmp_pat
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._runs_on_row
             row.post_message(DetailValueRow.Activated(row))
@@ -4990,7 +5076,7 @@ async def test_definition_runs_on_dropdown_confirm_begins_to_local_transfer_with
 
             mirror = db.get_automation_definition(mirror_id)
             detail = pilot.app.screen.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             detail.set_definition(mirror, runs_on_options=[("This device", "local")])
             await pilot.pause()
@@ -5046,11 +5132,12 @@ async def test_definition_runs_on_dropdown_confirm_begins_to_server_transfer(tmp
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             assert table.row_count == 1
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
@@ -5058,7 +5145,7 @@ async def test_definition_runs_on_dropdown_confirm_begins_to_server_transfer(tmp
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             row = detail._runs_on_row
             row.post_message(DetailValueRow.Activated(row))
@@ -5114,22 +5201,24 @@ async def test_definition_runs_on_cancel_button_cancels_the_dormant_copy_using_i
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
-            # `_load_local_automations` only ever shows a `server_id`-less
-            # row (survey §3): the copy, not the mirror -- the mirror is
-            # the SERVER fetch half's row, and this harness's fake server
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
+            # The local half only ever shows a `server_id`-less row
+            # (survey §3): the copy, not the mirror -- the mirror is the
+            # SERVER fetch half's row, and this harness's fake server
             # client has no `list_automation_definitions` (out of this
             # test's scope; the mirror-side assertion below reads the DB
             # directly instead of depending on the table showing it).
             assert table.row_count == 1
             copy_index = next(
                 index
-                for index, definition in enumerate(workbench._automations)
-                if str(definition.get("id")) == copy_id
+                for index, unified_row in enumerate(workbench._visible_rows)
+                if unified_row.kind == "definition"
+                and str(unified_row.source_row.get("id")) == copy_id
             )
             table.cursor_coordinate = (copy_index, 0)
             await pilot.pause()
@@ -5137,7 +5226,7 @@ async def test_definition_runs_on_cancel_button_cancels_the_dormant_copy_using_i
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             assert detail._runs_on_cancel_button.display is True
             detail._runs_on_cancel_button.press()
@@ -5178,11 +5267,12 @@ async def test_definition_runs_on_retry_button_rebegins_a_failed_transfer(tmp_pa
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             assert table.row_count == 1
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
@@ -5190,7 +5280,7 @@ async def test_definition_runs_on_retry_button_rebegins_a_failed_transfer(tmp_pa
             await pilot.pause()
 
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             assert detail._runs_on_retry_button.display is True
             detail._runs_on_retry_button.press()
@@ -5249,11 +5339,12 @@ async def test_automations_tab_transfer_keybindings_are_retired(tmp_path):
             await pilot.pause()
 
             workbench = pilot.app.screen
-            workbench.query_one("#scheduling-tabs", TabbedContent).active = (
-                "scheduling-automations-tab"
-            )
-            await pilot.pause()
-            table = workbench.query_one("#scheduling-automations-table", DataTable)
+            # redesign PR-4 task 5: the Automations tab this used to
+            # activate first is retired -- the definition row is
+            # selected in the unified queue table instead, and the
+            # pane under test is the queue's own `DefinitionDetail`
+            # (the sibling instance that always shared this code).
+            table = workbench.query_one("#scheduling-task-table", DataTable)
             table.cursor_coordinate = (0, 0)
             await pilot.pause()
             await pilot.app.workers.wait_for_complete()
@@ -5263,7 +5354,7 @@ async def test_automations_tab_transfer_keybindings_are_retired(tmp_path):
             # Automations tab's own DefinitionDetail instance -- the
             # retired keybindings' removal did not touch it.
             detail = workbench.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
+                "#scheduling-queue-definition-detail", DefinitionDetail
             )
             assert detail._runs_on_row.affordance is True
     finally:

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -27,6 +27,7 @@ from tldw_chatbook.Scheduling.events import (
     ReminderOwnerActionRequested,
     SyncCompleted,
     SyncFailed,
+    ViewDefinitionResultsRequested,
 )
 from tldw_chatbook.Scheduling.models import (
     ReminderTask,
@@ -43,6 +44,7 @@ from tldw_chatbook.Scheduling.services import (
     scheduling_service as scheduling_service_module,
 )
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
+from tldw_chatbook.UI.Screens.scheduling.results_tab import ResultsHostScreen, ResultsTab
 from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
 from tldw_chatbook.UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from tldw_chatbook.UI.Screens.scheduling.task_detail import (
@@ -3806,6 +3808,196 @@ async def test_conflicts_badge_defaults_to_no_count():
 
         badge = pilot.app.screen.query_one("#scheduling-conflicts-badge", Button)
         assert str(badge.label) == "Conflicts"
+
+
+@pytest.mark.asyncio
+async def test_results_badge_shows_unread_count_and_pushes_global_overlay():
+    """redesign PR-4, task 2: the rail's `Results (N)` affordance mirrors
+    `_refresh_results_tab`'s own existing unread count (no new query,
+    the status strip's Conflicts badge's own idiom) and pushes a fresh
+    `ResultsHostScreen` overlay -- the Results TAB itself stays reachable
+    until Task 5 retires it (both paths coexist this task)."""
+    app = _RailTestApp(_RailService(unread=True))
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = pilot.app.screen
+
+        badge = workbench.query_one("#scheduling-results-badge", Button)
+        assert str(badge.label) == "Results (1)"
+
+        tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
+        original_active = tabs.active
+
+        badge.press()
+        await pilot.pause()
+
+        # No tab flip -- a fresh screen is pushed on top instead.
+        assert tabs.active == original_active
+        assert pilot.app.screen is not workbench
+        assert isinstance(pilot.app.screen, ResultsHostScreen)
+
+        overlay_tab = pilot.app.screen.query_one(ResultsTab)
+        overlay_table = overlay_tab.query_one("#scheduling-results-table", DataTable)
+        assert overlay_table.row_count == 1
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Esc pops back to the same underlying workbench instance.
+        assert pilot.app.screen is workbench
+
+
+@pytest.mark.asyncio
+async def test_results_badge_defaults_to_no_count():
+    app = _RailTestApp(_RailService())
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        badge = pilot.app.screen.query_one("#scheduling-results-badge", Button)
+        assert str(badge.label) == "Results"
+
+
+@pytest.mark.asyncio
+async def test_unread_row_activation_pushes_definition_filtered_results_overlay(
+    tmp_path,
+):
+    """redesign PR-4, task 2: the definition pane's `Unread results` row
+    is the live replacement for the retired "See Results tab" pointer
+    (survey :734-736) -- activating it pushes a `ResultsHostScreen`
+    scoped to ONLY that definition's results, and `a` inside it only
+    marks THIS definition's unread results read (a sibling definition's
+    unread result must survive). Popping (Esc) re-syncs the rail badge
+    from the DB (`dismissed`)."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        target_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Weekly digest",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What changed?"},
+        )
+        other_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Other automation",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "Other?"},
+        )
+        target_result_id = db.create_automation_result(
+            owner_id="local",
+            definition_id=target_id,
+            run_id="run-1",
+            kind="finding",
+            title="Digest finding",
+            summary="s",
+            dedupe_key="d1",
+            answer="a",
+            source_refs=[],
+            review_state="unread",
+        )
+        db.create_automation_result(
+            owner_id="local",
+            definition_id=other_id,
+            run_id="run-1",
+            kind="finding",
+            title="Other finding",
+            summary="s",
+            dedupe_key="d2",
+            answer="a",
+            source_refs=[],
+            review_state="unread",
+        )
+
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+            workbench = pilot.app.screen
+
+            detail = workbench.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            )
+            definition = db.get_automation_definition(target_id)
+            detail.set_definition(definition, unread_count=1)
+            await pilot.pause()
+
+            row = detail._unread_row
+            assert row.affordance is True
+            row.post_message(DetailValueRow.Activated(row))
+            await pilot.pause()
+
+            assert isinstance(pilot.app.screen, ResultsHostScreen)
+            overlay_tab = pilot.app.screen.query_one(ResultsTab)
+            overlay_table = overlay_tab.query_one("#scheduling-results-table", DataTable)
+            assert overlay_table.row_count == 1
+            assert rendered_row_cells(overlay_table, 0)[1] == "Digest finding"
+
+            await pilot.press("a")
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert db.get_automation_result(target_result_id)["review_state"] == "read"
+            other_result = db.list_automation_results(
+                owner_id=None, definition_id=other_id
+            )[0]
+            assert other_result["review_state"] == "unread"
+
+            await pilot.press("escape")
+            await pilot.pause()
+
+            assert pilot.app.screen is workbench
+            # `dismissed` re-synced the rail badge from the DB: the
+            # target definition's unread result is now read, but the
+            # other definition's is still unread -> total unread == 1.
+            badge = workbench.query_one("#scheduling-results-badge", Button)
+            assert str(badge.label) == "Results (1)"
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_definition_filtered_overlay_heading_escapes_the_definition_name(
+    tmp_path,
+):
+    """redesign PR-4, task 2: the definition-filtered heading is rendered
+    through the same `Static.update(str)` -> `Content.from_markup` parser
+    the detail pane's own `escape_markup` guards against (results_tab.py's
+    docstring) -- a bracket-bearing definition name must render
+    literally, not get eaten as a markup tag."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        definition_id = db.create_automation_definition(
+            "local",
+            "recurring_question",
+            "Digest [urgent]",
+            schedule={"kind": "cron", "cron": "0 9 * * 1", "timezone": "UTC"},
+            input={"question": "What changed?"},
+        )
+        async with app.run_test(size=(220, 60)) as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            workbench = pilot.app.screen
+
+            definition = db.get_automation_definition(definition_id)
+            workbench._push_results_overlay(definition=definition)
+            await pilot.pause()
+
+            overlay_tab = pilot.app.screen.query_one(ResultsTab)
+            heading = str(
+                overlay_tab.query_one("#scheduling-results-heading").render()
+            ).strip()
+            assert "Digest [urgent]" in heading
+    finally:
+        db.close()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -51,6 +51,9 @@ from tldw_chatbook.UI.Screens.scheduling.task_detail import (
     _STATUS_BADGE_CLASSES,
     _humanize_cron,
 )
+from tldw_chatbook.UI.Screens.scheduling.workbench_host_screen import (
+    WorkbenchHostScreen,
+)
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.Widgets.delete_confirmation_dialog import DeleteConfirmationDialog
 from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
@@ -3745,12 +3748,17 @@ async def test_mark_all_read_visible_when_a_definition_has_unread_results():
 
 
 @pytest.mark.asyncio
-async def test_conflicts_badge_shows_count_and_switches_to_conflicts_tab():
-    """redesign PR-2, Task 3, plan ruling 4: the status strip's conflicts
-    badge mirrors `_refresh_conflicts_tab`'s own existing count (no new
-    query) and switches to the Conflicts tab on click -- no overlay."""
+async def test_conflicts_badge_pushes_conflicts_overlay_with_painted_content():
+    """redesign PR-4, Task 1: the status strip's conflicts badge mirrors
+    `_refresh_conflicts_tab`'s own existing count (no new query) and
+    pushes a fresh `ConflictsTab` overlay via `WorkbenchHostScreen` on
+    click -- the tab-flip this replaced cannot work once the tab bar is
+    retired (Task 5). The Conflicts TAB itself stays untouched by the
+    push (it is retired separately, in Task 5)."""
     app = _RailTestApp(
-        _RailService(conflicts=[{"id": "c1"}, {"id": "c2"}])
+        _RailService(
+            conflicts=[{"id": "c1", "local_state": {"title": "Digest"}}]
+        )
     )
     async with app.run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
@@ -3758,16 +3766,35 @@ async def test_conflicts_badge_shows_count_and_switches_to_conflicts_tab():
         workbench = pilot.app.screen
 
         badge = workbench.query_one("#scheduling-conflicts-badge", Button)
-        assert str(badge.label) == "Conflicts (2)"
+        assert str(badge.label) == "Conflicts (1)"
         assert "scheduled task" in str(badge.tooltip).lower()
 
         tabs = workbench.query_one("#scheduling-tabs", TabbedContent)
-        assert tabs.active != "scheduling-conflicts-tab"
+        original_active = tabs.active
 
         badge.press()
         await pilot.pause()
 
-        assert tabs.active == "scheduling-conflicts-tab"
+        # No tab flip -- a fresh screen is pushed on top instead.
+        assert tabs.active == original_active
+        assert pilot.app.screen is not workbench
+        assert isinstance(pilot.app.screen, WorkbenchHostScreen)
+
+        overlay_tab = pilot.app.screen.query_one(
+            "#scheduling-conflicts-overlay", ConflictsTab
+        )
+        overlay_table = overlay_tab.query_one(
+            "#scheduling-conflicts-table", DataTable
+        )
+        # Painted, not stored: what the table would actually render for
+        # row 0 (schedules_test_helpers.rendered_row_cells).
+        assert rendered_row_cells(overlay_table, 0)[0] == "Digest"
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        # Esc pops back to the same underlying workbench instance.
+        assert pilot.app.screen is workbench
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_workbench_host_screen.py
+++ b/Tests/UI/test_workbench_host_screen.py
@@ -1,0 +1,146 @@
+"""Tests for `WorkbenchHostScreen` -- the pushed, fresh-instance widget
+host (redesign PR-4, Task 1).
+
+Generic push/pop mechanics only. The conflicts-badge integration (a real
+`ConflictsTab` pushed through this host) is covered in
+`test_schedules_workbench.py`, alongside the badge's own behavior.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import ComposeResult
+from textual.screen import Screen
+from textual.widgets import Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.UI.Screens.scheduling.workbench_host_screen import (
+    WorkbenchHostScreen,
+)
+
+
+class _Marker(Static):
+    """A trivially paintable, identity-checkable hosted widget."""
+
+
+class _BaseScreen(Screen):
+    """Stand-in for the pane a host overlay is pushed on top of."""
+
+    def compose(self) -> ComposeResult:
+        yield Static("base pane", id="base-marker")
+
+
+class _HostTestApp(ConsolidatedCSSApp):
+    pass
+
+
+@pytest.mark.asyncio
+async def test_push_pop_round_trip_yields_a_fresh_instance_each_time():
+    """Two pushes of the same factory must build two distinct widgets --
+    the spec's no-reparenting rule (survey §2)."""
+    app = _HostTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(_BaseScreen())
+        await pilot.pause()
+
+        built: list[_Marker] = []
+
+        def factory() -> _Marker:
+            widget = _Marker()
+            built.append(widget)
+            return widget
+
+        await pilot.app.push_screen(WorkbenchHostScreen(factory, title="Overlay"))
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        await pilot.app.push_screen(WorkbenchHostScreen(factory, title="Overlay"))
+        await pilot.pause()
+
+        assert len(built) == 2
+        assert built[0] is not built[1]
+
+
+@pytest.mark.asyncio
+async def test_escape_pops_the_host_screen():
+    app = _HostTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(_BaseScreen())
+        await pilot.pause()
+
+        host = WorkbenchHostScreen(lambda: _Marker(), title="Overlay")
+        await pilot.app.push_screen(host)
+        await pilot.pause()
+        assert pilot.app.screen is host
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert pilot.app.screen is not host
+        assert isinstance(pilot.app.screen, _BaseScreen)
+
+
+@pytest.mark.asyncio
+async def test_pane_behind_survives_the_round_trip_untouched():
+    """Pushing/popping an overlay must not recompose or replace the
+    screen underneath -- same widget identity before and after."""
+    app = _HostTestApp()
+    async with app.run_test() as pilot:
+        base = _BaseScreen()
+        await pilot.app.push_screen(base)
+        await pilot.pause()
+        marker_before = base.query_one("#base-marker", Static)
+
+        await pilot.app.push_screen(
+            WorkbenchHostScreen(lambda: _Marker(), title="Overlay")
+        )
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+
+        marker_after = base.query_one("#base-marker", Static)
+        assert marker_after is marker_before
+
+
+@pytest.mark.asyncio
+async def test_dismissed_callback_fires_once_on_pop():
+    app = _HostTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(_BaseScreen())
+        await pilot.pause()
+
+        calls: list[None] = []
+        host = WorkbenchHostScreen(
+            lambda: _Marker(),
+            title="Overlay",
+            dismissed=lambda: calls.append(None),
+        )
+        await pilot.app.push_screen(host)
+        await pilot.pause()
+        assert calls == []
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert calls == [None]
+
+
+@pytest.mark.asyncio
+async def test_hosted_widget_paints_within_the_screen():
+    """Real geometry, not internal state: the hosted widget must occupy
+    actual screen space and show its content."""
+    app = _HostTestApp()
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(_BaseScreen())
+        await pilot.pause()
+
+        await pilot.app.push_screen(
+            WorkbenchHostScreen(lambda: _Marker("hosted content"), title="Overlay")
+        )
+        await pilot.pause()
+
+        marker = pilot.app.screen.query_one(_Marker)
+        assert marker.region.width > 0
+        assert marker.region.height > 0
+        assert str(marker.renderable) == "hosted content"

--- a/backlog/decisions/116-schedules-inspector-editing.md
+++ b/backlog/decisions/116-schedules-inspector-editing.md
@@ -127,3 +127,33 @@ responsive floor later decides to hide the detail pane.
   definition_lifecycle`, the PR-5 transfer facade); the only DB change is
   the two-layer guard's extra `SELECT`/parameter, not a new column or
   table.
+
+## Amendment (2026-09-04) — PR-4 chose the pushed pane, not the modal
+
+Two lines above are now stale and are superseded by redesign PR-4 (plan
+`.superpowers/sdd/plan-2026-09-04-schedules-redesign-pr4/`, ruling 6):
+
+- Decision 1's "A width at which the detail pane is hidden altogether is
+  PR-4's responsive floor to define, **and the modal is the fallback
+  there when it does**", and
+- the Context section's "Enter on a list row still opens the modal
+  unchanged, at every width — including any width at which PR-4's
+  responsive floor later decides to hide the detail pane."
+
+PR-4 defined that width (84 columns) and chose the **pushed detail pane**
+as the fallback, not the modal: below the threshold `Enter` pushes the
+SAME pane widget class as a fresh instance inside a full-screen
+`WorkbenchHostScreen`, fed by the same service-backed loads the docked
+pane gets, with `Esc` to return. `m` (move owner) routes the same way
+(final review F1). "Edit in full…" still opens `ReminderForm` from inside
+the pushed pane, so ADR-099's modal remains reachable at every width and
+its width-cliff argument is untouched — what changed is only which
+surface stands in for the *hidden inspector*, and the pushed pane keeps
+in-place row editing working at 80×24 rather than dropping back to a
+whole-form modal for a single field.
+
+The Consequences bullet about "the owner row's dropdown and the legacy
+Move/Retry/Cancel buttons are two live surfaces" is also closed: PR-4
+task 4 deleted the legacy buttons and `_begin_transfer`/`_cancel_
+transfer`, leaving the Runs-on row's dropdown as the one transfer
+surface (PR-4 plan ruling 2).

--- a/backlog/docs/plan-2026-09-04-schedules-redesign-pr4.md
+++ b/backlog/docs/plan-2026-09-04-schedules-redesign-pr4.md
@@ -1,0 +1,77 @@
+# Schedules Redesign — PR-4 (FINAL): Responsive floor, keyboard map, tab retirement
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The redesign completes: one surface (the unified Queue), the spec-§12 keyboard map, an 80×24-safe responsive floor, and the Automations/Conflicts/Results tabs retired — with every unique capability they held relocated (audit trail, results detail + actions, conflicts view, run-now/edit for definitions) and the accumulated cleanup riders resolved.
+
+**Architecture:** One new `WorkbenchHostScreen` pattern (a minimal pushed `Screen` hosting a given workbench widget class as a FRESH instance, Esc-to-close — the spec's no-reparenting rule; the repo has no precedent, this invents it) serves all four push needs: the narrow-width detail push, the results view, the conflicts view, and the audit view. The unified list drops its family filter (all server families render read-only rows with the existing unsupported-family fallback — retiring the Automations tab must not make agent_task invisible); definition rows gain run-now/edit routing; the Results tab's rendering+actions relocate into the pushed results view reachable from the rail and the panes' now-live results rows. The §12 keyboard map lands with its collisions resolved (legacy fixed-direction transfer keys and their duplicated flow DELETE — the Runs-on dropdown is the transfer surface); Up/Down detail-row traversal is new `DetailValueRow`/pane work. The retirement then deletes the three TabPanes, tab-gated code, legacy transfer buttons, and the dead branches.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, SQLite, pytest.
+
+**Spec:** `backlog/docs/spec-2026-09-02-schedules-screen-redesign.md` §11-phase-4/§12/§13 (tracked). Planning rulings (binding):
+1. **Family filter drops** (the ledgered revisit): all families list in the unified Queue; non-`recurring_question` rows are read-only (the `_UNSUPPORTED_FAMILY_NOTE` fallback `DefinitionDetail` already has) — visibility is the honest v1, authoring/editing stays recurring_question-only. Spec §13 scopes out only the Create entry.
+2. **Keyboard per spec §12 exactly**: `1-4`/`f` chips, `/` search, `n` create, `p` pause/resume, `m` move owner (the dropdown opener), `r` mark read, `Esc` back/close, `Up/Down` detail-row traversal. Legacy `m/M/y/k` fixed-direction transfer keys DELETE with their duplicated flow (`_begin_automation_transfer`/`_cancel_automation_transfer`, `_run_owner_*`'s legacy twins) and `TaskDetail`'s legacy transfer buttons — the Runs-on row is the one transfer surface. Run-now is NOT a global key: it is a detail-pane button (DefinitionDetail gains one beside pause/resume; TaskDetail already has one).
+3. **Push pattern**: `WorkbenchHostScreen(widget_factory, title)` — fresh instance per push, Esc pops, no state reparenting; data flows through the same service seams the tab versions used. The conflicts badge repoints to it (the tab-flip breaks with the tab bar).
+4. **Results relocation semantics preserved**: the 200-row sync-window listing + honest cap line, read/dismiss/mark-solved (+`r` per the map), detail rendering, Mark-all — all in the pushed results view; `DefinitionDetail`'s dangling "See Results tab" string and dead unread row become a live "view results" activation (affordance on) pushing the view filtered to that definition.
+5. **Stale rider coordinates**: the PR-2-era isinstance-branch line numbers are stale — re-locate by PATTERN (single-primitive guards made dead by `include_projections=False` and the unified loader), verify each is genuinely unreachable before deleting.
+6. **Responsive floor**: <84 cols the detail pane no longer blank-hides — Enter on a row pushes the hosted detail; chips collapse to the cycling control at ~80; every operation reachable at 80×24 via push or modal (pinned at 80×24 and ~110). The `_definitions_stale` TabActivated consumer re-homes (no tabs) onto the push/pop lifecycle.
+
+## Global Constraints
+
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-redesign-pr4`, branch `feat/schedules-single-surface` off current `origin/dev`. Never the main checkout; NEVER `git stash` (baselines: `git show <ref>:<path>` / throwaway detached worktree); no pkill beyond own PIDs; `git --no-pager`; FOREGROUND pytest only; tmp_path DBs.
+- NO schema migration; NO service-seam changes except deletions of now-unconsumed legacy paths (verify zero consumers before deleting).
+- Survey with exact seams: `redesign-pr4-survey.md` in the SDD workspace.
+- Diagnostics pin (SCRIPT, `--write`+JSON) on logger changes; census COUNT parity vs dev CI; bare-type CSS ratchet (class-target, never ancestor-scoped bare types — bit us in PR-3); CSS via build flow source+bundle; `CSS_PATH = BUNDLED_STYLESHEET` for geometry tests; painted assertions; escape/Text discipline.
+- Retirement = preservation flips: tests pinning the RETIRED surfaces update deliberately (each change cited with the retirement rationale); tests pinning KEPT behavior stay untouched.
+- UI change ⇒ `Docs/User_Guide/` schedules page — this one is a REWRITE (single surface).
+- Commit trailer on every commit:
+
+```
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv
+```
+
+---
+
+### Task 1: `WorkbenchHostScreen` + conflicts repoint
+
+**Files:** Create `tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py`. Modify `schedules_workbench.py` (the conflicts badge pushes the hosted `ConflictsTab` instead of flipping tabs — the tab itself stays until Task 5). Tests: new `Tests/UI/test_workbench_host_screen.py` + the badge test updates.
+
+**Interfaces (produced; Tasks 2/3/6 consume):** `WorkbenchHostScreen(widget_factory: Callable[[], Widget], *, title: str)` — pushes with the factory-built fresh instance, styles via the existing features CSS (class-targeted — the ratchet), `Esc` pops, footer hint registered; a `dismissed` callback slot for pop-time refresh (the staleness re-home consumer).
+
+- [ ] TDD: push/pop round-trip (fresh instance each push — two pushes yield distinct widgets); Esc pops; badge push renders the conflicts content painted; the pane behind survives the round-trip untouched. FAIL → implement → PASS → commit `feat(ui): WorkbenchHostScreen push pattern + conflicts repoint`.
+
+### Task 2: Results relocation
+
+**Files:** Modify `results_tab.py` (the widget must compose cleanly inside the host screen — factor its tab-coupling out if any; add an optional `definition_id` filter mode preserving the cap-line honesty), `schedules_workbench.py` (rail: a "Results (N)" affordance beside Mark-all-read pushing the hosted view), `definition_detail.py` (+`task_detail.py` if reminders reference results — check): the unread row gains `affordance=True` and the dangling "See Results tab" string becomes the live "view results" activation pushing the view filtered to the definition. Tests: results-tab file + pane files.
+
+- [ ] TDD: pushed view lists/read/dismiss/mark-solved/mark-all work hosted (the existing results tests' behaviors re-pinned in the pushed context); definition-filtered push shows only that definition's results with the honest cap line; the unread row activation; badge/unread refresh on pop (the dismissed callback). FAIL → implement → PASS → commit `feat(scheduling): results view relocated to the pushed surface`.
+
+### Task 3: Definition-row actions + all-families listing + audit relocation
+
+**Files:** Modify `unified_rows.py` (drop the family filter per ruling 1 — bucket/glyph handling for unknown families defers to honest defaults; search_blob etc. still safe), `schedules_workbench.py` (Queue definition rows: run-now routed to the existing local/server run-now paths by owner, `e` edit-in-full opens the modal for recurring_question rows — both routed by row kind; non-recurring_question rows: read-only + honest refusals), `definition_detail.py` (a Run-now button beside pause/resume — the tab's `r` relocates here as a button per ruling 2; the History "view runs" pointer becomes a live activation pushing a hosted audit view — a small `definition_audit_view.py` widget reusing `list_automation_definition_audit` + the tab's rendering). Tests: unified-list + pane + workbench files.
+
+- [ ] TDD: agent_task rows visible/read-only with the honest note (bucket sanity for unknown families pinned); run-now both owners from the Queue; edit-in-full routing; audit view pushed with painted events; family-gated refusals. FAIL → implement → PASS → commit `feat(scheduling): definition actions on the queue + all-families listing + audit view`.
+
+### Task 4: Keyboard map + detail-row traversal
+
+**Files:** Modify `schedules_workbench.py` (BINDINGS + `SCHEDULES_SHORTCUTS` to the §12 map: `1-4`/`f` chips, `/` focus-search, `n` create chooser, `p` pause/resume for the selected row (reminders toggle enable, definitions lifecycle — routed by kind, honest refusal where locked), `m` opens the Runs-on dropdown on the selected row's detail, `r` mark-read (selected definition row's unread → read; refusal copy when nothing unread), `Esc` existing semantics); `detail_value_row.py`/pane files (Up/Down traversal across focusable rows within the pane — new key handling; Textual's default chain is Tab-based, arrows are new work; keep the editor-open input-ownership rule from PR-3). LEGACY DELETIONS: the `m/M/y/k` transfer keys + `_begin_automation_transfer`/`_cancel_automation_transfer` + `TaskDetail`'s legacy transfer buttons + the `_run_owner_*` duplication's legacy side (verify zero remaining consumers each — ruling 2). Tests across the affected files; every deleted-surface test updated WITH the retirement citation.
+
+- [ ] TDD: each §12 key end-to-end (painted/effect assertions); traversal round-trip incl. skip-non-focusable and editor-open ownership; deleted keys genuinely gone (no-op or rebound); footer tuple matches. FAIL → implement → PASS → commit `feat(scheduling): spec keyboard map + row traversal, legacy transfer surface retired`.
+
+### Task 5: The retirement + dead-code sweep
+
+**Files:** Modify `schedules_workbench.py` (delete the Automations/Conflicts/Results TabPanes + ALL tab-gated code — the TabbedContent likely reduces to the bare Queue content, remove it if so; `_definitions_stale`'s TabActivated consumer re-homes onto push/pop dismissed callbacks + the existing refresh seams; the second `DefinitionDetail` instance and `_refresh_*_tab` paths for retired tabs go), `task_detail.py` (dead managed-by branch :1514-1519 region — verify unreachable then delete), the stale-rider sweep per ruling 5 (re-locate by pattern; delete only what's provably dead), the per-tick reminder tick-skip guard (the asymmetry: mirror the definition branch's guard), `results_tab.py`/`conflicts_tab.py` renames if their "tab" identity is now wrong (judgment: keep module names, update docstrings — smallest diff). Tests: the big deliberate update — every retired-surface test removed/rewritten WITH citations; kept-behavior tests untouched.
+
+- [ ] TDD: the workbench composes single-surface (painted); all relocated capabilities still reachable (smoke each: conflicts push, results push, audit push, run-now, edit); staleness re-home pinned (an Automations-era mutation path → the Queue refreshes via the new consumer); no orphaned imports/dead services (grep sweep recorded). FAIL → implement → PASS → commit `feat(scheduling): single-surface workbench — tabs retired`.
+
+### Task 6: Responsive floor + docs rewrite + gates
+
+**Files:** Modify `schedules_workbench.py` + CSS (per ruling 6: <84 the detail region hides and Enter pushes the hosted detail — the SAME widget classes fresh-instanced with the row's data; chips collapse to the cycling control at ~80; the rail/status strip degrade readably), `Docs/User_Guide/` schedules page (REWRITE for the single surface: the list, chips, keys, editing, transfers, results/conflicts/audit pushes, responsive behavior). Gates.
+
+- [ ] TDD: 80×24 full-operation smoke (create/edit/pause/transfer/results each reachable via push or modal — painted at that size with `CSS_PATH = BUNDLED_STYLESHEET`); ~110 and full-width layouts pinned; chip collapse; pushed-detail data correctness. Then FULL gates: `Tests/Scheduling/ -q`; the assembled UI set (accounting for the deliberate retirement updates); census COUNT parity vs dev CI; the bare-type + boot-css ratchets checked with attribution; pin script; ruff; bundle byte-identical. Commit `feat(scheduling): responsive floor + single-surface docs`.
+
+---
+
+## After the tasks
+Final whole-branch review (opus; relocation-completeness + retirement-cleanliness + 80×24 lenses) → one fix wave → PR `feat(scheduling): single-surface schedules workbench (redesign PR-4, final)` → paged bot read → adjudicate → the full-cycle merge pipeline (in-loop merge; peer window if >2 laps). Post-merge: PROGRAM CLOSE-OUT — memory, lessons file (the accumulated cross-program lessons), backlog follow-up tasks (backfill normalizer, post-transfer history identity, keyring isolation, auth_token precedence, MRO double-unmount, C1-mirror... verify which remain), TASK-18940 status, and the redesign spec marked Delivered.

--- a/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
+++ b/backlog/docs/spec-2026-09-02-schedules-screen-redesign.md
@@ -233,6 +233,14 @@ After the handoff program:
 Up/Down traverse detail rows when the pane has focus. Footer-visible key
 hints extend ADR-099's parity requirement to the pane.
 
+**PR-4 amendment (2026-09-04).** `Enter` is honored only below the
+responsive floor's 84-column threshold, where it PUSHES the row's detail
+full-screen (plan ruling 6); at or above it the detail pane is already
+docked beside the list showing that row, so `Enter` stays the no-op it
+has always been. `m` follows the same split: below the threshold it
+pushes the detail and opens the Runs-on dropdown inside it, because the
+docked pane is hidden there (final review F1).
+
 ## 13. Out of scope
 
 - `agent_task` rows beyond the disabled Create entry.

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -218,6 +218,20 @@ class DefinitionOwnerActionRequested(Message):
         self.row = row
 
 
+class ViewDefinitionResultsRequested(Message):
+    """Posted when a definition pane's 'Unread results' row is activated
+    (redesign PR-4, task 2 -- the retired "See Results tab" pointer's
+    live replacement). ``definition`` is the raw dict `DefinitionDetail.
+    set_definition` was last painted with; the workbench resolves both
+    its local/server id spaces (`index_definitions_by_id`'s own caveat)
+    and pushes a `ResultsTab` scoped to this one definition.
+    """
+
+    def __init__(self, definition: dict[str, Any]) -> None:
+        super().__init__()
+        self.definition = definition
+
+
 class SyncCompleted(Message):
     """Posted when a non-failing sync attempt completes.
 

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -67,40 +67,16 @@ class RunReminderNowRequested(Message):
         self.task = task
 
 
-class TransferToServerRequested(Message):
-    """Posted when the user asks to move a local reminder to the server
-    (schedules-handoff spec §6.1, PR-5 task 7)."""
 
-    def __init__(self, task: ReminderTask) -> None:
-        super().__init__()
-        self.task = task
-
-
-class TransferToLocalRequested(Message):
-    """Posted when the user asks to move a server-owned reminder mirror to
-    this device (schedules-handoff spec §6.2, PR-5 task 7)."""
-
-    def __init__(self, task: ReminderTask) -> None:
-        super().__init__()
-        self.task = task
-
-
-class CancelTransferRequested(Message):
-    """Posted when the user cancels a reminder's in-progress transfer
-    (schedules-handoff spec §6.3, PR-5 task 7)."""
-
-    def __init__(self, task: ReminderTask) -> None:
-        super().__init__()
-        self.task = task
-
-
-class RetryTransferRequested(Message):
-    """Posted when the user retries a definitively-failed local -> server
-    transfer (schedules-handoff spec §6.1.5, PR-5 task 7)."""
-
-    def __init__(self, task: ReminderTask) -> None:
-        super().__init__()
-        self.task = task
+# redesign PR-4, task 4 (ruling 2): `TransferToServerRequested`/
+# `TransferToLocalRequested`/`CancelTransferRequested`/
+# `RetryTransferRequested` (schedules-handoff spec §6, PR-5 task 7) were
+# posted only by `TaskDetail`'s now-retired legacy Move/Retry/Cancel
+# buttons and consumed only by `SchedulesWorkbench`'s now-retired
+# `_begin_transfer`/`_cancel_transfer` -- deleted with both ends (`git
+# grep` verified zero remaining producers/consumers before removal). The
+# Runs-on row's dropdown + mini-bar uses `ReminderOwnerActionRequested`
+# below instead.
 
 
 class ReminderFieldEditRequested(Message):

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -205,6 +205,12 @@ class ViewDefinitionResultsRequested(Message):
     """
 
     def __init__(self, definition: dict[str, Any]) -> None:
+        """
+        Args:
+            definition: The raw dict `DefinitionDetail.set_definition`
+                was last painted with (local DB row or raw server
+                list-response dict).
+        """
         super().__init__()
         self.definition = definition
 
@@ -219,6 +225,12 @@ class DefinitionRunNowRequested(Message):
     """
 
     def __init__(self, definition: dict[str, Any]) -> None:
+        """
+        Args:
+            definition: The raw dict `DefinitionDetail.set_definition`
+                was last painted with (local DB row or raw server
+                list-response dict).
+        """
         super().__init__()
         self.definition = definition
 
@@ -235,6 +247,12 @@ class ViewDefinitionAuditRequested(Message):
     """
 
     def __init__(self, definition: dict[str, Any]) -> None:
+        """
+        Args:
+            definition: The raw dict `DefinitionDetail.set_definition`
+                was last painted with (local DB row or raw server
+                list-response dict).
+        """
         super().__init__()
         self.definition = definition
 

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -232,6 +232,36 @@ class ViewDefinitionResultsRequested(Message):
         self.definition = definition
 
 
+class DefinitionRunNowRequested(Message):
+    """Posted when a definition pane's header 'Run now' button is pressed
+    (redesign PR-4, task 3 -- the retired Automations-tab `r` key's live
+    replacement, ruling 2). ``definition`` is the raw dict
+    `DefinitionDetail.set_definition` was last painted with; the workbench
+    routes it to the existing owner-routed dispatch
+    (`SchedulesWorkbench._run_automation_now`) unchanged.
+    """
+
+    def __init__(self, definition: dict[str, Any]) -> None:
+        super().__init__()
+        self.definition = definition
+
+
+class ViewDefinitionAuditRequested(Message):
+    """Posted when a definition pane's 'Last run' row is activated
+    (redesign PR-4, task 3 -- the retired Automations-tab's third
+    (run-history/audit) pane's live replacement; the row's own "...see
+    Run history" copy for a server-owned definition is the pointer this
+    activation makes live). ``definition`` is the raw dict
+    `DefinitionDetail.set_definition` was last painted with; the
+    workbench pushes a `definition_audit_view.DefinitionAuditView` scoped
+    to this one definition.
+    """
+
+    def __init__(self, definition: dict[str, Any]) -> None:
+        super().__init__()
+        self.definition = definition
+
+
 class SyncCompleted(Message):
     """Posted when a non-failing sync attempt completes.
 

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -67,7 +67,6 @@ class RunReminderNowRequested(Message):
         self.task = task
 
 
-
 # redesign PR-4, task 4 (ruling 2): `TransferToServerRequested`/
 # `TransferToLocalRequested`/`CancelTransferRequested`/
 # `RetryTransferRequested` (schedules-handoff spec §6, PR-5 task 7) were
@@ -164,11 +163,13 @@ class ReminderOwnerActionRequested(Message):
     idiom `DetailValueRow.Activated`/`ReminderFieldEditRequested` already
     use) so the workbench can call `row.show_error(...)` directly on a
     refusal -- this row's transfer refusals render inline (health-quoting
-    preserved), NOT through the legacy toast the existing Move/Cancel/
-    Retry buttons still use (`SchedulesWorkbench._begin_transfer`'s own
-    ``notify(reason, ...)``) -- the two surfaces are deliberately
-    independent (coexistence, task-5 brief). `TaskDetail` has already
-    called `row.end_edit()` (a dropdown commit) before posting this.
+    preserved) rather than as a toast. That inline rendering was
+    originally the coexisting alternative to the legacy Move/Cancel/Retry
+    buttons' `SchedulesWorkbench._begin_transfer` toast (PR-3 task 5
+    brief); redesign PR-4 task 4 deleted those buttons and that method, so
+    this row's dropdown is now the ONE transfer surface (ruling 2).
+    `TaskDetail` has already called `row.end_edit()` (a dropdown commit)
+    before posting this.
     """
 
     def __init__(self, task: ReminderTask, action: str, row: DetailValueRow) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
@@ -61,16 +61,30 @@ class ConflictsTab(Vertical):
     }
     """
 
-    def __init__(self, sync_engine: _SyncEngineProtocol | None, **kwargs) -> None:
+    def __init__(
+        self,
+        sync_engine: _SyncEngineProtocol | None,
+        *,
+        initial_conflicts: list[dict[str, Any]] | None = None,
+        **kwargs,
+    ) -> None:
         """Initialize the conflicts tab.
 
         Args:
             sync_engine: Engine providing ``resolve_conflict(conflict_id, resolution)``.
+            initial_conflicts: When given, ``populate()``s the table with
+                these on mount. The still-live Conflicts TAB instance stays
+                externally driven (the workbench calls ``.populate()``
+                itself after its own ``get_conflicts`` read); a standalone
+                pushed instance (redesign PR-4, Task 1's conflicts-badge
+                overlay, via ``WorkbenchHostScreen``) has no such external
+                driver, so it self-populates instead.
             **kwargs: Passed to the parent widget.
         """
         super().__init__(**kwargs)
         self.sync_engine = sync_engine
         self._conflicts_by_id: dict[str, dict[str, Any]] = {}
+        self._initial_conflicts = initial_conflicts
 
     def compose(self) -> ComposeResult:
         """Build the tab layout."""
@@ -154,10 +168,13 @@ class ConflictsTab(Vertical):
             )
 
     def on_mount(self) -> None:
-        """Configure the table cursor."""
+        """Configure the table cursor, and self-populate if constructed with data."""
         table = self.query_one("#scheduling-conflicts-table", DataTable)
         table.cursor_type = "row"
-        self._set_actions_enabled(False)
+        if self._initial_conflicts is not None:
+            self.populate(self._initial_conflicts)
+        else:
+            self._set_actions_enabled(False)
 
     @on(DataTable.RowHighlighted, "#scheduling-conflicts-table")
     def _on_conflict_highlighted(self, event: DataTable.RowHighlighted) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
@@ -74,7 +74,7 @@ class ConflictsTab(Vertical):
         sync_engine: _SyncEngineProtocol | None,
         *,
         initial_conflicts: list[dict[str, Any]] | None = None,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """Initialize the conflicts tab.
 

--- a/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/conflicts_tab.py
@@ -1,4 +1,12 @@
-"""Conflicts tab for the Schedules workbench."""
+"""Sync-conflicts view for the Schedules workbench.
+
+The module keeps its `conflicts_tab` name (redesign PR-4 task 5's own
+judgment: renaming the file buys nothing but churn), but the TAB it was
+built for is retired. `ConflictsTab` is now mounted only as a fresh
+instance inside a pushed `WorkbenchHostScreen`, opened from the status
+strip's Conflicts badge (task 1) -- so it self-populates from
+`initial_conflicts` rather than being driven by an owner screen.
+"""
 
 from __future__ import annotations
 
@@ -73,12 +81,12 @@ class ConflictsTab(Vertical):
         Args:
             sync_engine: Engine providing ``resolve_conflict(conflict_id, resolution)``.
             initial_conflicts: When given, ``populate()``s the table with
-                these on mount. The still-live Conflicts TAB instance stays
-                externally driven (the workbench calls ``.populate()``
-                itself after its own ``get_conflicts`` read); a standalone
-                pushed instance (redesign PR-4, Task 1's conflicts-badge
-                overlay, via ``WorkbenchHostScreen``) has no such external
-                driver, so it self-populates instead.
+                these on mount. A pushed instance (redesign PR-4, Task
+                1's conflicts-badge overlay, via ``WorkbenchHostScreen``)
+                has no external ``.populate()`` driver the way the
+                retired mounted tab instance did, so it self-populates
+                instead. Still optional: ``populate()`` remains callable
+                from outside.
             **kwargs: Passed to the parent widget.
         """
         super().__init__(**kwargs)

--- a/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
@@ -165,11 +165,26 @@ class DefinitionAuditView(Vertical):
     def __init__(
         self, service: Any, definition: dict[str, Any], **kwargs: Any
     ) -> None:
+        """Store the fetch inputs; the fetch itself waits for `on_mount`.
+
+        Args:
+            service: The `SchedulingService` (or a test double exposing
+                the same `server_client` attribute), or `None` --
+                forwarded verbatim to `fetch_definition_audit`.
+            definition: The definition row dict this audit trail is for
+                (local DB row or raw server list-response dict).
+            **kwargs: Forwarded to `Vertical.__init__` (e.g. `id`).
+        """
         super().__init__(**kwargs)
         self._service = service
         self._definition = definition
 
     def compose(self) -> ComposeResult:
+        """Yield the loading notice and the (initially empty) audit table.
+
+        `_populate` (kicked off from `on_mount`) fills the table and
+        replaces the notice text once the fetch resolves.
+        """
         yield Static(
             "Loading run history…",
             id="scheduling-audit-view-notice",
@@ -180,6 +195,14 @@ class DefinitionAuditView(Vertical):
         yield table
 
     def on_mount(self) -> None:
+        """Kick off the self-populating fetch (`_populate`).
+
+        `exclusive=True` + a dedicated worker group: this widget is
+        pushed fresh on every activation (Task 1's factory contract), so
+        there is never a prior `_populate` run of THIS instance to
+        collide with -- the group only needs to be distinct from other
+        panes' own worker groups, not de-duplicate repeats.
+        """
         self.run_worker(
             self._populate, exclusive=True, group="schedules-audit-view"
         )

--- a/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
@@ -1,0 +1,207 @@
+"""Read-only, pushed audit-trail view for one automation definition.
+
+redesign PR-4, task 3 (audit-view relocation): the Automations tab's
+third pane (`SchedulesWorkbench._load_automation_history`, the survey's
+":3222-3271") is the only place a definition's SERVER-side execution
+audit trail (``list_automation_definition_audit`` -- task-18940 slice 4,
+distinct from both the local `automation_runs` history and the Results
+inbox) has ever been readable. That tab retires in Task 5; this module
+is its replacement surface, pushed via `WorkbenchHostScreen` from a
+`DefinitionDetail` pane's `Last run` row (the row whose own copy already
+says "...see Run history" for a server-owned definition -- this
+activation is what makes that pointer live, `ViewDefinitionAuditRequested`
+in `Scheduling/events.py`).
+
+`fetch_definition_audit` factors OUT the fetch-and-branch logic
+`_load_automation_history` already established (pending-sync / local-only
+/ no-server-client / fetch-failed / success) so both call sites share one
+implementation -- `schedules_workbench.py`'s own loader is refactored to
+call it too, rather than this module duplicating that branching. Each
+caller keeps its OWN paint code: the tab's own DataTable/notice/title ids
+and staleness re-check are untouched (it still exists until Task 5), and
+this widget owns a fresh, independent set.
+
+Escape discipline: `summary`/`event_type` are free-form SERVER text (an
+automation's own audit log, task-18940 slice 4's `summary` field is
+explicitly documented there as arbitrary), routed into the `DataTable`
+as `rich.text.Text` (never a bare `str`) -- the same "`Text`, not `str`"
+rule `schedules_workbench.py`'s own table renderers already use, since a
+`DataTable` cell built from a plain string is re-parsed as Rich markup
+and can silently eat a bracketed token. The notice line is always an
+internally-composed count/placeholder string, never server text, but its
+`Static` is still built `markup=False` for the same "safe by
+construction" reason `definition_detail.py`'s own question-card Static
+is.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from loguru import logger
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Vertical
+from textual.widgets import DataTable, Static
+
+
+@dataclass
+class DefinitionAuditFetch:
+    """The result of one `fetch_definition_audit` call.
+
+    ``notice_override`` is set for every non-success branch (pending
+    sync / local-only / no server connection / fetch failure) -- the
+    caller shows it verbatim instead of painting `items`/`total` (which
+    are empty/zero in that case, not a genuine "no events" reading).
+    ``None`` means the fetch succeeded (`items` may still be empty --
+    a real "no recorded events yet" outcome, distinct from a refusal).
+    """
+
+    items: list[dict[str, Any]] = field(default_factory=list)
+    total: int = 0
+    notice_override: str | None = None
+
+
+async def fetch_definition_audit(
+    service: Any, definition: dict[str, Any]
+) -> DefinitionAuditFetch:
+    """Fetch one definition's server audit trail, or an honest refusal.
+
+    Mirrors `SchedulesWorkbench._load_automation_history`'s own
+    branching exactly (this IS that logic, factored out so both callers
+    share it): a definition that never synced, a local-only definition
+    (no durable audit trail exists for local dispatch yet), no connected
+    server, or a fetch that raised all return a `notice_override`
+    instead of raising -- this function never propagates an exception.
+
+    Args:
+        service: The `SchedulingService` (or a test double exposing the
+            same `server_client` attribute), or `None`.
+        definition: The definition row dict (local DB row or raw server
+            list-response dict -- either shape, same as `DefinitionDetail
+            .set_definition`).
+
+    Returns:
+        A `DefinitionAuditFetch`.
+    """
+    # ADR-097: scheduler.queue stays off the boot census -- function-local
+    # import, matching every other reader of this predicate in this
+    # package (`unified_rows.owner_display_label`, `definition_detail
+    # ._definition_history_labels`, `schedules_workbench._load_automation
+    # _history`).
+    from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
+
+    owner_id = (definition or {}).get("owner_id")
+    if (definition or {}).get("pending_sync"):
+        return DefinitionAuditFetch(
+            notice_override=(
+                "This automation hasn't synced to the server yet, so it "
+                "has no run history."
+            )
+        )
+    if not is_server_scoped_owner(owner_id):
+        return DefinitionAuditFetch(
+            notice_override="Local automation history isn't available yet."
+        )
+    server_client = getattr(service, "server_client", None) if service else None
+    if server_client is None:
+        return DefinitionAuditFetch(
+            notice_override="Run history needs a connected server."
+        )
+    definition_id = str(definition.get("id") or "")
+    try:
+        response = await server_client.list_automation_definition_audit(
+            definition_id
+        )
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "Failed to load automation audit trail (definition_id={})",
+            definition_id,
+        )
+        return DefinitionAuditFetch(
+            notice_override="Could not load the run history — see the log."
+        )
+    items = list(response.get("items", []))
+    total = int(response.get("total", len(items)) or 0)
+    return DefinitionAuditFetch(items=items, total=total)
+
+
+def audit_notice_text(items: list[dict[str, Any]], total: int) -> str:
+    """The success-path notice line -- same wording `_load_automation_
+    history` already renders, factored out so both callers stay in sync."""
+    if not items:
+        return "No recorded events for this automation yet."
+    suffix = f" of {total}" if total > len(items) else ""
+    return f"{len(items)} event{'' if len(items) == 1 else 's'}{suffix}."
+
+
+class DefinitionAuditView(Vertical):
+    """Pushed, read-only widget rendering one definition's audit trail.
+
+    Self-populating (`on_mount` kicks off its own fetch through `fetch_
+    definition_audit`) -- unlike `ResultsTab`/`ConflictsTab`'s `initial_*`
+    seam, the fetch here is unavoidably async (a `server_client` call),
+    so there is no synchronous value to hand over at construction time
+    the way those two pre-read before pushing. No mutation surface (pure
+    render), so the caller pushes it through the plain `WorkbenchHostScreen`
+    -- unlike `ResultsHostScreen`, this widget needs no dedicated Screen
+    subclass.
+    """
+
+    # Same shape `ConflictsTab`/`ResultsTab`'s own `BUNDLED_CSS` uses
+    # (`.workbench-host-body` on the pushed root gives THIS widget
+    # height:1fr; the table needs its own rule to actually expand into
+    # that space rather than sizing to its rows).
+    BUNDLED_CSS = """
+    DefinitionAuditView {
+        height: 1fr;
+    }
+    #scheduling-audit-view-table {
+        height: 1fr;
+    }
+    """
+
+    def __init__(
+        self, service: Any, definition: dict[str, Any], **kwargs: Any
+    ) -> None:
+        super().__init__(**kwargs)
+        self._service = service
+        self._definition = definition
+
+    def compose(self) -> ComposeResult:
+        yield Static(
+            "Loading run history…",
+            id="scheduling-audit-view-notice",
+            markup=False,
+        )
+        table = DataTable(id="scheduling-audit-view-table", cursor_type="row")
+        table.add_columns("When", "Event", "Summary")
+        yield table
+
+    def on_mount(self) -> None:
+        self.run_worker(
+            self._populate, exclusive=True, group="schedules-audit-view"
+        )
+
+    async def _populate(self) -> None:
+        notice = self.query_one("#scheduling-audit-view-notice", Static)
+        table = self.query_one("#scheduling-audit-view-table", DataTable)
+        result = await fetch_definition_audit(self._service, self._definition)
+        table.clear()
+        if result.notice_override is not None:
+            notice.update(result.notice_override)
+            return
+        for event in result.items:
+            created = str(event.get("created_at") or "")
+            # Keep the timestamp compact: date and minute-level time, no
+            # microseconds/timezone noise in a table cell -- same slice
+            # the tab's own history table uses.
+            stamp = created[:16].replace("T", " ") if created else "?"
+            summary = str(event.get("summary") or "")
+            table.add_row(
+                Text(stamp),
+                Text(str(event.get("event_type") or "?")),
+                Text(summary),
+            )
+        notice.update(audit_notice_text(result.items, result.total))

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -1,12 +1,14 @@
-"""Automations tab per-definition detail pane (schedules-redesign PR-1, Task 4).
+"""Per-definition detail pane (schedules-redesign PR-1, Task 4).
 
-The Automations tab's FIRST per-row detail widget -- until now the tab
-had no field-level rendering of a selected `automation_definition` at all
-(only the definitions `DataTable`'s five columns and the audit-trail
+Introduced as the Automations tab's FIRST per-row detail widget -- that
+tab had no field-level rendering of a selected `automation_definition` at
+all (only the definitions `DataTable`'s five columns and the audit-trail
 history pane; see `redesign-pr1-survey.md` section 1's "no per-row detail
-widget" finding). `DefinitionDetail` fills that gap using the same
-`DetailValueRow`/`DetailGroup` row grammar Task 3 used to regrammar the
-Queue tab's `TaskDetail` -- Details/Frequency/History groups. PR-1 shipped
+widget" finding). redesign PR-4 task 5 retired that tab; this pane lives
+on as the queue's definition-row detail, the sibling of `TaskDetail` in
+the same detail pane. It uses the same `DetailValueRow`/`DetailGroup` row
+grammar Task 3 used to regrammar `TaskDetail` -- Details/Frequency/
+History groups. PR-1 shipped
 every row read-only (`affordance` at its `False` default); schedules-
 redesign PR-3, task 4 wires in-pane editing onto the Details/Frequency
 rows (Model/Generation/Finding policy/Sources/Notifications editable,
@@ -513,7 +515,7 @@ def _definition_last_run_label(last_run: dict[str, Any] | None) -> str:
 
 
 class DefinitionDetail(Vertical):
-    """Automations tab (and Queue tab sibling) per-definition detail pane.
+    """Per-definition detail pane (the queue's definition-row detail).
 
     schedules-redesign PR-3, task 4 wires in-pane editing onto the
     Details/Frequency rows PR-1 left read-only, plus the header Pause/

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -1044,6 +1044,16 @@ class DefinitionDetail(Vertical):
             row.clear_error()
 
     @property
+    def runs_on_row(self) -> DetailValueRow | None:
+        """The Runs-on row, for the workbench's `m` keybinding (redesign
+        PR-4 task 4) to activate programmatically -- posting `DetailValueRow.
+        Activated(row)` on it drives the exact same `on_detail_value_row_
+        activated` path (honest lock/family-note refusal, then the
+        dropdown) a real Enter/click already does, so `m` needs no new
+        activation logic, only this reference."""
+        return self._runs_on_row
+
+    @property
     def shown_definition_id(self) -> str:
         """The id of the definition this pane is painting, `""` for none.
 

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -1625,10 +1625,11 @@ class DefinitionDetail(Vertical):
 
     def _request_runs_on_cancel(self) -> None:
         """Post a cancel request from the Runs-on row's own mini-bar
-        (PR-3 task 5) -- a SEPARATE surface from the Automations tab's
-        `k`-key `_cancel_automation_transfer` (coexistence, task-5
-        brief): this one renders a refusal via `row.show_error`, not the
-        tab's shared inline-notice Static."""
+        (PR-3 task 5). It began as a SEPARATE surface coexisting with the
+        Automations tab's `k`-key `_cancel_automation_transfer` (task-5
+        brief); redesign PR-4 task 5 retired that tab and its key, so this
+        mini-bar is now the only cancel affordance -- and it still renders
+        a refusal via `row.show_error`, never a shared notice Static."""
         definition = self._definition
         row = self._runs_on_row
         if definition is not None and row is not None:
@@ -1692,7 +1693,9 @@ class DefinitionDetail(Vertical):
         toggle (the task-4 brief's "optimistic repaint") -- called by the
         workbench on EVERY mounted `DefinitionDetail` instance right
         after `set_definition_lifecycle` succeeds, ahead of the slower
-        background refresh (`_request_automations_refresh`), so this pane
+        background refresh (`_request_tasks_refresh` -- redesign PR-4 task
+        5 retired the Automations tab's `_request_automations_refresh`
+        this used to name), so this pane
         never shows a stale Pause/Resume label while that worker is still
         running. Task 2's own DB-level pull-guard is what then keeps a
         RACING sync pull from reverting the value that background refresh

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -73,6 +73,7 @@ from ....Scheduling.events import (
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
     DefinitionOwnerActionRequested,
+    ViewDefinitionResultsRequested,
 )
 # PR-3 task 5: same lock/failed-state gating `task_detail.py`'s own
 # Runs-on row uses (survey §3) -- see that module's import comment for
@@ -524,9 +525,12 @@ class DefinitionDetail(Vertical):
     the workbench handles, mirroring `TaskDetail`'s own Task 3 Frequency
     rows exactly -- this widget still performs no I/O of its own.
 
-    `Runs on`/`Last run`/`Run count`/`Unread results`/`Results` stay
-    permanently read-only (out of this task's row list; owner transfer is
-    a separate, not-yet-built feature per survey §7).
+    `Last run`/`Run count` stay permanently read-only. `Runs on` gets its
+    own owner-transfer affordance (survey §7, PR-3 task 5). `Unread
+    results` is activatable too (redesign PR-4, task 2): it is the live
+    replacement for the old "See Results tab" pointer, pushing a
+    `ResultsTab` scoped to this definition -- see `ViewDefinitionResults
+    Requested` and `on_detail_value_row_activated` below.
     """
 
     def __init__(self, *args, **kwargs: object) -> None:
@@ -727,21 +731,27 @@ class DefinitionDetail(Vertical):
             self._run_count_row = DetailValueRow(
                 "Run count", "-", value_id="scheduling-automation-detail-run-count"
             )
+            # redesign PR-4, task 2: the retired "See Results tab" pointer
+            # (a dangling string once the tab bar goes away, survey
+            # :734-736) becomes THIS row's live activation instead of a
+            # separate row -- the count and the destination are the same
+            # fact, so a second row saying "Results -- See Results tab"
+            # next to it was redundant, not a second affordance.
+            # Unconditionally clickable/focusable (never family-gated
+            # like the editable rows above): viewing history is sensible
+            # for any definition, including one with zero unread results.
             self._unread_row = DetailValueRow(
                 "Unread results",
                 "-",
                 value_id="scheduling-automation-detail-unread-results",
-            )
-            view_results_row = DetailValueRow(
-                "Results",
-                "See Results tab",
-                value_id="scheduling-automation-detail-view-results",
+                affordance=True,
+                can_focus=True,
+                row_key="view_results",
             )
             yield DetailGroup(
                 self._last_run_row,
                 self._run_count_row,
                 self._unread_row,
-                view_results_row,
                 title="History",
                 collapsed=True,
                 id="scheduling-automation-detail-group-history",
@@ -1030,8 +1040,21 @@ class DefinitionDetail(Vertical):
 
     def on_detail_value_row_activated(self, event: DetailValueRow.Activated) -> None:
         """Open the activated row's editor, or -- locked -- show why
-        editing is refused instead of doing nothing (ruling 2)."""
+        editing is refused instead of doing nothing (ruling 2).
+
+        The `Unread results` row is not an editable row at all (it never
+        opens an in-place editor) -- activating it instead posts
+        `ViewDefinitionResultsRequested` upward for the workbench to push
+        the definition-filtered Results view. Never gated on the
+        lifecycle lock or the family note: viewing history is not an
+        edit, so a locked/unsupported-family row can still be browsed.
+        """
         row = event.row
+        if row is self._unread_row:
+            event.stop()
+            if self._definition is not None:
+                self.post_message(ViewDefinitionResultsRequested(self._definition))
+            return
         if row not in self._editable_rows():
             return
         event.stop()

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -73,6 +73,8 @@ from ....Scheduling.events import (
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
     DefinitionOwnerActionRequested,
+    DefinitionRunNowRequested,
+    ViewDefinitionAuditRequested,
     ViewDefinitionResultsRequested,
 )
 # PR-3 task 5: same lock/failed-state gating `task_detail.py`'s own
@@ -525,12 +527,18 @@ class DefinitionDetail(Vertical):
     the workbench handles, mirroring `TaskDetail`'s own Task 3 Frequency
     rows exactly -- this widget still performs no I/O of its own.
 
-    `Last run`/`Run count` stay permanently read-only. `Runs on` gets its
-    own owner-transfer affordance (survey §7, PR-3 task 5). `Unread
-    results` is activatable too (redesign PR-4, task 2): it is the live
-    replacement for the old "See Results tab" pointer, pushing a
-    `ResultsTab` scoped to this definition -- see `ViewDefinitionResults
-    Requested` and `on_detail_value_row_activated` below.
+    `Run count` stays permanently read-only. `Runs on` gets its own
+    owner-transfer affordance (survey §7, PR-3 task 5). `Unread results`
+    is activatable (redesign PR-4, task 2): it is the live replacement
+    for the old "See Results tab" pointer, pushing a `ResultsTab` scoped
+    to this definition. `Last run` is activatable too (redesign PR-4,
+    task 3): it is the live replacement for the retired Automations-tab
+    third pane, pushing a `definition_audit_view.DefinitionAuditView`
+    scoped to this definition -- see `ViewDefinitionResultsRequested`/
+    `ViewDefinitionAuditRequested` and `on_detail_value_row_activated`
+    below. A header `Run now` button sits beside Pause/Resume (redesign
+    PR-4, task 3, ruling 2): the retired Automations-tab `r` key's live
+    replacement, posting `DefinitionRunNowRequested`.
     """
 
     def __init__(self, *args, **kwargs: object) -> None:
@@ -551,6 +559,9 @@ class DefinitionDetail(Vertical):
         # PR-3 task 4:
         self._definition: dict[str, Any] | None = None
         self._pause_resume_button: Button | None = None
+        #: redesign PR-4, task 3: the retired Automations-tab `r` key's
+        #: live replacement (ruling 2 -- a button, not a new global key).
+        self._run_now_button: Button | None = None
         self._why_static: Static | None = None
         #: Cached from `set_lifecycle_lock` (never re-derived here) --
         #: same one-source-of-truth rule survey §8 documents for
@@ -613,6 +624,19 @@ class DefinitionDetail(Vertical):
                     classes="detail-lifecycle-button",
                 )
                 yield self._pause_resume_button
+                # redesign PR-4, task 3: the retired Automations-tab `r`
+                # key's live replacement (ruling 2 -- a button here, no
+                # new global keybinding). Unconditionally enabled/never
+                # family-gated -- `_run_automation_now` itself is
+                # family-agnostic (it only routes by owner), the same as
+                # the tab's own `r` key was.
+                self._run_now_button = Button(
+                    "Run now",
+                    id="scheduling-automation-run-now",
+                    variant="primary",
+                    classes="detail-lifecycle-button",
+                )
+                yield self._run_now_button
             # Visible when the lifecycle button (or an editable row) is
             # locked by an in-flight transfer: keyboard users can't see
             # hover tooltips, so the reason must live in text too
@@ -725,8 +749,23 @@ class DefinitionDetail(Vertical):
                 id="scheduling-automation-detail-group-frequency",
             )
 
+            # redesign PR-4, task 3: the retired Automations-tab third
+            # (run-history/audit) pane's live replacement -- this row's
+            # own copy already says "...see Run history" for a
+            # server-owned definition (`_SERVER_LAST_RUN`); activating it
+            # pushes a `DefinitionAuditView` scoped to this definition.
+            # Unconditionally clickable/focusable, same "viewing history
+            # is not an edit" rule task 2 established for `_unread_row`
+            # below -- a local definition's activation still pushes the
+            # view, which renders its OWN honest "not available yet"
+            # copy rather than the row being gated/disabled here.
             self._last_run_row = DetailValueRow(
-                "Last run", "-", value_id="scheduling-automation-detail-last-run"
+                "Last run",
+                "-",
+                value_id="scheduling-automation-detail-last-run",
+                affordance=True,
+                can_focus=True,
+                row_key="view_runs",
             )
             self._run_count_row = DetailValueRow(
                 "Run count", "-", value_id="scheduling-automation-detail-run-count"
@@ -1045,15 +1084,22 @@ class DefinitionDetail(Vertical):
         The `Unread results` row is not an editable row at all (it never
         opens an in-place editor) -- activating it instead posts
         `ViewDefinitionResultsRequested` upward for the workbench to push
-        the definition-filtered Results view. Never gated on the
-        lifecycle lock or the family note: viewing history is not an
-        edit, so a locked/unsupported-family row can still be browsed.
+        the definition-filtered Results view. `Last run` is the same
+        shape (redesign PR-4, task 3): activating it posts `ViewDefinition
+        AuditRequested` to push this definition's audit-trail view.
+        Neither is gated on the lifecycle lock or the family note: viewing
+        history is not an edit, so a locked/unsupported-family row can
+        still be browsed.
         """
         row = event.row
-        if row is self._unread_row:
+        if row is self._unread_row or row is self._last_run_row:
             event.stop()
-            if self._definition is not None:
+            if self._definition is None:
+                return
+            if row is self._unread_row:
                 self.post_message(ViewDefinitionResultsRequested(self._definition))
+            else:
+                self.post_message(ViewDefinitionAuditRequested(self._definition))
             return
         if row not in self._editable_rows():
             return
@@ -1311,6 +1357,9 @@ class DefinitionDetail(Vertical):
         elif button_id == "scheduling-automation-pause-resume":
             event.stop()
             self._toggle_lifecycle()
+        elif button_id == "scheduling-automation-run-now":
+            event.stop()
+            self._request_run_now()
         elif button_id == _RUNS_ON_CANCEL_ID:
             event.stop()
             self._request_runs_on_cancel()
@@ -1611,6 +1660,20 @@ class DefinitionDetail(Vertical):
         lifecycle = str(definition.get("lifecycle") or "configured")
         action = "resume" if lifecycle != "configured" else "pause"
         self.post_message(DefinitionLifecycleToggleRequested(definition, action))
+
+    def _request_run_now(self) -> None:
+        """`Run now` button pressed (redesign PR-4, task 3).
+
+        Never gated on `_lifecycle_lock_reason`/`_family_note`: the
+        Automations tab's own `r` key never gated run-now on either
+        (`_run_automation_now` refuses on its own terms -- pending sync,
+        paused/archived lifecycle, unready health -- and reports why via
+        a notification, the same honest-refusal shape this button keeps).
+        """
+        definition = self._definition
+        if definition is None:
+            return
+        self.post_message(DefinitionRunNowRequested(definition))
 
     def apply_lifecycle(self, definition_id: str, lifecycle: str) -> None:
         """Patch + repaint the lifecycle in place after a successful

--- a/tldw_chatbook/UI/Screens/scheduling/results_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/results_tab.py
@@ -1,11 +1,18 @@
-"""Results tab for the Schedules workbench (schedules-handoff PR-6 Task 3).
+"""Automation-results view for the Schedules workbench (schedules-handoff
+PR-6 Task 3).
+
+The module keeps its `results_tab` name (redesign PR-4 task 5's own
+judgment: renaming the file buys nothing but churn), but the TAB it was
+built for is retired -- `ResultsTab` is mounted only inside a pushed
+`ResultsHostScreen` now (task 2), reached from the rail's `Results (N)`
+button or a definition pane's unread row.
+
 
 Minimal-honest inbox (plan ruling 1): a `DataTable` of `automation_results`
 rows spanning every owner (Task 1's `list_automation_results(owner_id=None)`)
 plus a read-only detail pane. Row mutations (read/dismiss/mark-solved/mark
 all read) are keybindings owned by `SchedulesWorkbench` -- this widget is a
-pure renderer, the same split the Automations tab uses for its `m`/`M`/`y`/
-`k` actions (no per-row detail widget there either). Unlike `ConflictsTab`
+pure renderer. Unlike `ConflictsTab`
 (whose "Use server"/"Use local" buttons resolve locally, synchronously),
 the actions here (`SchedulingService.review_automation_result`/
 `resolve_definition`) are async server-aware calls, so they live on the
@@ -24,11 +31,11 @@ heading itself -- it is rendered through the same `Static.update(str)` ->
 `Content.from_markup` parser `escape_markup`'s own docstring warns about).
 (2) `review_selected_result`/`mark_selected_result_solved`/`mark_results_
 read` are the read/dismiss/mark-solved/mark-all-read orchestration,
-factored out of `SchedulesWorkbench`'s own tab-routed actions so BOTH the
-still-live Results TAB (tab-gated bindings, `SchedulesWorkbench`) and the
-pushed view's own binding surface (`ResultsHostScreen`, no tab to gate on
--- a pushed `Screen` never receives a screen-underneath's `BINDINGS`) call
-the exact same service orchestration instead of drifting apart. The
+factored out of `SchedulesWorkbench`'s own tab-routed actions so the tab
+and the pushed view could not drift apart. Task 5 then retired the tab
+and its copies of those actions, leaving `ResultsHostScreen` (a pushed
+`Screen` never receives a screen-underneath's `BINDINGS`, so it must own
+them) as the only caller of the first two. The
 synchronous "nothing selected"/eligibility gates stay in each CALLER,
 not in these helpers (`SchedulesWorkbench.action_mark_result_solved`'s
 existing tests pin those refusals firing WITHOUT a worker round-trip);
@@ -281,12 +288,12 @@ class ResultsTab(Vertical):
         Args:
             initial_results: When given, `populate()`s the table with
                 these on mount -- `ConflictsTab.initial_conflicts`'s own
-                idiom (task 1). The still-live Results TAB instance stays
-                externally driven (`SchedulesWorkbench._refresh_results_
-                tab` calls `.populate()` itself); a standalone pushed
-                instance (redesign PR-4, task 2's rail/definition-pane
-                overlays, via `WorkbenchHostScreen`/`ResultsHostScreen`)
-                has no such external driver, so it self-populates.
+                idiom (task 1). A pushed instance (redesign PR-4, task
+                2's rail/definition-pane overlays, via `ResultsHostScreen`)
+                has no external `.populate()` driver the way the retired
+                mounted tab instance did, so it self-populates. Still
+                optional: `populate()` remains callable from outside, and
+                `ResultsHostScreen` re-calls it after every mutation.
             initial_definitions_by_id: Paired with `initial_results` --
                 the mark-solved eligibility index (`solved_eligibility`).
             initial_total: Paired with `initial_results` -- the honest
@@ -419,8 +426,8 @@ class ResultsTab(Vertical):
         row_keys = [result["id"] for result in results]
         if previous_selection in row_keys:
             # Restoring the cursor fires RowHighlighted, which re-records
-            # the same id -- belt and braces, set both explicitly (matches
-            # the Automations tab's load_automations reconciliation).
+            # the same id -- belt and braces, set both explicitly (the
+            # same by-id reconciliation every table rebuild here uses).
             table.cursor_coordinate = (row_keys.index(previous_selection), 0)
             self._selected_result_id = previous_selection
             self._show_detail(self._results_by_id[previous_selection])
@@ -522,10 +529,11 @@ class ResultsTab(Vertical):
 
 # -- Shared read/dismiss/mark-solved/mark-all-read orchestration -----------
 #
-# redesign PR-4, task 2: factored out of `SchedulesWorkbench` so both the
-# still-live Results TAB (tab-gated bindings) and `ResultsHostScreen`
-# below (the pushed view's own binding surface) drive the exact same
-# service calls. `notify` is `Callable[[message, severity], None]` --
+# redesign PR-4, task 2: factored out of `SchedulesWorkbench` so the
+# Results tab and `ResultsHostScreen` below could not drift apart; task 5
+# retired the tab, so the host screen is now the only caller of the first
+# two (the workbench still calls `mark_results_read` for its rail-level
+# `Mark all read`). `notify` is `Callable[[message, severity], None]` --
 # the caller's own notification sink (`app_instance.notify`/`app.notify`,
 # same call shape, different attribute name depending on whether the
 # caller is a `BaseAppScreen` subclass or a plain `Screen`).

--- a/tldw_chatbook/UI/Screens/scheduling/results_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/results_tab.py
@@ -11,13 +11,15 @@ button or a definition pane's unread row.
 Minimal-honest inbox (plan ruling 1): a `DataTable` of `automation_results`
 rows spanning every owner (Task 1's `list_automation_results(owner_id=None)`)
 plus a read-only detail pane. Row mutations (read/dismiss/mark-solved/mark
-all read) are keybindings owned by `SchedulesWorkbench` -- this widget is a
-pure renderer. Unlike `ConflictsTab`
+all read) are keybindings owned by the SCREEN, not by this widget -- this
+widget is a pure renderer. They began as `SchedulesWorkbench` bindings; task
+2 factored the orchestration into the module-level helpers below and task 5
+retired the workbench's copies, leaving `ResultsHostScreen` (bottom of this
+module) as their owner. Unlike `ConflictsTab`
 (whose "Use server"/"Use local" buttons resolve locally, synchronously),
 the actions here (`SchedulingService.review_automation_result`/
-`resolve_definition`) are async server-aware calls, so they live on the
-screen that already owns `run_worker` plumbing for exactly that shape
-(`_begin_automation_transfer`).
+`resolve_definition`) are async server-aware calls, so they live on a screen
+with `run_worker` plumbing rather than in the renderer.
 
 redesign PR-4, task 2 (Results relocation) adds two things on top of the
 above, unchanged: (1) `ResultsTab` gains the same `initial_*`-self-paints-
@@ -44,8 +46,9 @@ these helpers only need to be async because the mutation itself is.
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
-from typing import Any, Callable
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any, ClassVar
 
 from rich.text import Text
 from textual import on
@@ -53,8 +56,6 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Static
-
-from .workbench_host_screen import WorkbenchHostScreen
 
 # `index_definitions_by_id`/`definition_for_result` moved to
 # `unified_rows.py` (redesign PR-2 Task 1 -- that pure module resolves
@@ -65,6 +66,7 @@ from .unified_rows import (
     definition_for_result,
     index_definitions_by_id,  # noqa: F401  (re-export: schedules_workbench.py imports this from here)
 )
+from .workbench_host_screen import WorkbenchHostScreen
 
 _KIND_GLYPHS = {"finding": "●", "failure": "✕"}  # ● / ✕
 
@@ -145,7 +147,7 @@ def _parse_created_at(created_at: str | None) -> datetime | None:
     except ValueError:
         return None
     if created.tzinfo is None:
-        created = created.replace(tzinfo=timezone.utc)
+        created = created.replace(tzinfo=UTC)
     return created
 
 
@@ -166,7 +168,7 @@ def _result_sort_key(result: dict[str, Any]) -> datetime:
     definition-scoped tie ever turns out to matter.
     """
     return _parse_created_at(result.get("created_at")) or datetime.min.replace(
-        tzinfo=timezone.utc
+        tzinfo=UTC
     )
 
 
@@ -182,7 +184,7 @@ def _format_result_created(
     created = _parse_created_at(created_at)
     if created is None:
         return "-" if not created_at else str(created_at)
-    reference = now if now is not None else datetime.now(timezone.utc)
+    reference = now if now is not None else datetime.now(UTC)
     seconds = (reference - created).total_seconds()
     future = seconds < 0
     seconds = abs(seconds)
@@ -541,7 +543,7 @@ class ResultsTab(Vertical):
 
 async def review_selected_result(
     service: Any,
-    results_tab: "ResultsTab",
+    results_tab: ResultsTab,
     review_state: str,
     notify: Callable[[str, str], None],
 ) -> None:
@@ -607,15 +609,15 @@ class ResultsHostScreen(WorkbenchHostScreen):
     """`WorkbenchHostScreen` + the Results-specific r/d/o/a bindings
     (redesign PR-4, task 2).
 
-    `SchedulesWorkbench`'s own r/d/o/a bindings are tab-gated
-    (`_is_results_tab_active`) AND, more fundamentally, never receive a
-    key event while this screen sits on top of the stack -- Textual
-    routes a key through the CURRENTLY ACTIVE screen's own binding chain
-    only, and a screen underneath is not part of that chain. The pushed
-    view therefore needs its own copies of the same four actions; they
-    share the underlying service orchestration with the tab
-    (`review_selected_result`/`mark_selected_result_solved`/`mark_
-    results_read` above) so the two surfaces cannot drift apart.
+    `SchedulesWorkbench` has no r/d/o/a bindings at all any more (task 5
+    retired its tab-gated copies along with the Results tab), and it could
+    not receive those keys here regardless -- Textual routes a key through
+    the CURRENTLY ACTIVE screen's own binding chain only, and a screen
+    underneath is not part of that chain. This pushed view therefore owns
+    the four actions outright, over the module-level service orchestration
+    above (`review_selected_result`/`mark_selected_result_solved`/`mark_
+    results_read`), which is where the tab-era logic was factored to
+    before the tab went away.
 
     `query`/`unread_ids` are closures the constructing `SchedulesWorkbench`
     supplies, scoped to whatever this push is (the global inbox, or one
@@ -628,7 +630,7 @@ class ResultsHostScreen(WorkbenchHostScreen):
     dismissed").
     """
 
-    BINDINGS = [
+    BINDINGS: ClassVar = [
         *WorkbenchHostScreen.BINDINGS,
         Binding("r", "review_read", "Read"),
         Binding("d", "review_dismiss", "Dismiss"),
@@ -638,7 +640,7 @@ class ResultsHostScreen(WorkbenchHostScreen):
 
     def __init__(
         self,
-        widget_factory: Callable[[], "ResultsTab"],
+        widget_factory: Callable[[], ResultsTab],
         *,
         title: str,
         service: Any,
@@ -666,7 +668,7 @@ class ResultsHostScreen(WorkbenchHostScreen):
         self._query = query
         self._unread_ids = unread_ids
 
-    def _results_tab(self) -> "ResultsTab":
+    def _results_tab(self) -> ResultsTab:
         return self.query_one(ResultsTab)
 
     def _notify(self, message: str, severity: str) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/results_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/results_tab.py
@@ -552,6 +552,15 @@ async def review_selected_result(
     `SchedulingService.review_automation_result` writes the local row
     and, for a server mirror, queues the sync pushback mutation in the
     same DB transaction -- nothing extra to do here for that half.
+
+    Args:
+        service: The `SchedulingService` whose `review_automation_result`
+            performs the write.
+        results_tab: The `ResultsTab` instance whose cursor selects the
+            result to review.
+        review_state: `"read"` or `"dismissed"` (the two states the `r`/
+            `d` actions drive).
+        notify: The caller's notification sink, `(message, severity)`.
     """
     result = results_tab.selected_result()
     if result is None:
@@ -571,7 +580,16 @@ async def mark_selected_result_solved(
     """Mark `result`'s definition solved -- the async half of the `o`
     action. Eligibility (`solved_eligibility`) is checked by the CALLER,
     synchronously, before spawning the worker this runs in (existing
-    tests pin that refusal firing without a worker round-trip)."""
+    tests pin that refusal firing without a worker round-trip).
+
+    Args:
+        service: The `SchedulingService` whose `resolve_definition`
+            performs the write.
+        result: The `automation_results` row under the cursor.
+        definitions_by_id: The index built by `index_definitions_by_id`,
+            used to resolve `result`'s owning definition.
+        notify: The caller's notification sink, `(message, severity)`.
+    """
     definition = definition_for_result(result, definitions_by_id)
     local_definition_id = str((definition or {}).get("id") or "")
     outcome = await service.resolve_definition(
@@ -591,7 +609,16 @@ async def mark_results_read(
     """Per-row `review_automation_result` fan-out for a batch of result
     ids -- there is no bulk DB primitive for this (documented fan-out,
     mirroring `SchedulesWorkbench._on_bulk_delete_confirmed`'s loop-and-
-    count shape)."""
+    count shape).
+
+    Args:
+        service: The `SchedulingService` whose `review_automation_result`
+            performs each write.
+        result_ids: Every result id to mark `"read"` (the `a` action's
+            scope -- global or one definition's, per the caller).
+        notify: The caller's notification sink, `(message, severity)`;
+            called once at the end with the read/failed count.
+    """
     errors = 0
     for result_id in result_ids:
         if not await service.review_automation_result(result_id, "read"):
@@ -679,9 +706,11 @@ class ResultsHostScreen(WorkbenchHostScreen):
         self._results_tab().populate(results, definitions_by_id, total=total)
 
     def action_review_read(self) -> None:
+        """`r`: mark the result under the cursor read."""
         self._run_review("read")
 
     def action_review_dismiss(self) -> None:
+        """`d`: dismiss the result under the cursor."""
         self._run_review("dismissed")
 
     def _run_review(self, review_state: str) -> None:
@@ -696,6 +725,12 @@ class ResultsHostScreen(WorkbenchHostScreen):
         self.run_worker(_do, exclusive=True, group="schedules-results-host")
 
     def action_mark_solved(self) -> None:
+        """`o`: mark the result under the cursor's definition solved.
+
+        The synchronous eligibility gate (`solved_eligibility`) runs here,
+        before the worker -- a refusal notifies without a worker round-
+        trip.
+        """
         results_tab = self._results_tab()
         result = results_tab.selected_result()
         if result is None:
@@ -715,6 +750,11 @@ class ResultsHostScreen(WorkbenchHostScreen):
         self.run_worker(_do, exclusive=True, group="schedules-results-host")
 
     def action_mark_all_read(self) -> None:
+        """`a`: mark every unread result in this screen's scope read.
+
+        Scope is whatever `unread_ids` (constructor arg) was built to
+        return -- the global inbox, or one definition's results.
+        """
         unread_ids = self._unread_ids()
         if not unread_ids:
             self._notify("Nothing unread.", "information")

--- a/tldw_chatbook/UI/Screens/scheduling/results_tab.py
+++ b/tldw_chatbook/UI/Screens/scheduling/results_tab.py
@@ -11,18 +11,43 @@ the actions here (`SchedulingService.review_automation_result`/
 `resolve_definition`) are async server-aware calls, so they live on the
 screen that already owns `run_worker` plumbing for exactly that shape
 (`_begin_automation_transfer`).
+
+redesign PR-4, task 2 (Results relocation) adds two things on top of the
+above, unchanged: (1) `ResultsTab` gains the same `initial_*`-self-paints-
+on-mount seam `ConflictsTab.initial_conflicts` established in task 1, plus
+an optional `heading` override -- a caller (`SchedulesWorkbench._push_
+results_overlay`) can hand a pushed instance an already-scoped (optionally
+definition-filtered) results/total pair, and the SAME "showing newest N of
+TOTAL" cap-line math renders under whatever heading text it is given,
+already-escaped by the caller (this widget never markup-escapes the
+heading itself -- it is rendered through the same `Static.update(str)` ->
+`Content.from_markup` parser `escape_markup`'s own docstring warns about).
+(2) `review_selected_result`/`mark_selected_result_solved`/`mark_results_
+read` are the read/dismiss/mark-solved/mark-all-read orchestration,
+factored out of `SchedulesWorkbench`'s own tab-routed actions so BOTH the
+still-live Results TAB (tab-gated bindings, `SchedulesWorkbench`) and the
+pushed view's own binding surface (`ResultsHostScreen`, no tab to gate on
+-- a pushed `Screen` never receives a screen-underneath's `BINDINGS`) call
+the exact same service orchestration instead of drifting apart. The
+synchronous "nothing selected"/eligibility gates stay in each CALLER,
+not in these helpers (`SchedulesWorkbench.action_mark_result_solved`'s
+existing tests pin those refusals firing WITHOUT a worker round-trip);
+these helpers only need to be async because the mutation itself is.
 """
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, Callable
 
 from rich.text import Text
 from textual import on
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.widgets import DataTable, Static
+
+from .workbench_host_screen import WorkbenchHostScreen
 
 # `index_definitions_by_id`/`definition_for_result` moved to
 # `unified_rows.py` (redesign PR-2 Task 1 -- that pure module resolves
@@ -94,6 +119,50 @@ def _result_owner_suffix(result: dict[str, Any]) -> str:
     return f" (server: {label})"
 
 
+def _parse_created_at(created_at: str | None) -> datetime | None:
+    """Parse a result's `created_at` into an aware UTC `datetime`, or
+    `None` when missing/unparseable.
+
+    `datetime.fromisoformat` (3.11+) accepts both a `Z` suffix (server-
+    mirrored rows) and a `+00:00` offset (locally-written rows) -- the
+    real comparison this repo's DB layer takes pains to get right via
+    `strftime` ordering (`ScheduledTasksDB.list_automation_results`'s own
+    docstring: raw text comparison mis-orders those two forms). Naive
+    timestamps are treated as UTC, matching `_format_relative`'s
+    convention.
+    """
+    if not created_at:
+        return None
+    try:
+        created = datetime.fromisoformat(str(created_at))
+    except ValueError:
+        return None
+    if created.tzinfo is None:
+        created = created.replace(tzinfo=timezone.utc)
+    return created
+
+
+def _result_sort_key(result: dict[str, Any]) -> datetime:
+    """Newest-first sort key for MERGING two already-DB-sorted result
+    lists (redesign PR-4 task 2's definition-filtered query, which reads
+    the local- and server-id spaces as two separate queries -- see
+    `SchedulesWorkbench._definition_results_query`). An unparseable/
+    missing timestamp sorts last (oldest), never raises.
+
+    ``ponytail:`` this compares REAL instants (via `_parse_created_at`),
+    correctly ordering the `Z`-vs-`+00:00` mix the DB's own docstring
+    warns a raw string sort gets wrong -- but does not replicate that
+    same docstring's millisecond-then-raw-text-then-id tie-break for two
+    results stamped in the same microsecond. Only used to merge a single
+    definition's (at most two id-spaces') results, a low-volume case
+    where an exact tie is unlikely; upgrade to a real SQL merge if a
+    definition-scoped tie ever turns out to matter.
+    """
+    return _parse_created_at(result.get("created_at")) or datetime.min.replace(
+        tzinfo=timezone.utc
+    )
+
+
 def _format_result_created(
     created_at: str | None, *, now: datetime | None = None
 ) -> str:
@@ -101,17 +170,11 @@ def _format_result_created(
 
     Same distance-math shape as `task_detail._format_relative`, but a
     result is a past event, not a future run -- "overdue" would be a
-    category error, so this uses "X ago" instead. Naive timestamps are
-    treated as UTC, matching `_format_relative`'s own convention.
+    category error, so this uses "X ago" instead.
     """
-    if not created_at:
-        return "-"
-    try:
-        created = datetime.fromisoformat(str(created_at))
-    except ValueError:
-        return str(created_at)
-    if created.tzinfo is None:
-        created = created.replace(tzinfo=timezone.utc)
+    created = _parse_created_at(created_at)
+    if created is None:
+        return "-" if not created_at else str(created_at)
     reference = now if now is not None else datetime.now(timezone.utc)
     seconds = (reference - created).total_seconds()
     future = seconds < 0
@@ -204,20 +267,54 @@ class ResultsTab(Vertical):
     }
     """
 
-    def __init__(self, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        *,
+        initial_results: list[dict[str, Any]] | None = None,
+        initial_definitions_by_id: dict[str, dict[str, Any]] | None = None,
+        initial_total: int | None = None,
+        heading: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         """Initialize the results tab.
 
         Args:
+            initial_results: When given, `populate()`s the table with
+                these on mount -- `ConflictsTab.initial_conflicts`'s own
+                idiom (task 1). The still-live Results TAB instance stays
+                externally driven (`SchedulesWorkbench._refresh_results_
+                tab` calls `.populate()` itself); a standalone pushed
+                instance (redesign PR-4, task 2's rail/definition-pane
+                overlays, via `WorkbenchHostScreen`/`ResultsHostScreen`)
+                has no such external driver, so it self-populates.
+            initial_definitions_by_id: Paired with `initial_results` --
+                the mark-solved eligibility index (`solved_eligibility`).
+            initial_total: Paired with `initial_results` -- the honest
+                "of TOTAL" denominator for the cap line.
+            heading: Overrides `RESULTS_HEADING` (default `None` keeps
+                it). MUST already be markup-safe (`escape_markup`): this
+                is rendered through the same `Static.update(str)` ->
+                `Content.from_markup` parser the detail pane's own
+                escaping discipline guards against, and, unlike the
+                heading's own hardcoded text, a caller-built heading may
+                now carry a user-authored definition name. Lets a
+                definition-filtered pushed view say what it's scoped to
+                while reusing the SAME "showing newest N of TOTAL" cap
+                math unchanged.
             **kwargs: Forwarded verbatim to `Vertical` (id, classes, ...).
         """
         super().__init__(**kwargs)
         self._results_by_id: dict[str, dict[str, Any]] = {}
         self._definitions_by_id: dict[str, dict[str, Any]] = {}
         self._selected_result_id: str | None = None
+        self._heading = heading or RESULTS_HEADING
+        self._initial_results = initial_results
+        self._initial_definitions_by_id = initial_definitions_by_id
+        self._initial_total = initial_total
 
     def compose(self) -> ComposeResult:
         """Build the tab layout."""
-        yield Static(RESULTS_HEADING, id="scheduling-results-heading")
+        yield Static(self._heading, id="scheduling-results-heading")
         table = DataTable(id="scheduling-results-table")
         table.add_columns("Kind", "Result", "Created", "State")
         yield table
@@ -229,9 +326,16 @@ class ResultsTab(Vertical):
         yield Static("No results yet.", id="scheduling-results-empty")
 
     def on_mount(self) -> None:
-        """Configure the table cursor."""
+        """Configure the table cursor, and self-populate if constructed
+        with data (see `initial_results`)."""
         table = self.query_one("#scheduling-results-table", DataTable)
         table.cursor_type = "row"
+        if self._initial_results is not None:
+            self.populate(
+                self._initial_results,
+                self._initial_definitions_by_id,
+                total=self._initial_total,
+            )
 
     @property
     def definitions_by_id(self) -> dict[str, dict[str, Any]]:
@@ -270,9 +374,9 @@ class ResultsTab(Vertical):
         previous_selection = self._selected_result_id
         self._results_by_id = {result["id"]: result for result in results}
         self.query_one("#scheduling-results-heading", Static).update(
-            f"{RESULTS_HEADING} — showing newest {len(results)} of {total}"
+            f"{self._heading} — showing newest {len(results)} of {total}"
             if total is not None and total > len(results)
-            else RESULTS_HEADING
+            else self._heading
         )
 
         table = self.query_one("#scheduling-results-table", DataTable)
@@ -414,3 +518,200 @@ class ResultsTab(Vertical):
             )
 
         self.query_one("#scheduling-results-detail", Static).update("\n".join(lines))
+
+
+# -- Shared read/dismiss/mark-solved/mark-all-read orchestration -----------
+#
+# redesign PR-4, task 2: factored out of `SchedulesWorkbench` so both the
+# still-live Results TAB (tab-gated bindings) and `ResultsHostScreen`
+# below (the pushed view's own binding surface) drive the exact same
+# service calls. `notify` is `Callable[[message, severity], None]` --
+# the caller's own notification sink (`app_instance.notify`/`app.notify`,
+# same call shape, different attribute name depending on whether the
+# caller is a `BaseAppScreen` subclass or a plain `Screen`).
+
+
+async def review_selected_result(
+    service: Any,
+    results_tab: "ResultsTab",
+    review_state: str,
+    notify: Callable[[str, str], None],
+) -> None:
+    """Read/dismiss the result under `results_tab`'s cursor.
+
+    `SchedulingService.review_automation_result` writes the local row
+    and, for a server mirror, queues the sync pushback mutation in the
+    same DB transaction -- nothing extra to do here for that half.
+    """
+    result = results_tab.selected_result()
+    if result is None:
+        notify("Select a result first.", "warning")
+        return
+    updated = await service.review_automation_result(result["id"], review_state)
+    if not updated:
+        notify("Could not update this result — see the log.", "error")
+
+
+async def mark_selected_result_solved(
+    service: Any,
+    result: dict[str, Any],
+    definitions_by_id: dict[str, dict[str, Any]],
+    notify: Callable[[str, str], None],
+) -> None:
+    """Mark `result`'s definition solved -- the async half of the `o`
+    action. Eligibility (`solved_eligibility`) is checked by the CALLER,
+    synchronously, before spawning the worker this runs in (existing
+    tests pin that refusal firing without a worker round-trip)."""
+    definition = definition_for_result(result, definitions_by_id)
+    local_definition_id = str((definition or {}).get("id") or "")
+    outcome = await service.resolve_definition(
+        local_definition_id, solved=True, result_id=result["id"]
+    )
+    if outcome.status == "saved":
+        notify("Marked solved.", "information")
+    else:
+        notify(outcome.reason or "Could not mark this result solved.", "warning")
+
+
+async def mark_results_read(
+    service: Any,
+    result_ids: list[str],
+    notify: Callable[[str, str], None],
+) -> None:
+    """Per-row `review_automation_result` fan-out for a batch of result
+    ids -- there is no bulk DB primitive for this (documented fan-out,
+    mirroring `SchedulesWorkbench._on_bulk_delete_confirmed`'s loop-and-
+    count shape)."""
+    errors = 0
+    for result_id in result_ids:
+        if not await service.review_automation_result(result_id, "read"):
+            errors += 1
+    count = len(result_ids) - errors
+    notify(
+        f"Marked {count} result{'s' if count != 1 else ''} read"
+        + (f" ({errors} failed)" if errors else "")
+        + ".",
+        "information" if not errors else "warning",
+    )
+
+
+class ResultsHostScreen(WorkbenchHostScreen):
+    """`WorkbenchHostScreen` + the Results-specific r/d/o/a bindings
+    (redesign PR-4, task 2).
+
+    `SchedulesWorkbench`'s own r/d/o/a bindings are tab-gated
+    (`_is_results_tab_active`) AND, more fundamentally, never receive a
+    key event while this screen sits on top of the stack -- Textual
+    routes a key through the CURRENTLY ACTIVE screen's own binding chain
+    only, and a screen underneath is not part of that chain. The pushed
+    view therefore needs its own copies of the same four actions; they
+    share the underlying service orchestration with the tab
+    (`review_selected_result`/`mark_selected_result_solved`/`mark_
+    results_read` above) so the two surfaces cannot drift apart.
+
+    `query`/`unread_ids` are closures the constructing `SchedulesWorkbench`
+    supplies, scoped to whatever this push is (the global inbox, or one
+    definition's results across both its id spaces) -- this class has no
+    opinion on that scope, it only re-runs whichever closure it was given
+    after each mutation to repaint ITS OWN `ResultsTab` instance in place.
+    The rail/Queue-tab/badge refresh on the workbench BEHIND this screen
+    happens once, on pop, via the base class's `dismissed` hook -- not on
+    every keystroke here (brief: "refresh the rail + unified rows on
+    dismissed").
+    """
+
+    BINDINGS = [
+        *WorkbenchHostScreen.BINDINGS,
+        Binding("r", "review_read", "Read"),
+        Binding("d", "review_dismiss", "Dismiss"),
+        Binding("o", "mark_solved", "Mark solved"),
+        Binding("a", "mark_all_read", "Mark all read"),
+    ]
+
+    def __init__(
+        self,
+        widget_factory: Callable[[], "ResultsTab"],
+        *,
+        title: str,
+        service: Any,
+        query: Callable[[], tuple[list[dict[str, Any]], dict[str, dict[str, Any]], int]],
+        unread_ids: Callable[[], list[str]],
+        dismissed: Callable[[], None] | None = None,
+    ) -> None:
+        """Initialize the host.
+
+        Args:
+            widget_factory: Builds the fresh `ResultsTab` instance (see
+                `WorkbenchHostScreen`).
+            title: Shown in the `Header`.
+            service: The `SchedulingService` the r/d/o/a actions call.
+            query: Re-runs the scope's own results/definitions/total read
+                (global or definition-filtered) -- called once after
+                every mutation to repaint this screen's `ResultsTab`.
+            unread_ids: Every unread result id in THIS scope, uncapped by
+                `RESULTS_INBOX_LIMIT` (the `a` action's own Qodo-HIGH
+                fix: `SchedulesWorkbench._unread_result_ids`'s docstring).
+            dismissed: Runs once on pop (`Esc`), same as the base class.
+        """
+        super().__init__(widget_factory, title=title, dismissed=dismissed)
+        self._service = service
+        self._query = query
+        self._unread_ids = unread_ids
+
+    def _results_tab(self) -> "ResultsTab":
+        return self.query_one(ResultsTab)
+
+    def _notify(self, message: str, severity: str) -> None:
+        self.app.notify(message, severity=severity)
+
+    def _repaint(self) -> None:
+        results, definitions_by_id, total = self._query()
+        self._results_tab().populate(results, definitions_by_id, total=total)
+
+    def action_review_read(self) -> None:
+        self._run_review("read")
+
+    def action_review_dismiss(self) -> None:
+        self._run_review("dismissed")
+
+    def _run_review(self, review_state: str) -> None:
+        results_tab = self._results_tab()
+
+        async def _do() -> None:
+            await review_selected_result(
+                self._service, results_tab, review_state, self._notify
+            )
+            self._repaint()
+
+        self.run_worker(_do, exclusive=True, group="schedules-results-host")
+
+    def action_mark_solved(self) -> None:
+        results_tab = self._results_tab()
+        result = results_tab.selected_result()
+        if result is None:
+            self._notify("Select a result first.", "warning")
+            return
+        eligible, reason = solved_eligibility(result, results_tab.definitions_by_id)
+        if not eligible:
+            self._notify(reason or "This result cannot be marked solved.", "warning")
+            return
+
+        async def _do() -> None:
+            await mark_selected_result_solved(
+                self._service, result, results_tab.definitions_by_id, self._notify
+            )
+            self._repaint()
+
+        self.run_worker(_do, exclusive=True, group="schedules-results-host")
+
+    def action_mark_all_read(self) -> None:
+        unread_ids = self._unread_ids()
+        if not unread_ids:
+            self._notify("Nothing unread.", "information")
+            return
+
+        async def _do() -> None:
+            await mark_results_read(self._service, unread_ids, self._notify)
+            self._repaint()
+
+        self.run_worker(_do, exclusive=True, group="schedules-results-host")

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -45,6 +45,7 @@ from ....Scheduling.events import (
     SyncFailed,
     TransferToLocalRequested,
     TransferToServerRequested,
+    ViewDefinitionResultsRequested,
 )
 from ....Scheduling.models import ReminderTask, ScheduledTask
 from ....Scheduling.services.server_client import (
@@ -57,15 +58,20 @@ from ....Scheduling.services.sync_engine import (
 )
 from ....UI.Screens.scheduling.conflicts_tab import ConflictsTab
 from ....UI.Screens.scheduling.results_tab import (
+    RESULTS_HEADING,
+    ResultsHostScreen,
     ResultsTab,
-    definition_for_result,
     # NOT `rich.markup.escape`: this dialog copy is rendered by a
     # Textual `Label` -> `Content.from_markup`, whose tokenizer eats ANY
     # `[...]`, while rich's escape only covers `[a-z#/@]...` tags (task 6
     # round 1). Same parser, same escape as the results detail pane.
     escape_markup,
     index_definitions_by_id,
+    mark_results_read,
+    mark_selected_result_solved,
+    review_selected_result,
     solved_eligibility,
+    _result_sort_key,
 )
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from ....UI.Screens.scheduling.workbench_host_screen import WorkbenchHostScreen
@@ -488,6 +494,21 @@ class SchedulesWorkbench(BaseAppScreen):
                                     "Mark all read",
                                     id="scheduling-mark-all-read",
                                     tooltip="Mark every unread automation result read (a).",
+                                )
+                                # redesign PR-4, task 2: the Results
+                                # relocation's rail affordance -- always
+                                # visible (unlike Mark all read, which
+                                # hides at zero unread: browsing READ
+                                # results is still useful), mirroring the
+                                # status strip's Conflicts badge's own
+                                # "(N)" idiom.
+                                yield Button(
+                                    "Results",
+                                    id="scheduling-results-badge",
+                                    tooltip=(
+                                        "Browse every automation result "
+                                        "(view/read/dismiss/mark solved)."
+                                    ),
                                 )
                             # redesign PR-2, Task 2: the chip row (spec S3)
                             # -- one of the four buttons always carries
@@ -1964,6 +1985,102 @@ class SchedulesWorkbench(BaseAppScreen):
         Results tab active."""
         event.stop()
         self._rail_mark_all_read()
+
+    @on(Button.Pressed, "#scheduling-results-badge")
+    def _on_results_badge_pressed(self, event: Button.Pressed) -> None:
+        """Rail `Results (N)` (redesign PR-4, task 2) -- pushes the whole
+        (unfiltered) inbox as a fresh `ResultsHostScreen` overlay, beside
+        `Mark all read`. The Results TAB itself stays reachable until
+        Task 5 retires it -- both paths coexist this task."""
+        event.stop()
+        self._push_results_overlay()
+
+    @on(ViewDefinitionResultsRequested)
+    def _on_view_definition_results_requested(
+        self, event: ViewDefinitionResultsRequested
+    ) -> None:
+        """A definition pane's `Unread results` row was activated
+        (redesign PR-4, task 2) -- the live replacement for the retired
+        "See Results tab" pointer. Fires from either sibling
+        `DefinitionDetail` instance (Queue or Automations tab)."""
+        event.stop()
+        self._push_results_overlay(definition=event.definition)
+
+    def _push_results_overlay(
+        self, *, definition: dict[str, Any] | None = None
+    ) -> None:
+        """Push a standalone `ResultsTab` instance via `ResultsHostScreen`
+        (redesign PR-4, task 2's Results relocation).
+
+        Mirrors `_push_conflicts_overlay`'s shape (pre-read once, hand
+        the fresh instance its own data) but the pushed view ALSO needs
+        its own read/dismiss/mark-solved/mark-all binding surface
+        (`ResultsHostScreen`, not the plain `WorkbenchHostScreen`):
+        `SchedulesWorkbench`'s own r/d/o/a bindings are tab-gated and,
+        more fundamentally, never fire while this screen is on top of
+        the stack. `query`/`unread_ids` are re-run after every mutation
+        to repaint the SAME scope; the workbench's own rail/Queue/tab
+        state only re-syncs once, on pop, via `dismissed` (brief:
+        "refresh the rail + unified rows on dismissed").
+
+        `definition=None` is the rail's global inbox; otherwise the
+        listing (and its cap line) is scoped to that one definition,
+        across both its local/server id spaces.
+        """
+        service = self._service()
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable.", severity="warning"
+            )
+            return
+
+        def _query() -> tuple[
+            list[dict[str, Any]], dict[str, dict[str, Any]], int
+        ]:
+            if definition is None:
+                results = service.db.list_automation_results(
+                    owner_id=None, limit=RESULTS_INBOX_LIMIT
+                )
+                total = service.db.count_automation_results(owner_id=None)
+            else:
+                results, total = self._definition_results_query(service, definition)
+            definitions_by_id = index_definitions_by_id(
+                service.db.list_automation_definitions(owner_id=None)
+            )
+            return results, definitions_by_id, total
+
+        def _unread_ids() -> list[str]:
+            if definition is None:
+                return self._unread_result_ids(service)
+            return self._definition_unread_result_ids(service, definition)
+
+        results, definitions_by_id, total = _query()
+        heading = RESULTS_HEADING
+        if definition is not None:
+            name = str(
+                definition.get("name") or definition.get("id") or "Untitled automation"
+            )
+            heading = f"{RESULTS_HEADING} — {escape_markup(name)}"
+
+        def _factory() -> ResultsTab:
+            return ResultsTab(
+                id="scheduling-results-overlay",
+                initial_results=results,
+                initial_definitions_by_id=definitions_by_id,
+                initial_total=total,
+                heading=heading,
+            )
+
+        self.app.push_screen(
+            ResultsHostScreen(
+                _factory,
+                title="Results",
+                service=service,
+                query=_query,
+                unread_ids=_unread_ids,
+                dismissed=self._refresh_results_surfaces,
+            )
+        )
 
     @on(Button.Pressed, "#scheduling-conflicts-badge")
     def _on_conflicts_badge_pressed(self, event: Button.Pressed) -> None:
@@ -4084,12 +4201,18 @@ class SchedulesWorkbench(BaseAppScreen):
         except Exception:  # noqa: BLE001
             return False
 
+    def _notify(self, message: str, severity: str) -> None:
+        self.app_instance.notify(message, severity=severity)
+
     def _review_selected_result(self, review_state: str) -> None:
         """r/d on the Results tab: read/dismiss the selected result.
 
-        `SchedulingService.review_automation_result` writes the local row
-        and, for a server mirror, queues the PR-3 pushback mutation in the
-        SAME DB transaction -- nothing extra to do here for that half.
+        The actual orchestration (`review_selected_result`, results_tab.py)
+        is shared with the pushed view's own `r`/`d` bindings
+        (`ResultsHostScreen`, redesign PR-4 task 2) -- both call the same
+        `SchedulingService.review_automation_result`, which writes the
+        local row and, for a server mirror, queues the sync pushback
+        mutation in the SAME DB transaction.
         """
         service = self._service()
         if service is None:
@@ -4098,20 +4221,11 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
         results_tab = self.query_one("#scheduling-results", ResultsTab)
-        result = results_tab.selected_result()
-        if result is None:
-            self.app_instance.notify("Select a result first.", severity="warning")
-            return
 
         async def _review() -> None:
-            updated = await service.review_automation_result(
-                result["id"], review_state
+            await review_selected_result(
+                service, results_tab, review_state, self._notify
             )
-            if not updated:
-                self.app_instance.notify(
-                    "Could not update this result — see the log.",
-                    severity="error",
-                )
             self._refresh_results_surfaces()
 
         self.run_worker(
@@ -4159,20 +4273,14 @@ class SchedulesWorkbench(BaseAppScreen):
         # than re-deriving the id a second, divergent way. Non-None here
         # by construction: `solved_eligibility` returns ineligible when
         # the same lookup misses.
-        definition = definition_for_result(result, results_tab.definitions_by_id)
-        local_definition_id = str((definition or {}).get("id") or "")
+        # The async orchestration (`mark_selected_result_solved`,
+        # results_tab.py) is shared with the pushed view's own `o`
+        # binding (`ResultsHostScreen`, redesign PR-4 task 2).
 
         async def _mark_solved() -> None:
-            outcome = await service.resolve_definition(
-                local_definition_id, solved=True, result_id=result["id"]
+            await mark_selected_result_solved(
+                service, result, results_tab.definitions_by_id, self._notify
             )
-            if outcome.status == "saved":
-                self.app_instance.notify("Marked solved.", severity="information")
-            else:
-                self.app_instance.notify(
-                    outcome.reason or "Could not mark this result solved.",
-                    severity="warning",
-                )
             self._refresh_results_surfaces()
 
         self.run_worker(
@@ -4196,31 +4304,92 @@ class SchedulesWorkbench(BaseAppScreen):
         )
         return [result["id"] for result in results]
 
+    @staticmethod
+    def _definition_id_space(
+        definition: dict[str, Any],
+    ) -> tuple[str | None, str | None]:
+        """`(local_id, server_id)` for `definition`, either half `None`
+        when absent -- the two ids `automation_results.definition_id` may
+        carry for results BELONGING to this one definition
+        (`index_definitions_by_id`'s own caveat: a locally-created result
+        carries the local id, a server-mirrored one carries the server's)."""
+        local_id = str(definition.get("id") or "") or None
+        server_id = definition.get("server_id")
+        return local_id, (str(server_id) if server_id else None)
+
+    def _definition_results_query(
+        self, service: "SchedulingService", definition: dict[str, Any]
+    ) -> tuple[list[dict[str, Any]], int]:
+        """`(results, total)` for `definition` alone, across BOTH its id
+        spaces -- the definition-filtered pushed Results view's listing
+        (redesign PR-4 task 2). Capped at `RESULTS_INBOX_LIMIT`, same as
+        the global inbox (the brief: "preserve the cap-line honesty").
+
+        `ScheduledTasksDB.list_automation_results`/`count_automation_
+        results` only equality-filter ONE `definition_id` at a time (own
+        docstring's caveat), so a definition with results in both spaces
+        needs two queries, merged here and re-sorted by REAL instant
+        (`_result_sort_key`) rather than trusting either query's own
+        newest-first order to interleave correctly across the merge.
+        """
+        local_id, server_id = self._definition_id_space(definition)
+        merged: dict[str, dict[str, Any]] = {}
+        total = 0
+        for definition_id in (local_id, server_id):
+            if not definition_id:
+                continue
+            total += service.db.count_automation_results(
+                owner_id=None, definition_id=definition_id
+            )
+            for row in service.db.list_automation_results(
+                owner_id=None, definition_id=definition_id, limit=RESULTS_INBOX_LIMIT
+            ):
+                merged[row["id"]] = row
+        results = sorted(merged.values(), key=_result_sort_key, reverse=True)
+        return results[:RESULTS_INBOX_LIMIT], total
+
+    def _definition_unread_result_ids(
+        self, service: "SchedulingService", definition: dict[str, Any]
+    ) -> list[str]:
+        """Definition-scoped counterpart of `_unread_result_ids` -- every
+        unread result id for THIS definition alone (both id spaces),
+        uncapped by `RESULTS_INBOX_LIMIT` for the same Qodo-HIGH reason
+        that method's own docstring documents."""
+        local_id, server_id = self._definition_id_space(definition)
+        ids: list[str] = []
+        for definition_id in (local_id, server_id):
+            if not definition_id:
+                continue
+            unread_total = service.db.count_unread_results(
+                owner_id=None, definition_id=definition_id
+            )
+            if not unread_total:
+                continue
+            results = service.db.list_automation_results(
+                owner_id=None,
+                definition_id=definition_id,
+                review_state="unread",
+                limit=unread_total,
+            )
+            ids.extend(result["id"] for result in results)
+        return ids
+
     async def _dispatch_mark_all_results_read(
         self, service: "SchedulingService", unread_ids: list[str]
     ) -> None:
-        """Per-row `review_automation_result` fan-out for a batch of
-        result ids -- there is no bulk DB primitive for this (spec's
-        documented fan-out, mirroring `_on_bulk_delete_confirmed`'s
-        loop-and-count shape). Shared by the Results tab's `a` keybinding
-        and the rail's `Mark all read` button (redesign PR-2, Task 3) --
-        the Queue refresh included, which used to sit in the rail
-        button's own wrapper as if it were a rail-specific nicety (final
-        review F5): pressing `a` on the Results tab left the Queue's
-        unread dots painted and its rail button visible, and pressing
-        that button then reported "Nothing unread."
+        """Per-row fan-out for a batch of result ids -- the shared
+        `mark_results_read` (results_tab.py) does the actual DB calls +
+        notify, now also driving the pushed view's own `a` binding
+        (`ResultsHostScreen`, redesign PR-4 task 2). Shared by the
+        Results tab's `a` keybinding and the rail's `Mark all read`
+        button (redesign PR-2, Task 3) -- the Queue refresh included,
+        which used to sit in the rail button's own wrapper as if it were
+        a rail-specific nicety (final review F5): pressing `a` on the
+        Results tab left the Queue's unread dots painted and its rail
+        button visible, and pressing that button then reported "Nothing
+        unread."
         """
-        errors = 0
-        for result_id in unread_ids:
-            if not await service.review_automation_result(result_id, "read"):
-                errors += 1
-        count = len(unread_ids) - errors
-        self.app_instance.notify(
-            f"Marked {count} result{'s' if count != 1 else ''} read"
-            + (f" ({errors} failed)" if errors else "")
-            + ".",
-            severity="information" if not errors else "warning",
-        )
+        await mark_results_read(service, unread_ids, self._notify)
         self._refresh_results_surfaces()
 
     def action_mark_all_results_read(self) -> None:
@@ -4589,12 +4758,17 @@ class SchedulesWorkbench(BaseAppScreen):
             service.db.list_automation_definitions(owner_id=None)
         )
         results_tab.populate(results, definitions_by_id, total=total)
+        label = f"Results ({unread})" if unread else "Results"
         # Surface the unread count on the tab label itself (spec §4's
         # inbox badge, same UX-063 idiom as the Conflicts tab above).
-        self._set_tab_label(
-            "scheduling-results-tab",
-            f"Results ({unread})" if unread else "Results",
-        )
+        self._set_tab_label("scheduling-results-tab", label)
+        # redesign PR-4, task 2: same count, mirrored onto the rail's
+        # `Results` button (no new query) -- `_refresh_conflicts_tab`'s
+        # own precedent for its status-strip badge.
+        try:
+            self.query_one("#scheduling-results-badge", Button).label = label
+        except Exception:  # noqa: BLE001 - rail not mounted yet
+            pass
 
     def _refresh_results_surfaces(self) -> None:
         """Every surface a results MUTATION moves: the Results tab and the

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -14,6 +14,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.message import Message
 from textual.timer import Timer
 from textual.widgets import Button, DataTable, Input, Static
 
@@ -145,6 +146,37 @@ RESULTS_PULL_DEBOUNCE_SECONDS = 0.3
 #: could not. Beyond the cap the view says so out loud (`ResultsTab.
 #: populate`'s `total`); deliberately no pagination machinery.
 RESULTS_INBOX_LIMIT = _RESULTS_PAGE_SIZE * _SYNC_MAX_PAGES
+
+#: redesign PR-4, task 6 (spec §11): the messages a PUSHED detail pane can
+#: post whose handler lives on THIS screen rather than on the
+#: `WorkbenchHostScreen` hosting it. Textual bubbles a message
+#: widget -> parent -> Screen -> App, and the workbench is a different
+#: screen, so without relaying these the pushed pane would render
+#: correctly and do nothing (`WorkbenchHostScreen(route_message=...)`).
+#: An allowlist rather than "relay everything": Textual's own internal
+#: `messages.Update`/`Layout` bubble too and carry a widget belonging to
+#: another screen.
+_PUSHED_DETAIL_MESSAGES: tuple[type[Message], ...] = (
+    AcknowledgeIncidentRequested,
+    DefinitionFieldEditRequested,
+    DefinitionLifecycleToggleRequested,
+    DefinitionOwnerActionRequested,
+    DefinitionRunNowRequested,
+    DeleteTaskRequested,
+    DisableTaskRequested,
+    EditTaskRequested,
+    EnableTaskRequested,
+    ReminderFieldEditRequested,
+    ReminderOwnerActionRequested,
+    RunReminderNowRequested,
+    ViewDefinitionAuditRequested,
+    ViewDefinitionResultsRequested,
+    #: `#schedules-follow-in-console` sits INSIDE `TaskDetail` while its
+    #: handler is on this screen. Every other `Button.Pressed` handler
+    #: here is id/class-scoped to a control the panes do not contain, so
+    #: relaying the type wholesale cannot misfire.
+    Button.Pressed,
+)
 
 #: How many transport reconnects `EventObserver.run()` absorbs internally
 #: (its own built-in exponential backoff, capped at 5s per attempt) before
@@ -389,6 +421,13 @@ class SchedulesWorkbench(BaseAppScreen):
         # `_selected_task_id` above stays reminder-only for the existing
         # action code that reads it directly.
         self._selected_row_id: str | None = None
+        #: redesign PR-4, task 6 (spec §11): the FRESH `TaskDetail`/
+        #: `DefinitionDetail` instance currently hosted by a pushed
+        #: `WorkbenchHostScreen` at narrow widths, or None. Held only so
+        #: the docked panes' own paint seams can feed it the same data
+        #: (`_detail_panes`) -- never to reparent or reuse it; the next
+        #: push builds another instance.
+        self._pushed_detail: TaskDetail | DefinitionDetail | None = None
         #: One `asyncio.Lock` per definition an in-pane row edit has
         #: touched, serializing that definition's read-merge-write saves
         #: (Qodo finding 7) -- see `_edit_definition_field`.
@@ -534,6 +573,21 @@ class SchedulesWorkbench(BaseAppScreen):
                             id="scheduling-chip-completed",
                             classes="scheduling-queue-chip",
                         )
+                        # redesign PR-4, task 6 (spec §11): below the
+                        # 84-column threshold the four chips above
+                        # collapse into this one cycling control rather
+                        # than vanishing, so a mouse user keeps a filter
+                        # affordance at the 80x24 floor. Purely
+                        # CSS-driven (`.compact`, `_scheduling.tcss`) and
+                        # deliberately NOT `.scheduling-queue-chip`: that
+                        # class is what the compact rule hides, and this
+                        # button drives `action_cycle_chip` rather than
+                        # selecting one named chip.
+                        yield Button(
+                            "Filter: All",
+                            id="scheduling-chip-cycle",
+                            tooltip="Cycle the queue filter (f).",
+                        )
                     yield Input(
                         # Says what ruling 5's search actually
                         # matches -- title + question/body (final
@@ -607,6 +661,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._refresh_owner_select()
         self._refresh_conflicts_badge()
         self._refresh_results_badge()
+        self._sync_chip_cycle_label()
         # redesign PR-2, Task 3: hidden until `load_tasks` finds unread
         # rows (mirrors `SyncStatusWidget`'s own Clear-button idiom of
         # starting hidden rather than flashing visible-then-hidden).
@@ -1263,27 +1318,64 @@ class SchedulesWorkbench(BaseAppScreen):
                         "Clear the filter to see the queue."
                     )
                 else:
-                    # The chip row is hidden below width 84 (the `compact`
-                    # class this same threshold sets), while the selected
-                    # chip persists -- so don't point at a control that is
-                    # not on screen (final review F10).
+                    # Point at the control that is actually on screen
+                    # (final review F10): the four chips below width 84
+                    # are collapsed into the cycling control, which is
+                    # what the user has to reach for there (redesign
+                    # PR-4, task 6 -- the copy used to go silent because
+                    # the row vanished entirely).
                     notice = "No tasks in this view."
-                    if not self._chips_hidden():
-                        notice += " Choose a different chip to see the queue."
+                    notice += (
+                        " Cycle the filter (f) to see the queue."
+                        if self._chips_hidden()
+                        else " Choose a different chip to see the queue."
+                    )
                 self._update_static_content(
                     self.query_one("#scheduling-task-detail-empty-state", Static),
                     notice,
                 )
 
     def _chips_hidden(self) -> bool:
-        """True when the chip row is off screen (`_scheduling.tcss`:
-        `#scheduling-workbench.compact #scheduling-queue-chips { display:
-        none }`). Reads the class `on_resize` actually set rather than
+        """True when the four named chips are off screen (`_scheduling.
+        tcss`: `#scheduling-workbench.compact #scheduling-queue-chips
+        .scheduling-queue-chip { display: none }`), i.e. when the
+        collapsed cycling control is standing in for them (redesign PR-4,
+        task 6). Reads the class `on_resize` actually set rather than
         re-deriving its width threshold here."""
         try:
             return self.query_one("#scheduling-workbench").has_class("compact")
         except Exception:  # noqa: BLE001 - not mounted yet
             return False
+
+    def _detail_hidden(self) -> bool:
+        """True when `on_resize` has hidden the docked detail region.
+
+        The same read-the-class-not-the-width discipline `_chips_hidden`
+        uses: the threshold lives in `on_resize` alone, and this is what
+        routes `Enter` to the pushed detail (redesign PR-4, task 6).
+        """
+        try:
+            return self.query_one("#scheduling-detail-pane").has_class("pane-hidden")
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return False
+
+    def _detail_panes(
+        self, pane_id: str, pane_type: type[TaskDetail | DefinitionDetail]
+    ) -> list[Any]:
+        """Every live instance of one detail pane class to paint.
+
+        The docked pane always, plus the pushed instance whenever the
+        narrow layout has one of the SAME class open (redesign PR-4, task
+        6). Routing both through one list is what makes "the pushed pane
+        is fed by the same service-backed loads the docked pane is" true
+        by construction rather than by a parallel code path -- a mutation
+        that repaints the pane behind repaints the one on screen too.
+        """
+        panes: list[Any] = [self.query_one(pane_id, pane_type)]
+        pushed = self._pushed_detail
+        if isinstance(pushed, pane_type) and pushed.is_mounted:
+            panes.append(pushed)
+        return panes
 
     def _show_queue_detail_pane(self, kind: RowKind) -> None:
         """Toggle which Queue detail widget is visible (redesign PR-2,
@@ -1337,6 +1429,34 @@ class SchedulesWorkbench(BaseAppScreen):
         if chip is not None:
             self._set_queue_chip(chip)
 
+    @on(Button.Pressed, "#scheduling-chip-cycle")
+    def _on_queue_chip_cycle_pressed(self, event: Button.Pressed) -> None:
+        """The collapsed-chip control (redesign PR-4, task 6): the mouse
+        route into the SAME `f` cycle, so the narrow layout loses no
+        filter capability -- only the four-button row."""
+        event.stop()
+        self.action_cycle_chip()
+
+    def _sync_chip_cycle_label(self) -> None:
+        """Name the current chip on the collapsed control.
+
+        Reads the selected chip button's own label rather than restating
+        the four names here -- one source for the chip vocabulary.
+        """
+        try:
+            chip_button = self.query_one(
+                f"#scheduling-chip-{self._chip}", Button
+            )
+            cycle = self.query_one("#scheduling-chip-cycle", Button)
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return
+        cycle.label = f"Filter: {chip_button.label}"
+        # `Button.label` refreshes the widget but not the LAYOUT, and this
+        # button is `width: auto` -- without this the box keeps the width
+        # it was measured at ("Filter: All") and every longer chip name
+        # paints clipped.
+        cycle.refresh(layout=True)
+
     def _set_queue_chip(self, chip: Chip) -> None:
         if chip == self._chip:
             return
@@ -1345,6 +1465,7 @@ class SchedulesWorkbench(BaseAppScreen):
             self.query_one(f"#{button_id}", Button).variant = (
                 "primary" if candidate == chip else "default"
             )
+        self._sync_chip_cycle_label()
         self._render_table()
 
     # -- redesign PR-4, task 4: spec §12 keyboard map ------------------------
@@ -1424,6 +1545,85 @@ class SchedulesWorkbench(BaseAppScreen):
         if self._visible_rows[event.cursor_row].row_id == self._selected_row_id:
             return
         self._update_detail_for_index(event.cursor_row)
+
+    @on(DataTable.RowSelected, "#scheduling-task-table")
+    async def _on_task_row_selected(self, event: DataTable.RowSelected) -> None:
+        """`Enter` on a queue row: at the narrow floor, push the detail.
+
+        redesign PR-4, task 6 (spec §11, ruling 6). Above the threshold
+        the detail pane is docked beside the queue and already shows this
+        row, so `Enter` keeps being the no-op it has always been -- the
+        push exists to replace the blank-hide, not to add a second way of
+        seeing what is already on screen.
+        """
+        event.stop()
+        if not self._detail_hidden():
+            return
+        await self._push_row_detail(event.cursor_row)
+
+    async def _push_row_detail(self, index: int) -> None:
+        """Host a FRESH detail pane for one queue row, full-screen.
+
+        The same widget CLASS the docked pane uses, built by a factory
+        per push (Task 1's contract -- never the docked instance
+        reparented), then fed through `_update_detail_for_index`: the
+        SAME service-backed loads the docked pane gets, so there is no
+        second data path to keep in step. The push is awaited because
+        that is what guarantees the hosted widget is mounted (and has
+        composed its own children) before it is painted -- `App.push_
+        screen`'s awaitable "waits for the screen to be mounted", and
+        `TaskDetail.set_task`/`DefinitionDetail.set_definition` both
+        query their children.
+        """
+        if not (0 <= index < len(self._visible_rows)):
+            return
+        row = self._visible_rows[index]
+        built: list[TaskDetail | DefinitionDetail] = []
+
+        def _factory() -> TaskDetail | DefinitionDetail:
+            pane: TaskDetail | DefinitionDetail = (
+                TaskDetail(id="scheduling-task-detail-overlay")
+                if row.kind == "reminder"
+                else DefinitionDetail(id="scheduling-definition-detail-overlay")
+            )
+            built.append(pane)
+            return pane
+
+        await self.app.push_screen(
+            WorkbenchHostScreen(
+                _factory,
+                title=row.title,
+                dismissed=self._pushed_detail_dismissed,
+                route_message=self._route_pushed_detail_message,
+            )
+        )
+        if not built:
+            return
+        self._pushed_detail = built[0]
+        self._update_detail_for_index(index)
+
+    def _pushed_detail_dismissed(self) -> None:
+        """Drop the pushed pane and re-read the queue behind it.
+
+        Anything the overlay changed (an in-pane edit, a pause, a
+        transfer) already refreshed through its own mutation path; this
+        covers the rest -- and, more importantly, clears the reference so
+        `_detail_panes` stops feeding a widget that is about to be
+        pruned.
+        """
+        self._pushed_detail = None
+        self._request_tasks_refresh()
+
+    def _route_pushed_detail_message(self, message: Message) -> None:
+        """Relay a pushed pane's request messages back to this screen.
+
+        See `_PUSHED_DETAIL_MESSAGES`: a pushed pane's messages bubble to
+        the host screen and then to `App`, never sideways to the screen
+        underneath, so without this the pane would paint correctly and do
+        nothing.
+        """
+        if isinstance(message, _PUSHED_DETAIL_MESSAGES):
+            self.post_message(message)
 
     def _incidents_for(self, task_id) -> list:
         """TASK-26027: the selected task's failure incidents (fail-safe).
@@ -1508,21 +1708,31 @@ class SchedulesWorkbench(BaseAppScreen):
                 # still re-feed unconditionally: the DATA can change
                 # while the selection stands still.
                 return
-            task_detail = self.query_one("#scheduling-task-detail", TaskDetail)
-            task_detail.set_task(
-                task,
-                run_history=self._run_history_for(task.id),
-                incidents=self._incidents_for(task.id),
-                # PR-3 task 3: same option source the create/edit modal's
-                # own Timezone selector reads (`_task_timezones`), so the
-                # pane's inline Timezone row editor offers the same zones.
-                known_timezones=self._task_timezones(),
-                # PR-3 task 5: same option source the create/edit forms'
-                # own owner selector reads, so the Runs-on row's dropdown
-                # offers the same choices.
-                runs_on_options=self._runs_on_options()[0],
-            )
-            self._update_transfer_actions(task_detail, task)
+            # One read of each source, fed to every live instance of this
+            # pane (redesign PR-4 task 6: the docked one, plus a pushed
+            # one at narrow widths).
+            run_history = self._run_history_for(task.id)
+            incidents = self._incidents_for(task.id)
+            known_timezones = self._task_timezones()
+            runs_on_options = self._runs_on_options()[0]
+            for task_detail in self._detail_panes(
+                "#scheduling-task-detail", TaskDetail
+            ):
+                task_detail.set_task(
+                    task,
+                    run_history=run_history,
+                    incidents=incidents,
+                    # PR-3 task 3: same option source the create/edit
+                    # modal's own Timezone selector reads
+                    # (`_task_timezones`), so the pane's inline Timezone
+                    # row editor offers the same zones.
+                    known_timezones=known_timezones,
+                    # PR-3 task 5: same option source the create/edit
+                    # forms' own owner selector reads, so the Runs-on
+                    # row's dropdown offers the same choices.
+                    runs_on_options=runs_on_options,
+                )
+                self._update_transfer_actions(task_detail, task)
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
         else:
             # `_selected_task_id = None` keeps every reminder-only
@@ -1711,12 +1921,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._update_follow_button_state()
 
     def _update_follow_button_state(self) -> None:
-        task_detail = self.query_one("#scheduling-task-detail", TaskDetail)
         available = (
             self._latest_console_follow_item_id is not None
             or self._latest_console_launch_kwargs is not None
         )
-        task_detail.set_follow_available(available)
+        for task_detail in self._detail_panes("#scheduling-task-detail", TaskDetail):
+            task_detail.set_follow_available(available)
 
     @on(DeleteTaskRequested)
     def _on_delete_task_requested(self, event: DeleteTaskRequested) -> None:
@@ -3234,18 +3444,21 @@ class SchedulesWorkbench(BaseAppScreen):
         definition row (redesign PR-2, Task 2), reading its counts off
         the event loop.
         """
-        detail = self.query_one(
-            "#scheduling-queue-definition-detail", DefinitionDetail
-        )
+        # Every live instance of this pane (redesign PR-4 task 6: the
+        # docked one, plus a pushed one at narrow widths) -- re-queried
+        # after the await, since a push/pop can land while it runs.
         definition_id = str(definition.get("id") or "")
         service = self._scheduling_service
         if service is None:
             if row_id == self._selected_row_id:
-                detail.set_definition(
-                    definition, run_count=0, last_run=None, unread_count=0
-                )
-                detail.set_lifecycle_lock(None)
-                detail.set_runs_on_transfer_errors([])
+                for detail in self._detail_panes(
+                    "#scheduling-queue-definition-detail", DefinitionDetail
+                ):
+                    detail.set_definition(
+                        definition, run_count=0, last_run=None, unread_count=0
+                    )
+                    detail.set_lifecycle_lock(None)
+                    detail.set_runs_on_transfer_errors([])
             return
         run_count, last_run, unread_count, history_error = (
             await self._fetch_definition_detail_counts(
@@ -3256,28 +3469,33 @@ class SchedulesWorkbench(BaseAppScreen):
         # nothing for a stale row (same guard `_load_automation_detail` uses).
         if row_id != self._selected_row_id:
             return
-        detail.set_definition(
-            definition,
-            run_count=run_count,
-            last_run=last_run,
-            unread_count=unread_count,
-            history_error=history_error,
-            known_timezones=self._task_timezones(),
-            # PR-3 task 5: same option source the reminder pane's own
-            # Runs-on row reads (`_update_detail_for_index`).
-            runs_on_options=self._runs_on_options()[0],
-        )
-        # PR-3 task 4: `reason` comes from `SchedulingService.transfer_
-        # lock_reason` (never re-derived in the widget), fed right after
-        # `set_definition` per that method's own docstring -- the same
-        # discipline `_update_transfer_actions` follows for the reminder
-        # pane.
-        detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
-        # PR-3 task 5 fix round 1 (finding 2): the Runs-on row's own
-        # failure text, from the same source.
-        detail.set_runs_on_transfer_errors(
-            _definition_transfer_errors(service, definition)
-        )
+        known_timezones = self._task_timezones()
+        # PR-3 task 5: same option source the reminder pane's own Runs-on
+        # row reads (`_update_detail_for_index`).
+        runs_on_options = self._runs_on_options()[0]
+        lifecycle_lock = service.transfer_lock_reason(definition)
+        transfer_errors = _definition_transfer_errors(service, definition)
+        for detail in self._detail_panes(
+            "#scheduling-queue-definition-detail", DefinitionDetail
+        ):
+            detail.set_definition(
+                definition,
+                run_count=run_count,
+                last_run=last_run,
+                unread_count=unread_count,
+                history_error=history_error,
+                known_timezones=known_timezones,
+                runs_on_options=runs_on_options,
+            )
+            # PR-3 task 4: `reason` comes from `SchedulingService.
+            # transfer_lock_reason` (never re-derived in the widget), fed
+            # right after `set_definition` per that method's own
+            # docstring -- the same discipline `_update_transfer_actions`
+            # follows for the reminder pane.
+            detail.set_lifecycle_lock(lifecycle_lock)
+            # PR-3 task 5 fix round 1 (finding 2): the Runs-on row's own
+            # failure text, from the same source.
+            detail.set_runs_on_transfer_errors(transfer_errors)
 
     def _run_automation_now(self, definition: dict[str, Any]) -> None:
         """Dispatch one automation definition now, routed by its owner.
@@ -3796,7 +4014,16 @@ class SchedulesWorkbench(BaseAppScreen):
         )
 
     def on_resize(self) -> None:
-        """Hide side panes (with a notice) instead of clipping them."""
+        """Degrade the side panes instead of clipping them.
+
+        redesign PR-4, task 6 (spec §11, ruling 6): below 84 columns the
+        detail region no longer just disappears behind a "widen the
+        window" apology -- the queue takes the full width and `Enter` on
+        a row PUSHES the same pane class full-screen
+        (`_on_task_row_selected`), so every operation stays reachable at
+        the 80x24 floor. The inspector, which is a read-only summary of
+        what the detail pane already shows, still simply yields.
+        """
         self._sync_responsive_workbench()
         try:
             width = self.size.width
@@ -3810,20 +4037,42 @@ class SchedulesWorkbench(BaseAppScreen):
         detail.set_class(hide_detail, "pane-hidden")
         # At detail-hiding widths the pane chrome also gets too tall to fit:
         # the screen header already names this pane, so the in-pane title
-        # yields its row to the table + notice (see _scheduling.tcss).
+        # yields its row to the table + notice, the chip row collapses to
+        # its cycling control, and the queue rail takes the whole width
+        # (see _scheduling.tcss).
         self.query_one("#scheduling-workbench").set_class(hide_detail, "compact")
-        if hide_detail:
-            # The create CTA normally lives in the (now hidden) detail pane;
-            # keep it reachable at compact widths when the queue is empty.
-            base = "Detail and inspector hidden — widen the window to see them."
-            if not self._tasks:
-                base += " Press n to schedule your first task."
-            self._resize_notice = base
-        elif hide_inspector:
+        self._sync_resize_notice()
+        self._update_pane_notice()
+
+    def _sync_resize_notice(self) -> None:
+        """Recompute the width-driven half of the queue-pane notice.
+
+        Reads the classes `on_resize` set rather than the width, and is
+        called from `_update_pane_notice` as well as from the resize
+        itself: the compact copy branches on whether the queue has any
+        tasks, which a resize handler alone cannot keep current (a
+        first-run screen mounts, resizes with zero tasks, and only then
+        loads them -- redesign PR-4, task 6).
+        """
+        if self._detail_hidden():
+            self._resize_notice = (
+                "Press n to schedule your first task."
+                if not self._tasks
+                else "Press Enter on a row to open its details."
+            )
+        elif self._inspector_hidden():
             self._resize_notice = "Inspector hidden — widen the window to see it."
         else:
             self._resize_notice = ""
-        self._update_pane_notice()
+
+    def _inspector_hidden(self) -> bool:
+        """True when `on_resize` has hidden the inspector pane."""
+        try:
+            return self.query_one("#scheduling-inspector-pane").has_class(
+                "pane-hidden"
+            )
+        except Exception:  # noqa: BLE001 - not mounted yet
+            return False
 
     def _update_pane_notice(self) -> None:
         """Compose the queue-pane notice: hidden panes, marks, glyph legend.
@@ -3837,6 +4086,7 @@ class SchedulesWorkbench(BaseAppScreen):
             notice = self.query_one("#scheduling-pane-notice", Static)
         except Exception:  # noqa: BLE001 - not mounted yet
             return
+        self._sync_resize_notice()
         parts: list[str] = []
         if self._resize_notice:
             parts.append(self._resize_notice)

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -428,6 +428,19 @@ class SchedulesWorkbench(BaseAppScreen):
         #: (`_detail_panes`) -- never to reparent or reuse it; the next
         #: push builds another instance.
         self._pushed_detail: TaskDetail | DefinitionDetail | None = None
+        #: The `UnifiedRow.row_id` `_pushed_detail` was pushed FOR (fix
+        #: wave F2). The pushed pane is pinned to this identity, never to
+        #: a row index: a background refresh that drops the open row used
+        #: to fall through `_render_table`'s `target_index = 0` and re-feed
+        #: the overlay with a DIFFERENT row's data while its Header still
+        #: named the original -- a pane whose Delete button then targeted
+        #: the wrong reminder. `_detail_panes` now only feeds the pushed
+        #: instance for THIS row_id, and `_pop_pushed_detail_if_gone`
+        #: closes it (with a notice) when the row leaves the queue.
+        self._pushed_row_id: str | None = None
+        #: The `WorkbenchHostScreen` hosting `_pushed_detail`, held only so
+        #: the gone-row check above can pop it.
+        self._pushed_host: WorkbenchHostScreen | None = None
         #: One `asyncio.Lock` per definition an in-pane row edit has
         #: touched, serializing that definition's read-merge-write saves
         #: (Qodo finding 7) -- see `_edit_definition_field`.
@@ -1256,6 +1269,10 @@ class SchedulesWorkbench(BaseAppScreen):
         deterministic tests.
         """
         render_now = now if now is not None else datetime.now(timezone.utc)
+        # Fix wave F2: before anything re-feeds the panes, close a pushed
+        # overlay whose row is no longer in `_all_rows` -- otherwise the
+        # restore/empty branches below would hand it another row's data.
+        self._pop_pushed_detail_if_gone()
         previous_selected_row_id = self._selected_row_id
         self._visible_rows = sort_rows(
             filter_rows(self._all_rows, chip=self._chip, query=self._filter_text),
@@ -1360,7 +1377,11 @@ class SchedulesWorkbench(BaseAppScreen):
             return False
 
     def _detail_panes(
-        self, pane_id: str, pane_type: type[TaskDetail | DefinitionDetail]
+        self,
+        pane_id: str,
+        pane_type: type[TaskDetail | DefinitionDetail],
+        *,
+        row_id: str | None = None,
     ) -> list[Any]:
         """Every live instance of one detail pane class to paint.
 
@@ -1370,12 +1391,66 @@ class SchedulesWorkbench(BaseAppScreen):
         is fed by the same service-backed loads the docked pane is" true
         by construction rather than by a parallel code path -- a mutation
         that repaints the pane behind repaints the one on screen too.
+
+        ``row_id`` is the identity gate (fix wave F2). A row-scoped feed
+        passes the `UnifiedRow.row_id` whose data it is about to write,
+        and the pushed instance joins the list only when that is the row
+        it was PUSHED for: the docked pane follows the queue cursor (and
+        `_render_table`'s row-0 fallback when the selection vanishes),
+        the pushed pane must not, or its Header names one reminder while
+        its body -- and its Delete button -- belong to another. Feeds
+        that carry no row identity at all (`_update_follow_button_state`'s
+        availability flag) pass ``None`` and reach every instance, as
+        before.
         """
         panes: list[Any] = [self.query_one(pane_id, pane_type)]
         pushed = self._pushed_detail
-        if isinstance(pushed, pane_type) and pushed.is_mounted:
+        if (
+            isinstance(pushed, pane_type)
+            and pushed.is_mounted
+            and (row_id is None or row_id == self._pushed_row_id)
+        ):
             panes.append(pushed)
         return panes
+
+    def _pop_pushed_detail_if_gone(self) -> None:
+        """Close a pushed detail whose row has left the queue (fix wave F2).
+
+        The chosen honest gone-state is **auto-pop with a notice**, not a
+        blanked overlay: a full-screen pane titled after a reminder that no
+        longer exists has nothing true left to show, and popping is the
+        one outcome that also removes its Delete/Disable/Run-now buttons
+        from reach. Keyed off `_all_rows` (what EXISTS), never
+        `_visible_rows` (what the current chip/filter shows) -- a filter
+        narrowing must not close an open pane.
+
+        Clears the pushed state inline rather than routing through
+        `_pushed_detail_dismissed`: this runs from inside `_render_table`,
+        i.e. inside the `schedules-load-tasks` worker, and that hook's own
+        `_request_tasks_refresh()` would cancel the very load we are in
+        (same exclusive group). If the host is not the active screen (a
+        modal opened over it), the pop is skipped this round; the identity
+        gate above still keeps the stale pane from being re-fed.
+
+        Only `load_tasks`'s SUCCESS path reaches `_render_table` -- its
+        `except` branch empties `_all_rows` and returns early -- so a
+        transient service failure never closes an open pane.
+        """
+        host = self._pushed_host
+        row_id = self._pushed_row_id
+        if host is None or row_id is None:
+            return
+        if any(row.row_id == row_id for row in self._all_rows):
+            return
+        self._pushed_detail = None
+        self._pushed_row_id = None
+        self._pushed_host = None
+        if self.app.screen is not host:
+            return
+        self.app_instance.notify(
+            f"'{host.title}' is no longer in the queue.", severity="warning"
+        )
+        host.dismiss()
 
     def _show_queue_detail_pane(self, kind: RowKind) -> None:
         """Toggle which Queue detail widget is visible (redesign PR-2,
@@ -1589,17 +1664,24 @@ class SchedulesWorkbench(BaseAppScreen):
             built.append(pane)
             return pane
 
-        await self.app.push_screen(
-            WorkbenchHostScreen(
-                _factory,
-                title=row.title,
-                dismissed=self._pushed_detail_dismissed,
-                route_message=self._route_pushed_detail_message,
-            )
+        host = WorkbenchHostScreen(
+            _factory,
+            title=row.title,
+            dismissed=self._pushed_detail_dismissed,
+            route_message=self._route_pushed_detail_message,
         )
+        await self.app.push_screen(host)
         if not built:
             return
         self._pushed_detail = built[0]
+        # Fix wave F2: the pane is pinned to the row it was pushed for,
+        # and the Header's `title` above is that same row's -- so the two
+        # can no longer disagree. (A later rename of the pinned row does
+        # leave the Header stale until the pane is reopened; the identity
+        # it names stays correct, which is what the wrong-target-delete
+        # defect turned on.)
+        self._pushed_row_id = row.row_id
+        self._pushed_host = host
         self._update_detail_for_index(index)
 
     def _pushed_detail_dismissed(self) -> None:
@@ -1612,6 +1694,8 @@ class SchedulesWorkbench(BaseAppScreen):
         pruned.
         """
         self._pushed_detail = None
+        self._pushed_row_id = None
+        self._pushed_host = None
         self._request_tasks_refresh()
 
     def _route_pushed_detail_message(self, message: Message) -> None:
@@ -1716,7 +1800,7 @@ class SchedulesWorkbench(BaseAppScreen):
             known_timezones = self._task_timezones()
             runs_on_options = self._runs_on_options()[0]
             for task_detail in self._detail_panes(
-                "#scheduling-task-detail", TaskDetail
+                "#scheduling-task-detail", TaskDetail, row_id=row.row_id
             ):
                 task_detail.set_task(
                     task,
@@ -2143,6 +2227,15 @@ class SchedulesWorkbench(BaseAppScreen):
         mounted tab instance that did). `dismissed=self._refresh_
         conflicts_badge` re-syncs the badge count on pop, in case the
         overlay resolved anything while it was open.
+
+        Fix wave F3: the push also relays `ConflictsTab.ConflictResolved`
+        back here (task 6's `route_message` pattern). Without it the
+        message bubbled tab -> host screen -> App and never reached
+        `_on_conflict_resolved`, so resolving a conflict updated the badge
+        on pop but never reloaded the queue -- the row kept showing the
+        LOSING side's title/schedule until some unrelated refresh
+        happened to fire. Relaying restores the LIVE reload the mounted
+        tab used to get, while the overlay is still open.
         """
         service = self._service()
         conflicts = (
@@ -2164,8 +2257,18 @@ class SchedulesWorkbench(BaseAppScreen):
                 _factory,
                 title="Conflicts",
                 dismissed=self._refresh_conflicts_badge,
+                route_message=self._route_conflicts_message,
             )
         )
+
+    def _route_conflicts_message(self, message: Message) -> None:
+        """Relay a pushed `ConflictsTab`'s resolution back to this screen
+        (fix wave F3) -- the allowlisted counterpart of `_route_pushed_
+        detail_message`, kept separate because the two pushes carry
+        entirely different message vocabularies.
+        """
+        if isinstance(message, ConflictsTab.ConflictResolved):
+            self.post_message(message)
 
     @on(DefinitionRunNowRequested)
     def _on_definition_run_now_requested(
@@ -3172,7 +3275,7 @@ class SchedulesWorkbench(BaseAppScreen):
             self._no_task_notice("pause or resume"), severity="warning"
         )
 
-    def action_move_owner(self) -> None:
+    async def action_move_owner(self) -> None:
         """`m`: open the selected row's Runs-on dropdown (spec §12/§7).
 
         Posting `DetailValueRow.Activated` on the row directly drives the
@@ -3181,8 +3284,30 @@ class SchedulesWorkbench(BaseAppScreen):
         show_error`), then the dropdown -- so this needs no new
         activation logic, only a reference to the right pane's row
         (`TaskDetail`/`DefinitionDetail.runs_on_row`).
+
+        Fix wave F1: below the responsive floor the docked detail region
+        is `display: none`, and this used to resolve the DOCKED pane's
+        row anyway -- mounting a `Select` inside an invisible pane, taking
+        focus off the queue table, and painting nothing. The queue's
+        arrow keys then stopped working with no notification and no
+        visible editor: a silent input trap, only escapable by a guessed
+        `Esc`. Narrow widths now take the SAME route `Enter` does
+        (`_push_row_detail`, ruling 6) and activate the Runs-on row of the
+        pane that is actually on screen -- `m` still means "open the
+        transfer dropdown for this row", it just opens it where the user
+        can see it. At or above the threshold nothing changes.
         """
-        if self._selected_task() is not None:
+        row: DetailValueRow | None
+        if self._detail_hidden():
+            table = self.query_one("#scheduling-task-table", DataTable)
+            index = table.cursor_row
+            if index is None or not (0 <= index < len(self._visible_rows)):
+                row = None
+            else:
+                await self._push_row_detail(index)
+                pushed = self._pushed_detail
+                row = pushed.runs_on_row if pushed is not None else None
+        elif self._selected_task() is not None:
             row = self.query_one("#scheduling-task-detail", TaskDetail).runs_on_row
         elif self._selected_queue_definition() is not None:
             row = self.query_one(
@@ -3452,7 +3577,9 @@ class SchedulesWorkbench(BaseAppScreen):
         if service is None:
             if row_id == self._selected_row_id:
                 for detail in self._detail_panes(
-                    "#scheduling-queue-definition-detail", DefinitionDetail
+                    "#scheduling-queue-definition-detail",
+                    DefinitionDetail,
+                    row_id=row_id,
                 ):
                     detail.set_definition(
                         definition, run_count=0, last_run=None, unread_count=0
@@ -3476,7 +3603,7 @@ class SchedulesWorkbench(BaseAppScreen):
         lifecycle_lock = service.transfer_lock_reason(definition)
         transfer_errors = _definition_transfer_errors(service, definition)
         for detail in self._detail_panes(
-            "#scheduling-queue-definition-detail", DefinitionDetail
+            "#scheduling-queue-definition-detail", DefinitionDetail, row_id=row_id
         ):
             detail.set_definition(
                 definition,
@@ -4181,6 +4308,13 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @on(ConflictsTab.ConflictResolved)
     def _on_conflict_resolved(self, event: ConflictsTab.ConflictResolved) -> None:
+        """Reload the queue when a conflict is resolved.
+
+        The `ConflictsTab` posting this lives on a pushed
+        `WorkbenchHostScreen` (task 5 retired the mounted one), so the
+        message reaches this handler only through that push's
+        `route_message` relay -- see `_route_conflicts_message`.
+        """
         self._request_tasks_refresh(refresh_definitions=False)
         self._refresh_conflicts_badge()
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -28,7 +28,6 @@ from ...Workbench.workbench_widgets import DestinationHeader, RecoveryCallout
 from ....runtime_policy.bootstrap import set_authoritative_runtime_source
 from ....Scheduling.automation_health import compute_local_health
 from ....Scheduling.events import (
-    CancelTransferRequested,
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
     DefinitionOwnerActionRequested,
@@ -40,12 +39,9 @@ from ....Scheduling.events import (
     EnableTaskRequested,
     ReminderFieldEditRequested,
     ReminderOwnerActionRequested,
-    RetryTransferRequested,
     RunReminderNowRequested,
     SyncCompleted,
     SyncFailed,
-    TransferToLocalRequested,
-    TransferToServerRequested,
     ViewDefinitionAuditRequested,
     ViewDefinitionResultsRequested,
 )
@@ -123,7 +119,6 @@ from .unified_rows import (
 if TYPE_CHECKING:
     from tldw_chatbook.Scheduling.services.scheduling_service import (
         SchedulingService,
-        TransferOutcome,
     )
     from tldw_chatbook.app import TldwCli
 
@@ -292,49 +287,73 @@ def _row_subtitle(row: UnifiedRow, now: datetime) -> str:
 class SchedulesWorkbench(BaseAppScreen):
     """Main workbench for managing scheduled runs, reminders, and jobs."""
 
+    # redesign PR-4, task 4: the spec §12 keyboard map. `1`-`4`/`f` cycle
+    # the Queue chips, `/` focuses the filter, `n` opens the create
+    # chooser (renamed from `c` -- straight rebind, survey §3), `p`
+    # pauses/resumes the selected row (routed by kind), `m` opens the
+    # selected row's Runs-on dropdown (the SAME activation Enter/click on
+    # the row already drives), `r` marks a selected definition row's
+    # unread results read. The legacy Automations-tab-only m/M/y/k
+    # transfer keybindings (schedules-handoff PR-5 task 7 fix round) are
+    # RETIRED here -- the Runs-on dropdown is the one transfer surface
+    # (ruling 2; `_begin_automation_transfer`/`_cancel_automation_
+    # transfer` and their action_* wrappers are deleted, zero remaining
+    # consumers verified). `escape` keeps its existing "clear marks"
+    # semantics (spec §12: "Esc back/close" -- WorkbenchHostScreen's own
+    # `escape` pop handles the pushed-view half of that; this screen has
+    # no back/close state beyond marks). `space`/`e`/`d`/`x`/`s`/`o`/`a`
+    # are not named in spec §12 -- the survey's own reading ("stay as-is,
+    # the spec text doesn't rule") keeps them unchanged. `r`'s OLD
+    # meaning (tab-routed run-now/mark-read, `action_run_task_now`) is no
+    # longer reachable via a key (ruling 2: "Run-now is NOT a global key
+    # -- a detail-pane button" -- `DefinitionDetail`/`TaskDetail` both
+    # already have one, task 3); the method itself stays for the
+    # still-live Automations/Results tabs' own routing until task 5
+    # retires them.
     BINDINGS = [
-        Binding("c", "create_reminder", "Create"),
+        Binding("1", "chip_all", "All", show=False),
+        Binding("2", "chip_active", "Active", show=False),
+        Binding("3", "chip_paused", "Paused", show=False),
+        Binding("4", "chip_completed", "Completed", show=False),
+        Binding("f", "cycle_chip", "Cycle filter"),
+        Binding("/", "focus_search", "Search"),
+        Binding("n", "create", "Create"),
+        Binding("p", "pause_resume", "Pause/Resume"),
+        Binding("m", "move_owner", "Move owner"),
+        Binding("r", "mark_read", "Mark read"),
         Binding("e", "edit_task", "Edit"),
-        Binding("r", "run_task_now", "Run now"),
         Binding("space", "toggle_enabled", "Enable/Disable"),
         Binding("d", "delete", "Delete"),
         Binding("x", "mark_task", "Mark"),
         Binding("escape", "clear_marks", "Clear marks"),
         Binding("s", "sync_now", "Sync"),
-        # Automations-tab-only (schedules-handoff PR-5 task 7 fix round):
-        # the tab has no per-row detail widget, so its actions are
-        # keybindings routed by active tab -- same idiom as r/e above,
-        # not new buttons (mirrors _edit_selected_automation/
-        # _run_automation_now, the tab's existing action grammar).
-        Binding("m", "move_automation_to_local", "Move to local"),
-        Binding("M", "move_automation_to_server", "Move to server"),
-        Binding("y", "retry_automation_transfer", "Retry transfer"),
-        Binding("k", "cancel_automation_transfer", "Cancel transfer"),
-        # Results-tab-only (schedules-handoff PR-6 task 3): read/dismiss
-        # reuse r/d via the SAME active-tab routing action_run_task_now/
-        # action_delete already do for Automations -- r=Read and d=Dismiss
-        # are natural readings of those same keys on this tab. Mark
-        # solved/Mark all read have no existing-key mnemonic to reuse, so
-        # they get fresh letters (o/a), guarded the same way m/M/y/k are.
+        # Results-tab-only (schedules-handoff PR-6 task 3), unaffected by
+        # the §12 remap: mark-solved/mark-all-read have no existing-key
+        # mnemonic to reuse, so they keep their own letters.
         Binding("o", "mark_result_solved", "Mark solved"),
         Binding("a", "mark_all_results_read", "Mark all read"),
     ]
 
-    # Footer hints must stay 1:1 with BINDINGS and only advertise implemented
-    # actions (ADR-031). Single letters are safe: focused inputs consume
-    # printable keys before screen bindings fire.
+    # Footer hints must stay 1:1 with BINDINGS (minus escape, which needs
+    # no advertising) and only advertise implemented actions (ADR-031).
+    # Single letters are safe: focused inputs consume printable keys
+    # before screen bindings fire.
     SCHEDULES_SHORTCUTS = (
-        ("c", "create"),
+        ("1", "all"),
+        ("2", "active"),
+        ("3", "paused"),
+        ("4", "completed"),
+        ("f", "cycle filter"),
+        ("/", "search"),
+        ("n", "create"),
+        ("p", "pause/resume"),
+        ("m", "move owner"),
+        ("r", "mark read"),
         ("e", "edit"),
-        ("r", "run now"),
         ("space", "toggle"),
         ("d", "delete"),
         ("x", "mark"),
         ("s", "sync"),
-        ("m", "move to local"),
-        ("M", "move to server"),
-        ("y", "retry transfer"),
-        ("k", "cancel transfer"),
         ("o", "mark solved"),
         ("a", "mark all read"),
     )
@@ -491,7 +510,7 @@ class SchedulesWorkbench(BaseAppScreen):
                                     "Create ▾",
                                     id="scheduling-new-task",
                                     variant="primary",
-                                    tooltip="Schedule a new task (c).",
+                                    tooltip="Schedule a new task (n).",
                                 )
                                 yield Button(
                                     "Mark all read",
@@ -1390,6 +1409,58 @@ class SchedulesWorkbench(BaseAppScreen):
             )
         self._render_table()
 
+    # -- redesign PR-4, task 4: spec §12 keyboard map ------------------------
+
+    def action_chip_all(self) -> None:
+        """`1`: switch the Queue chip to All."""
+        self._set_queue_chip("all")
+
+    def action_chip_active(self) -> None:
+        """`2`: switch the Queue chip to Active."""
+        self._set_queue_chip("active")
+
+    def action_chip_paused(self) -> None:
+        """`3`: switch the Queue chip to Paused."""
+        self._set_queue_chip("paused")
+
+    def action_chip_completed(self) -> None:
+        """`4`: switch the Queue chip to Completed."""
+        self._set_queue_chip("completed")
+
+    def action_cycle_chip(self) -> None:
+        """`f`: cycle to the next Queue chip, wrapping at the end.
+
+        Works "at every width" (task-4 brief: don't couple to chip
+        visibility) -- the chip row hides below 84 cols (`.compact`,
+        `_chips_hidden`), but `_set_queue_chip` only ever touches
+        `self._chip` and the still-MOUNTED button widgets' `.variant`,
+        never their `.display`, so cycling never depends on the row
+        being shown. `_CHIP_BY_BUTTON_ID`'s own insertion order
+        (all/active/paused/completed, matching the chip row's visual
+        left-to-right order) is reused as the cycle order rather than a
+        second hard-coded tuple.
+        """
+        order = list(self._CHIP_BY_BUTTON_ID.values())
+        next_chip = order[(order.index(self._chip) + 1) % len(order)]
+        self._set_queue_chip(next_chip)
+
+    def action_focus_search(self) -> None:
+        """`/`: focus the Queue filter input."""
+        search = self.query_one("#scheduling-queue-filter", Input)
+        if search.display:
+            search.focus()
+
+    def action_create(self) -> None:
+        """`n`: open the create-task chooser.
+
+        Renamed from `c` (survey §3: "straight rename/rebind, no
+        functional conflict") -- previously `c` skipped the chooser and
+        went straight to the reminder form (`action_create_reminder`),
+        which had drifted from the rail's own `Create ▾` button (always
+        the chooser); `n` now matches the button.
+        """
+        self._open_new_task_chooser()
+
     @on(DataTable.RowHighlighted)
     def _on_task_row_highlighted(self, event: DataTable.RowHighlighted) -> None:
         """Update the detail pane when the user highlights a task row.
@@ -1523,53 +1594,26 @@ class SchedulesWorkbench(BaseAppScreen):
     def _update_transfer_actions(
         self, task_detail: TaskDetail, task: ReminderTask | ScheduledTask
     ) -> None:
-        """Compute Move/Retry/Cancel disabled-reasons for the detail pane.
+        """Cache the Runs-on row's lock/failure state for the detail pane.
 
-        Reasons come straight from `SchedulingService.transfer_refusal`/
-        `cancel_refusal` (spec §6.4/§6.3) so the UI never re-derives the
-        refusal rules itself (health quoting included, and -- fix round
-        finding 1 -- cancel's own state branching too) -- each reason is
-        only computed for the button `TaskDetail.set_task` already
-        decided is structurally relevant (e.g. `to_local_reason` is never
-        computed for a local row, which would always trivially refuse
-        with "not server-owned" noise).
+        redesign PR-4 task 4 (ruling 2): this used to ALSO compute the
+        legacy Move/Retry/Cancel buttons' disabled-reasons via `set_
+        transfer_reasons` -- retired along with those buttons (the Runs-on
+        dropdown is the one transfer surface now). What is left is what
+        the dropdown/mini-bar still need: `transfer_lock_reason` (spec
+        §6.3 read-only-except-cancel, final review I7) and the stored
+        `to_server_failed` mutation errors (PR-3 task 5 fix round 1,
+        finding 2), both never re-derived elsewhere.
         """
         service = self._scheduling_service
         if service is None or not isinstance(task, ReminderTask):
-            task_detail.set_transfer_reasons(
-                to_server_reason=None,
-                to_local_reason=None,
-                retry_reason=None,
-                cancel_reason=None,
-                retry_errors=[],
-            )
             task_detail.set_lifecycle_lock(None)
             task_detail.set_runs_on_transfer_errors([])
             return
 
         row = transfer_row_dict(task)
-        is_server_owned = str(task.owner_id or "").startswith("server:")
-        transfer_state = task.transfer_state
-
-        # `transfer_refusal` already returns None for `to_server_failed`
-        # (Task 6's retry leg deliberately excludes it from "already in
-        # progress"), so this needs no extra state carve-out -- the same
-        # call also backs the Retry button below.
-        to_server_reason = (
-            service.transfer_refusal(row, "to_server") if not is_server_owned else None
-        )
-        to_local_reason = (
-            service.transfer_refusal(row, "to_local") if is_server_owned else None
-        )
-        cancel_reason = service.cancel_refusal(row)
-
-        # A `to_server_failed` row is never server-owned, so this is the
-        # exact same call `to_server_reason` already made above -- reused
-        # rather than repeated.
-        retry_reason: str | None = None
         retry_errors: list[str] = []
-        if transfer_state == "to_server_failed":
-            retry_reason = to_server_reason
+        if task.transfer_state == "to_server_failed":
             # fix round finding 3: keyed off the mutation's OWN owner_id
             # column, not a guess via "today's active server" -- a
             # `to_server_failed` row's mutation was recorded under
@@ -1578,19 +1622,10 @@ class SchedulesWorkbench(BaseAppScreen):
             # switch if guessed instead of read.
             retry_errors = _pending_transfer_errors(service, "reminder_task", task.id)
 
-        task_detail.set_transfer_reasons(
-            to_server_reason=to_server_reason,
-            to_local_reason=to_local_reason,
-            retry_reason=retry_reason,
-            cancel_reason=cancel_reason,
-            retry_errors=retry_errors,
-        )
-        # spec §6.3 read-only-except-cancel (final review I7). Applied
-        # AFTER set_transfer_reasons, which owns the same reason Static.
+        # spec §6.3 read-only-except-cancel (final review I7).
         task_detail.set_lifecycle_lock(service.transfer_lock_reason(row))
-        # PR-3 task 5 fix round 1 (finding 2): the SAME `retry_errors`
-        # feeds the Runs-on row's own failure text -- one source, not a
-        # second derivation.
+        # PR-3 task 5 fix round 1 (finding 2): feeds the Runs-on row's own
+        # failure text -- one source, not a second derivation.
         task_detail.set_runs_on_transfer_errors(retry_errors)
 
     def _refuse_if_transfer_locked(self, task: Any, verb: str) -> bool:
@@ -1773,43 +1808,17 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-delete-task",
         )  # type: ignore[arg-type]
 
-    @on(TransferToServerRequested)
-    def _on_transfer_to_server_requested(
-        self, event: TransferToServerRequested
-    ) -> None:
-        event.stop()
-        self._begin_transfer(event.task, "to_server")
-
-    @on(TransferToLocalRequested)
-    def _on_transfer_to_local_requested(
-        self, event: TransferToLocalRequested
-    ) -> None:
-        event.stop()
-        self._begin_transfer(event.task, "to_local")
-
-    @on(RetryTransferRequested)
-    def _on_retry_transfer_requested(self, event: RetryTransferRequested) -> None:
-        # Obligation (f)/spec §6.1.5: retrying a `to_server_failed` row is
-        # the SAME facade call as a first-time begin -- `transfer_refusal`
-        # deliberately narrows its "already in progress" check to exclude
-        # `to_server_failed`, and `begin_transfer_to_server`'s CAS accepts
-        # both `None` and `to_server_failed` as its starting state.
-        event.stop()
-        self._begin_transfer(event.task, "to_server")
-
-    @on(CancelTransferRequested)
-    def _on_cancel_transfer_requested(self, event: CancelTransferRequested) -> None:
-        event.stop()
-        self._cancel_transfer(event.task)
-
     @staticmethod
     def _transfer_confirm_dialog(
         name: str, direction: str, warnings: list[str]
     ) -> ConfirmationDialog:
         """Build the Move confirm dialog (spec §6.1/§6.2/§6.4) -- shared by
-        the reminder (`_begin_transfer`) and Automations-tab
-        (`_begin_automation_transfer`) flows (Task 7 fix round item 1: two
-        near-identical call sites, one copy of the confirm-dialog copy)."""
+        the reminder and definition Runs-on dropdown flows (`_run_owner_
+        transfer`, PR-3 task 5). The legacy button-driven `_begin_
+        transfer`/`_begin_automation_transfer` call sites this originally
+        served (Task 7 fix round item 1's "two near-identical call
+        sites") were retired in redesign PR-4 task 4 -- this stayed
+        because the dropdown is now the surface using it."""
         destination_label = "the server" if direction == "to_server" else "this device"
         lines = [f'Move "{escape_markup(name)}" to {destination_label}?']
         if warnings:
@@ -1842,134 +1851,6 @@ class SchedulesWorkbench(BaseAppScreen):
             f"'{name}' is queued to move to this device -- a dormant copy "
             "is ready and will arm once the server releases it."
         )
-
-    def _begin_transfer(self, task: ReminderTask, direction: str) -> None:
-        """Confirm, then start a transfer for ``task`` (spec §6.1/§6.2).
-
-        Always confirms first -- Move is not a casual action, and the
-        dialog is the one place `transfer_warnings` (imminent one-time
-        `run_at`, non-transferring `timeout_seconds`) actually reaches the
-        user before they commit, not only when something happens to be
-        wrong. `transfer_refusal` is checked again defensively (the
-        button should already be disabled when refused) before ever
-        opening the dialog.
-        """
-        service = self._scheduling_service
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable; cannot start a transfer.",
-                severity="warning",
-            )
-            return
-
-        row = transfer_row_dict(task)
-        reason = service.transfer_refusal(row, direction)
-        if reason is not None:
-            self.app_instance.notify(reason, severity="warning")
-            return
-        warnings = service.transfer_warnings(row, direction)
-        dialog = self._transfer_confirm_dialog(task.title, direction, warnings)
-
-        async def _confirm_and_begin() -> None:
-            confirmed = await self.app.push_screen_wait(dialog)
-            if not confirmed:
-                return
-            try:
-                if direction == "to_server":
-                    outcome = await service.begin_transfer_to_server(
-                        "reminder_task", task.id
-                    )
-                else:
-                    outcome = await service.begin_transfer_to_local(
-                        "reminder_task", task.id
-                    )
-            except Exception:  # noqa: BLE001
-                logger.exception("Failed to begin transfer for {}", task.id)
-                self.app_instance.notify(
-                    f"Failed to start the transfer for '{task.title}'.",
-                    severity="error",
-                )
-                self._request_tasks_refresh(refresh_definitions=False)
-                return
-            self._notify_transfer_outcome(task, direction, outcome)
-            self._request_tasks_refresh(refresh_definitions=False)
-
-        self.run_worker(
-            _confirm_and_begin,
-            exclusive=True,
-            group="schedules-transfer",
-        )  # type: ignore[arg-type]
-
-    def _notify_transfer_outcome(
-        self, task: ReminderTask, direction: str, outcome: "TransferOutcome"
-    ) -> None:
-        """Toast a transfer's result -- honest about what actually happened
-        (spec §6.1.1: a queued-not-sent transfer never claims the task
-        stopped running here)."""
-        if outcome.status == "pending":
-            self.app_instance.notify(
-                self._transfer_pending_toast_text(task.title, direction),
-                severity="information",
-            )
-        elif outcome.status == "refused":
-            self.app_instance.notify(
-                outcome.reason or f"Could not move '{task.title}'.",
-                severity="warning",
-            )
-        elif outcome.status == "not_found":
-            self.app_instance.notify(
-                f"'{task.title}' no longer exists.", severity="warning"
-            )
-
-    def _cancel_transfer(self, task: ReminderTask) -> None:
-        """Cancel ``task``'s in-progress transfer immediately.
-
-        No confirm dialog: cancel is the escape hatch spec §6.3 exists
-        for, and gating the escape hatch behind its own confirmation
-        fights the point of it. `task.id` is whichever row is currently
-        selected -- for a release's dormant local copy that is already
-        the copy's OWN id (it is a first-class queue row, not reached
-        through the mirror), which is exactly the id `cancel_transfer`
-        needs for that leg (Task 6 handoff note).
-        """
-        service = self._scheduling_service
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable; cannot cancel the "
-                "transfer.",
-                severity="warning",
-            )
-            return
-
-        async def _cancel_and_refresh() -> None:
-            try:
-                outcome = await service.cancel_transfer("reminder_task", task.id)
-            except Exception:  # noqa: BLE001
-                logger.exception("Failed to cancel transfer for {}", task.id)
-                self.app_instance.notify(
-                    f"Failed to cancel the transfer for '{task.title}'.",
-                    severity="error",
-                )
-                self._request_tasks_refresh(refresh_definitions=False)
-                return
-            if outcome.status == "cancelled":
-                self.app_instance.notify(
-                    _cancel_toast_text(task.title),
-                    severity="information",
-                )
-            else:
-                self.app_instance.notify(
-                    outcome.reason
-                    or f"Could not cancel the transfer for '{task.title}'.",
-                    severity="warning",
-                )
-            self._request_tasks_refresh(refresh_definitions=False)
-
-        self.run_worker(
-            _cancel_and_refresh,
-            exclusive=True,
-            group="schedules-transfer",
-        )  # type: ignore[arg-type]
 
     @on(Button.Pressed, "#scheduling-new-task")
     def _on_new_task_pressed(self, event: Button.Pressed) -> None:
@@ -2812,14 +2693,12 @@ class SchedulesWorkbench(BaseAppScreen):
 
     # -- Owner-row transfer dropdown (PR-3 task 5, spec §7 flow) -------------
     #
-    # A SECOND, row-scoped surface onto the SAME PR-5 transfer facade the
-    # legacy Move/Retry/Cancel buttons (`_begin_transfer`/`_cancel_
-    # transfer`/`_begin_automation_transfer`/`_cancel_automation_transfer`
-    # above/below) already drive -- deliberately independent end to end
-    # (own events, own helpers), not a refactor of them: coexistence is a
-    # pinned requirement (task-5 brief), and the two surfaces differ in
-    # how a refusal renders (this one uses `DetailValueRow.show_error`,
-    # the legacy ones toast/write the tab's shared inline notice).
+    # Originally a SECOND, row-scoped surface onto the PR-5 transfer
+    # facade alongside the legacy Move/Retry/Cancel buttons/keybindings
+    # (own events, own helpers, deliberately independent end to end --
+    # coexistence was a pinned requirement, task-5 brief). redesign PR-4
+    # task 4 retired the legacy side (ruling 2) -- this is now the ONE
+    # transfer surface. A refusal renders inline via `row.show_error`.
 
     async def _run_owner_transfer(
         self,
@@ -2834,10 +2713,9 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> None:
         """Shared move/retry body for both panes' Runs-on row.
 
-        `transfer_refusal` runs FIRST (health-quoting preserved, since it
-        is the SAME call `_begin_transfer`/`_begin_automation_transfer`
-        make) -- a refusal renders inline via `row.show_error`, never the
-        legacy toast/notice. Allowed -> the SAME `ConfirmationDialog` +
+        `transfer_refusal` runs FIRST (health-quoting preserved) -- a
+        refusal renders inline via `row.show_error`, never a toast.
+        Allowed -> the SAME `ConfirmationDialog` +
         `transfer_warnings` + honest-toast shape those flows already use;
         confirmed -> `begin_transfer_to_server`/`to_local` by `direction`
         with `row_id` (the CURRENTLY DISPLAYED row's own local id for
@@ -3045,17 +2923,24 @@ class SchedulesWorkbench(BaseAppScreen):
         self._run_reminder_now(event.task)
 
     def action_run_task_now(self) -> None:
-        """Run the highlighted task immediately (``r`` key).
+        """Run the highlighted task immediately.
 
-        Routes by active tab: the Automations tab's ``r`` dispatches a
+        redesign PR-4, task 4: no longer key-bound (ruling 2 -- "Run-now
+        is NOT a global key", `r` is reassigned to `action_mark_read`
+        below). This method itself stays: the still-live Automations
+        tab's own run-now routing (task 5 retires the tab) and the
+        Results tab's tab-routed mark-read both still call it, and a
+        Queue definition row's own `Run now` button (task 3) reaches the
+        SAME `_run_automation_now` this falls through to, directly.
+
+        Routes by active tab: the Automations tab dispatches a
         server-side run (ADR-077 -- the server owns execution); the
-        Results tab's ``r`` marks the selected result read instead
-        (schedules-handoff PR-6 task 3 -- a natural reading of the same
-        key); everywhere else it is the local reminder Run-now
-        (task-18938) OR, redesign PR-4 task 3, a Queue definition row's
-        own run-now (same owner-routed dispatch the Automations tab's
-        ``r`` uses -- `_run_automation_now` is family-agnostic, so this
-        works for every definition family, not just `recurring_
+        Results tab marks the selected result read instead
+        (schedules-handoff PR-6 task 3); everywhere else it is the local
+        reminder Run-now (task-18938) OR, redesign PR-4 task 3, a Queue
+        definition row's own run-now (same owner-routed dispatch the
+        Automations tab uses -- `_run_automation_now` is family-agnostic,
+        so this works for every definition family, not just `recurring_
         question`).
         """
         try:
@@ -3110,6 +2995,112 @@ class SchedulesWorkbench(BaseAppScreen):
         if row.kind != "definition":
             return None
         return row.source_row
+
+    def action_pause_resume(self) -> None:
+        """`p`: pause/resume the selected row (spec §12), routed by kind.
+
+        A reminder row (or a bulk mark selection) reuses `action_toggle_
+        enabled` VERBATIM -- same single-row/bulk-marked seam, same
+        transfer-lock refusal (`_refuse_if_transfer_locked`). A
+        definition row toggles `lifecycle` via the SAME facade call the
+        header Pause/Resume button drives (`_toggle_definition_
+        lifecycle`) -- the SAME `transfer_lock_reason` (never re-derived)
+        the button's own honest refusal uses, reported here as a
+        notification since this is a screen-level key, not a row with
+        its own error slot.
+        """
+        if self._marked_ids or self._selected_task() is not None:
+            self.action_toggle_enabled()
+            return
+        definition = self._selected_queue_definition()
+        if definition is not None:
+            service = self._scheduling_service
+            if service is None:
+                self.app_instance.notify(
+                    "Scheduling service is unavailable; cannot update the "
+                    "automation.",
+                    severity="warning",
+                )
+                return
+            name = str(definition.get("name") or definition.get("id") or "")
+            lock_reason = service.transfer_lock_reason(definition)
+            if lock_reason is not None:
+                self.app_instance.notify(
+                    f"Cannot pause/resume '{name}': {lock_reason}",
+                    severity="warning",
+                )
+                return
+            lifecycle = str(definition.get("lifecycle") or "configured")
+            action = "resume" if lifecycle != "configured" else "pause"
+            self._toggle_definition_lifecycle(definition, action)
+            return
+        self.app_instance.notify(
+            self._no_task_notice("pause or resume"), severity="warning"
+        )
+
+    def action_move_owner(self) -> None:
+        """`m`: open the selected row's Runs-on dropdown (spec §12/§7).
+
+        Posting `DetailValueRow.Activated` on the row directly drives the
+        exact same `on_detail_value_row_activated` path a real Enter/
+        click already does -- honest lock/family-note refusal (`row.
+        show_error`), then the dropdown -- so this needs no new
+        activation logic, only a reference to the right pane's row
+        (`TaskDetail`/`DefinitionDetail.runs_on_row`).
+        """
+        if self._selected_task() is not None:
+            row = self.query_one("#scheduling-task-detail", TaskDetail).runs_on_row
+        elif self._selected_queue_definition() is not None:
+            row = self.query_one(
+                "#scheduling-queue-definition-detail", DefinitionDetail
+            ).runs_on_row
+        else:
+            row = None
+        if row is None:
+            self.app_instance.notify(
+                self._no_task_notice("move"), severity="warning"
+            )
+            return
+        row.post_message(DetailValueRow.Activated(row))
+
+    def action_mark_read(self) -> None:
+        """`r`: mark the selected definition row's unread results read
+        (spec §12/§8) -- the SAME per-id fan-out `a`/the rail's `Mark all
+        read` already drive (`_dispatch_mark_all_results_read`), scoped
+        to just this one definition via `_definition_unread_result_ids`
+        (both id spaces). A reminder row has no results concept at all
+        (honest no-op copy)."""
+        if self._selected_task() is not None:
+            self.app_instance.notify(
+                "This task has no results to mark read.",
+                severity="information",
+            )
+            return
+        definition = self._selected_queue_definition()
+        if definition is None:
+            self.app_instance.notify(
+                self._no_task_notice("mark read"), severity="warning"
+            )
+            return
+        service = self._service()
+        if service is None:
+            self.app_instance.notify(
+                "Scheduling service is unavailable.", severity="warning"
+            )
+            return
+        unread_ids = self._definition_unread_result_ids(service, definition)
+        if not unread_ids:
+            self.app_instance.notify(
+                "Nothing unread for this automation.", severity="information"
+            )
+            return
+
+        async def _mark() -> None:
+            await self._dispatch_mark_all_results_read(service, unread_ids)
+
+        self.run_worker(
+            _mark, exclusive=True, group="schedules-mark-all-read"
+        )  # type: ignore[arg-type]
 
     def _run_reminder_now(self, task: ReminderTask) -> None:
         """Dispatch one reminder through the scheduler's own path (task-18938)."""
@@ -3991,262 +3982,16 @@ class SchedulesWorkbench(BaseAppScreen):
         )
         return mirrored.get("id") if mirrored else None
 
-    # -- Automations-tab transfer actions (schedules-handoff spec §6,
-    # PR-5 task 7 fix round item 1) -----------------------------------
-    #
-    # With PR-5 as first shipped, `begin_transfer_to_server`/`begin_
-    # transfer_to_local`/`cancel_transfer` had no UI call site at all for
-    # `table_kind="automation_definition"` -- the facade fully supports
-    # it (Task 6), but nothing let a user ever start, cancel, or retry a
-    # definition's transfer. The tab has no per-row detail widget (no
-    # `TaskDetail` equivalent), so these are keybindings routed by active
-    # tab -- the SAME idiom `action_run_task_now`/`action_edit_task`
-    # already use for this tab's Run-now/Edit, not new buttons. A
-    # refusal renders inline in the tab's own notice Static (its only
-    # existing status affordance -- reused rather than adding a second
-    # one); an allowed Move reuses the same `ConfirmationDialog` +
-    # honest-toast shape the Queue tab's reminder flow already
-    # established. Move to server (`M`) and Retry (`y`) share one call:
-    # a retry IS a re-begin, so the difference is the label and which
-    # state each is offered in, not the code path.
-
-    def action_move_automation_to_local(self) -> None:
-        """m key: queue a server-owned automation mirror to move here
-        (spec §6.2), Automations-tab only."""
-        self._begin_automation_transfer("to_local")
-
-    def action_move_automation_to_server(self) -> None:
-        """M key: queue a LOCAL automation definition to move to the
-        server (spec §6.1), Automations-tab only.
-
-        The missing half of the definitions transfer UI (final review
-        M8): `y`/Retry already reached `begin_transfer_to_server`, but
-        only ever as a retry beside a failed transfer, so a plain local
-        definition had no way to start one. Same facade call -- a retry
-        IS a re-begin (`transfer_refusal` excludes `to_server_failed`
-        from "in progress", and the CAS accepts both `None` and
-        `to_server_failed`) -- given its own honest label and key, rather
-        than teaching users that "Retry" means "Move".
-        """
-        self._begin_automation_transfer("to_server")
-
-    def action_retry_automation_transfer(self) -> None:
-        """y key: retry a definitively-failed local -> server automation
-        transfer (spec §6.1.5), Automations-tab only."""
-        self._begin_automation_transfer("to_server")
-
-    def action_cancel_automation_transfer(self) -> None:
-        """k key: cancel the selected automation's in-progress transfer
-        (spec §6.3), Automations-tab only."""
-        self._cancel_automation_transfer()
-
-    def _is_automations_tab_active(self) -> bool:
-        try:
-            return (
-                self.query_one("#scheduling-tabs", TabbedContent).active
-                == "scheduling-automations-tab"
-            )
-        except Exception:  # noqa: BLE001
-            return False
-
-    def _show_automations_inline_reason(self, reason: str) -> None:
-        """Surface a transfer refusal/failure inline (fix round item 1's
-        "refusal -> inline reason" flow) -- the Automations pane's notice
-        Static is the tab's only existing status affordance
-        (`_automations_notice_text`'s own home), reused rather than
-        adding a second one. The next `load_automations()` (any other
-        action, or a completed transfer's own reload) naturally replaces
-        it with the aggregate summary again.
-        """
-        try:
-            notice = self.query_one("#scheduling-automations-notice", Static)
-        except Exception:  # noqa: BLE001
-            return
-        self._update_static_content(notice, reason)
-
-    def _begin_automation_transfer(self, direction: str) -> None:
-        """Move-to-local / Retry for the selected automation (spec
-        §6.1/§6.2), Automations-tab only. Same flow as the Queue tab's
-        `_begin_transfer`: refusal -> inline reason; allowed ->
-        `ConfirmationDialog` listing `transfer_warnings`; honest toast on
-        completion; reload via the tab's existing `_request_automations_
-        refresh` wiring.
-        """
-        if not self._is_automations_tab_active():
-            self.app_instance.notify(
-                "Switch to the Automations tab to move or retry an "
-                "automation's transfer.",
-                severity="warning",
-            )
-            return
-        definition = self._selected_automation()
-        if definition is None:
-            self.app_instance.notify(
-                "Nothing selected — select an automation first.",
-                severity="warning",
-            )
-            return
-        service = self._scheduling_service
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable; cannot start a transfer.",
-                severity="warning",
-            )
-            return
-
-        async def _resolve_and_begin() -> None:
-            # redesign PR-2 Task 2 review round 2: a genuine user-
-            # triggered transfer attempt (m/M/y) -- the Queue's cached
-            # definitions rows may now be outdated regardless of which
-            # branch below this lands on (refused/pending/not_found all
-            # still touch the local mirror row via `_resolve_local_
-            # definition_id`).
-            self._definitions_stale = True
-            local_id = await self._resolve_local_definition_id(service, definition)
-            if local_id is None:
-                self.app_instance.notify(
-                    "Could not prepare this automation for transfer — see "
-                    "the log.",
-                    severity="error",
-                )
-                return
-            row = await asyncio.to_thread(
-                service.db.get_automation_definition, local_id
-            )
-            if row is None:
-                self.app_instance.notify(
-                    "This automation no longer exists.", severity="warning"
-                )
-                self._request_automations_refresh()
-                return
-            name = str(row.get("name") or definition.get("name") or local_id)
-            reason = service.transfer_refusal(row, direction)
-            if reason is not None:
-                self._show_automations_inline_reason(reason)
-                return
-            warnings = service.transfer_warnings(row, direction)
-            dialog = self._transfer_confirm_dialog(name, direction, warnings)
-            confirmed = await self.app.push_screen_wait(dialog)
-            if not confirmed:
-                return
-            try:
-                if direction == "to_server":
-                    outcome = await service.begin_transfer_to_server(
-                        "automation_definition", local_id
-                    )
-                else:
-                    outcome = await service.begin_transfer_to_local(
-                        "automation_definition", local_id
-                    )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Failed to begin automation transfer for {}", local_id
-                )
-                self.app_instance.notify(
-                    f"Failed to start the transfer for '{name}'.",
-                    severity="error",
-                )
-                self._request_automations_refresh()
-                return
-            if outcome.status == "pending":
-                self.app_instance.notify(
-                    self._transfer_pending_toast_text(name, direction),
-                    severity="information",
-                )
-            elif outcome.status == "refused":
-                self._show_automations_inline_reason(
-                    outcome.reason or f"Could not move '{name}'."
-                )
-            elif outcome.status == "not_found":
-                self.app_instance.notify(
-                    f"'{name}' no longer exists.", severity="warning"
-                )
-            self._request_automations_refresh()
-
-        self.run_worker(
-            _resolve_and_begin,
-            exclusive=True,
-            group="schedules-automation-transfer",
-        )  # type: ignore[arg-type]
-
-    def _cancel_automation_transfer(self) -> None:
-        """Cancel the selected automation's in-progress transfer (spec
-        §6.3), Automations-tab only. No confirm dialog -- same rationale
-        as the Queue tab's cancel: it is the escape hatch, gating it
-        behind its own confirmation fights the point. The resolved LOCAL
-        row id is already the dormant copy's own id for a release in
-        progress -- `_load_local_automations` shows that copy directly (a
-        `server_id`-less local row), never through the mirror, so
-        resolution never routes to the mirror's id for that leg (same
-        construction as the reminder side's cancel).
-        """
-        if not self._is_automations_tab_active():
-            self.app_instance.notify(
-                "Switch to the Automations tab to cancel an automation's "
-                "transfer.",
-                severity="warning",
-            )
-            return
-        definition = self._selected_automation()
-        if definition is None:
-            self.app_instance.notify(
-                "Nothing selected — select an automation first.",
-                severity="warning",
-            )
-            return
-        service = self._scheduling_service
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable; cannot cancel the "
-                "transfer.",
-                severity="warning",
-            )
-            return
-
-        async def _resolve_and_cancel() -> None:
-            # redesign PR-2 Task 2 review round 2: a genuine user-
-            # triggered cancel (k) -- see `_resolve_and_begin`'s matching
-            # comment for why this is marked unconditionally.
-            self._definitions_stale = True
-            local_id = await self._resolve_local_definition_id(service, definition)
-            if local_id is None:
-                self.app_instance.notify(
-                    "Could not resolve this automation locally — see the "
-                    "log.",
-                    severity="error",
-                )
-                return
-            name = str(definition.get("name") or local_id)
-            try:
-                outcome = await service.cancel_transfer(
-                    "automation_definition", local_id
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Failed to cancel automation transfer for {}", local_id
-                )
-                self.app_instance.notify(
-                    f"Failed to cancel the transfer for '{name}'.",
-                    severity="error",
-                )
-                self._request_automations_refresh()
-                return
-            if outcome.status == "cancelled":
-                self.app_instance.notify(
-                    _cancel_toast_text(name), severity="information"
-                )
-            else:
-                self._show_automations_inline_reason(
-                    outcome.reason
-                    or f"Could not cancel the transfer for '{name}'."
-                )
-            self._request_automations_refresh()
-
-        self.run_worker(
-            _resolve_and_cancel,
-            exclusive=True,
-            group="schedules-automation-transfer",
-        )  # type: ignore[arg-type]
+    # redesign PR-4, task 4 (ruling 2): the Automations-tab-only
+    # m/M/y/k transfer keybindings and their `_begin_automation_
+    # transfer`/`_cancel_automation_transfer` flow (schedules-handoff
+    # spec §6, PR-5 task 7 fix round item 1) are RETIRED -- the Runs-on
+    # row's dropdown (`_run_owner_transfer`/`_run_owner_cancel`, PR-3
+    # task 5) is the one transfer surface now. `git grep` verified zero
+    # remaining consumers of `action_move_automation_to_local`/`_to_
+    # server`, `action_retry_automation_transfer`, `action_cancel_
+    # automation_transfer`, `_is_automations_tab_active`, `_show_
+    # automations_inline_reason` before deleting them.
 
     # -- Results-tab actions (schedules-handoff PR-6 task 3) ---------------
     #
@@ -4626,7 +4371,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # keep it reachable at compact widths when the queue is empty.
             base = "Detail and inspector hidden — widen the window to see them."
             if not self._tasks:
-                base += " Press c to schedule your first task."
+                base += " Press n to schedule your first task."
             self._resize_notice = base
         elif hide_inspector:
             self._resize_notice = "Inspector hidden — widen the window to see it."

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -1682,7 +1682,24 @@ class SchedulesWorkbench(BaseAppScreen):
         # defect turned on.)
         self._pushed_row_id = row.row_id
         self._pushed_host = host
-        self._update_detail_for_index(index)
+        # Fix wave (finding 7): `index` is a POSITION captured before the
+        # `await` above -- the queue can reorder, refresh, or filter while
+        # the screen mounts, so replaying it here would repaint whatever
+        # row now happens to sit at that position, not the one this pane
+        # was pushed for. Resolve by IDENTITY instead (`row.row_id`,
+        # captured before the await same as `_pushed_row_id`), the same
+        # discipline F2 already applies to RE-feeds via the `_detail_
+        # panes` gate. A row that vanished from `_all_rows` between the
+        # `m`/Enter press and the mount completing takes the SAME
+        # auto-pop-with-notice path `_pop_pushed_detail_if_gone` builds
+        # for that case -- never a wrong-row paint.
+        self._pop_pushed_detail_if_gone()
+        if self._pushed_row_id is None:
+            return
+        for fresh_index, visible_row in enumerate(self._visible_rows):
+            if visible_row.row_id == row.row_id:
+                self._update_detail_for_index(fresh_index)
+                break
 
     def _pushed_detail_dismissed(self) -> None:
         """Drop the pushed pane and re-read the queue behind it.

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -15,7 +15,7 @@ from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
 from textual.timer import Timer
-from textual.widgets import Button, DataTable, Input, Static, TabbedContent, TabPane
+from textual.widgets import Button, DataTable, Input, Static
 
 from ...Navigation.base_app_screen import BaseAppScreen
 from ...Navigation.screen_state_store import RuntimeIdentity
@@ -66,28 +66,17 @@ from ....UI.Screens.scheduling.results_tab import (
     escape_markup,
     index_definitions_by_id,
     mark_results_read,
-    mark_selected_result_solved,
-    review_selected_result,
-    solved_eligibility,
     _result_sort_key,
 )
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from ....UI.Screens.scheduling.workbench_host_screen import WorkbenchHostScreen
 from ....Widgets.confirmation_dialog import ConfirmationDialog
 from ....Widgets.detail_value_row import DetailValueRow
-# schedules-redesign PR-1, Task 4: `automation_execution_target_label`/
-# `automation_name_cell` moved to `definition_detail.py` (that leaf
-# module's own "Model"/"Runs on" row formatters need them and importing
-# them back from here would be circular) -- re-exported via this import
-# so the DataTable render call site below and the pre-existing
-# `test_execution_target_label_matrix` test (which imports
-# `automation_execution_target_label` from THIS module) keep working.
-from .definition_audit_view import DefinitionAuditView, audit_notice_text, fetch_definition_audit
+from .definition_audit_view import DefinitionAuditView
 from .definition_detail import (
     DefinitionDetail,
     _definition_transfer_suffix,
     _LIFECYCLE_TOGGLE_RESULTS,
-    automation_execution_target_label,
     automation_name_cell,
 )
 from .forms.automation_definition_form import AutomationDefinitionForm
@@ -137,9 +126,9 @@ QUEUE_FILTER_DEBOUNCE_SECONDS = 0.2
 #: not current, per the hidden-progress-clock rule (TASK-23022).
 NEXT_RUN_REFRESH_SECONDS = 60.0
 
-#: Defensive cap for the Automations tab's follow-the-pages load -- the loop
-#: exists so the tail of a large definition list is never silently hidden,
-#: not to render unbounded rows.
+#: Defensive cap for the server definitions' follow-the-pages load -- the
+#: loop exists so the tail of a large definition list is never silently
+#: hidden, not to render unbounded rows.
 AUTOMATIONS_LOAD_MAX_ROWS = 500
 
 #: Debounce before acting on a notification-triggered results pull
@@ -149,11 +138,11 @@ AUTOMATIONS_LOAD_MAX_ROWS = 500
 RESULTS_PULL_DEBOUNCE_SECONDS = 0.3
 
 #: How many results the inbox lists. The DB default (50) silently hid older
-#: rows while the badge counted EVERY unread one, so the tab could read
+#: rows while the badge counted EVERY unread one, so the badge could read
 #: "Results (120)" over 50 rows. This is the sync-mirrored window --
 #: exactly the newest-pages walk `SyncEngine._pull_results` performs -- so
 #: the inbox shows everything a pull could have brought down and nothing it
-#: could not. Beyond the cap the tab says so out loud (`ResultsTab.
+#: could not. Beyond the cap the view says so out loud (`ResultsTab.
 #: populate`'s `total`); deliberately no pagination machinery.
 RESULTS_INBOX_LIMIT = _RESULTS_PAGE_SIZE * _SYNC_MAX_PAGES
 
@@ -220,12 +209,6 @@ def _definition_transfer_errors(
     )
 
 
-#: Delayed second fetch of the run-history pane after a Run-now dispatch:
-#: the terminal audit event lands only after the server finishes executing
-#: the run, so an immediate fetch alone would usually miss it.
-AUTOMATION_HISTORY_FOLLOWUP_SECONDS = 5.0
-
-
 def _row_title_cell(
     row: UnifiedRow, *, marked_ids: set[str], compact_owner_suffix: bool
 ) -> Text:
@@ -234,8 +217,9 @@ def _row_title_cell(
     Each primitive keeps its OWN existing title-suffix/prefix rendering
     verbatim -- a reminder row is byte-identical to the pre-redesign
     Title column (`_transfer_row_suffix`/`_queue_owner_suffix`), a
-    definition row reuses the Automations tab's own Name-cell rendering
-    (`automation_name_cell`/`_definition_transfer_suffix`) -- rather than
+    definition row reuses `definition_detail.py`'s own Name-cell
+    rendering (`automation_name_cell`/`_definition_transfer_suffix`) --
+    rather than
     inventing one shared format neither primitive used before.
     """
     if row.kind == "reminder":
@@ -301,15 +285,15 @@ class SchedulesWorkbench(BaseAppScreen):
     # consumers verified). `escape` keeps its existing "clear marks"
     # semantics (spec §12: "Esc back/close" -- WorkbenchHostScreen's own
     # `escape` pop handles the pushed-view half of that; this screen has
-    # no back/close state beyond marks). `space`/`e`/`d`/`x`/`s`/`o`/`a`
+    # no back/close state beyond marks). `space`/`e`/`d`/`x`/`s`/`a`
     # are not named in spec §12 -- the survey's own reading ("stay as-is,
     # the spec text doesn't rule") keeps them unchanged. `r`'s OLD
     # meaning (tab-routed run-now/mark-read, `action_run_task_now`) is no
     # longer reachable via a key (ruling 2: "Run-now is NOT a global key
     # -- a detail-pane button" -- `DefinitionDetail`/`TaskDetail` both
-    # already have one, task 3); the method itself stays for the
-    # still-live Automations/Results tabs' own routing until task 5
-    # retires them.
+    # already have one, task 3); redesign PR-4 task 5 then deleted that
+    # method's tab routing with the tabs (one row-kind route left) and
+    # retired the Results-tab-only `o` alongside it.
     BINDINGS = [
         Binding("1", "chip_all", "All", show=False),
         Binding("2", "chip_active", "Active", show=False),
@@ -327,10 +311,11 @@ class SchedulesWorkbench(BaseAppScreen):
         Binding("x", "mark_task", "Mark"),
         Binding("escape", "clear_marks", "Clear marks"),
         Binding("s", "sync_now", "Sync"),
-        # Results-tab-only (schedules-handoff PR-6 task 3), unaffected by
-        # the §12 remap: mark-solved/mark-all-read have no existing-key
-        # mnemonic to reuse, so they keep their own letters.
-        Binding("o", "mark_result_solved", "Mark solved"),
+        # `a` mirrors the rail's `Mark all read` button (schedules-handoff
+        # PR-6 task 3), unaffected by the §12 remap. redesign PR-4 task 5
+        # retired `o`/mark-solved here with the Results tab: it acted only
+        # on that tab's selected row, and the pushed results view owns the
+        # key now (`ResultsHostScreen`).
         Binding("a", "mark_all_results_read", "Mark all read"),
     ]
 
@@ -354,7 +339,6 @@ class SchedulesWorkbench(BaseAppScreen):
         ("d", "delete"),
         ("x", "mark"),
         ("s", "sync"),
-        ("o", "mark solved"),
         ("a", "mark all read"),
     )
 
@@ -381,15 +365,15 @@ class SchedulesWorkbench(BaseAppScreen):
         # row that has a `server_id`, so a transferred definition's
         # pre-transfer results have no key to resolve through without it.
         self._queue_local_definitions: list[dict[str, Any]] = []
-        # redesign PR-2, Task 2 review round 2: any Automations-tab
-        # mutation of a definition (create/edit save, run-now, transfer
-        # begin/cancel -- everything that funnels through
-        # `_request_automations_refresh`) sets this; a reminder-only
-        # refresh (`refresh_definitions=False`) upgrades to a full one
-        # and clears it, and switching TO the Queue tab while stale does
-        # the same. Without this, the Queue's cached definition rows
-        # could go stale for the whole session -- reminder-only actions
-        # deliberately stopped self-healing it (finding 3's own fix).
+        # redesign PR-2, Task 2 review round 2: any definition mutation
+        # (create/edit save, run-now, transfer begin/cancel) sets this; a
+        # reminder-only refresh (`refresh_definitions=False`) upgrades to
+        # a full one and clears it, and returning to this screen while
+        # stale does the same (`_consume_definitions_stale` -- redesign
+        # PR-4 task 5 re-homed that trigger off the retired Queue-tab
+        # `TabActivated`). Without this, the Queue's cached definition
+        # rows could go stale for the whole session -- reminder-only
+        # actions deliberately stopped self-healing it (finding 3's fix).
         self._definitions_stale = False
         self._chip: Chip = "all"
         self._filter_text = ""
@@ -414,12 +398,6 @@ class SchedulesWorkbench(BaseAppScreen):
         #: the marks/glyph legend in _update_pane_notice (task-23107).
         self._resize_notice = ""
         self._sync_running = False
-        # ADR-077: server-owned automation definitions shown in the
-        # Automations tab. Kept as the raw dicts the server client returns
-        # (model_dump(mode="json")) -- the server owns the enum vocabularies
-        # and the tab must not break when a new lifecycle/health value ships.
-        self._automations: list[dict[str, Any]] = []
-        self._selected_automation_id: str | None = None
         self._current_console_follow_item = None
         self._latest_console_follow_item_id: str | None = None
         self._latest_console_launch_kwargs: dict[str, Any] | None = None
@@ -488,159 +466,112 @@ class SchedulesWorkbench(BaseAppScreen):
             # TASK-26025: scheduler liveness -- a stale heartbeat reads
             # distinctly from an empty queue and a never-started loop.
             yield Static("", id="scheduling-liveness")
-            with TabbedContent(id="scheduling-tabs"):
-                with TabPane("Queue", id="scheduling-queue-tab"):
-                    with Horizontal(id="scheduling-workbench"):
-                        with Vertical(id="scheduling-list-pane"):
-                            # redesign PR-2, Task 3: the rail header --
-                            # `Create ▾` is the pre-existing 2-choice
-                            # chooser button (`scheduling-new-task`,
-                            # unchanged id/handler, relabeled/repositioned
-                            # here); `Mark all read` is new, and only shown
-                            # once `_update_mark_all_read_visibility` finds
-                            # unread rows (default hidden below, mirrors
-                            # `SyncStatusWidget`'s own Clear-button idiom).
-                            with Horizontal(id="scheduling-list-header"):
-                                yield Static(
-                                    "Schedule Queue",
-                                    id="scheduling-list-title",
-                                    classes="scheduling-column-title",
-                                )
-                                yield Button(
-                                    "Create ▾",
-                                    id="scheduling-new-task",
-                                    variant="primary",
-                                    tooltip="Schedule a new task (n).",
-                                )
-                                yield Button(
-                                    "Mark all read",
-                                    id="scheduling-mark-all-read",
-                                    tooltip="Mark every unread automation result read (a).",
-                                )
-                                # redesign PR-4, task 2: the Results
-                                # relocation's rail affordance -- always
-                                # visible (unlike Mark all read, which
-                                # hides at zero unread: browsing READ
-                                # results is still useful), mirroring the
-                                # status strip's Conflicts badge's own
-                                # "(N)" idiom.
-                                yield Button(
-                                    "Results",
-                                    id="scheduling-results-badge",
-                                    tooltip=(
-                                        "Browse every automation result "
-                                        "(view/read/dismiss/mark solved)."
-                                    ),
-                                )
-                            # redesign PR-2, Task 2: the chip row (spec S3)
-                            # -- one of the four buttons always carries
-                            # variant="primary" for "current", the same
-                            # idiom `SyncStatusWidget`'s owner toggle uses.
-                            with Horizontal(id="scheduling-queue-chips"):
-                                yield Button(
-                                    "All",
-                                    id="scheduling-chip-all",
-                                    variant="primary",
-                                    classes="scheduling-queue-chip",
-                                )
-                                yield Button(
-                                    "Active",
-                                    id="scheduling-chip-active",
-                                    classes="scheduling-queue-chip",
-                                )
-                                yield Button(
-                                    "Paused",
-                                    id="scheduling-chip-paused",
-                                    classes="scheduling-queue-chip",
-                                )
-                                yield Button(
-                                    "Completed",
-                                    id="scheduling-chip-completed",
-                                    classes="scheduling-queue-chip",
-                                )
-                            yield Input(
-                                # Says what ruling 5's search actually
-                                # matches -- title + question/body (final
-                                # review F6: the Type/Status columns are
-                                # gone and status words like "missed" no
-                                # longer match, which the user guide
-                                # already documents).
-                                placeholder="Filter: title or question…",
-                                id="scheduling-queue-filter",
-                            )
-                            yield DataTable(
-                                id="scheduling-task-table", cursor_type="row"
-                            )
-                            yield Static("", id="scheduling-pane-notice")
-                        with Vertical(id="scheduling-detail-pane"):
-                            yield TaskDetail(id="scheduling-task-detail")
-                            # redesign PR-2, Task 2: a sibling of TaskDetail
-                            # in the SAME pane -- highlight routes between
-                            # the two via the `pane-hidden` class (survey
-                            # section 3's recipe), never both visible.
-                            # Definition rows are viewable + detail-only
-                            # here (no actions until PR-4).
-                            yield DefinitionDetail(
-                                id="scheduling-queue-definition-detail",
-                                classes="pane-hidden",
-                            )
-                        with Vertical(id="scheduling-inspector-pane"):
-                            yield TaskInspector(id="scheduling-task-inspector")
-                with TabPane("Automations", id="scheduling-automations-tab"):
-                    with Horizontal(id="scheduling-automations-split"):
-                        with Vertical(id="scheduling-automations-pane"):
-                            with Horizontal(id="scheduling-automations-header"):
-                                yield Static(
-                                    "Server Automations",
-                                    id="scheduling-automations-title",
-                                    classes="scheduling-column-title",
-                                )
-                                yield Button(
-                                    "+ New",
-                                    id="scheduling-new-automation",
-                                    variant="primary",
-                                    tooltip="Schedule a new recurring question.",
-                                )
-                            yield DataTable(
-                                id="scheduling-automations-table", cursor_type="row"
-                            )
-                            yield Static("", id="scheduling-automations-notice")
-                        # schedules-redesign PR-1, Task 4: the definitions
-                        # detail pane -- the first per-row detail widget the
-                        # Automations tab has had (see redesign-pr1-survey.md
-                        # section 1's "no per-row detail widget" finding).
-                        # Third pane alongside list|history, matching the
-                        # Queue tab's list|detail|inspector idiom.
-                        with Vertical(id="scheduling-automations-detail-pane"):
-                            yield DefinitionDetail(id="scheduling-automation-detail")
-                        with Vertical(id="scheduling-automation-history-pane"):
-                            yield Static(
-                                "Run history",
-                                id="scheduling-automation-history-title",
-                                classes="scheduling-column-title",
-                            )
-                            yield DataTable(
-                                id="scheduling-automation-history-table",
-                                cursor_type="row",
-                            )
-                            yield Static(
-                                "",
-                                id="scheduling-automation-history-notice",
-                            )
-                with TabPane("Conflicts", id="scheduling-conflicts-tab"):
-                    yield ConflictsTab(
-                        id="scheduling-conflicts",
-                        sync_engine=service.sync_engine if service else None,
+            with Horizontal(id="scheduling-workbench"):
+                with Vertical(id="scheduling-list-pane"):
+                    # redesign PR-2, Task 3: the rail header --
+                    # `Create ▾` is the pre-existing 2-choice
+                    # chooser button (`scheduling-new-task`,
+                    # unchanged id/handler, relabeled/repositioned
+                    # here); `Mark all read` is new, and only shown
+                    # once `_update_mark_all_read_visibility` finds
+                    # unread rows (default hidden below, mirrors
+                    # `SyncStatusWidget`'s own Clear-button idiom).
+                    with Horizontal(id="scheduling-list-header"):
+                        yield Static(
+                            "Schedule Queue",
+                            id="scheduling-list-title",
+                            classes="scheduling-column-title",
+                        )
+                        yield Button(
+                            "Create ▾",
+                            id="scheduling-new-task",
+                            variant="primary",
+                            tooltip="Schedule a new task (n).",
+                        )
+                        yield Button(
+                            "Mark all read",
+                            id="scheduling-mark-all-read",
+                            tooltip="Mark every unread automation result read (a).",
+                        )
+                        # redesign PR-4, task 2: the Results
+                        # relocation's rail affordance -- always
+                        # visible (unlike Mark all read, which
+                        # hides at zero unread: browsing READ
+                        # results is still useful), mirroring the
+                        # status strip's Conflicts badge's own
+                        # "(N)" idiom.
+                        yield Button(
+                            "Results",
+                            id="scheduling-results-badge",
+                            tooltip=(
+                                "Browse every automation result "
+                                "(view/read/dismiss/mark solved)."
+                            ),
+                        )
+                    # redesign PR-2, Task 2: the chip row (spec S3)
+                    # -- one of the four buttons always carries
+                    # variant="primary" for "current", the same
+                    # idiom `SyncStatusWidget`'s owner toggle uses.
+                    with Horizontal(id="scheduling-queue-chips"):
+                        yield Button(
+                            "All",
+                            id="scheduling-chip-all",
+                            variant="primary",
+                            classes="scheduling-queue-chip",
+                        )
+                        yield Button(
+                            "Active",
+                            id="scheduling-chip-active",
+                            classes="scheduling-queue-chip",
+                        )
+                        yield Button(
+                            "Paused",
+                            id="scheduling-chip-paused",
+                            classes="scheduling-queue-chip",
+                        )
+                        yield Button(
+                            "Completed",
+                            id="scheduling-chip-completed",
+                            classes="scheduling-queue-chip",
+                        )
+                    yield Input(
+                        # Says what ruling 5's search actually
+                        # matches -- title + question/body (final
+                        # review F6: the Type/Status columns are
+                        # gone and status words like "missed" no
+                        # longer match, which the user guide
+                        # already documents).
+                        placeholder="Filter: title or question…",
+                        id="scheduling-queue-filter",
                     )
-                with TabPane("Results", id="scheduling-results-tab"):
-                    yield ResultsTab(id="scheduling-results")
+                    yield DataTable(
+                        id="scheduling-task-table", cursor_type="row"
+                    )
+                    yield Static("", id="scheduling-pane-notice")
+                with Vertical(id="scheduling-detail-pane"):
+                    yield TaskDetail(id="scheduling-task-detail")
+                    # redesign PR-2, Task 2: a sibling of TaskDetail
+                    # in the SAME pane -- highlight routes between
+                    # the two via the `pane-hidden` class (survey
+                    # section 3's recipe), never both visible.
+                    # redesign PR-4 task 5: with the Automations tab
+                    # retired this is the ONLY `DefinitionDetail`
+                    # instance left, and definition rows carry their
+                    # own run-now/edit/pause actions (task 3).
+                    yield DefinitionDetail(
+                        id="scheduling-queue-definition-detail",
+                        classes="pane-hidden",
+                    )
+                with Vertical(id="scheduling-inspector-pane"):
+                    yield TaskInspector(id="scheduling-task-inspector")
             # redesign PR-2, Task 3: the bottom status strip (plan ruling
-            # 4) -- shared across every tab (not Queue-specific, so it
-            # sits below the TabbedContent rather than inside one
-            # TabPane), hosting the existing `SyncStatusWidget` (owner
-            # indicator + sync health, now with a width-compact styling
-            # path -- see `_sync_responsive_workbench`) and a conflicts
-            # badge chip that switches to the Conflicts tab.
+            # 4) -- sits below the list/detail/inspector row, hosting the
+            # existing `SyncStatusWidget` (owner indicator + sync health,
+            # with a width-compact styling path -- see `_sync_responsive_
+            # workbench`) and a conflicts badge chip. redesign PR-4 task
+            # 5: the tab bar it used to span is retired, so the badge
+            # pushes the hosted Conflicts view (task 1) instead of
+            # flipping to a tab.
             with Horizontal(id="scheduling-status-strip"):
                 yield SyncStatusWidget(
                     id="scheduling-sync-status",
@@ -654,7 +585,7 @@ class SchedulesWorkbench(BaseAppScreen):
                     classes="scheduling-queue-chip",
                     tooltip=(
                         "Sync conflicts for the current owner's scheduled "
-                        "tasks only. Click to open the Conflicts tab."
+                        "tasks only. Click to open the conflicts view."
                     ),
                 )
 
@@ -674,8 +605,8 @@ class SchedulesWorkbench(BaseAppScreen):
         self._sync_responsive_workbench()
         self._register_footer_shortcuts()
         self._refresh_owner_select()
-        self._refresh_conflicts_tab()
-        self._refresh_results_tab()
+        self._refresh_conflicts_badge()
+        self._refresh_results_badge()
         # redesign PR-2, Task 3: hidden until `load_tasks` finds unread
         # rows (mirrors `SyncStatusWidget`'s own Clear-button idiom of
         # starting hidden rather than flashing visible-then-hidden).
@@ -685,21 +616,12 @@ class SchedulesWorkbench(BaseAppScreen):
         # column set no longer fits a mixed reminder+definition list.
         table = self.query_one("#scheduling-task-table", DataTable)
         table.add_columns("", "Title", "Details")
-        automations_table = self.query_one("#scheduling-automations-table", DataTable)
-        automations_table.add_columns(
-            "Name", "Family", "Lifecycle", "Health", "Model"
-        )
-        history_table = self.query_one(
-            "#scheduling-automation-history-table", DataTable
-        )
-        history_table.add_columns("Time", "Event", "Summary")
         # task-23111 review F9: the relative next-run column ("in 25m")
         # is render-time text; refresh it periodically while visible.
         self._next_run_refresh_timer = self.set_interval(
             NEXT_RUN_REFRESH_SECONDS, self._refresh_next_run_rendering
         )
         self._request_tasks_refresh()
-        self._request_automations_refresh()
         self._refresh_scheduler_liveness()
         self._start_server_notification_observer()
         self._schedule_catch_up_results_pull()
@@ -1023,6 +945,9 @@ class SchedulesWorkbench(BaseAppScreen):
         if self._next_run_refresh_timer is not None:
             self._next_run_refresh_timer.resume()
         self._refresh_next_run_rendering()
+        # redesign PR-4 task 5: the retired Queue-tab `TabActivated`
+        # staleness consumer's new home -- see `_consume_definitions_stale`.
+        self._consume_definitions_stale()
 
     def _sync_responsive_workbench(self) -> None:
         """Keep the primary queue and detail action visible at narrow widths."""
@@ -1083,11 +1008,28 @@ class SchedulesWorkbench(BaseAppScreen):
             return
         button.display = sum(row.unread_count for row in self._all_rows) > 0
 
-    @on(TabbedContent.TabActivated, pane="#scheduling-queue-tab")
-    def _on_queue_tab_activated(self, event: TabbedContent.TabActivated) -> None:
-        """Arriving on the Queue tab while definitions are stale (review
-        round 2) upgrades the next refresh to a full one, rather than
-        waiting for a reminder action to (maybe never) trigger one."""
+    def _consume_definitions_stale(self) -> None:
+        """Upgrade the next Queue refresh when a definition mutation left
+        the snapshot stale, rather than waiting for a reminder action to
+        (maybe never) trigger one (review round 2).
+
+        redesign PR-4 task 5: this used to be a `TabbedContent.
+        TabActivated` handler for the Queue tab -- "the user just arrived
+        back on the Queue". With the tab bar retired, the equivalent
+        moment is the push/pop lifecycle (ruling 6): every surface this
+        screen pushes (the hosted Conflicts/Results/audit views, and
+        every modal form) suspends this screen and resumes it on pop, so
+        `on_screen_resume` is the ONE seam covering all of them --
+        `WorkbenchHostScreen`'s `dismissed` hooks fire alongside it for
+        their own surface-specific refreshes.
+
+        Safe at mount for the same reason the retired handler was not:
+        `ScreenResume` also fires when this screen first becomes active,
+        but the flag is only ever set by a genuine definition mutation,
+        so nothing is pending yet at that point. (The old handler's
+        regression came from `_request_automations_refresh` marking
+        staleness at mount; that call site is retired with the tab.)
+        """
         if self._definitions_stale:
             self._request_tasks_refresh()
 
@@ -1102,16 +1044,16 @@ class SchedulesWorkbench(BaseAppScreen):
         and `include_projections=False` (Task 2 review finding 2) stops
         `list_tasks` from building AND sorting them in the first place,
         since this call site discarded every one of them anyway), both
-        definition halves (the Automations tab's existing local+server
-        merge, reused verbatim -- or, when ``refresh_definitions`` is
+        definition halves (the local+server merge in `_load_queue_
+        definitions` -- or, when ``refresh_definitions`` is
         False AND nothing marked the cache stale, the definitions
         already in `self._all_rows` from the last full load, review
         finding 3), and one all-owners results listing (unread-count
         derivation only). The results read + row build are pushed off
         the event loop (`asyncio.to_thread`), the same "local DB read,
-        off-thread" discipline `_load_local_automations` already uses.
+        off-thread" discipline every `service.db.*` read here uses.
 
-        `self._definitions_stale` (review round 2): an Automations-tab
+        `self._definitions_stale` (review round 2): a definition
         mutation upgrades the NEXT call here to a full definitions fetch
         even when the caller only asked for `refresh_definitions=False`
         -- a reminder-only refresh must not keep painting a definitions
@@ -1187,11 +1129,10 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> list[dict[str, Any]]:
         """Local + server automation-definition rows for the unified list.
 
-        Reuses the Automations tab's own both-owners merge precedent
-        (`_load_local_automations` + `_load_server_automations`) rather
-        than a third fetch shape -- this is a SEPARATE fetch from
-        `load_automations`'s own cadence (own tab, own refresh triggers),
-        not a shared cache.
+        The both-owners merge the retired Automations tab's own loader
+        established (redesign PR-4 task 5 deleted that loader; this is
+        the only definitions fetch left): the device-only half of the
+        local listing plus the paged server listing.
 
         Also stashes the UNFILTERED local listing in
         `self._queue_local_definitions` for `build_unified_rows`'s
@@ -1205,10 +1146,7 @@ class SchedulesWorkbench(BaseAppScreen):
             local_rows = await asyncio.to_thread(service.db.list_automation_definitions)
         except Exception:  # noqa: BLE001
             # `owner_id`/"Queue list" context only (Qodo LOW) -- never
-            # payload content. This is the sibling of the identical
-            # message `_load_local_automations` logs for the Automations
-            # tab's own refresh; without a call-site tag the two were
-            # indistinguishable in the log.
+            # payload content.
             logger.exception(
                 "Failed to load local automation definitions for the "
                 "Queue list (owner_id={})",
@@ -1557,6 +1495,19 @@ class SchedulesWorkbench(BaseAppScreen):
             assert isinstance(task, ReminderTask)
             self._selected_task_id = task.id
             self._show_queue_detail_pane("reminder")
+            if from_tick and row.row_id == previously_selected_row_id:
+                # redesign PR-4 task 5: the definition branch's F12 guard
+                # below, mirrored here -- it was only ever applied to one
+                # of the two branches. `_run_history_for` and `_incidents_
+                # for` are SYNCHRONOUS `service.db` reads (list_task_runs,
+                # plus list_task_incidents twice for both id spellings),
+                # so a selected reminder row cost the ticker three DB
+                # reads a minute for a row that did not move -- against
+                # the ticker's own "no reload/DB on tick" contract (PR-2
+                # plan Task 4). Refresh-driven calls (`from_tick=False`)
+                # still re-feed unconditionally: the DATA can change
+                # while the selection stands still.
+                return
             task_detail = self.query_one("#scheduling-task-detail", TaskDetail)
             task_detail.set_task(
                 task,
@@ -1574,11 +1525,11 @@ class SchedulesWorkbench(BaseAppScreen):
             self._update_transfer_actions(task_detail, task)
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(task)
         else:
-            # Definition rows expose no actions in this PR (viewable +
-            # detail only, plan ruling 1) -- `_selected_task_id = None`
-            # means every existing reminder action (`_selected_task`,
-            # edit/mark/toggle/delete) already no-ops gracefully here,
-            # with no new guard branches needed.
+            # `_selected_task_id = None` keeps every reminder-only
+            # action (`_selected_task`, mark/toggle/delete) no-oping
+            # gracefully on a definition row; the actions definitions DO
+            # have (run-now/edit/pause/move/mark-read, PR-4 tasks 3/4)
+            # route through `_selected_queue_definition` instead.
             self._selected_task_id = None
             self._show_queue_detail_pane("definition")
             self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
@@ -1841,7 +1792,7 @@ class SchedulesWorkbench(BaseAppScreen):
     @staticmethod
     def _transfer_pending_toast_text(name: str, direction: str) -> str:
         """Honest §6.1.1 "still runs here" / dormant-copy copy, shared by
-        the reminder and Automations-tab transfer flows."""
+        the reminder and definition transfer flows."""
         if direction == "to_server":
             return (
                 f"'{name}' is queued to move to the server -- it still "
@@ -1857,25 +1808,21 @@ class SchedulesWorkbench(BaseAppScreen):
         event.stop()
         self._open_new_task_chooser()
 
-    @on(Button.Pressed, "#scheduling-new-automation")
-    def _on_new_automation_pressed(self, event: Button.Pressed) -> None:
-        event.stop()
-        self.action_create_automation()
-
     @on(Button.Pressed, "#scheduling-mark-all-read")
     def _on_mark_all_read_pressed(self, event: Button.Pressed) -> None:
-        """Rail `Mark all read` (redesign PR-2, Task 3) -- reachable from
-        the Queue tab, unlike the `a` keybinding which requires the
-        Results tab active."""
+        """Rail `Mark all read` (redesign PR-2, Task 3) -- the same
+        fan-out `a` runs; redesign PR-4 task 5 collapsed the rail's own
+        ungated twin into `action_mark_all_results_read` when the tab
+        gate that forced the duplication was retired."""
         event.stop()
-        self._rail_mark_all_read()
+        self.action_mark_all_results_read()
 
     @on(Button.Pressed, "#scheduling-results-badge")
     def _on_results_badge_pressed(self, event: Button.Pressed) -> None:
         """Rail `Results (N)` (redesign PR-4, task 2) -- pushes the whole
         (unfiltered) inbox as a fresh `ResultsHostScreen` overlay, beside
-        `Mark all read`. The Results TAB itself stays reachable until
-        Task 5 retires it -- both paths coexist this task."""
+        `Mark all read`. Task 5 retired the Results tab, so this (and the
+        definition panes' own unread row) is the only route to it."""
         event.stop()
         self._push_results_overlay()
 
@@ -1885,8 +1832,7 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> None:
         """A definition pane's `Unread results` row was activated
         (redesign PR-4, task 2) -- the live replacement for the retired
-        "See Results tab" pointer. Fires from either sibling
-        `DefinitionDetail` instance (Queue or Automations tab)."""
+        "See Results tab" pointer."""
         event.stop()
         self._push_results_overlay(definition=event.definition)
 
@@ -1899,13 +1845,14 @@ class SchedulesWorkbench(BaseAppScreen):
         Mirrors `_push_conflicts_overlay`'s shape (pre-read once, hand
         the fresh instance its own data) but the pushed view ALSO needs
         its own read/dismiss/mark-solved/mark-all binding surface
-        (`ResultsHostScreen`, not the plain `WorkbenchHostScreen`):
-        `SchedulesWorkbench`'s own r/d/o/a bindings are tab-gated and,
-        more fundamentally, never fire while this screen is on top of
-        the stack. `query`/`unread_ids` are re-run after every mutation
-        to repaint the SAME scope; the workbench's own rail/Queue/tab
-        state only re-syncs once, on pop, via `dismissed` (brief:
-        "refresh the rail + unified rows on dismissed").
+        (`ResultsHostScreen`, not the plain `WorkbenchHostScreen`): a
+        screen underneath never receives a key event, so the workbench's
+        own bindings cannot serve this view (task 5 then retired the
+        workbench's tab-gated r/d/o copies outright). `query`/`unread_
+        ids` are re-run after every mutation to repaint the SAME scope;
+        the workbench's own rail/Queue state re-syncs once, on pop, via
+        `dismissed` (brief: "refresh the rail + unified rows on
+        dismissed").
 
         `definition=None` is the rail's global inbox; otherwise the
         listing (and its cap line) is scoped to that one definition,
@@ -1970,22 +1917,22 @@ class SchedulesWorkbench(BaseAppScreen):
     def _on_conflicts_badge_pressed(self, event: Button.Pressed) -> None:
         """Status-strip conflicts badge (redesign PR-4, Task 1) -- pushes
         the hosted Conflicts view as a fresh overlay instance instead of
-        flipping tabs (the tab flip cannot work once the tab bar is
-        retired). The Conflicts TAB itself stays reachable until Task 5
-        retires it -- both paths coexist this task."""
+        flipping tabs (the tab flip could not survive the tab bar). Task
+        5 retired the Conflicts tab, so this badge is the only route to
+        the view."""
         event.stop()
         self._push_conflicts_overlay()
 
     def _push_conflicts_overlay(self) -> None:
         """Push a standalone `ConflictsTab` instance via `WorkbenchHostScreen`.
 
-        Pre-reads the same `get_conflicts` shape `_refresh_conflicts_tab`
+        Pre-reads the same `get_conflicts` shape `_refresh_conflicts_badge`
         uses (no new query) and hands the result to the fresh instance as
-        `initial_conflicts` so it paints immediately on mount -- this
-        pushed instance has no external `.populate()` driver the way the
-        still-live TAB instance does. `dismissed=self._refresh_conflicts_
-        tab` re-syncs the tab/badge count on pop, in case the overlay
-        resolved anything while it was open.
+        `initial_conflicts` so it paints immediately on mount -- a pushed
+        instance has no external `.populate()` driver (task 5 retired the
+        mounted tab instance that did). `dismissed=self._refresh_
+        conflicts_badge` re-syncs the badge count on pop, in case the
+        overlay resolved anything while it was open.
         """
         service = self._service()
         conflicts = (
@@ -2006,7 +1953,7 @@ class SchedulesWorkbench(BaseAppScreen):
             WorkbenchHostScreen(
                 _factory,
                 title="Conflicts",
-                dismissed=self._refresh_conflicts_tab,
+                dismissed=self._refresh_conflicts_badge,
             )
         )
 
@@ -2016,9 +1963,8 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> None:
         """A definition pane's `Run now` button was pressed (redesign
         PR-4, task 3 -- the retired Automations-tab `r` key's live
-        replacement, ruling 2). Fires from either sibling
-        `DefinitionDetail` instance (Queue or Automations tab); routed
-        through the existing owner-routed dispatch unchanged."""
+        replacement, ruling 2); routed through the existing owner-routed
+        dispatch unchanged."""
         event.stop()
         self._run_automation_now(event.definition)
 
@@ -2028,8 +1974,7 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> None:
         """A definition pane's `Last run` row was activated (redesign
         PR-4, task 3 -- the retired Automations-tab third pane's live
-        replacement). Fires from either sibling `DefinitionDetail`
-        instance (Queue or Automations tab)."""
+        replacement)."""
         event.stop()
         self._push_definition_audit_overlay(event.definition)
 
@@ -2187,13 +2132,13 @@ class SchedulesWorkbench(BaseAppScreen):
         "created") -- an edit reusing the create-mode "created" copy
         would misreport what actually happened.
 
-        Refreshes the QUEUE too, not just the Automations list (final
-        review F1): Task 3 moved the create entry point onto the Queue
-        rail (`Create ▾` -> "Recurring question…"), so this save's
-        flagship path never leaves the Queue tab -- `TabActivated`, the
-        only consumer of `_definitions_stale`, never fires, and the
-        automation the user just created stayed invisible on the surface
-        it was created from. Symmetric with the reminder half
+        Refreshes the QUEUE eagerly rather than leaving it to the lazy
+        staleness consumer (final review F1): Task 3 moved the create
+        entry point onto the Queue rail (`Create ▾` -> "Recurring
+        question…"), so this save's flagship path never leaves the
+        screen -- nothing pops back onto it, and the automation the user
+        just created stayed invisible on the surface it was created
+        from. Symmetric with the reminder half
         (`_on_reminder_form_result`), which has always refreshed here.
         """
         if outcome is None:
@@ -2212,10 +2157,11 @@ class SchedulesWorkbench(BaseAppScreen):
                 f"Automation {verb} locally — it will sync to the server.",
                 severity="information",
             )
-        self._request_automations_refresh()
         # Full refresh (definitions included): `_definitions_stale` is set
         # above, so a `refresh_definitions=False` call would upgrade
-        # itself anyway -- ask for what this actually needs.
+        # itself anyway -- ask for what this actually needs. redesign PR-4
+        # task 5: the paired Automations-list reload retired with the tab;
+        # the Queue IS the definitions list now.
         self._request_tasks_refresh()
 
     def _on_reminder_form_result(
@@ -2439,12 +2385,11 @@ class SchedulesWorkbench(BaseAppScreen):
         Success repaints authoritatively via the SAME staleness-plus-
         refresh seam every other definition mutation in this file uses
         (run-now, transfer begin/cancel) -- `_definitions_stale = True`
-        + `_request_automations_refresh()`, which reloads the Automations
-        tab's own table+detail immediately and marks the Queue's unified
-        list stale for its own next (lazy, tab-activation-gated) refresh
-        -- PLUS `_repaint_queue_definition_detail`, because that lazy
-        Queue refresh is not a repaint of the Queue tab's own SECOND
-        `DefinitionDetail` instance (final review F4/I4).
+        + `_request_tasks_refresh()`, which rebuilds the unified rows --
+        PLUS `_repaint_queue_definition_detail`, because a rows rebuild
+        is not a repaint of the detail pane beside them (final review
+        F4/I4). redesign PR-4 task 5: the refresh call used to be
+        `_request_automations_refresh()` (the retired tab's own list).
 
         Every failure path paints through `_show_definition_row_error`
         rather than `row.show_error` directly (Qodo finding 9): this
@@ -2533,7 +2478,7 @@ class SchedulesWorkbench(BaseAppScreen):
             return
         row.clear_error()
         self._definitions_stale = True
-        self._request_automations_refresh()
+        self._request_tasks_refresh()
         await self._repaint_queue_definition_detail(service, local_id, definition)
 
     def _show_definition_row_error(
@@ -2574,23 +2519,18 @@ class SchedulesWorkbench(BaseAppScreen):
         local_id: str,
         definition: dict[str, Any],
     ) -> None:
-        """Repaint the QUEUE tab's `DefinitionDetail` for ``local_id``.
+        """Repaint the queue's `DefinitionDetail` for ``local_id``.
 
-        `DefinitionDetail` is mounted TWICE -- `#scheduling-automation-
-        detail` (Automations tab) and `#scheduling-queue-definition-
-        detail` (Queue tab) -- and `_request_automations_refresh` only
-        ever repaints the first. The Queue one is painted from
-        `_update_detail_for_index`, which early-returns for the same row
-        on a tick, so nothing repainted it after an in-pane edit: the
-        editor closed, the row restored the OLD value, and stayed that
-        way indefinitely even though the edit had persisted (final review
-        F4/I4). `_toggle_definition_lifecycle` got this right by looping
-        over both widget ids via `apply_lifecycle`; this is the same
-        both-homes discipline for a field edit, which needs the
-        authoritative re-read `apply_lifecycle`'s single known column
-        does not.
+        The pane is painted from `_update_detail_for_index`, which
+        early-returns for the same row on a tick, so nothing repainted it
+        after an in-pane edit: the editor closed, the row restored the
+        OLD value, and stayed that way indefinitely even though the edit
+        had persisted (final review F4/I4). A rows refresh rebuilds the
+        TABLE, not the pane beside it, so this stays a separate step --
+        it needs the authoritative re-read `apply_lifecycle`'s single
+        known column does not.
 
-        Only paints when the Queue's selected row IS this definition --
+        Only paints when the selected row IS this definition --
         which is also what makes the widget guaranteed-mounted here. The
         row id is matched against BOTH ids: `build_unified_rows` keys the
         row on whatever id the merged listing carried (the SERVER id for
@@ -2673,17 +2613,20 @@ class SchedulesWorkbench(BaseAppScreen):
                 return
             new_lifecycle = _LIFECYCLE_TOGGLE_RESULTS[action]
             definition["lifecycle"] = new_lifecycle
-            for widget_id in (
-                "#scheduling-automation-detail",
-                "#scheduling-queue-definition-detail",
-            ):
-                try:
-                    detail = self.query_one(widget_id, DefinitionDetail)
-                except Exception:  # noqa: BLE001 - not mounted yet
-                    continue
+            # redesign PR-4 task 5: this used to loop over BOTH
+            # `DefinitionDetail` instances (the Automations tab's and the
+            # Queue's); the tab's is retired, so one query remains -- the
+            # try/except stays because the pane can be unmounted mid-worker.
+            try:
+                detail = self.query_one(
+                    "#scheduling-queue-definition-detail", DefinitionDetail
+                )
+            except Exception:  # noqa: BLE001 - not mounted yet
+                pass
+            else:
                 detail.apply_lifecycle(definition_id, new_lifecycle)
             self._definitions_stale = True
-            self._request_automations_refresh()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _toggle_and_refresh,
@@ -2867,7 +2810,7 @@ class SchedulesWorkbench(BaseAppScreen):
         name = str(definition.get("name") or definition.get("id") or "")
 
         def _refresh() -> None:
-            self._request_automations_refresh()
+            self._request_tasks_refresh()
 
         async def _do() -> None:
             # fix round 1 finding 1: unconditional, BEFORE resolving --
@@ -2878,7 +2821,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # the first time a pure server-fetch definition is touched --
             # regardless of which branch below this lands on (refused,
             # failed, `local_id is None`, or a genuine success), the
-            # Automations tab's cached list may now be outdated.
+            # Queue's cached definitions may now be outdated.
             self._definitions_stale = True
             local_id = await self._resolve_local_definition_id(service, definition)
             if local_id is None:
@@ -2923,38 +2866,20 @@ class SchedulesWorkbench(BaseAppScreen):
         self._run_reminder_now(event.task)
 
     def action_run_task_now(self) -> None:
-        """Run the highlighted task immediately.
+        """Run the highlighted Queue row immediately.
 
         redesign PR-4, task 4: no longer key-bound (ruling 2 -- "Run-now
-        is NOT a global key", `r` is reassigned to `action_mark_read`
-        below). This method itself stays: the still-live Automations
-        tab's own run-now routing (task 5 retires the tab) and the
-        Results tab's tab-routed mark-read both still call it, and a
-        Queue definition row's own `Run now` button (task 3) reaches the
-        SAME `_run_automation_now` this falls through to, directly.
+        is NOT a global key"; `r` is `action_mark_read`). It stays as the
+        one run-now entry point the panes' own `Run now` buttons and the
+        tests both reach.
 
-        Routes by active tab: the Automations tab dispatches a
-        server-side run (ADR-077 -- the server owns execution); the
-        Results tab marks the selected result read instead
-        (schedules-handoff PR-6 task 3); everywhere else it is the local
-        reminder Run-now (task-18938) OR, redesign PR-4 task 3, a Queue
-        definition row's own run-now (same owner-routed dispatch the
-        Automations tab uses -- `_run_automation_now` is family-agnostic,
-        so this works for every definition family, not just `recurring_
+        redesign PR-4, task 5: the Automations/Results tab-routing
+        branches are gone with the tabs -- there is one surface now, so a
+        reminder row runs the local reminder dispatch (task-18938) and a
+        definition row runs the owner-routed `_run_automation_now` (task
+        3, family-agnostic: every definition family, not just `recurring_
         question`).
         """
-        try:
-            active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
-        except Exception:  # noqa: BLE001
-            active_pane = None
-        if active_pane == "scheduling-automations-tab":
-            definition = self._selected_automation()
-            if definition is not None:
-                self._run_automation_now(definition)
-            return
-        if active_pane == "scheduling-results-tab":
-            self._review_selected_result("read")
-            return
         task = self._selected_reminder_task()
         if task is not None:
             self._run_reminder_now(task)
@@ -2977,9 +2902,8 @@ class SchedulesWorkbench(BaseAppScreen):
     def _selected_queue_definition(self) -> dict[str, Any] | None:
         """Return the automation definition under the QUEUE cursor, if any.
 
-        redesign PR-4, task 3: the Queue-row counterpart of `_selected_
-        automation` (which reads the Automations tab's own table) --
-        `_selected_task`'s own row-index routing (the two lists diverge
+        redesign PR-4, task 3: the definition-row counterpart of
+        `_selected_task` -- its own row-index routing (the two lists diverge
         whenever a definition row precedes the cursor), but returning the
         DEFINITION instead of `None` for a definition row rather than
         `_selected_task`'s "nothing to act on" contract, since Queue
@@ -3168,175 +3092,22 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-run-reminder-now",
         )  # type: ignore[arg-type]
 
-    def _request_automations_refresh(self) -> None:
-        """Schedule the automations loader through its exclusive worker group.
-
-        NOTE: this alone must NOT set `self._definitions_stale` -- it is
-        also called at mount and from sync-completed/failed
-        (`schedules-load-automations` fires concurrently with the
-        Queue's own mount-time full refresh), and doing so here caused a
-        real regression (round 2 fix-round-1 draft): the Queue tab's
-        `TabbedContent.TabActivated` fires for the INITIAL default-active
-        tab too, so a stale flag set by mount's own automations refresh
-        was immediately consumed by the tab-activation handler, forcing
-        a SECOND full Queue reload on every mount. Staleness is instead
-        marked at each genuine mutation call site (create/edit save,
-        run-now, transfer begin/cancel) -- see their own `self.
-        _definitions_stale = True` lines.
-        """
-        self.run_worker(
-            self.load_automations,
-            exclusive=True,
-            group="schedules-load-automations",
-        )  # type: ignore[arg-type]
-
-    async def load_automations(self) -> None:
-        """Fetch and merge local + server automation definitions (task-5 fix round).
-
-        This tab used to be server-only: a locally-saved recurring
-        question had no on-screen home. Local rows are now merged in
-        (owner distinguished via `automation_name_cell`'s Name-cell
-        prefix) so a local save's refresh actually shows the new row.
-        """
-        notice = self.query_one("#scheduling-automations-notice", Static)
-        table = self.query_one("#scheduling-automations-table", DataTable)
-        service = self._scheduling_service
-        if service is None:
-            self._automations = []
-            self._selected_automation_id = None
-            table.clear()
-            self._update_static_content(
-                notice, "Server automations need a connected server."
-            )
-            self._clear_automation_history(
-                "Run history needs a connected server."
-            )
-            self.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
-            ).set_definition(None)
-            return
-
-        # task-15476 discipline: a rebuild must reconcile the selection by
-        # id -- keep the cursor on the same definition when it survives the
-        # refresh, and clear it when it does not, so `r`/`e` can never act
-        # on a row the user is no longer looking at.
-        previous_selection = self._selected_automation_id
-
-        local_items = await self._load_local_automations(service)
-
-        server_client = getattr(service, "server_client", None)
-        server_available = server_client is not None and self._server_available(
-            service, self._active_server_id()
-        )
-        server_items: list[dict[str, Any]] = []
-        total_server = 0
-        server_error = False
-        if server_available:
-            try:
-                server_items, total_server = await self._load_server_automations(
-                    server_client
-                )
-            except Exception:  # noqa: BLE001
-                logger.exception(
-                    "Failed to load server automations (server_id={})",
-                    self._active_server_id(),
-                )
-                server_error = True
-
-        items = local_items + server_items
-        self._automations = items
-        table.clear()
-        for definition in items:
-            # Every cell goes in as `Text`, never `str` (task 6 round 2,
-            # D8). `DataTable` runs string cells through `rich.text.Text.
-            # from_markup`, whose tag regex matches `\[[a-z#/@]...]` -- so
-            # a server row's own owner prefix, `[http://127.0.0.1:8020]
-            # ...`, was consumed whole and server automations rendered
-            # with NO ownership prefix while the pane's own count line
-            # still said "1 automation on the server". (The old
-            # `server:42` fixture value would have been eaten identically,
-            # so no fixture shape could have caught this.) The cell
-            # formatter returns a `Text` untouched, so nothing re-parses
-            # content that came from outside this module -- structural,
-            # rather than depending on picking the right escape for
-            # whichever parser consumes the cell, which is the mistake
-            # this saga has now made three times.
-            table.add_row(
-                Text(automation_name_cell(definition)),
-                Text(str(definition.get("family", "?"))),
-                Text(str(definition.get("lifecycle", "?"))),
-                Text(str(definition.get("health", "?"))),
-                Text(automation_execution_target_label(definition)),
-                key=str(definition.get("id")),
-            )
-        row_keys = [str(definition.get("id")) for definition in items]
-        if previous_selection in row_keys:
-            # Restoring the cursor fires RowHighlighted, which re-records
-            # the same id -- belt and braces, set both explicitly.
-            table.cursor_coordinate = (row_keys.index(previous_selection), 0)
-            # ...and that RowHighlighted hits the unchanged-id early
-            # return, so the pane would keep painting the PRE-refresh row
-            # (final review F4: edit a definition's model/cron/sources and
-            # save -- the table cell updated, the detail pane beside it
-            # did not, until the user selected another row and came back).
-            # The row DATA changed even though its id did not, so re-feed
-            # the pane explicitly. The detail worker is exclusive within
-            # its own group, so repeated refreshes are latest-wins, never
-            # a pile-up.
-            self._request_automation_detail(previous_selection)
-        else:
-            self._selected_automation_id = None
-            self._clear_automation_history("Select an automation to see its history.")
-            self.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
-            ).set_definition(None)
-
-        notice_text = self._automations_notice_text(
-            local_items, server_items, server_available, total_server, server_error
-        )
-        self._update_static_content(notice, notice_text)
-
-    async def _load_local_automations(
-        self, service: "SchedulingService"
-    ) -> list[dict[str, Any]]:
-        """Every definition that exists ONLY on this device, off the event loop.
-
-        That is not the same as `owner_id="local"`: an automation authored
-        offline with "Runs on: Server" is stored under `owner_id=
-        "server:<id>"` with `server_id IS NULL` until a sync pushes it, so
-        filtering on the local owner hid it from this half while the
-        server half could not know about it either -- it appeared in
-        NEITHER list (final review I5). Any row with no `server_id`
-        belongs here, whoever owns it; rows that HAVE a `server_id` are the
-        server half's by construction, so the two halves cannot duplicate.
-
-        Rows in that pending state are stamped `pending_sync` so the
-        renderer can say so (`automation_name_cell`) and the actions that
-        need a real server id can refuse honestly rather than calling the
-        server with a local uuid.
-
-        Health is never persisted (`automation_health.py`'s own docstring)
-        -- it is computed fresh here the same way `run_automation_now`
-        computes it before dispatching, so the column never shows the
-        create-time placeholder (`execution_unavailable`) as if it were
-        live.
-        """
-        try:
-            all_rows = await asyncio.to_thread(service.db.list_automation_definitions)
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to load local automation definitions")
-            return []
-        return self._device_only_automations(all_rows)
-
     def _device_only_automations(
         self, all_rows: list[dict[str, Any]]
     ) -> list[dict[str, Any]]:
         """The device-only half of a local definitions listing, decorated.
 
-        Split out of `_load_local_automations` (final review F2) so the
-        Queue loader can keep the UNFILTERED listing for its unread-count
-        resolution while still deriving the same display half from it --
-        one `list_automation_definitions` call per refresh either way.
+        Split out of the retired Automations loader (final review F2) so
+        the Queue loader can keep the UNFILTERED listing for its
+        unread-count resolution while still deriving the same display
+        half from it -- one `list_automation_definitions` call per
+        refresh either way.
+
+        Health is never persisted (`automation_health.py`'s own
+        docstring) -- it is computed fresh here the same way `run_
+        automation_now` computes it before dispatching, so the column
+        never shows the create-time placeholder
+        (`execution_unavailable`) as if it were live.
         """
         from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
 
@@ -3351,9 +3122,9 @@ class SchedulesWorkbench(BaseAppScreen):
     async def _load_server_automations(
         self, server_client: Any
     ) -> tuple[list[dict[str, Any]], int]:
-        """Follow `has_more` pages so the tab never silently hides the tail
-        of a large definition list; the cap is a defensive bound, not an
-        expected cliff.
+        """Follow `has_more` pages so the list never silently hides the
+        tail of a large definition list; the cap is a defensive bound,
+        not an expected cliff.
 
         Every item's `owner_id` is OVERWRITTEN with this connection's
         `server:<active-server-id>` scope -- never read from the payload.
@@ -3397,185 +3168,6 @@ class SchedulesWorkbench(BaseAppScreen):
             item["owner_id"] = owner_id
         return items, total
 
-    @staticmethod
-    def _automations_notice_text(
-        local_items: list[dict[str, Any]],
-        server_items: list[dict[str, Any]],
-        server_available: bool,
-        total_server: int,
-        server_error: bool,
-    ) -> str:
-        """Compose the Automations-pane notice honestly from what actually loaded.
-
-        A server failure never hides local rows that DID load -- the two
-        sources degrade independently, so the server segment reports its
-        own outcome and a local-count addendum is appended only when there
-        is one to report.
-        """
-        if server_error:
-            base = "Could not load server automations — see the log."
-        elif server_available:
-            shown = len(server_items)
-            suffix = f" (showing {shown} of {total_server})" if total_server > shown else ""
-            base = (
-                f"{shown} automation{'' if shown == 1 else 's'} on the server{suffix}."
-                if shown
-                else "No automations on the server yet."
-            )
-        else:
-            base = "Server automations need a connected server."
-        if local_items:
-            base += f" {len(local_items)} on this device."
-        return base
-
-    def _clear_automation_history(self, notice_text: str) -> None:
-        """Reset the run-history pane to an explanatory notice."""
-        table = self.query_one("#scheduling-automation-history-table", DataTable)
-        notice = self.query_one("#scheduling-automation-history-notice", Static)
-        title = self.query_one("#scheduling-automation-history-title", Static)
-        table.clear()
-        self._update_static_content(notice, notice_text)
-        self._update_static_content(title, "Run history")
-
-    def _request_automation_history(self, definition_id: str) -> None:
-        """Schedule the audit-trail loader through its exclusive worker group."""
-        # run_worker takes no worker arguments in Textual 8.x -- bind the id
-        # in a closure (same shape as _run_automation_now's _run).
-        async def _load() -> None:
-            await self._load_automation_history(definition_id)
-
-        self.run_worker(
-            _load,
-            exclusive=True,
-            group="schedules-load-automation-history",
-        )  # type: ignore[arg-type]
-
-    async def _load_automation_history(self, definition_id: str) -> None:
-        """Fetch and render one definition's durable execution-audit trail.
-
-        The fetch+branch logic is `definition_audit_view.fetch_
-        definition_audit` (redesign PR-4, task 3: factored out so the
-        new pushed `DefinitionAuditView` shares it rather than
-        duplicating this method's own five-way branch) -- this method
-        keeps its own paint code (this pane's own DataTable/notice/title
-        ids, plus the staleness re-checks a background worker needs)
-        unchanged."""
-        table = self.query_one("#scheduling-automation-history-table", DataTable)
-        notice = self.query_one("#scheduling-automation-history-notice", Static)
-        title = self.query_one("#scheduling-automation-history-title", Static)
-        # A newer selection may have won the race with this worker; render
-        # nothing for a stale definition id.
-        if definition_id != self._selected_automation_id:
-            return
-        definition = self._selected_automation()
-        name = str((definition or {}).get("name") or definition_id)
-        self._update_static_content(title, f"Run history — {name}")
-        # Drop the previous definition's rows BEFORE awaiting: a slow fetch
-        # must never leave another definition's trail under the new title.
-        table.clear()
-        self._update_static_content(notice, "Loading run history…")
-
-        result = await fetch_definition_audit(
-            self._scheduling_service, definition or {"id": definition_id}
-        )
-        if definition_id != self._selected_automation_id:
-            return
-        table.clear()
-        if result.notice_override is not None:
-            self._update_static_content(notice, result.notice_override)
-            return
-        for event in result.items:
-            created = str(event.get("created_at") or "")
-            # Keep the timestamp compact: date and minute-level time,
-            # no microseconds or timezone noise in a table cell.
-            stamp = created[:16].replace("T", " ") if created else "?"
-            summary = str(event.get("summary") or "")
-            # `Text`, not `str` -- same D8 rule as the definitions table
-            # above. `summary` is free-form server text ("Run failed:
-            # ChatConfigurationError: ..."), the likeliest of all these
-            # cells to carry a bracket token.
-            table.add_row(
-                Text(stamp),
-                Text(str(event.get("event_type") or "?")),
-                Text(summary),
-            )
-        self._update_static_content(
-            notice, audit_notice_text(result.items, result.total)
-        )
-
-    def _request_automation_detail(self, definition_id: str) -> None:
-        """Schedule the definitions detail pane's DB reads through their
-        own exclusive worker group (schedules-redesign PR-1, Task 4): the
-        pane's counts are local-only sqlite reads, taken off the event
-        loop the same way `_load_local_automations` already reads
-        `service.db.*` from inside a worker coroutine."""
-        # run_worker takes no worker arguments in Textual 8.x -- bind the id
-        # in a closure (same shape as _request_automation_history's _load).
-        async def _load() -> None:
-            await self._load_automation_detail(definition_id)
-
-        self.run_worker(
-            _load,
-            exclusive=True,
-            group="schedules-load-automation-detail",
-        )  # type: ignore[arg-type]
-
-    async def _load_automation_detail(self, definition_id: str) -> None:
-        """Paint the definitions detail pane for `definition_id`.
-
-        `DefinitionDetail.set_definition` performs no I/O itself; this
-        method fetches the Task 2 count seams off the event loop
-        (`asyncio.to_thread`) and passes the results in.
-        """
-        detail = self.query_one("#scheduling-automation-detail", DefinitionDetail)
-        definition = self._selected_automation()
-        # A newer selection may have won the race with this worker; render
-        # nothing for a stale definition id (same guard `_load_automation_
-        # history` uses).
-        if definition is None or definition_id != self._selected_automation_id:
-            return
-        service = self._scheduling_service
-        if service is None:
-            detail.set_definition(
-                definition, run_count=0, last_run=None, unread_count=0
-            )
-            # Same fallback `_update_transfer_actions` uses for `TaskDetail`
-            # when there is no service to derive a real reason from.
-            detail.set_lifecycle_lock(None)
-            detail.set_runs_on_transfer_errors([])
-            return
-
-        run_count, last_run, unread_count, history_error = (
-            await self._fetch_definition_detail_counts(
-                service, definition, definition_id
-            )
-        )
-        if definition_id != self._selected_automation_id:
-            return
-        detail.set_definition(
-            definition,
-            run_count=run_count,
-            last_run=last_run,
-            unread_count=unread_count,
-            history_error=history_error,
-            known_timezones=self._task_timezones(),
-            # PR-3 task 5: same option source the Queue reminder pane's
-            # own Runs-on row reads (`_update_detail_for_index`).
-            runs_on_options=self._runs_on_options()[0],
-        )
-        # PR-3 task 4: `DefinitionDetail` gains the SAME transfer-lock
-        # wiring `TaskDetail` has (survey point 10) -- `reason` comes from
-        # `SchedulingService.transfer_lock_reason` (never re-derived in
-        # the widget), fed right after `set_definition` per that
-        # method's own docstring, same as `_update_transfer_actions` does
-        # for the reminder pane.
-        detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
-        # PR-3 task 5 fix round 1 (finding 2): the Runs-on row's own
-        # failure text, same source the legacy Retry button would use.
-        detail.set_runs_on_transfer_errors(
-            _definition_transfer_errors(service, definition)
-        )
-
     async def _fetch_definition_detail_counts(
         self,
         service: "SchedulingService",
@@ -3583,11 +3175,12 @@ class SchedulesWorkbench(BaseAppScreen):
         definition_id: str,
     ) -> tuple[int, dict[str, Any] | None, int, bool]:
         """Off-thread run_count/last_run/unread_count read for one
-        definition -- shared by the Automations tab's own detail pane
-        (`_load_automation_detail`) and the Queue tab's definition-row
-        routing (redesign PR-2, Task 2: `_load_queue_definition_detail`),
-        same DB reads, same owner-scoping (final review F11), same
-        never-paint-0-off-a-failed-read guard (F14).
+        definition, for `_load_queue_definition_detail` (redesign PR-2,
+        Task 2) -- owner-scoped (final review F11), with the
+        never-paint-0-off-a-failed-read guard (F14). It used to be shared
+        with the Automations tab's own detail pane; task 5 retired that
+        second caller, and this stays a separate method because the
+        `asyncio.to_thread` read is the part worth naming.
         """
 
         def _read_counts() -> tuple[int, dict[str, Any] | None, int]:
@@ -3620,10 +3213,10 @@ class SchedulesWorkbench(BaseAppScreen):
     def _request_queue_definition_detail(
         self, row_id: str, definition: dict[str, Any]
     ) -> None:
-        """Schedule the Queue tab's definition-detail counts through their
-        own exclusive worker group (redesign PR-2, Task 2) -- mirrors
-        `_request_automation_detail`'s shape, separate group so a Queue
-        selection and an Automations-tab selection can never contend."""
+        """Schedule the definition-detail counts through their own
+        exclusive worker group (redesign PR-2, Task 2) -- latest
+        selection wins, and the group is its own so a definition
+        selection never contends with the reminder/table loaders."""
 
         async def _load() -> None:
             await self._load_queue_definition_detail(row_id, definition)
@@ -3637,10 +3230,9 @@ class SchedulesWorkbench(BaseAppScreen):
     async def _load_queue_definition_detail(
         self, row_id: str, definition: dict[str, Any]
     ) -> None:
-        """Paint the Queue tab's `DefinitionDetail` sibling for the
-        highlighted definition row (redesign PR-2, Task 2). Reuses how
-        the Automations tab loads its own detail pane's counts, off the
-        event loop.
+        """Paint the `DefinitionDetail` pane for the highlighted
+        definition row (redesign PR-2, Task 2), reading its counts off
+        the event loop.
         """
         detail = self.query_one(
             "#scheduling-queue-definition-detail", DefinitionDetail
@@ -3671,49 +3263,21 @@ class SchedulesWorkbench(BaseAppScreen):
             unread_count=unread_count,
             history_error=history_error,
             known_timezones=self._task_timezones(),
-            # PR-3 task 5: same option source the Automations-tab sibling
-            # instance's own Runs-on row reads (`_load_automation_detail`).
+            # PR-3 task 5: same option source the reminder pane's own
+            # Runs-on row reads (`_update_detail_for_index`).
             runs_on_options=self._runs_on_options()[0],
         )
-        # PR-3 task 4: same transfer-lock wiring as `_load_automation_
-        # detail`'s Automations-tab pane -- this is the Queue tab's own
-        # sibling instance of the SAME widget class, so it needs the
-        # same call, independently (each `DefinitionDetail` instance
-        # locks itself; there's no shared state between them).
+        # PR-3 task 4: `reason` comes from `SchedulingService.transfer_
+        # lock_reason` (never re-derived in the widget), fed right after
+        # `set_definition` per that method's own docstring -- the same
+        # discipline `_update_transfer_actions` follows for the reminder
+        # pane.
         detail.set_lifecycle_lock(service.transfer_lock_reason(definition))
-        # PR-3 task 5 fix round 1 (finding 2): same as the Automations-tab
-        # sibling instance above.
+        # PR-3 task 5 fix round 1 (finding 2): the Runs-on row's own
+        # failure text, from the same source.
         detail.set_runs_on_transfer_errors(
             _definition_transfer_errors(service, definition)
         )
-
-    @on(DataTable.RowHighlighted, "#scheduling-automations-table")
-    def _on_automations_row_highlighted(
-        self, event: DataTable.RowHighlighted
-    ) -> None:
-        """Track the highlighted definition for Run-now, its history pane,
-        and its detail pane (schedules-redesign PR-1, Task 4)."""
-        new_id = (
-            str(event.row_key.value) if event.row_key and event.row_key.value else None
-        )
-        if new_id == self._selected_automation_id:
-            return
-        self._selected_automation_id = new_id
-        if new_id is None:
-            self._clear_automation_history("Select an automation to see its history.")
-            self.query_one(
-                "#scheduling-automation-detail", DefinitionDetail
-            ).set_definition(None)
-        else:
-            self._request_automation_history(new_id)
-            self._request_automation_detail(new_id)
-
-    def _selected_automation(self) -> dict[str, Any] | None:
-        """Return the highlighted automation definition, if any."""
-        for definition in self._automations:
-            if str(definition.get("id")) == self._selected_automation_id:
-                return definition
-        return None
 
     def _run_automation_now(self, definition: dict[str, Any]) -> None:
         """Dispatch one automation definition now, routed by its owner.
@@ -3782,7 +3346,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # redesign PR-2 Task 2 review round 2: a real local run --
             # the Queue's cached definitions rows may now be outdated.
             self._definitions_stale = True
-            self._request_automations_refresh()
+            self._request_tasks_refresh()
 
         self.run_worker(
             _run,
@@ -3840,19 +3404,14 @@ class SchedulesWorkbench(BaseAppScreen):
             # run-now can change what the next `_load_server_automations`
             # returns (next_run_at, health, last-run state).
             self._definitions_stale = True
-            # The dispatch returns when the run is ENQUEUED, not finished:
-            # the terminal audit event lands only after the server executes
-            # (an LLM call -- seconds). One immediate fetch catches the
-            # dispatch-time events; a delayed fetch catches quick terminal
-            # outcomes. Long runs stay stale until the next selection or
-            # sync -- honest, and the notification still reports the result.
-            self._request_automation_history(definition_id)
-            self.set_timer(
-                AUTOMATION_HISTORY_FOLLOWUP_SECONDS,
-                lambda: self._request_automation_history(definition_id)
-                if self._selected_automation_id == definition_id
-                else None,
-            )
+            self._request_tasks_refresh()
+            # redesign PR-4 task 5: the immediate + 5s-delayed audit-trail
+            # re-fetches that used to follow retired with the Automations
+            # tab's history pane. The audit trail's home is now the pushed
+            # `DefinitionAuditView`, which fetches on mount -- so it is
+            # never showing a stale trail that needs poking. The dispatch
+            # still returns when the run is ENQUEUED, not finished, and
+            # the notification still reports the result.
 
         self.run_worker(
             _run,
@@ -3861,7 +3420,7 @@ class SchedulesWorkbench(BaseAppScreen):
         )  # type: ignore[arg-type]
 
     def _edit_selected_automation(
-        self, definition: dict[str, Any] | None = None
+        self, definition: dict[str, Any] | None
     ) -> None:
         """Open an automation definition for editing (e key).
 
@@ -3870,16 +3429,13 @@ class SchedulesWorkbench(BaseAppScreen):
         itself enforces via `_reject_unsupported_family`).
 
         Args:
-            definition: The definition to edit, already resolved by the
-                caller. Defaults to `_selected_automation()` (the
-                Automations tab's own highlighted row) -- every pre-
-                task-3 call site omits this and is unaffected. redesign
-                PR-4, task 3's Queue-row routing passes `_selected_queue_
-                definition()`'s result instead, reusing this same
-                resolve-id/open-form body rather than a second copy.
+            definition: The definition to edit, resolved by the caller
+                (`_selected_queue_definition()`, redesign PR-4 task 3's
+                Queue-row routing) -- ``None`` gets the honest refusal
+                below. Task 5 dropped the old `_selected_automation()`
+                default with the Automations tab it read from; the one
+                remaining caller always passes a value explicitly.
         """
-        if definition is None:
-            definition = self._selected_automation()
         if definition is None:
             self.app_instance.notify(
                 "Nothing to edit — select an automation first.",
@@ -3993,112 +3549,27 @@ class SchedulesWorkbench(BaseAppScreen):
     # automation_transfer`, `_is_automations_tab_active`, `_show_
     # automations_inline_reason` before deleting them.
 
-    # -- Results-tab actions (schedules-handoff PR-6 task 3) ---------------
+    # -- Results actions (schedules-handoff PR-6 task 3) ------------------
     #
-    # Read/dismiss reuse r/d via action_run_task_now/action_delete's own
-    # tab routing above. Mark-solved/Mark-all-read get fresh keys (o/a),
-    # guarded the same way m/M/y/k refuse off the Automations tab.
-
-    def _is_results_tab_active(self) -> bool:
-        try:
-            return (
-                self.query_one("#scheduling-tabs", TabbedContent).active
-                == "scheduling-results-tab"
-            )
-        except Exception:  # noqa: BLE001
-            return False
+    # redesign PR-4, task 5: the Results TAB is retired, and with it the
+    # tab-gated `r`/`d`/`o` bindings that only ever acted on its own
+    # selected row (`_is_results_tab_active`, `_review_selected_result`,
+    # `action_mark_result_solved`). The pushed results view owns those
+    # verbs now (`ResultsHostScreen`'s own r/d/o/a, task 2) -- and owns
+    # them ALONE, since Textual never routes a key to a screen underneath
+    # the active one. `git grep` verified zero remaining consumers of all
+    # three before deleting them. `a` survives on this screen because its
+    # target survives: the rail's `Mark all read` button, whose fan-out is
+    # scoped to the FULL unread set rather than any one listing.
 
     def _notify(self, message: str, severity: str) -> None:
         self.app_instance.notify(message, severity=severity)
 
-    def _review_selected_result(self, review_state: str) -> None:
-        """r/d on the Results tab: read/dismiss the selected result.
-
-        The actual orchestration (`review_selected_result`, results_tab.py)
-        is shared with the pushed view's own `r`/`d` bindings
-        (`ResultsHostScreen`, redesign PR-4 task 2) -- both call the same
-        `SchedulingService.review_automation_result`, which writes the
-        local row and, for a server mirror, queues the sync pushback
-        mutation in the SAME DB transaction.
-        """
-        service = self._service()
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable.", severity="warning"
-            )
-            return
-        results_tab = self.query_one("#scheduling-results", ResultsTab)
-
-        async def _review() -> None:
-            await review_selected_result(
-                service, results_tab, review_state, self._notify
-            )
-            self._refresh_results_surfaces()
-
-        self.run_worker(
-            _review, exclusive=True, group="schedules-review-result"
-        )  # type: ignore[arg-type]
-
-    def action_mark_result_solved(self) -> None:
-        """o key: mark the selected finding's definition solved (Task 2's
-        facade), Results-tab only. Refused client-side for a row `solved_
-        eligibility` already rules out (wrong kind, already solved, or an
-        unknown definition); a still-eligible row can still be refused by
-        the facade itself (transfer lock, offline+server-owned -- UX-073),
-        surfaced from `ResolveOutcome.reason`.
-        """
-        if not self._is_results_tab_active():
-            self.app_instance.notify(
-                "Switch to the Results tab to mark a result solved.",
-                severity="warning",
-            )
-            return
-        service = self._service()
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable.", severity="warning"
-            )
-            return
-        results_tab = self.query_one("#scheduling-results", ResultsTab)
-        result = results_tab.selected_result()
-        if result is None:
-            self.app_instance.notify("Select a result first.", severity="warning")
-            return
-        eligible, reason = solved_eligibility(result, results_tab.definitions_by_id)
-        if not eligible:
-            self.app_instance.notify(
-                reason or "This result cannot be marked solved.",
-                severity="warning",
-            )
-            return
-        # `resolve_definition` takes a LOCAL definition id (its own
-        # contract), but a synced result's `definition_id` is the SERVER's
-        # id -- passing it through unresolved refused with "Automation
-        # definition <server id> was not found" on exactly the rows the
-        # action exists for (live verification task 6, D3). The gate above
-        # already resolved the row across both id spaces; reuse it rather
-        # than re-deriving the id a second, divergent way. Non-None here
-        # by construction: `solved_eligibility` returns ineligible when
-        # the same lookup misses.
-        # The async orchestration (`mark_selected_result_solved`,
-        # results_tab.py) is shared with the pushed view's own `o`
-        # binding (`ResultsHostScreen`, redesign PR-4 task 2).
-
-        async def _mark_solved() -> None:
-            await mark_selected_result_solved(
-                service, result, results_tab.definitions_by_id, self._notify
-            )
-            self._refresh_results_surfaces()
-
-        self.run_worker(
-            _mark_solved, exclusive=True, group="schedules-mark-solved"
-        )  # type: ignore[arg-type]
-
     def _unread_result_ids(self, service: "SchedulingService") -> list[str]:
         """Every unread result id across the FULL table, read straight
-        from the DB -- not the Results tab's own listing, which is capped
+        from the DB -- not the pushed view's own listing, which is capped
         at `RESULTS_INBOX_LIMIT` (200) rows. The rail button's visibility
-        already sums the full-table unread count (`_refresh_results_tab`'s
+        already sums the full-table unread count (`_refresh_results_badge`'s
         `count_unread_results`); mark-all-read has to clear that same set
         or an unread row older than the loaded window survives while the
         button hides itself as if nothing were left (Qodo HIGH).
@@ -4186,55 +3657,30 @@ class SchedulesWorkbench(BaseAppScreen):
     ) -> None:
         """Per-row fan-out for a batch of result ids -- the shared
         `mark_results_read` (results_tab.py) does the actual DB calls +
-        notify, now also driving the pushed view's own `a` binding
-        (`ResultsHostScreen`, redesign PR-4 task 2). Shared by the
-        Results tab's `a` keybinding and the rail's `Mark all read`
-        button (redesign PR-2, Task 3) -- the Queue refresh included,
-        which used to sit in the rail button's own wrapper as if it were
-        a rail-specific nicety (final review F5): pressing `a` on the
-        Results tab left the Queue's unread dots painted and its rail
-        button visible, and pressing that button then reported "Nothing
-        unread."
+        notify, and also drives the pushed view's own `a` binding
+        (`ResultsHostScreen`, redesign PR-4 task 2). The Queue refresh is
+        included here rather than in a caller (final review F5): it used
+        to sit in the rail button's wrapper as if it were a rail-specific
+        nicety, so marking everything read from anywhere else left the
+        Queue's unread dots painted and its rail button visible, and
+        pressing that button then reported "Nothing unread."
         """
         await mark_results_read(service, unread_ids, self._notify)
         self._refresh_results_surfaces()
 
     def action_mark_all_results_read(self) -> None:
-        """a key: mark every currently-loaded unread result read,
-        Results-tab only (the rail's `Mark all read` button reaches the
-        same fan-out from the Queue tab, see `_rail_mark_all_read`).
-        """
-        if not self._is_results_tab_active():
-            self.app_instance.notify(
-                "Switch to the Results tab to mark all results read.",
-                severity="warning",
-            )
-            return
-        service = self._service()
-        if service is None:
-            self.app_instance.notify(
-                "Scheduling service is unavailable.", severity="warning"
-            )
-            return
-        unread_ids = self._unread_result_ids(service)
-        if not unread_ids:
-            self.app_instance.notify("Nothing unread.", severity="information")
-            return
+        """`a` / the rail's `Mark all read` button: mark every unread
+        result read, across the FULL table (not just a loaded window --
+        `_unread_result_ids`' own Qodo-HIGH contract).
 
-        async def _mark_all() -> None:
-            await self._dispatch_mark_all_results_read(service, unread_ids)
-
-        self.run_worker(
-            _mark_all, exclusive=True, group="schedules-mark-all-read"
-        )  # type: ignore[arg-type]
-
-    def _rail_mark_all_read(self) -> None:
-        """Rail `Mark all read` (redesign PR-2, Task 3): reuses the exact
-        same per-row fan-out as the `a` keybinding above, but reachable
-        without switching to the Results tab first -- the whole point of
-        a rail-level affordance for it. The Queue refresh that used to
-        live here moved INTO that shared fan-out (final review F5): it
-        was never rail-specific.
+        redesign PR-4, task 5: this used to be Results-tab-gated, with an
+        UNGATED byte-identical twin (`_rail_mark_all_read`) behind the
+        rail button for exactly the reachability the gate removed. The
+        tab is retired, so the gate is retired and the two collapse into
+        this one method -- the rail button is now the only on-screen
+        target for it, and it is always reachable. The pushed results
+        view keeps its own `a` (`ResultsHostScreen`), scoped to whatever
+        that push is showing.
         """
         service = self._service()
         if service is None:
@@ -4363,7 +3809,7 @@ class SchedulesWorkbench(BaseAppScreen):
         inspector.set_class(hide_inspector, "pane-hidden")
         detail.set_class(hide_detail, "pane-hidden")
         # At detail-hiding widths the pane chrome also gets too tall to fit:
-        # the Queue tab label already names this pane, so the in-pane title
+        # the screen header already names this pane, so the in-pane title
         # yields its row to the table + notice (see _scheduling.tcss).
         self.query_one("#scheduling-workbench").set_class(hide_detail, "compact")
         if hide_detail:
@@ -4378,16 +3824,6 @@ class SchedulesWorkbench(BaseAppScreen):
         else:
             self._resize_notice = ""
         self._update_pane_notice()
-        # schedules-redesign PR-1, Task 4: the Automations tab's detail
-        # pane hides at the same width the Queue tab's own detail pane
-        # does -- same mechanism (`pane-hidden`), separate try/except so a
-        # missing pane here (e.g. before the Automations TabPane mounts)
-        # never short-circuits the Queue-pane handling above.
-        try:
-            automations_detail = self.query_one("#scheduling-automations-detail-pane")
-        except Exception:  # noqa: BLE001 - pane not mounted yet
-            return
-        automations_detail.set_class(hide_detail, "pane-hidden")
 
     def _update_pane_notice(self) -> None:
         """Compose the queue-pane notice: hidden panes, marks, glyph legend.
@@ -4449,7 +3885,7 @@ class SchedulesWorkbench(BaseAppScreen):
         )
         self._refresh_owner_select()
         self._request_tasks_refresh(refresh_definitions=False)
-        self._refresh_conflicts_tab()
+        self._refresh_conflicts_badge()
 
     @on(Button.Pressed, "#scheduling-clear-error")
     def _on_clear_sync_errors(self) -> None:
@@ -4481,9 +3917,8 @@ class SchedulesWorkbench(BaseAppScreen):
         self.app_instance.notify(message, severity="information")
         self._refresh_owner_select()
         self._request_tasks_refresh()
-        self._request_automations_refresh()
-        self._refresh_conflicts_tab()
-        self._refresh_results_tab()
+        self._refresh_conflicts_badge()
+        self._refresh_results_badge()
 
     @on(SyncFailed)
     def _on_sync_failed(self, event: SyncFailed) -> None:
@@ -4491,101 +3926,71 @@ class SchedulesWorkbench(BaseAppScreen):
         self.app_instance.notify(f"Sync failed: {event.error}", severity="error")
         self._refresh_owner_select()
         self._request_tasks_refresh()
-        self._request_automations_refresh()
-        self._refresh_conflicts_tab()
-        self._refresh_results_tab()
+        self._refresh_conflicts_badge()
+        self._refresh_results_badge()
 
     @on(ConflictsTab.ConflictResolved)
     def _on_conflict_resolved(self, event: ConflictsTab.ConflictResolved) -> None:
         self._request_tasks_refresh(refresh_definitions=False)
-        self._refresh_conflicts_tab()
+        self._refresh_conflicts_badge()
 
-    def _refresh_conflicts_tab(self) -> None:
+    def _refresh_conflicts_badge(self) -> None:
+        """Re-count this owner's reminder sync conflicts onto the status
+        strip's badge (UX-063's count, plan ruling 4's home).
+
+        redesign PR-4 task 5: this used to ALSO populate the mounted
+        Conflicts tab and relabel its tab (`_set_tab_label`, deleted with
+        the `TabbedContent`). The conflicts view is pushed now
+        (`_push_conflicts_overlay`, task 1), pre-read at push time from
+        this same `get_conflicts` shape, so only the badge is left to
+        keep current -- and it is the affordance that opens the view.
+        """
         service = self._service()
         if service is None:
             return
-        conflicts_tab = self.query_one("#scheduling-conflicts", ConflictsTab)
         conflicts = service.db.get_conflicts(
             service.owner_id, primitive="reminder_task"
         )
-        conflicts_tab.populate(conflicts)
         label = f"Conflicts ({len(conflicts)})" if conflicts else "Conflicts"
-        # Surface the conflict count on the tab label itself (UX-063).
-        self._set_tab_label("scheduling-conflicts-tab", label)
-        # redesign PR-2, Task 3: same count, mirrored onto the status
-        # strip's badge (plan ruling 4) -- no new query.
         try:
             self.query_one("#scheduling-conflicts-badge", Button).label = label
         except Exception:  # noqa: BLE001 - strip not mounted yet
             pass
 
-    def _set_tab_label(self, pane_id: str, label: str) -> None:
-        """Relabel one tab in the workbench's `TabbedContent`.
+    def _refresh_results_badge(self) -> None:
+        """Re-count unread results onto the rail's `Results` button
+        (schedules-handoff PR-6 task 3's badge, redesign PR-4 task 2's
+        home). Direct `service.db.*` calls (`count_unread_results` spans
+        every owner -- Task 1), no worker: a local DB-only read, same
+        cost class as `get_conflicts`. Called after Task 4's
+        notification-triggered pull and after every results mutation.
 
-        `TabPane.label` does not exist in Textual 8.x -- a pane stores its
-        title in `_title` and exposes no `label` reactive, so the previous
-        `pane.label = ...` assignment silently created an inert Python
-        attribute and the rendered tab text never changed (live
-        verification task 6, D2: both the Results unread badge and the
-        Conflicts badge it was copied from were no-ops on screen while
-        their tests passed by reading the attribute back). The real seam
-        is `TabbedContent.get_tab(pane_id)` -> the `Tab` widget's own
-        `label` setter, which calls `Tab.update` and repaints.
-        """
-        try:
-            tab = self.query_one("#scheduling-tabs", TabbedContent).get_tab(pane_id)
-        except Exception:  # noqa: BLE001 - tabs/pane not mounted yet
-            return
-        tab.label = label
-
-    def _refresh_results_tab(self) -> None:
-        """Reload the Results tab and its unread badge (schedules-handoff
-        PR-6 task 3). Mirrors `_refresh_conflicts_tab`'s shape: direct
-        `service.db.*` calls (list_automation_results/count_unread_
-        results span every owner -- Task 1), no worker -- this is a local
-        DB-only read, same cost class as `get_conflicts`. Also called
-        after Task 4's notification-triggered pull and after every
-        read/dismiss/mark-solved/mark-all-read action below.
-
-        Lists `RESULTS_INBOX_LIMIT` rows, not the DB's own default 50: the
-        badge counts EVERY unread result, so a 50-row listing made the two
-        numbers disagree and quietly hid the rest. `total` is passed so the
-        tab can say "showing newest N of M" once the cap bites.
+        redesign PR-4 task 5: this used to also list `RESULTS_INBOX_LIMIT`
+        rows and populate the mounted Results tab. The pushed results view
+        (task 2) runs that listing itself, at push time and after each of
+        its own mutations, so the listing here had no consumer left -- the
+        count is all that is mirrored now, and it is one query instead of
+        four.
         """
         service = self._service()
         if service is None:
             return
-        results_tab = self.query_one("#scheduling-results", ResultsTab)
-        results = service.db.list_automation_results(
-            owner_id=None, limit=RESULTS_INBOX_LIMIT
-        )
         unread = service.db.count_unread_results(owner_id=None)
-        total = service.db.count_automation_results(owner_id=None)
-        definitions_by_id = index_definitions_by_id(
-            service.db.list_automation_definitions(owner_id=None)
-        )
-        results_tab.populate(results, definitions_by_id, total=total)
         label = f"Results ({unread})" if unread else "Results"
-        # Surface the unread count on the tab label itself (spec §4's
-        # inbox badge, same UX-063 idiom as the Conflicts tab above).
-        self._set_tab_label("scheduling-results-tab", label)
-        # redesign PR-4, task 2: same count, mirrored onto the rail's
-        # `Results` button (no new query) -- `_refresh_conflicts_tab`'s
-        # own precedent for its status-strip badge.
         try:
             self.query_one("#scheduling-results-badge", Button).label = label
         except Exception:  # noqa: BLE001 - rail not mounted yet
             pass
 
     def _refresh_results_surfaces(self) -> None:
-        """Every surface a results MUTATION moves: the Results tab and the
-        Queue's own unread dots + rail `Mark all read` visibility.
+        """Every surface a results MUTATION moves: the rail's `Results`
+        count and the Queue's own unread dots + `Mark all read` visibility.
 
         Final review F5: the unread affordances Task 3 added to the Queue
         derive from `UnifiedRow.unread_count`, which is only recomputed by
         `load_tasks` -- so an SSE-triggered pull, a read/dismiss, a
-        mark-solved or a mark-all-read updated the Results tab and left
-        the Queue's dots (and the rail button, gated on
+        mark-solved or a mark-all-read updated the results surface and
+        left the Queue's dots (and the rail button, gated on
         `sum(row.unread_count) > 0`) stale in both directions: hidden
         while unread work existed, or visible with nothing left to mark.
         `refresh_definitions=False` -- results never change which
@@ -4593,7 +3998,7 @@ class SchedulesWorkbench(BaseAppScreen):
         Called from the mutation paths only, never from the mount/reload
         paths that already run their own `_request_tasks_refresh`.
         """
-        self._refresh_results_tab()
+        self._refresh_results_badge()
         self._request_tasks_refresh(refresh_definitions=False)
 
     def action_delete(self) -> None:
@@ -4601,17 +4006,13 @@ class SchedulesWorkbench(BaseAppScreen):
 
         While ANY mark exists, d never falls through to the highlighted,
         unmarked row (task-23107 review F1): acting on a row the user
-        never marked is worse than refusing. On the Results tab, ``d``
-        dismisses the selected result instead (schedules-handoff PR-6
-        task 3) -- same key, the tab-appropriate "remove from view" verb.
+        never marked is worse than refusing.
+
+        redesign PR-4, task 5: the Results-tab "dismiss the selected
+        result" branch retired with the tab -- the pushed results view
+        (`ResultsHostScreen`) owns its own `d`, and a screen underneath
+        never receives the key anyway.
         """
-        try:
-            active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
-        except Exception:  # noqa: BLE001
-            active_pane = None
-        if active_pane == "scheduling-results-tab":
-            self._review_selected_result("dismissed")
-            return
         if self._marked_ids:
             marked = self._marked_reminder_tasks()
             if not marked:
@@ -4734,37 +4135,34 @@ class SchedulesWorkbench(BaseAppScreen):
 
         A definition row IS selected and highlighted when the cursor sits
         on one, so "select a task first" reads as a bug (final review
-        F8). Say where the action lives instead -- the same "managed
-        elsewhere" vocabulary `_managed_elsewhere_notice` established for
-        projection rows. Definition rows stay action-free here per plan
-        ruling 1; this only fixes how the refusal is REPORTED.
+        F8). Say what the row does not support instead.
+
+        redesign PR-4 task 5: this used to point at the Automations tab
+        ("managed on the Automations tab for now"), which is retired --
+        and by task 3 the pointer was already wrong for the verbs that
+        DO reach a definition row (run/edit/pause/move/mark-read are all
+        routed by kind before this is ever consulted). What is left is
+        the genuinely reminder-only half -- delete/mark/enable -- plus
+        the rare cursor-divergence fallthrough, so the copy names the
+        limit rather than a place to go.
         """
         if (self._selected_row_id or "").startswith("definition:"):
             return (
-                "This automation is managed on the Automations tab for "
-                f"now — {verb} it there."
+                f"Automations don't support {verb} — use the actions in "
+                "this automation's own detail pane."
             )
         return f"Nothing to {verb} — select a task first."
 
     def action_edit_task(self) -> None:
         """Open the highlighted task/definition in its edit form (e key).
 
-        Routes by active tab, same shape as `action_run_task_now`: the
-        Automations tab's `e` opens `AutomationDefinitionForm` pre-filled
-        for a `recurring_question` row (either owner); everywhere else it
-        is the existing reminder edit flow OR, redesign PR-4 task 3, a
-        Queue definition row's own edit-in-full -- `_edit_selected_
-        automation` itself refuses honestly for a non-`recurring_question`
-        row (the same refusal the Automations tab's `e` already gives),
-        so a Queue `agent_task` row's `e` reads the identical copy.
+        Routes by row kind (redesign PR-4 task 5 dropped the Automations
+        tab branch with the tab): a reminder row opens the existing
+        reminder edit flow; a definition row opens `AutomationDefinition
+        Form` pre-filled via `_edit_selected_automation` (task 3's
+        edit-in-full), which refuses honestly for a
+        non-`recurring_question` row.
         """
-        try:
-            active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
-        except Exception:  # noqa: BLE001
-            active_pane = None
-        if active_pane == "scheduling-automations-tab":
-            self._edit_selected_automation()
-            return
         task = self._selected_task()
         if task is not None:
             if not isinstance(task, ReminderTask):

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -32,6 +32,7 @@ from ....Scheduling.events import (
     DefinitionFieldEditRequested,
     DefinitionLifecycleToggleRequested,
     DefinitionOwnerActionRequested,
+    DefinitionRunNowRequested,
     DeleteTaskRequested,
     DisableTaskRequested,
     AcknowledgeIncidentRequested,
@@ -45,6 +46,7 @@ from ....Scheduling.events import (
     SyncFailed,
     TransferToLocalRequested,
     TransferToServerRequested,
+    ViewDefinitionAuditRequested,
     ViewDefinitionResultsRequested,
 )
 from ....Scheduling.models import ReminderTask, ScheduledTask
@@ -84,6 +86,7 @@ from ....Widgets.detail_value_row import DetailValueRow
 # so the DataTable render call site below and the pre-existing
 # `test_execution_target_label_matrix` test (which imports
 # `automation_execution_target_label` from THIS module) keep working.
+from .definition_audit_view import DefinitionAuditView, audit_notice_text, fetch_definition_audit
 from .definition_detail import (
     DefinitionDetail,
     _definition_transfer_suffix,
@@ -2126,6 +2129,62 @@ class SchedulesWorkbench(BaseAppScreen):
             )
         )
 
+    @on(DefinitionRunNowRequested)
+    def _on_definition_run_now_requested(
+        self, event: DefinitionRunNowRequested
+    ) -> None:
+        """A definition pane's `Run now` button was pressed (redesign
+        PR-4, task 3 -- the retired Automations-tab `r` key's live
+        replacement, ruling 2). Fires from either sibling
+        `DefinitionDetail` instance (Queue or Automations tab); routed
+        through the existing owner-routed dispatch unchanged."""
+        event.stop()
+        self._run_automation_now(event.definition)
+
+    @on(ViewDefinitionAuditRequested)
+    def _on_view_definition_audit_requested(
+        self, event: ViewDefinitionAuditRequested
+    ) -> None:
+        """A definition pane's `Last run` row was activated (redesign
+        PR-4, task 3 -- the retired Automations-tab third pane's live
+        replacement). Fires from either sibling `DefinitionDetail`
+        instance (Queue or Automations tab)."""
+        event.stop()
+        self._push_definition_audit_overlay(event.definition)
+
+    def _push_definition_audit_overlay(self, definition: dict[str, Any]) -> None:
+        """Push a standalone `DefinitionAuditView` via `WorkbenchHostScreen`.
+
+        Unlike `_push_conflicts_overlay`/`_push_results_overlay`, the
+        fetch here is unavoidably async (`server_client.list_automation_
+        definition_audit`) -- there is no synchronous value to pre-read
+        before pushing, so the widget fetches its OWN data on mount
+        (`DefinitionAuditView.on_mount`) rather than being handed one.
+        Read-only (no r/d/o/a-shaped mutation surface), so the plain
+        `WorkbenchHostScreen` hosts it directly -- no dedicated Screen
+        subclass, no `dismissed` hook needed (nothing here can go stale
+        by being viewed).
+        """
+        service = self._service()
+        name = str(
+            definition.get("name") or definition.get("id") or "Untitled automation"
+        )
+
+        def _factory() -> DefinitionAuditView:
+            return DefinitionAuditView(
+                service, dict(definition), id="scheduling-audit-view-overlay"
+            )
+
+        # The `Screen.title` -> `Header` route renders through `Content
+        # (title)` (a LITERAL constructor, unlike `Static.update(str)` ->
+        # `Content.from_markup`) -- verified against Textual's own
+        # `App.format_title`/`Content.__init__` -- so the definition's
+        # name needs no `escape_markup` here, unlike `ResultsTab`'s own
+        # `heading` Static.
+        self.app.push_screen(
+            WorkbenchHostScreen(_factory, title=f"Run history — {name}")
+        )
+
     @on(Button.Pressed, "#schedules-follow-in-console")
     def follow_latest_schedule_run_in_console(self, event: Button.Pressed) -> None:
         """Hand off the active schedule run or digest output to the Console."""
@@ -2993,7 +3052,11 @@ class SchedulesWorkbench(BaseAppScreen):
         Results tab's ``r`` marks the selected result read instead
         (schedules-handoff PR-6 task 3 -- a natural reading of the same
         key); everywhere else it is the local reminder Run-now
-        (task-18938).
+        (task-18938) OR, redesign PR-4 task 3, a Queue definition row's
+        own run-now (same owner-routed dispatch the Automations tab's
+        ``r`` uses -- `_run_automation_now` is family-agnostic, so this
+        works for every definition family, not just `recurring_
+        question`).
         """
         try:
             active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
@@ -3008,14 +3071,16 @@ class SchedulesWorkbench(BaseAppScreen):
             self._review_selected_result("read")
             return
         task = self._selected_reminder_task()
-        if task is None:
-            # Never swallow the key silently (final review F8): on a
-            # definition row `r` did nothing at all, with no message.
-            self.app_instance.notify(
-                self._no_task_notice("run"), severity="warning"
-            )
+        if task is not None:
+            self._run_reminder_now(task)
             return
-        self._run_reminder_now(task)
+        definition = self._selected_queue_definition()
+        if definition is not None:
+            self._run_automation_now(definition)
+            return
+        # Never swallow the key silently (final review F8): nothing at
+        # all under the cursor did nothing, with no message.
+        self.app_instance.notify(self._no_task_notice("run"), severity="warning")
 
     def _selected_reminder_task(self) -> ReminderTask | None:
         """Return the highlighted task when it is a reminder (not a projection)."""
@@ -3023,6 +3088,28 @@ class SchedulesWorkbench(BaseAppScreen):
             if task.id == self._selected_task_id and isinstance(task, ReminderTask):
                 return task
         return None
+
+    def _selected_queue_definition(self) -> dict[str, Any] | None:
+        """Return the automation definition under the QUEUE cursor, if any.
+
+        redesign PR-4, task 3: the Queue-row counterpart of `_selected_
+        automation` (which reads the Automations tab's own table) --
+        `_selected_task`'s own row-index routing (the two lists diverge
+        whenever a definition row precedes the cursor), but returning the
+        DEFINITION instead of `None` for a definition row rather than
+        `_selected_task`'s "nothing to act on" contract, since Queue
+        definition rows now have run-now/edit actions of their own.
+        """
+        if not self._visible_rows:
+            return None
+        table = self.query_one("#scheduling-task-table", DataTable)
+        row_index = table.cursor_row
+        if row_index is None or not (0 <= row_index < len(self._visible_rows)):
+            return None
+        row = self._visible_rows[row_index]
+        if row.kind != "definition":
+            return None
+        return row.source_row
 
     def _run_reminder_now(self, task: ReminderTask) -> None:
         """Dispatch one reminder through the scheduler's own path (task-18938)."""
@@ -3373,7 +3460,15 @@ class SchedulesWorkbench(BaseAppScreen):
         )  # type: ignore[arg-type]
 
     async def _load_automation_history(self, definition_id: str) -> None:
-        """Fetch and render one definition's durable execution-audit trail."""
+        """Fetch and render one definition's durable execution-audit trail.
+
+        The fetch+branch logic is `definition_audit_view.fetch_
+        definition_audit` (redesign PR-4, task 3: factored out so the
+        new pushed `DefinitionAuditView` shares it rather than
+        duplicating this method's own five-way branch) -- this method
+        keeps its own paint code (this pane's own DataTable/notice/title
+        ids, plus the staleness re-checks a background worker needs)
+        unchanged."""
         table = self.query_one("#scheduling-automation-history-table", DataTable)
         notice = self.query_one("#scheduling-automation-history-notice", Static)
         title = self.query_one("#scheduling-automation-history-title", Static)
@@ -3389,57 +3484,16 @@ class SchedulesWorkbench(BaseAppScreen):
         table.clear()
         self._update_static_content(notice, "Loading run history…")
 
-        from tldw_chatbook.Scheduling.scheduler.queue import is_server_scoped_owner
-
-        owner_id = (definition or {}).get("owner_id")
-        if (definition or {}).get("pending_sync"):
-            # Never synced: the audit endpoint has no id to look up, and
-            # asking it with a local uuid would render a bare error.
-            table.clear()
-            self._update_static_content(
-                notice,
-                "This automation hasn't synced to the server yet, so it has "
-                "no run history.",
-            )
-            return
-        if not is_server_scoped_owner(owner_id):
-            # Honest gap (task-5 fix round): local automation runs are not
-            # tracked in a durable audit trail yet -- only the server side
-            # is. Never claim a server-shaped history for a local row.
-            table.clear()
-            self._update_static_content(
-                notice, "Local automation history isn't available yet."
-            )
-            return
-
-        service = self._scheduling_service
-        server_client = getattr(service, "server_client", None) if service else None
-        if server_client is None:
-            table.clear()
-            self._update_static_content(
-                notice, "Run history needs a connected server."
-            )
-            return
-        try:
-            response = await server_client.list_automation_definition_audit(
-                definition_id
-            )
-        except Exception:  # noqa: BLE001
-            logger.exception(
-                "Failed to load automation audit trail (definition_id={})",
-                definition_id,
-            )
-            table.clear()
-            self._update_static_content(
-                notice, "Could not load the run history — see the log."
-            )
-            return
+        result = await fetch_definition_audit(
+            self._scheduling_service, definition or {"id": definition_id}
+        )
         if definition_id != self._selected_automation_id:
             return
-        items = list(response.get("items", []))
-        total = int(response.get("total", len(items)) or 0)
         table.clear()
-        for event in items:
+        if result.notice_override is not None:
+            self._update_static_content(notice, result.notice_override)
+            return
+        for event in result.items:
             created = str(event.get("created_at") or "")
             # Keep the timestamp compact: date and minute-level time,
             # no microseconds or timezone noise in a table cell.
@@ -3454,12 +3508,8 @@ class SchedulesWorkbench(BaseAppScreen):
                 Text(str(event.get("event_type") or "?")),
                 Text(summary),
             )
-        suffix = f" of {total}" if total > len(items) else ""
         self._update_static_content(
-            notice,
-            f"{len(items)} event{'' if len(items) == 1 else 's'}{suffix}."
-            if items
-            else "No recorded events for this automation yet.",
+            notice, audit_notice_text(result.items, result.total)
         )
 
     def _request_automation_detail(self, definition_id: str) -> None:
@@ -3819,14 +3869,26 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-run-automation-now",
         )  # type: ignore[arg-type]
 
-    def _edit_selected_automation(self) -> None:
-        """Open the selected automation definition for editing (e key).
+    def _edit_selected_automation(
+        self, definition: dict[str, Any] | None = None
+    ) -> None:
+        """Open an automation definition for editing (e key).
 
         `agent_task` rows are excluded -- only `recurring_question`
         authoring exists (the same v1 scope guard `save_definition`
         itself enforces via `_reject_unsupported_family`).
+
+        Args:
+            definition: The definition to edit, already resolved by the
+                caller. Defaults to `_selected_automation()` (the
+                Automations tab's own highlighted row) -- every pre-
+                task-3 call site omits this and is unaffected. redesign
+                PR-4, task 3's Queue-row routing passes `_selected_queue_
+                definition()`'s result instead, reusing this same
+                resolve-id/open-form body rather than a second copy.
         """
-        definition = self._selected_automation()
+        if definition is None:
+            definition = self._selected_automation()
         if definition is None:
             self.app_instance.notify(
                 "Nothing to edit — select an automation first.",
@@ -4945,7 +5007,11 @@ class SchedulesWorkbench(BaseAppScreen):
         Routes by active tab, same shape as `action_run_task_now`: the
         Automations tab's `e` opens `AutomationDefinitionForm` pre-filled
         for a `recurring_question` row (either owner); everywhere else it
-        is the existing reminder edit flow.
+        is the existing reminder edit flow OR, redesign PR-4 task 3, a
+        Queue definition row's own edit-in-full -- `_edit_selected_
+        automation` itself refuses honestly for a non-`recurring_question`
+        row (the same refusal the Automations tab's `e` already gives),
+        so a Queue `agent_task` row's `e` reads the identical copy.
         """
         try:
             active_pane = self.query_one("#scheduling-tabs", TabbedContent).active
@@ -4955,23 +5021,27 @@ class SchedulesWorkbench(BaseAppScreen):
             self._edit_selected_automation()
             return
         task = self._selected_task()
-        if task is None:
-            self.app_instance.notify(
-                self._no_task_notice("edit"),
-                severity="warning",
-            )
+        if task is not None:
+            if not isinstance(task, ReminderTask):
+                # task-23106: say who owns the row instead of exposing the
+                # internal reminder/projection split.
+                self.app_instance.notify(
+                    _managed_elsewhere_notice(task, verb="edit"),
+                    severity="warning",
+                )
+                return
+            if self._refuse_if_transfer_locked(task, "edit this task"):
+                return
+            self.post_message(EditTaskRequested(task))
             return
-        if not isinstance(task, ReminderTask):
-            # task-23106: say who owns the row instead of exposing the
-            # internal reminder/projection split.
-            self.app_instance.notify(
-                _managed_elsewhere_notice(task, verb="edit"),
-                severity="warning",
-            )
+        definition = self._selected_queue_definition()
+        if definition is not None:
+            self._edit_selected_automation(definition)
             return
-        if self._refuse_if_transfer_locked(task, "edit this task"):
-            return
-        self.post_message(EditTaskRequested(task))
+        self.app_instance.notify(
+            self._no_task_notice("edit"),
+            severity="warning",
+        )
 
     def action_mark_task(self) -> None:
         """Mark/unmark the highlighted task for bulk actions (x key).

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -68,6 +68,7 @@ from ....UI.Screens.scheduling.results_tab import (
     solved_eligibility,
 )
 from ....UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
+from ....UI.Screens.scheduling.workbench_host_screen import WorkbenchHostScreen
 from ....Widgets.confirmation_dialog import ConfirmationDialog
 from ....Widgets.detail_value_row import DetailValueRow
 # schedules-redesign PR-1, Task 4: `automation_execution_target_label`/
@@ -1966,11 +1967,46 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @on(Button.Pressed, "#scheduling-conflicts-badge")
     def _on_conflicts_badge_pressed(self, event: Button.Pressed) -> None:
-        """Status-strip conflicts badge (redesign PR-2, Task 3, plan
-        ruling 4) -- switches to the Conflicts tab, no overlay."""
+        """Status-strip conflicts badge (redesign PR-4, Task 1) -- pushes
+        the hosted Conflicts view as a fresh overlay instance instead of
+        flipping tabs (the tab flip cannot work once the tab bar is
+        retired). The Conflicts TAB itself stays reachable until Task 5
+        retires it -- both paths coexist this task."""
         event.stop()
-        self.query_one("#scheduling-tabs", TabbedContent).active = (
-            "scheduling-conflicts-tab"
+        self._push_conflicts_overlay()
+
+    def _push_conflicts_overlay(self) -> None:
+        """Push a standalone `ConflictsTab` instance via `WorkbenchHostScreen`.
+
+        Pre-reads the same `get_conflicts` shape `_refresh_conflicts_tab`
+        uses (no new query) and hands the result to the fresh instance as
+        `initial_conflicts` so it paints immediately on mount -- this
+        pushed instance has no external `.populate()` driver the way the
+        still-live TAB instance does. `dismissed=self._refresh_conflicts_
+        tab` re-syncs the tab/badge count on pop, in case the overlay
+        resolved anything while it was open.
+        """
+        service = self._service()
+        conflicts = (
+            service.db.get_conflicts(service.owner_id, primitive="reminder_task")
+            if service is not None
+            else []
+        )
+        sync_engine = service.sync_engine if service is not None else None
+
+        def _factory() -> ConflictsTab:
+            return ConflictsTab(
+                sync_engine=sync_engine,
+                initial_conflicts=conflicts,
+                id="scheduling-conflicts-overlay",
+            )
+
+        self.app.push_screen(
+            WorkbenchHostScreen(
+                _factory,
+                title="Conflicts",
+                dismissed=self._refresh_conflicts_tab,
+            )
         )
 
     @on(Button.Pressed, "#schedules-follow-in-console")

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -540,11 +540,6 @@ class TaskDetail(Vertical):
         height: auto;
     }
 
-    .scheduling-detail-managed {
-        color: $text-muted;
-        height: auto;
-        margin-top: 1;
-    }
     """
 
     def __init__(self, *args, **kwargs) -> None:
@@ -776,13 +771,6 @@ class TaskDetail(Vertical):
                 "No open incidents",
                 id="scheduling-task-detail-incidents",
                 classes="scheduling-detail-value",
-            )
-            # task-23106: rows managed by other systems say so, and where
-            # to edit them, instead of silently hiding the action row.
-            yield Static(
-                "",
-                id="scheduling-task-detail-managed",
-                classes="scheduling-detail-managed",
             )
         yield Horizontal(
             Button(
@@ -1378,11 +1366,6 @@ class TaskDetail(Vertical):
             missed_notice = self.query_one("#scheduling-task-detail-missed", Static)
             missed_notice.update("")
             missed_notice.display = False
-            managed_notice = self.query_one(
-                "#scheduling-task-detail-managed", Static
-            )
-            managed_notice.update("")
-            managed_notice.display = False
             self.query_one("#schedules-follow-in-console", Button).label = (
                 "Follow in Console"
             )
@@ -1437,15 +1420,20 @@ class TaskDetail(Vertical):
         # `#scheduling-transfer-why`'s content, so no explicit reset is
         # needed here either.
 
-        # task-23106: a row Schedules does not own says who owns it and
-        # where to edit it, instead of only hiding the action row.
-        managed_notice = self.query_one("#scheduling-task-detail-managed", Static)
-        if isinstance(task, ReminderTask):
-            managed_notice.update("")
-            managed_notice.display = False
-        else:
-            managed_notice.update(_managed_elsewhere_notice(task))
-            managed_notice.display = True
+        # redesign PR-4 task 5 (ruling 5): the task-23106 ownership line
+        # ("#scheduling-task-detail-managed") and its `else` branch are
+        # DELETED -- provably unreachable, not merely unused. `TaskDetail(`
+        # is constructed exactly once in the repo (schedules_workbench.py's
+        # detail pane) and fed only from `load_tasks`, which calls
+        # `list_tasks(owner_id=None, include_projections=False)` and then
+        # filters the result to `ReminderTask` anyway; `_update_detail_for_
+        # index` asserts the same before every call. So `task` here is
+        # never anything but a `ReminderTask`, the `else` never ran, and
+        # the empty Static it painted into was pure weight. The copy
+        # generator itself (`_managed_elsewhere_notice`) STAYS: the
+        # workbench's own edit/mark/enable action guards still call it,
+        # and `test_managed_elsewhere_notice_names_the_owning_screen`
+        # covers it directly.
 
         follow_button = self.query_one("#schedules-follow-in-console", Button)
         short_title = task.title if len(task.title) <= 24 else f"{task.title[:23]}…"
@@ -1701,8 +1689,8 @@ class TaskInspector(Vertical):
         """Update the conflict card for the current task state.
 
         Underlying status (review F5): a disabled task's conflict is
-        still a conflict -- the Conflicts tab lists it, so this card must
-        not claim "No conflict".
+        still a conflict -- the conflicts view lists it, so this card
+        must not claim "No conflict".
         """
         card = self.query_one("#scheduling-conflict-card", Vertical)
         text = self.query_one("#scheduling-conflict-text", Static)

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -1423,11 +1423,16 @@ class TaskDetail(Vertical):
         # redesign PR-4 task 5 (ruling 5): the task-23106 ownership line
         # ("#scheduling-task-detail-managed") and its `else` branch are
         # DELETED -- provably unreachable, not merely unused. `TaskDetail(`
-        # is constructed exactly once in the repo (schedules_workbench.py's
-        # detail pane) and fed only from `load_tasks`, which calls
-        # `list_tasks(owner_id=None, include_projections=False)` and then
-        # filters the result to `ReminderTask` anyway; `_update_detail_for_
-        # index` asserts the same before every call. So `task` here is
+        # is constructed in exactly TWO places in the repo, both in
+        # `schedules_workbench.py` (the docked detail pane, and task 6's
+        # fresh per-push overlay instance -- final review F5 corrected the
+        # original "exactly once" wording, which task 6 had made false).
+        # Both are fed through the SAME single seam, `_update_detail_for_
+        # index` (`_detail_panes` is one list, not a second data path),
+        # whose data comes from `load_tasks` -> `list_tasks(owner_id=None,
+        # include_projections=False)` filtered to `ReminderTask`, and which
+        # asserts `isinstance(task, ReminderTask)` before every call. So
+        # `task` here is
         # never anything but a `ReminderTask`, the `else` never ran, and
         # the empty Static it painted into was pure weight. The copy
         # generator itself (`_managed_elsewhere_notice`) STAYS: the

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -13,7 +13,6 @@ from textual.containers import Horizontal, Vertical
 from textual.widgets import Button, Input, Select, Static
 
 from ....Scheduling.events import (
-    CancelTransferRequested,
     DeleteTaskRequested,
     DisableTaskRequested,
     AcknowledgeIncidentRequested,
@@ -21,10 +20,7 @@ from ....Scheduling.events import (
     EnableTaskRequested,
     ReminderFieldEditRequested,
     ReminderOwnerActionRequested,
-    RetryTransferRequested,
     RunReminderNowRequested,
-    TransferToLocalRequested,
-    TransferToServerRequested,
 )
 from ....Scheduling.models import ReminderTask, ScheduledTask, ScheduleKind, TaskStatus
 # PR-3 task 5: the owner-row dropdown's own lock/failed-state gating reads
@@ -610,7 +606,7 @@ class TaskDetail(Vertical):
             classes="scheduling-column-title",
         )
         yield Static(
-            "Select a task from the queue, or press c to schedule one.",
+            "Select a task from the queue, or press n to schedule one.",
             id="scheduling-task-detail-empty-state",
         )
         with Vertical(id="scheduling-task-detail-metadata"):
@@ -832,40 +828,15 @@ class TaskDetail(Vertical):
             ),
             id="scheduling-task-detail-lifecycle",
         )
-        # schedules-handoff spec §6: per-task ownership transfer. All four
-        # buttons stay visible per-row per UX-059 (only the state-changing
-        # action is enabled); `_update_transfer_buttons` toggles `.display`
-        # per row structure, `set_transfer_reasons` toggles `.disabled` +
-        # the reason text (UX-073).
-        yield Horizontal(
-            Button(
-                "Move to server",
-                id="scheduling-transfer-to-server",
-                variant="primary",
-                tooltip="Queue this task to move to the connected server.",
-            ),
-            Button(
-                "Move to local",
-                id="scheduling-transfer-to-local",
-                variant="primary",
-                tooltip="Queue this server-owned task to move to this device.",
-            ),
-            Button(
-                "Retry transfer",
-                id="scheduling-retry-transfer",
-                variant="warning",
-                tooltip="Retry the failed transfer to the server.",
-            ),
-            Button(
-                "Cancel transfer",
-                id="scheduling-cancel-transfer",
-                variant="warning",
-                tooltip="Cancel this task's in-progress transfer.",
-            ),
-            id="scheduling-task-detail-transfer",
-        )
-        # Visible when a transfer action is disabled: keyboard users can't
-        # see hover tooltips, so the reason must live in text (UX-073).
+        # redesign PR-4, task 4 (ruling 2): the legacy Move/Retry/Cancel
+        # button row that lived here (schedules-handoff spec §6, PR-5
+        # task 7) is RETIRED -- the Runs-on row's own dropdown + mini-bar
+        # (`_runs_on_cancel_button`/`_runs_on_retry_button` above) is now
+        # the one transfer surface (PR-3 task 5's "coexistence pinned"
+        # window is over). `#scheduling-transfer-why` stays: `set_
+        # lifecycle_lock` still writes the Edit/Enable/Disable/Delete
+        # read-only reason into it (UX-073 -- keyboard users can't see
+        # hover tooltips).
         yield Static("", id="scheduling-transfer-why", classes="follow-why")
         yield Button(
             "Follow in Console",
@@ -887,10 +858,6 @@ class TaskDetail(Vertical):
             "scheduling-disable-task",
             "scheduling-delete-task",
             "scheduling-ack-incident",
-            "scheduling-transfer-to-server",
-            "scheduling-transfer-to-local",
-            "scheduling-retry-transfer",
-            "scheduling-cancel-transfer",
             _RUNS_ON_CANCEL_ID,
             _RUNS_ON_RETRY_ID,
         }:
@@ -905,14 +872,6 @@ class TaskDetail(Vertical):
             self._request_disable()
         elif button_id == "scheduling-delete-task":
             self.request_delete()
-        elif button_id == "scheduling-transfer-to-server":
-            self._request_transfer_to_server()
-        elif button_id == "scheduling-transfer-to-local":
-            self._request_transfer_to_local()
-        elif button_id == "scheduling-retry-transfer":
-            self._request_retry_transfer()
-        elif button_id == "scheduling-cancel-transfer":
-            self._request_cancel_transfer()
         elif button_id == "scheduling-ack-incident":
             self._request_acknowledge()
         elif button_id == _RUNS_ON_CANCEL_ID:
@@ -965,31 +924,12 @@ class TaskDetail(Vertical):
         if isinstance(self._current_task, ReminderTask):
             self.post_message(RunReminderNowRequested(self._current_task))
 
-    def _request_transfer_to_server(self) -> None:
-        """Post a local -> server transfer request (spec §6.1)."""
-        if isinstance(self._current_task, ReminderTask):
-            self.post_message(TransferToServerRequested(self._current_task))
-
-    def _request_transfer_to_local(self) -> None:
-        """Post a server -> local release request (spec §6.2)."""
-        if isinstance(self._current_task, ReminderTask):
-            self.post_message(TransferToLocalRequested(self._current_task))
-
-    def _request_retry_transfer(self) -> None:
-        """Post a retry request for a definitively-failed transfer."""
-        if isinstance(self._current_task, ReminderTask):
-            self.post_message(RetryTransferRequested(self._current_task))
-
-    def _request_cancel_transfer(self) -> None:
-        """Post a cancel request for the current task's in-flight transfer."""
-        if isinstance(self._current_task, ReminderTask):
-            self.post_message(CancelTransferRequested(self._current_task))
-
     def _request_runs_on_cancel(self) -> None:
         """Post a cancel request from the Runs-on row's own mini-bar
-        (PR-3 task 5) -- a SEPARATE surface from `_request_cancel_
-        transfer` above (coexistence, task-5 brief): this one renders a
-        refusal via `row.show_error`, not the legacy toast."""
+        (PR-3 task 5) -- the ONE transfer surface now (redesign PR-4 task
+        4 retired the legacy `_request_cancel_transfer` this docstring
+        used to contrast with): renders a refusal via `row.show_error`,
+        not a toast."""
         task = self._current_task
         row = self._runs_on_row
         if isinstance(task, ReminderTask) and row is not None:
@@ -997,8 +937,7 @@ class TaskDetail(Vertical):
 
     def _request_runs_on_retry(self) -> None:
         """Post a retry request from the Runs-on row's own mini-bar
-        (PR-3 task 5) -- the PR-5 retry leg (re-begin), same SEPARATE
-        row-scoped surface as `_request_runs_on_cancel` above."""
+        (PR-3 task 5) -- the PR-5 retry leg (re-begin)."""
         task = self._current_task
         row = self._runs_on_row
         if isinstance(task, ReminderTask) and row is not None:
@@ -1110,6 +1049,16 @@ class TaskDetail(Vertical):
         return _TRANSFER_STATE_ROW_LABELS.get(
             task.transfer_state or "", "This transfer failed."
         )
+
+    @property
+    def runs_on_row(self) -> DetailValueRow | None:
+        """The Runs-on row, for the workbench's `m` keybinding (redesign
+        PR-4 task 4) to activate programmatically -- posting `DetailValueRow.
+        Activated(row)` on it drives the exact same `on_detail_value_row_
+        activated` path (honest lock/failed-transfer refusal, then the
+        dropdown) a real Enter/click already does, so `m` needs no new
+        activation logic, only this reference."""
+        return self._runs_on_row
 
     def _editable_rows(self) -> tuple[DetailValueRow, ...]:
         """Every row this pane can open an editor on (mounted ones only).
@@ -1414,19 +1363,17 @@ class TaskDetail(Vertical):
         lifecycle = self.query_one("#scheduling-task-detail-lifecycle", Horizontal)
         self.query_one("#schedules-follow-in-console", Button)
         empty_state = self.query_one("#scheduling-task-detail-empty-state", Static)
-        transfer_row = self.query_one("#scheduling-task-detail-transfer", Horizontal)
 
         if task is None:
             empty_copy = (
-                "No scheduled tasks yet. Press c to schedule your first task."
+                "No scheduled tasks yet. Press n to schedule your first task."
                 if queue_empty
-                else "Select a task from the queue, or press c to schedule one."
+                else "Select a task from the queue, or press n to schedule one."
             )
             empty_state.update(empty_copy)
             empty_state.display = True
             metadata.display = False
             lifecycle.display = False
-            transfer_row.display = False
             self.query_one("#scheduling-transfer-why", Static).update("")
             missed_notice = self.query_one("#scheduling-task-detail-missed", Static)
             missed_notice.update("")
@@ -1456,7 +1403,6 @@ class TaskDetail(Vertical):
         empty_state.display = False
         metadata.display = True
         lifecycle.display = isinstance(task, ReminderTask)
-        transfer_row.display = isinstance(task, ReminderTask)
 
         # schedules-redesign PR-1, task 3: the Details/Frequency/History
         # groups are reminder-only (spec §5's reminder column); a
@@ -1483,31 +1429,13 @@ class TaskDetail(Vertical):
             self._configure_frequency_editability(task)
             self._configure_runs_on_row(task)
 
-        if isinstance(task, ReminderTask):
-            # Structural visibility only (spec §6, PR-5 task 7): Move to
-            # server on any local row, Move to local on any server mirror,
-            # Cancel on any in-flight state, Retry only alongside a
-            # definitively-failed to_server transfer (it re-triggers the
-            # SAME facade call as Move to server, but carries the stored
-            # `transfer_errors` beside it -- worth the redundancy). Which
-            # of the always-shown buttons are ENABLED is `set_transfer_
-            # reasons`' job (workbench-computed, via `transfer_refusal`).
-            is_server_owned = str(task.owner_id or "").startswith("server:")
-            transfer_state = task.transfer_state
-            self.query_one("#scheduling-transfer-to-server", Button).display = (
-                not is_server_owned
-            )
-            self.query_one("#scheduling-transfer-to-local", Button).display = (
-                is_server_owned
-            )
-            self.query_one("#scheduling-retry-transfer", Button).display = (
-                transfer_state == "to_server_failed"
-            )
-            self.query_one("#scheduling-cancel-transfer", Button).display = (
-                transfer_state is not None
-            )
-        else:
-            self.query_one("#scheduling-transfer-why", Static).update("")
+        # redesign PR-4, task 4: the legacy Move/Retry/Cancel button
+        # display-toggling that used to live here is retired along with
+        # the buttons themselves (ruling 2) -- the caller's `_update_
+        # transfer_actions` -> `set_lifecycle_lock` (which runs right
+        # after every `set_task`, for every task type) already owns
+        # `#scheduling-transfer-why`'s content, so no explicit reset is
+        # needed here either.
 
         # task-23106: a row Schedules does not own says who owns it and
         # where to edit it, instead of only hiding the action row.
@@ -1651,69 +1579,13 @@ class TaskDetail(Vertical):
         except Exception:  # noqa: BLE001 - widget not mounted yet
             pass
 
-    def set_transfer_reasons(
-        self,
-        *,
-        to_server_reason: str | None,
-        to_local_reason: str | None,
-        retry_reason: str | None,
-        cancel_reason: str | None,
-        retry_errors: list[str],
-    ) -> None:
-        """Apply disabled-with-reason state to the transfer buttons (UX-073).
-
-        Called by the workbench right after `set_task` -- it holds the
-        `SchedulingService` this widget doesn't reach into, so it computes
-        each reason via `transfer_refusal` (spec §6.4, quoting local
-        health verbatim for a refused `recurring_question` release) and
-        passes only the reason relevant to a button `set_task` already
-        decided to show; `None` means the action is allowed. Each reason
-        is BOTH the button's tooltip and a line in the always-visible
-        Static below the row -- keyboard users can't see hover tooltips.
-        """
-        to_server_btn = self.query_one("#scheduling-transfer-to-server", Button)
-        to_local_btn = self.query_one("#scheduling-transfer-to-local", Button)
-        retry_btn = self.query_one("#scheduling-retry-transfer", Button)
-        cancel_btn = self.query_one("#scheduling-cancel-transfer", Button)
-
-        to_server_btn.disabled = to_server_reason is not None
-        to_server_btn.tooltip = (
-            to_server_reason or "Queue this task to move to the connected server."
-        )
-        to_local_btn.disabled = to_local_reason is not None
-        to_local_btn.tooltip = (
-            to_local_reason
-            or "Queue this server-owned task to move to this device."
-        )
-        retry_btn.disabled = retry_reason is not None
-        retry_btn.tooltip = retry_reason or "Retry the failed transfer to the server."
-        cancel_btn.disabled = cancel_reason is not None
-        cancel_btn.tooltip = (
-            cancel_reason or "Cancel this task's in-progress transfer."
-        )
-
-        reason_lines: list[str] = []
-        if to_server_reason:
-            reason_lines.append(f"Move to server: {to_server_reason}")
-        if to_local_reason:
-            reason_lines.append(f"Move to local: {to_local_reason}")
-        if retry_reason:
-            reason_lines.append(f"Retry transfer: {retry_reason}")
-        if cancel_reason:
-            reason_lines.append(f"Cancel transfer: {cancel_reason}")
-        if retry_errors:
-            reason_lines.append("Last transfer error: " + "; ".join(retry_errors))
-        self.query_one("#scheduling-transfer-why", Static).update(
-            "\n".join(reason_lines)
-        )
-
     def set_runs_on_transfer_errors(self, errors: list[str]) -> None:
         """Cache a `to_server_failed` row's stored `transfer_errors` (PR-3
         task 5 fix round 1, finding 2) for `_runs_on_failure_reason` --
-        called by the workbench right alongside `set_transfer_reasons`,
-        fed from the SAME `retry_errors` list that already backs the
-        legacy Retry button's own reason line (one source, not a second
-        derivation)."""
+        fed from the same `retry_errors` the workbench computes (redesign
+        PR-4 task 4: the legacy Retry button that USED to also read this
+        list, via the now-retired `set_transfer_reasons`, is gone; this
+        stays the Runs-on row's own single source)."""
         self._runs_on_transfer_errors = list(errors)
 
     def set_lifecycle_lock(self, reason: str | None) -> None:

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -681,22 +681,22 @@ def build_unified_rows(
             real `ReminderTask` rows -- briefing/watchlist projections
             stay out of the unified list per plan ruling 1).
         definitions: Local + server-mirrored definition rows of EVERY
-            family (PR-4 ruling 1 -- not just ``recurring_question``; the
-            existing Automations-tab merge precedent: `_load_local_
-            automations` + `_load_server_automations`).
+            family (PR-4 ruling 1 -- not just ``recurring_question``),
+            from `SchedulesWorkbench._load_queue_definitions`' local +
+            server merge.
         results: One all-owners `list_automation_results(owner_id=None)`
             listing, used only to derive `UnifiedRow.unread_count`.
         local_definitions: The FULL local definitions table
             (`list_automation_definitions(owner_id=None)`, the same input
-            the Results tab's own index uses), for result->definition
+            the results view's own index uses), for result->definition
             resolution ONLY -- never a source of rows. Final review F2:
             the display merge above deliberately EXCLUDES every local row
             that carries a ``server_id``, so a definition transferred to
             the server is a key in NEITHER of the merge's two id spaces;
             its pre-transfer, locally-produced results resolved to
             nothing and dropped out of the unread count, hiding the
-            rail's `Mark all read` button while the Results tab's badge
-            still counted them. Resolution indexes these rows AND the
+            rail's `Mark all read` button while the rail's `Results (N)`
+            badge still counted them. Resolution indexes these rows AND the
             display rows, since a server definition with no local mirror
             row is absent from the local table. Defaults to
             ``definitions`` -- every caller with no separate local

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -712,23 +712,25 @@ def build_unified_rows(
     )
     unread_by_row_key = _unread_counts_by_row_key(results, definitions_by_id)
     rows = [_reminder_row(task) for task in reminders]
-    # `family == "recurring_question"` only (Qodo MEDIUM): `definitions`
-    # is never family-filtered upstream (`list_automation_definitions`'s
-    # `family=` default, and a server page can return `agent_task` rows
-    # too -- same guard `_definition_row` for the plain Automations
-    # listing has no equivalent of, since that tab is family-agnostic by
-    # design). An `agent_task`/unknown-family row rendered here would be
-    # a pseudo-recurring Queue entry with no recurring semantics behind
-    # it. Definitions of every family stay visible on the Automations
-    # tab -- still the all-families home until PR-4 retires it (plan
-    # ruling: "their actions stay on the Automations tab until PR-4
-    # retires it") -- PR-4 MUST revisit this filter when that tab goes
-    # away, or agent_task definitions lose their only remaining surface.
-    rows.extend(
-        _definition_row(d, unread_by_row_key)
-        for d in definitions
-        if d.get("family") == "recurring_question"
-    )
+    # PR-4 ruling 1 (was: `family == "recurring_question"` only, Qodo
+    # MEDIUM): every definition family renders now, not just
+    # `recurring_question`. That original filter existed because the
+    # Automations tab was the all-families home and this list's own
+    # actions/editors only understood `recurring_question` -- but PR-4
+    # retires that tab, so filtering here would make every `agent_task`
+    # (or other unrecognized-family) definition permanently invisible,
+    # with no surface left at all. `_definition_bucket`/`_definition_
+    # glyph`/`_definition_at_label`/`_definition_question_text` are
+    # already family-agnostic (read `lifecycle`/`schedule`/`input` generi-
+    # cally, degrading to honest defaults for a shape they don't
+    # recognize -- verified against the real server fixture, which gives
+    # an `agent_task` row the same `schedule`/`lifecycle` shape as a
+    # `recurring_question` one). `DefinitionDetail` already has a
+    # read-only `_UNSUPPORTED_FAMILY_NOTE` fallback for a non-`recurring_
+    # question` row (built for the Automations tab, reused verbatim
+    # here) -- viewing is universal, editing stays `recurring_question`-
+    # only.
+    rows.extend(_definition_row(d, unread_by_row_key) for d in definitions)
     return rows
 
 

--- a/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
+++ b/tldw_chatbook/UI/Screens/scheduling/unified_rows.py
@@ -680,9 +680,10 @@ def build_unified_rows(
             ``SchedulingService.list_tasks(owner_id=None)``, filtered to
             real `ReminderTask` rows -- briefing/watchlist projections
             stay out of the unified list per plan ruling 1).
-        definitions: Local + server-mirrored ``recurring_question``
-            definition rows (the existing Automations-tab merge
-            precedent: `_load_local_automations` + `_load_server_automations`).
+        definitions: Local + server-mirrored definition rows of EVERY
+            family (PR-4 ruling 1 -- not just ``recurring_question``; the
+            existing Automations-tab merge precedent: `_load_local_
+            automations` + `_load_server_automations`).
         results: One all-owners `list_automation_results(owner_id=None)`
             listing, used only to derive `UnifiedRow.unread_count`.
         local_definitions: The FULL local definitions table

--- a/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
+++ b/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
@@ -16,10 +16,11 @@ with no shared state, is architecturally normal here.
 
 from __future__ import annotations
 
-from typing import Callable, Optional
+from typing import Callable
 
 from textual.app import ComposeResult
 from textual.binding import Binding
+from textual.message import Message
 from textual.screen import Screen
 from textual.widget import Widget
 from textual.widgets import Footer, Header
@@ -42,7 +43,8 @@ class WorkbenchHostScreen(Screen):
         widget_factory: Callable[[], Widget],
         *,
         title: str,
-        dismissed: Optional[Callable[[], None]] = None,
+        dismissed: Callable[[], None] | None = None,
+        route_message: Callable[[Message], None] | None = None,
     ) -> None:
         """Initialize the host.
 
@@ -54,11 +56,22 @@ class WorkbenchHostScreen(Screen):
             title: Shown in the screen's ``Header``.
             dismissed: Optional hook run once when this screen pops
                 (``Esc``), before the pop completes.
+            route_message: Optional hook called with EVERY message this
+                screen processes (task 6). A hosted pane that posts
+                request messages for a handler living on the screen
+                BEHIND needs them relayed: Textual bubbles a message
+                widget -> parent -> Screen -> App, and the pane behind is
+                on a different screen, so those messages would otherwise
+                die here. The hook is deliberately unfiltered -- which
+                messages are worth relaying is the caller's business, not
+                a generic host's (`SchedulesWorkbench._route_pushed_
+                detail_message` allowlists its own).
         """
         super().__init__()
         self._widget_factory = widget_factory
         self.title = title
         self._dismissed = dismissed
+        self._route_message = route_message
 
     def compose(self) -> ComposeResult:
         """Header (title) + the hosted widget (fills remaining space) + Footer (Esc hint)."""
@@ -67,6 +80,20 @@ class WorkbenchHostScreen(Screen):
         body.add_class("workbench-host-body")
         yield body
         yield Footer()
+
+    async def _on_message(self, message: Message) -> None:
+        """Dispatch normally, then hand the message to ``route_message``.
+
+        `MessagePump._on_message` is the only seam that sees a message
+        AFTER this screen's own handlers and its bubble to `App`; Textual
+        exposes no public "unhandled message" hook on `Screen` (verified
+        against `textual/message_pump.py` -- neither `Screen` nor
+        `Widget` overrides it, so the `super()` call is the whole of the
+        normal path).
+        """
+        await super()._on_message(message)
+        if self._route_message is not None:
+            self._route_message(message)
 
     def action_dismiss_screen(self) -> None:
         """``Esc``: run the on-dismiss hook (if any), then pop.

--- a/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
+++ b/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
@@ -16,7 +16,8 @@ with no shared state, is architecturally normal here.
 
 from __future__ import annotations
 
-from typing import Callable
+from collections.abc import Callable
+from typing import ClassVar
 
 from textual.app import ComposeResult
 from textual.binding import Binding
@@ -36,7 +37,7 @@ class WorkbenchHostScreen(Screen):
     for later tasks, and this task's own conflicts-badge repoint.
     """
 
-    BINDINGS = [Binding("escape", "dismiss_screen", "Back")]
+    BINDINGS: ClassVar = [Binding("escape", "dismiss_screen", "Back")]
 
     def __init__(
         self,

--- a/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
+++ b/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
@@ -7,11 +7,11 @@ FRESH instance on every push. Two pushes -- sequential, or in principle
 started from two different callers -- therefore never share state through
 a widget still attached to the pane behind. No existing precedent for
 "push the same widget class as a fresh full-screen instance" existed in
-this codebase before this module (survey §2); the closest prior art is
-the Queue/Automations tabs' own sibling ``DefinitionDetail`` instances,
-which already establish that two independent instances of the same
-widget class, each self-syncing with no shared state, is architecturally
-normal here.
+this codebase before this module (survey §2); the closest prior art was
+the Queue/Automations tabs' own sibling ``DefinitionDetail`` instances
+(the Automations one retired in task 5), which already established that
+two independent instances of the same widget class, each self-syncing
+with no shared state, is architecturally normal here.
 """
 
 from __future__ import annotations

--- a/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
+++ b/tldw_chatbook/UI/Screens/scheduling/workbench_host_screen.py
@@ -1,0 +1,80 @@
+"""Generic full-screen host for one pushed workbench-pane widget instance.
+
+redesign PR-4, Task 1 (spec §11's narrow-layout push pattern): rather than
+reparenting an already-mounted pane widget out of the Schedules workbench
+into an overlay, a caller hands over a ``widget_factory`` that builds a
+FRESH instance on every push. Two pushes -- sequential, or in principle
+started from two different callers -- therefore never share state through
+a widget still attached to the pane behind. No existing precedent for
+"push the same widget class as a fresh full-screen instance" existed in
+this codebase before this module (survey §2); the closest prior art is
+the Queue/Automations tabs' own sibling ``DefinitionDetail`` instances,
+which already establish that two independent instances of the same
+widget class, each self-syncing with no shared state, is architecturally
+normal here.
+"""
+
+from __future__ import annotations
+
+from typing import Callable, Optional
+
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.screen import Screen
+from textual.widget import Widget
+from textual.widgets import Footer, Header
+
+
+class WorkbenchHostScreen(Screen):
+    """Pushes ``widget_factory()``'s fresh widget instance full-screen.
+
+    ``Esc`` pops. An optional ``dismissed`` hook runs once on pop, letting
+    the pane behind refresh itself (e.g. re-read data that may have
+    changed while the overlay was open) without either screen needing to
+    know about the other's internals -- the staleness re-home consumer
+    for later tasks, and this task's own conflicts-badge repoint.
+    """
+
+    BINDINGS = [Binding("escape", "dismiss_screen", "Back")]
+
+    def __init__(
+        self,
+        widget_factory: Callable[[], Widget],
+        *,
+        title: str,
+        dismissed: Optional[Callable[[], None]] = None,
+    ) -> None:
+        """Initialize the host.
+
+        Args:
+            widget_factory: Builds one fresh widget instance to host.
+                Called exactly once, from ``compose()`` -- never reused
+                across pushes; the caller is responsible for passing a
+                factory that itself builds a new instance per call.
+            title: Shown in the screen's ``Header``.
+            dismissed: Optional hook run once when this screen pops
+                (``Esc``), before the pop completes.
+        """
+        super().__init__()
+        self._widget_factory = widget_factory
+        self.title = title
+        self._dismissed = dismissed
+
+    def compose(self) -> ComposeResult:
+        """Header (title) + the hosted widget (fills remaining space) + Footer (Esc hint)."""
+        yield Header()
+        body = self._widget_factory()
+        body.add_class("workbench-host-body")
+        yield body
+        yield Footer()
+
+    def action_dismiss_screen(self) -> None:
+        """``Esc``: run the on-dismiss hook (if any), then pop.
+
+        Mirrors ``Screen.dismiss()``'s own ordering (result callback before
+        the pop) and its documented safe-usage rule: call without
+        awaiting from within an action handler.
+        """
+        if self._dismissed is not None:
+            self._dismissed()
+        self.dismiss()

--- a/tldw_chatbook/Widgets/detail_value_row.py
+++ b/tldw_chatbook/Widgets/detail_value_row.py
@@ -235,7 +235,8 @@ class DetailValueRow(Vertical):
         self.post_message(self.Activated(self))
 
     def _on_key(self, event: events.Key) -> None:
-        """Activate on Enter, or cancel an open editor on Escape.
+        """Activate on Enter, cancel an open editor on Escape, or
+        traverse to the next/previous row on Up/Down.
 
         PR-3 Task 3: Escape while editing closes the editor without
         committing (``end_edit()``, no caller notified) -- checked FIRST
@@ -249,11 +250,38 @@ class DetailValueRow(Vertical):
         for the OPEN case; stopping it here for the EDITING case is safe
         and deliberate, unlike the open-Select-overlay's own Enter, which
         must keep bubbling to resolve via `App`'s BINDINGS chain.
+
+        redesign PR-4, task 4 (spec §12's "Up/Down traverse detail rows
+        when the pane has focus"): guarded by ``self._editor is None``,
+        the SAME editor-open-ownership rule Enter/Escape already use --
+        an open editor (e.g. a mounted `Select`, which binds Up/Down
+        itself to `show_overlay`) owns the arrow keys, not the row. When
+        no editor is open, Up/Down move focus to the previous/next
+        `DetailValueRow` using Textual's OWN focus-chain machinery
+        (`Screen.focus_previous`/`focus_next`, selector-scoped to this
+        widget class) rather than a hand-rolled row registry: `focus_
+        chain` already excludes non-focusable rows (`can_focus=False`)
+        and anything inside a `display:none` ancestor -- a hidden sibling
+        pane (`.pane-hidden`) or a collapsed `DetailGroup` -- for free, so
+        traversal is naturally scoped to THIS pane's currently-visible,
+        focusable rows without this widget needing to know its own
+        container. Wraps at the ends (`_move_focus`'s own modulo
+        wrap-around) rather than stopping -- picked over stopping since
+        it is what the native mechanism gives for free and is the more
+        common list-traversal convention.
         """
         if event.key == "escape" and self._editor is not None:
             event.stop()
             event.prevent_default()
             self.end_edit()
+            return
+        if event.key in ("up", "down") and self._editor is None:
+            event.stop()
+            event.prevent_default()
+            if event.key == "up":
+                self.screen.focus_previous(DetailValueRow)
+            else:
+                self.screen.focus_next(DetailValueRow)
             return
         if event.key != "enter" or not self._affordance or self._editor is not None:
             return

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -30,13 +30,6 @@
     width: 1fr;
 }
 
-SchedulesWorkbench TabbedContent,
-SchedulesWorkbench TabbedContent ContentSwitcher,
-SchedulesWorkbench TabbedContent TabPane {
-    height: 1fr;
-    min-height: 0;
-}
-
 #scheduling-workbench {
     layout: horizontal;
     height: 1fr;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -509,3 +509,17 @@ DetailGroup {
     background: $ds-surface-panel;
     border-top: hkey $ds-grid-line;
 }
+
+/* redesign PR-4, Task 1: `WorkbenchHostScreen` (the narrow-layout/overlay
+ * push pattern, spec §11) hands the factory-built widget this class so it
+ * fills the space between the screen's `Header`/`Footer` regardless of
+ * whether the hosted widget sizes itself (`ConflictsTab` already does,
+ * via its own `BUNDLED_CSS` -- this covers the panes that don't, e.g.
+ * `TaskDetail`/`DefinitionDetail`, once later tasks push those). Bare
+ * class selector, carried only by whatever `WorkbenchHostScreen.compose`
+ * tags with it -- not ancestor-scoped, so it never counts against the
+ * bare-type fastpath ratchet (PR-3's `test_ancestor_scoped_bare_type_
+ * rule_count_is_a_ratchet`). */
+.workbench-host-body {
+    height: 1fr;
+}

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -235,6 +235,15 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-left: 1;
 }
 
+/* redesign PR-4, task 2: the rail's Results relocation affordance,
+ * beside Mark-all-read -- same auto-width row shape, always visible
+ * (never hidden, unlike Mark-all-read). */
+#scheduling-results-badge {
+    width: auto;
+    min-width: 9;
+    margin-left: 1;
+}
+
 /* Automations tab header (task-5): same title+button row shape as the
  * Queue pane's #scheduling-list-header above. */
 #scheduling-automations-header {

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -13,10 +13,6 @@
     min-height: 0;
 }
 
-#scheduling-tabs {
-    height: 1fr;
-}
-
 /* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
  * across every tab (not Queue-specific), hosting the existing
  * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
@@ -65,55 +61,11 @@ SchedulesWorkbench TabbedContent TabPane {
     height: 1fr;
 }
 
-/* Automations tab (ADR-077): definitions list on the left, the selected
- * definition's durable run history on the right -- the same list|detail
- * idiom as the Queue tab's three panes. */
-#scheduling-automations-split {
-    layout: horizontal;
-    height: 1fr;
-    min-height: 0;
-}
-
-#scheduling-automations-pane {
-    width: 1fr;
-    min-width: 30;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
-#scheduling-automation-history-pane {
-    width: 1fr;
-    min-width: 30;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
-/* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
- * the definitions detail widget (DefinitionDetail), the same list|detail|
- * inspector idiom as the Queue tab's three panes above.
- *
- * min-width 22, not 30 (final review F5): the three panes' min-widths must
- * SUM to no more than the narrowest width at which all three are still
- * shown -- 84, the same `hide_detail` threshold the Queue tab's own detail
- * pane uses. At 30+30+30 = 90 the 84-89 band could not satisfy that, and
- * Textual's fr layout then gave EVERY pane the full container width,
- * laying the detail and history panes out entirely off-screen; the split
- * has overflow: hidden, so not even a scrollbar hinted at it. 30+30+22 =
- * 82 fits 84 with slack. This floor only ever binds inside that band -- at
- * any wider width the 1fr share is larger anyway. */
-#scheduling-automations-detail-pane {
-    width: 1fr;
-    min-width: 22;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
+/* redesign PR-4, task 5: the Automations tab's own three-pane split
+ * (#scheduling-automations-split / -pane / -detail-pane / -history-pane)
+ * is retired with the tab. The ids below that still start with
+ * `#scheduling-automation-detail-` are DefinitionDetail's own CHILD ids,
+ * not that pane's -- they follow the widget wherever it is mounted. */
 #scheduling-automation-detail-empty-state {
     color: $text-muted;
     text-align: center;
@@ -130,19 +82,6 @@ SchedulesWorkbench TabbedContent TabPane {
     border: solid $ds-grid-line;
     background: $ds-surface-panel;
     color: $text;
-}
-
-#scheduling-automations-table {
-    height: 1fr;
-}
-
-#scheduling-automation-history-table {
-    height: 1fr;
-}
-
-#scheduling-automations-notice,
-#scheduling-automation-history-notice {
-    color: $text-muted;
 }
 
 #scheduling-queue-filter {
@@ -244,21 +183,6 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-left: 1;
 }
 
-/* Automations tab header (task-5): same title+button row shape as the
- * Queue pane's #scheduling-list-header above. */
-#scheduling-automations-header {
-    height: auto;
-}
-
-#scheduling-automations-header #scheduling-automations-title {
-    width: 1fr;
-}
-
-#scheduling-new-automation {
-    width: auto;
-    min-width: 9;
-}
-
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;
@@ -308,7 +232,6 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-#scheduling-automation-detail .follow-why,
 #scheduling-queue-definition-detail .follow-why {
     color: $text-muted;
     height: auto;

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -101,26 +101,69 @@
     background: $surface-darken-1;
 }
 
+/* redesign PR-4, task 6 (spec §11): the collapsed-chip control -- one
+ * button standing in for the four named chips below 84 columns. Same
+ * flat single-row look as the chips it replaces (it deliberately does
+ * NOT carry `.scheduling-queue-chip`: that class is what the compact
+ * rule below hides). `display: none` by default, so it only ever appears
+ * at the widths where the four chips are gone. */
+#scheduling-chip-cycle {
+    display: none;
+    height: 1;
+    border: none;
+    width: auto;
+    min-width: 8;
+    background: $surface-darken-1;
+}
+
 /* Compact mode: the filter's margin row goes to the table (80x24 has
- * exactly one spare row; without this the queue shows only the filter).
- * The chip row is hidden outright at this width rather than squeezed
- * further -- it is a filter convenience, not a required affordance, and
- * the narrow-width floor already prioritizes the table + detail pane. */
+ * exactly one spare row; without this the queue shows only the filter). */
 #scheduling-workbench.compact #scheduling-queue-filter {
     margin: 0;
 }
 
+/* The four chips collapse into the cycling control rather than the whole
+ * row disappearing (ruling 6) -- one row either way, and a mouse user
+ * keeps a filter affordance at the floor. The row's own bottom margin
+ * goes to the table for the same reason the filter's does. */
 #scheduling-workbench.compact #scheduling-queue-chips {
+    margin: 0;
+}
+
+#scheduling-workbench.compact #scheduling-queue-chips .scheduling-queue-chip {
     display: none;
+}
+
+#scheduling-workbench.compact #scheduling-chip-cycle {
+    display: block;
+}
+
+/* With both side panes hidden the rail is the only thing on screen, so it
+ * takes the whole width -- it used to keep the 24-column width the
+ * three-pane compact split gives it, wrapping the queue into a gutter
+ * while 54 columns sat empty -- and drops its own frame: the workbench's
+ * border is already the visible edge, and 4 rows of pane chrome is a
+ * sixth of an 80x24 terminal. */
+#scheduling-workbench.compact #scheduling-list-pane {
+    width: 1fr;
+    min-width: 0;
+    border: none;
+    padding: 0 1;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-workbench {
     padding: 0;
 }
 
+/* redesign PR-4, task 6: this used to pin the rail to 24 columns, which
+ * left ~20 usable ones -- narrow enough that the header's three Buttons
+ * wrapped their labels, and an auto-height row of wrapped Buttons grew to
+ * SIXTEEN rows, leaving the queue table a single line at 110x40. Sharing
+ * the width with the detail pane (which keeps its own min-width) fits the
+ * header on one row again and gives the table back its space. */
 SchedulesWorkbench.schedules-workbench-compact #scheduling-list-pane {
-    width: 24;
-    min-width: 20;
+    width: 1fr;
+    min-width: 28;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-detail-pane {
@@ -205,7 +248,12 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     text-style: bold;
 }
 
-#scheduling-task-detail .follow-why {
+/* Both live instances of the pane: the docked one and, at narrow widths,
+ * the fresh instance `WorkbenchHostScreen` hosts (redesign PR-4, task 6).
+ * Listed by id rather than re-keyed to `TaskDetail .follow-why`, which
+ * would be an ancestor-scoped bare-type rule (PR-3's fastpath ratchet). */
+#scheduling-task-detail .follow-why,
+#scheduling-task-detail-overlay .follow-why {
     color: $text-muted;
     height: auto;
     padding: 0 1;
@@ -225,7 +273,9 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-#scheduling-queue-definition-detail .follow-why {
+/* Same pair as the reminder pane's rule above: docked + pushed instance. */
+#scheduling-queue-definition-detail .follow-why,
+#scheduling-definition-detail-overlay .follow-why {
     color: $text-muted;
     height: auto;
     padding: 0 1;
@@ -320,13 +370,25 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0;
 }
 
-/* Compact mode (see SchedulesWorkbench.on_resize): the Queue tab label
- * already names the pane; the in-pane title/New-button row goes to the
- * table (80x24 has exactly one spare row -- the New button stays reachable
- * via the `c` key, which the footer advertises). Hiding the header hides
- * the title Static nested inside it too. */
-#scheduling-workbench.compact #scheduling-list-header {
+/* Compact mode (see SchedulesWorkbench.on_resize): the screen header
+ * already names the pane, so the in-pane TITLE yields its row -- but the
+ * header's buttons do not. redesign PR-4, task 6 (ruling 6: "the rail
+ * degrades readably at 80"): `Create ▾`, `Mark all read` and `Results`
+ * are the only routes to those operations that need no selected row, and
+ * what made the row unaffordable at the floor was the 3-row bordered
+ * Button box, not the buttons. They flatten to one row instead
+ * (height:1/border:none -- the same idiom the chip row and the Runs-on
+ * mini-bar already use), and the header goes from 3 rows to 1. */
+#scheduling-workbench.compact #scheduling-list-title {
     display: none;
+}
+
+#scheduling-workbench.compact #scheduling-new-task,
+#scheduling-workbench.compact #scheduling-mark-all-read,
+#scheduling-workbench.compact #scheduling-results-badge {
+    height: 1;
+    border: none;
+    background: $surface-darken-1;
 }
 
 /* schedules-redesign PR-1, Task 1 (fix round 1): DetailValueRow /

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -5,18 +5,20 @@
  * ======================================== */
 
 /* The liveness Static + bottom status strip are auto-height siblings of
- * the TabbedContent; without an explicit 1fr the auto-height TabbedContent
- * measures its fr children against the whole content area and overflows
- * past the footer. */
+ * #scheduling-workbench (redesign PR-4 task 5 retired the TabbedContent
+ * this rationale used to name); without an explicit 1fr the auto-height
+ * workbench row measures its fr children against the whole content area
+ * and overflows past the footer. */
 #schedules-shell {
     height: 1fr;
     min-height: 0;
 }
 
-/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
- * across every tab (not Queue-specific), hosting the existing
+/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- it sits
+ * below the whole workbench, not inside the list pane, hosting the existing
  * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
- * that switches to the Conflicts tab. SyncStatusWidget takes the
+ * that PUSHES the conflicts view over the list (redesign PR-4 task 5: the
+ * Conflicts tab it used to switch to is retired). SyncStatusWidget takes the
  * remaining width so the badge sits flush right; `align` centers the
  * badge (height:1, from .scheduling-queue-chip) against the taller
  * padded SyncStatusWidget row. */

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -277,15 +277,9 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-/* Transfer action row (schedules-handoff spec §6, PR-5 task 7) */
-#scheduling-task-detail-transfer {
-    height: auto;
-    padding: 0 0 1 0;
-}
-
-#scheduling-task-detail-transfer Button {
-    margin: 0 1 0 0;
-}
+/* redesign PR-4, task 4: the legacy transfer action row (schedules-
+   handoff spec §6, PR-5 task 7) is retired along with its buttons -- the
+   Runs-on row's own dropdown/mini-bar is the one transfer surface now. */
 
 /* Follow-in-Console prominence */
 #schedules-follow-in-console {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13666,18 +13666,20 @@ Button.error:hover {
  * ======================================== */
 
 /* The liveness Static + bottom status strip are auto-height siblings of
- * the TabbedContent; without an explicit 1fr the auto-height TabbedContent
- * measures its fr children against the whole content area and overflows
- * past the footer. */
+ * #scheduling-workbench (redesign PR-4 task 5 retired the TabbedContent
+ * this rationale used to name); without an explicit 1fr the auto-height
+ * workbench row measures its fr children against the whole content area
+ * and overflows past the footer. */
 #schedules-shell {
     height: 1fr;
     min-height: 0;
 }
 
-/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
- * across every tab (not Queue-specific), hosting the existing
+/* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- it sits
+ * below the whole workbench, not inside the list pane, hosting the existing
  * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
- * that switches to the Conflicts tab. SyncStatusWidget takes the
+ * that PUSHES the conflicts view over the list (redesign PR-4 task 5: the
+ * Conflicts tab it used to switch to is retired). SyncStatusWidget takes the
  * remaining width so the badge sits flush right; `align` centers the
  * badge (height:1, from .scheduling-queue-chip) against the taller
  * padded SyncStatusWidget row. */

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13674,10 +13674,6 @@ Button.error:hover {
     min-height: 0;
 }
 
-#scheduling-tabs {
-    height: 1fr;
-}
-
 /* redesign PR-2, Task 3: the bottom status strip (plan ruling 4) -- shared
  * across every tab (not Queue-specific), hosting the existing
  * SyncStatusWidget (owner indicator + sync health) and a conflicts badge
@@ -13726,55 +13722,11 @@ SchedulesWorkbench TabbedContent TabPane {
     height: 1fr;
 }
 
-/* Automations tab (ADR-077): definitions list on the left, the selected
- * definition's durable run history on the right -- the same list|detail
- * idiom as the Queue tab's three panes. */
-#scheduling-automations-split {
-    layout: horizontal;
-    height: 1fr;
-    min-height: 0;
-}
-
-#scheduling-automations-pane {
-    width: 1fr;
-    min-width: 30;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
-#scheduling-automation-history-pane {
-    width: 1fr;
-    min-width: 30;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
-/* schedules-redesign PR-1, Task 4: the Automations tab's third pane --
- * the definitions detail widget (DefinitionDetail), the same list|detail|
- * inspector idiom as the Queue tab's three panes above.
- *
- * min-width 22, not 30 (final review F5): the three panes' min-widths must
- * SUM to no more than the narrowest width at which all three are still
- * shown -- 84, the same `hide_detail` threshold the Queue tab's own detail
- * pane uses. At 30+30+30 = 90 the 84-89 band could not satisfy that, and
- * Textual's fr layout then gave EVERY pane the full container width,
- * laying the detail and history panes out entirely off-screen; the split
- * has overflow: hidden, so not even a scrollbar hinted at it. 30+30+22 =
- * 82 fits 84 with slack. This floor only ever binds inside that band -- at
- * any wider width the 1fr share is larger anyway. */
-#scheduling-automations-detail-pane {
-    width: 1fr;
-    min-width: 22;
-    height: 1fr;
-    min-height: 0;
-    padding: 1;
-    border: solid $ds-grid-line;
-}
-
+/* redesign PR-4, task 5: the Automations tab's own three-pane split
+ * (#scheduling-automations-split / -pane / -detail-pane / -history-pane)
+ * is retired with the tab. The ids below that still start with
+ * `#scheduling-automation-detail-` are DefinitionDetail's own CHILD ids,
+ * not that pane's -- they follow the widget wherever it is mounted. */
 #scheduling-automation-detail-empty-state {
     color: $text-muted;
     text-align: center;
@@ -13791,19 +13743,6 @@ SchedulesWorkbench TabbedContent TabPane {
     border: solid $ds-grid-line;
     background: $ds-surface-panel;
     color: $text;
-}
-
-#scheduling-automations-table {
-    height: 1fr;
-}
-
-#scheduling-automation-history-table {
-    height: 1fr;
-}
-
-#scheduling-automations-notice,
-#scheduling-automation-history-notice {
-    color: $text-muted;
 }
 
 #scheduling-queue-filter {
@@ -13905,21 +13844,6 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-left: 1;
 }
 
-/* Automations tab header (task-5): same title+button row shape as the
- * Queue pane's #scheduling-list-header above. */
-#scheduling-automations-header {
-    height: auto;
-}
-
-#scheduling-automations-header #scheduling-automations-title {
-    width: 1fr;
-}
-
-#scheduling-new-automation {
-    width: auto;
-    min-width: 9;
-}
-
 /* Empty state */
 #scheduling-task-detail-empty-state {
     color: $text-muted;
@@ -13969,7 +13893,6 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-#scheduling-automation-detail .follow-why,
 #scheduling-queue-definition-detail .follow-why {
     color: $text-muted;
     height: auto;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -14171,6 +14171,20 @@ DetailGroup {
     border-top: hkey $ds-grid-line;
 }
 
+/* redesign PR-4, Task 1: `WorkbenchHostScreen` (the narrow-layout/overlay
+ * push pattern, spec §11) hands the factory-built widget this class so it
+ * fills the space between the screen's `Header`/`Footer` regardless of
+ * whether the hosted widget sizes itself (`ConflictsTab` already does,
+ * via its own `BUNDLED_CSS` -- this covers the panes that don't, e.g.
+ * `TaskDetail`/`DefinitionDetail`, once later tasks push those). Bare
+ * class selector, carried only by whatever `WorkbenchHostScreen.compose`
+ * tags with it -- not ancestor-scoped, so it never counts against the
+ * bare-type fastpath ratchet (PR-3's `test_ancestor_scoped_bare_type_
+ * rule_count_is_a_ratchet`). */
+.workbench-host-body {
+    height: 1fr;
+}
+
 /* ===== MODULE: features/_code_repo.tcss ===== */
 /* ========================================
  * Code Repository Copy/Paste Feature Styles

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13691,13 +13691,6 @@ Button.error:hover {
     width: 1fr;
 }
 
-SchedulesWorkbench TabbedContent,
-SchedulesWorkbench TabbedContent ContentSwitcher,
-SchedulesWorkbench TabbedContent TabPane {
-    height: 1fr;
-    min-height: 0;
-}
-
 #scheduling-workbench {
     layout: horizontal;
     height: 1fr;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13762,26 +13762,69 @@ Button.error:hover {
     background: $surface-darken-1;
 }
 
+/* redesign PR-4, task 6 (spec §11): the collapsed-chip control -- one
+ * button standing in for the four named chips below 84 columns. Same
+ * flat single-row look as the chips it replaces (it deliberately does
+ * NOT carry `.scheduling-queue-chip`: that class is what the compact
+ * rule below hides). `display: none` by default, so it only ever appears
+ * at the widths where the four chips are gone. */
+#scheduling-chip-cycle {
+    display: none;
+    height: 1;
+    border: none;
+    width: auto;
+    min-width: 8;
+    background: $surface-darken-1;
+}
+
 /* Compact mode: the filter's margin row goes to the table (80x24 has
- * exactly one spare row; without this the queue shows only the filter).
- * The chip row is hidden outright at this width rather than squeezed
- * further -- it is a filter convenience, not a required affordance, and
- * the narrow-width floor already prioritizes the table + detail pane. */
+ * exactly one spare row; without this the queue shows only the filter). */
 #scheduling-workbench.compact #scheduling-queue-filter {
     margin: 0;
 }
 
+/* The four chips collapse into the cycling control rather than the whole
+ * row disappearing (ruling 6) -- one row either way, and a mouse user
+ * keeps a filter affordance at the floor. The row's own bottom margin
+ * goes to the table for the same reason the filter's does. */
 #scheduling-workbench.compact #scheduling-queue-chips {
+    margin: 0;
+}
+
+#scheduling-workbench.compact #scheduling-queue-chips .scheduling-queue-chip {
     display: none;
+}
+
+#scheduling-workbench.compact #scheduling-chip-cycle {
+    display: block;
+}
+
+/* With both side panes hidden the rail is the only thing on screen, so it
+ * takes the whole width -- it used to keep the 24-column width the
+ * three-pane compact split gives it, wrapping the queue into a gutter
+ * while 54 columns sat empty -- and drops its own frame: the workbench's
+ * border is already the visible edge, and 4 rows of pane chrome is a
+ * sixth of an 80x24 terminal. */
+#scheduling-workbench.compact #scheduling-list-pane {
+    width: 1fr;
+    min-width: 0;
+    border: none;
+    padding: 0 1;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-workbench {
     padding: 0;
 }
 
+/* redesign PR-4, task 6: this used to pin the rail to 24 columns, which
+ * left ~20 usable ones -- narrow enough that the header's three Buttons
+ * wrapped their labels, and an auto-height row of wrapped Buttons grew to
+ * SIXTEEN rows, leaving the queue table a single line at 110x40. Sharing
+ * the width with the detail pane (which keeps its own min-width) fits the
+ * header on one row again and gives the table back its space. */
 SchedulesWorkbench.schedules-workbench-compact #scheduling-list-pane {
-    width: 24;
-    min-width: 20;
+    width: 1fr;
+    min-width: 28;
 }
 
 SchedulesWorkbench.schedules-workbench-compact #scheduling-detail-pane {
@@ -13866,7 +13909,12 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     text-style: bold;
 }
 
-#scheduling-task-detail .follow-why {
+/* Both live instances of the pane: the docked one and, at narrow widths,
+ * the fresh instance `WorkbenchHostScreen` hosts (redesign PR-4, task 6).
+ * Listed by id rather than re-keyed to `TaskDetail .follow-why`, which
+ * would be an ancestor-scoped bare-type rule (PR-3's fastpath ratchet). */
+#scheduling-task-detail .follow-why,
+#scheduling-task-detail-overlay .follow-why {
     color: $text-muted;
     height: auto;
     padding: 0 1;
@@ -13886,7 +13934,9 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-#scheduling-queue-definition-detail .follow-why {
+/* Same pair as the reminder pane's rule above: docked + pushed instance. */
+#scheduling-queue-definition-detail .follow-why,
+#scheduling-definition-detail-overlay .follow-why {
     color: $text-muted;
     height: auto;
     padding: 0 1;
@@ -13981,13 +14031,25 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     padding: 0;
 }
 
-/* Compact mode (see SchedulesWorkbench.on_resize): the Queue tab label
- * already names the pane; the in-pane title/New-button row goes to the
- * table (80x24 has exactly one spare row -- the New button stays reachable
- * via the `c` key, which the footer advertises). Hiding the header hides
- * the title Static nested inside it too. */
-#scheduling-workbench.compact #scheduling-list-header {
+/* Compact mode (see SchedulesWorkbench.on_resize): the screen header
+ * already names the pane, so the in-pane TITLE yields its row -- but the
+ * header's buttons do not. redesign PR-4, task 6 (ruling 6: "the rail
+ * degrades readably at 80"): `Create ▾`, `Mark all read` and `Results`
+ * are the only routes to those operations that need no selected row, and
+ * what made the row unaffordable at the floor was the 3-row bordered
+ * Button box, not the buttons. They flatten to one row instead
+ * (height:1/border:none -- the same idiom the chip row and the Runs-on
+ * mini-bar already use), and the header goes from 3 rows to 1. */
+#scheduling-workbench.compact #scheduling-list-title {
     display: none;
+}
+
+#scheduling-workbench.compact #scheduling-new-task,
+#scheduling-workbench.compact #scheduling-mark-all-read,
+#scheduling-workbench.compact #scheduling-results-badge {
+    height: 1;
+    border: none;
+    background: $surface-darken-1;
 }
 
 /* schedules-redesign PR-1, Task 1 (fix round 1): DetailValueRow /

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13938,15 +13938,9 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin: 0 1 0 0;
 }
 
-/* Transfer action row (schedules-handoff spec §6, PR-5 task 7) */
-#scheduling-task-detail-transfer {
-    height: auto;
-    padding: 0 0 1 0;
-}
-
-#scheduling-task-detail-transfer Button {
-    margin: 0 1 0 0;
-}
+/* redesign PR-4, task 4: the legacy transfer action row (schedules-
+   handoff spec §6, PR-5 task 7) is retired along with its buttons -- the
+   Runs-on row's own dropdown/mini-bar is the one transfer surface now. */
 
 /* Follow-in-Console prominence */
 #schedules-follow-in-console {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13896,6 +13896,15 @@ SchedulesWorkbench.schedules-workbench-compact #scheduling-inspector-pane {
     margin-left: 1;
 }
 
+/* redesign PR-4, task 2: the rail's Results relocation affordance,
+ * beside Mark-all-read -- same auto-width row shape, always visible
+ * (never hidden, unlike Mark-all-read). */
+#scheduling-results-badge {
+    width: auto;
+    min-width: 9;
+    margin-left: 1;
+}
+
 /* Automations tab header (task-5): same title+button row shape as the
  * Queue pane's #scheduling-list-header above. */
 #scheduling-automations-header {

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -1975,6 +1975,14 @@
     }
 
 
+/* ===== WIDGET: DefinitionAuditView (UI/Screens/scheduling/definition_audit_view.py) ===== */
+
+
+    DefinitionAuditView #scheduling-audit-view-table {
+        height: 1fr;
+    }
+
+
 /* ===== WIDGET: ResultsTab (UI/Screens/scheduling/results_tab.py) ===== */
 
 

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2063,11 +2063,6 @@
         height: auto;
     }
 
-    TaskDetail .scheduling-detail-managed {
-        color: $text-muted;
-        height: auto;
-        margin-top: 1;
-    }
 
 
 /* ===== WIDGET: TrajectoryScreen (UI/Screens/trajectory_screen.py) ===== */

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -1530,6 +1530,14 @@
 
 
 
+/* ===== WIDGET: DefinitionAuditView (UI/Screens/scheduling/definition_audit_view.py) ===== */
+
+    DefinitionAuditView {
+        height: 1fr;
+    }
+
+
+
 /* ===== WIDGET: ResultsTab (UI/Screens/scheduling/results_tab.py) ===== */
 
     ResultsTab {


### PR DESCRIPTION
The fourth and final slice of the schedules-screen redesign (spec §11-phase-4/§12/§13; plan tracked in this PR). The redesign program completes: the Schedules screen is now ONE surface.

## What ships
- **The tabs are gone**: Automations, Conflicts, and Results retired with every unique capability relocated — the execution-audit trail, the results view (list/read/dismiss/mark-solved/mark-all, definition-filtered), the conflicts view, and definition run-now/edit all live on or push from the unified Queue. The workbench shed ~600 lines net.
- **`WorkbenchHostScreen`** — the repo's first pushed-surface pattern (fresh instance per push, Esc pops, allowlisted message routing, pop-time refresh callbacks) serves conflicts, results, the audit view, and the narrow-width detail.
- **All families visible**: agent_task and unknown-family server definitions list read-only with honest notes (retiring the tab no longer hides them); authoring stays recurring_question-pinned.
- **The spec-§12 keyboard map**: `1-4`/`f` chips, `/` search, `n` create, `p` pause/resume, `m` move owner (width-aware — below the floor it pushes the detail and activates the Runs-on row), `r` mark read, Up/Down detail-row traversal riding Textual's native focus chain; the legacy fixed-direction transfer keys and their duplicated flow are deleted — the Runs-on row is the one transfer surface.
- **The 80×24 floor genuinely works** — at base it painted zero queue rows (and 110 cols wrapped the rail into a 16-row header); now every operation is reachable at 80×24 via push or modal, pinned at three widths. The pushed detail is identity-pinned (a background refresh can never re-feed it with a different row — the wrong-row-delete class closed; a vanished row auto-pops with a notice).
- **The User Guide rewritten** for the single surface (+455/−310).

## Review trail
6 SDD tasks, each reviewed (one Critical process incident — a false green-test claim — caught by the reviewer's independent gate re-run and formally corrected; the exact-tail-lines discipline now standing). Final whole-branch review (opus): 1 Critical + 3 Important, all MEASURED (the `m`-key freeze at 80×24, the pushed-pane index-0 re-feed, the unreachable ConflictResolved handler masked by a direct-call test, a mount-race flake) — one wave fixed all 9 findings with 5 self-neuter-verified pins, scoped re-review ALL RESOLVED. Gates: 1029 Scheduling + 413 UI + 22 floor pins green; bare-type census IMPROVED (274→273); pin no-drift; bundle byte-identical.

## Pre-existing, NOT this PR (attributed via detached-worktree baselines)
The 3 baseline-red ratchet/allowlist tests (identical names at base); the boot-css byte snapshot predates the whole program (base red ~19KB; this branch adds +1,905B — the snapshot refresh is a named close-out follow-up with task-24459).

## Deferred (ledgered for close-out follow-ups)
TaskDetail's unreachable projection-rendering layer (deletion argument documented, ~6 live None-guards excluded); pushed-detail key mirroring (v1: the operations live on rows/buttons inside); shell-chrome floor rows (13 of 24 belong to the app shell, not this screen).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retires the Automations, Conflicts, and Results tabs so the Schedules screen is one unified Queue surface. Every capability those tabs served — execution audit trail, results inbox with read/dismiss/solve, conflicts view, and definition run-now/edit — now lives on or pushes from the Queue, netting ~600 fewer lines.

**Key changes**
- `WorkbenchHostScreen` pushes fresh full-screen instances (Esc pops) for the detail, results, conflicts, and audit views.
- All definition families (including `agent_task` and unknown) list read-only with honest notes; authoring stays `recurring_question`-pinned.
- Spec §12 keyboard map: `1-4`/`f` chips, `/` search, `n` create, `p` pause/resume, `m` move owner (width-aware), `r` mark read, Up/Down detail-row traversal.
- The 80×24 floor works: every operation is reachable at base width via push or modal, and pushed detail is identity-pinned so a stale refresh can’t re-feed a different row.
- The legacy transfer keys and their duplicate flow are gone; the Runs-on row is the only transfer surface.

**Rollout notes**
- The boot CSS byte snapshot predates the redesign program and still needs refreshing (falls out as a named close-out follow-up).
- Three baseline-red ratchet/allowlist tests are pre-existing and not addressed here.

<sup>Written for commit 6aad17298c2251d59dbf9fe1e0fa0d22ce503c9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2389?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

