### PR TITLE
Seventh holistic performance review: evidence, tasks 31500-31511, scheduler tick I/O off-loop

### DIFF
--- a/Docs/Design/2026-09-04-holistic-perf-review.md
+++ b/Docs/Design/2026-09-04-holistic-perf-review.md
@@ -1,0 +1,272 @@
+# Holistic performance review — 2026-09-04
+
+Seventh holistic performance review. Pin: dev `f51fcaf204` (1,119 commits since
+the 2026-08-30 review's pin `0ef6f3fd4e`). Baseline arm for paired
+measurements: `b62407e258` (2026-09-01, the merge of PR #2281 — i.e. *after*
+the previous review's CSS wins landed, so deltas measure the last ~3.5 days of
+feature work, not the previous review's own improvements).
+
+Commissioned with the same prompt as the 2026-08-22/24/27/29/30 reviews, with
+one new datum: **users report the app has recently slowed down.**
+
+Tasks filed: **31500–31511.**
+
+## Method and its limits
+
+- All probes ran against detached worktrees of the two pins, isolated config
+  (`TLDW_CONFIG_PATH` + redirected `HOME`/`XDG_*`, splash disabled,
+  `first_run.setup_completed = true`, `TLDW_TEST_MODE=1`,
+  `TLDW_SCREEN_PREIMPORT=0` — the same environment as
+  `Tests/Performance/test_ui_ready_module_census.py`).
+- **The machine carried load average 7–9 with nine concurrent pytest processes
+  from other sessions for the whole review.** Absolute wall numbers are
+  inflated roughly 1.5–2× against prior reviews' quiet-machine numbers and are
+  NOT comparable across review dates. Every regression verdict below therefore
+  comes from interleaved same-day paired arms (ABBA/BAAB), and per-switch
+  process-CPU is reported alongside wall time because it attributes better
+  under load.
+- Boot runs: cold subprocess per run, profile pre-warmed once per arm (the
+  first boot on a fresh profile pays one-time schema creation — 08-29 trap).
+- A first probe run measured `_ui_ready` at ~9.3 s and was **discarded**: the
+  scratch config had not disabled the splash screen or marked first-run setup
+  complete. Probe configs must match the canonical census config exactly
+  before any number is comparable.
+
+## 0. Ratchet state on pristine dev (ADR-097)
+
+| guard | state | value |
+|---|---|---|
+| import weight | GREEN | 637/660 (headroom 23) |
+| ui-ready module census | GREEN | 966/972 (headroom 6) |
+| boot worker census | GREEN | pass |
+| CSS fastpath (incl. bare-type rule ratchet) | GREEN | pass |
+| **boot-parsed CSS bytes** | **RED** | **821,753 / 806,000** |
+
+The CSS byte ratchet is red on pristine dev for the fourth review running.
+PR #2281 paid it down to 780,368 B on 2026-09-01; dev added **+41,385 B of
+first-paint CSS in ~4 days**. Culprits (from the guard's own diff):
+`features/_scheduling.tcss` 5,994 → 16,165 (+10,171, nearly tripled),
+`components/_agentic_terminal.tcss` +5,342 (still growing despite the 25812
+split), `screen_agentic_console.tcss` +4,530, `core/_variables.tcss` +1,558,
+plus ~19 new widget-default segments (tool-pack import modals ≈4.7 KB,
+profile interview, settings personal context, library media canvas, review-set
+picker, scheduling views). → **TASK-31500** (paydown). The consumption
+pattern ADR-097 exists to stop is still running; the byte guard is still not
+in `perf-guard.yml` (task-24459), so breaches keep landing silently.
+
+## 1. Regression verdicts (paired arms, current vs 2026-09-01)
+
+| metric | current `f51fcaf204` | baseline `b62407e258` | verdict |
+|---|---|---|---|
+| cold boot → `_ui_ready` (4 runs/arm) | mean 2.84 s | mean 2.68 s | no regression (Δ within within-arm spread of ±0.5 s) |
+| import of `tldw_chatbook.app` | 0.95–1.5 s | 0.93–1.1 s | no regression |
+| switch tour, Chat ping-pong CPU (4 visits) | mean ≈924 ms | mean ≈983 ms | no regression |
+| switch tour, Library ping-pong CPU | mean ≈469 ms | mean ≈555 ms | no regression |
+| typing, CPU/key on empty Console (40 keys) | 32.6 / 36.6 ms | 28.3 / 56.3 ms | no regression (high variance under load) |
+| idle CPU on Console, 15 s | 46–61 ms (0.3–0.4 % core) | 46–62 ms | no regression |
+| ChaChaNotes per-statement overhead | **1.94 µs** | **0.82 µs** | **+137 % — regressed** (§3) |
+| ChaChaNotes per-`transaction()` block | **23.3 µs** | **18.2 µs** | **+29 % — regressed** (§3) |
+
+**The interactive hot paths measured by prior reviews did not regress in this
+window.** What DID change is background/ambient behavior (§2–§4) and
+per-statement DB overhead (§3) — the kind of cost that shows up as "the app
+feels slower lately" on battery, on slower disks, and under concurrent
+activity, without moving any single foreground metric.
+
+## 2. NEW: a 1 Hz write-lock poll on the main DB, forever (TASK-31501)
+
+`Chat/console_runtime.py:994-1152` (`_schedule_legacy_trace_maintenance`) —
+armed for every real profile whenever the Console chat store binds a DB with
+a `transaction` attribute (`console_runtime.py:913`, `:989`). The loop:
+
+- calls `asyncio.to_thread(maintenance.run_batch)` then sleeps 1.0 s in every
+  steady-state branch → **~1 wake/second for the life of the process**;
+- `run_batch` (`Chat/console_trace_maintenance.py:735`) opens
+  `self.db.transaction(immediate=True)` — an **immediate transaction acquires
+  the write lock** — and runs 3 SELECTs *even when the migration is
+  `logical_complete` and there is nothing to do* (the completion check lives
+  inside the transaction);
+- every 60 s it additionally runs `TraceGarbageCollector.current_graph_epoch`
+  and, on epoch change, GC + physical compaction;
+- there is **no idle gate, no visibility gate, and no config off-switch**
+  (`legacy_normalization_enabled = callable(getattr(db, "transaction", None))`).
+
+This silently breaks the "zero SQL at idle" property the 08-27 review's
+notes-sync fix established, wakes the CPU every second (battery), churns a
+thread-pool hop per second, and acquires the same write lock user sends
+contend for. Introduced by the semantic-trace-ledger wave (commit
+`6004b02038` and siblings); no task records the 1 Hz cadence as a decision.
+
+Fix directions (either preserves behavior): event-driven wake — the exchange
+writer signals when a new `message_exchanges` row lands, the loop parks until
+then once `logical_complete`; or a steady-state backoff (1 s while provider
+recently active, 30–60 s otherwise) with the completion check moved to a
+read-only transaction.
+
+## 3. NEW: every ChaChaNotes statement now pays a shared-lock tax (TASK-31502)
+
+`DB/base_db.py:35-410` adds `SQLiteConnectionQuiescenceRegistry` (one
+process-wide `Condition(RLock())` per DB file) and wraps the ChaChaNotes
+connection so **every** `execute`/`executemany`/`executescript` runs
+`begin_use()`/`end_use()` — lock acquire, release, and `notify_all()` — around
+every single statement (`ChaChaNotes_DB.py:3339`, `:22895`), plus a second
+pair around each `transaction()` block and a third around connection
+acquisition. It exists so the trace-compaction VACUUM (§2's 60 s pass) can
+quiesce all connections — a maintenance event that is rare to nonexistent in
+a normal session — but the bookkeeping is unconditional.
+
+Measured (file-backed DB, warm, 20k statements, reproduced twice per arm):
+per-`SELECT 1` through `get_connection()` **0.82 → 1.94 µs (+137 %)**; per
+single-statement `transaction()` block **18.2 → 23.3 µs (+29 %)**; raw
+sqlite3 floor 0.51 µs both arms. Honest sizing: ~1.1 µs × even 10,000
+statements ≈ 11 ms — **not** the user-visible slowdown by itself, but it is
+an unconditional tax on the hottest layer of the app, it grows with
+cross-thread contention (`notify_all` per statement on a shared condition),
+and it multiplies with §2 (the 1 Hz loop's statements all pay it too).
+
+Fix direction: an uncontended fast path — e.g. check a relaxed "quiesce
+requested" flag before touching the condition variable, taking the full lock
+protocol only while a quiesce is pending or in progress.
+
+## 4. NEW: Terminal sessions scan the whole process table at 50 Hz (TASK-31503)
+
+`Terminal/posix_backend.py:53` (`_PROCESS_POLL_SECONDS = 0.01`), `:968`
+(`_monitor_owned_processes` wakes every 20 ms), `:1128-1200`
+(`_default_scan_locked`): every tick enumerates `psutil.pids()` and calls
+`os.getsid` + `os.getpgid` **for every PID on the system**, plus
+`psutil.Process(...).create_time()` for candidates.
+
+Measured on this machine (663 processes): **0.30 ms CPU per scan → ~1.5 % of
+a core per open terminal session, continuously**, ~30k syscalls/s, even at an
+idle shell prompt. Two terminal tabs ≈ 3 %, and each session runs its own
+monitor thread. The whole `Terminal/` package is new in this window — a user
+who adopted the feature gets a permanent background tax that would read
+exactly as "the app got slower lately."
+
+Fix direction: drop the monitor cadence to 250–500 ms (ownership bookkeeping
+does not need 50 Hz), and/or scan adaptively (fast only briefly after spawn
+activity on the PTY).
+
+## 5. NEW: Personal Context pays hardened connects per send, even unconfigured (TASK-31504)
+
+`Personal_Context/repository.py:419` opens a fresh owner-checked connection
+per repository method (25 `closing(self._connect())` sites); each connect
+walks the directory path from `/` with `dir_fd`/`O_NOFOLLOW` ownership checks
+(`Utils/private_paths.py:1282`), prepares 3 sidecar files, and issues extra
+PRAGMAs. `Chat/console_chat_controller.py:2769`
+(`_compose_profile_tool_provider`, on the default agent send path) calls
+`authorized_context_view` **twice** (consistency check) plus `list_scopes`,
+`get_scope_authority`, `get_manifest` — and an unconfigured profile still
+pays `status()`'s connects before failing closed; nothing caches the
+negative result between sends.
+
+Measured: connect ≈ 0.44 ms; `is_destroyed` ≈ 0.43 ms; `get_manifest` ≈
+0.44 ms; **unconfigured per-send floor ≈ 1.75 ms** (off-thread). Small
+today — but for a *configured* profile the same path is 6+ connects plus
+**two full decrypts of the export snapshot per send**, which scales with
+profile size. Fix: cache the locked/unconfigured status, build the view once
+per send, reuse one connection across a logical operation.
+
+## 6. NEW: opt-in custom-PII redaction spawns a subprocess on the event loop, inside a held write transaction (TASK-31505)
+
+`Chat/console_trace_regex_worker.py:126-225` (`run_custom_pii_batch`) runs
+`subprocess.Popen([sys.executable, "-I", ...])` and blocks on
+`process.communicate(...)` (deadline 500 ms). Called (when
+`pii_redaction_enabled` with a *custom* ruleset):
+
+- from `console_provider_gateway.py:1133` via the synchronous
+  `_complete_scoped_exchange` in the streaming `finally:` — **on the event
+  loop**, once per completed/stopped exchange;
+- from `console_chat_controller.py:8587` inside
+  `_build_durable_trace_request`'s per-saved-row loop **while
+  `transaction(immediate=True)` is held** (`:8559`) — a fresh interpreter
+  spawn per message row with the write lock held, on the event loop.
+
+Off by default (`RuntimeCapturePolicy.pii_redaction_enabled = False`), but
+when enabled this freezes the UI on every send. Fix: pre-compute redactions
+before the transaction opens, and move the spawn+wait off the loop. (The
+worker-subprocess *isolation* is presumably deliberate for `-I` sandboxing —
+keep it, relocate the wait.)
+
+## 7. Smaller new items
+
+- **Session-switcher modal (Ctrl+K) polls at 5 Hz** while open
+  (`Widgets/Console/console_session_switcher_modal.py:55`, `:253`), and each
+  tick recomputes the full active-session projection — iterating
+  `store.sessions()` and calling `activity_for` **twice** per session
+  (`UI/Console_Modules/workspace.py:2563-2774`) — unconditionally, just to
+  compute a change fingerprint. O(open sessions) × 5/s; fleet users pay most.
+  → **TASK-31506**.
+- **Scheduler tick does sync file I/O on the event loop** every poll interval
+  (30 s), for every user, always: heartbeat write (mkdir + mkstemp + write +
+  rename; `Scheduling/scheduler/loop.py:380`, `scheduler_heartbeat.py:94`)
+  and emergency-stop `read_text` (`loop.py:411`). Sub-ms on a healthy SSD;
+  still the wrong thread — `asyncio.to_thread` both. → **TASK-31507**.
+- **Review-set listing is an N+1**: `Library/review_set_service.py:174-198`
+  issues 2N+1 statements (re-fetching each header row it just enumerated) and
+  an unbounded `SELECT * FROM review_set_items` per set, to render a picker
+  that needs a name and a progress summary. Off-loop, but scales with
+  accumulated sets × items. → **TASK-31508**.
+- **Media Trash canvas re-measures on every recompose**:
+  `Widgets/Library/library_media_trash_canvas.py:167-244` chains
+  `call_after_refresh(_measure_after_layout)` from mount, resize AND
+  recompose; each pass is 3+ `query_one` + per-child geometry + a possible
+  second pass — and the screen builds a fresh canvas instance per state
+  transition, multiplying with the known per-visit fresh-screen cost.
+  → **TASK-31509**.
+- **`TldwCli.__init__` does sync JSON read (and possibly write) before first
+  paint** for legacy MCP server-target sync
+  (`app.py:8442` → `MCP/server_target_store.py:300-342`) — only for users
+  with a legacy `tldw_api` base_url configured; small, but it is on the
+  pre-paint critical path. → **TASK-31510**.
+- **Agent-run webhooks spawn a thread + a fresh asyncio loop per delivery**
+  and `load_settings()` from disk per run completion
+  (`Agents/run_webhooks.py:~257`, `agent_service.py:3264`). Opt-in, low
+  frequency. → **TASK-31511**.
+
+## 8. Standing findings re-confirmed (not refiled)
+
+- **Console visits cost ~0.7–1.25 s of CPU each and warm visits are no
+  cheaper** (this review's tour, both arms) — the fresh-screen-instance
+  architecture (task-24452, owner call open since 08-29) is still the single
+  largest interactive lever in the app.
+- **Typing on an empty Console costs ~30 ms CPU/key under load**, and the
+  profile shows why it scales badly: 40 keystrokes drove ~41,000
+  message-pump iterations — every keystroke wakes every mounted widget's
+  pump for an idle/refresh check, so per-key cost is proportional to mounted
+  widget count (~1,000 pumps with Console up). Same in both arms (not a
+  recent regression). Reducing mounted-widget count (24452 and Console
+  decomposition) is the lever; `textual._callback.count_parameters` also
+  recomputed `inspect.signature` 40,892× in the window (upstream cache
+  misses on bound methods — a possible upstream delegation like the 08-29
+  fastpath, sized ~0.27 s/40 keys ≈ 7 ms/key here, load-inflated).
+- Idle is otherwise still clean (0.3–0.4 % core in-harness; the §2 loop's
+  1 Hz work sits mostly in the to_thread hop and DB layer).
+
+## 9. Verified healthy / not filed
+
+- Boot, switch, typing, idle: no regression vs 2026-09-01 (§1 table).
+- Console transcript/streaming append path: untouched in this window
+  (verified by lane sweep + git log).
+- Collections capture/offline store, media browse/trash controllers, ingest
+  pipeline: clean patterns (batched INs, to_thread, bounded reconcile;
+  ingest untouched).
+- Sync_Interop/MCP/Tool_Packs boot surface: module-scope imports are
+  constants-only; heavy work correctly deferred (several ADR-097 "perf:"
+  commits in-window did this proactively).
+- Composer per-keystroke path: only a constant-work width helper added.
+- Scheduling workbench timers: screen-scoped, stop on unmount.
+
+## Appendix: probe inventory
+
+Probes live in the session scratchpad (not committed): cold-boot milestones
+(subprocess, 4 runs/arm), destination tour (8 destinations × cold/warm +
+Chat↔Library ping-pong ×4, arrival/settled/CPU per switch), typing (40 keys,
+CPU/key + cProfile attribution), idle (15 s CPU), ChaChaNotes statement/txn
+micro-bench (20k/2k iterations, ×2 per arm), Personal Context op timings
+(50 reps), terminal scan micro-bench (50 scans). Lane sweeps: five read-only
+subagent lanes over `git diff 0ef6f3fd4e..f51fcaf204` (Chat; Console
+widgets; Personal_Context/Tool_Packs/Sync_Interop/MCP; Library;
+Scheduling/Agents/DB/app/Utils/Terminal), each reporting file:line findings
+that were then re-verified in source and, where impactful, measured before
+filing.

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1860,8 +1860,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 19,
-      "diagnostic_digest": "c0a91b586f6f9f2946fa",
+      "call_count": 20,
+      "diagnostic_digest": "0a83b4c6ae83f35bc0a7",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11360,6 +11360,6 @@
     "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
     "task_492_calls": 1334,
-    "task_494_calls": 7598
+    "task_494_calls": 7599
   }
 }

--- a/Tests/Scheduling/test_scheduler_heartbeat.py
+++ b/Tests/Scheduling/test_scheduler_heartbeat.py
@@ -153,3 +153,128 @@ def test_liveness_summary_distinguishes_all_three_states():
     assert "boom" in stale, "the last error is surfaced, not only logged (AC#3)"
     # empty-queue live state must read differently from a stall
     assert stale != live
+
+
+# --- TASK-31507 (Qodo #2399): the offload semantics themselves ---------------
+#
+# The outcome tests above prove WHAT gets persisted; these pin WHERE the file
+# I/O runs (off the event-loop thread), the fail-safe when the offload path
+# itself breaks, and the shutdown-cancellation ordering guarantee.
+
+import threading  # noqa: E402 -- this file groups imports with its sections
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_write_runs_off_the_event_loop(tmp_path, monkeypatch):
+    """The heartbeat's blocking file I/O must not run on the loop thread."""
+    from tldw_chatbook.Scheduling import scheduler_heartbeat
+
+    write_thread_ids = []
+    real_write = scheduler_heartbeat.write_heartbeat
+
+    def recording_write(path, hb):
+        write_thread_ids.append(threading.get_ident())
+        real_write(path, hb)
+
+    monkeypatch.setattr(scheduler_heartbeat, "write_heartbeat", recording_write)
+    loop = _make_loop(tmp_path)
+    await loop.tick()
+    assert write_thread_ids, "tick() must still write a heartbeat"
+    assert write_thread_ids[0] != threading.get_ident(), (
+        "the heartbeat write ran ON the event-loop thread -- the entire "
+        "point of the TASK-31507 offload"
+    )
+
+
+@pytest.mark.asyncio
+async def test_emergency_stop_read_runs_off_the_event_loop(
+    tmp_path, monkeypatch
+):
+    """The stop-state read is blocking file I/O too; same rule."""
+    from tldw_chatbook import emergency_stop
+
+    read_thread_ids = []
+
+    def recording_read(path):
+        read_thread_ids.append(threading.get_ident())
+        return False
+
+    monkeypatch.setattr(emergency_stop, "is_emergency_stopped", recording_read)
+    loop = _make_loop(tmp_path)
+    loop._emergency_stop_path = tmp_path / "stop.json"
+    await loop.tick()
+    assert read_thread_ids, "tick() must still consult the emergency stop"
+    assert read_thread_ids[0] != threading.get_ident()
+
+
+@pytest.mark.asyncio
+async def test_emergency_stop_offload_failure_holds_dispatch(
+    tmp_path, monkeypatch
+):
+    """A broken stop read holds work (doubt = stopped, 26004 AC#4)."""
+    from tldw_chatbook import emergency_stop
+
+    def broken_read(path):
+        raise OSError("stop state unreadable")
+
+    monkeypatch.setattr(emergency_stop, "is_emergency_stopped", broken_read)
+    loop = _make_loop(tmp_path)
+    loop._emergency_stop_path = tmp_path / "stop.json"
+    pops = []
+    loop.queue.pop_due = lambda now: pops.append(now) or []
+    await loop.tick()
+    assert not pops, (
+        "the offload path failed and dispatch proceeded anyway -- the "
+        "fail-safe must read a broken stop state as STOPPED"
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_tick_still_completes_the_started_heartbeat_write(
+    tmp_path, monkeypatch
+):
+    """Shutdown cancellation must not outrun an in-flight heartbeat write.
+
+    Qodo #2399 finding 2: the write thread cannot be cancelled, so a tick
+    cancelled mid-write has to WAIT for it -- otherwise the scheduler
+    reports stopped while the old worker later mutates heartbeat state.
+    The write is gated so the cancellation provably arrives while the
+    offload is in flight; without the shield-then-wait fix, the cancelled
+    task finishes while the gate is still closed and the completion assert
+    below goes red.
+    """
+    from tldw_chatbook.Scheduling import scheduler_heartbeat
+
+    write_started = threading.Event()
+    release_write = threading.Event()
+    write_completed = threading.Event()
+
+    def gated_write(path, hb):
+        write_started.set()
+        assert release_write.wait(timeout=10), "test gate never released"
+        write_completed.set()
+
+    monkeypatch.setattr(scheduler_heartbeat, "write_heartbeat", gated_write)
+    loop = _make_loop(tmp_path)
+    task = asyncio.ensure_future(loop.tick())
+    assert await asyncio.to_thread(write_started.wait, 10), (
+        "heartbeat write never started"
+    )
+    task.cancel()
+    # The discriminating window: while the write is still GATED, a correctly
+    # shielded tick cannot finish -- it is waiting on the write. (The first
+    # version of this test released the gate before awaiting the task; the
+    # near-instant write then completed before the assert either way, and
+    # the un-shielded mutation passed. Order is the assertion here.)
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if task.done():
+            break
+    assert not task.done(), (
+        "tick() finished (cancelled) while the heartbeat write was still "
+        "gated -- the write may now land after the scheduler stopped"
+    )
+    release_write.set()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert write_completed.is_set()

--- a/Tests/Scheduling/test_scheduler_loop.py
+++ b/Tests/Scheduling/test_scheduler_loop.py
@@ -168,9 +168,15 @@ async def test_scheduler_periodically_reloads_queue(db):
 
     with patch.object(loop.queue, "load") as mock_load:
         task = asyncio.create_task(loop.run())
-        await asyncio.sleep(0.01)
+        # TASK-31507 moved each tick's heartbeat write and stop read onto
+        # asyncio.to_thread; at this test's 1ms poll interval those two
+        # thread-pool round-trips dominate the tick, so the old 0.01s
+        # window fit fewer than the 4 ticks two reloads need. Nothing at
+        # the production 30s cadence changed -- this is wall-clock budget,
+        # not behavior.
+        await asyncio.sleep(0.1)
         loop.stop()
-        await asyncio.wait_for(task, timeout=1.0)
+        await asyncio.wait_for(task, timeout=2.0)
 
     assert mock_load.call_count >= 2
 

--- a/backlog/tasks/task-31500 - Pay-down-the-boot-CSS-byte-ratchet-breach-821753-over-806000.md
+++ b/backlog/tasks/task-31500 - Pay-down-the-boot-CSS-byte-ratchet-breach-821753-over-806000.md
@@ -1,0 +1,33 @@
+---
+id: TASK-31500
+title: Pay down the boot-CSS byte ratchet breach (821,753 B over the 806,000 B limit)
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - css
+  - adr-097
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+`Tests/Performance/test_boot_css_byte_budget.py` is RED on pristine dev
+(`f51fcaf204`): 821,753 B of first-paint-parsed CSS against the 806,000 B
+ratchet. PR #2281 paid this down to 780,368 B on 2026-09-01; dev added
++41,385 B in ~4 days. Guard-named culprits: `features/_scheduling.tcss`
+5,994 -> 16,165 (+10,171, nearly tripled), `components/_agentic_terminal.tcss`
++5,342, `screen_agentic_console.tcss` +4,530, `core/_variables.tcss` +1,558,
+plus ~19 new widget-default segments (tool-pack import modals ~4.7 KB across
+four modal classes in one file, profile interview, settings personal context,
+library media/review-set widgets, scheduling views). Every byte here is parsed
+before first paint (ADR-097). Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 0.
+
+## Acceptance Criteria (the what)
+
+- [ ] `test_boot_parsed_css_bytes_stay_within_budget` passes on dev without raising `MAX_BOOT_PARSED_CSS_BYTES` (defer/shed, per ADR-097; any exception needs an owner ledger row)
+- [ ] `features/_scheduling.tcss` boot-parsed weight is materially reduced (screen-scoped CSS_PATH or demotion of non-first-paint rules), or an owner note records why it must stay
+- [ ] Modal-only widget defaults added in this window (tool-pack import/review modals at minimum) do not sit on the first-paint parse leg

--- a/backlog/tasks/task-31501 - Legacy-trace-maintenance-polls-a-write-lock-transaction-at-1Hz-forever.md
+++ b/backlog/tasks/task-31501 - Legacy-trace-maintenance-polls-a-write-lock-transaction-at-1Hz-forever.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31501
+title: Legacy trace maintenance polls a write-lock transaction at 1 Hz forever
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - console
+  - chat
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+`Chat/console_runtime.py:994-1152` (`_schedule_legacy_trace_maintenance`)
+loops `asyncio.to_thread(maintenance.run_batch)` + `asyncio.sleep(1.0)` for
+the life of the process, for every real profile. `run_batch`
+(`Chat/console_trace_maintenance.py:735`) opens
+`db.transaction(immediate=True)` -- acquiring the ChaChaNotes WRITE lock --
+and runs 3 SELECTs even in the fully-migrated steady state (the
+logical-complete check lives inside the transaction). There is no idle gate,
+no visibility gate, and no config off-switch. This breaks the zero-SQL-at-idle
+property the 2026-08-27 review established, wakes the CPU every second
+(battery), and contends with user writes on the same lock -- it also pays the
+TASK-31502 per-statement tax every tick. No task records the 1 Hz cadence as
+a deliberate decision. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 2.
+
+## Acceptance Criteria (the what)
+
+- [ ] In the steady state (migration logical_complete, no pending legacy rows, provider idle) the maintenance loop performs no write-lock acquisition more often than once per 30 s (event-driven wake on new legacy rows, or an equivalent backoff)
+- [ ] Steady-state completeness checks run without `immediate=True` (read path), or without any transaction at all
+- [ ] Migration progress behavior while legacy rows ARE pending is unchanged (existing maintenance tests stay green)
+- [ ] A test pins the steady-state cadence so a future change cannot silently restore the 1 Hz write-lock poll

--- a/backlog/tasks/task-31502 - Quiescence-registry-taxes-every-ChaChaNotes-statement-with-a-shared-lock.md
+++ b/backlog/tasks/task-31502 - Quiescence-registry-taxes-every-ChaChaNotes-statement-with-a-shared-lock.md
@@ -1,0 +1,34 @@
+---
+id: TASK-31502
+title: Quiescence registry taxes every ChaChaNotes statement with a shared lock
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - db
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+`DB/base_db.py:35-410` (`SQLiteConnectionQuiescenceRegistry`,
+`_QuiescentSQLiteCursor`) wraps the ChaChaNotes connection
+(`ChaChaNotes_DB.py:3339`, `:22895`) so every single
+`execute`/`executemany`/`executescript` acquires and releases a process-wide
+`Condition(RLock())` and calls `notify_all()`, with a second pair per
+`transaction()` block and a third around connection acquisition. It exists so
+trace-compaction VACUUM can quiesce connections -- a rare maintenance event --
+but the tax is unconditional. Measured (2026-09-04 review, file-backed DB,
+20k statements, reproduced twice per arm): per-statement 0.82 -> 1.94 us
+(+137%), per-transaction block 18.2 -> 23.3 us (+29%); raw sqlite floor
+0.51 us. Small in absolute terms but on the hottest layer, growing with
+cross-thread contention, and multiplied by the TASK-31501 1 Hz loop.
+Evidence: `Docs/Design/2026-09-04-holistic-perf-review.md` section 3.
+
+## Acceptance Criteria (the what)
+
+- [ ] The uncontended path (no quiesce requested or in progress) adds no lock acquisition and no `notify_all()` per statement (e.g. a relaxed pending-flag check before touching the condition variable)
+- [ ] Quiesce correctness is preserved: a quiesce request still drains in-flight statements and blocks new ones (existing quiescence tests stay green, including under concurrent threads)
+- [ ] The micro-benchmark shows per-statement overhead through `get_connection()` within ~20% of the pre-registry baseline (~0.8-1.0 us on the review machine)

--- a/backlog/tasks/task-31503 - Terminal-ownership-monitor-scans-the-whole-process-table-at-50Hz.md
+++ b/backlog/tasks/task-31503 - Terminal-ownership-monitor-scans-the-whole-process-table-at-50Hz.md
@@ -1,0 +1,30 @@
+---
+id: TASK-31503
+title: Terminal ownership monitor scans the whole process table at 50 Hz
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - terminal
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+`Terminal/posix_backend.py:968` (`_monitor_owned_processes`) wakes every
+`_PROCESS_POLL_SECONDS * 2` = 20 ms and runs `_default_scan_locked`
+(`:1128`), which enumerates `psutil.pids()` and calls `os.getsid` +
+`os.getpgid` for EVERY pid on the system, plus `create_time()` per candidate.
+Measured on the review machine (663 processes): 0.30 ms CPU per scan -> ~1.5%
+of a core per open terminal session, continuously, ~30k syscalls/s, even at
+an idle prompt; each session runs its own monitor thread, so open tabs
+multiply linearly. Ownership bookkeeping does not need 50 Hz. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 4.
+
+## Acceptance Criteria (the what)
+
+- [ ] An idle terminal session's monitor consumes under 0.2% of a core (measured, not asserted from the constant)
+- [ ] Ownership/reaping semantics are unchanged where they matter: process spawn/exit detection latency stays within the product's existing guarantees (existing Terminal ownership tests stay green)
+- [ ] The chosen cadence/backoff is documented in the module with the measured cost that motivated it

--- a/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
+++ b/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
@@ -1,0 +1,35 @@
+---
+id: TASK-31504
+title: Personal Context pays repeated hardened connects on every send
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - personal-context
+  - chat
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+`PersonalContextRepository._connect()` (`Personal_Context/repository.py:419`)
+opens a fresh owner-checked connection per repository method (25 call sites);
+each connect walks the directory path from `/` with dir_fd/O_NOFOLLOW checks
+(`Utils/private_paths.py:1282`), prepares 3 sidecars, and issues extra
+PRAGMAs. `Chat/console_chat_controller.py:2769`
+(`_compose_profile_tool_provider`, default agent send path) builds
+`authorized_context_view` TWICE per send plus `list_scopes`,
+`get_scope_authority`, `get_manifest`; an unconfigured profile still pays
+`status()`'s connects before failing closed, and nothing caches the negative
+between sends. Measured: connect ~0.44 ms, unconfigured per-send floor
+~1.75 ms off-thread; a CONFIGURED profile pays 6+ connects plus two full
+export-snapshot decrypts per send, scaling with profile size. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 5.
+
+## Acceptance Criteria (the what)
+
+- [ ] A send with Personal Context unconfigured/locked performs zero Personal Context DB connects after the first (the locked/absent status is cached with a correct invalidation story for setup/unlock)
+- [ ] A send with a configured profile builds the authorized view once and reuses one connection across the operation (or an owner note records why the double-build consistency check must stay)
+- [ ] Security semantics unchanged: fail-closed behavior and owner checks still hold (existing Personal Context authority tests stay green)

--- a/backlog/tasks/task-31505 - Custom-PII-redaction-spawns-a-subprocess-on-the-event-loop-inside-a-write-txn.md
+++ b/backlog/tasks/task-31505 - Custom-PII-redaction-spawns-a-subprocess-on-the-event-loop-inside-a-write-txn.md
@@ -1,0 +1,35 @@
+---
+id: TASK-31505
+title: Custom-PII redaction spawns a subprocess on the event loop inside a write txn
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - console
+  - chat
+dependencies: []
+priority: medium
+---
+
+## Description (the why)
+
+With `pii_redaction_enabled` and a custom ruleset (opt-in),
+`run_custom_pii_batch` (`Chat/console_trace_regex_worker.py:126-225`) spawns
+`Popen([sys.executable, "-I", ...])` and blocks on `communicate()` (up to
+500 ms) -- and it is called (a) from the streaming `finally:` via synchronous
+`_complete_scoped_exchange` (`console_provider_gateway.py:1133`) ON THE EVENT
+LOOP once per completed exchange, and (b) from
+`_build_durable_trace_request`'s per-saved-row loop
+(`console_chat_controller.py:8587`) while `transaction(immediate=True)` is
+held (`:8559`) -- a fresh interpreter spawn per message row with the write
+lock held, on the event loop. When the feature is on, every send freezes the
+UI. The `-I` subprocess isolation is presumably deliberate (regex sandboxing)
+and should be kept; the wait belongs off-loop and outside the transaction.
+Evidence: `Docs/Design/2026-09-04-holistic-perf-review.md` section 6.
+
+## Acceptance Criteria (the what)
+
+- [ ] No subprocess spawn/wait occurs on the Textual event loop on the send or exchange-completion paths
+- [ ] No subprocess spawn/wait occurs while a database write transaction is held (redactions computed before the transaction opens)
+- [ ] Redaction semantics unchanged: redact-before-persist ordering, deadline handling, and continuation masks behave as before (existing custom-PII tests stay green)

--- a/backlog/tasks/task-31506 - Session-switcher-modal-recomputes-the-full-projection-at-5Hz.md
+++ b/backlog/tasks/task-31506 - Session-switcher-modal-recomputes-the-full-projection-at-5Hz.md
@@ -1,0 +1,30 @@
+---
+id: TASK-31506
+title: Session switcher modal recomputes the full projection at 5 Hz
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - console
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+`Widgets/Console/console_session_switcher_modal.py:55,253` polls the active
+projection every 200 ms while the modal is open. Each tick calls
+`console_session_switcher_active_entries()`
+(`UI/Console_Modules/workspace.py:2719`), which iterates `store.sessions()`
+calling `controller.activity_for` per session, then iterates the produced
+rows a second time calling `activity_for` AND `run_state_for` per session
+again, then builds the results object -- all unconditionally, purely to
+compute a change fingerprint. O(open sessions) x 5/s; fleet users with many
+sessions pay most. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] The per-tick steady-state work no longer performs duplicate `activity_for` lookups per session (single pass, or a cheap fingerprint that avoids the full projection build when nothing changed)
+- [ ] Modal responsiveness to real activity changes is preserved (existing switcher tests stay green)

--- a/backlog/tasks/task-31507 - Scheduler-tick-does-synchronous-file-IO-on-the-event-loop.md
+++ b/backlog/tasks/task-31507 - Scheduler-tick-does-synchronous-file-IO-on-the-event-loop.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31507
+title: Scheduler tick does synchronous file IO on the event loop
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - scheduling
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+Every scheduler tick (30 s default, runs for every user from boot),
+`_record_heartbeat` (`Scheduling/scheduler/loop.py:380`) synchronously does
+mkdir + mkstemp + write + rename on the event loop
+(`scheduler_heartbeat.py:94`), and `_emergency_stopped` (`loop.py:411`) does
+a blocking `read_text` per tick. Sub-ms on a healthy SSD, but it is blocking
+I/O on the render thread and degrades on slow or network-mounted home directories. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] Heartbeat writes and emergency-stop reads on the tick path run off the event loop (e.g. `asyncio.to_thread`)
+- [ ] Heartbeat "never raises / never breaks the loop" contract and TASK-26025 diagnostics behavior are preserved (existing tests stay green)

--- a/backlog/tasks/task-31507 - Scheduler-tick-does-synchronous-file-IO-on-the-event-loop.md
+++ b/backlog/tasks/task-31507 - Scheduler-tick-does-synchronous-file-IO-on-the-event-loop.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31507
 title: Scheduler tick does synchronous file IO on the event loop
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 19:30'
 labels:
@@ -23,5 +23,23 @@ I/O on the render thread and degrades on slow or network-mounted home directorie
 
 ## Acceptance Criteria (the what)
 
-- [ ] Heartbeat writes and emergency-stop reads on the tick path run off the event loop (e.g. `asyncio.to_thread`)
-- [ ] Heartbeat "never raises / never breaks the loop" contract and TASK-26025 diagnostics behavior are preserved (existing tests stay green)
+- [x] Heartbeat writes and emergency-stop reads on the tick path run off the event loop (e.g. `asyncio.to_thread`)
+- [x] Heartbeat "never raises / never breaks the loop" contract and TASK-26025 diagnostics behavior are preserved (existing tests stay green)
+
+## Implementation Plan (the how)
+
+1. Offload the heartbeat write in `tick()`'s `finally` via `asyncio.to_thread`, awaited so a reader observing a finished tick always sees its heartbeat.
+2. Make `_emergency_stopped` async and offload the stop-state read the same way; failure reads as stopped (fail-safe preserved).
+3. Run the full Tests/Scheduling suite.
+
+## Implementation Notes
+
+Both blocking file operations on the scheduler tick path now run via
+`asyncio.to_thread`, awaited in place so ordering and observable behavior are
+unchanged: a finished `tick()` has always written its heartbeat (the
+TASK-26025 tests pin this), and an erroring tick still records liveness before
+re-raising. `_emergency_stopped` became async (its only caller is
+`_dispatch_due`); an offload failure returns True, holding work on doubt per
+TASK-26004 AC#4. No API surface outside `Scheduling/scheduler/loop.py`
+changed. Verified: full `Tests/Scheduling/` -- 1,029 passed.
+Files: `tldw_chatbook/Scheduling/scheduler/loop.py`.

--- a/backlog/tasks/task-31508 - Review-set-listing-issues-2N+1-statements-with-unbounded-item-scans.md
+++ b/backlog/tasks/task-31508 - Review-set-listing-issues-2N+1-statements-with-unbounded-item-scans.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31508
+title: Review-set listing issues 2N+1 statements with unbounded item scans
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - library
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+`Library/review_set_service.py:174-198` (`list_review_sets`) fetches up to
+200 set ids, then per id calls `_read_review_set` (`:402-420`), which
+re-fetches the header row it just enumerated and runs an unbounded
+`SELECT * FROM review_set_items ... ORDER BY position` -- 2N+1 statements and
+N full item scans to render a picker that needs each set's name and a
+progress summary. Off the event loop (isolate_in_worker), but scales with
+accumulated sets x items. Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] Listing review sets for the picker runs a bounded number of statements independent of set count (join or aggregate), without loading full item rows when only counts/summary are needed
+- [ ] Picker rows render identically for the existing fixtures (existing review-set tests stay green)

--- a/backlog/tasks/task-31509 - Media-Trash-canvas-re-measures-the-DOM-on-every-recompose.md
+++ b/backlog/tasks/task-31509 - Media-Trash-canvas-re-measures-the-DOM-on-every-recompose.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31509
+title: Media Trash canvas re-measures the DOM on every recompose
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - library
+  - ui
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+`Widgets/Library/library_media_trash_canvas.py:167-244` schedules
+`call_after_refresh(_measure_after_layout)` from `on_mount`, `on_resize` AND
+`_after_recompose`; each pass runs 3+ `query_one` lookups plus per-child
+geometry math and may schedule a second capping pass. The screen constructs a
+brand-new canvas instance per state transition (page load, filter change,
+mutation commit), so the chain fires on every transition and multiplies with
+the known per-visit fresh-screen-instance cost (task-24452). Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] A single state transition of the Trash canvas triggers at most one measurement pass (coalesced), and unchanged geometry skips the second capping pass
+- [ ] Fold/cap visual behavior is unchanged (existing trash-canvas tests stay green)

--- a/backlog/tasks/task-31510 - Defer-legacy-MCP-server-target-JSON-sync-off-the-pre-paint-path.md
+++ b/backlog/tasks/task-31510 - Defer-legacy-MCP-server-target-JSON-sync-off-the-pre-paint-path.md
@@ -1,0 +1,30 @@
+---
+id: TASK-31510
+title: Defer legacy MCP server-target JSON sync off the pre-paint path
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - mcp
+  - boot
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+`TldwCli.__init__` calls `_wire_server_context_provider` (`app.py:8442`),
+which runs `upsert_legacy_config_target`
+(`MCP/server_target_store.py:300-342`): a synchronous JSON read of
+`mcp_server_targets.json` and, when the legacy config differs, a synchronous
+write -- on the main thread, before first paint. Only users with a legacy
+`tldw_api` base_url pay it, and the file is small, but it is blocking I/O on
+the pre-paint critical path that first-use or post-paint wiring would serve
+equally well. Evidence: `Docs/Design/2026-09-04-holistic-perf-review.md`
+section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] The legacy-target reconciliation no longer performs file I/O before first paint (deferred wiring or first-use), with behavior for consumers unchanged
+- [ ] Existing server-target store tests stay green

--- a/backlog/tasks/task-31511 - Agent-run-webhook-delivery-spawns-a-thread-and-event-loop-per-run.md
+++ b/backlog/tasks/task-31511 - Agent-run-webhook-delivery-spawns-a-thread-and-event-loop-per-run.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31511
+title: Agent-run webhook delivery spawns a thread and event loop per run
+status: To Do
+assignee: []
+created_date: '2026-09-04 19:30'
+labels:
+  - performance
+  - agents
+dependencies: []
+priority: low
+---
+
+## Description (the why)
+
+`Agents/run_webhooks.py` (`schedule_run_webhook`) spawns a fresh
+`threading.Thread` whose target calls `asyncio.run(deliver_webhook(...))` --
+a new OS thread plus a new event loop per delivery -- and
+`_maybe_emit_run_webhook` (`agent_service.py:3264`) re-reads settings from
+disk on every run completion. Opt-in and low-frequency, so low priority; the
+shape is the issue (unbounded thread creation under bursty fleets, settings
+re-read per event). Evidence:
+`Docs/Design/2026-09-04-holistic-perf-review.md` section 7.
+
+## Acceptance Criteria (the what)
+
+- [ ] Webhook deliveries reuse an executor or long-lived worker rather than a fresh thread + event loop per run
+- [ ] Settings are not re-read from disk per completion when unchanged (cache with invalidation, or read once per run batch)
+- [ ] Delivery semantics (fire-and-forget, never blocks run finalization) are unchanged

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -379,10 +379,27 @@ class SchedulerLoop:
             # TASK-31507: the heartbeat write is blocking file I/O (mkstemp +
             # rename); it must not run on the event loop. Awaited so a reader
             # observing the finished tick always sees its heartbeat.
+            heartbeat = asyncio.ensure_future(
+                asyncio.to_thread(self._record_heartbeat, now, error=tick_error)
+            )
             try:
-                await asyncio.to_thread(
-                    self._record_heartbeat, now, error=tick_error
-                )
+                await asyncio.shield(heartbeat)
+            except asyncio.CancelledError:
+                # Shutdown cancels tick() while it awaits the write (Qodo
+                # #2399 finding 2). The thread cannot be cancelled and must
+                # not mutate heartbeat state after the scheduler reports
+                # stopped, so wait for the started write to finish before
+                # propagating -- a reader observing the stopped scheduler
+                # then still sees this tick's heartbeat, not the previous
+                # one. A second cancellation while waiting abandons the
+                # wait: a forced double-cancel outranks the guarantee.
+                try:
+                    await asyncio.wait({heartbeat})
+                    if heartbeat.done() and not heartbeat.cancelled():
+                        heartbeat.exception()  # consume; observation never raises
+                except Exception:  # noqa: BLE001 -- best effort under cancel
+                    pass
+                raise
             except Exception:  # noqa: BLE001 -- observation never breaks the loop
                 logger.debug("scheduler heartbeat offload failed")
 

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -376,7 +376,15 @@ class SchedulerLoop:
             self._last_tick_dispatch_seconds = max(
                 (self.clock() - now).total_seconds(), 0.0
             )
-            self._record_heartbeat(now, error=tick_error)
+            # TASK-31507: the heartbeat write is blocking file I/O (mkstemp +
+            # rename); it must not run on the event loop. Awaited so a reader
+            # observing the finished tick always sees its heartbeat.
+            try:
+                await asyncio.to_thread(
+                    self._record_heartbeat, now, error=tick_error
+                )
+            except Exception:  # noqa: BLE001 -- observation never breaks the loop
+                logger.debug("scheduler heartbeat offload failed")
 
     def _record_heartbeat(
         self, tick_at: datetime, *, error: str | None
@@ -407,8 +415,13 @@ class SchedulerLoop:
             ),
         )
 
-    def _emergency_stopped(self) -> bool:
-        """Whether the global emergency stop holds new dispatches (26004)."""
+    async def _emergency_stopped(self) -> bool:
+        """Whether the global emergency stop holds new dispatches (26004).
+
+        The stop-state read is blocking file I/O, so it runs off the event
+        loop (TASK-31507). Fail-safe is preserved: an offload failure reads
+        as stopped, holding work rather than proceeding on doubt.
+        """
         # ADR-097 boot ratchet: deferred off the boot path (loads on first use).
         from tldw_chatbook.emergency_stop import (
             default_emergency_stop_path,
@@ -418,7 +431,10 @@ class SchedulerLoop:
         path = getattr(self, "_emergency_stop_path", None) or (
             default_emergency_stop_path()
         )
-        return is_emergency_stopped(path)
+        try:
+            return await asyncio.to_thread(is_emergency_stopped, path)
+        except Exception:  # noqa: BLE001 -- doubt holds work (AC#4 of 26004)
+            return True
 
     async def _reconcile_and_prune_run_ledger(self) -> None:
         """Startup maintenance for the TASK-26026 run ledger. Never raises."""
@@ -445,7 +461,7 @@ class SchedulerLoop:
         Fail-safe: an unreadable stop state reads as stopped, so a doubt
         holds work rather than proceeding (AC#4).
         """
-        if self._emergency_stopped():
+        if await self._emergency_stopped():
             logger.debug("scheduler: emergency stop active; holding due dispatches")
             return
         due = self.queue.pop_due(now)


### PR DESCRIPTION
## Summary

Seventh holistic perf review, pinned at dev `f51fcaf204` (1,119 commits since the 08-30 review). Full evidence: `Docs/Design/2026-09-04-holistic-perf-review.md`.

**Regression verdicts (interleaved paired arms vs `b62407e258`, 2026-09-01):** cold boot, screen-switch tour, typing, and idle did **not** regress. What did land in this window is ambient/background cost:

- **1 Hz write-lock poll forever** on the main DB from legacy trace maintenance, no idle gate or off-switch (TASK-31501)
- **+137% per-statement overhead** on ChaChaNotes from the new quiescence registry (0.82 → 1.94 µs, measured twice per arm) (TASK-31502)
- **50 Hz whole-process-table scan** per open Terminal session, ~1.5% of a core each, measured (TASK-31503)
- Personal Context pays hardened root-walking connects per send even when unconfigured (~1.75 ms floor, worse configured) (TASK-31504)
- Opt-in custom-PII redaction spawns a subprocess **on the event loop inside a held write transaction** (TASK-31505)
- **Boot-CSS byte ratchet RED again on pristine dev**: 821,753 / 806,000 — +41,385 B in the 4 days since PR #2281's paydown; `_scheduling.tcss` nearly tripled (TASK-31500)
- Smaller: 5 Hz switcher-modal poll, review-set N+1, trash-canvas re-measure chain, pre-paint MCP JSON sync, per-run webhook threads (TASK-31506, 31508-31511)

## Implemented here

**TASK-31507**: scheduler tick-path heartbeat write + emergency-stop read moved off the event loop via `asyncio.to_thread`, awaited in place (observable ordering unchanged; stop-read failure holds work, per 26004 AC#4). `Tests/Scheduling/`: **1,029 passed**. Diagnostic inventory row for the one new static debug line reviewed via `--statements` and regenerated.

## Verification

- Budget ratchets run on the pristine pin: import weight 637/660, ui-ready census 966/972, worker census and CSS fastpath green; CSS bytes red as reported above
- All measurements from cold subprocesses / settled windows / paired same-day arms; machine carried load 7-9 throughout, so absolute walls are load-inflated and every verdict is A/B
- preflight: all derived-artifact checks passed; ruff clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ7TGpcXMtHqAwR34fNczp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files the seventh holistic performance review — an evidence doc plus 12 filed tasks (31500–31511) — and implements the one fix that landed: scheduler tick file I/O moved off the event loop.

Paired arms vs the 09-01 baseline show boot, switch tour, typing, and idle did not regress; the new costs are ambient: a 1 Hz write-lock poll on the main DB, a +137% per-statement shared-lock tax on ChaChaNotes, a 50 Hz whole-process-table scan per Terminal session, and repeated hardened connects per send from Personal Context. The boot-CSS byte ratchet is red again at 821,753 / 806,000 (+41,385 B in 4 days).

**Bug Fixes**

- Scheduler tick heartbeat writes and emergency-stop reads moved from the event loop to `asyncio.to_thread`, awaited in place so ordering is unchanged.
- A tick cancelled mid-offload now waits for the started heartbeat write before propagating, so a stopped scheduler never races a late write.
- An emergency-stop offload failure returns True (reads as stopped), preserving the fail-safe per TASK-26004 AC#4.
- `Tests/Scheduling/` passes (1,033 tests); the diagnostic inventory was refreshed for the one new static debug line.

<sup>Written for commit 8a9bc8fddbff898e6921d6188fbbfdd20c85f7ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2399?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

