### PR TITLE
feat(agents): serve the ask_user tool description from the internal-prompts registry (task-31420)

### DIFF
--- a/Tests/Agents/test_ask_user_questions.py
+++ b/Tests/Agents/test_ask_user_questions.py
@@ -141,3 +141,15 @@ def test_validate_answers_accepts_the_card_shape_and_rejects_drift():
         with pytest.raises(AskUserValidationError) as excinfo:
             validate_answers(bad)
         assert fragment in str(excinfo.value), str(excinfo.value)
+
+
+def test_resolve_tool_description_takes_the_first_valid_candidate():
+    from tldw_chatbook.Agents.ask_user_questions import (
+        MAX_TOOL_DESCRIPTION_CHARS,
+        resolve_tool_description,
+    )
+
+    assert resolve_tool_description(None, "  a\nb ", "c") == "a b"
+    assert resolve_tool_description("", 42, "x" * (MAX_TOOL_DESCRIPTION_CHARS + 1), "ok") == "ok"
+    with pytest.raises(AskUserValidationError):
+        resolve_tool_description("", None)

--- a/Tests/Agents/test_ask_user_tool.py
+++ b/Tests/Agents/test_ask_user_tool.py
@@ -163,3 +163,34 @@ def test_gate_row_is_enumerated_and_defaults_on():
     assert (gate.section, gate.key, gate.group) == ("tools", "ask_user_enabled", "local")
     assert gate.enabled is True
     assert [(g.section, g.key) for g in all_tool_gates()] == _gate_key_pairs()
+
+
+# --- task-31420: the description is a registry prompt ---------------------------
+
+
+def _spec(provider):
+    return next(
+        s
+        for s in provider.specs_for_exposure(LocalToolExposure.CONSOLE_ONLY)
+        if s.name == "ask_user"
+    )
+
+
+def test_description_defaults_to_the_catalog_text(tmp_path):
+    from tldw_chatbook.Agents.ask_user_questions import ASK_USER_DESCRIPTION
+
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == ASK_USER_DESCRIPTION
+
+
+def test_a_registry_override_reaches_the_built_spec(tmp_path, monkeypatch):
+    import tldw_chatbook.config as config_module
+
+    def fake_setting(section, key=None, default=None):
+        if (section, key) == ("internal_prompts.agents", "ask_user_tool_description"):
+            return "Ask only about deployment targets."
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_setting)
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == "Ask only about deployment targets."

--- a/Tests/Agents/test_ask_user_tool.py
+++ b/Tests/Agents/test_ask_user_tool.py
@@ -194,3 +194,40 @@ def test_a_registry_override_reaches_the_built_spec(tmp_path, monkeypatch):
     monkeypatch.setattr(config_module, "get_cli_setting", fake_setting)
     provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
     assert _spec(provider).description == "Ask only about deployment targets."
+
+
+def test_env_override_beats_the_registry_and_blank_or_bad_env_is_skipped(tmp_path, monkeypatch):
+    import tldw_chatbook.config as config_module
+
+    monkeypatch.setattr(
+        config_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: "Registry text."
+        if (section, key) == ("internal_prompts.agents", "ask_user_tool_description")
+        else default,
+    )
+    monkeypatch.setenv("TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION", "  Env text.\n ")
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == "Env text."
+    monkeypatch.setenv("TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION", "   ")
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == "Registry text."
+    monkeypatch.setenv("TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION", "x" * 5000)
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == "Registry text.", "over-long env value is skipped"
+
+
+def test_an_over_long_registry_override_falls_back_to_the_constant(tmp_path, monkeypatch):
+    import tldw_chatbook.config as config_module
+    from tldw_chatbook.Agents.ask_user_questions import ASK_USER_DESCRIPTION
+
+    monkeypatch.delenv("TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION", raising=False)
+    monkeypatch.setattr(
+        config_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: "y" * 5000
+        if (section, key) == ("internal_prompts.agents", "ask_user_tool_description")
+        else default,
+    )
+    provider = make_provider(root=tmp_path, ask_user=lambda questions: {})
+    assert _spec(provider).description == ASK_USER_DESCRIPTION

--- a/Tests/Internal_Prompts/test_agents_prompt_parity.py
+++ b/Tests/Internal_Prompts/test_agents_prompt_parity.py
@@ -26,7 +26,7 @@ def test_console_agent_operating_matches_source_constant():
 def test_tool_protocol_template_renders_original_scaffold():
     # Pre-migration expected output, built exactly as agent_runtime.py:183-193
     # does today (copy the f-string expression verbatim with sample values).
-    from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN, _FENCE_CLOSE
+    from tldw_chatbook.Agents.agent_runtime import _FENCE_CLOSE, FENCE_OPEN
 
     tool_list = '{\n  "name": "demo",\n  "description": "d",\n  "parameters": {}\n}'
     expected = (
@@ -46,3 +46,11 @@ def test_tool_protocol_template_renders_original_scaffold():
         fence_open=FENCE_OPEN,
         fence_close=_FENCE_CLOSE,
     ) == expected
+
+
+def test_ask_user_tool_description_matches_source_constant():
+    from tldw_chatbook.Agents.ask_user_questions import ASK_USER_DESCRIPTION
+
+    spec = CATALOG["agents.ask_user_tool_description"]
+    assert spec.default == ASK_USER_DESCRIPTION
+    assert spec.required_placeholders == () and spec.optional_placeholders == ()

--- a/backlog/tasks/task-31420 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
+++ b/backlog/tasks/task-31420 - Register-the-ask_user-restraint-description-in-the-internal-prompts-registry.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31420
 title: Register the ask_user restraint description in the internal-prompts registry
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Robert'
 created_date: '2026-09-04 19:28'
+updated_date: '2026-09-05 00:05'
 labels:
   - console
   - agents
@@ -20,17 +22,21 @@ The design spec (2026-08-19-console-user-interaction-design.md, section 5.1) ask
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The ask_user tool description is served from the internal-prompts registry with a stable key and the constant becomes its default
-- [ ] #2 The LocalToolSpec built by _default_specs reads the registry copy at spec-build time
-- [ ] #3 Existing ask_user tests pass unchanged and one test pins that a registry override reaches the spec
+- [x] #1 The ask_user tool description is served from the internal-prompts registry with a stable key and the constant becomes its default
+- [x] #2 The LocalToolSpec built by _default_specs reads the registry copy at spec-build time
+- [x] #3 Existing ask_user tests pass unchanged and one test pins that a registry override reaches the spec
 <!-- AC:END -->
 
-## Renumbering provenance
+## Implementation Plan
 
-Filed as task-31383 on 2026-09-04 (PR #2383, branch
-chore/console-interaction-follow-up-tasks). Renumbered to task-31420 the
-same day: while the PR waited, dev landed its own task-31383 ("Make failed
-Console replies offer Retry instead of Continue"), and under the 2026-08-21
-owner rule (TASK-19601) the older arrival keeps the id. 31420 is the first
-id above the highest task id on any remote branch or local worktree at the
-time (31419). No dependency, doc, or code referenced the old id.
+<!-- SECTION:PLAN:BEGIN -->
+1. Add PromptSpec agents.ask_user_tool_description to Internal_Prompts/agents_prompts.py with the ASK_USER_DESCRIPTION literal as its default (no placeholders; contract note on restraint + default-ON gate).
+2. local_tool_provider._default_specs reads the description through get_internal_prompt at spec-build time (lazy import; the constant stays the catalog default).
+3. Tests: golden parity between the catalog default and ASK_USER_DESCRIPTION; an override via the resolver's config seam reaches the built spec; existing ask_user suites unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+agents.ask_user_tool_description is a PromptSpec in Internal_Prompts/agents_prompts.py whose default is byte-identical to ASK_USER_DESCRIPTION (pinned by test_ask_user_tool_description_matches_source_constant). _default_specs builds the ask_user LocalToolSpec from get_internal_prompt('agents.ask_user_tool_description') at spec-build time (lazy import, so Internal_Prompts stays off the boot path -- census unchanged at 966), falling back to the constant if the resolver returns empty. An [internal_prompts.agents] override reaches the built spec (test_a_registry_override_reaches_the_built_spec). No placeholders; the contract note explains the default-ON gate and the busy sentence.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/ask_user_questions.py
+++ b/tldw_chatbook/Agents/ask_user_questions.py
@@ -113,6 +113,54 @@ ASK_USER_PARAMETERS = {
 }
 
 
+#: task-31420: env override for the registry prompt `agents.ask_user_tool_description`
+#: (env -> config -> catalog default, the repo's precedence rule).
+ASK_USER_DESCRIPTION_ENV_VAR = "TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION"
+MAX_TOOL_DESCRIPTION_CHARS = 4000
+
+
+class ToolDescriptionText(BaseModel):
+    """A configurable tool description: non-blank, bounded, control-free text."""
+
+    model_config = ConfigDict(extra="forbid", strict=True)
+
+    text: str = Field(min_length=1, max_length=MAX_TOOL_DESCRIPTION_CHARS)
+
+    @field_validator("text", mode="before")
+    @classmethod
+    def _clean(cls, value: object) -> str:
+        return _clean_text(value, required=True)
+
+
+def resolve_tool_description(*candidates: object) -> str:
+    """Pick the first candidate that validates as a tool description.
+
+    task-31420: the ask_user description is user-configurable. Each
+    candidate (environment value, registry value, shipped constant) is run
+    through ``ToolDescriptionText``; the first that validates wins, so an
+    empty, blank, over-long, or non-text override is skipped rather than
+    shipped to the model.
+
+    Args:
+        *candidates: Values in precedence order; ``None`` entries are skipped.
+
+    Returns:
+        The validated text of the first acceptable candidate.
+
+    Raises:
+        AskUserValidationError: No candidate validated -- unreachable while
+            the shipped constant is the last candidate.
+    """
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        try:
+            return ToolDescriptionText(text=candidate).text
+        except ValidationError:
+            continue
+    raise AskUserValidationError("no usable tool description")
+
+
 class AskUserValidationError(ValueError):
     """A rejected ``ask_user`` payload; the message names the field and the rule."""
 

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -4187,12 +4187,22 @@ def _default_specs(
         # callback (the todo_* pattern -- absent in headless runs, A10),
         # exempt from the permission layer (A12), imported lazily so the
         # module stays off the boot path (ADR-097).
+        from tldw_chatbook.Internal_Prompts import get_internal_prompt
+
         from .ask_user_questions import ASK_USER_DESCRIPTION, ASK_USER_PARAMETERS
 
+        # task-31420: the description is a registry prompt (its catalog
+        # default is byte-identical to ASK_USER_DESCRIPTION) so a user can
+        # inspect and override the restraint text like any other prompt the
+        # app puts in front of a model. The resolver never raises for a bad
+        # override; an empty result falls back to the constant.
+        description = (
+            get_internal_prompt("agents.ask_user_tool_description") or ASK_USER_DESCRIPTION
+        )
         specs.append(
             LocalToolSpec(
                 name="ask_user",
-                description=ASK_USER_DESCRIPTION,
+                description=description,
                 parameters=ASK_USER_PARAMETERS,
                 handler=_make_ask_user_handler(ask_user),
                 exposure=LocalToolExposure.CONSOLE_ONLY,

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -4187,17 +4187,28 @@ def _default_specs(
         # callback (the todo_* pattern -- absent in headless runs, A10),
         # exempt from the permission layer (A12), imported lazily so the
         # module stays off the boot path (ADR-097).
+        import os
+
         from tldw_chatbook.Internal_Prompts import get_internal_prompt
 
-        from .ask_user_questions import ASK_USER_DESCRIPTION, ASK_USER_PARAMETERS
+        from .ask_user_questions import (
+            ASK_USER_DESCRIPTION,
+            ASK_USER_DESCRIPTION_ENV_VAR,
+            ASK_USER_PARAMETERS,
+            resolve_tool_description,
+        )
 
         # task-31420: the description is a registry prompt (its catalog
         # default is byte-identical to ASK_USER_DESCRIPTION) so a user can
         # inspect and override the restraint text like any other prompt the
-        # app puts in front of a model. The resolver never raises for a bad
-        # override; an empty result falls back to the constant.
-        description = (
-            get_internal_prompt("agents.ask_user_tool_description") or ASK_USER_DESCRIPTION
+        # app puts in front of a model. Precedence is env -> config/registry
+        # -> shipped constant, and every candidate is validated through the
+        # Pydantic `ToolDescriptionText` model before it can reach the spec;
+        # a blank, over-long, or non-text override is skipped, never shipped.
+        description = resolve_tool_description(
+            os.environ.get(ASK_USER_DESCRIPTION_ENV_VAR),
+            get_internal_prompt("agents.ask_user_tool_description"),
+            ASK_USER_DESCRIPTION,
         )
         specs.append(
             LocalToolSpec(

--- a/tldw_chatbook/Internal_Prompts/agents_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/agents_prompts.py
@@ -78,3 +78,39 @@ register(
         ),
     )
 )
+
+register(
+    PromptSpec(
+        id="agents.ask_user_tool_description",
+        subsystem="agents",
+        title="ask_user tool description",
+        description=(
+            "The description the ask_user tool presents to the model; most of "
+            "its words say when NOT to ask."
+        ),
+        used_in="Agents/local_tool_provider.py (_default_specs, via ASK_USER_DESCRIPTION)",
+        default=(
+            "Ask the user up to 4 multiple-choice questions and wait for the "
+            "answers. Use it ONLY for a decision that is genuinely the user's to "
+            "make: a preference, a trade-off between valid designs, or something "
+            "neither the code nor the conversation can tell you. Do not ask when a "
+            "conventional default exists, when the answer is discoverable by "
+            "reading the code or running a tool, when you can proceed and state "
+            "your assumption, or to confirm a plan you already have. Batch related "
+            "questions into ONE call instead of asking several times. Each question "
+            "offers 2-4 options; the user can always type a free-text 'Other' "
+            "answer instead. The result lists the selected labels per question; "
+            "'unanswered' marks questions the user skipped, and 'answered': false "
+            "with a reason means no answer will come. If the reason is 'busy', "
+            "another question is already waiting for the user: proceed without "
+            "asking again this turn."
+        ),
+        contract_note=(
+            "task-31420: the [tools] ask_user_enabled gate defaults ON, so every "
+            "user gets whatever this text says -- it is the restraint guidance "
+            "(PRD A13). No placeholders. Keep the 'busy' sentence: the tool's "
+            "busy result tells the model not to retry, and this is where it "
+            "learns what that means."
+        ),
+    )
+)


### PR DESCRIPTION
## Summary

Closes task-31420. The `ask_user` tool description (PRD A13's restraint guidance, most of whose words say when *not* to ask) becomes a registry prompt, `agents.ask_user_tool_description`, so a user can inspect and override it like every other prompt the app puts in front of a model. With the `[tools] ask_user_enabled` gate defaulting on, every user gets this text.

- `Internal_Prompts/agents_prompts.py`: the `PromptSpec`, default byte-identical to `ASK_USER_DESCRIPTION` (golden-parity test), no placeholders, contract note on the gate and the `busy` sentence.
- `Agents/local_tool_provider.py`: `_default_specs` builds the spec's description from `get_internal_prompt(...)` at spec-build time; the resolver never raises and an empty result falls back to the constant. Lazy import, so `Internal_Prompts` stays off the boot path (UI-ready census unchanged at 966/972).
- Tests: `test_ask_user_tool_description_matches_source_constant`, `test_description_defaults_to_the_catalog_text`, `test_a_registry_override_reaches_the_built_spec`. `Tests/Internal_Prompts/` (incl. import hygiene) and `Tests/Agents/test_ask_user_tool.py`: 94 passed. `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018q5PsHwn5kgHPmNwX9DKoo

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closes task-31420 by serving the `ask_user` tool description from the internal-prompts registry instead of a hardcoded constant. The registry prompt (`agents.ask_user_tool_description`) is user-configurable with a default byte-identical to the old constant, and a new env override (`TLDW_INTERNAL_PROMPT_AGENTS_ASK_USER_TOOL_DESCRIPTION`) takes precedence over the registry; invalid (blank, over-long, non-text) values are skipped and fall back to the registry or the constant.

- Precedence is env → config/registry → shipped constant, validated via a strict Pydantic model before reaching the spec.
- The `[tools] ask_user_enabled` gate defaults ON, so every user receives the new text; the spec reads the prompt lazily, keeping `Internal_Prompts` off the boot path.
- New tests pin golden parity with `ASK_USER_DESCRIPTION` and confirm registry/env overrides and fallbacks.

<sup>Written for commit b0341be49061319ad86e47496774ecc7051ec37b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2394?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

