### PR TITLE
Fix automatic compaction and clarify Console context spend

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2771,7 +2771,7 @@
     },
     {
       "call_count": 118,
-      "diagnostic_digest": "f064d65042be4456ba04",
+      "diagnostic_digest": "8ebfd952b60e3615aeba",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/chat_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Tests/Chat/test_console_cost_tracker.py
+++ b/Tests/Chat/test_console_cost_tracker.py
@@ -7,12 +7,12 @@ display time from usage rows via the pricing catalog.
 
 from types import SimpleNamespace
 
+from tldw_chatbook.Chat import console_cost_tracker as tracker
 from tldw_chatbook.Chat.console_cost_tracker import (
     ConsoleCacheState,
     ConsoleCostRow,
     ConsoleCostRowTotals,
     ConsoleCostSnapshot,
-    PayloadFingerprint,
     build_cost_rows,
     build_cost_rows_totals,
     build_cost_snapshot,
@@ -30,8 +30,10 @@ def _msg(content="hi", usage=None, role="assistant"):
 
 def test_snapshot_sums_priced_usage_rows():
     usage = ProviderUsage(
-        uncached_input=1_000_000, output=1_000_000,
-        provider="anthropic", model="claude-sonnet-4-6",
+        uncached_input=1_000_000,
+        output=1_000_000,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     snap = build_cost_snapshot(
         [_msg(usage=usage)], provider="anthropic", model="claude-sonnet-4-6"
@@ -59,8 +61,10 @@ def test_fleet_tokens_fold_into_total_tokens_but_never_price():
     price accurately (see ``ConsoleCostSnapshot.fleet_tokens``'s
     docstring)."""
     usage = ProviderUsage(
-        uncached_input=1_000_000, output=1_000_000,
-        provider="anthropic", model="claude-sonnet-4-6",
+        uncached_input=1_000_000,
+        output=1_000_000,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     snap = build_cost_snapshot(
         [_msg(usage=usage)],
@@ -141,8 +145,12 @@ def test_unknown_model_yields_tokens_only():
 def test_state_normal_warm():
     snap = ConsoleCostSnapshot(0.4821, 12000, True, False, 3)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.WARM, break_reason=None,
-        projected_delta_usd=None, ttl_remaining_s=240.0, pricing_as_of="2026-08-02",
+        snap,
+        cache_state=ConsoleCacheState.WARM,
+        break_reason=None,
+        projected_delta_usd=None,
+        ttl_remaining_s=240.0,
+        pricing_as_of="2026-08-02",
     )
     assert state.label == "$0.4821 ●"
     assert state.alert is False and state.cold is False
@@ -152,8 +160,12 @@ def test_state_normal_warm():
 def test_state_alert_carries_delta_and_reason():
     snap = ConsoleCostSnapshot(0.48, 12000, True, False, 3)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.WARM, break_reason="system prompt changed",
-        projected_delta_usd=0.13, ttl_remaining_s=120.0, pricing_as_of="2026-08-02",
+        snap,
+        cache_state=ConsoleCacheState.WARM,
+        break_reason="system prompt changed",
+        projected_delta_usd=0.13,
+        ttl_remaining_s=120.0,
+        pricing_as_of="2026-08-02",
     )
     assert state.label == "$0.48 ⚠ ~+$0.13"
     assert state.compact_label == "$0.48 ⚠"
@@ -164,8 +176,12 @@ def test_state_alert_carries_delta_and_reason():
 def test_state_alert_requires_warm_cache():
     snap = ConsoleCostSnapshot(0.48, 12000, True, False, 3)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.NONE, break_reason="system prompt changed",
-        projected_delta_usd=0.13, ttl_remaining_s=None, pricing_as_of=None,
+        snap,
+        cache_state=ConsoleCacheState.NONE,
+        break_reason="system prompt changed",
+        projected_delta_usd=0.13,
+        ttl_remaining_s=None,
+        pricing_as_of=None,
     )
     assert state.alert is False  # no warm cache -> nothing to break
 
@@ -173,8 +189,12 @@ def test_state_alert_requires_warm_cache():
 def test_state_expired_is_cold_not_alert():
     snap = ConsoleCostSnapshot(0.48, 12000, True, False, 3)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.EXPIRED, break_reason=None,
-        projected_delta_usd=0.13, ttl_remaining_s=None, pricing_as_of=None,
+        snap,
+        cache_state=ConsoleCacheState.EXPIRED,
+        break_reason=None,
+        projected_delta_usd=0.13,
+        ttl_remaining_s=None,
+        pricing_as_of=None,
     )
     assert state.label == "$0.48 ○"
     assert state.cold is True and state.alert is False
@@ -184,18 +204,81 @@ def test_state_expired_is_cold_not_alert():
 def test_state_no_pricing_shows_tokens():
     snap = ConsoleCostSnapshot(None, 12_345, False, False, 2)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.NONE, break_reason=None,
-        projected_delta_usd=None, ttl_remaining_s=None, pricing_as_of=None,
+        snap,
+        cache_state=ConsoleCacheState.NONE,
+        break_reason=None,
+        projected_delta_usd=None,
+        ttl_remaining_s=None,
+        pricing_as_of=None,
     )
     assert state.label == "12.3k tok"
     assert "[pricing]" in state.tooltip
 
 
+def test_unpriced_estimated_history_is_marked_as_local_not_unsent():
+    snap = ConsoleCostSnapshot(None, 12_345, False, True, 2)
+    state = build_cost_state(
+        snap,
+        cache_state=ConsoleCacheState.NONE,
+        break_reason=None,
+        projected_delta_usd=None,
+        ttl_remaining_s=None,
+        pricing_as_of=None,
+    )
+    assert state.label == "~12.3k tok"
+    assert "Includes locally estimated transcript rows." in state.tooltip
+    assert "unsent" not in state.tooltip
+
+
+def test_snapshot_failure_is_unavailable_without_losing_cache_narration(
+    monkeypatch,
+):
+    class BrokenCatalog:
+        def get_pricing(self, *_args):
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(tracker, "get_pricing_catalog", BrokenCatalog)
+    snapshot = build_cost_snapshot(
+        [_msg(content="persisted history")],
+        provider="anthropic",
+        model="claude-sonnet-4-6",
+    )
+    state = build_cost_state(
+        snapshot,
+        cache_state=ConsoleCacheState.WARM,
+        break_reason="system prompt changed",
+        projected_delta_usd=0.13,
+        ttl_remaining_s=90.0,
+        pricing_as_of="2026-09-04",
+    )
+
+    assert snapshot.available is False
+    assert state.label == "unavailable"
+    assert state.alert is True and state.cold is False
+    assert "Cache: warm" in state.tooltip
+    assert "system prompt changed" in state.tooltip
+
+    expired = build_cost_state(
+        snapshot,
+        cache_state=ConsoleCacheState.EXPIRED,
+        break_reason=None,
+        projected_delta_usd=None,
+        ttl_remaining_s=None,
+        pricing_as_of="2026-09-04",
+    )
+    assert expired.alert is False and expired.cold is True
+    assert "Cache: expired" in expired.tooltip
+
+
 def test_estimated_entries_marked_in_tooltip_and_label():
     snap = ConsoleCostSnapshot(0.10, 5000, True, True, 2)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.NONE, break_reason=None,
-        projected_delta_usd=None, ttl_remaining_s=None, pricing_as_of=None,
+        snap,
+        cache_state=ConsoleCacheState.NONE,
+        break_reason=None,
+        projected_delta_usd=None,
+        ttl_remaining_s=None,
+        pricing_as_of=None,
     )
     assert state.label.startswith("~$0.10")
     assert "estimated" in state.tooltip.lower()
@@ -214,11 +297,13 @@ def test_estimated_row_pricing_depends_on_role():
 
     user_snap = build_cost_snapshot(
         [_msg(content=content, usage=None, role="user")],
-        provider="anthropic", model="claude-sonnet-4-6",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     assistant_snap = build_cost_snapshot(
         [_msg(content=content, usage=None, role="assistant")],
-        provider="anthropic", model="claude-sonnet-4-6",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     assert user_snap.pricing_known is True
     assert assistant_snap.pricing_known is True
@@ -242,7 +327,8 @@ def test_estimated_row_pricing_depends_on_role():
             _msg(content=content, usage=None, role="user"),
             _msg(content=content, usage=None, role="assistant"),
         ],
-        provider="anthropic", model="claude-sonnet-4-6",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     assert combined_snap.total_usd == expected_total
 
@@ -257,11 +343,13 @@ def test_estimate_provider_is_normalized_before_ratio_lookup():
 
     snap_lower = build_cost_snapshot(
         [_msg(content=content, usage=None, role="user")],
-        provider="google", model="gemini-2.5-flash",
+        provider="google",
+        model="gemini-2.5-flash",
     )
     snap_mixed = build_cost_snapshot(
         [_msg(content=content, usage=None, role="user")],
-        provider="Google", model="gemini-2.5-flash",
+        provider="Google",
+        model="gemini-2.5-flash",
     )
     assert snap_mixed.total_tokens == snap_lower.total_tokens
     assert snap_mixed.total_usd == snap_lower.total_usd
@@ -274,8 +362,12 @@ def test_tokens_only_tooltip_narrates_cache_state():
     """
     snap = ConsoleCostSnapshot(None, 12_345, False, False, 2)
     state = build_cost_state(
-        snap, cache_state=ConsoleCacheState.WARM, break_reason="system prompt changed",
-        projected_delta_usd=0.13, ttl_remaining_s=90.0, pricing_as_of=None,
+        snap,
+        cache_state=ConsoleCacheState.WARM,
+        break_reason="system prompt changed",
+        projected_delta_usd=0.13,
+        ttl_remaining_s=90.0,
+        pricing_as_of=None,
     )
     assert state.alert is True
     assert "system prompt changed" in state.tooltip
@@ -303,15 +395,24 @@ BASE = [
 
 def test_appended_turn_is_not_a_break():
     baseline = _fp(BASE)
-    current = _fp(BASE + [{"role": "user", "content": "q2"}, {"role": "assistant", "content": "a2"}])
+    current = _fp(
+        BASE
+        + [{"role": "user", "content": "q2"}, {"role": "assistant", "content": "a2"}]
+    )
     assert fingerprint_break_reason(baseline, current) is None
 
 
 def test_each_component_yields_its_reason_with_priority():
     baseline = _fp(BASE)
-    assert fingerprint_break_reason(baseline, _fp(BASE, model="other")) == "model or provider changed"
+    assert (
+        fingerprint_break_reason(baseline, _fp(BASE, model="other"))
+        == "model or provider changed"
+    )
     changed_system = [{"role": "system", "content": "be verbose"}] + BASE[1:]
-    assert fingerprint_break_reason(baseline, _fp(changed_system)) == "system prompt changed"
+    assert (
+        fingerprint_break_reason(baseline, _fp(changed_system))
+        == "system prompt changed"
+    )
     edited = [BASE[0], {"role": "user", "content": "EDITED"}, BASE[2]]
     assert fingerprint_break_reason(baseline, _fp(edited)) == "earlier history changed"
     # model beats system when both changed
@@ -323,7 +424,9 @@ def test_each_component_yields_its_reason_with_priority():
 
 def test_truncated_history_is_a_break():
     baseline = _fp(BASE)
-    assert fingerprint_break_reason(baseline, _fp(BASE[:2])) == "earlier history changed"
+    assert (
+        fingerprint_break_reason(baseline, _fp(BASE[:2])) == "earlier history changed"
+    )
 
 
 def test_list_content_rows_hash_stably():
@@ -336,8 +439,12 @@ def test_list_content_rows_hash_stably():
 
 def test_build_cost_rows_prices_a_usage_row():
     usage = ProviderUsage(
-        uncached_input=1000, cache_read=200, cache_write=50, output=500,
-        provider="anthropic", model="claude-sonnet-4-6",
+        uncached_input=1000,
+        cache_read=200,
+        cache_write=50,
+        output=500,
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     rows = build_cost_rows(
         [_msg(usage=usage)], provider="anthropic", model="claude-sonnet-4-6"
@@ -378,7 +485,9 @@ def test_build_cost_rows_estimates_row_without_usage_role_aware():
 
 
 def test_build_cost_rows_unknown_model_yields_unpriced_row():
-    usage = ProviderUsage(uncached_input=100, provider="anthropic", model="mystery-9000")
+    usage = ProviderUsage(
+        uncached_input=100, provider="anthropic", model="mystery-9000"
+    )
     rows = build_cost_rows(
         [_msg(usage=usage)], provider="anthropic", model="mystery-9000"
     )
@@ -451,12 +560,15 @@ def test_build_cost_rows_totals_empty_is_unpriced_zero():
 
 def test_build_cost_rows_carries_audio_and_transcription_fields():
     usage = ProviderUsage(
-        uncached_input=33, output=118, audio_input=18, audio_output=90,
-        transcription_seconds=2.5, provider="openai", model="gpt-realtime",
+        uncached_input=33,
+        output=118,
+        audio_input=18,
+        audio_output=90,
+        transcription_seconds=2.5,
+        provider="openai",
+        model="gpt-realtime",
     )
-    rows = build_cost_rows(
-        [_msg(usage=usage)], provider="openai", model="gpt-realtime"
-    )
+    rows = build_cost_rows([_msg(usage=usage)], provider="openai", model="gpt-realtime")
     assert len(rows) == 1
     row = rows[0]
     assert row.audio_input == 18
@@ -472,7 +584,8 @@ def test_build_cost_rows_carries_audio_and_transcription_fields():
 def test_build_cost_rows_estimated_row_has_zero_audio_fields():
     rows = build_cost_rows(
         [_msg(content="hi there", usage=None, role="user")],
-        provider="anthropic", model="claude-sonnet-4-6",
+        provider="anthropic",
+        model="claude-sonnet-4-6",
     )
     assert rows[0].audio_input == 0
     assert rows[0].audio_output == 0

--- a/Tests/Chat/test_console_status_chips_cost.py
+++ b/Tests/Chat/test_console_status_chips_cost.py
@@ -9,6 +9,7 @@ import re
 from pathlib import Path
 
 import pytest
+from rich.cells import cell_len
 from textual import on
 from textual.app import App, ComposeResult
 
@@ -22,6 +23,7 @@ from tldw_chatbook.Widgets.Console.console_status_chips import (
 ROOT = Path(__file__).resolve().parents[2]
 AGENTIC = ROOT / "tldw_chatbook/css/components/_agentic_terminal.tcss"
 BUNDLE = ROOT / "tldw_chatbook/css/tldw_cli_modular.tcss"
+CONSOLE_SCREEN = ROOT / "tldw_chatbook/css/screen_agentic_console.tcss"
 
 
 def _control_state(**overrides) -> ConsoleControlState:
@@ -76,6 +78,13 @@ class _ChipsApp(App):
         self.captured_pressed.append(event)
 
 
+class _ProductionChipsApp(_ChipsApp):
+    """Status-chip harness using the shipped stylesheet and hierarchy."""
+
+    CSS = ""
+    CSS_PATH = [str(BUNDLE), str(CONSOLE_SCREEN)]
+
+
 @pytest.mark.asyncio
 async def test_cost_chip_is_composed_last():
     app = _ChipsApp(_control_state(), cost_state=_cost_state())
@@ -86,16 +95,12 @@ async def test_cost_chip_is_composed_last():
             chip.id for chip in chips.query(".console-control-chip") if chip.display
         ]
         assert visible_ids[-1] == "console-cost-chip"
-        assert isinstance(
-            app.query_one("#console-cost-chip"), ConsoleCostChip
-        )
+        assert isinstance(app.query_one("#console-cost-chip"), ConsoleCostChip)
 
 
 @pytest.mark.asyncio
 async def test_cost_chip_renders_label_from_state():
-    app = _ChipsApp(
-        _control_state(), cost_state=_cost_state(label="$1.23 ● ~+$0.05")
-    )
+    app = _ChipsApp(_control_state(), cost_state=_cost_state(label="$1.23 ● ~+$0.05"))
     async with app.run_test(size=(200, 6)) as pilot:
         await pilot.pause()
         chip = app.query_one("#console-cost-chip", ConsoleCostChip)
@@ -195,9 +200,7 @@ async def test_sync_cost_state_toggles_cold_class():
 @pytest.mark.asyncio
 async def test_cold_state_at_compose_time():
     """The cold class must also apply on the very first frame (F1 precedent)."""
-    app = _ChipsApp(
-        _control_state(), cost_state=_cost_state(alert=False, cold=True)
-    )
+    app = _ChipsApp(_control_state(), cost_state=_cost_state(alert=False, cold=True))
     async with app.run_test(size=(200, 6)) as pilot:
         await pilot.pause()
         chip = app.query_one("#console-cost-chip", ConsoleCostChip)
@@ -274,6 +277,81 @@ async def test_sync_cost_state_uses_full_label_when_wide():
 
 
 @pytest.mark.asyncio
+async def test_context_cost_label_uses_compact_copy_on_initial_narrow_mount():
+    state = _cost_state(
+        label="Context 45% · Current $0.48 · On next send ~+$0.13",
+        compact_label="Ctx 45% · Now $0.48 · Next ~+$0.13",
+    )
+    app = _ChipsApp(_control_state(), cost_state=state)
+
+    async with app.run_test(size=(80, 6)) as pilot:
+        await pilot.pause()
+        rendered = str(app.query_one("#console-cost-chip", ConsoleCostChip).render())
+
+        assert "Ctx 45% · Now $0.48 · Next ~+$0.13" in rendered
+        assert "On next send" not in rendered
+
+
+@pytest.mark.asyncio
+async def test_context_cost_label_tracks_live_resize_without_state_change():
+    state = _cost_state(
+        label="Context 45% · Current $0.48 · On next send ~+$0.13",
+        compact_label="Ctx 45% · Now $0.48 · Next ~+$0.13",
+    )
+    app = _ChipsApp(_control_state(), cost_state=state)
+
+    async with app.run_test(size=(200, 6)) as pilot:
+        await pilot.pause()
+        chip = app.query_one("#console-cost-chip", ConsoleCostChip)
+        assert "On next send" in str(chip.render())
+
+        await pilot.resize_terminal(80, 6)
+        await pilot.pause()
+        assert "Ctx 45% · Now $0.48 · Next ~+$0.13" in str(chip.render())
+
+        await pilot.resize_terminal(200, 6)
+        await pilot.pause()
+        assert "Context 45% · Current $0.48 · On next send ~+$0.13" in str(
+            chip.render()
+        )
+
+
+@pytest.mark.parametrize(
+    ("width", "height", "expected"),
+    (
+        (80, 24, "Ctx 100%+ · Now $12,345.67 · Next ~+$987.65"),
+        (
+            120,
+            35,
+            "Context 100%+ · Current $12,345.67 · On next send ~+$987.65",
+        ),
+    ),
+)
+@pytest.mark.asyncio
+async def test_context_cost_label_fits_shipped_status_strip(
+    width: int, height: int, expected: str
+) -> None:
+    app = _ProductionChipsApp(
+        _control_state(),
+        cost_state=_cost_state(
+            label="Context 100%+ · Current $12,345.67 · On next send ~+$987.65",
+            compact_label="Ctx 100%+ · Now $12,345.67 · Next ~+$987.65",
+        ),
+    )
+    async with app.run_test(size=(width, height)) as pilot:
+        await pilot.pause()
+        chip = app.query_one("#console-cost-chip", ConsoleCostChip)
+        scroll = app.query_one("#console-status-chip-scroll")
+
+        rendered = str(chip.render())
+        assert rendered == expected
+        assert "…" not in rendered and "..." not in rendered
+        assert chip.region.height == 1
+        assert chip.region.y == scroll.content_region.y
+        assert chip.content_region.width >= cell_len(expected)
+
+
+@pytest.mark.asyncio
 async def test_cost_chip_click_posts_pressed_message():
     """A real ``pilot.click`` must dispatch through the normal message pump.
 
@@ -330,11 +408,9 @@ def _chip_cold_body(css_text: str) -> str:
     return match.group(1) if match else ""
 
 
-def test_console_chip_cold_css_exists_in_both_source_and_bundle():
-    """Dossier §9c dual-file contract: the source module and the generated
-    bundle must both carry the new class (the bundle is regenerated from
-    source, never hand-edited -- this just proves the rebuild happened)."""
-    for css_path in (AGENTIC, BUNDLE):
+def test_console_chip_cold_css_exists_in_source_and_generated_screen_sheet():
+    """The source rule must be regenerated into dev's split Console sheet."""
+    for css_path in (AGENTIC, CONSOLE_SCREEN):
         body = _chip_cold_body(css_path.read_text(encoding="utf-8"))
         assert body, f"{css_path.name}: no .console-chip-cold rule"
         assert "$ds-status-info" in body or "color" in body

--- a/Tests/UI/test_console_controller_wiring.py
+++ b/Tests/UI/test_console_controller_wiring.py
@@ -45,6 +45,9 @@ from tldw_chatbook.UI.Console_Modules import hands_free as hands_free_module
 from tldw_chatbook.UI.Console_Modules import wiring as wiring_module
 from tldw_chatbook.UI.Console_Modules.agent import ConsoleAgentController
 from tldw_chatbook.UI.Console_Modules.character import ConsoleCharacterController
+from tldw_chatbook.UI.Console_Modules.console_spend_projection import (
+    ConsoleDraftSpendRefresh,
+)
 from tldw_chatbook.UI.Console_Modules.dictation import ConsoleDictationController
 from tldw_chatbook.UI.Console_Modules.fleet import ConsoleFleetLifecycleController
 from tldw_chatbook.UI.Console_Modules.hands_free import ConsoleHandsFreeController
@@ -99,6 +102,7 @@ _ALL_CONTROLLER_SLOTS: list[tuple[str, type]] = [
     ("_prompt_queue", ConsolePromptQueueUIController),
     ("_review_selection", ConsoleReviewSelectionController),
     ("_send_price", ConsoleSendPriceController),
+    ("_console_draft_spend_refresh", ConsoleDraftSpendRefresh),
 ]
 
 #: Every controller takes `chat_store_accessor=lambda: self._ensure_console_
@@ -402,6 +406,20 @@ def test_send_price_controller_is_constructed_with_late_bound_screen_edges() -> 
         projection,
         "session-1",
     )
+
+
+def test_draft_spend_refresh_is_wired_with_late_bound_screen_edges() -> None:
+    screen = _unmounted_console()
+    controller = screen._console_draft_spend_refresh
+    settings_calls: list[str] = []
+    cost_calls: list[str] = []
+    screen._sync_console_settings_summary = lambda: settings_calls.append("settings")
+    screen._sync_console_cost_chip = lambda: cost_calls.append("cost")
+
+    controller.refresh()
+
+    assert settings_calls == ["settings"]
+    assert cost_calls == ["cost"]
 
 
 def test_realtime_controller_is_wired_late_bound_with_empty_owned_state() -> None:

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -1260,6 +1260,75 @@ async def test_dispatched_echo_keeps_context_full_and_current_frozen():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "excluded", ["failed", "assistant", "missing-data", "nonvision", "unaccepted"]
+)
+async def test_excluded_historical_media_keeps_next_send_priced(monkeypatch, excluded):
+    from types import SimpleNamespace
+    from tldw_chatbook.Chat.console_turn_preparation import ConsoleTurnPreparationState
+
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+        store.append_message(session_id, role=ConsoleMessageRole.USER, content="prior")
+        message = store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT
+            if excluded == "assistant"
+            else ConsoleMessageRole.USER,
+            content="image row",
+            attachments=(
+                MessageAttachment(
+                    None if excluded == "missing-data" else b"pixels",
+                    "image/png",
+                    "history.png",
+                    0,
+                ),
+            ),
+        )
+        if excluded == "failed":
+            store.mark_message_send_blocked(message.id)
+        controller = console._ensure_console_chat_controller()
+        if excluded == "nonvision":
+            configuration = controller.resolve_turn_configuration_snapshot(session_id)
+            monkeypatch.setattr(
+                controller,
+                "resolve_turn_configuration_snapshot",
+                lambda _id: replace(
+                    configuration,
+                    capabilities={**configuration.capabilities, "vision": False},
+                ),
+            )
+        if excluded == "unaccepted":
+            monkeypatch.setattr(
+                store,
+                "preparation_for_session",
+                lambda _id: SimpleNamespace(
+                    transient_user_message_id=message.id,
+                    state=ConsoleTurnPreparationState.PREPARING,
+                ),
+            )
+        monkeypatch.setattr(
+            controller,
+            "_provider_message_payloads",
+            Mock(side_effect=AssertionError("serialized media")),
+        )
+        console.query_one("#console-native-composer", ConsoleComposerBar).load_draft(
+            "follow up " * 500
+        )
+        console._sync_console_settings_summary()
+        state = console._build_console_cost_state()
+        assert state is not None
+        assert _next_send_dollars(state) > 0
+
+
+@pytest.mark.asyncio
 async def test_context_cost_refresh_does_not_materialize_attachment_payloads(
     monkeypatch,
 ):

--- a/Tests/UI/test_console_cost_chip_screen.py
+++ b/Tests/UI/test_console_cost_chip_screen.py
@@ -17,9 +17,9 @@ call), and ``_wait_for_visible_text``/``_wait_for_selector`` from
 from __future__ import annotations
 
 import asyncio
+import re
 import time
 from dataclasses import replace
-from types import SimpleNamespace
 from unittest.mock import Mock
 
 import pytest
@@ -42,7 +42,12 @@ from tldw_chatbook.Chat.citation_evidence_models import (
     EvidenceBundle,
     EvidenceReference,
 )
-from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+    MessageAttachment,
+)
 from tldw_chatbook.Chat.console_cost_tracker import ConsoleCacheState
 from tldw_chatbook.Chat.console_live_work import ConsoleLiveWorkLaunch
 from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
@@ -69,6 +74,12 @@ WARM_USAGE = {
     "cache_creation_input_tokens": 800,
     "output_tokens": 120,
 }
+
+
+def _next_send_dollars(state) -> float:
+    match = re.search(r"On next send ~\+\$(\d+\.\d+)", state.label)
+    assert match is not None
+    return float(match.group(1))
 
 
 def _configure_anthropic_ready_console(app, model: str = "claude-sonnet-4-6") -> None:
@@ -151,6 +162,33 @@ class _AnthropicWaitingGateway:
         yield " done"
 
 
+class _AnthropicReadinessWaitingGateway:
+    """Ready gateway that exposes the optimistic-echo readiness window."""
+
+    def __init__(self) -> None:
+        self.resolving = asyncio.Event()
+        self.release = asyncio.Event()
+
+    async def resolve_for_send(self, selection):
+        self.resolving.set()
+        await self.release.wait()
+        return provider_resolution(
+            provider="anthropic",
+            base_url=selection.base_url or "",
+            model=(
+                selection.explicit_model
+                or selection.configured_model
+                or "claude-sonnet-4-6"
+            ),
+            ready=True,
+            visible_copy="",
+            prompt_caching=True,
+        )
+
+    async def stream_chat(self, resolution, messages, **kwargs):
+        yield "ready answer"
+
+
 async def _send_and_settle(console, pilot, draft: str, expect_text: str) -> None:
     """Load a composer draft, press Send, and wait for the reply to land."""
     await _wait_for_selector(console, pilot, "#console-native-composer")
@@ -188,6 +226,9 @@ async def test_cost_chip_shows_dollar_figure_after_priced_send():
         state = console._last_console_cost_state
         assert state is not None
         assert state.alert is False
+        assert "Current $0.006 ·" in state.label
+        assert "Current $0.006 ●" not in state.label
+        assert "Current ~$" not in state.label
 
 
 # --- (b)/(c) editing earlier history alerts a WARM cache, reverting clears --
@@ -507,13 +548,7 @@ def test_build_console_cost_state_returns_none_without_native_session():
 
 
 @pytest.mark.asyncio
-async def test_build_console_cost_state_counts_staged_evidence_before_send():
-    """task-6: reproduces the critique's exact symptom -- "0 tok" with five
-    sources staged (one a 942 KB corpus), none of it sent yet. Staged,
-    unsent evidence must price into the chip as an ESTIMATED row so the
-    total moves off zero and the `~` honesty marker (an unsent estimate,
-    not a real spend) appears -- even though the session has zero
-    messages."""
+async def test_staged_evidence_changes_next_send_but_not_current_spend():
     app = _build_test_app()
     attach_chachanotes_db(app)
     _configure_anthropic_ready_console(app)
@@ -523,9 +558,13 @@ async def test_build_console_cost_state_counts_staged_evidence_before_send():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-cost-chip")
 
-        empty_state = console._build_console_cost_state()
-        assert empty_state is not None
-        assert "Tokens: 0" in empty_state.tooltip
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("price this request")
+        console._sync_console_settings_summary()
+        before = console._build_console_cost_state()
+        assert before is not None
+        assert "Current $0.00" in before.label
+        assert "On next send ~+$" in before.label
 
         big_reference = EvidenceReference(
             evidence_id="S1",
@@ -552,12 +591,12 @@ async def test_build_console_cost_state_counts_staged_evidence_before_send():
         console._retrieval._stage_console_library_rag_launch(launch)
         await pilot.pause()
 
-        state = console._build_console_cost_state()
+        after = console._build_console_cost_state()
 
-        assert state is not None
-        assert "Tokens: 0" not in state.tooltip
-        assert "includes estimated" in state.tooltip.lower()
-        assert state.label.startswith("~")
+        assert after is not None
+        assert "Current $0.00" in after.label
+        assert _next_send_dollars(after) > _next_send_dollars(before)
+        assert "Estimated text input:" in after.tooltip
 
 
 @pytest.mark.asyncio
@@ -810,9 +849,7 @@ async def test_cost_chip_state_isolated_across_session_tabs():
         state_b = console._last_console_cost_state
         assert state_b is not None
         assert state_b != state_a
-        # B was never sent to -- no priced total, so no dollar glyph at all
-        # (build_cost_state's tokens-only fallback for an all-zero snapshot).
-        assert "$" not in state_b.label
+        assert "Current $0.00 · On next send —" in state_b.label
 
         # Hop 3: B -> A again -- A's state must come back EXACTLY, not a
         # ghost of B's (e.g. a stale single shared memo instead of a
@@ -866,52 +903,11 @@ async def test_build_console_cost_state_includes_a_survivors_post_turn_spend():
         assert "Sub-agents: 1.3k tok (not priced)" in state.tooltip
 
 
-# --- task-25836: first-send context/tool/draft rows -------------------------
-#
-# The chip's running total ignored everything a FIRST send actually ships
-# (session system prompt, tool schemas, the draft itself), so a brand-new
-# conversation with a typed draft still read "0 tok" until the first reply
-# landed. The fold-in is first-send-only: once a reply (or any usage row)
-# exists, the chip reverts to the running-total semantics.
-
-
-_DEMO_TOOL_SCHEMA = {
-    "name": "demo_tool",
-    "description": "does demo things",
-    "parameters": {"type": "object", "properties": {}},
-}
-
-
-def _first_send_tool_bridge():
-    """Stub agent bridge: the real native schemas for the fold-in, plus a
-    permissive fallback for the OTHER bridge surfaces the Console sync
-    paths touch on a tick (e.g. ``subagent_counts``) -- a bare
-    SimpleNamespace made those workers raise ``AttributeError``."""
-
-    class _BridgeStub:
-        def native_tool_schemas(self):
-            return [_DEMO_TOOL_SCHEMA]
-
-        def subagent_counts(self, conversation_ids):
-            return {}
-
-        def __getattr__(self, name):
-            # Unknown bridge surface: callable returning an empty mapping
-            # keeps tick-path consumers happy without encoding each one.
-            def _empty(*_args, **_kwargs):
-                return {}
-
-            return _empty
-
-    return _BridgeStub()
-
-
-def _row_roles(rows) -> list[str]:
-    return [str(getattr(row.role, "value", row.role)) for row in rows]
+# --- Current-versus-next-send ownership ------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_absent_while_draft_is_blank():
+async def test_blank_draft_has_exact_zero_current_and_no_next_send():
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
     host = ConsoleHarness(app)
@@ -920,14 +916,13 @@ async def test_first_send_pseudo_rows_absent_while_draft_is_blank():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
 
-        assert console._console_first_send_pseudo_rows() == []
         state = console._build_console_cost_state()
         assert state is not None
-        assert "Tokens: 0" in state.tooltip
+        assert "Current $0.00 · On next send —" in state.label
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_carry_system_tools_and_draft():
+async def test_first_send_draft_changes_next_send_without_changing_current():
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
     host = ConsoleHarness(app)
@@ -939,32 +934,19 @@ async def test_first_send_pseudo_rows_carry_system_tools_and_draft():
         console._session._apply_console_session_system_prompt(
             "You are a thorough assistant. " * 5
         )
-        console._ensure_console_agent_bridge = _first_send_tool_bridge
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         composer.load_draft("hello, this is my first message")
-
-        rows = console._console_first_send_pseudo_rows()
-        roles = _row_roles(rows)
-        contents = [row.content for row in rows]
-        assert all(getattr(row, "usage", "missing") is None for row in rows)
-        system_contents = [
-            content for role, content in zip(roles, contents) if role == "system"
-        ]
-        assert any("thorough assistant" in content for content in system_contents)
-        assert any('"demo_tool"' in content for content in system_contents)
-        assert any(
-            role == "user" and "first message" in content
-            for role, content in zip(roles, contents)
-        )
+        console._sync_console_settings_summary()
 
         state = console._build_console_cost_state()
         assert state is not None
-        assert "Tokens: 0" not in state.tooltip
-        assert state.label.startswith("~")
+        assert "Current $0.00" in state.label
+        assert "On next send ~+$" in state.label
+        assert "thorough assistant" not in state.label
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_draft_only_without_prompt_or_tools():
+async def test_live_draft_increases_context_fullness():
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
     host = ConsoleHarness(app)
@@ -973,16 +955,18 @@ async def test_first_send_pseudo_rows_draft_only_without_prompt_or_tools():
         console = host.screen_stack[-1]
         await _wait_for_selector(console, pilot, "#console-native-composer")
 
-        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
-        composer.load_draft("just a draft")
+        console._sync_console_settings_summary()
+        before = console._last_console_context_control_state.request_tokens
 
-        rows = console._console_first_send_pseudo_rows()
-        assert _row_roles(rows) == ["user"]
-        assert "just a draft" in rows[0].content
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("just a draft " * 10_000)
+        console._sync_console_settings_summary()
+
+        assert console._last_console_context_control_state.request_tokens > before
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_stop_once_a_reply_exists():
+async def test_followup_draft_does_not_change_completed_current_spend():
     gateway = _AnthropicCostGateway(PRICED_USAGE, reply="the priced answer")
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
@@ -1001,11 +985,8 @@ async def test_first_send_pseudo_rows_stop_once_a_reply_exists():
         console._session._apply_console_session_system_prompt(
             "You are a thorough assistant. " * 20
         )
-        console._ensure_console_agent_bridge = _first_send_tool_bridge
         composer = console.query_one("#console-native-composer", ConsoleComposerBar)
         composer.load_draft("a queued follow-up message " * 100)
-
-        assert console._console_first_send_pseudo_rows() == []
 
         after = console._build_console_cost_state()
         assert after is not None
@@ -1018,6 +999,11 @@ async def test_first_send_pseudo_rows_stop_once_a_reply_exists():
             )
 
         assert _tokens_line(after) == _tokens_line(before)
+        assert (
+            after.label.partition(" · On next send")[0]
+            == before.label.partition(" · On next send")[0]
+        )
+        assert "On next send ~+$" in after.label
 
 
 @pytest.mark.asyncio
@@ -1037,9 +1023,9 @@ async def test_console_next_send_token_estimate_counts_context_not_just_draft():
         await _wait_for_selector(console, pilot, "#console-native-composer")
         controller = console._ensure_console_chat_controller()
         store = controller.store
-        session_id = store.active_session_id or store.ensure_session(
-            title="First message"
-        ).id
+        session_id = (
+            store.active_session_id or store.ensure_session(title="First message").id
+        )
         console._session._apply_console_session_system_prompt(
             "You are a thorough assistant. " * 5
         )
@@ -1064,12 +1050,7 @@ async def test_console_next_send_token_estimate_counts_context_not_just_draft():
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_skip_draft_once_it_is_the_trailing_row():
-    """Qodo finding 2 (High): during the mouse-send window the real user
-    row is already in the store while the composer draft is not yet
-    cleared -- the draft pseudo-row must be dropped, not double-counted."""
-    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
-
+async def test_historical_text_without_a_draft_is_not_sendable():
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
     host = ConsoleHarness(app)
@@ -1080,33 +1061,19 @@ async def test_first_send_pseudo_rows_skip_draft_once_it_is_the_trailing_row():
         store = console._ensure_console_chat_store()
         session_id = store.active_session_id
 
-        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
-        composer.load_draft("hello, this is my first message")
         store.append_message(
             session_id,
             role=ConsoleMessageRole.USER,
-            content="hello, this is my first message",
+            content="already sent",
         )
-        await pilot.pause()
-
-        rows = console._console_first_send_pseudo_rows()
-        assert all(
-            not (row.role == "user" and "first message" in str(row.content))
-            for row in rows
-        ), f"draft re-added next to its own persisted row: {rows}"
-        # The persisted user row itself is what the chip prices for the
-        # draft now -- the fold-in may still carry system/tools context.
+        console._sync_console_settings_summary()
         state = console._build_console_cost_state()
         assert state is not None
+        assert "On next send —" in state.label
 
 
 @pytest.mark.asyncio
-async def test_first_send_pseudo_rows_include_prefill_and_memory_projection():
-    """Qodo finding 1: the fold-in must reuse the controller's own
-    effective-memory and prefill projections instead of under-counting a
-    configured session."""
-    from types import SimpleNamespace as _NS
-
+async def test_seeded_leading_assistant_greeting_counts_in_context_not_current():
     app = _build_test_app()
     _configure_anthropic_ready_console(app)
     host = ConsoleHarness(app)
@@ -1116,31 +1083,217 @@ async def test_first_send_pseudo_rows_include_prefill_and_memory_projection():
         await _wait_for_selector(console, pilot, "#console-native-composer")
         store = console._ensure_console_chat_store()
         session_id = store.active_session_id
+        console._sync_console_settings_summary()
+        before = console._last_console_context_control_state.request_tokens
+        store.append_message(
+            session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="A long seeded greeting. " * 2_000,
+        )
+        console._sync_console_settings_summary()
+        state = console._build_console_cost_state()
+
+        assert console._last_console_context_control_state.request_tokens > before
+        assert state is not None
+        assert "Current $0.00" in state.label
+
+
+@pytest.mark.asyncio
+async def test_idle_draft_edit_burst_coalesces_one_cost_refresh(monkeypatch):
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        summary_refresh = Mock(wraps=console._sync_console_settings_summary)
+        cost_refresh = Mock(wraps=console._sync_console_cost_chip)
+        monkeypatch.setattr(console, "_sync_console_settings_summary", summary_refresh)
+        monkeypatch.setattr(console, "_sync_console_cost_chip", cost_refresh)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+
+        composer.load_draft("first")
+        composer.load_draft("second")
+        composer.load_draft("final forecast " * 1_000)
+        for _ in range(100):
+            await pilot.pause(0.01)
+            if summary_refresh.call_count:
+                break
+
+        assert summary_refresh.call_count == 1
+        assert cost_refresh.call_count == 1
+        assert console._console_draft_spend_refresh.timer is None
+        assert "On next send ~+$" in console._last_console_cost_state.label
+
+
+@pytest.mark.asyncio
+async def test_active_edit_cancels_an_already_armed_idle_cost_timer(monkeypatch):
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        summary_refresh = Mock()
+        cost_refresh = Mock()
+        monkeypatch.setattr(console, "_sync_console_settings_summary", summary_refresh)
+        monkeypatch.setattr(console, "_sync_console_cost_chip", cost_refresh)
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("arm while idle")
+        await pilot.pause(0.01)
+        assert console._console_draft_spend_refresh.timer is not None
+
         controller = console._ensure_console_chat_controller()
-        store.set_session_one_shot_prefill(session_id, "Sure thing:")
-
-        original_projection = controller._project_session_effective_memory
-        controller._project_session_effective_memory = (
-            lambda sid, rows: (
-                None,
-                _NS(memory=[{"role": "system", "content": "MEMORY FACTS"}]),
-            )
+        session_id = console._ensure_console_chat_store().active_session_id
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.VALIDATING, "Validating provider."),
+            session_id=session_id,
         )
-        try:
-            composer = console.query_one(
-                "#console-native-composer", ConsoleComposerBar
-            )
-            composer.load_draft("hello")
-            rows = console._console_first_send_pseudo_rows()
-        finally:
-            controller._project_session_effective_memory = original_projection
+        composer.load_draft("edit after send starts")
+        await pilot.pause(0.3)
 
-        contents = [str(row.content) for row in rows]
-        assert any("MEMORY FACTS" in content for content in contents)
-        assert any(
-            row.role == "assistant" and "Sure thing:" in str(row.content)
-            for row in rows
+        assert console._console_draft_spend_refresh.timer is None
+        summary_refresh.assert_not_called()
+        cost_refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_keyboard_send_cancels_idle_refresh_before_run_starts(monkeypatch):
+    gateway = _AnthropicReadinessWaitingGateway()
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        refresh_callback = Mock()
+        monkeypatch.setattr(
+            type(console._console_draft_spend_refresh), "refresh", refresh_callback
         )
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.focus()
+        composer.load_draft("send before debounce fires")
+        await pilot.pause(0.01)
+        assert console._console_draft_spend_refresh.timer is not None
+
+        await pilot.press("enter")
+        await asyncio.wait_for(gateway.resolving.wait(), timeout=_ASYNC_SETTLE_TIMEOUT)
+        await pilot.pause(0.3)
+
+        assert composer.draft_text() == ""
+        assert console._console_draft_spend_refresh.timer is None
+        refresh_callback.assert_not_called()
+
+        gateway.release.set()
+        await _wait_for_visible_text(console, pilot, "ready answer")
+
+
+@pytest.mark.asyncio
+async def test_predispatch_echo_stays_in_context_but_not_current():
+    gateway = _AnthropicReadinessWaitingGateway()
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("slow readiness request")
+        console._sync_console_settings_summary()
+        before_tokens = console._last_console_context_control_state.request_tokens
+
+        console.query_one("#console-send-message", Button).press()
+        await asyncio.wait_for(gateway.resolving.wait(), timeout=_ASYNC_SETTLE_TIMEOUT)
+        console._sync_console_settings_summary()
+        state = console._build_console_cost_state()
+
+        assert (
+            console._last_console_context_control_state.request_tokens == before_tokens
+        )
+        assert state is not None
+        assert "Current $0.00" in state.label
+
+        gateway.release.set()
+        await _wait_for_visible_text(console, pilot, "ready answer")
+
+
+@pytest.mark.asyncio
+async def test_dispatched_echo_keeps_context_full_and_current_frozen():
+    gateway = _AnthropicWaitingGateway()
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("keep current frozen")
+        console._sync_console_settings_summary()
+        before_tokens = console._last_console_context_control_state.request_tokens
+        console.query_one("#console-send-message", Button).press()
+
+        await asyncio.wait_for(gateway.started.wait(), timeout=_ASYNC_SETTLE_TIMEOUT)
+        console._sync_console_settings_summary()
+        state = console._build_console_cost_state()
+
+        assert (
+            console._last_console_context_control_state.request_tokens >= before_tokens
+        )
+        assert state is not None
+        assert "Current $0.00" in state.label
+
+        gateway.release.set()
+        await _wait_for_visible_text(console, pilot, "partial done")
+
+
+@pytest.mark.asyncio
+async def test_context_cost_refresh_does_not_materialize_attachment_payloads(
+    monkeypatch,
+):
+    app = _build_test_app()
+    attach_chachanotes_db(app)
+    _configure_anthropic_ready_console(app)
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(200, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        store = console._ensure_console_chat_store()
+        store.append_message(
+            store.active_session_id,
+            role=ConsoleMessageRole.USER,
+            content="historical image",
+            attachments=(MessageAttachment(b"pixels", "image/png", "history.png", 0),),
+        )
+        controller = console._ensure_console_chat_controller()
+        monkeypatch.setattr(
+            controller,
+            "_provider_message_payloads",
+            Mock(side_effect=AssertionError("serialized provider attachments")),
+        )
+        console.query_one("#console-native-composer", ConsoleComposerBar).load_draft(
+            "text follow-up"
+        )
+
+        console._sync_console_settings_summary()
+        state = console._build_console_cost_state()
+
+        assert console._last_console_context_control_state.request_tokens is not None
+        assert state is not None
+        assert "On next send unavailable" in state.label
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -12,7 +12,7 @@ from textual.app import App
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
-from textual.widgets import Button, Static
+from textual.widgets import Button, Select, Static
 
 from tldw_chatbook.Chat.console_onboarding_state import (
     CONSOLE_QUIET_EMPTY_COPY,
@@ -20,9 +20,13 @@ from tldw_chatbook.Chat.console_onboarding_state import (
     ConsoleSetupCardState,
     ConsoleSetupStep,
 )
-from tldw_chatbook.Chat.console_context_policy import ConsoleContextPolicyOverrides
+from tldw_chatbook.Chat.console_context_policy import (
+    ConsoleContextPolicyOverrides,
+    ContextCompactionMode,
+)
 from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
+    ConsoleSettingsContextEstimate,
     ConsoleSettingsReadiness,
     ConsoleSettingsSummaryState,
 )
@@ -38,6 +42,9 @@ from tldw_chatbook.Chat.console_settings_apply import (
 )
 from tldw_chatbook.Widgets.Console.console_model_popover import (
     ConsoleModelPopover,
+)
+from tldw_chatbook.Widgets.Console.console_context_controls import (
+    build_console_context_control_state,
 )
 from tldw_chatbook.Widgets.Console.console_settings_summary import (
     ConsoleSettingsSummary,
@@ -155,6 +162,7 @@ async def test_console_rail_summary_uses_canonical_provider_and_honest_empty_cop
         identity_row="Assistant: General",
         readiness=readiness,
     )
+
     class _HonestCopyApp(ConsolidatedCSSApp):
         def compose(self):
             yield ConsoleSettingsSummary(state)
@@ -908,11 +916,14 @@ _POPOVER_PROVIDERS = {"llama_cpp": ["model-a", "model-b"], "openai": ["gpt-4o"]}
 def _test_popover(
     settings: ConsoleSessionSettings,
     providers_models,
+    *,
+    overrides: ConsoleContextPolicyOverrides | None = None,
+    global_overrides: ConsoleContextPolicyOverrides | None = None,
 ) -> ConsoleModelPopover:
     origin = ConsoleSettingsOrigin("popover-session", None, 0)
     draft = ConsoleSettingsDraftState(
         settings=settings,
-        context_policy_overrides=ConsoleContextPolicyOverrides(),
+        context_policy_overrides=overrides or ConsoleContextPolicyOverrides(),
         field_drafts=tuple(
             ConsoleSettingsFieldDraft(
                 name=name,
@@ -960,6 +971,14 @@ def _test_popover(
         },
         initial_draft=draft,
         providers_models=providers_models,
+        context_state=build_console_context_control_state(
+            settings=settings,
+            estimate=ConsoleSettingsContextEstimate(
+                used_tokens=None, token_limit=None, label="unavailable"
+            ),
+            overrides=draft.context_policy_overrides,
+            global_overrides=global_overrides,
+        ),
         scope_copy="Applies to this conversation",
         durability_copy="Temporary until this chat is promoted",
         draft_rebaser=rebase,
@@ -971,9 +990,16 @@ def _test_popover(
 
 
 class _PopoverApp(ConsolidatedCSSApp):
-    def __init__(self):
+    def __init__(
+        self,
+        *,
+        overrides: ConsoleContextPolicyOverrides | None = None,
+        global_overrides: ConsoleContextPolicyOverrides | None = None,
+    ):
         super().__init__()
         self.result = "unset"
+        self.overrides = overrides
+        self.global_overrides = global_overrides
 
     async def on_mount(self) -> None:
         settings = ConsoleSessionSettings(provider="llama_cpp", model="model-a")
@@ -982,7 +1008,12 @@ class _PopoverApp(ConsolidatedCSSApp):
             self.result = result
 
         await self.push_screen(
-            _test_popover(settings, _POPOVER_PROVIDERS),
+            _test_popover(
+                settings,
+                _POPOVER_PROVIDERS,
+                overrides=self.overrides,
+                global_overrides=self.global_overrides,
+            ),
             callback=_capture,
         )
 
@@ -1007,6 +1038,41 @@ async def test_popover_apply_returns_replaced_settings():
         assert committed.provider == "llama_cpp"
         # ConsoleSessionSettings defaults streaming True; one toggle flips it.
         assert committed.streaming is False
+
+
+@pytest.mark.asyncio
+async def test_popover_untouched_automatic_compaction_stays_inherited():
+    app = _PopoverApp(
+        global_overrides=ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.AUTOMATIC
+        )
+    )
+    async with app.run_test(size=(90, 30)) as pilot:
+        await pilot.click("#console-popover-apply")
+        await pilot.pause()
+
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    assert app.result.live_commit.context_policy_overrides.compaction_mode is None
+
+
+@pytest.mark.asyncio
+async def test_popover_off_then_automatic_compaction_is_explicit():
+    app = _PopoverApp(
+        overrides=ConsoleContextPolicyOverrides(
+            compaction_mode=ContextCompactionMode.OFF
+        )
+    )
+    async with app.run_test(size=(90, 30)) as pilot:
+        select = app.screen.query_one("#console-popover-compaction-mode", Select)
+        select.value = ContextCompactionMode.AUTOMATIC.value
+        await pilot.click("#console-popover-apply")
+        await pilot.pause()
+
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    assert (
+        app.result.live_commit.context_policy_overrides.compaction_mode
+        is ContextCompactionMode.AUTOMATIC
+    )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_spend_projection.py
+++ b/Tests/UI/test_console_spend_projection.py
@@ -60,10 +60,12 @@ def _context_state(*, request_tokens: int | None = 1_000):
     ),
 )
 def test_accepted_user_remains_in_request_context_but_not_current(kind):
-    user = ConsoleChatMessage(ConsoleMessageRole.USER, "accepted", id="user")
+    user = ConsoleChatMessage(
+        ConsoleMessageRole.USER, "accepted", id="user", persisted_message_id="db-user"
+    )
     recovery = SimpleNamespace(
         kind=kind,
-        checkpoint=SimpleNamespace(user_message_id=user.id),
+        checkpoint=SimpleNamespace(user_message_id=user.persisted_message_id),
     )
 
     projection = build_console_spend_history_projection(
@@ -72,6 +74,21 @@ def test_accepted_user_remains_in_request_context_but_not_current(kind):
 
     assert user.id in projection.request_ids
     assert user.id not in projection.current_ids
+
+
+def test_unaccepted_checkpoint_excludes_persisted_user_from_both_projections():
+    user = ConsoleChatMessage(
+        ConsoleMessageRole.USER, "unaccepted", id="user", persisted_message_id="db-user"
+    )
+    recovery = SimpleNamespace(
+        kind=ConsoleDispatchRecoveryKind.QUARANTINED,
+        checkpoint=SimpleNamespace(user_message_id=user.persisted_message_id),
+    )
+    projection = build_console_spend_history_projection(
+        [user], recovery, None, ConsoleRunStatus.IDLE, False
+    )
+    assert not projection.request_ids
+    assert not projection.current_ids
 
 
 def test_production_shaped_remote_owner_is_not_current():
@@ -213,37 +230,21 @@ def test_context_projection_adds_live_draft_and_seeded_greeting():
     ]
 
 
-@pytest.mark.parametrize(
-    "message",
-    (
-        ConsoleChatMessage(
-            ConsoleMessageRole.ASSISTANT,
-            "generated",
-            attachments=(SimpleNamespace(id="image"),),
-        ),
-        ConsoleChatMessage(
-            ConsoleMessageRole.USER,
-            "failed image",
-            status="failed",
-            image_data=b"image",
-        ),
-    ),
-)
-def test_any_historical_media_makes_forecast_unavailable(message):
-    state = build_console_next_send_projection([message], False, 1_000, 3.0, "sendable")
+def test_admitted_historical_media_makes_forecast_unavailable():
+    state = build_console_next_send_projection(True, False, 1_000, 3.0, "sendable")
     assert state.label == "unavailable"
     assert "Media cost is not estimated" in state.tooltip
 
 
 def test_zero_input_price_is_known_and_empty_draft_is_dash():
-    priced = build_console_next_send_projection([], False, 1_000, 0.0, "send")
-    empty = build_console_next_send_projection([], False, 1_000, 3.0, "  ")
+    priced = build_console_next_send_projection(False, False, 1_000, 0.0, "send")
+    empty = build_console_next_send_projection(False, False, 1_000, 3.0, "  ")
     assert priced.label == "~+$0.00"
     assert empty.label == "—"
 
 
 def test_invalid_draft_never_promises_a_next_send_charge():
-    state = build_console_next_send_projection([], False, 1_000, 3.0, "x" * 200_001)
+    state = build_console_next_send_projection(False, False, 1_000, 3.0, "x" * 200_001)
 
     assert state.label == "unavailable"
     assert "cannot be sent" in state.tooltip
@@ -257,7 +258,7 @@ def test_pending_media_or_unknown_forecast_inputs_are_unavailable(
     has_pending, request_tokens, input_per_mtok
 ):
     state = build_console_next_send_projection(
-        [], has_pending, request_tokens, input_per_mtok, "sendable"
+        False, has_pending, request_tokens, input_per_mtok, "sendable"
     )
     assert state.label == "unavailable"
 
@@ -272,7 +273,7 @@ def test_unknown_current_pricing_does_not_hide_known_next_send_forecast():
         None,
         True,
         _context_state(),
-        [ConsoleChatMessage(ConsoleMessageRole.USER, "history")],
+        False,
         False,
         3.0,
         "draft",
@@ -286,7 +287,6 @@ def test_nonempty_tracker_failure_is_unavailable_but_true_empty_is_zero():
     failed = ConsoleCostSnapshot(None, 0, False, False, 0, available=False)
     empty = ConsoleCostSnapshot(None, 0, False, False, 0)
     context = _context_state()
-    message = ConsoleChatMessage(ConsoleMessageRole.USER, "history")
     failed_state = build_console_spend_cost_state(
         failed,
         ConsoleCacheState.WARM,
@@ -296,7 +296,7 @@ def test_nonempty_tracker_failure_is_unavailable_but_true_empty_is_zero():
         "2026-09-04",
         True,
         context,
-        [message],
+        False,
         False,
         3.0,
         "draft",
@@ -310,7 +310,7 @@ def test_nonempty_tracker_failure_is_unavailable_but_true_empty_is_zero():
         "2026-09-04",
         True,
         context,
-        [],
+        False,
         False,
         3.0,
         "",

--- a/Tests/UI/test_console_spend_projection.py
+++ b/Tests/UI/test_console_spend_projection.py
@@ -1,0 +1,355 @@
+"""Focused contracts for Console current and next-send spend projections."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleDispatchRecoveryKind,
+    ConsoleDispatchRecoveryState,
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Chat.console_cost_tracker import (
+    ConsoleCacheState,
+    ConsoleCostSnapshot,
+)
+from tldw_chatbook.Chat.provider_continuation import ProviderContinuationCheckpoint
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.UI.Console_Modules.console_spend_projection import (
+    ConsoleDraftSpendRefresh,
+    build_console_context_messages,
+    build_console_current_cost_messages,
+    build_console_next_send_projection,
+    build_console_spend_cost_state,
+    build_console_spend_history_projection,
+    fold_system_prompt,
+)
+from tldw_chatbook.Widgets.Console.console_context_controls import (
+    build_console_context_control_state,
+)
+from tldw_chatbook.Chat.console_session_settings import (
+    ConsoleSessionSettings,
+    ConsoleSettingsContextEstimate,
+)
+
+
+def _context_state(*, request_tokens: int | None = 1_000):
+    return build_console_context_control_state(
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-sonnet-4-6", max_tokens=1_000
+        ),
+        estimate=ConsoleSettingsContextEstimate(
+            used_tokens=request_tokens,
+            token_limit=10_000,
+            label="context",
+        ),
+    )
+
+
+@pytest.mark.parametrize(
+    "kind",
+    (
+        ConsoleDispatchRecoveryKind.ACCEPTED,
+        ConsoleDispatchRecoveryKind.DISPATCH_STARTED,
+        ConsoleDispatchRecoveryKind.EPHEMERAL_ACCEPTED,
+        ConsoleDispatchRecoveryKind.EPHEMERAL_DISPATCH_STARTED,
+    ),
+)
+def test_accepted_user_remains_in_request_context_but_not_current(kind):
+    user = ConsoleChatMessage(ConsoleMessageRole.USER, "accepted", id="user")
+    recovery = SimpleNamespace(
+        kind=kind,
+        checkpoint=SimpleNamespace(user_message_id=user.id),
+    )
+
+    projection = build_console_spend_history_projection(
+        [user], recovery, None, ConsoleRunStatus.STREAMING, True
+    )
+
+    assert user.id in projection.request_ids
+    assert user.id not in projection.current_ids
+
+
+def test_production_shaped_remote_owner_is_not_current():
+    history = ConsoleChatMessage(
+        ConsoleMessageRole.USER,
+        "history",
+        id="history",
+        persisted_message_id="p-history",
+    )
+    active = ConsoleChatMessage(
+        ConsoleMessageRole.USER,
+        "accepted",
+        id="active",
+        persisted_message_id="p-active",
+    )
+    assistant = ConsoleChatMessage(
+        ConsoleMessageRole.ASSISTANT,
+        "",
+        id="assistant",
+        persisted_message_id="p-assistant",
+        parent_message_id="p-active",
+        assistant_generation_state="dispatch_started",
+    )
+    recovery = ConsoleDispatchRecoveryState(
+        kind=ConsoleDispatchRecoveryKind.REMOTE_DISPATCH_STARTED,
+        assistant_message_id="p-assistant",
+        conversation_id="conversation",
+        visible_copy="Remote dispatch pending.",
+        actions=(),
+    )
+
+    projection = build_console_spend_history_projection(
+        [history, active, assistant], recovery, None, ConsoleRunStatus.IDLE, False
+    )
+
+    assert recovery.checkpoint is None
+    assert history.id in projection.current_ids
+    assert active.id in projection.request_ids
+    assert active.id not in projection.current_ids
+
+
+def test_failed_user_is_excluded_but_failed_assistant_usage_is_current():
+    user = ConsoleChatMessage(ConsoleMessageRole.USER, "sent", id="user")
+    failed_echo = ConsoleChatMessage(
+        ConsoleMessageRole.USER, "never sent", id="failed-user", status="failed"
+    )
+    failed_assistant = ConsoleChatMessage(
+        ConsoleMessageRole.ASSISTANT,
+        "partial",
+        id="failed-assistant",
+        status="failed",
+        usage=ProviderUsage(
+            uncached_input=100,
+            output=20,
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+        ),
+    )
+
+    projection = build_console_spend_history_projection(
+        [user, failed_echo, failed_assistant],
+        None,
+        None,
+        ConsoleRunStatus.IDLE,
+        False,
+    )
+
+    assert failed_echo.id not in projection.request_ids
+    assert failed_echo.id not in projection.current_ids
+    assert failed_assistant.id not in projection.request_ids
+    assert failed_assistant.id in projection.current_ids
+
+
+def test_stopped_continuation_usage_is_current_but_not_request_context():
+    user = ConsoleChatMessage(ConsoleMessageRole.USER, "sent", id="user")
+    assistant = ConsoleChatMessage(
+        ConsoleMessageRole.ASSISTANT,
+        "partial",
+        id="assistant",
+        status="stopped",
+        assistant_generation_state="stopped",
+        provider_continuation=ProviderContinuationCheckpoint(
+            schema_version=1,
+            checkpoint_revision=1,
+            provider="deepseek",
+            protocol="chat_completions",
+            model="deepseek-chat",
+            api_base_url="https://api.deepseek.com",
+            state="active",
+            rounds=(),
+        ),
+        usage=ProviderUsage(
+            uncached_input=100,
+            output=20,
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+        ),
+    )
+
+    projection = build_console_spend_history_projection(
+        [user, assistant], None, None, ConsoleRunStatus.IDLE, False
+    )
+
+    assert assistant.id not in projection.request_ids
+    assert assistant.id in projection.current_ids
+
+
+def test_actual_turn_usage_replaces_the_user_row_estimate_in_current():
+    user = ConsoleChatMessage(ConsoleMessageRole.USER, "hello", id="user")
+    assistant = ConsoleChatMessage(
+        ConsoleMessageRole.ASSISTANT,
+        "answer",
+        id="assistant",
+        usage=ProviderUsage(
+            uncached_input=1_000,
+            output=200,
+            provider="anthropic",
+            model="claude-sonnet-4-6",
+        ),
+    )
+
+    rows = build_console_current_cost_messages(
+        [user, assistant], {user.id, assistant.id}
+    )
+
+    assert rows == [assistant]
+
+
+def test_context_projection_adds_live_draft_and_seeded_greeting():
+    greeting = ConsoleChatMessage(ConsoleMessageRole.ASSISTANT, "Hello there", id="g")
+    user = ConsoleChatMessage(ConsoleMessageRole.USER, "Prior turn", id="u")
+
+    projected = build_console_context_messages([greeting, user], {user.id}, "New draft")
+
+    assert fold_system_prompt("Be helpful", greeting.content).endswith("Hello there")
+    assert projected == [
+        {"role": "user", "content": "Prior turn"},
+        {"role": "user", "content": "New draft"},
+    ]
+
+
+@pytest.mark.parametrize(
+    "message",
+    (
+        ConsoleChatMessage(
+            ConsoleMessageRole.ASSISTANT,
+            "generated",
+            attachments=(SimpleNamespace(id="image"),),
+        ),
+        ConsoleChatMessage(
+            ConsoleMessageRole.USER,
+            "failed image",
+            status="failed",
+            image_data=b"image",
+        ),
+    ),
+)
+def test_any_historical_media_makes_forecast_unavailable(message):
+    state = build_console_next_send_projection([message], False, 1_000, 3.0, "sendable")
+    assert state.label == "unavailable"
+    assert "Media cost is not estimated" in state.tooltip
+
+
+def test_zero_input_price_is_known_and_empty_draft_is_dash():
+    priced = build_console_next_send_projection([], False, 1_000, 0.0, "send")
+    empty = build_console_next_send_projection([], False, 1_000, 3.0, "  ")
+    assert priced.label == "~+$0.00"
+    assert empty.label == "—"
+
+
+def test_invalid_draft_never_promises_a_next_send_charge():
+    state = build_console_next_send_projection([], False, 1_000, 3.0, "x" * 200_001)
+
+    assert state.label == "unavailable"
+    assert "cannot be sent" in state.tooltip
+
+
+@pytest.mark.parametrize(
+    ("has_pending", "request_tokens", "input_per_mtok"),
+    ((True, 1_000, 3.0), (False, None, 3.0), (False, 1_000, None)),
+)
+def test_pending_media_or_unknown_forecast_inputs_are_unavailable(
+    has_pending, request_tokens, input_per_mtok
+):
+    state = build_console_next_send_projection(
+        [], has_pending, request_tokens, input_per_mtok, "sendable"
+    )
+    assert state.label == "unavailable"
+
+
+def test_unknown_current_pricing_does_not_hide_known_next_send_forecast():
+    state = build_console_spend_cost_state(
+        ConsoleCostSnapshot(None, 1_000, False, False, 1),
+        ConsoleCacheState.NONE,
+        None,
+        None,
+        None,
+        None,
+        True,
+        _context_state(),
+        [ConsoleChatMessage(ConsoleMessageRole.USER, "history")],
+        False,
+        3.0,
+        "draft",
+    )
+
+    assert "Current 1.0k tok" in state.label
+    assert "On next send ~+$0.003" in state.label
+
+
+def test_nonempty_tracker_failure_is_unavailable_but_true_empty_is_zero():
+    failed = ConsoleCostSnapshot(None, 0, False, False, 0, available=False)
+    empty = ConsoleCostSnapshot(None, 0, False, False, 0)
+    context = _context_state()
+    message = ConsoleChatMessage(ConsoleMessageRole.USER, "history")
+    failed_state = build_console_spend_cost_state(
+        failed,
+        ConsoleCacheState.WARM,
+        "system prompt changed",
+        0.01,
+        60.0,
+        "2026-09-04",
+        True,
+        context,
+        [message],
+        False,
+        3.0,
+        "draft",
+    )
+    empty_state = build_console_spend_cost_state(
+        empty,
+        ConsoleCacheState.NONE,
+        None,
+        None,
+        None,
+        "2026-09-04",
+        True,
+        context,
+        [],
+        False,
+        3.0,
+        "",
+    )
+
+    assert "Current unavailable" in failed_state.label
+    assert "On next send ~+$" in failed_state.label
+    assert failed_state.alert is True
+    assert "system prompt changed" in failed_state.tooltip
+    assert empty_state.label == "Context 11% · Current $0.00 · On next send —"
+
+
+def test_idle_refresh_coalesces_and_uses_late_bound_callbacks():
+    scheduled = []
+    calls = []
+
+    class Timer:
+        stopped = False
+
+        def stop(self):
+            self.stopped = True
+
+    owner = SimpleNamespace(summary=lambda: calls.append("old-summary"))
+    controller = ConsoleDraftSpendRefresh(
+        schedule_timer=lambda delay, callback: (
+            scheduled.append((delay, callback, Timer())) or scheduled[-1][2]
+        ),
+        sync_settings_summary=lambda: owner.summary(),
+        sync_cost_chip=lambda: calls.append("cost"),
+    )
+    controller.route_edit(run_active=False)
+    first = scheduled[-1][2]
+    controller.route_edit(run_active=False)
+    assert first.stopped is True
+    owner.summary = lambda: calls.append("new-summary")
+    scheduled[-1][1]()
+    assert calls == ["new-summary", "cost"]
+    controller.route_edit(run_active=False)
+    last = scheduled[-1][2]
+    controller.route_edit(run_active=True)
+    assert last.stopped is True
+    assert controller.timer is None

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -18,6 +18,10 @@ The recovery tests also reused one ID for the transient row and its database
 record, hiding a mismatch that counted unfinished recovered turns as Current
 spend. Mounted regressions reproduced the media cases; distinct persisted and
 transient IDs reproduced both accepted and quarantined recovery errors.
+The first media fix then captured full send configuration even for an empty
+chat, pulling RAG imports onto startup: CI and the local census measured 1,030
+modules against the 972 limit while clean dev passed. Checking for admitted
+user attachments before resolving media capabilities removes that eager work.
 
 **What to do.** Reuse the provider's metadata-only admission and image-budget
 projection for display decisions. Give hydrated test rows distinct transient

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,22 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## Spend forecasts must test admitted media and durable recovery IDs
+
+**PR #2397, 2026-09-04.** The next-send estimate scanned every transcript
+attachment, so failed echoes, assistant images, missing attachment bytes, and
+images omitted by a non-vision model all suppressed a valid text estimate.
+The recovery tests also reused one ID for the transient row and its database
+record, hiding a mismatch that counted unfinished recovered turns as Current
+spend. Mounted regressions reproduced the media cases; distinct persisted and
+transient IDs reproduced both accepted and quarantined recovery errors.
+
+**What to do.** Reuse the provider's metadata-only admission and image-budget
+projection for display decisions. Give hydrated test rows distinct transient
+and persisted IDs, and verify both request-context and settled-spend ownership.
+
+---
+
 ## SQLite progress handlers must not query their active connection
 
 **TASK-23113.11, 2026-09-02.** The first physical trace-compaction worker

--- a/tldw_chatbook/Chat/console_cost_tracker.py
+++ b/tldw_chatbook/Chat/console_cost_tracker.py
@@ -240,6 +240,7 @@ class ConsoleCostSnapshot:
     has_estimated_entries: bool
     row_count: int
     fleet_tokens: int = 0
+    available: bool = True
 
 
 @dataclass(frozen=True)
@@ -741,6 +742,7 @@ def build_cost_snapshot(
             has_estimated_entries=False,
             row_count=0,
             fleet_tokens=0,
+            available=False,
         )
 
 
@@ -803,11 +805,28 @@ def build_cost_state(
         alert = cache_state == ConsoleCacheState.WARM and bool(break_reason)
         cold = cache_state == ConsoleCacheState.EXPIRED
 
+        if not snapshot.available:
+            return ConsoleCostState(
+                label="unavailable",
+                compact_label="unavailable",
+                tooltip="Cost data unavailable.\n"
+                + _cache_state_line(
+                    cache_state,
+                    cold=cold,
+                    ttl_remaining_s=ttl_remaining_s,
+                    break_reason=break_reason,
+                    projected_delta_usd=projected_delta_usd,
+                ),
+                alert=alert,
+                cold=cold,
+            )
+
         if not snapshot.pricing_known or snapshot.total_usd is None:
-            label = f"{_format_tokens(snapshot.total_tokens)} tok"
+            estimate_prefix = "~" if snapshot.has_estimated_entries else ""
+            label = f"{estimate_prefix}{_format_tokens(snapshot.total_tokens)} tok"
             tooltip_lines = [f"Tokens: {_format_tokens(snapshot.total_tokens)}"]
             if snapshot.has_estimated_entries:
-                tooltip_lines.append("Includes estimated (unsent) rows.")
+                tooltip_lines.append("Includes locally estimated transcript rows.")
             if snapshot.fleet_tokens:
                 tooltip_lines.append(
                     f"Sub-agents: {_format_tokens(snapshot.fleet_tokens)} tok "
@@ -831,7 +850,11 @@ def build_cost_state(
             )
             tooltip = "\n".join(tooltip_lines)
             return ConsoleCostState(
-                label=label, compact_label=label, tooltip=tooltip, alert=alert, cold=cold,
+                label=label,
+                compact_label=label,
+                tooltip=tooltip,
+                alert=alert,
+                cold=cold,
             )
 
         amount_text = _format_amount(snapshot.total_usd)
@@ -851,8 +874,7 @@ def build_cost_state(
         tooltip_lines = [total_line, f"Tokens: {_format_tokens(snapshot.total_tokens)}"]
         if snapshot.fleet_tokens:
             tooltip_lines.append(
-                f"Sub-agents: {_format_tokens(snapshot.fleet_tokens)} tok "
-                "(not priced)"
+                f"Sub-agents: {_format_tokens(snapshot.fleet_tokens)} tok (not priced)"
             )
         tooltip_lines.append(
             _cache_state_line(
@@ -1023,7 +1045,9 @@ def build_cost_rows_totals(rows: Sequence[ConsoleCostRow]) -> ConsoleCostRowTota
     cost_known = True
     has_estimated = False
     for row in rows:
-        total_tokens += row.uncached_input + row.cache_read + row.cache_write + row.output
+        total_tokens += (
+            row.uncached_input + row.cache_read + row.cache_write + row.output
+        )
         has_estimated = has_estimated or row.estimated
         if row.cost_usd is None:
             cost_known = False

--- a/tldw_chatbook/UI/Console_Modules/console_spend_projection.py
+++ b/tldw_chatbook/UI/Console_Modules/console_spend_projection.py
@@ -61,7 +61,15 @@ _REMOTE_RECOVERY_KINDS = frozenset(
 
 
 def fold_system_prompt(system_prompt: str | None, greeting: str) -> str:
-    """Fold the seeded greeting exactly as the provider send path does."""
+    """Fold the seeded greeting exactly as the provider send path does.
+
+    Args:
+        system_prompt: Configured system text, if any.
+        greeting: Seeded assistant greeting folded into system context.
+
+    Returns:
+        Combined system text.
+    """
     return fold_greeting_into_system_prompt(system_prompt or "", greeting)
 
 
@@ -108,15 +116,34 @@ def build_console_spend_history_projection(
     run_status: ConsoleRunStatus,
     has_submit_task: bool,
 ) -> ConsoleSpendHistoryProjection:
-    """Project provider-request and billed-history rows without reading media."""
+    """Project provider-request and billed-history rows without reading media.
+
+    Args:
+        messages: Ordered transcript rows for the active session.
+        recovery: Recovery ownership, whose checkpoint uses persisted IDs.
+        preparation: Local preparation ownership using transient message IDs.
+        run_status: Current provider-run lifecycle state.
+        has_submit_task: Whether a submission is currently in progress.
+
+    Returns:
+        Transient IDs admitted to request context and settled spend history.
+    """
     request_excluded_user_id: str | None = None
     current_excluded_user_id: str | None = None
     checkpoint = recovery.checkpoint if recovery is not None else None
     remote_user = _remote_active_user_id(messages, recovery)
     if checkpoint is not None:
-        current_excluded_user_id = checkpoint.user_message_id
+        current_excluded_user_id = next(
+            (
+                message.id
+                for message in messages
+                if message.role is ConsoleMessageRole.USER
+                and message.persisted_message_id == checkpoint.user_message_id
+            ),
+            checkpoint.user_message_id,
+        )
         if recovery.kind not in _ACCEPTED_RECOVERY_KINDS:
-            request_excluded_user_id = checkpoint.user_message_id
+            request_excluded_user_id = current_excluded_user_id
     elif remote_user is not None:
         current_excluded_user_id = remote_user
     elif preparation is not None and preparation.transient_user_message_id is not None:
@@ -185,7 +212,15 @@ def build_console_current_cost_messages(
     messages: Sequence[ConsoleChatMessage],
     current_ids: Collection[str],
 ) -> list[ConsoleChatMessage]:
-    """Return settled cost rows without estimating input already in real usage."""
+    """Return settled cost rows without estimating input already in real usage.
+
+    Args:
+        messages: Ordered session transcript.
+        current_ids: Transient IDs admitted to settled spend history.
+
+    Returns:
+        Settled rows, omitting user estimates covered by assistant usage.
+    """
     rows = [
         message
         for message in messages
@@ -211,7 +246,16 @@ def build_console_context_messages(
     request_ids: Collection[str] | None,
     draft_text: str,
 ) -> list[dict[str, str]]:
-    """Return lifecycle-filtered text rows plus the mounted draft."""
+    """Return lifecycle-filtered text rows plus the mounted draft.
+
+    Args:
+        messages: Ordered session transcript.
+        request_ids: Admitted transient IDs, or None to include all rows.
+        draft_text: Current composer text.
+
+    Returns:
+        Role/content dictionaries with a nonblank draft appended.
+    """
     rows = [
         {
             "role": str(getattr(message.role, "value", message.role)),
@@ -226,13 +270,25 @@ def build_console_context_messages(
 
 
 def build_console_next_send_projection(
-    messages: Sequence[ConsoleChatMessage],
+    has_historical_media: bool,
     has_pending_attachments: bool,
     request_tokens: int | None,
     input_per_mtok: float | None,
     draft_text: str,
 ) -> ConsoleNextSendSpendState:
-    """Build the input-only forecast from text and attachment metadata."""
+    """Build the input-only forecast from text and admitted media metadata.
+
+    Args:
+        has_historical_media: Whether provider-admitted history carries media,
+            after lifecycle filtering, capability checks, and image budgeting.
+        has_pending_attachments: Whether the draft carries staged media.
+        request_tokens: Estimated next-request text tokens, if available.
+        input_per_mtok: Uncached input price per million tokens, if known.
+        draft_text: Composer text before canonical validation.
+
+    Returns:
+        Additional input-charge estimate or an explicit unavailable state.
+    """
     validated_draft, validation_error = validate_console_draft(
         draft_text, allow_empty=True
     )
@@ -242,14 +298,11 @@ def build_console_next_send_projection(
             "On next send: unavailable\n"
             "This message cannot be sent until the draft is corrected.",
         )
-    has_media = has_pending_attachments or any(
-        message.attachments or message.image_data is not None for message in messages
-    )
     return build_console_next_send_spend_state(
         request_tokens=request_tokens,
         input_per_mtok=input_per_mtok,
         sendable_text=bool(validated_draft.strip()),
-        has_media=has_media,
+        has_media=has_pending_attachments or has_historical_media,
     )
 
 
@@ -262,12 +315,30 @@ def build_console_spend_cost_state(
     pricing_as_of: str | None,
     pricing_available: bool,
     context_state: ConsoleContextControlState | None,
-    messages: Sequence[ConsoleChatMessage],
+    has_historical_media: bool,
     has_pending_attachments: bool,
     input_per_mtok: float | None,
     draft_text: str,
 ) -> ConsoleCostState:
-    """Compose Current and next-send display state from captured pure inputs."""
+    """Compose Current and next-send display state from captured pure inputs.
+
+    Args:
+        snapshot: Settled current-spend totals and availability.
+        cache_state: Observed prompt-cache status.
+        break_reason: Safe description of a cache invalidation, if any.
+        projected_delta_usd: Estimated extra charge from cache invalidation.
+        ttl_remaining_s: Remaining cache lifetime in seconds, if known.
+        pricing_as_of: Pricing catalog timestamp, if known.
+        pricing_available: Whether the selected model has known pricing.
+        context_state: Context usage presentation, if available.
+        has_historical_media: Whether admitted request history includes media.
+        has_pending_attachments: Whether the draft carries staged media.
+        input_per_mtok: Uncached input price per million tokens, if known.
+        draft_text: Current composer text before canonical validation.
+
+    Returns:
+        Current spend, optionally combined with context and next-send copy.
+    """
     empty_priced = (
         snapshot.available
         and snapshot.row_count == 0
@@ -289,7 +360,7 @@ def build_console_spend_cost_state(
     if context_state is None:
         return current
     next_send = build_console_next_send_projection(
-        messages,
+        has_historical_media,
         has_pending_attachments,
         context_state.request_tokens,
         input_per_mtok,
@@ -309,21 +380,29 @@ class ConsoleDraftSpendRefresh:
     timer: Any | None = None
 
     def schedule(self) -> None:
+        """Replace any pending timer with one coalesced refresh."""
         self.stop()
         self.timer = self.schedule_timer(self.delay_seconds, self.refresh)
 
     def route_edit(self, *, run_active: bool) -> None:
+        """Schedule an idle edit or cancel refreshes during an active run.
+
+        Args:
+            run_active: Whether provider work currently owns the draft.
+        """
         if run_active:
             self.stop()
         else:
             self.schedule()
 
     def stop(self) -> None:
+        """Cancel the pending refresh timer, if one exists."""
         if self.timer is not None:
             self.timer.stop()
         self.timer = None
 
     def refresh(self) -> None:
+        """Clear timer ownership and refresh context and spend displays."""
         self.timer = None
         self.sync_settings_summary()
         self.sync_cost_chip()

--- a/tldw_chatbook/UI/Console_Modules/console_spend_projection.py
+++ b/tldw_chatbook/UI/Console_Modules/console_spend_projection.py
@@ -1,0 +1,329 @@
+"""Cheap, UI-neutral projections for Console current and next-send spend."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Collection, Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+
+from ...Chat.assistant_generation_state import assistant_state_allows_provider_history
+from ...Chat.console_chat_controller import _is_empty_transcript_row
+from ...Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleDispatchRecoveryKind,
+    ConsoleDispatchRecoveryState,
+    ConsoleMessageRole,
+    ConsoleRunStatus,
+    fold_greeting_into_system_prompt,
+)
+from ...Chat.console_cost_tracker import (
+    ConsoleCacheState,
+    ConsoleCostSnapshot,
+    ConsoleCostState,
+    build_cost_state,
+)
+from ...Chat.console_turn_preparation import (
+    ConsoleTurnPreparation,
+    ConsoleTurnPreparationState,
+)
+from ...Chat.provider_continuation import ProviderContinuationCheckpoint
+from ...Utils.input_validation import validate_console_draft
+from ...Widgets.Console.console_context_controls import (
+    ConsoleContextControlState,
+    ConsoleNextSendSpendState,
+    build_console_context_cost_state,
+    build_console_next_send_spend_state,
+)
+
+_ACCEPTED_RECOVERY_KINDS = frozenset(
+    {
+        ConsoleDispatchRecoveryKind.ACCEPTED,
+        ConsoleDispatchRecoveryKind.DISPATCH_STARTED,
+        ConsoleDispatchRecoveryKind.EPHEMERAL_ACCEPTED,
+        ConsoleDispatchRecoveryKind.EPHEMERAL_DISPATCH_STARTED,
+        ConsoleDispatchRecoveryKind.REMOTE_ACCEPTED,
+        ConsoleDispatchRecoveryKind.REMOTE_DISPATCH_STARTED,
+    }
+)
+_ACCEPTED_PREPARATION_STATES = frozenset(
+    {
+        ConsoleTurnPreparationState.ACCEPTED,
+        ConsoleTurnPreparationState.DISPATCH_STARTED,
+        ConsoleTurnPreparationState.DISPATCHED,
+    }
+)
+_REMOTE_RECOVERY_KINDS = frozenset(
+    {
+        ConsoleDispatchRecoveryKind.REMOTE_ACCEPTED,
+        ConsoleDispatchRecoveryKind.REMOTE_DISPATCH_STARTED,
+    }
+)
+
+
+def fold_system_prompt(system_prompt: str | None, greeting: str) -> str:
+    """Fold the seeded greeting exactly as the provider send path does."""
+    return fold_greeting_into_system_prompt(system_prompt or "", greeting)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleSpendHistoryProjection:
+    """Message ownership split for the next request and realized Current."""
+
+    request_ids: frozenset[str]
+    current_ids: frozenset[str]
+
+
+def _remote_active_user_id(
+    messages: Sequence[ConsoleChatMessage],
+    recovery: ConsoleDispatchRecoveryState | None,
+) -> str | None:
+    if recovery is None or recovery.kind not in _REMOTE_RECOVERY_KINDS:
+        return None
+    assistant = next(
+        (
+            message
+            for message in messages
+            if message.role is ConsoleMessageRole.ASSISTANT
+            and message.persisted_message_id == recovery.assistant_message_id
+        ),
+        None,
+    )
+    if assistant is None or assistant.parent_message_id is None:
+        return None
+    return next(
+        (
+            message.id
+            for message in messages
+            if message.role is ConsoleMessageRole.USER
+            and message.persisted_message_id == assistant.parent_message_id
+        ),
+        None,
+    )
+
+
+def build_console_spend_history_projection(
+    messages: Sequence[ConsoleChatMessage],
+    recovery: ConsoleDispatchRecoveryState | None,
+    preparation: ConsoleTurnPreparation | None,
+    run_status: ConsoleRunStatus,
+    has_submit_task: bool,
+) -> ConsoleSpendHistoryProjection:
+    """Project provider-request and billed-history rows without reading media."""
+    request_excluded_user_id: str | None = None
+    current_excluded_user_id: str | None = None
+    checkpoint = recovery.checkpoint if recovery is not None else None
+    remote_user = _remote_active_user_id(messages, recovery)
+    if checkpoint is not None:
+        current_excluded_user_id = checkpoint.user_message_id
+        if recovery.kind not in _ACCEPTED_RECOVERY_KINDS:
+            request_excluded_user_id = checkpoint.user_message_id
+    elif remote_user is not None:
+        current_excluded_user_id = remote_user
+    elif preparation is not None and preparation.transient_user_message_id is not None:
+        current_excluded_user_id = preparation.transient_user_message_id
+        if preparation.state not in _ACCEPTED_PREPARATION_STATES:
+            request_excluded_user_id = preparation.transient_user_message_id
+    elif (
+        run_status is ConsoleRunStatus.VALIDATING
+        and has_submit_task
+        and messages
+        and messages[-1].role is ConsoleMessageRole.USER
+    ):
+        request_excluded_user_id = current_excluded_user_id = messages[-1].id
+
+    request_ids: set[str] = set()
+    current_ids: set[str] = set()
+    seen_user = False
+    for message in messages:
+        if message.role not in {ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT}:
+            continue
+        excluded_request = message.id == request_excluded_user_id
+        excluded_current = message.id == current_excluded_user_id
+        if message.status == "failed":
+            if (
+                not excluded_current
+                and message.role is ConsoleMessageRole.ASSISTANT
+                and seen_user
+            ):
+                current_ids.add(message.id)
+            continue
+        if _is_empty_transcript_row(message):
+            continue
+        if not seen_user and message.role is ConsoleMessageRole.ASSISTANT:
+            continue
+        if message.role is ConsoleMessageRole.USER:
+            seen_user = True
+        provider_eligible = not (
+            message.role is ConsoleMessageRole.ASSISTANT
+            and not assistant_state_allows_provider_history(
+                state=message.assistant_generation_state,
+                has_valid_continuation=(
+                    isinstance(
+                        message.provider_continuation, ProviderContinuationCheckpoint
+                    )
+                    and message.provider_continuation.state == "active"
+                ),
+                content=message.content,
+            )
+        )
+        if (
+            not excluded_current
+            and message.role is ConsoleMessageRole.ASSISTANT
+            and message.status == "stopped"
+        ):
+            current_ids.add(message.id)
+        if not provider_eligible:
+            continue
+        if not excluded_request:
+            request_ids.add(message.id)
+        if not excluded_current:
+            current_ids.add(message.id)
+    return ConsoleSpendHistoryProjection(frozenset(request_ids), frozenset(current_ids))
+
+
+def build_console_current_cost_messages(
+    messages: Sequence[ConsoleChatMessage],
+    current_ids: Collection[str],
+) -> list[ConsoleChatMessage]:
+    """Return settled cost rows without estimating input already in real usage."""
+    rows = [
+        message
+        for message in messages
+        if message.id in current_ids
+        and getattr(message, "status", "complete") not in {"pending", "streaming"}
+    ]
+    accounted_users: set[str] = set()
+    current_user: ConsoleChatMessage | None = None
+    for message in rows:
+        if message.role is ConsoleMessageRole.USER:
+            current_user = message
+        elif (
+            message.role is ConsoleMessageRole.ASSISTANT
+            and message.usage is not None
+            and current_user is not None
+        ):
+            accounted_users.add(current_user.id)
+    return [message for message in rows if message.id not in accounted_users]
+
+
+def build_console_context_messages(
+    messages: Sequence[ConsoleChatMessage],
+    request_ids: Collection[str] | None,
+    draft_text: str,
+) -> list[dict[str, str]]:
+    """Return lifecycle-filtered text rows plus the mounted draft."""
+    rows = [
+        {
+            "role": str(getattr(message.role, "value", message.role)),
+            "content": message.content,
+        }
+        for message in messages
+        if request_ids is None or message.id in request_ids
+    ]
+    if draft_text.strip():
+        rows.append({"role": "user", "content": draft_text})
+    return rows
+
+
+def build_console_next_send_projection(
+    messages: Sequence[ConsoleChatMessage],
+    has_pending_attachments: bool,
+    request_tokens: int | None,
+    input_per_mtok: float | None,
+    draft_text: str,
+) -> ConsoleNextSendSpendState:
+    """Build the input-only forecast from text and attachment metadata."""
+    validated_draft, validation_error = validate_console_draft(
+        draft_text, allow_empty=True
+    )
+    if validation_error is not None:
+        return ConsoleNextSendSpendState(
+            "unavailable",
+            "On next send: unavailable\n"
+            "This message cannot be sent until the draft is corrected.",
+        )
+    has_media = has_pending_attachments or any(
+        message.attachments or message.image_data is not None for message in messages
+    )
+    return build_console_next_send_spend_state(
+        request_tokens=request_tokens,
+        input_per_mtok=input_per_mtok,
+        sendable_text=bool(validated_draft.strip()),
+        has_media=has_media,
+    )
+
+
+def build_console_spend_cost_state(
+    snapshot: ConsoleCostSnapshot,
+    cache_state: ConsoleCacheState,
+    break_reason: str | None,
+    projected_delta_usd: float | None,
+    ttl_remaining_s: float | None,
+    pricing_as_of: str | None,
+    pricing_available: bool,
+    context_state: ConsoleContextControlState | None,
+    messages: Sequence[ConsoleChatMessage],
+    has_pending_attachments: bool,
+    input_per_mtok: float | None,
+    draft_text: str,
+) -> ConsoleCostState:
+    """Compose Current and next-send display state from captured pure inputs."""
+    empty_priced = (
+        snapshot.available
+        and snapshot.row_count == 0
+        and snapshot.fleet_tokens == 0
+        and pricing_available
+    )
+    if empty_priced:
+        snapshot = replace(snapshot, total_usd=0.0, pricing_known=True)
+    current = build_cost_state(
+        snapshot,
+        cache_state=cache_state,
+        break_reason=break_reason,
+        projected_delta_usd=projected_delta_usd,
+        ttl_remaining_s=ttl_remaining_s,
+        pricing_as_of=pricing_as_of,
+    )
+    if empty_priced:
+        current = replace(current, label="$0.00", compact_label="$0.00")
+    if context_state is None:
+        return current
+    next_send = build_console_next_send_projection(
+        messages,
+        has_pending_attachments,
+        context_state.request_tokens,
+        input_per_mtok,
+        draft_text,
+    )
+    return build_console_context_cost_state(context_state, current, next_send)
+
+
+@dataclass(slots=True, kw_only=True)
+class ConsoleDraftSpendRefresh:
+    """Own the single coalesced timer used for idle draft spend refreshes."""
+
+    schedule_timer: Callable[[float, Callable[[], None]], Any]
+    sync_settings_summary: Callable[[], None]
+    sync_cost_chip: Callable[[], None]
+    delay_seconds: float = 0.2
+    timer: Any | None = None
+
+    def schedule(self) -> None:
+        self.stop()
+        self.timer = self.schedule_timer(self.delay_seconds, self.refresh)
+
+    def route_edit(self, *, run_active: bool) -> None:
+        if run_active:
+            self.stop()
+        else:
+            self.schedule()
+
+    def stop(self) -> None:
+        if self.timer is not None:
+            self.timer.stop()
+        self.timer = None
+
+    def refresh(self) -> None:
+        self.timer = None
+        self.sync_settings_summary()
+        self.sync_cost_chip()

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -76,6 +76,7 @@ from ..Screens.settings_library_rag_defaults import load_direct_library_tools
 from .agent import ConsoleAgentController
 from .capture_policy_bindings import build_capture_policy_bindings
 from .character import ConsoleCharacterController
+from .console_spend_projection import ConsoleDraftSpendRefresh
 from .dictation import ConsoleDictationController
 from .fleet import ConsoleFleetLifecycleController
 from .hands_free import ConsoleHandsFreeController
@@ -1915,4 +1916,9 @@ def build_console_controllers(
             )
         ),
         pending_launch_accessor=lambda: screen._pending_console_launch_context,
+    )
+    screen._console_draft_spend_refresh = ConsoleDraftSpendRefresh(
+        schedule_timer=lambda delay, callback: screen.set_timer(delay, callback),
+        sync_settings_summary=lambda: screen._sync_console_settings_summary(),
+        sync_cost_chip=lambda: screen._sync_console_cost_chip(),
     )

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -5107,7 +5107,10 @@ class ChatScreen(BaseAppScreen):
                     )
                 )
             except Exception:
-                logger.exception("Console settings display-name preparation failed")
+                logger.exception(
+                    "Console settings display-name preparation failed (submission_id={})",
+                    submission.submission_id,
+                )
                 display_name_prepare_failed = True
 
         async def persist_display_name() -> None:
@@ -5126,7 +5129,10 @@ class ChatScreen(BaseAppScreen):
                     display_name_plan,
                 )
             except Exception:
-                logger.exception("Console settings display-name persistence failed")
+                logger.exception(
+                    "Console settings display-name persistence failed (submission_id={})",
+                    submission.submission_id,
+                )
                 self.app_instance.notify(
                     "Name changed for this session, but it may not survive reopening.",
                     severity="warning",
@@ -10257,7 +10263,21 @@ class ChatScreen(BaseAppScreen):
                 pricing_as_of,
                 pricing is not None,
                 context_state,
-                messages,
+                any(
+                    row.attachments
+                    for row in controller._lightweight_provider_message_rows(
+                        [
+                            message
+                            for message in messages
+                            if message.id in history.request_ids
+                        ],
+                        skip_failed=True,
+                        session_id=session_id,
+                        turn_context=controller.resolve_turn_configuration_snapshot(
+                            session_id
+                        ),
+                    )
+                ),
                 bool(store.pending_attachments(session_id)),
                 pricing.input_per_mtok if pricing is not None else None,
                 composer.draft_text() if composer is not None else "",

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -15,7 +15,6 @@ from pathlib import Path
 import re
 import threading
 import time
-from types import SimpleNamespace
 from typing import Any, Dict, Literal, Optional, TYPE_CHECKING
 
 import toml
@@ -159,6 +158,7 @@ from ..Console_Modules.retrieval import (
     source_mentions_rag as _source_mentions_rag,
 )
 from ..Console_Modules.transcript import _ConsoleTranscriptReadingState
+from ..Console_Modules import console_spend_projection as spend
 from ..Console_Modules.wiring import build_console_controllers
 from ..Console_Modules import raw_cli as raw_cli_ui
 from ..Console_Modules.session import (
@@ -231,8 +231,6 @@ from ...Chat.console_cost_tracker import (
     build_cost_rows,
     build_cost_rows_totals,
     build_cost_snapshot,
-    build_cost_state,
-    console_cost_snapshot_messages,
     fingerprint_break_reason,
     token_estimate_signature,
 )
@@ -417,6 +415,7 @@ from ...Chat.console_command_suggestions import (
     suggestions_for_draft,
     _COMMAND_DESCRIPTIONS,
 )
+
 # ADR-097 boot ratchet: deferred off the boot path (loads on first use). (console_help imports inside _console_command_help.)
 from ...Chat.console_image_view import (
     ConsoleImageRenderCache,
@@ -659,6 +658,7 @@ from ...Widgets.Console.console_rewind_modal import (
     KIND_SUMMARIZE_UP_TO,
     RewindPromptRow,
 )
+
 # ADR-097 boot ratchet: deferred off the boot path (loads on first use). (the summarize-preview modal imports where it is pushed.)
 from ...Widgets.Console.console_workbench_state import build_console_workbench_state
 from ...Workspaces.display_state import (
@@ -1611,9 +1611,7 @@ class _ControllerState:
         setattr(self._owner(instance), self._state_name, value)
 
 
-def _active_lineage_rows(
-    db, conversation_id: str, rows: list[dict]
-) -> list[dict]:
+def _active_lineage_rows(db, conversation_id: str, rows: list[dict]) -> list[dict]:
     """Filter fetched rows to the conversation's active branch.
 
     PR #2262 review: a conversation can hold off-path branches (regenerate
@@ -3032,9 +3030,7 @@ class ChatScreen(BaseAppScreen):
         active_provider = settings.provider
         active_model = settings.model
         if suspended_draft is not None:
-            raw_provider = suspended_draft.raw_values.get(
-                "console-settings-provider"
-            )
+            raw_provider = suspended_draft.raw_values.get("console-settings-provider")
             if type(raw_provider) is str:
                 active_provider = raw_provider
             active_model = suspended_draft.provider_model_drafts.get(
@@ -3073,8 +3069,7 @@ class ChatScreen(BaseAppScreen):
             context_estimate=context_estimate,
             context_state=context_state,
             can_save=(
-                controller.run_state_for(session_id).is_send_allowed
-                and not active_run
+                controller.run_state_for(session_id).is_send_allowed and not active_run
             ),
             active_run=active_run,
             focus_model=focus_model,
@@ -3262,7 +3257,9 @@ class ChatScreen(BaseAppScreen):
             field="api_key",
             return_revision=handoff_revision,
         )
-        request_token = getattr(self, "_next_suspended_conversation_settings_token", 0) + 1
+        request_token = (
+            getattr(self, "_next_suspended_conversation_settings_token", 0) + 1
+        )
         self._next_suspended_conversation_settings_token = request_token
         self._suspended_conversation_settings = request.snapshot
         self._suspended_conversation_settings_token = request_token
@@ -3278,7 +3275,10 @@ class ChatScreen(BaseAppScreen):
             )
             if not discarded:
                 return
-            if getattr(self, "_suspended_conversation_settings_token", None) != request_token:
+            if (
+                getattr(self, "_suspended_conversation_settings_token", None)
+                != request_token
+            ):
                 return
             if self._owns_console_screen_stack():
                 self.run_worker(
@@ -3407,7 +3407,7 @@ class ChatScreen(BaseAppScreen):
             self._discard_conversation_settings_return(
                 target,
                 "Conversation settings return is no longer available. "
-                "Open Conversation settings again."
+                "Open Conversation settings again.",
             )
             return False
         claim = handoffs.claim(HandoffChannel.CONVERSATION_SETTINGS_RETURN)
@@ -3760,10 +3760,13 @@ class ChatScreen(BaseAppScreen):
                 and replacement is not None
             ):
                 try:
-                    replacement_is_pending = handoffs.exact_revision_status(
-                        HandoffChannel.CONVERSATION_SETTINGS_RETURN,
-                        replacement.return_revision,
-                    ) == "pending"
+                    replacement_is_pending = (
+                        handoffs.exact_revision_status(
+                            HandoffChannel.CONVERSATION_SETTINGS_RETURN,
+                            replacement.return_revision,
+                        )
+                        == "pending"
+                    )
                 except Exception:
                     logger.debug(
                         "Unable to inspect replacement Conversation settings return"
@@ -4022,7 +4025,6 @@ class ChatScreen(BaseAppScreen):
         )
         if endpoint_warning:
             self.app_instance.notify(endpoint_warning, severity="warning")
-
 
     async def _refresh_console_roleplay_projections(
         self,
@@ -4853,9 +4855,7 @@ class ChatScreen(BaseAppScreen):
             self._workspace._console_switcher_authority()
         )
         projection_generation = (
-            receipt_service.projection_generation
-            if receipt_service is not None
-            else 0
+            receipt_service.projection_generation if receipt_service is not None else 0
         )
 
         def authority_snapshot() -> tuple[str, str, int]:
@@ -5644,10 +5644,8 @@ class ChatScreen(BaseAppScreen):
             # session is captured so a session switch behind the open
             # inspector cannot splice the wrong session's staged evidence
             # into the estimate.
-            payload_estimate=lambda snapshot: (
-                self._console_next_send_token_estimate(
-                    snapshot, session_id=session_id
-                )
+            payload_estimate=lambda snapshot: self._console_next_send_token_estimate(
+                snapshot, session_id=session_id
             ),
             **project_instruction_ui.project_instruction_context_kwargs(
                 self, controller, session_id
@@ -5757,18 +5755,14 @@ class ChatScreen(BaseAppScreen):
         include_staged = True
         if session_id is not None:
             store = self._console_chat_store
-            include_staged = (
-                store is not None and store.active_session_id == session_id
-            )
+            include_staged = store is not None and store.active_session_id == session_id
         provider, model, _settings = self._active_console_provider_model_display()
         return estimate_console_next_send_tokens(
             payload_messages=payload.get("messages") or [],
             payload_system=payload.get("system"),
             tools_info=payload.get("tools"),
             extra_texts=(
-                console_prompted_evidence_text(
-                    self._pending_console_launch_context
-                ),
+                console_prompted_evidence_text(self._pending_console_launch_context),
             )
             if include_staged
             else (),
@@ -6216,7 +6210,7 @@ class ChatScreen(BaseAppScreen):
             return
         self.run_worker(
             self._open_console_tree_conversation_action_menu(
-                    conversation_id=event.conversation_id,
+                conversation_id=event.conversation_id,
                 title=event.title,
                 native_session_id=str(getattr(event, "native_session_id", "") or ""),
                 screen_x=event.screen_x,
@@ -6354,9 +6348,7 @@ class ChatScreen(BaseAppScreen):
         if db is None:
             return False
         try:
-            return bool(
-                db.get_messages_for_conversation(conversation_id, limit=1)
-            )
+            return bool(db.get_messages_for_conversation(conversation_id, limit=1))
         except Exception:
             return False
 
@@ -6380,9 +6372,7 @@ class ChatScreen(BaseAppScreen):
                 store = self._ensure_console_chat_store()
                 live = store.read_only_messages_for_session(native_session_id)
             except Exception:
-                logger.opt(exception=True).debug(
-                    "copy-markdown live read failed"
-                )
+                logger.opt(exception=True).debug("copy-markdown live read failed")
                 live = []
             if live:
                 return markdown_messages_from_store(live)
@@ -6478,7 +6468,9 @@ class ChatScreen(BaseAppScreen):
                 group="console-copy-markdown",
             )
 
-        self.push_screen(ConsoleSaveMarkdownModal(default_path=default_path), callback=_write)
+        self.push_screen(
+            ConsoleSaveMarkdownModal(default_path=default_path), callback=_write
+        )
 
     async def _write_console_markdown_file(self, path_text: str, markdown: str) -> None:
         """Validate and write one markdown export off the loop."""
@@ -6583,7 +6575,6 @@ class ChatScreen(BaseAppScreen):
             conversation_id, new_state, conversation_title=target.title
         )
 
-
     @on(Button.Pressed, "#console-workspace-rag-scope-open")
     def on_console_workspace_rag_scope_open(self, event: Button.Pressed) -> None:
         """Open the workspace-level RAG retrieval-scope picker (task-13).
@@ -6640,7 +6631,9 @@ class ChatScreen(BaseAppScreen):
         self._console_settings_coordinated_submission_ids: deque[str] = deque(maxlen=64)
         self._handoff_consumption_in_progress = False
         self._pending_console_launch_context: Optional[ConsoleLiveWorkLaunch] = None
-        self._suspended_conversation_settings: ConsoleSettingsDraftSnapshot | None = None
+        self._suspended_conversation_settings: ConsoleSettingsDraftSnapshot | None = (
+            None
+        )
         self._suspended_conversation_settings_token: int | None = None
         self._next_suspended_conversation_settings_token = 0
         self._pending_conversation_settings_return_claim = None
@@ -6848,6 +6841,9 @@ class ChatScreen(BaseAppScreen):
         # when the session's payload has actually changed since the last
         # check, and never while a run is actively streaming.
         self._last_console_cost_state: ConsoleCostState | None = None
+        self._last_console_context_control_state: ConsoleContextControlState | None = (
+            None
+        )
         self._console_cost_cache_state: ConsoleCacheState = ConsoleCacheState.NONE
         self._console_cost_fp_revisions: dict[str, int] = {}
         self._console_cost_break_reasons: dict[str, str | None] = {}
@@ -6901,6 +6897,7 @@ class ChatScreen(BaseAppScreen):
     #: no pass is open. A CLASS attribute default because the hand-built
     #: `ChatScreen.__new__()` test fixtures never run `__init__`.
     _console_derivation_memo: dict[Any, Any] | None = None
+    _last_console_context_control_state: ConsoleContextControlState | None = None
 
     #: Cross-tick memo for the cost chip's per-row token estimates
     #: (task-15451), lazily created by `_console_cost_estimate_cache_or_new`.
@@ -7488,8 +7485,8 @@ class ChatScreen(BaseAppScreen):
             if active_session.id != session_id:
                 raise RuntimeError("Console active session changed before adoption")
             current_has_user_work = active_session.has_user_work
-            current_endpoint_policy = (
-                session_store.session_ephemeral_endpoint_policy(session_id)
+            current_endpoint_policy = session_store.session_ephemeral_endpoint_policy(
+                session_id
             )
             current_controller = self._console_chat_controller
             current_provider_selection = self._build_console_provider_selection()
@@ -7542,14 +7539,16 @@ class ChatScreen(BaseAppScreen):
                 and current_has_user_work is not None
             ):
                 try:
-                    outcome = session_store.rollback_session_ephemeral_endpoint_adoption(
-                        session_id,
-                        expected_settings=next_settings,
-                        expected_policy=endpoint_policy,
-                        prior_settings=current,
-                        prior_policy=current_endpoint_policy,
-                        prior_has_user_work=current_has_user_work,
-                        receipt=adoption_receipt,
+                    outcome = (
+                        session_store.rollback_session_ephemeral_endpoint_adoption(
+                            session_id,
+                            expected_settings=next_settings,
+                            expected_policy=endpoint_policy,
+                            prior_settings=current,
+                            prior_policy=current_endpoint_policy,
+                            prior_has_user_work=current_has_user_work,
+                            receipt=adoption_receipt,
+                        )
                     )
                     if outcome is ConsoleEndpointRollbackOutcome.LOST_SESSION_FENCE:
                         raise RuntimeError(
@@ -7700,21 +7699,29 @@ class ChatScreen(BaseAppScreen):
             self._pending_console_launch_context if include_active_staging else None
         )
         staged_context_state = self._build_console_staged_context_state(pending_launch)
-        messages: list[dict[str, str]] = []
         try:
-            messages = [
-                {
-                    "role": str(
-                        message.role.value
-                        if hasattr(message.role, "value")
-                        else message.role
-                    ),
-                    "content": message.content,
-                }
-                for message in store.messages_for_session(session_id)
-            ]
+            session_messages = store.messages_for_session(session_id)
         except KeyError:
-            messages = []
+            session_messages = []
+        greeting = ""
+        composer = self._console_composer_or_none() if include_active_staging else None
+        if include_active_staging:
+            controller = self._ensure_console_chat_controller()
+            history = spend.build_console_spend_history_projection(
+                session_messages,
+                store.dispatch_recovery_for_session(session_id),
+                store.preparation_for_session(session_id),
+                controller.run_state_for(session_id).status,
+                bool(controller._submit_tasks_for_session(session_id)),
+            )
+            messages = spend.build_console_context_messages(
+                session_messages,
+                history.request_ids,
+                composer.draft_text() if composer is not None else "",
+            )
+            greeting = controller._seeded_greeting_text(session_id, session_messages)
+        else:
+            messages = spend.build_console_context_messages(session_messages, None, "")
         return build_console_context_estimate(
             messages,
             settings.provider,
@@ -7726,7 +7733,7 @@ class ChatScreen(BaseAppScreen):
             ),
             staged_context_summary=staged_context_state.summary,
             max_tokens_response=settings.max_tokens,
-            system_prompt=settings.system_prompt,
+            system_prompt=spend.fold_system_prompt(settings.system_prompt, greeting),
             # task-6: staged evidence used to move only the label's "; N
             # sources staged" suffix (`staged_source_count` above) while
             # `used_tokens` silently reported zero for content the send
@@ -7814,9 +7821,16 @@ class ChatScreen(BaseAppScreen):
     def _build_console_settings_summary_state(self) -> ConsoleSettingsSummaryState:
         """Build compact summary state for the active Console session settings."""
         settings, readiness = self._active_console_settings_readiness()
+        estimate = self._active_console_settings_context_estimate()
+        try:
+            self._last_console_context_control_state = (
+                self._active_console_context_control_state(estimate=estimate)
+            )
+        except (KeyError, ValueError):
+            self._last_console_context_control_state = None
         return build_console_settings_summary_state(
             settings,
-            self._active_console_settings_context_estimate(),
+            estimate,
             readiness,
         )
 
@@ -8219,9 +8233,7 @@ class ChatScreen(BaseAppScreen):
         return ConsoleProviderSelection(
             provider=provider,
             base_url=base_url,
-            configured_endpoint_fallback_allowed=(
-                not endpoint_policy_owns_selection
-            ),
+            configured_endpoint_fallback_allowed=(not endpoint_policy_owns_selection),
             endpoint_provenance=(
                 ConsoleEndpointProvenance.EPHEMERAL_SESSION
                 if endpoint_policy_owns_selection
@@ -8422,9 +8434,7 @@ class ChatScreen(BaseAppScreen):
         )
         if store is None:
             store = self._console_runtime().ensure_chat_store(
-                workspace_context=(
-                    None if resume_pending else workspace_context
-                ),
+                workspace_context=(None if resume_pending else workspace_context),
                 on_scope_flushed=self._on_console_scope_flushed,
             )
         elif store.active_session_id is None and not resume_pending:
@@ -10031,129 +10041,6 @@ class ChatScreen(BaseAppScreen):
             system_prompt_set=bool(getattr(settings, "system_prompt", None)),
         )
 
-    def _console_first_send_pseudo_rows(self) -> list[Any]:
-        """Return estimated rows for the context a FIRST send will ship.
-
-        task-25886: while a conversation has no answered/billed turns, the
-        next request carries the session system prompt, the native tool
-        schemas, the effective-memory rows, an optional response prefill,
-        and the composer draft -- none of which are transcript rows, so the
-        cost chip under-reported a first send as "0 tok". Memory and
-        prefill are resolved through the controller's own read-only seams
-        (``_project_session_effective_memory`` /
-        ``_resolve_submit_prefill`` -- the same projections the real
-        assembly uses) rather than re-derived here, so the estimate tracks
-        what dispatch would actually carry. Returns duck-typed rows
-        (``.role``/``.content``/``.usage=None``, the same contract as the
-        staged-evidence pseudo-row) that ``build_cost_snapshot`` prices
-        through its ESTIMATED-row branch, flipping
-        ``has_estimated_entries`` so the chip's ``~`` honesty marker shows.
-
-        Empty when no send is pending: a blank draft short-circuits before
-        any state is read (the steady-state cost of this on the sync tick
-        is one composer read), and the fold-in stops the moment the session
-        has ANY assistant row or recorded usage -- after that the chip is a
-        running total of what was actually sent, and re-adding
-        system/tools per tick would corrupt it.
-
-        The DRAFT row is dropped when the trailing transcript row is a
-        user message carrying the same text: that is the mouse-send window
-        where the real user row is already persisted (and priced) but the
-        composer draft is not cleared until the send completes -- appending
-        the draft again would double-count it.
-        """
-        composer = self._console_composer_or_none()
-        draft = composer.draft_text() if composer is not None else ""
-        if not str(draft).strip():
-            return []
-        store = self._console_chat_store
-        session_id = store.active_session_id if store is not None else None
-        if session_id is None:
-            return []
-        try:
-            messages = store.messages_for_session(session_id)
-        except KeyError:
-            return []
-        for message in messages:
-            if getattr(message, "usage", None) is not None:
-                return []
-            if str(getattr(message.role, "value", message.role)) == "assistant":
-                return []
-        # Qodo review finding 2 (mouse-send race): with no assistant/usage
-        # rows, a trailing user row whose content matches the draft means
-        # the send is already in flight and the draft is persisted as a
-        # real (estimated) row -- re-adding it here would double-count.
-        draft_pending = True
-        if messages:
-            last = messages[-1]
-            if (
-                str(getattr(last.role, "value", last.role)) == "user"
-                and str(getattr(last, "content", "") or "").strip()
-                == str(draft).strip()
-            ):
-                draft_pending = False
-        rows: list[Any] = []
-        settings = self._session._active_console_session_settings()
-        system_prompt = str(getattr(settings, "system_prompt", "") or "")
-        if system_prompt.strip():
-            rows.append(
-                SimpleNamespace(role="system", content=system_prompt, usage=None)
-            )
-        try:
-            bridge = self._ensure_console_agent_bridge()
-            schemas = (
-                bridge.native_tool_schemas()
-                if bridge is not None and hasattr(bridge, "native_tool_schemas")
-                else []
-            )
-        except Exception:
-            schemas = []
-        if schemas:
-            rows.append(
-                SimpleNamespace(
-                    role="system", content=json.dumps(schemas, default=str), usage=None
-                )
-            )
-        # Qodo review finding 1: fold the controller's own effective-memory
-        # and prefill projections in rather than under-counting a
-        # configured session. Both seams are synchronous and read-only
-        # (the preview path uses them the same way, without consuming the
-        # one-shot); best-effort, since a chip estimate must never raise.
-        controller = self._console_chat_controller
-        try:
-            projection_rows = [
-                {"role": str(getattr(row.role, "value", row.role)), "content": row.content}
-                for row in rows
-            ]
-            _effective, projection = (
-                controller._project_session_effective_memory(
-                    session_id, projection_rows
-                )
-            )
-            for memory_row in projection.memory:
-                content = memory_row.get("content", "")
-                if str(content).strip():
-                    rows.append(
-                        SimpleNamespace(
-                            role=memory_row.get("role", "system"),
-                            content=content,
-                            usage=None,
-                        )
-                    )
-        except Exception:
-            pass
-        try:
-            prefill, _from_one_shot = controller._resolve_submit_prefill(session_id)
-        except Exception:
-            prefill = None
-        if prefill and str(prefill).strip():
-            rows.append(
-                SimpleNamespace(role="assistant", content=prefill, usage=None)
-            )
-        if draft_pending:
-            rows.append(SimpleNamespace(role="user", content=draft, usage=None))
-        return rows
-
     def _build_console_cost_state(self) -> ConsoleCostState | None:
         """Build the cost chip's display state for the active session (task-5).
 
@@ -10179,40 +10066,17 @@ class ChatScreen(BaseAppScreen):
                 self._console_cost_cache_state = ConsoleCacheState.NONE
                 return None
 
-            # Keep the chip stable until provider rows finish; direct raw
-            # commands are local actions and never provider-billed rows.
-            snapshot_messages = console_cost_snapshot_messages(messages)
-            # task-6: staged (not-yet-sent) evidence used to be invisible to
-            # the cost chip entirely -- `ConsoleStagedSource` carries no
-            # text, so a session with zero messages but several staged
-            # sources (even a 942 KB one) showed "0 tok". Feed the same
-            # formatted pre-authority staged-text estimate the context
-            # estimate now counts (`console_prompted_evidence_text`,
-            # pure/zero-I/O) in as one
-            # more transcript row satisfying `build_cost_snapshot`'s
-            # duck-typed contract (`.role`/`.content`/`.usage`) with
-            # `usage=None` -- it prices through the ESTIMATED-row branch,
-            # at the input rate, and flips `has_estimated_entries` so the
-            # chip's `~` prefix (its existing "this includes an unsent
-            # estimate" marker) shows rather than claiming a real total.
-            staged_text = console_prompted_evidence_text(
-                self._pending_console_launch_context
+            controller = self._ensure_console_chat_controller()
+            history = spend.build_console_spend_history_projection(
+                messages,
+                store.dispatch_recovery_for_session(session_id),
+                store.preparation_for_session(session_id),
+                controller.run_state_for(session_id).status,
+                bool(controller._submit_tasks_for_session(session_id)),
             )
-            if staged_text:
-                snapshot_messages = snapshot_messages + [
-                    SimpleNamespace(role="user", content=staged_text, usage=None)
-                ]
-            # task-25886: a FIRST send ships the session system prompt, tool
-            # schemas, and the draft itself on top of the staged evidence
-            # above -- none of which existed as transcript rows, so a
-            # brand-new conversation with a typed draft still read "0 tok".
-            # Same pseudo-row treatment as the staged evidence: folded in
-            # only while the session has nothing answered/billed yet (see
-            # `_console_first_send_pseudo_rows`), so the running-total
-            # semantics after a reply are untouched.
-            first_send_rows = self._console_first_send_pseudo_rows()
-            if first_send_rows:
-                snapshot_messages = snapshot_messages + first_send_rows
+            snapshot_messages = spend.build_console_current_cost_messages(
+                messages, history.current_ids
+            )
             provider, model, _settings = self._active_console_provider_model_display()
             # PR2b Task 5 (cost rollup): the active conversation's LIVE
             # sub-agent fleet spend, folded into the snapshot's token total
@@ -10377,13 +10241,26 @@ class ChatScreen(BaseAppScreen):
                     ) / 1_000_000
                     projected_delta_usd = round(estimated_tokens * rate_delta, 6)
 
-            return build_cost_state(
+            composer = self._console_composer_or_none()
+            context_state = self._last_console_context_control_state
+            if context_state is None:
+                try:
+                    context_state = self._active_console_context_control_state()
+                except (KeyError, ValueError):
+                    pass
+            return spend.build_console_spend_cost_state(
                 snapshot,
-                cache_state=cache_state,
-                break_reason=break_reason,
-                projected_delta_usd=projected_delta_usd,
-                ttl_remaining_s=ttl_remaining_s,
-                pricing_as_of=pricing_as_of,
+                cache_state,
+                break_reason,
+                projected_delta_usd,
+                ttl_remaining_s,
+                pricing_as_of,
+                pricing is not None,
+                context_state,
+                messages,
+                bool(store.pending_attachments(session_id)),
+                pricing.input_per_mtok if pricing is not None else None,
+                composer.draft_text() if composer is not None else "",
             )
         except Exception:
             logger.opt(exception=True).warning("cost_chip_state_failed")
@@ -12451,9 +12328,7 @@ class ChatScreen(BaseAppScreen):
                 if provider_runtime_ready and not model_selected
                 else "Select a provider and model before sending."
                 if explicit_provider_ready is False
-                else build_console_readiness_presentation(
-                    settings_readiness
-                ).detail
+                else build_console_readiness_presentation(settings_readiness).detail
             )
         can_save_chatbook = self._console_can_save_chatbook_flag(pending_launch)
         evidence_state = build_console_evidence_display_state(pending_launch)
@@ -12464,17 +12339,13 @@ class ChatScreen(BaseAppScreen):
         # way to know the last send had failed and answered "Ready".
         run_controller = self._console_chat_controller
         run_state = getattr(run_controller, "run_state", None)
-        run_failed = (
-            getattr(run_state, "status", None) is ConsoleRunStatus.FAILED
-        )
+        run_failed = getattr(run_state, "status", None) is ConsoleRunStatus.FAILED
         inspector_state = ConsoleInspectorState.from_values(
             live_work_title=pending_launch.title if pending_launch else None,
             run_active=self._console_run_active(),
             run_failed=run_failed,
             run_failure_reason=(
-                str(getattr(run_state, "visible_copy", "") or "")
-                if run_failed
-                else ""
+                str(getattr(run_state, "visible_copy", "") or "") if run_failed else ""
             ),
             provider_label=settings_readiness.provider_display_name or "Provider",
             model_label=model,
@@ -14907,6 +14778,7 @@ class ChatScreen(BaseAppScreen):
         self._stop_console_transcript_sync_timer()
         self._fleet._stop_console_fleet_survivor_tick()
         self._stop_console_cost_ttl_timer()
+        self._console_draft_spend_refresh.stop()
         await self._teardown_console_roleplay_persistence()
         # The pipeline hands-free loop's own two-statement abandon teardown
         # now lives in the decomposed controller (wave-2 console
@@ -16344,8 +16216,8 @@ class ChatScreen(BaseAppScreen):
             # interleaving during the awaits keep building live.
             with self._workspace.tick_workspace_build_scope():
                 rail_state = self._current_console_rail_state()
-                self._sync_console_control_bar(rail_state)
                 self._sync_console_settings_summary()
+                self._sync_console_control_bar(rail_state)
                 # Settings failures may arrive after Apply has returned:
                 # ordinary first persistence and temporary-chat promotion
                 # both update the session ledger on their own later path.
@@ -16547,6 +16419,7 @@ class ChatScreen(BaseAppScreen):
         self, draft: str, session_id: str | None = None
     ) -> None:
         controller = self._ensure_console_chat_controller()
+        self._console_draft_spend_refresh.stop()
         self._start_console_transcript_sync_timer()
         # Task 3b: `session_id` is the session THIS worker was dispatched
         # for (`_dispatch_console_draft_send` already resolved it via the
@@ -16853,7 +16726,9 @@ class ChatScreen(BaseAppScreen):
             if readiness.recovery_action == "select_model":
                 return "Console send blocked: Select a model before sending."
             if readiness.recovery_action == "save_endpoint":
-                return "Console send blocked: Save the provider endpoint before sending."
+                return (
+                    "Console send blocked: Save the provider endpoint before sending."
+                )
             if readiness.recovery_action == "configure_endpoint":
                 return "Console send blocked: Enter a valid provider endpoint before sending."
             if readiness.recovery_action == "retry_connection":
@@ -17188,7 +17063,9 @@ class ChatScreen(BaseAppScreen):
 
         include_network = "network" in (parse.args or "").lower()
         try:
-            checks = await _asyncio.to_thread(run_doctor, include_network=include_network)
+            checks = await _asyncio.to_thread(
+                run_doctor, include_network=include_network
+            )
             report = format_doctor_report(checks)
         except Exception as exc:  # noqa: BLE001 - a command must not crash the screen
             report = f"Doctor could not complete: {exc}"
@@ -17645,9 +17522,7 @@ class ChatScreen(BaseAppScreen):
         controller = self._ensure_console_chat_controller()
         refusal = controller.redirect_active_run(text)
         if refusal is not None:
-            self.app_instance.notify(
-                f"Not redirected: {refusal}", severity="warning"
-            )
+            self.app_instance.notify(f"Not redirected: {refusal}", severity="warning")
             return False
         # Same double-delivery guard as /steer (review I-3): dispatch
         # restores the stash, so the command would sit in the composer and
@@ -17685,9 +17560,7 @@ class ChatScreen(BaseAppScreen):
         )
         return True
 
-    async def handle_console_redirect_generation(
-        self, event: Button.Pressed
-    ) -> None:
+    async def handle_console_redirect_generation(self, event: Button.Pressed) -> None:
         """The Redirect button next to Stop: sends the composer draft as the
         correction. An empty draft is a prompt to type one, not a no-op."""
         event.stop()
@@ -17704,9 +17577,7 @@ class ChatScreen(BaseAppScreen):
         controller = self._ensure_console_chat_controller()
         refusal = controller.redirect_active_run(text)
         if refusal is not None:
-            self.app_instance.notify(
-                f"Not redirected: {refusal}", severity="warning"
-            )
+            self.app_instance.notify(f"Not redirected: {refusal}", severity="warning")
             return
         self._clear_console_composer_draft()
         self.app_instance.notify("Redirect sent — correcting the running turn.")
@@ -18005,6 +17876,17 @@ class ChatScreen(BaseAppScreen):
             wake = getattr(self._console_chat_controller, "fleet_wake", None)
             if wake is not None:
                 wake.retry_soon()
+        store = self._console_chat_store
+        session_id = store.active_session_id if store is not None else None
+        controller = self._console_chat_controller
+        self._console_draft_spend_refresh.route_edit(
+            run_active=bool(
+                session_id is not None
+                and controller is not None
+                and controller.run_state_for(session_id).status
+                in CONSOLE_ACTIVE_RUN_STATUSES
+            )
+        )
 
     @on(Button.Pressed, "#console-composer-collapse")
     def handle_console_composer_collapse(self, event: Button.Pressed) -> None:
@@ -18650,7 +18532,9 @@ class ChatScreen(BaseAppScreen):
             if question is not None:
                 with contextlib.suppress(Exception):
                     question.scroll_visible(animate=False)
-                target = next(iter(question.query("RadioSet, SelectionList, Input")), None)
+                target = next(
+                    iter(question.query("RadioSet, SelectionList, Input")), None
+                )
                 if target is not None:
                     target.focus()
                 return
@@ -18813,9 +18697,7 @@ class ChatScreen(BaseAppScreen):
                 preview = None
             if isinstance(preview, ConsoleSubmitResult):
                 if preview.visible_copy:
-                    self.app_instance.notify(
-                        preview.visible_copy, severity="warning"
-                    )
+                    self.app_instance.notify(preview.visible_copy, severity="warning")
                 return
             focus = ""
             if preview is not None:
@@ -20807,7 +20689,10 @@ class ChatScreen(BaseAppScreen):
         """Follow canonical durable receipts without retaining tool payloads."""
         followed = tuple(
             dict.fromkeys(
-                (*self._task_resume_state.followed_watchlists_operations, *operation_ids)
+                (
+                    *self._task_resume_state.followed_watchlists_operations,
+                    *operation_ids,
+                )
             )
         )
         self._task_resume_state = replace(
@@ -20954,16 +20839,14 @@ class ChatScreen(BaseAppScreen):
             source_id = source.get("id") if isinstance(source, Mapping) else None
             if (
                 not isinstance(source_id, str)
-                or re.fullmatch(r"local:subscription:[1-9][0-9]*", source_id)
-                is None
+                or re.fullmatch(r"local:subscription:[1-9][0-9]*", source_id) is None
             ):
                 return
             receipts = await coordinator.accept_checks(
                 [int(source_id.rsplit(":", 1)[-1])]
             )
             followed = tuple(
-                f"local:watchlist_run:{int(receipt['run_id'])}"
-                for receipt in receipts
+                f"local:watchlist_run:{int(receipt['run_id'])}" for receipt in receipts
             )
         else:
             collection = operation.get("collection")
@@ -20972,8 +20855,7 @@ class ChatScreen(BaseAppScreen):
             )
             if (
                 not isinstance(collection_id, str)
-                or re.fullmatch(r"local:watchlist:[1-9][0-9]*", collection_id)
-                is None
+                or re.fullmatch(r"local:watchlist:[1-9][0-9]*", collection_id) is None
             ):
                 return
             receipt = await coordinator.accept_briefing(
@@ -21091,7 +20973,9 @@ class ChatScreen(BaseAppScreen):
         if not request_id:
             return False
         payload_session = (getattr(card, "_payload", None) or {}).get("session_id")
-        if payload_session and payload_session != (controller.store.active_session_id or ""):
+        if payload_session and payload_session != (
+            controller.store.active_session_id or ""
+        ):
             # A stale card mounted for another session must never take the
             # text typed into this one (Qodo #2380).
             return False
@@ -21452,7 +21336,9 @@ class ChatScreen(BaseAppScreen):
         event.stop()
         controller = self._console_chat_controller
         if controller is not None:
-            controller.resolve_pending_question(event.answers, request_id=event.request_id)
+            controller.resolve_pending_question(
+                event.answers, request_id=event.request_id
+            )
 
     async def on_button_pressed(self, event: Button.Pressed) -> None:
         """

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -10263,7 +10263,15 @@ class ChatScreen(BaseAppScreen):
                 pricing_as_of,
                 pricing is not None,
                 context_state,
+                # Configuration capture resolves RAG defaults; text-only
+                # display refreshes must not pull that work onto first paint.
                 any(
+                    message.role is ConsoleMessageRole.USER
+                    and message.attachments
+                    and message.id in history.request_ids
+                    for message in messages
+                )
+                and any(
                     row.attachments
                     for row in controller._lightweight_provider_message_rows(
                         [

--- a/tldw_chatbook/Widgets/Console/console_context_controls.py
+++ b/tldw_chatbook/Widgets/Console/console_context_controls.py
@@ -7,7 +7,7 @@ store/controller while making the quick and full settings surfaces agree.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
@@ -23,6 +23,7 @@ from tldw_chatbook.Chat.console_context_policy import (
     ConsoleContextCapacity,
     ConsoleContextPolicyDefaults,
     ConsoleContextPolicyOverrides,
+    ContextCompactionMode,
     ResolvedConsoleContextPolicy,
     application_context_policy_defaults,
     merge_context_policy,
@@ -34,6 +35,8 @@ from tldw_chatbook.Chat.console_context_repository import (
     MemoryCoverageKind,
     MemoryOriginKind,
 )
+from tldw_chatbook.Chat.console_cost_tracker import ConsoleCostState
+from tldw_chatbook.Chat.cost_display import format_cost_amount
 from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
     ConsoleSettingsContextEstimate,
@@ -133,6 +136,61 @@ class ConsoleContextControlState:
         return f"{estimate_prefix}{used} / {budget} max tokens"
 
 
+@dataclass(frozen=True, slots=True)
+class ConsoleNextSendSpendState:
+    """Presentation state for incremental input cost on the next send."""
+
+    label: str
+    tooltip: str
+
+
+def build_console_next_send_spend_state(
+    *,
+    request_tokens: int | None,
+    input_per_mtok: float | None,
+    sendable_text: bool,
+    has_media: bool,
+) -> ConsoleNextSendSpendState:
+    """Build an honest uncached-input forecast for the next request."""
+    detail = (
+        f"Estimated text input: ~{format_context_tokens(request_tokens)} tokens."
+        if request_tokens is not None
+        else None
+    )
+    if has_media:
+        lines = ["On next send: unavailable", "Media cost is not estimated."]
+        if detail is not None:
+            lines.append(detail)
+        return ConsoleNextSendSpendState("unavailable", "\n".join(lines))
+    if request_tokens is None:
+        return ConsoleNextSendSpendState(
+            "unavailable",
+            "On next send: unavailable\n"
+            "The next-request text token estimate is unavailable.",
+        )
+    if input_per_mtok is None:
+        return ConsoleNextSendSpendState(
+            "unavailable",
+            "On next send: unavailable\n"
+            "Selected-model input pricing is unavailable.\n"
+            f"{detail}",
+        )
+    if not sendable_text:
+        return ConsoleNextSendSpendState(
+            "—",
+            "On next send: —\nType a message to estimate the next-send input spend.",
+        )
+    amount = round(request_tokens * input_per_mtok / 1_000_000, 6)
+    label = f"~+${format_cost_amount(amount)}"
+    return ConsoleNextSendSpendState(
+        label,
+        f"On next send: {label} uncached input baseline\n"
+        f"{detail}\n"
+        "Response/output spend is added after completion.\n"
+        "Cache reads may lower it; cache writes may raise it.",
+    )
+
+
 @dataclass(frozen=True)
 class ContextBreakdownRow:
     """One named slice of the request window (TASK-26019)."""
@@ -157,9 +215,7 @@ def build_context_breakdown(
     attachments = accounting.attachment_tokens
     conversation = max(
         0,
-        accounting.compactable_tokens
-        + accounting.active_request_tokens
-        - attachments,
+        accounting.compactable_tokens + accounting.active_request_tokens - attachments,
     )
     rows: list[ContextBreakdownRow] = [
         ContextBreakdownRow("System prompt", accounting.system_tokens),
@@ -323,9 +379,82 @@ def build_console_context_control_state(
     )
 
 
+def build_console_context_cost_state(
+    context: ConsoleContextControlState,
+    cost: ConsoleCostState,
+    next_send: ConsoleNextSendSpendState | None = None,
+) -> ConsoleCostState:
+    """Combine context fullness with current and next-send spend states."""
+    next_send = next_send or ConsoleNextSendSpendState(
+        "unavailable",
+        "On next send: unavailable\nA next-send spend estimate has not been provided.",
+    )
+    used = context.request_tokens
+    ceiling = context.safe_input_ceiling_tokens
+    if used is None or ceiling is None or ceiling <= 0:
+        fullness = "unknown"
+        context_line = (
+            "Context: model context window is unavailable; choose a model "
+            "with a known window in Settings."
+        )
+    else:
+        raw_percent = used * 100 / ceiling
+        fullness = "100%+" if raw_percent > 100 else f"{round(raw_percent)}%"
+        context_line = (
+            f"Context: ~{format_context_tokens(used)} / "
+            f"{format_context_tokens(ceiling)} safe input ({fullness} full)"
+        )
+    conversation = format_context_tokens(context.conversation_tokens)
+    budget = format_context_tokens(context.conversation_budget_tokens)
+    prefix = "~" if context.conversation_tokens is not None else ""
+    compaction_mode = context.resolved_policy.policy.compaction_mode
+    trigger = context.compaction_trigger_tokens
+    if compaction_mode is ContextCompactionMode.OFF:
+        compaction_line = "Compaction: off."
+    elif trigger is None:
+        compaction_line = f"Compaction: {compaction_mode.value}; trigger unknown."
+    elif compaction_mode is ContextCompactionMode.AUTOMATIC:
+        compaction_line = (
+            f"Compaction: automatic at {format_context_tokens(trigger)} "
+            "conversation tokens."
+        )
+    else:
+        compaction_line = (
+            f"Compaction: asks at {format_context_tokens(trigger)} conversation tokens."
+        )
+    current_label = cost.compact_label
+    for suffix in (" ⚠", " ○", " ●"):
+        if current_label.endswith(suffix):
+            current_label = current_label.removesuffix(suffix)
+            break
+    return replace(
+        cost,
+        label=(
+            f"Context {fullness} · Current {current_label} "
+            f"· On next send {next_send.label}"
+        ),
+        compact_label=(
+            f"Ctx {fullness} · Now {current_label} · Next {next_send.label}"
+        ),
+        tooltip="\n".join(
+            (
+                context_line,
+                f"Conversation: {prefix}{conversation} / {budget} budget",
+                compaction_line,
+                cost.tooltip,
+                next_send.tooltip,
+                "Open Conversation Inspector for Costs, Exchange, and Next Send.",
+            )
+        ),
+    )
+
+
 __all__ = [
     "ConsoleContextControlState",
+    "ConsoleNextSendSpendState",
     "ThinkingHistoryControlState",
     "build_console_context_control_state",
+    "build_console_context_cost_state",
+    "build_console_next_send_spend_state",
     "format_context_tokens",
 ]

--- a/tldw_chatbook/Widgets/Console/console_context_controls.py
+++ b/tldw_chatbook/Widgets/Console/console_context_controls.py
@@ -151,7 +151,17 @@ def build_console_next_send_spend_state(
     sendable_text: bool,
     has_media: bool,
 ) -> ConsoleNextSendSpendState:
-    """Build an honest uncached-input forecast for the next request."""
+    """Build an honest uncached-input forecast for the next request.
+
+    Args:
+        request_tokens: Estimated next-request text tokens, if known.
+        input_per_mtok: Uncached input price per million tokens, if known.
+        sendable_text: Whether the validated draft contains text to send.
+        has_media: Whether the request includes media with unestimated cost.
+
+    Returns:
+        Additional input charge or an explicit empty/unavailable state.
+    """
     detail = (
         f"Estimated text input: ~{format_context_tokens(request_tokens)} tokens."
         if request_tokens is not None
@@ -384,7 +394,16 @@ def build_console_context_cost_state(
     cost: ConsoleCostState,
     next_send: ConsoleNextSendSpendState | None = None,
 ) -> ConsoleCostState:
-    """Combine context fullness with current and next-send spend states."""
+    """Combine context fullness with current and next-send spend states.
+
+    Args:
+        context: Estimated request occupancy and model capacity.
+        cost: Current settled spend and cache presentation.
+        next_send: Additional input-charge forecast, if available.
+
+    Returns:
+        Full and compact labels with detailed context and spend tooltips.
+    """
     next_send = next_send or ConsoleNextSendSpendState(
         "unavailable",
         "On next send: unavailable\nA next-send spend estimate has not been provided.",

--- a/tldw_chatbook/Widgets/Console/console_model_popover.py
+++ b/tldw_chatbook/Widgets/Console/console_model_popover.py
@@ -49,7 +49,10 @@ from .console_context_controls import (
     build_console_context_control_state,
     format_context_tokens,
 )
-from tldw_chatbook.Widgets.model_search_picker import ModelPickerInput, ModelSearchPicker
+from tldw_chatbook.Widgets.model_search_picker import (
+    ModelPickerInput,
+    ModelSearchPicker,
+)
 
 CONSOLE_POPOVER_OPEN_FULL_SETTINGS = "open-full-settings"
 
@@ -298,6 +301,13 @@ class ConsoleModelPopover(
             ),
             overrides=initial_draft.context_policy_overrides,
         )
+        self._initial_compaction_mode = (
+            self._context_state.resolved_policy.policy.compaction_mode
+        )
+        self._initial_compaction_override = (
+            initial_draft.context_policy_overrides.compaction_mode
+        )
+        self._compaction_mode_edited = False
         self._scope_copy = scope_copy
         self._durability_copy = durability_copy
         self._draft_rebaser = draft_rebaser
@@ -747,11 +757,19 @@ class ConsoleModelPopover(
             settings=replace(self._draft.settings, streaming=self._streaming),
             context_policy_overrides=replace(
                 self._draft.context_policy_overrides,
-                compaction_mode=mode,
+                compaction_mode=self._compaction_override_for(mode),
             ),
         )
         self._draft = remember_model_draft(self._draft)
         return self._draft
+
+    def _compaction_override_for(
+        self, mode: ContextCompactionMode | None
+    ) -> ContextCompactionMode | None:
+        """Keep an untouched effective mode sparse without erasing edits."""
+        if not self._compaction_mode_edited and mode == self._initial_compaction_mode:
+            return self._initial_compaction_override
+        return mode
 
     def _rebase_to(
         self,
@@ -903,6 +921,13 @@ class ConsoleModelPopover(
         if provider == self._model_options_provider:
             return
         self._rebase_to(provider, None)
+
+    @on(Select.Changed, "#console-popover-compaction-mode")
+    def _compaction_mode_changed(self, event: Select.Changed) -> None:
+        """Remember a deliberate edit even when the initial mode is reselected."""
+        event.stop()
+        if event.value != self._initial_compaction_mode.value:
+            self._compaction_mode_edited = True
 
     @on(ModelSearchPicker.ModelSelected)
     def _model_search_selected(self, event: ModelSearchPicker.ModelSelected) -> None:
@@ -1084,9 +1109,13 @@ class ConsoleModelPopover(
             ),
             context_policy_overrides=replace(
                 self._draft.context_policy_overrides,
-                compaction_mode=ContextCompactionMode(
-                    str(
-                        self.query_one("#console-popover-compaction-mode", Select).value
+                compaction_mode=self._compaction_override_for(
+                    ContextCompactionMode(
+                        str(
+                            self.query_one(
+                                "#console-popover-compaction-mode", Select
+                            ).value
+                        )
                     )
                 ),
             ),

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -177,12 +177,8 @@ class ConsoleLibraryChip(ConsoleChip):
     """Two-axis Library policy chip that opens conversation access controls."""
 
     BINDINGS = [
-        Binding(
-            "enter", "open_library_access", "Open Library access", show=False
-        ),
-        Binding(
-            "space", "open_library_access", "Open Library access", show=False
-        ),
+        Binding("enter", "open_library_access", "Open Library access", show=False),
+        Binding("space", "open_library_access", "Open Library access", show=False),
     ]
 
     class OpenRequested(Message):
@@ -549,12 +545,12 @@ class ConsoleStatusChips(Horizontal):
     def set_collapsed(self, collapsed: bool) -> None:
         """Toggle the mounted status presentations without touching chip state."""
         self._collapsed = bool(collapsed)
-        self.query_one("#console-status-expanded", Horizontal).display = (
-            not self._collapsed
-        )
-        self.query_one("#console-status-collapsed", Horizontal).display = (
-            self._collapsed
-        )
+        self.query_one(
+            "#console-status-expanded", Horizontal
+        ).display = not self._collapsed
+        self.query_one(
+            "#console-status-collapsed", Horizontal
+        ).display = self._collapsed
 
     def _run_chip(self) -> ConsoleRunChip:
         label, tooltip, hidden = self._run_chip_render(*self._run_chip_state)
@@ -804,7 +800,7 @@ class ConsoleStatusChips(Horizontal):
         Returns:
             ``label``: chip text (the full ``state.label``; the strip
             hasn't been laid out yet at compose time, so the width-aware
-            compact form only applies from ``sync_cost_state``).
+            compact form applies on the first resize or ``sync_cost_state``).
             ``tooltip``: hover/focus text. ``hidden``: ``True`` when
             ``state`` is ``None``. ``alert``/``cold``: ``state.alert``/
             ``state.cold``.
@@ -836,19 +832,29 @@ class ConsoleStatusChips(Horizontal):
         if state is None:
             chip.display = False
             return
-        # Narrow strips fall back to the delta-free compact label; pre-
-        # layout (``size.width`` still zero) falls back to the full label.
-        label = (
-            state.compact_label
-            if self.size.width and self.size.width < 120
-            else state.label
-        )
-        chip.update(label)
+        self._apply_cost_chip_label(chip)
         chip.tooltip = Content(state.tooltip)
         chip.display = True
         chip.set_class(state.alert, "console-chip-alert")
         chip.set_class(state.cold, "console-chip-cold")
         chip.set_class(not state.alert and not state.cold, "console-chip-dim")
+
+    def _apply_cost_chip_label(self, chip: ConsoleCostChip) -> None:
+        """Apply the current cost state's full or compact width-aware label."""
+        state = self._cost_state
+        if state is None:
+            return
+        label = state.compact_label if self.screen.size.width < 120 else state.label
+        chip.update(label)
+        chip.refresh(layout=True)
+
+    def on_resize(self, _event: events.Resize) -> None:
+        """Reapply width-aware cost copy without requiring a state change."""
+        try:
+            chip = self.query_one("#console-cost-chip", ConsoleCostChip)
+        except NoMatches:
+            return
+        self._apply_cost_chip_label(chip)
 
     def sync_state(self, state: ConsoleControlState) -> None:
         """Refresh pill labels and counter emphasis from a new snapshot."""

--- a/tldw_chatbook/Widgets/Console/console_status_chips.py
+++ b/tldw_chatbook/Widgets/Console/console_status_chips.py
@@ -849,7 +849,11 @@ class ConsoleStatusChips(Horizontal):
         chip.refresh(layout=True)
 
     def on_resize(self, _event: events.Resize) -> None:
-        """Reapply width-aware cost copy without requiring a state change."""
+        """Reapply width-aware cost copy without requiring a state change.
+
+        Args:
+            _event: Textual resize notification; width is read from the app.
+        """
         try:
             chip = self.query_one("#console-cost-chip", ConsoleCostChip)
         except NoMatches:

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3998,6 +3998,10 @@ with stray left-edge border fragments), and padding 0 1 so the full
     text-wrap: nowrap;
 }
 
+#console-cost-chip {
+    max-width: 100%;
+}
+
 /* The policy label has two independent axes (or an explicit unavailable
    state), so it needs more room than ordinary metadata chips. */
 #console-library-chip {

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -686,6 +686,10 @@ $ds-library-source-browser-width: 31;
     text-wrap: nowrap;
 }
 
+#console-cost-chip {
+    max-width: 100%;
+}
+
 /* The policy label has two independent axes (or an explicit unavailable
    state), so it needs more room than ordinary metadata chips. */
 #console-library-chip {


### PR DESCRIPTION
## Summary

- preserve deliberate per-chat Automatic compaction choices while keeping untouched inherited settings sparse
- show context fullness alongside completed **Current** spend and estimated incremental **On next send** additional charge
- avoid double-counting a locally estimated user turn when the provider reports actual usage for the following assistant response
- keep spend/context estimates accurate across dispatch, failure, continuation, remote recovery, media, cache, validation, and pricing edge cases
- provide responsive full and compact labels without clipping at production terminal sizes

## Verification

- 204 focused Console cost, status-chip, wiring, projection, rail, and mounted-screen tests passed after rebasing onto dev at 68f9d865fa
- additional context-control suite matched clean `dev` exactly: 25 passed and the same 6 pre-existing failures
- Ruff lint and format checks passed across all touched Python files
- `py_compile` passed for touched production modules
- generated CSS bundles are synchronized
- `git diff --check` passed
- all six Qodo findings addressed: canonical admitted-media filtering, persisted recovery IDs, API documentation, and safe submission IDs in error logs
- reviewed diagnostic statement changes and regenerated the diagnostic inventory; no new sinks or user-content logging
- fixed the startup regression from eager media configuration: the UI-ready census and media regressions now pass (10 tests), with 972 modules at startup and the existing limit unchanged

The full repository test suite was not run, following the repository policy requiring explicit opt-in.
