### PR TITLE
feat(console): theme-aware colour grammar for the context rail (TASK-31429)

### DIFF
--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -48,6 +48,17 @@ Top to bottom:
   the rail; while collapsed, the **Context->** handle on the far left
   brings it back. With focus anywhere in the rail, **Ctrl+Shift+←**
   collapses every section and **Ctrl+Shift+→** expands them all.
+  Colour in the rail follows your theme and carries four meanings: the
+  theme's **primary** hue marks what you are *in* (the active workspace
+  name, the active-chat line, and the selected conversation row); the
+  **accent** hue marks a *value* beside its grey label (Temperature,
+  Max tokens, Storage, …); **status** colours mark *state* (the Agent line
+  while a run is running, done, stuck, or failed, and conversation rows
+  whose fleet marker shows a run is running, needs approval, or finished);
+  plain grey is labels and help copy. Keyboard focus keeps its own
+  separate tint, so "which chat am I in" and "where is focus" never look
+  the same. Every built-in theme and any theme saved from
+  **Settings ▸ Theme** recolours the rail automatically.
 - **Conversation pane** — titled "Conversation", extended to
   "Conversation | \<session title\>" once a session is active.
   Above it sits the session tab strip: one button per tab (each with a
@@ -565,7 +576,14 @@ operation immediately, no restart needed.
   "Console: Change model…".
 
 —
-*Verified against working tree — 2026-08-30 (TASK-23193/23195/23196/23197/
+*Verified against working tree — 2026-09-04 (TASK-31429, Context-rail colour
+grammar: live tmux captures of the real app on textual-dark, textual-light,
+and the Orb apricot theme, colour-decoded from `capture-pane -e`, show the
+active-chat line and selected row in each theme's text-primary, label/value
+pairs as muted label + text-accent value, and the Agent line in the theme
+primary while a real llama-server run was in progress; a mounted rule-match
+probe pins the same three resolutions in `test_console_rail_color_grammar.py`).
+Verified against working tree — 2026-08-30 (TASK-23193/23195/23196/23197/
 23198/23199/23200, Context rail UX pass: the rail's default open set is now
 Sessions + Conversations and the whole rail fits at 160x48 with all seven
 headers reachable; the header reads **Context ◂**; the outer hint names the

--- a/Tests/UI/test_console_keyboard_trust.py
+++ b/Tests/UI/test_console_keyboard_trust.py
@@ -64,7 +64,9 @@ def test_focus_bg_token_is_visibly_raised_not_surface():
     [
         ".console-rail-collapse-button:focus",
         ".console-switcher-result:focus",
-        ".console-workspace-conversation-row Button:focus",
+        # TASK-31429 (Qodo review): the row IS the Button, so the rule must
+        # target it directly -- the former descendant form never matched.
+        ".console-workspace-conversation-row:focus",
     ],
 )
 def test_console_focus_gaps_have_contract_style_rules(selector):

--- a/Tests/UI/test_console_rail_color_grammar.py
+++ b/Tests/UI/test_console_rail_color_grammar.py
@@ -346,3 +346,133 @@ async def test_rail_grammar_resolves_to_the_active_theme_colors() -> None:
         # $ds-active-fg -> $text-primary
         assert workspace.styles.color.hex == Color.parse(theme["text-primary"]).hex
         assert workspace.styles.color.hex != value.styles.color.hex
+
+
+# --- review follow-ups (Qodo, PR #2393) -------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_focused_selected_row_still_paints_the_focus_contract() -> None:
+    """Selection is now a foreground hue; keyboard focus must remain its own
+    visible signal on the SAME row. The row is itself a Button, so the focus
+    rule has to target `.console-workspace-conversation-row:focus` -- the
+    former descendant form (`… Button:focus`) matched nothing."""
+    from dataclasses import replace
+
+    from textual.color import Color
+    from textual.widgets import Button
+
+    from Tests.UI.test_console_workspace_context_rail import (
+        ConsoleHarness,
+        _base_grouped_workspace_state,
+        _browser_row,
+        _build_test_app,
+        _grouped_browser_state,
+        _wait_for_selector,
+    )
+    from tldw_chatbook.Widgets.Console.console_workspace_context import (
+        ConsoleWorkspaceContextTray,
+    )
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+        browser = _grouped_browser_state(
+            rows=(
+                _browser_row(
+                    "conv-a",
+                    "Selected chat",
+                    scope_type="global",
+                    workspace_id=None,
+                    workspace_label="Chats",
+                    selected=True,
+                ),
+            )
+        )
+        tray.sync_state(
+            replace(_base_grouped_workspace_state(), conversation_browser=browser)
+        )
+        selected: Button | None = None
+        for _ in range(200):
+            rows = [
+                b
+                for b in console.query(Button)
+                if b.has_class("console-workspace-conversation-row-selected")
+            ]
+            if rows:
+                selected = rows[0]
+                break
+            await pilot.pause(0.01)
+        assert selected is not None, "no selected conversation row rendered"
+
+        theme = host.get_css_variables()
+        resting_bg = selected.styles.background
+        selected.focus()
+        await pilot.pause()
+        assert selected.has_focus
+        focus_tint = Color.parse(theme["block-cursor-blurred-background"])
+        assert selected.styles.background.hex == focus_tint.hex, (
+            f"focused row bg {selected.styles.background.hex} != $ds-focus-bg"
+        )
+        assert selected.styles.background != resting_bg
+        assert "underline" in str(selected.styles.text_style)
+
+
+@pytest.mark.asyncio
+async def test_fresh_rail_compose_applies_the_agent_status_class() -> None:
+    """A recomposed rail builds a NEW status Static; the screen-side sync
+    skips unchanged payloads, so the colour class must be applied at compose
+    time from the status line the rail is constructed with."""
+    from textual.app import App, ComposeResult
+
+    from Tests.UI.test_console_rail_reconciliation import (
+        _all_open_rail_state,
+        _workspace_state,
+    )
+    from tldw_chatbook.Chat.console_session_settings import ConsoleSettingsSummaryState
+    from tldw_chatbook.UI.Console_Modules.left_rail import ConsoleLeftRail
+    from tldw_chatbook.Widgets.Console.console_inspector_section import (
+        ConsoleInspectorSectionState,
+    )
+
+    class _RailApp(App[None]):
+        def compose(self) -> ComposeResult:
+            yield ConsoleLeftRail(
+                rail_state=_all_open_rail_state(),
+                workspace_context_state=_workspace_state(),
+                workspace_tree_expanded_ids=None,
+                workspace_tree_expansion_preferences_changed=None,
+                settings_summary_state=ConsoleSettingsSummaryState(
+                    model_row="Model: test",
+                    context_row="Context: 0",
+                    sampling_row="T 0.7 · max_tokens 100",
+                    identity_row="Identity: character",
+                ),
+                system_line_text="System: none",
+                system_line_dim=True,
+                fleet_line="",
+                agent_status_line="Agent: done",
+                agent_steps_text="",
+                agent_fleet_section_state=ConsoleInspectorSectionState(
+                    rows=(), summary=""
+                ),
+                agent_drilldown_active=False,
+                agent_full_log_available=False,
+                show_character_section=False,
+                character_avatar_widget_builder=(
+                    lambda _box=None, **_kwargs: Static("avatar")
+                ),
+                character_avatar_name="Samira",
+            )
+
+    app = _RailApp()
+    async with app.run_test(size=(60, 50)) as pilot:
+        await pilot.pause()
+        status = app.query_one("#console-agent-section-status", Static)
+        assert status.has_class("console-agent-section-status-done")
+        assert status.has_class("console-agent-section-line")

--- a/Tests/UI/test_console_rail_color_grammar.py
+++ b/Tests/UI/test_console_rail_color_grammar.py
@@ -1,0 +1,348 @@
+"""Console context rail colour grammar (TASK-31429).
+
+Four meanings, no decoration: primary hue = what you are in, accent hue = a
+value, status hues = state, muted = labels/help. Both new tokens reference
+Textual's generated polarity-aware variables so every theme recolors the
+rail without editor changes (mechanism note atop themes.py: theme-dict
+``ds-*`` entries are inert, tcss references to generated names are not).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.test_console_agent_tool_row_css import (
+    _STYLESHEETS,
+    _css_block,
+    _stylesheet_text,
+)
+from tldw_chatbook.Chat.console_chat_models import (
+    CONSOLE_RUN_MARKER_GLYPHS,
+    ConsoleRunMarker,
+)
+
+_CORE_VARIABLES = Path("tldw_chatbook/css/core/_variables.tcss")
+_SOURCE = Path("tldw_chatbook/css/components/_agentic_terminal.tcss")
+
+_ROW_MARKER_CLASSES = {
+    marker: f"console-workspace-conversation-row-{marker.value}"
+    for marker in ConsoleRunMarker
+    if marker is not ConsoleRunMarker.NONE
+}
+
+# selector -> (property, value) the rail grammar pins in source AND in the
+# generated sheet the running app loads.
+_EXPECTED_DECLARATIONS = {
+    ".console-workspace-status-value": ("color", "$ds-value-fg"),
+    ".console-model-section-value": ("color", "$ds-value-fg"),
+    "#console-active-workspace-value": ("color", "$ds-active-fg"),
+    # id+class: the muted placeholder rule on the same Static is an id rule.
+    "#console-workspace-selected-conversation.console-workspace-selected-conversation-active": (
+        "color",
+        "$ds-active-fg",
+    ),
+    ".console-workspace-conversation-row-selected": ("color", "$ds-active-fg"),
+    "#console-model-section-recovery": ("color", "$ds-status-error-readable"),
+    ".console-agent-section-status-running": ("color", "$ds-status-running"),
+    ".console-agent-section-status-done": ("color", "$ds-status-ready"),
+    ".console-agent-section-status-stuck": ("color", "$ds-status-warning"),
+    ".console-agent-section-status-error": ("color", "$ds-status-error-readable"),
+    ".console-agent-section-status-cancelled": ("color", "$ds-status-error-readable"),
+    ".console-workspace-conversation-row-running": ("color", "$ds-status-running"),
+    ".console-workspace-conversation-row-needs-approval": (
+        "color",
+        "$ds-status-approval-required",
+    ),
+    ".console-workspace-conversation-row-finished-ok": ("color", "$ds-status-ready"),
+    ".console-workspace-conversation-row-finished-failed": (
+        "color",
+        "$ds-status-error-readable",
+    ),
+    ".console-workspace-conversation-row-subagent-unseen": ("color", "$ds-status-info"),
+}
+
+
+def _declaration(block: str, prop: str) -> str:
+    match = re.search(rf"(?m)^\s*{re.escape(prop)}\s*:\s*([^;]+);", block)
+    assert match, f"no `{prop}` declaration in block: {block!r}"
+    return match.group(1).strip()
+
+
+# --- tokens -----------------------------------------------------------------
+
+
+def test_rail_tokens_reference_generated_theme_variables() -> None:
+    text = _CORE_VARIABLES.read_text(encoding="utf-8")
+    assert re.search(r"^\$ds-active-fg:\s*\$text-primary;", text, re.MULTILINE)
+    assert re.search(r"^\$ds-value-fg:\s*\$text-accent;", text, re.MULTILINE)
+
+
+# --- agent status line --------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("status_line", "expected"),
+    [
+        ("Agent: running · step 3", "running"),
+        ("Agent: done", "done"),
+        ("Agent: stuck", "stuck"),
+        ("Agent: error", "error"),
+        ("Agent: cancelled", "cancelled"),
+        ("Sub-agent · running", "running"),
+        ("Sub-agent · done", "done"),
+        ("Agent: idle", ""),
+        ("Agent: unavailable", ""),
+        ("", ""),
+    ],
+)
+def test_agent_status_state_maps_known_statuses(
+    status_line: str, expected: str
+) -> None:
+    from tldw_chatbook.UI.Console_Modules.agent import console_agent_status_state
+
+    assert console_agent_status_state(status_line) == expected
+
+
+def test_apply_agent_status_state_swaps_one_state_class() -> None:
+    from tldw_chatbook.UI.Console_Modules.agent import apply_console_agent_status_state
+
+    status = Static("", classes="console-agent-section-line")
+    apply_console_agent_status_state(status, "Agent: running · step 1")
+    assert status.has_class("console-agent-section-status-running")
+
+    apply_console_agent_status_state(status, "Agent: done")
+    assert status.has_class("console-agent-section-status-done")
+    assert not status.has_class("console-agent-section-status-running")
+
+    apply_console_agent_status_state(status, "Agent: idle")
+    assert not any(
+        cls.startswith("console-agent-section-status-") for cls in status.classes
+    ), "idle must leave the line uncolored"
+    assert status.has_class("console-agent-section-line"), "base class must survive"
+
+
+@pytest.mark.asyncio
+async def test_mounted_agent_status_line_carries_state_class(monkeypatch) -> None:
+    """The screen's section sync applies the state class to the real Static."""
+    from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-agent-section-status")
+        real_payload = console._agent._console_agent_section_payload()
+        patched = ("Agent: running · step 1",) + tuple(real_payload[1:])
+        monkeypatch.setattr(
+            console._agent, "_console_agent_section_payload", lambda: patched
+        )
+        console._sync_console_agent_section()
+        await pilot.pause()
+        status = console.query_one("#console-agent-section-status", Static)
+        assert status.has_class("console-agent-section-status-running")
+
+
+# --- conversation rows ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "marker",
+    [m for m in ConsoleRunMarker if m is not ConsoleRunMarker.NONE],
+    ids=lambda m: m.value,
+)
+def test_conversation_row_carries_run_marker_state_class(
+    marker: ConsoleRunMarker,
+) -> None:
+    from tldw_chatbook.Widgets.Console.console_workspace_context import (
+        ConsoleWorkspaceContextTray,
+    )
+
+    button = ConsoleWorkspaceContextTray._conversation_button(
+        "Title\nsecondary",
+        id="row-marked",
+        conversation_id="c1",
+        run_marker=CONSOLE_RUN_MARKER_GLYPHS[marker],
+    )
+    assert button.has_class(_ROW_MARKER_CLASSES[marker])
+    others = set(_ROW_MARKER_CLASSES.values()) - {_ROW_MARKER_CLASSES[marker]}
+    assert not any(button.has_class(cls) for cls in others)
+
+
+def test_unmarked_conversation_row_has_no_state_class() -> None:
+    from tldw_chatbook.Widgets.Console.console_workspace_context import (
+        ConsoleWorkspaceContextTray,
+    )
+
+    button = ConsoleWorkspaceContextTray._conversation_button(
+        "Title\nsecondary", id="row-plain", conversation_id="c1", run_marker=""
+    )
+    assert not any(button.has_class(cls) for cls in _ROW_MARKER_CLASSES.values())
+
+
+@pytest.mark.asyncio
+async def test_selected_conversation_line_is_marked_active_only_with_a_summary() -> (
+    None
+):
+    from dataclasses import replace
+
+    from Tests.UI.test_console_workspace_context_rail import (
+        ConsoleHarness,
+        _base_grouped_workspace_state,
+        _browser_row,
+        _build_test_app,
+        _grouped_browser_state,
+        _wait_for_selector,
+    )
+    from tldw_chatbook.Widgets.Console.console_workspace_context import (
+        ConsoleWorkspaceContextTray,
+    )
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 44)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        tray = console.query_one(
+            "#console-workspace-context", ConsoleWorkspaceContextTray
+        )
+
+        active_class = "console-workspace-selected-conversation-active"
+
+        async def _line_after_recompose(expected_text: str) -> Static:
+            # sync_state schedules refresh(recompose=True); wait for the
+            # rebuilt Static to carry the new summary before asserting.
+            for _ in range(200):
+                line = console.query_one(
+                    "#console-workspace-selected-conversation", Static
+                )
+                if str(line.renderable).strip() == expected_text:
+                    return line
+                await pilot.pause(0.01)
+            raise AssertionError(f"line never showed {expected_text!r}")
+
+        def _chats_bucket_row(selected: bool):
+            # The Conversations tray summarises only the Chats bucket
+            # (global rows); workspace rows are summarised by their tray.
+            return _browser_row(
+                "conv-a",
+                "Loose chat",
+                scope_type="global",
+                workspace_id=None,
+                workspace_label="Chats",
+                selected=selected,
+            )
+
+        # A selected row yields a non-empty summary -> the line names the
+        # active chat and takes the active hue.
+        state = _base_grouped_workspace_state()
+        selected = _grouped_browser_state(rows=(_chats_bucket_row(True),))
+        assert selected.selected_summary, "fixture must select a row"
+        tray.sync_state(replace(state, conversation_browser=selected))
+        line = await _line_after_recompose(selected.selected_summary)
+        assert line.has_class(active_class)
+
+        # No selected row -> placeholder copy stays muted.
+        unselected = _grouped_browser_state(rows=(_chats_bucket_row(False),))
+        assert not unselected.selected_summary
+        tray.sync_state(replace(state, conversation_browser=unselected))
+        line = await _line_after_recompose("No active conversation.")
+        assert not line.has_class(active_class)
+
+
+# --- stylesheet contract -------------------------------------------------------
+
+
+@pytest.mark.parametrize("entry", _STYLESHEETS, ids=lambda e: _stylesheet_text(e)[0])
+@pytest.mark.parametrize(
+    ("selector", "declaration"),
+    sorted(_EXPECTED_DECLARATIONS.items()),
+    ids=lambda v: v if isinstance(v, str) else v[1],
+)
+def test_rail_grammar_declarations_in_source_and_generated_sheet(
+    entry, selector: str, declaration: tuple[str, str]
+) -> None:
+    label, text = _stylesheet_text(entry)
+    prop, value = declaration
+    assert _declaration(_css_block(text, selector), prop) == value, (
+        f"{label}: {selector} {prop} must be {value}"
+    )
+
+
+@pytest.mark.parametrize("entry", _STYLESHEETS, ids=lambda e: _stylesheet_text(e)[0])
+def test_status_labels_are_muted_and_not_bold(entry) -> None:
+    label, text = _stylesheet_text(entry)
+    block = _css_block(text, ".console-workspace-status-label")
+    assert _declaration(block, "color") == "$ds-text-muted", label
+    assert "bold" not in block, f"{label}: labels must not compete with values"
+
+
+def test_selected_row_rule_follows_every_marker_rule_in_source() -> None:
+    """Equal specificity: source order decides, and selection must win."""
+    text = re.sub(
+        r"/\*.*?\*/", "", _SOURCE.read_text(encoding="utf-8"), flags=re.DOTALL
+    )
+    selected_at = text.index(".console-workspace-conversation-row-selected {")
+    for cls in _ROW_MARKER_CLASSES.values():
+        assert text.index(f".{cls} {{") < selected_at, cls
+
+
+# --- resolved paint --------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rail_grammar_resolves_to_the_active_theme_colors() -> None:
+    """Rule-match probe on the mounted Console (lessons-testing-evidence,
+    task-31264): the tokens must RESOLVE to the running theme's generated
+    values, not merely be declared -- a shadowed token would pass the text
+    contracts above and still paint the wrong colour."""
+    from textual.color import Color
+
+    from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+    from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+        ConsoleHarness,
+    )
+    from tldw_chatbook.UI.Console_Modules.agent import apply_console_agent_status_state
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-agent-section-status")
+        theme = host.get_css_variables()
+
+        status = console.query_one("#console-agent-section-status", Static)
+        apply_console_agent_status_state(status, "Agent: running · step 1")
+        await pilot.pause()
+        # $ds-status-running -> $primary
+        assert status.styles.color.hex == Color.parse(theme["primary"]).hex
+
+        # Model and Workspaces ship collapsed; a closed section has no body.
+        rail_state = console._current_console_rail_state()
+        if not rail_state.model_open:
+            console._toggle_console_rail_section("model")
+        if not rail_state.workspace_open:
+            console._toggle_console_rail_section("workspace")
+        await _wait_for_selector(console, pilot, "#console-model-section-temperature")
+        await _wait_for_selector(console, pilot, "#console-active-workspace-value")
+
+        value = console.query_one(
+            "#console-model-section-temperature .console-model-section-value", Static
+        )
+        label = console.query_one(
+            "#console-model-section-temperature .console-model-section-label", Static
+        )
+        # $ds-value-fg -> $text-accent; the label stays a different, muted colour.
+        assert value.styles.color.hex == Color.parse(theme["text-accent"]).hex
+        assert label.styles.color.hex != value.styles.color.hex
+
+        workspace = console.query_one("#console-active-workspace-value", Static)
+        # $ds-active-fg -> $text-primary
+        assert workspace.styles.color.hex == Color.parse(theme["text-primary"]).hex
+        assert workspace.styles.color.hex != value.styles.color.hex

--- a/Tests/UI/test_theme_contrast.py
+++ b/Tests/UI/test_theme_contrast.py
@@ -46,6 +46,10 @@ def test_core_variables_do_not_freeze_readable_tokens_to_literals():
         "ds-status-error-readable",
         "ds-text-placeholder",
         "ds-text-disabled-readable",
+        # TASK-31429: Console rail grammar (active = primary hue, value =
+        # accent hue) must follow the theme the same way.
+        "ds-active-fg",
+        "ds-value-fg",
     ):
         match = re.search(rf"^\${re.escape(token)}:\s*([^;]+);", text, re.M)
         assert match, f"{token} not defined in _variables.tcss"
@@ -80,16 +84,43 @@ def test_resolved_readable_tokens_clear_aa_on_every_theme(theme: Theme) -> None:
     """The values `$text-error` / `$text-muted` resolve to at runtime (theme
     variables dict over Textual's generated set) must clear AA on the theme's
     own surfaces — these feed the ds readable tokens since task-31264;
-    task-31283 extended the gate from the Orb 12 to every registered theme."""
+    task-31283 extended the gate from the Orb 12 to every registered theme.
+    TASK-31429 adds `text-primary` / `text-accent`: the Console rail paints
+    the active workspace/conversation and every label's value with them."""
     resolved = _resolved_variables(theme)
     surfaces = [Color.parse(resolved[k]) for k in ("surface", "panel")]
-    for token in ("text-error", "text-muted"):
+    for token in ("text-error", "text-muted", "text-primary", "text-accent"):
         for surface in surfaces:
             blended = _resolve_color(resolved[token], surface)
             ratio = _ratio(blended.hex, surface.hex)
             assert ratio >= AA, (
                 f"{theme.name}: resolved {token} {blended.hex} is {ratio:.2f}:1 "
                 f"against {surface.hex} (needs {AA}:1)"
+            )
+
+
+def test_user_saved_theme_gets_readable_text_hues(tmp_path) -> None:
+    """TASK-31429: a theme saved from Settings ▸ Theme with a mid-tone
+    primary/accent on a light canvas (pastel_dreams' palette) must still
+    resolve readable `text-primary` / `text-accent` — the readability fix has
+    to live on the load path, not only in the shipped catalog."""
+    from tldw_chatbook.css.Themes.themes import load_user_themes
+
+    (tmp_path / "pastel.toml").write_text(
+        '[theme]\nname = "pastel_probe"\ndark = false\n'
+        '[colors]\nprimary = "#F4C2C2"\naccent = "#B3D9E6"\n'
+        'background = "#FFF8F8"\nsurface = "#FFFFFF"\npanel = "#FBEFEF"\n'
+        'foreground = "#4A4A4A"\n',
+        encoding="utf-8",
+    )
+    (theme,) = load_user_themes(tmp_path)
+    resolved = _resolved_variables(theme)
+    for token in ("text-primary", "text-accent"):
+        for key in ("surface", "panel"):
+            surface = Color.parse(resolved[key])
+            blended = _resolve_color(resolved[token], surface)
+            assert _ratio(blended.hex, surface.hex) >= AA, (
+                f"user theme {token} {blended.hex} on {surface.hex}"
             )
 
 

--- a/backlog/docs/lessons-backlog-hygiene.md
+++ b/backlog/docs/lessons-backlog-hygiene.md
@@ -83,6 +83,20 @@ carried a bad number.
   Historical refs remain useful collision-discovery inputs, but they are immutable
   snapshots—not a uniqueness invariant a feature PR can retroactively repair.
 
+- **2026-09-04, Console rail colour grammar (TASK-31429, formerly 31420).** A
+  one-command sweep, `git log --all --diff-filter=A --name-only -- backlog/`,
+  reported max **31419** and "0 files named task-31420" — and was wrong on the
+  second count within the hour: PR #2383 had landed a *different* `task-31420`
+  on dev as a **merge commit**, and `git log` without `-m` lists no file adds
+  for merge commits, so the sweep could see every branch commit that was still
+  around but not a squash/merge-only add. The collision surfaced only because
+  another session's memory note named the id. Fix was the older-keeps-id rule
+  (theirs: created 19:28; mine: 22:30 → mine renumbered to 31429 with
+  provenance). **Sweep with `git ls-tree -r --name-only <ref> backlog/` per
+  ref (the loop above) or add `-m` to any `git log --all` shortcut**, and
+  re-run the sweep right before pushing — the id was free at filing and taken
+  at PR time.
+
 **What to do.** Before filing, sweep **every remote ref** plus every worktree, and
 re-check at merge time — dev moves under you. Never trust the CLI's auto-assignment.
 When a collision is found after both tasks have started, use add-commit provenance:

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -1961,3 +1961,25 @@ did not reach as far as the mechanism did.
   fix that round 2 had to make again.
 - Re-derive before re-driving. The cheapest step in a fix round is grepping the call sites
   of the function you are about to change; the most expensive is a second live gate.
+
+## The theme palette matches "Theme: Switch to Textual Light", not the theme id (TASK-31429, 2026-09-04)
+
+**What happened.** Driving a live theme switch through the command palette
+for the Console-rail colour check: typing `textual-light` (the id every
+config file and test uses) returned zero hits, and the one hit for the
+generic query, "Theme: Change Theme", only posts a notification telling
+you to search — activating it looked like the palette had silently
+dismissed itself (the TASK-397 fast-Down+Enter trap was the first, wrong,
+suspect). `ThemeCommandProvider.search` (app.py) builds each hit as
+`"Theme: Switch to " + name.replace("_"," ").replace("-"," ").title()` and
+fuzzy-matches the QUERY against that Title-Cased string, so the hyphen in
+the id is what killed the match.
+
+**What to do.** Query the palette with the rendered command text — `Switch
+to Textual Light`, `Switch to Apricot` — narrow to one hit, then Down,
+Enter. Two smaller traps from the same session: SGR clicks on the rail's
+section-header toggles registered only on the NEXT input event (the header
+looked untoggled in the capture taken right after the click, then opened
+when the following key arrived), so capture again before concluding a
+click was dead; and Ctrl+Shift+Right (expand every rail section) did
+nothing when sent through tmux — open sections one at a time instead.

--- a/backlog/tasks/task-31429 - Console-context-rail-theme-aware-color-grammar-for-active-value-and-state.md
+++ b/backlog/tasks/task-31429 - Console-context-rail-theme-aware-color-grammar-for-active-value-and-state.md
@@ -62,6 +62,8 @@ Give the rail a small semantic color grammar that rides the existing theme infra
 **Files.** `tldw_chatbook/css/core/_variables.tcss`, `css/components/_agentic_terminal.tcss`, generated `css/tldw_cli_modular.tcss` + `css/screen_agentic_{console,library,settings}.tcss`, `css/Themes/themes.py`, `UI/Console_Modules/agent.py`, `UI/Screens/chat_screen.py`, `Widgets/Console/console_workspace_context.py`, `Tests/UI/test_console_rail_color_grammar.py` (new), `Tests/UI/test_theme_contrast.py`, `Docs/User_Guide/console.md`, `backlog/docs/lessons-live-verification.md`.
 
 **Out of scope (by design):** section headers (shared `DestinationRailSectionHeader` with Library/Home), Inspector-rail parity (can adopt the same two tokens), the collapsed Details "not configured" rows.
+
+**Review follow-up (Qodo on PR #2393, 4 findings, all addressed):** Google-style `Args:`/`Returns:` added to the two new agent.py helpers; the rail row focus rule corrected from the never-matching descendant form `.console-workspace-conversation-row Button:focus` to `.console-workspace-conversation-row:focus` (focus was in fact already painted by `ConsoleTerminalWorkspace Button:focus`, proven by the new mounted probe before the change; the fix makes the row-level contract rule real and `test_console_keyboard_trust.py` pins it); and `ConsoleLeftRail.compose` now seeds the status colour class from its `agent_status_line`, so a recomposed rail is coloured even when the screen-side payload memo skips the sync (`test_fresh_rail_compose_applies_the_agent_status_class`).
 <!-- SECTION:NOTES:END -->
 
 ## Implementation Plan

--- a/backlog/tasks/task-31429 - Console-context-rail-theme-aware-color-grammar-for-active-value-and-state.md
+++ b/backlog/tasks/task-31429 - Console-context-rail-theme-aware-color-grammar-for-active-value-and-state.md
@@ -1,0 +1,78 @@
+---
+id: TASK-31429
+title: Console context rail - theme-aware color grammar for active, value, and state
+status: Done
+assignee:
+  - '@claude'
+created_date: '2026-09-04 22:30'
+updated_date: '2026-09-04 23:55'
+labels:
+  - console
+  - ui
+  - theme
+dependencies: []
+priority: medium
+---
+
+## Renumbering provenance
+
+Filed 2026-09-04 22:30 as **TASK-31420** (the id was free across every ref at
+filing). PR #2383 landed a different `task-31420` ("Register the ask_user
+restraint description in the internal-prompts registry", created 19:28) on
+dev the same evening as a merge commit, which a `git log --all
+--diff-filter=A` sweep without `-m` cannot see. Per the older-arrival-keeps-id
+rule (TASK-19601) this task moved to TASK-31429; every inbound reference
+(code comments, tests, docs, the PR) moved with it. See
+`backlog/docs/lessons-backlog-hygiene.md` (2026-09-04 entry).
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The Console left rail ("Console context") is monochrome: labels, values, the active workspace/conversation, and agent/run state all render in the same white/grey, so users cannot tell state at a glance, cannot see which conversation is current versus which row merely has keyboard focus, and cannot separate fixed labels from live values.
+
+Give the rail a small semantic color grammar that rides the existing theme infrastructure: two new `$ds-*` tokens that reference Textual's generated polarity-aware variables (so every built-in, Orb, and user-saved theme recolors the rail with no theme-editor changes), plus the existing `$ds-status-*` tokens for state. Approved design (brainstorm 2026-09-04): primary hue = what you are in; accent hue = a value; status hues = state; grey = labels and help copy. Section headers (shared with the Library/Home rails) and the Inspector rail are out of scope.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The active workspace value, the active-conversation line, and the selected conversation row render in the theme-primary text hue (`$ds-active-fg` -> `$text-primary`) at rest; keyboard focus keeps its existing distinct treatment and wins when a selected row is focused; empty placeholders stay muted
+- [x] #2 Label/value pairs in the rail (Workspaces, Model, Details) render labels muted and non-bold and values in the theme-accent text hue (`$ds-value-fg` -> `$text-accent`)
+- [x] #3 The Agent status line carries a state class derived from the run status (running/done/stuck/error/cancelled) and is colored with the matching `$ds-status-*` token; idle and unavailable stay uncolored
+- [x] #4 Conversation rows carry a class per ConsoleRunMarker (running, needs-approval, finished-ok, finished-failed, subagent-unseen) and are colored with the matching `$ds-status-*` token; a selected row overrides the marker color
+- [x] #5 The Model section not-ready line uses `$ds-status-error-readable` instead of the decorative error hue
+- [x] #6 Both new tokens are defined in `_variables.tcss` as `$`-references (no hex literals) and the all-themes AA contrast gate covers `$text-primary` and `$text-accent` over the rail surfaces; any theme that fails gets a per-theme `variables` override
+- [x] #7 Live verification in the real app on textual-dark, textual-light, and one Orb theme shows the grammar (selected row, values, a running agent) and the regenerated CSS bundle is committed
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Summary.** The Console context rail now carries a four-meaning colour grammar driven entirely by the active theme: primary hue = what you are in, accent hue = a value, `$ds-status-*` = state, muted = labels/help. Two new tokens (`$ds-active-fg: $text-primary`, `$ds-value-fg: $text-accent`) in `_variables.tcss`, ~12 rail rules in `_agentic_terminal.tcss`, two small class-toggle seams in Python, and a readability pin in themes.py.
+
+**Approach.**
+- CSS: `.console-workspace-status-value` / `.console-model-section-value` -> `$ds-value-fg`; labels drop `bold`; `#console-active-workspace-value`, `#console-workspace-selected-conversation.…-active` (id+class, because the placeholder rule on the same Static is an id rule) and `.console-workspace-conversation-row-selected` -> `$ds-active-fg`; selection no longer borrows the focus tint (fg + bold only), so focus and selection read as two signals. Five `.console-workspace-conversation-row-<ConsoleRunMarker.value>` rules ordered BEFORE `-selected` so selection wins at equal specificity; five `.console-agent-section-status-<status>` rules; `#console-model-section-recovery` -> `$ds-status-error-readable`.
+- Python: `console_agent_status_state()` / `apply_console_agent_status_state()` in `UI/Console_Modules/agent.py` parse the status word out of the existing "Agent: <status> …" / "Sub-agent · <status>" line (no payload-shape change; the timer-path census pin on the `.update()` receiver is preserved by a second `query_one`). `console_workspace_context.py` adds the marker class in `_conversation_button` via a glyph-keyed map derived from `CONSOLE_RUN_MARKER_GLYPHS`, and the `-active` class on the selected-conversation line only when a summary exists.
+- **Deviation from the plan (documented):** Textual 8.2.8 derives `text-primary`/`text-accent` as a 66% tint of the contrast text toward the hue; 20 of the 70 shipped themes still fail AA on their own surfaces (measured). Instead of 40 hand-edited `variables` dict entries, `themes.py` gained `ensure_readable_text_hues()`, applied to every shipped theme at import and to every user-saved theme in `create_theme_from_dict`: where a tint fails 4.5:1 on `surface` or `panel` it blends further toward the text pole until it clears. These are GENERATED names no tcss defines, so the entry is honoured (the mechanism note atop themes.py). Side effect worth knowing: `$ds-chat-user-accent` (also `$text-primary`) gets the same, slightly more readable value on those 20 themes.
+
+**Evidence.**
+- TDD: 57 new tests in `Tests/UI/test_console_rail_color_grammar.py` (pure helpers, class toggles on unmounted widgets, mounted class application through `_sync_console_agent_section` and the tray's recompose, source + generated-sheet declaration contracts, a source-order pin for selected-over-marker, and a mounted rule-match probe asserting the three tokens RESOLVE to the running theme's `primary` / `text-accent` / `text-primary`). `test_theme_contrast.py` now gates `text-primary`/`text-accent` on all 70 themes plus a user-saved pastel theme through `load_user_themes`. All were watched red before the implementation.
+- Live (real app, tmux, scratch profile, llama-server at :9099): `capture-pane -e` decoded per run; textual-dark painted active line + selected row `#57a5e2` (= text-primary), values `#ffc473` (= text-accent), labels `#a7abaf`, "Agent: running · step 3" `#0178d4` (= primary); textual-light `#002d4f` / `#a86d1c` / `#004578`; apricot `#7c4621` / `#345425` / `#bc6b32` — each equal to the theme's computed generated value. The launch rewrote no tracked generated file.
+- Baseline failures confirmed on a pristine detached `origin/dev` worktree, NOT introduced here: `test_css_class_coverage_contract` (identical 157-line failure list both trees), the three `test_timer_path_static_update_inventory` tests, both `test_console_agent_controller` bridge tests, and `test_console_parallel_runs::test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coordinates`.
+
+**Files.** `tldw_chatbook/css/core/_variables.tcss`, `css/components/_agentic_terminal.tcss`, generated `css/tldw_cli_modular.tcss` + `css/screen_agentic_{console,library,settings}.tcss`, `css/Themes/themes.py`, `UI/Console_Modules/agent.py`, `UI/Screens/chat_screen.py`, `Widgets/Console/console_workspace_context.py`, `Tests/UI/test_console_rail_color_grammar.py` (new), `Tests/UI/test_theme_contrast.py`, `Docs/User_Guide/console.md`, `backlog/docs/lessons-live-verification.md`.
+
+**Out of scope (by design):** section headers (shared `DestinationRailSectionHeader` with Library/Home), Inspector-rail parity (can adopt the same two tokens), the collapsed Details "not configured" rows.
+<!-- SECTION:NOTES:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+Reason: adds two design tokens and a handful of state classes inside the existing `$ds-*` token layer and the Console rail's existing CSS; no component boundaries or contracts change.
+
+1. TDD, tests first: (a) extend `Tests/UI/test_theme_contrast.py` so the resolved-token AA gate covers `text-primary` and `text-accent` on every theme and the no-literal check covers the two new tokens; (b) new `Tests/UI/test_console_rail_color_grammar.py` pinning the pure helpers (agent status line -> state class, run-marker glyph -> row class), the class toggles on unmounted widgets, and the CSS declarations in source and in the generated console sheet.
+2. `_variables.tcss`: add `$ds-active-fg: $text-primary;` and `$ds-value-fg: $text-accent;` with a mechanism comment.
+3. `_agentic_terminal.tcss`: recolor `.console-workspace-status-value`, `.console-model-section-value`, `#console-active-workspace-value`, `.console-workspace-selected-conversation-active`, `.console-workspace-conversation-row-selected`; drop bold from `.console-workspace-status-label`; `#console-model-section-recovery` -> readable error; add agent-status and row-marker state rules.
+4. Python: `agent.py` pure helper + apply function called from `ChatScreen._sync_console_agent_section`; `console_workspace_context.py` adds the marker class in `_conversation_button` and the `-active` class on the selected-conversation line when a summary exists.
+5. Rebuild the CSS bundle (`build_css.py`), fix any theme the AA gate flags via `Theme.variables` overrides (generated names only), run the rail/theme test files, then live-verify per AC #7 and update the Console user guide stamp.
+<!-- SECTION:PLAN:END -->

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -194,6 +194,14 @@ def console_agent_status_state(status_line: str) -> str:
 
     Only the statuses in ``_AGENT_STATUS_GLYPHS`` are colour-worthy; "idle",
     "unavailable", and anything unrecognised return "".
+
+    Args:
+        status_line: The rendered Agent-section status text, e.g.
+            ``"Agent: running · step 3"`` or ``"Sub-agent · done"``.
+
+    Returns:
+        The status word (``"running"``, ``"done"``, ``"stuck"``, ``"error"``,
+        ``"cancelled"``) when it should be coloured, otherwise ``""``.
     """
     match = _AGENT_STATUS_LINE_RE.match(status_line or "")
     status = match.group(1) if match else ""
@@ -205,6 +213,13 @@ def apply_console_agent_status_state(widget: Any, status_line: str) -> None:
 
     Exactly one state class (or none) is present after the call; the base
     classes are left alone.
+
+    Args:
+        widget: The status-line widget (any object exposing Textual's
+            ``set_class(bool, name)``), normally the
+            ``#console-agent-section-status`` Static.
+        status_line: The rendered status text the widget shows; see
+            :func:`console_agent_status_state` for the accepted shapes.
     """
     state = console_agent_status_state(status_line)
     for status in _AGENT_STATUS_GLYPHS:

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -139,6 +139,7 @@ from dataclasses import replace
 from functools import partial
 from typing import Any, Dict, Iterable, TYPE_CHECKING
 
+import re
 import time
 
 from loguru import logger
@@ -181,6 +182,34 @@ _AGENT_STATUS_GLYPHS: Dict[str, str] = {
     "error": "✗",
     "cancelled": "✗",
 }
+
+#: TASK-31429: the rail's Agent status line ("Agent: running · step 3",
+#: "Sub-agent · done") carries its run status as the first word after the
+#: prefix; that word selects the line's `$ds-status-*` colour class.
+_AGENT_STATUS_LINE_RE = re.compile(r"^(?:Agent:|Sub-agent ·)\s*([a-z-]+)")
+
+
+def console_agent_status_state(status_line: str) -> str:
+    """Return the run status a rail status line carries, or "" to stay uncoloured.
+
+    Only the statuses in ``_AGENT_STATUS_GLYPHS`` are colour-worthy; "idle",
+    "unavailable", and anything unrecognised return "".
+    """
+    match = _AGENT_STATUS_LINE_RE.match(status_line or "")
+    status = match.group(1) if match else ""
+    return status if status in _AGENT_STATUS_GLYPHS else ""
+
+
+def apply_console_agent_status_state(widget: Any, status_line: str) -> None:
+    """Swap ``widget``'s ``console-agent-section-status-<state>`` class to match.
+
+    Exactly one state class (or none) is present after the call; the base
+    classes are left alone.
+    """
+    state = console_agent_status_state(status_line)
+    for status in _AGENT_STATUS_GLYPHS:
+        widget.set_class(status == state, f"console-agent-section-status-{status}")
+
 
 #: The ``ConsoleInspectorSection.section_id`` the fleet mini-section is
 #: constructed with (``left_rail.py``'s ``compose()``) and the id

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -99,7 +99,11 @@ from ...Workspaces.conversation_browser_state import (
     console_rail_section_height_budget,
 )
 from ...Workspaces.display_state import ConsoleWorkspaceContextState
-from .agent import CONSOLE_AGENT_CANCEL_ALL_ID, CONSOLE_AGENT_FLEET_SECTION_ID
+from .agent import (
+    CONSOLE_AGENT_CANCEL_ALL_ID,
+    CONSOLE_AGENT_FLEET_SECTION_ID,
+    apply_console_agent_status_state,
+)
 from .frame import frame_console_region
 from .rail_section_layout import (
     ContextSectionDemand,
@@ -2228,6 +2232,11 @@ class ConsoleLeftRail(Vertical):
                 classes="console-agent-section-line",
                 markup=False,
             )
+            # TASK-31429 (Qodo review on PR #2393): a recomposed rail builds a
+            # fresh Static, and the screen-side sync skips an unchanged
+            # payload -- so the run-status colour class must be seeded here
+            # from the line this rail was constructed with.
+            apply_console_agent_status_state(agent_status, self._agent_status_line)
             agent_steps = Static(
                 self._agent_steps_text,
                 id="console-agent-section-steps",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -121,6 +121,7 @@ from ..Console_Modules.hands_free import (
 from ..Console_Modules.agent import (
     CONSOLE_AGENT_CANCEL_ALL_ID,
     CONSOLE_AGENT_FLEET_SECTION_ID,
+    apply_console_agent_status_state,
 )
 from ..Console_Modules.prompt_queue import (
     ConsolePromptDispatchStatus,
@@ -7784,6 +7785,12 @@ class ChatScreen(BaseAppScreen):
         ) = payload
         try:
             self.query_one("#console-agent-section-status", Static).update(status_line)
+            # TASK-31429: the run status word also picks the line's colour.
+            # (Separate lookup on purpose: the timer-path census pins the
+            # `.update()` receiver expression above.)
+            apply_console_agent_status_state(
+                self.query_one("#console-agent-section-status", Static), status_line
+            )
             self.query_one("#console-agent-section-steps", Static).update(steps_text)
             fleet_section = self.query_one(
                 "#console-agent-section-subagents", ConsoleInspectorSection

--- a/tldw_chatbook/Widgets/Console/console_workspace_context.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_context.py
@@ -15,6 +15,7 @@ from textual.message import Message
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Chat.console_chat_models import (
+    CONSOLE_RUN_MARKER_GLYPHS,
     CONSOLE_RUN_MARKER_MEANINGS_BY_GLYPH,
 )
 from tldw_chatbook.Chat.console_glyphs import (
@@ -259,6 +260,27 @@ def wrap_console_plain_text_uncapped(text: str, budget: int) -> tuple[str, ...]:
             lines.append(head)
             remaining = remaining[len(head) :].lstrip()
     return tuple(lines)
+
+
+#: TASK-31429: resolved fleet glyph -> the row colour class for that run
+#: state (`.console-workspace-conversation-row-<ConsoleRunMarker.value>`).
+#: The browser pipeline threads glyph strings, not the enum, so this is the
+#: same glyph-keyed shape as `CONSOLE_RUN_MARKER_MEANINGS_BY_GLYPH`.
+_ROW_STATE_CLASS_BY_GLYPH: dict[str, str] = {
+    glyph: f"console-workspace-conversation-row-{marker.value}"
+    for marker, glyph in CONSOLE_RUN_MARKER_GLYPHS.items()
+    if glyph
+}
+
+
+def _selected_conversation_active_class(selected_summary: str | None) -> str:
+    """Class suffix that paints the active-chat line in the active hue.
+
+    TASK-31429: the same Static also carries the "No active …" placeholder,
+    which must stay muted -- so the hue rides a class that is present only
+    when a real summary is being named.
+    """
+    return " console-workspace-selected-conversation-active" if selected_summary else ""
 
 
 def _row_marker(run_marker: str, starred: bool) -> str:
@@ -1158,6 +1180,12 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             run_marker,
         )
         button.set_class(selected, "console-workspace-conversation-row-selected")
+        # TASK-31429: the fleet glyph's state also colours the row text; the
+        # `-selected` rule is ordered after these in the stylesheet so a
+        # selected row keeps the active hue.
+        state_class = _ROW_STATE_CLASS_BY_GLYPH.get(str(run_marker or "").strip())
+        if state_class:
+            button.add_class(state_class)
         row_height = _conversation_row_render_height(name_line_count, subagent_count)
         button.styles.height = row_height
         button.styles.min_height = row_height
@@ -1572,6 +1600,7 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
                 classes=(
                     "console-workspace-selected-conversation "
                     "console-session-selected-conversation"
+                    + _selected_conversation_active_class(selected_summary)
                 ),
             )
             if self.state.scope_detail:
@@ -1605,7 +1634,8 @@ class ConsoleWorkspaceContextTray(RecomposeCaptureGuard, Vertical):
             yield self._static(
                 browser.selected_summary or "No active conversation.",
                 id="console-workspace-selected-conversation",
-                classes="console-workspace-selected-conversation",
+                classes="console-workspace-selected-conversation"
+                + _selected_conversation_active_class(browser.selected_summary),
             )
         with Horizontal(
             id="console-workspace-conversation-search-row",

--- a/tldw_chatbook/css/Themes/themes.py
+++ b/tldw_chatbook/css/Themes/themes.py
@@ -53,7 +53,77 @@ def create_theme_from_dict(name: str, theme_dict: dict) -> Theme:
                 # For example, Color.parse("red") or continue
         else:  # For any other variables Textual's Theme constructor might support (e.g., 'variables' dict)
             theme_args[key] = value
-    return Theme(**theme_args)
+    return ensure_readable_text_hues(Theme(**theme_args))
+
+
+#: Generated text tints the Console rail paints ordinary text with
+#: (TASK-31429: `$ds-active-fg` -> text-primary, `$ds-value-fg` -> text-accent).
+_READABLE_TEXT_HUES = ("text-primary", "text-accent")
+_AA_RATIO = 4.5
+
+
+def _relative_luminance(color: Color) -> float:
+    def channel(value: int) -> float:
+        c = value / 255
+        return c / 12.92 if c <= 0.03928 else ((c + 0.055) / 1.055) ** 2.4
+
+    return (
+        0.2126 * channel(color.r)
+        + 0.7152 * channel(color.g)
+        + 0.0722 * channel(color.b)
+    )
+
+
+def _contrast_ratio(a: Color, b: Color) -> float:
+    la, lb = _relative_luminance(a), _relative_luminance(b)
+    lo, hi = min(la, lb), max(la, lb)
+    return (hi + 0.05) / (lo + 0.05)
+
+
+def ensure_readable_text_hues(theme: Theme) -> Theme:
+    """Pin ``text-primary`` / ``text-accent`` to AA-readable values in place.
+
+    Textual derives both as a 66% tint of the theme's contrast text toward
+    the hue; on mid-tone palettes (20 of the 70 shipped themes, and any
+    pastel a user saves from Settings ▸ Theme) that lands below 4.5:1 on the
+    theme's own surfaces. Where it does, blend further toward the text pole
+    (white on dark surfaces, black on light) until both ``surface`` and
+    ``panel`` clear AA. These are GENERATED names no tcss defines, so the
+    ``variables`` entry is honoured (mechanism note atop this module); an
+    explicit per-theme entry is left alone. Themes whose colours cannot be
+    resolved (ANSI palettes) are returned untouched.
+
+    Args:
+        theme: The theme to adjust; mutated and returned for chaining.
+
+    Returns:
+        The same theme, with readable entries added to ``variables`` as needed.
+    """
+    try:
+        generated = theme.to_color_system().generate()
+        surfaces = [Color.parse(generated[key]) for key in ("surface", "panel")]
+    except Exception:  # noqa: BLE001 - ANSI/transparent palettes have no hex to measure
+        return theme
+    if any(surface.a < 1 for surface in surfaces):
+        return theme
+    dark_surface = sum(s.brightness for s in surfaces) / len(surfaces) < 0.5
+    pole = Color(255, 255, 255) if dark_surface else Color(0, 0, 0)
+    variables = dict(theme.variables or {})
+    for token in _READABLE_TEXT_HUES:
+        if token in variables:
+            continue
+        color = Color.parse(generated[token])
+        if all(_contrast_ratio(color, s) >= _AA_RATIO for s in surfaces):
+            continue
+        for step in range(1, 21):
+            candidate = color.blend(pole, step / 20)
+            if all(_contrast_ratio(candidate, s) >= _AA_RATIO for s in surfaces):
+                variables[token] = candidate.hex
+                break
+        else:
+            variables[token] = pole.hex
+    theme.variables = variables
+    return theme
 
 
 def load_user_themes(themes_dir: str | Path) -> list[Theme]:
@@ -1853,6 +1923,12 @@ ALL_THEMES = [
     sakura_viewing_picnic_theme,
     eighties_anime_ova_sunset_theme,
 ]
+
+# TASK-31429: the shipped catalog gets the same readability pin user themes
+# receive via create_theme_from_dict (gated by test_theme_contrast.py).
+for _shipped_theme in ALL_THEMES:
+    ensure_readable_text_hues(_shipped_theme)
+del _shipped_theme
 
 # Example of a theme with the 'variables' attribute as shown in Textual docs:
 # MY_THEMES["arctic_example"] = Theme(

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4641,7 +4641,12 @@ ConsoleTerminalWorkspace Button:focus {
     text-style: bold underline;
 }
 
-.console-workspace-conversation-row Button:focus {
+/* TASK-31429 (Qodo review on PR #2393): the conversation row IS the Button
+   (`_conversation_button`), so the former descendant form
+   `.console-workspace-conversation-row Button:focus` matched nothing. Target
+   the row itself; class+pseudo specificity outranks the `-selected` and
+   run-marker hue rules, so focus stays its own visible signal on top. */
+.console-workspace-conversation-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4156,6 +4156,13 @@ with stray left-edge border fragments), and padding 0 1 so the full
     background: $ds-surface-panel;
 }
 
+/* TASK-31429 (rail colour grammar): the line that NAMES the active chat
+   takes the active hue; the same Static's "No active …" placeholder keeps
+   the muted id rule above. id+class so it outranks that id rule. */
+#console-workspace-selected-conversation.console-workspace-selected-conversation-active {
+    color: $ds-active-fg;
+}
+
 /* The row is 3 rows tall so the bordered Input inside it can show its value:
    a `tall` border spends one row above and one below the text, so a 1-row
    input paints its top edge and nothing else. */
@@ -4208,10 +4215,37 @@ with stray left-edge border fragments), and padding 0 1 so the full
     color: $ds-text-primary;
 }
 
+/* TASK-31429 (rail colour grammar): a row's fleet run-marker state colours
+   its text with the same status tokens the Inspector rows use. Ordered
+   BEFORE `-selected` (equal specificity, last wins) so the selected row
+   keeps the active hue whatever its marker. */
+.console-workspace-conversation-row-running {
+    color: $ds-status-running;
+}
+
+.console-workspace-conversation-row-needs-approval {
+    color: $ds-status-approval-required;
+}
+
+.console-workspace-conversation-row-finished-ok {
+    color: $ds-status-ready;
+}
+
+.console-workspace-conversation-row-finished-failed {
+    color: $ds-status-error-readable;
+}
+
+.console-workspace-conversation-row-subagent-unseen {
+    color: $ds-status-info;
+}
+
+/* TASK-31429: selection is a foreground hue (primary = what you are in),
+   no longer the focus tint -- so "which chat am I in" and "where is
+   keyboard focus" read as two different signals. Focus rules below still
+   paint the focus tint on top when the selected row is focused. */
 .console-workspace-conversation-row-selected {
-    background: $ds-focus-bg;
-    color: $ds-focus-fg;
-    text-style: bold underline;
+    color: $ds-active-fg;
+    text-style: bold;
 }
 
 .console-conversation-browser-section-header {
@@ -4853,7 +4887,7 @@ ConsoleBoundedSection {
 .console-model-section-value {
     width: 1fr;
     min-width: 10;
-    color: $ds-text-primary;
+    color: $ds-value-fg;
 }
 
 #console-model-section-provider .console-model-section-value,
@@ -4869,12 +4903,34 @@ ConsoleBoundedSection {
 }
 
 #console-model-section-recovery {
-    color: $ds-status-blocked;
+    /* TASK-31429: this line is READ, not glanced -- readable error variant
+       (design-language rule: readable beats decorative). */
+    color: $ds-status-error-readable;
 }
 
 .console-agent-section-line {
     height: 1;
     color: $ds-text-primary;
+}
+
+/* TASK-31429 (rail colour grammar): the Agent status line's run status
+   (`apply_console_agent_status_state`) maps to the same status tokens the
+   Inspector's fleet rows already use; idle/unavailable carry no class. */
+.console-agent-section-status-running {
+    color: $ds-status-running;
+}
+
+.console-agent-section-status-done {
+    color: $ds-status-ready;
+}
+
+.console-agent-section-status-stuck {
+    color: $ds-status-warning;
+}
+
+.console-agent-section-status-error,
+.console-agent-section-status-cancelled {
+    color: $ds-status-error-readable;
 }
 
 .console-agent-section-steps {
@@ -6635,13 +6691,19 @@ ConsoleCitationSourcesModal {
     margin: 0;
 }
 
+/* TASK-31429 (rail colour grammar): quiet key, coloured value -- the label
+   drops its bold so it no longer competes with the value it introduces. */
 .console-workspace-status-label {
     color: $ds-text-muted;
-    text-style: bold;
 }
 
 .console-workspace-status-value {
-    color: $ds-text-primary;
+    color: $ds-value-fg;
+}
+
+/* The workspace you are IN is identity, not a setting: active hue. */
+#console-active-workspace-value {
+    color: $ds-active-fg;
 }
 
 .console-workspace-empty-copy {

--- a/tldw_chatbook/css/core/_variables.tcss
+++ b/tldw_chatbook/css/core/_variables.tcss
@@ -91,6 +91,14 @@ $ds-source-role-context: $accent;
 $ds-source-role-evidence: $accent;
 $ds-source-role-editable-target: $warning;
 $ds-source-role-output-seed: $secondary;
+/* TASK-31429: Console context-rail colour grammar. Primary hue = what you
+   are in (active workspace, active/selected conversation); accent hue = a
+   value beside a muted label. Both are references to Textual's generated
+   per-theme text tints, so every theme -- built-in, Orb, or user-saved --
+   recolors the rail; themes.py pins the two generated names to AA-readable
+   values where Textual's 66% tint falls short (see ensure_readable_text_hues). */
+$ds-active-fg: $text-primary;
+$ds-value-fg: $text-accent;
 
 /* Console transcript speaker accents. Textual exposes whether the active
    theme is dark or light as an App class; the two assistant tones keep the

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1226,7 +1226,12 @@ ConsoleTerminalWorkspace#console-main-column {
     text-style: bold underline;
 }
 
-.console-workspace-conversation-row Button:focus {
+/* TASK-31429 (Qodo review on PR #2393): the conversation row IS the Button
+   (`_conversation_button`), so the former descendant form
+   `.console-workspace-conversation-row Button:focus` matched nothing. Target
+   the row itself; class+pseudo specificity outranks the `-selected` and
+   run-marker hue rules, so focus stays its own visible signal on top. */
+.console-workspace-conversation-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -44,6 +44,8 @@ $ds-source-role-context: $accent;
 $ds-source-role-evidence: $accent;
 $ds-source-role-editable-target: $warning;
 $ds-source-role-output-seed: $secondary;
+$ds-active-fg: $text-primary;
+$ds-value-fg: $text-accent;
 
 $ds-chat-user-accent: $text-primary;
 $ds-chat-user-accent-dark: #8bd5ff;
@@ -818,6 +820,13 @@ $ds-library-source-browser-width: 31;
     background: $ds-surface-panel;
 }
 
+/* TASK-31429 (rail colour grammar): the line that NAMES the active chat
+   takes the active hue; the same Static's "No active …" placeholder keeps
+   the muted id rule above. id+class so it outranks that id rule. */
+#console-workspace-selected-conversation.console-workspace-selected-conversation-active {
+    color: $ds-active-fg;
+}
+
 /* The row is 3 rows tall so the bordered Input inside it can show its value:
    a `tall` border spends one row above and one below the text, so a 1-row
    input paints its top edge and nothing else. */
@@ -870,10 +879,37 @@ $ds-library-source-browser-width: 31;
     color: $ds-text-primary;
 }
 
+/* TASK-31429 (rail colour grammar): a row's fleet run-marker state colours
+   its text with the same status tokens the Inspector rows use. Ordered
+   BEFORE `-selected` (equal specificity, last wins) so the selected row
+   keeps the active hue whatever its marker. */
+.console-workspace-conversation-row-running {
+    color: $ds-status-running;
+}
+
+.console-workspace-conversation-row-needs-approval {
+    color: $ds-status-approval-required;
+}
+
+.console-workspace-conversation-row-finished-ok {
+    color: $ds-status-ready;
+}
+
+.console-workspace-conversation-row-finished-failed {
+    color: $ds-status-error-readable;
+}
+
+.console-workspace-conversation-row-subagent-unseen {
+    color: $ds-status-info;
+}
+
+/* TASK-31429: selection is a foreground hue (primary = what you are in),
+   no longer the focus tint -- so "which chat am I in" and "where is
+   keyboard focus" read as two different signals. Focus rules below still
+   paint the focus tint on top when the selected row is focused. */
 .console-workspace-conversation-row-selected {
-    background: $ds-focus-bg;
-    color: $ds-focus-fg;
-    text-style: bold underline;
+    color: $ds-active-fg;
+    text-style: bold;
 }
 
 .console-conversation-browser-section-header {
@@ -1336,7 +1372,7 @@ ConsoleTerminalWorkspace#console-main-column {
 .console-model-section-value {
     width: 1fr;
     min-width: 10;
-    color: $ds-text-primary;
+    color: $ds-value-fg;
 }
 
 #console-model-section-provider .console-model-section-value,
@@ -1352,12 +1388,34 @@ ConsoleTerminalWorkspace#console-main-column {
 }
 
 #console-model-section-recovery {
-    color: $ds-status-blocked;
+    /* TASK-31429: this line is READ, not glanced -- readable error variant
+       (design-language rule: readable beats decorative). */
+    color: $ds-status-error-readable;
 }
 
 .console-agent-section-line {
     height: 1;
     color: $ds-text-primary;
+}
+
+/* TASK-31429 (rail colour grammar): the Agent status line's run status
+   (`apply_console_agent_status_state`) maps to the same status tokens the
+   Inspector's fleet rows already use; idle/unavailable carry no class. */
+.console-agent-section-status-running {
+    color: $ds-status-running;
+}
+
+.console-agent-section-status-done {
+    color: $ds-status-ready;
+}
+
+.console-agent-section-status-stuck {
+    color: $ds-status-warning;
+}
+
+.console-agent-section-status-error,
+.console-agent-section-status-cancelled {
+    color: $ds-status-error-readable;
 }
 
 .console-agent-section-steps {
@@ -2841,13 +2899,19 @@ ConsoleTurnFileCard.console-turn-file-card-selected .console-turn-file-header {
     margin: 0;
 }
 
+/* TASK-31429 (rail colour grammar): quiet key, coloured value -- the label
+   drops its bold so it no longer competes with the value it introduces. */
 .console-workspace-status-label {
     color: $ds-text-muted;
-    text-style: bold;
 }
 
 .console-workspace-status-value {
-    color: $ds-text-primary;
+    color: $ds-value-fg;
+}
+
+/* The workspace you are IN is identity, not a setting: active hue. */
+#console-active-workspace-value {
+    color: $ds-active-fg;
 }
 
 .console-workspace-empty-copy {

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -44,6 +44,8 @@ $ds-source-role-context: $accent;
 $ds-source-role-evidence: $accent;
 $ds-source-role-editable-target: $warning;
 $ds-source-role-output-seed: $secondary;
+$ds-active-fg: $text-primary;
+$ds-value-fg: $text-accent;
 
 $ds-chat-user-accent: $text-primary;
 $ds-chat-user-accent-dark: #8bd5ff;

--- a/tldw_chatbook/css/screen_agentic_settings.tcss
+++ b/tldw_chatbook/css/screen_agentic_settings.tcss
@@ -44,6 +44,8 @@ $ds-source-role-context: $accent;
 $ds-source-role-evidence: $accent;
 $ds-source-role-editable-target: $warning;
 $ds-source-role-output-seed: $secondary;
+$ds-active-fg: $text-primary;
+$ds-value-fg: $text-accent;
 
 $ds-chat-user-accent: $text-primary;
 $ds-chat-user-accent-dark: #8bd5ff;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -103,6 +103,14 @@ $ds-source-role-context: $accent;
 $ds-source-role-evidence: $accent;
 $ds-source-role-editable-target: $warning;
 $ds-source-role-output-seed: $secondary;
+/* TASK-31429: Console context-rail colour grammar. Primary hue = what you
+   are in (active workspace, active/selected conversation); accent hue = a
+   value beside a muted label. Both are references to Textual's generated
+   per-theme text tints, so every theme -- built-in, Orb, or user-saved --
+   recolors the rail; themes.py pins the two generated names to AA-readable
+   values where Textual's 66% tint falls short (see ensure_readable_text_hues). */
+$ds-active-fg: $text-primary;
+$ds-value-fg: $text-accent;
 
 /* Console transcript speaker accents. Textual exposes whether the active
    theme is dark or light as an App class; the two assistant tones keep the


### PR DESCRIPTION
## Summary

TASK-31429. The Console left rail ("Console context") was monochrome: labels, values, the active conversation, and agent/run state all rendered in the same white/grey. This gives the rail a small semantic colour grammar that rides the existing theme infrastructure, so every built-in, Orb, and Settings-saved theme recolours it with no theme-editor change.

| Meaning | Token | Where |
|---|---|---|
| **what you are in** | `$ds-active-fg` → `$text-primary` | active workspace value, active-chat line, selected conversation row (selection no longer borrows the focus tint) |
| **a value** | `$ds-value-fg` → `$text-accent` | every label/value pair (Temperature, Max tokens, Storage …); labels drop bold |
| **state** | existing `$ds-status-*` | Agent status line (running/done/stuck/error/cancelled), conversation rows per `ConsoleRunMarker` glyph, Model not-ready line → readable error variant |
| labels / help | `$ds-text-muted` | unchanged |

Section headers (shared with the Library/Home rails) and the Inspector rail are deliberately out of scope.

## Notable finding

Textual 8.2.8 derives `text-primary` / `text-accent` as a 66% tint of the contrast text toward the hue; **20 of the 70 shipped themes still failed AA (4.5:1) on their own surface/panel.** Rather than 40 hand-edited `variables` entries, `themes.py` gains `ensure_readable_text_hues()`: applied to `ALL_THEMES` at import and inside `create_theme_from_dict` (so user-saved pastel themes get it too), it blends a failing tint toward the text pole until both surfaces clear AA. These are generated names no tcss defines, so the dict entry is honoured (see the mechanism note atop themes.py). Side effect: `$ds-chat-user-accent` (also `$text-primary`) gets the same, slightly more readable value on those 20 themes.

## Tests

- `Tests/UI/test_console_rail_color_grammar.py` (new, 57 tests, all watched red first): pure helpers, class toggles on unmounted widgets, mounted class application through `_sync_console_agent_section` and the tray recompose, source + generated-sheet declaration contracts, a source-order pin so `-selected` beats the marker rules, and a mounted rule-match probe asserting the tokens **resolve** to the running theme's `primary` / `text-accent` / `text-primary`.
- `Tests/UI/test_theme_contrast.py`: the all-themes AA gate now covers `text-primary` and `text-accent`, plus a `load_user_themes` pastel-theme case.
- CSS bundle regenerated (`build_css.py`), `check_bundle_sync.py` clean.

## Live verification

Real app in tmux on a scratch profile with a local llama-server, captures colour-decoded from `capture-pane -e`:

| theme | active line / selected row | value | Agent: running |
|---|---|---|---|
| textual-dark | `#57a5e2` (= text-primary) | `#ffc473` (= text-accent) | `#0178d4` (= primary) |
| textual-light | `#002d4f` | `#a86d1c` | `#004578` |
| apricot (Orb) | `#7c4621` | `#345425` | `#bc6b32` |

Each value equals the theme's computed generated value. The launch rewrote no tracked generated file.

## Baseline failures (pre-existing on `origin/dev` @ 91757b61e9, verified on a pristine detached worktree, not introduced here)

`test_css_class_coverage_contract` (identical 157-entry list both trees; the test reads only the boot bundle while Console rules live in the split console sheet), the three `Tests/Architecture/test_timer_path_static_update_inventory.py` tests, both `test_console_agent_controller` bridge tests, and `test_console_parallel_runs::test_navigation_guard_survives_stay_then_renavigate_then_leave_by_coordinates`.

## Docs

`Docs/User_Guide/console.md` (rail bullet + verification stamp), `backlog/docs/lessons-live-verification.md` (theme-palette query trap), `backlog/docs/lessons-backlog-hygiene.md` (id-sweep trap below), backlog task file with plan + implementation notes.

## Task id

Filed as TASK-31420 (swept free at the time); PR #2383 landed a different `task-31420` on dev the same evening as a merge commit, which a `git log --all --diff-filter=A` sweep without `-m` cannot see. Per the older-keeps-id rule (theirs 19:28, mine 22:30) this task is renumbered to **TASK-31429** with a provenance section; every reference in code, tests, docs and this PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DdHYVYApKJWWJRavaQZJ2A
