### PR TITLE
feat(console): name the asking sub-agent on the ask_user card and marker (task-31382)

### DIFF
--- a/Tests/Agents/test_subagent_display_label.py
+++ b/Tests/Agents/test_subagent_display_label.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from tldw_chatbook.Agents.agent_service import (
-    SUBAGENT_LABEL_MAX_CHARS,
     subagent_display_label,
 )
-from tldw_chatbook.Agents.run_context import CurrentRunActor
+from tldw_chatbook.Agents.run_context import (
+    SUBAGENT_LABEL_MAX_CHARS,
+    CurrentRunActor,
+    clean_subagent_label,
+)
 
 
 def test_actor_label_defaults_to_none_and_is_settable():
@@ -14,8 +17,16 @@ def test_actor_label_defaults_to_none_and_is_settable():
     assert CurrentRunActor("subagent", "r2", "r1", label="researcher").label == "researcher"
 
 
-def test_named_agent_wins_over_the_task():
+def test_named_agent_wins_over_the_task_and_is_cleaned_too():
     assert subagent_display_label(" researcher ", "Survey the schema") == "researcher"
+    assert subagent_display_label("bad\nname\x07 here", "task") == "bad name here"
+
+
+def test_clean_subagent_label_is_the_one_sanitizer_the_renderers_share():
+    assert clean_subagent_label(None) == ""
+    assert clean_subagent_label("  a \n b\x1b[31m c  ") == "a b [31m c"
+    cut = clean_subagent_label("y" * (SUBAGENT_LABEL_MAX_CHARS + 5))
+    assert len(cut) == SUBAGENT_LABEL_MAX_CHARS and cut.endswith("…")
 
 
 def test_task_first_line_is_the_fallback_and_is_cut_to_one_line():

--- a/Tests/Agents/test_subagent_display_label.py
+++ b/Tests/Agents/test_subagent_display_label.py
@@ -1,0 +1,27 @@
+"""task-31382: the display label a sub-agent run carries on its actor."""
+
+from __future__ import annotations
+
+from tldw_chatbook.Agents.agent_service import (
+    SUBAGENT_LABEL_MAX_CHARS,
+    subagent_display_label,
+)
+from tldw_chatbook.Agents.run_context import CurrentRunActor
+
+
+def test_actor_label_defaults_to_none_and_is_settable():
+    assert CurrentRunActor("primary", "r1", None).label is None
+    assert CurrentRunActor("subagent", "r2", "r1", label="researcher").label == "researcher"
+
+
+def test_named_agent_wins_over_the_task():
+    assert subagent_display_label(" researcher ", "Survey the schema") == "researcher"
+
+
+def test_task_first_line_is_the_fallback_and_is_cut_to_one_line():
+    assert subagent_display_label(None, "Survey the schema\nthen report") == "Survey the schema"
+    long = "x" * (SUBAGENT_LABEL_MAX_CHARS + 20)
+    label = subagent_display_label("", long)
+    assert len(label) == SUBAGENT_LABEL_MAX_CHARS and label.endswith("…")
+    assert subagent_display_label(None, "   ") is None
+    assert subagent_display_label(None, None) is None

--- a/Tests/Chat/test_console_ask_user_round.py
+++ b/Tests/Chat/test_console_ask_user_round.py
@@ -10,7 +10,7 @@ import pytest
 from Tests.Chat.test_console_skill_script_confirm import _FakeApp, _wait_until
 from Tests.console_provider_doubles import persisted_console_store
 from tldw_chatbook.Agents.ask_user_questions import AskUserBusyRefusal
-from tldw_chatbook.Agents.run_context import use_run_id
+from tldw_chatbook.Agents.run_context import CurrentRunActor, use_run_actor, use_run_id
 from tldw_chatbook.Chat.console_agent_bridge import format_question_marker
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 
@@ -333,3 +333,47 @@ def test_malformed_answers_are_dropped_and_the_round_stays_armed(make_controller
     )
     thread.join(timeout=5)
     assert box["result"]["answers"][0]["other_text"] == "fine"
+
+
+# --- task-31382: name the asking sub-agent -----------------------------------
+
+
+def test_marker_names_the_sub_agent_label_when_present():
+    result = {"answered": False, "reason": "timeout"}
+    text = format_question_marker("sub-agent", _questions(), result, asker_label="researcher")
+    assert text.splitlines()[0] == "? Questions from sub-agent 'researcher' (2):"
+    text = format_question_marker("sub-agent", _questions(), result, asker_label="  bad\nlabel\x07 ")
+    assert text.splitlines()[0] == "? Questions from sub-agent 'bad label' (2):"
+    assert format_question_marker("sub-agent", _questions(), result).splitlines()[0] == "? Questions from a sub-agent (2):"
+    assert format_question_marker("agent", _questions(), result, asker_label="ignored").splitlines()[0] == "? Questions from the agent (2):"
+
+
+def test_payload_carries_the_sub_agents_label_from_the_run_actor(make_controller):
+    controller = make_controller()
+    markers = []
+    controller._agent_bridge = SimpleNamespace(
+        append_question_marker=lambda sid, text: markers.append(text)
+    )
+    box = {}
+
+    def worker():
+        with use_run_actor(CurrentRunActor("subagent", "run-c", "run-p", label="researcher")):
+            box["result"] = controller.request_user_questions(_questions())
+
+    thread = threading.Thread(target=worker)
+    thread.start()
+    _wait_until(lambda: bool(controller.pending_question_payloads))
+    payload = controller.pending_question_payloads[0]
+    assert payload["asked_by"] == "sub-agent" and payload["asker_label"] == "researcher"
+    controller.resolve_pending_question([], request_id=payload["request_id"])
+    thread.join(timeout=5)
+    assert markers and markers[0].startswith("? Questions from sub-agent 'researcher'")
+
+
+def test_primary_agent_payload_has_no_label(make_controller):
+    controller = make_controller()
+    thread, box = _start(controller, _questions())
+    _wait_until(lambda: bool(controller.pending_question_payloads))
+    assert controller.pending_question_payloads[0]["asker_label"] is None
+    controller.resolve_pending_question([], request_id=controller.pending_question_ids()[0])
+    thread.join(timeout=5)

--- a/Tests/UI/test_chat_question_card.py
+++ b/Tests/UI/test_chat_question_card.py
@@ -348,3 +348,13 @@ async def test_title_names_the_sub_agent_label_and_falls_back_without_one():
         assert str(card.query_one("#question-title", Static).render()) == (
             "A sub-agent has 2 questions for you:"
         )
+        # A label with newlines / control characters is flattened to one
+        # line and cut, the same way the transcript marker renders it.
+        messy = _payload(1, request_id="round-3")
+        messy["asked_by"] = "sub-agent"
+        messy["asker_label"] = " re\nsearcher\x07 " + "z" * 60
+        app.query_one(ChatTaskCards).sync_state(TaskResumeState(pending_question=messy))
+        await pilot.pause()
+        title = str(card.query_one("#question-title", Static).render())
+        assert title.startswith("Sub-agent 're searcher z") and title.endswith("…' has 1 question for you:")
+        assert "\n" not in title and "\x07" not in title

--- a/Tests/UI/test_chat_question_card.py
+++ b/Tests/UI/test_chat_question_card.py
@@ -323,3 +323,28 @@ async def test_deadline_counts_down_from_the_absolute_deadline_and_stops_when_cl
         app.query_one(ChatTaskCards).sync_state(TaskResumeState())
         await pilot.pause()
         assert card._deadline_timer is None
+
+
+# --- task-31382: the title names the asking sub-agent --------------------------
+
+
+@pytest.mark.asyncio
+async def test_title_names_the_sub_agent_label_and_falls_back_without_one():
+    app = _Harness()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        payload = _payload(1)
+        payload["asked_by"] = "sub-agent"
+        payload["asker_label"] = "researcher"
+        card = await _mount(app, pilot, payload)
+        assert str(card.query_one("#question-title", Static).render()) == (
+            "Sub-agent 'researcher' has 1 question for you:"
+        )
+        unnamed = _payload(2, request_id="round-2")
+        unnamed["asked_by"] = "sub-agent"
+        unnamed["asker_label"] = None
+        app.query_one(ChatTaskCards).sync_state(TaskResumeState(pending_question=unnamed))
+        await pilot.pause()
+        assert str(card.query_one("#question-title", Static).render()) == (
+            "A sub-agent has 2 questions for you:"
+        )

--- a/backlog/tasks/task-31382 - Name-the-asking-sub-agent-on-the-ask_user-card-and-its-transcript-marker.md
+++ b/backlog/tasks/task-31382 - Name-the-asking-sub-agent-on-the-ask_user-card-and-its-transcript-marker.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31382
 title: Name the asking sub-agent on the ask_user card and its transcript marker
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@Robert'
 created_date: '2026-09-04 19:28'
+updated_date: '2026-09-05 00:01'
 labels:
   - console
   - agents
@@ -19,8 +21,23 @@ PRD A11 says the question card names the asking agent. M2 (PR #2379) ships the a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The question card title names the asking sub-agent by its display label when one exists, falling back to the current generic copy
-- [ ] #2 The A14 transcript marker header carries the same label
-- [ ] #3 A primary-agent question is unchanged
-- [ ] #4 The label lookup never blocks the worker thread or raises into the round
+- [x] #1 The question card title names the asking sub-agent by its display label when one exists, falling back to the current generic copy
+- [x] #2 The A14 transcript marker header carries the same label
+- [x] #3 A primary-agent question is unchanged
+- [x] #4 The label lookup never blocks the worker thread or raises into the round
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. CurrentRunActor gains an optional display label (default None) set by AgentService when it builds a sub-agent's actor: the named agent's name when the spawn named one, else a short form of the child's task.
+2. request_user_questions copies actor.label into the card payload as asker_label; asked_by stays the kind.
+3. ChatQuestionCard title and format_question_marker header name the label when present, falling back to the existing generic copy.
+4. Tests: actor default, payload carries the label from the run actor context, card title, marker header; existing ask_user suites unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CurrentRunActor gained an optional label (default None). AgentService sets it when it builds a sub-agent's actor in _run_one via subagent_display_label(agent_definition, task): the resolved named-agent name wins, else the task's first line cut to 40 chars. request_user_questions copies actor.label into the payload as asker_label; ChatQuestionCard's title reads "Sub-agent 'researcher' has N questions for you:" and format_question_marker's header reads "? Questions from sub-agent 'researcher' (N):", both falling back to the generic copy without a label; a primary agent is unchanged. The lookup is a field read on the run actor context, so it never blocks the worker thread or raises. Files: Agents/run_context.py, Agents/agent_service.py, Chat/console_chat_controller.py, Chat/console_agent_bridge.py, Widgets/Chat_Widgets/chat_question_card.py; tests in Tests/Agents/test_subagent_display_label.py, Tests/Chat/test_console_ask_user_round.py, Tests/UI/test_chat_question_card.py.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -1036,6 +1036,35 @@ _FILE_CONTENT_TOOL_NAMES = frozenset(
 )
 
 
+#: task-31382: a task-derived sub-agent label is cut here so a card title or
+#: marker header stays one line.
+SUBAGENT_LABEL_MAX_CHARS = 40
+
+
+def subagent_display_label(agent_name: str | None, task: str | None) -> str | None:
+    """Return the display label for a sub-agent run (task-31382).
+
+    The named agent's name wins when the spawn named one; otherwise the
+    first line of the child's task, cut to ``SUBAGENT_LABEL_MAX_CHARS``.
+
+    Args:
+        agent_name: The resolved named-agent name, or None.
+        task: The child's task text, or None.
+
+    Returns:
+        A one-line label, or None when neither source has text.
+    """
+    name = (agent_name or "").strip()
+    if name:
+        return name
+    first_line = (task or "").strip().splitlines()[0].strip() if (task or "").strip() else ""
+    if not first_line:
+        return None
+    if len(first_line) > SUBAGENT_LABEL_MAX_CHARS:
+        return first_line[: SUBAGENT_LABEL_MAX_CHARS - 1].rstrip() + "…"
+    return first_line
+
+
 def _is_file_content_tool(tool_name: str) -> bool:
     """Return whether a tool result may contain local filesystem content."""
     return tool_name.startswith("fs_") or tool_name in _FILE_CONTENT_TOOL_NAMES
@@ -6126,6 +6155,11 @@ class AgentService:
             "subagent" if agent_kind == AGENT_KIND_SUBAGENT else "primary",
             run_id,
             parent_run_id,
+            label=(
+                subagent_display_label(agent_definition, task)
+                if agent_kind == AGENT_KIND_SUBAGENT
+                else None
+            ),
         )
         builtin_invoke_tool = self._make_invoke_tool(
             config,

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -131,7 +131,12 @@ from .native_tools import (
     provider_supports_native_tools,
     schemas_to_openai_tools,
 )
-from .run_context import CurrentRunActor, use_run_actor, use_tool_call_id
+from .run_context import (
+    CurrentRunActor,
+    clean_subagent_label,
+    use_run_actor,
+    use_tool_call_id,
+)
 from .run_log import _setting
 from tldw_chatbook.config import coerce_bool_setting, coerce_int_setting
 from .run_log_eviction import (
@@ -1036,16 +1041,12 @@ _FILE_CONTENT_TOOL_NAMES = frozenset(
 )
 
 
-#: task-31382: a task-derived sub-agent label is cut here so a card title or
-#: marker header stays one line.
-SUBAGENT_LABEL_MAX_CHARS = 40
-
-
 def subagent_display_label(agent_name: str | None, task: str | None) -> str | None:
     """Return the display label for a sub-agent run (task-31382).
 
     The named agent's name wins when the spawn named one; otherwise the
-    first line of the child's task, cut to ``SUBAGENT_LABEL_MAX_CHARS``.
+    first line of the child's task. Either goes through
+    ``clean_subagent_label`` so the label is one bounded, control-free line.
 
     Args:
         agent_name: The resolved named-agent name, or None.
@@ -1054,15 +1055,12 @@ def subagent_display_label(agent_name: str | None, task: str | None) -> str | No
     Returns:
         A one-line label, or None when neither source has text.
     """
-    name = (agent_name or "").strip()
+    name = clean_subagent_label(agent_name)
     if name:
         return name
-    first_line = (task or "").strip().splitlines()[0].strip() if (task or "").strip() else ""
-    if not first_line:
-        return None
-    if len(first_line) > SUBAGENT_LABEL_MAX_CHARS:
-        return first_line[: SUBAGENT_LABEL_MAX_CHARS - 1].rstrip() + "…"
-    return first_line
+    stripped = (task or "").strip()
+    first_line = stripped.splitlines()[0] if stripped else ""
+    return clean_subagent_label(first_line) or None
 
 
 def _is_file_content_tool(tool_name: str) -> bool:

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -79,6 +79,11 @@ class CurrentRunActor:
     kind: Literal["primary", "subagent"]
     run_id: str
     parent_run_id: str | None
+    #: task-31382: a display label for a sub-agent (the named agent's name,
+    #: else a short form of its task) so surfaces that attribute a run's
+    #: work to the user -- the ask_user card and marker first -- can name
+    #: WHICH child. None for the primary and for callers that never set it.
+    label: str | None = None
 
 
 _CURRENT_RUN_ACTOR: ContextVar[CurrentRunActor | None] = ContextVar(

--- a/tldw_chatbook/Agents/run_context.py
+++ b/tldw_chatbook/Agents/run_context.py
@@ -72,17 +72,52 @@ from dataclasses import dataclass
 from typing import Iterator, Literal
 
 
+#: task-31382: a sub-agent display label is cut here so a card title or a
+#: marker header stays one line. Shared by the label's one producer
+#: (``subagent_display_label``) and both of its renderers.
+SUBAGENT_LABEL_MAX_CHARS = 40
+
+
+def clean_subagent_label(text: str | None) -> str:
+    """Return ``text`` as one bounded, single-line, terminal-safe label.
+
+    Newlines and control characters become spaces, runs of whitespace
+    collapse, and anything past ``SUBAGENT_LABEL_MAX_CHARS`` is cut with an
+    ellipsis. The empty string means "no label".
+
+    Args:
+        text: The raw label, or None.
+
+    Returns:
+        The cleaned label, possibly empty.
+    """
+    flattened = "".join(
+        char if char.isprintable() else " " for char in str(text or "")
+    )
+    cleaned = " ".join(flattened.split())
+    if len(cleaned) > SUBAGENT_LABEL_MAX_CHARS:
+        return cleaned[: SUBAGENT_LABEL_MAX_CHARS - 1].rstrip() + "…"
+    return cleaned
+
+
 @dataclass(frozen=True, slots=True)
 class CurrentRunActor:
-    """Attribution for the primary or subagent invoking a provider tool."""
+    """Attribution for the primary or subagent invoking a provider tool.
+
+    Args:
+        kind: Whether the actor is the primary run or a spawned sub-agent.
+        run_id: The acting run's id.
+        parent_run_id: The spawning run's id for a sub-agent, else None.
+        label: task-31382: a display label for a sub-agent (the named
+            agent's name, else a short form of its task) so surfaces that
+            attribute a run's work to the user -- the ask_user card and
+            marker first -- can name WHICH child. None for the primary and
+            for callers that never set it.
+    """
 
     kind: Literal["primary", "subagent"]
     run_id: str
     parent_run_id: str | None
-    #: task-31382: a display label for a sub-agent (the named agent's name,
-    #: else a short form of its task) so surfaces that attribute a run's
-    #: work to the user -- the ask_user card and marker first -- can name
-    #: WHICH child. None for the primary and for callers that never set it.
     label: str | None = None
 
 

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1534,7 +1534,11 @@ def format_todo_marker(tasks: list[dict[str, object]]) -> str:
 
 
 def format_question_marker(
-    asked_by: str, questions: list[dict[str, Any]], result: dict[str, Any]
+    asked_by: str,
+    questions: list[dict[str, Any]],
+    result: dict[str, Any],
+    *,
+    asker_label: str | None = None,
 ) -> str:
     """Render the transcript record of a resolved ``ask_user`` round (PRD A14).
 
@@ -1547,11 +1551,17 @@ def format_question_marker(
         asked_by: ``"agent"`` or ``"sub-agent"``.
         questions: The validated questions the round showed.
         result: The PRD A6 result dict the tool returned.
+        asker_label: task-31382: the sub-agent's display label when the run
+            carries one; the header then names it.
 
     Returns:
         The marker text.
     """
-    who = "a sub-agent" if asked_by == "sub-agent" else "the agent"
+    label = _sanitize_task_marker_label(str(asker_label or "")).strip()[:40]
+    if asked_by == "sub-agent":
+        who = f"sub-agent '{label}'" if label else "a sub-agent"
+    else:
+        who = "the agent"
     lines = [f"? Questions from {who} ({len(questions)}):"]
     answers = result.get("answers") if result.get("answered") else None
     reason = str(result.get("reason") or "cancelled")

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -1557,7 +1557,9 @@ def format_question_marker(
     Returns:
         The marker text.
     """
-    label = _sanitize_task_marker_label(str(asker_label or "")).strip()[:40]
+    from tldw_chatbook.Agents.run_context import clean_subagent_label
+
+    label = clean_subagent_label(asker_label)
     if asked_by == "sub-agent":
         who = f"sub-agent '{label}'" if label else "a sub-agent"
     else:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -13993,9 +13993,12 @@ class ConsoleChatController:
         deadline = time.monotonic() + timeout_seconds if timeout_seconds > 0 else None
         actor = current_run_actor()
         asked_by = "sub-agent" if actor is not None and actor.kind == "subagent" else "agent"
+        # task-31382: name WHICH sub-agent is asking when the run carries a label.
+        asker_label = actor.label if asked_by == "sub-agent" and actor is not None else None
         card_payload: dict[str, Any] = {
             "questions": [dict(question) for question in questions],
             "asked_by": asked_by,
+            "asker_label": asker_label,
             "timeout_seconds": timeout_seconds,
             "request_id": request_id,
             "session_id": owning_session_id,
@@ -14041,7 +14044,9 @@ class ConsoleChatController:
                 with contextlib.suppress(Exception):
                     bridge.append_question_marker(
                         owning_session_id,
-                        format_question_marker(asked_by, questions, result),
+                        format_question_marker(
+                            asked_by, questions, result, asker_label=asker_label
+                        ),
                     )
             return result
         finally:

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_question_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_question_card.py
@@ -268,7 +268,11 @@ class ChatQuestionCard(Container):
         except NoMatches:
             return
         payload = self._payload or {}
-        who = "A sub-agent" if payload.get("asked_by") == "sub-agent" else "The agent"
+        label = str(payload.get("asker_label") or "").strip()[:40]
+        if payload.get("asked_by") == "sub-agent":
+            who = f"Sub-agent '{label}'" if label else "A sub-agent"
+        else:
+            who = "The agent"
         count = len(self._questions)
         title.update(f"{who} has {count} question{'s' if count != 1 else ''} for you:")
         self._sync_deadline(deadline)

--- a/tldw_chatbook/Widgets/Chat_Widgets/chat_question_card.py
+++ b/tldw_chatbook/Widgets/Chat_Widgets/chat_question_card.py
@@ -267,8 +267,10 @@ class ChatQuestionCard(Container):
             sections = self.query_one("#question-sections", VerticalScroll)
         except NoMatches:
             return
+        from tldw_chatbook.Agents.run_context import clean_subagent_label
+
         payload = self._payload or {}
-        label = str(payload.get("asker_label") or "").strip()[:40]
+        label = clean_subagent_label(payload.get("asker_label"))
         if payload.get("asked_by") == "sub-agent":
             who = f"Sub-agent '{label}'" if label else "A sub-agent"
         else:


### PR DESCRIPTION
## Summary

Closes task-31382 (PRD A11: the question card names the asking agent). A fleet child's run actor now carries a display label, and the `ask_user` card title and transcript marker use it.

- `Agents/run_context.py`: `CurrentRunActor.label: str | None = None` (defaulted, so every existing constructor call is unchanged).
- `Agents/agent_service.py`: `_run_one` sets the label when it builds a sub-agent's actor via `subagent_display_label(agent_definition, task)`: the resolved named-agent name wins, else the task's first line cut to 40 chars. Pure function, no I/O.
- `Chat/console_chat_controller.py`: `request_user_questions` copies `actor.label` into the payload as `asker_label`; `asked_by` stays the kind.
- `Widgets/Chat_Widgets/chat_question_card.py`: title reads `Sub-agent 'researcher' has 2 questions for you:`; `Chat/console_agent_bridge.py`: marker header reads `? Questions from sub-agent 'researcher' (2):`. Both fall back to the previous generic copy without a label; the primary agent is unchanged. The lookup is a field read on the run-actor context, so it never blocks the worker thread or raises into the round.

## Verification

- New tests: `Tests/Agents/test_subagent_display_label.py` (actor default, name wins, task fallback and cut), round tests (payload carries the label from the actor context; primary has none; marker header), card title test. Ask_user suites: 48 passed.
- Agent-service, spawn, run-context, and fleet suites: **29 failed on the branch vs 29 on clean `origin/dev`** in a detached worktree, identical sets (the known fleet-wake family).
- `./scripts/preflight.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Names the asking sub-agent on the `ask_user` card and transcript marker, replacing the generic "A sub-agent" copy with the sub-agent's display label (for example, "Sub-agent 'researcher' has 2 questions for you:"). Falls back to the generic copy when no label exists; primary-agent questions are unchanged.

**New Features**
- The run actor gains an optional `label`, set when a sub-agent spawns: the named agent's name wins, else the task's first line cut to 40 chars.
- The label is a field read on the actor context, so it never blocks the worker thread or raises into the round; one shared `clean_subagent_label` helper sanitizes it for the card, marker, and producer so the two renderers cannot drift.

<sup>Written for commit 816a4e2f002cb9f0794b1597df7ea108f98f583d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

