### PR TITLE
Screen-instance reuse mechanism via installed screens (TASK-24452)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3974,8 +3974,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 378,
-      "diagnostic_digest": "6925a6612538de10d8a0",
+      "call_count": 381,
+      "diagnostic_digest": "cf3e8bfa48108a6a2a97",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11360,6 +11360,6 @@
     "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
     "task_492_calls": 1336,
-    "task_494_calls": 7599
+    "task_494_calls": 7602
   }
 }

--- a/Tests/UI/test_screen_reuse.py
+++ b/Tests/UI/test_screen_reuse.py
@@ -1,0 +1,230 @@
+"""Screen-instance reuse contracts for reusable routes (TASK-24452).
+
+The app hands ``switch_screen`` a fresh instance on every navigation --
+except routes whose ``ScreenRoute.reusable`` flag is set, whose screen is
+constructed once, installed, and re-switched to on later visits (Textual
+suspends installed screens instead of unmounting them). These tests pin:
+
+1. the reuse itself (same instance across a leave-and-return cycle, no
+   widget re-mint) -- the warm-visit guarantee the flag exists for;
+2. per-visit dashboard refresh moving to ``on_screen_resume``;
+3. runtime-identity scoping (a local<->server flip must not resume the
+   other identity's live widget state);
+4. the opt-in boundary: a route WITHOUT the flag keeps fresh instances,
+   because reuse changes on_mount/on_unmount frequency and every route
+   must opt in only after auditing that (see the flag's docstring).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.UI.Navigation.screen_registry import resolve_screen_route
+
+
+def _scratch_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
+    """Point every config/data seam at a scratch tree with setup completed."""
+    home = tmp_path / "home"
+    data = tmp_path / "data"
+    config = tmp_path / "config"
+    for sub in (home, data, config):
+        sub.mkdir(parents=True, exist_ok=True)
+    config_file = config / "tldw_cli" / "config.toml"
+    config_file.parent.mkdir(parents=True, exist_ok=True)
+    config_file.write_text(
+        "[first_run]\nsetup_completed = true\n\n[splash_screen]\nenabled = false\n"
+    )
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setenv("XDG_DATA_HOME", str(data))
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(config))
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_file))
+    monkeypatch.setenv("TLDW_TEST_MODE", "1")
+    monkeypatch.setenv("PYTEST_CURRENT_TEST", "screen_reuse")
+    return home
+
+
+async def _boot_settled(app):
+    while not getattr(app, "_ui_ready", False):
+        await asyncio.sleep(0.01)
+
+
+async def _settle(pilot, passes: int = 6, interval: float = 0.05) -> None:
+    for _ in range(passes):
+        await asyncio.sleep(interval)
+        await pilot.pause()
+
+
+async def _press_until_screen(pilot, key: str, expected: str) -> None:
+    deadline = asyncio.get_running_loop().time() + 30.0
+    await pilot.press(key)
+    while asyncio.get_running_loop().time() < deadline:
+        await pilot.pause()
+        if type(pilot.app.screen).__name__ == expected:
+            break
+    assert type(pilot.app.screen).__name__ == expected, (
+        f"never arrived at {expected}; stuck on "
+        f"{type(pilot.app.screen).__name__}"
+    )
+    await _settle(pilot)
+
+
+def test_home_route_is_flagged_reusable() -> None:
+    """The registry carries the enablement this suite exercises."""
+    route = resolve_screen_route("home")
+    assert route is not None and route.reusable is True
+
+
+@pytest.mark.ui
+@pytest.mark.asyncio
+async def test_reusable_route_returns_the_same_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Leave-and-return to Home resumes the SAME screen instance.
+
+    Also pins the anti-goal of the whole task: a warm visit must not
+    re-mint the widget tree, so the tree size is compared across visits
+    (a re-mint would build a second full tree before the first's removal).
+    """
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.app import TldwCli
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app)
+        await _settle(pilot, passes=20)
+
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        first_home = app.screen
+        first_widget_count = len(list(first_home.walk_children()))
+
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        assert first_home.is_attached is False or first_home is not app.screen
+
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        second_home = app.screen
+        assert second_home is first_home, (
+            "Home is a reusable route: returning to it must resume the "
+            "installed instance, not construct a new one"
+        )
+        second_widget_count = len(list(second_home.walk_children()))
+        assert second_widget_count <= first_widget_count * 1.5, (
+            "warm Home visit grew the widget tree "
+            f"({first_widget_count} -> {second_widget_count}) -- "
+            "re-minting is what reuse exists to prevent"
+        )
+
+
+@pytest.mark.ui
+@pytest.mark.asyncio
+async def test_resume_retriggers_home_refresh(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Returning to Home re-runs the per-visit refreshers.
+
+    With reuse, ``on_mount`` fires once per app run -- ``on_screen_resume``
+    is what keeps revisits from showing the previous visit's dashboard.
+    Deleting Home's resume hook must fail THIS test, not a user report.
+    """
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.app import TldwCli
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app)
+        await _settle(pilot, passes=20)
+
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        home = app.screen
+
+        calls: list[str] = []
+        monkeypatch.setattr(
+            home,
+            "_refresh_home_active_work_cache",
+            lambda: calls.append("active-work"),
+        )
+        monkeypatch.setattr(
+            home,
+            "_refresh_home_content_snapshot",
+            lambda: calls.append("content"),
+        )
+        monkeypatch.setattr(
+            home,
+            "_refresh_home_chatbook_artifact_snapshot",
+            lambda: calls.append("artifact"),
+        )
+
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        assert not calls, "suspending Home must not trigger its refreshers"
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        assert set(calls) == {"active-work", "content", "artifact"}, (
+            f"resume re-triggered {sorted(set(calls))}; expected all three "
+            "per-visit refreshers"
+        )
+
+
+@pytest.mark.ui
+@pytest.mark.asyncio
+async def test_identity_flip_invalidates_the_cached_instance(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A cached instance is scoped to the runtime identity that built it."""
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.UI.Navigation.screen_state_store import RuntimeIdentity
+    from tldw_chatbook.app import TldwCli
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app)
+        await _settle(pilot, passes=20)
+
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        cached_home = app.screen
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+
+        other_identity = RuntimeIdentity(
+            active_source="server", active_server_id="scope-flip-probe"
+        )
+        assert (
+            app._reusable_navigation_screen("home", other_identity) is None
+        ), "an identity flip must not hand back the other identity's screen"
+        assert "home" not in getattr(app, "_reusable_screen_instances", {}), (
+            "the stale entry must leave the cache, not linger for the next "
+            "same-identity lookup to resurrect"
+        )
+
+        # And the next navigation builds a FRESH instance rather than
+        # resuming the dropped one.
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        assert app.screen is not cached_home
+
+
+@pytest.mark.ui
+@pytest.mark.asyncio
+async def test_non_reusable_route_still_gets_fresh_instances(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Reuse stays opt-in: an unflagged route constructs per visit.
+
+    Console (chat) is the deliberate probe: its ``on_unmount`` tears down
+    a dozen subsystems per visit today, and flipping it to reuse without
+    that audit is exactly the change this guard exists to make loud.
+    """
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.app import TldwCli
+
+    route = resolve_screen_route("chat")
+    assert route is not None and route.reusable is False
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app)
+        await _settle(pilot, passes=20)
+
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        first_chat = app.screen
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        assert app.screen is not first_chat

--- a/Tests/UI/test_screen_reuse_helpers.py
+++ b/Tests/UI/test_screen_reuse_helpers.py
@@ -1,0 +1,117 @@
+"""Unit contracts for the screen-reuse cache helpers (TASK-24452, Qodo #2402).
+
+`Tests/UI/test_screen_reuse.py` proves the behavior through the running app;
+these pin each helper's own decision table in isolation -- cache hits and
+misses, runtime-identity scoping, stale-entry disposal (including the
+bounded in-stack leak), and the install-failure fallback -- against a stub
+app, so a regression names the helper rather than a navigation symptom.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tldw_chatbook.UI.Navigation.screen_state_store import RuntimeIdentity
+from tldw_chatbook.app import TldwCli
+
+LOCAL = RuntimeIdentity(active_source="local")
+SERVER = RuntimeIdentity(active_source="server", active_server_id="srv-1")
+
+
+class _StubScreen:
+    def __init__(self) -> None:
+        self.removed = False
+
+    def remove(self):
+        self.removed = True
+
+
+class _StubApp:
+    """Just the surface the two helpers touch, recorded."""
+
+    _reusable_navigation_screen = TldwCli._reusable_navigation_screen
+    _retain_reusable_navigation_screen = TldwCli._retain_reusable_navigation_screen
+
+    def __init__(self, *, install_raises: bool = False) -> None:
+        self._screen_stacks: dict[str, list] = {"_default": []}
+        self.installed: list[tuple] = []
+        self.uninstalled: list = []
+        self._install_raises = install_raises
+
+    def install_screen(self, screen, name: str) -> None:
+        if self._install_raises:
+            raise RuntimeError("install refused")
+        self.installed.append((screen, name))
+
+    def uninstall_screen(self, screen) -> None:
+        self.uninstalled.append(screen)
+
+
+def test_lookup_misses_before_any_retention() -> None:
+    app = _StubApp()
+    assert app._reusable_navigation_screen("home", LOCAL) is None
+    app._reusable_screen_instances = {}
+    assert app._reusable_navigation_screen("home", LOCAL) is None
+
+
+def test_retain_then_lookup_hits_for_the_same_identity() -> None:
+    app = _StubApp()
+    screen = _StubScreen()
+    app._retain_reusable_navigation_screen("home", LOCAL, screen)
+    assert len(app.installed) == 1
+    installed_screen, name = app.installed[0]
+    assert installed_screen is screen
+    assert name.startswith("tldw-reusable:home:"), (
+        "install names carry the instance id so a lingering stale install "
+        "can never block a replacement's"
+    )
+    assert app._reusable_navigation_screen("home", LOCAL) is screen
+
+
+def test_identity_mismatch_drops_uninstalls_and_removes() -> None:
+    app = _StubApp()
+    screen = _StubScreen()
+    app._retain_reusable_navigation_screen("home", LOCAL, screen)
+    assert app._reusable_navigation_screen("home", SERVER) is None
+    assert "home" not in app._reusable_screen_instances
+    assert app.uninstalled == [screen]
+    assert screen.removed is True
+
+
+def test_identity_mismatch_with_screen_in_stack_leaks_boundedly() -> None:
+    """A current screen cannot be uninstalled; the entry still leaves."""
+    app = _StubApp()
+    screen = _StubScreen()
+    app._retain_reusable_navigation_screen("home", LOCAL, screen)
+    app._screen_stacks["_default"].append(screen)
+    assert app._reusable_navigation_screen("home", SERVER) is None
+    assert "home" not in app._reusable_screen_instances, (
+        "the cache entry must leave even when disposal is deferred -- the "
+        "stale instance may linger installed, but must never be REUSED"
+    )
+    assert not app.uninstalled
+    assert screen.removed is False
+
+
+def test_install_failure_falls_back_to_per_visit_construction() -> None:
+    app = _StubApp(install_raises=True)
+    screen = _StubScreen()
+    app._retain_reusable_navigation_screen("home", LOCAL, screen)
+    assert getattr(app, "_reusable_screen_instances", {}).get("home") is None, (
+        "an uninstalled screen must never be cached: switch_screen would "
+        "unmount it and the next visit would resume a torn-down instance "
+        "-- the 2026-07-11 freeze class"
+    )
+
+
+def test_disposal_failure_still_returns_fresh(monkeypatch: pytest.MonkeyPatch) -> None:
+    app = _StubApp()
+    screen = _StubScreen()
+    app._retain_reusable_navigation_screen("home", LOCAL, screen)
+    monkeypatch.setattr(
+        _StubScreen,
+        "remove",
+        lambda self: (_ for _ in ()).throw(RuntimeError("remove exploded")),
+    )
+    assert app._reusable_navigation_screen("home", SERVER) is None
+    assert "home" not in app._reusable_screen_instances

--- a/backlog/tasks/task-24452 - Console-re-mints-559-widgets-on-every-visit-with-no-warm-benefit.md
+++ b/backlog/tasks/task-24452 - Console-re-mints-559-widgets-on-every-visit-with-no-warm-benefit.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-24452
 title: Console re-mints 559 widgets on every visit with no warm benefit
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-08-29'
 labels:
@@ -30,11 +30,21 @@ separate `update_nodes` passes into a batched update during construction.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Repeat visits to the Console construct materially fewer widgets than the first visit
-- [ ] #2 The number of `update_nodes` passes during a Console screen switch is reduced relative to the pre-change baseline
-- [ ] #3 Console screen-switch wall time improves measurably in an interleaved A/B on the same machine
-- [ ] #4 A guard pins the per-visit widget construction count so the warm path cannot silently regress
-- [ ] #5 Console behaviour and focus placement are unchanged across a switch-away-and-back cycle
+Re-scoped 2026-09-04 (owner call: "tackle 24452"): the root cause is the
+fresh-screen-instance-per-navigation architecture, and flipping Console to
+reuse safely requires a per-subsystem lifecycle audit of its ~dozen
+`on_unmount` teardowns. THIS task delivers the reuse mechanism, proven
+end-to-end on the lowest-risk route; the Console and Library enablements
+(where the measured wins are -80% and -95% switch CPU) are task-31520 and
+task-31521, gated on their audits.
+
+- [x] #1 An opt-in per-route screen-instance reuse mechanism exists (`ScreenRoute.reusable`): the instance is installed, suspended instead of unmounted on switch-away, and resumed on return
+- [x] #2 Repeat visits to a reusable route resume the SAME instance with no widget re-mint, pinned by a guard test
+- [x] #3 Reuse is scoped to the runtime identity that built the instance; an identity flip invalidates the cache (guard-tested)
+- [x] #4 Per-visit refresh for the enabled route runs from `on_screen_resume`, guard-tested by mutation (deleting the hook fails a test)
+- [x] #5 Non-reusable routes keep today's fresh-instance lifecycle, pinned by a guard test
+- [x] #6 The enabled route's behaviour is unchanged across a switch-away-and-back cycle (screen-reuse suite + home/master-shell/navigation-recovery suites green; nav-suite reds shown identical to pristine dev)
+- [ ] #7 Console re-mint elimination itself: moved to task-31520 (measured headroom recorded there); Library: task-31521
 <!-- AC:END -->
 
 ## Implementation Notes
@@ -58,3 +68,51 @@ the 402 separate `update_nodes` passes -- remains available and independent, and
 Note that task-24450 already took ~175 ms off the Console switch (1.96 -> 1.78 s mean of 6) by
 making each of those style applications cheaper rather than fewer.
 <!-- SECTION:NOTES:END -->
+
+
+## Implementation Plan (the how)
+
+1. Measure whether Textual installed-screen reuse avoids the 2026-07-11
+   freeze class and what it buys: bypass-probe Chat/Library instance
+   switching + typing-cost check with a suspended screen mounted.
+2. Add `ScreenRoute.reusable` (opt-in) + an app-side identity-scoped
+   instance cache; integrate at `_complete_screen_navigation` (skip
+   construction and snapshot-restore on a cache hit; install on first
+   build).
+3. Enable for Home (no unmount teardown, no timers); move its per-visit
+   refresh to `on_screen_resume`.
+4. Guard tests + mutation-test the flag and the resume hook.
+5. Interleaved A/B through the real navigation handler; file the Console/
+   Library enablement follow-ups with the measured headroom.
+
+## Implementation Notes
+
+Mechanism: `ScreenRoute.reusable` (default False) + TASK-24452 helpers in
+`app.py` (`_reusable_navigation_screen` / `_retain_reusable_navigation_
+screen`). A reusable route's screen is constructed once, INSTALLED
+(`App.install_screen`), and re-switched to on later visits -- Textual
+suspends installed screens instead of unmounting them, so the 2026-07-11
+re-mount-races-teardown freeze cannot start (no teardown ever runs
+mid-session). The cache is scoped to `RuntimeIdentity`; a local<->server
+flip drops and disposes the instance (bounded documented leak if the flip
+happens while the screen is current). Snapshot-restore is skipped on a
+cache hit (the live instance IS the state); the outgoing save_state path
+is unchanged (projection consumers).
+
+Enabled for Home; its three refresh workers re-trigger from
+`on_screen_resume` (exclusive groups coalesce the first-visit
+mount+resume double-fire). Guard suite `Tests/UI/test_screen_reuse.py`
+(5 tests); the route flag and the resume hook were each mutation-tested
+red. Honest measurement note: Home arrivals show NO wall/CPU win through
+the real nav handler -- the arrival window is dominated by the OUTGOING
+screen's teardown, and Home was always cheap to build. The wins live in
+Chat (-80% switch CPU) and Library (-95%), measured via installed-instance
+bypass probes on 2026-09-04, and land with task-31520/31521 after their
+lifecycle audits. Verified: screen-reuse + home + master-shell +
+navigation-recovery suites green (142 passed); full test_screen_navigation
+red set shown IDENTICAL to pristine dev (31 pre-existing, membership
+flake-stable); perf-guard suite 26 passed.
+
+Files: `UI/Navigation/screen_registry.py`, `app.py`,
+`UI/Screens/home_screen.py`, `Tests/UI/test_screen_reuse.py`,
+`backlog/tasks/task-31520`, `backlog/tasks/task-31521`.

--- a/backlog/tasks/task-31520 - Enable-screen-instance-reuse-for-the-Console-route.md
+++ b/backlog/tasks/task-31520 - Enable-screen-instance-reuse-for-the-Console-route.md
@@ -1,0 +1,38 @@
+---
+id: TASK-31520
+title: Enable screen-instance reuse for the Console route
+status: To Do
+assignee: []
+created_date: '2026-09-04 21:30'
+labels:
+  - performance
+  - console
+dependencies:
+  - task-24452
+priority: high
+---
+
+## Description (the why)
+
+TASK-24452 landed opt-in screen-instance reuse (`ScreenRoute.reusable`:
+construct once, install, suspend instead of unmount) and proved it on Home.
+The measured headroom for Console is the largest in the app: a warm
+installed-instance switch to ChatScreen cost 158 ms CPU against 750-820 ms
+for today's fresh construction (-80%, interleaved arms, 2026-09-04), and
+Console's ~559-widget re-mint per visit disappears. Enablement is gated on
+a lifecycle audit: `ChatScreen.on_unmount` tears down ~a dozen subsystems
+per visit (sidebar-state flush, terminal workspace detach, auto-speak,
+image-edit cancels, transcript-sync/fleet-survivor/cost-TTL timers,
+roleplay persistence, hands-free, realtime, dictation), and with reuse
+those must become suspend/resume-aware instead -- otherwise they keep
+ticking on a hidden screen. TASK-1143 F5's leave-confirmation ("navigating
+away cancels runs") also changes meaning when leaving no longer unmounts.
+
+## Acceptance Criteria (the what)
+
+- [ ] Every `ChatScreen.on_unmount` teardown step is dispositioned for reuse: paused on `on_screen_suspend` + resumed on `on_screen_resume`, moved to app-lifetime ownership, or documented as intentionally continuing while hidden
+- [ ] No Console-owned timer fires while the Console is suspended (measured, not asserted from code)
+- [ ] Repeat visits to the Console resume the same instance and construct materially fewer widgets (the TASK-24452 guard pattern, applied to the chat route)
+- [ ] Console switch CPU improves in an interleaved A/B against the fresh-instance baseline
+- [ ] Console behaviour and focus placement are unchanged across a switch-away-and-back cycle, including active-run, pending-approval, and dictation-active states
+- [ ] The TASK-1143 F5 leave-confirmation copy/behavior is reconciled with runs surviving navigation

--- a/backlog/tasks/task-31521 - Enable-screen-instance-reuse-for-the-Library-route.md
+++ b/backlog/tasks/task-31521 - Enable-screen-instance-reuse-for-the-Library-route.md
@@ -1,0 +1,36 @@
+---
+id: TASK-31521
+title: Enable screen-instance reuse for the Library route
+status: To Do
+assignee: []
+created_date: '2026-09-04 21:30'
+labels:
+  - performance
+  - library
+dependencies:
+  - task-24452
+priority: high
+---
+
+## Description (the why)
+
+TASK-24452 landed opt-in screen-instance reuse and proved it on Home.
+Library's measured headroom is the largest relative win: a warm
+installed-instance switch cost 33 ms CPU against 340-1,540 ms fresh
+(-95%, interleaved arms, 2026-09-04) -- and reuse also retires the
+per-visit costs already filed as task-24456 (43 config reads/visit) and
+task-24457 (8 SQLite connections/visit), since `on_mount` runs once.
+Enablement is gated on an audit of the remount-invalidation machinery:
+`LibraryScreen.on_unmount` bumps request generations, revokes reader/apply
+authority, and invalidates six controllers, all designed around
+fresh-construction; per-visit data refresh must move to
+`on_screen_resume`, and the ingest-registry listener keeps firing while
+suspended (recompose-on-hidden cost to disposition).
+
+## Acceptance Criteria (the what)
+
+- [ ] Every `LibraryScreen.on_unmount` invalidation is dispositioned for reuse (suspend/resume pairing, app-lifetime move, or documented as unnecessary under a live instance)
+- [ ] Revisits show fresh data (browse lists, sync status, ingest queue) without a full re-mint -- per-visit refresh runs from `on_screen_resume`
+- [ ] Repeat visits resume the same instance (TASK-24452 guard pattern applied to the library route)
+- [ ] Library switch CPU improves in an interleaved A/B against the fresh-instance baseline
+- [ ] The flush-veto path (`flush_pending_work`) still protects unsaved note edits across suspend/resume cycles

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -372,6 +372,22 @@ class BaseAppScreen(Screen):
         """
         logger.info(f"Screen {self.screen_name} mounted")
 
+    def on_screen_suspend(self) -> None:
+        """Release a live Buddy mouse capture when this screen is covered.
+
+        TASK-24452 (Qodo #2402 finding 3): reusable screens are SUSPENDED on
+        navigation, never unmounted, so the ``on_unmount`` release below no
+        longer runs between visits -- a Buddy drag in flight at the moment
+        of navigation would leave the hidden screen holding app-level mouse
+        capture and swallow input on the newly active screen. Releasing on
+        suspend covers every screen (a modal covering a mid-drag screen had
+        the same latent hold); the view itself is kept -- the resume
+        reconcile above replays its state on return.
+        """
+        view = self._persona_buddy_view
+        if view is not None:
+            view.release_interaction_capture()
+
     def on_unmount(self) -> None:
         """Called when the screen is unmounted."""
         logger.info(f"Screen {self.screen_name} unmounted")

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -372,21 +372,18 @@ class BaseAppScreen(Screen):
         """
         logger.info(f"Screen {self.screen_name} mounted")
 
-    def on_screen_suspend(self) -> None:
-        """Release a live Buddy mouse capture when this screen is covered.
-
-        TASK-24452 (Qodo #2402 finding 3): reusable screens are SUSPENDED on
-        navigation, never unmounted, so the ``on_unmount`` release below no
-        longer runs between visits -- a Buddy drag in flight at the moment
-        of navigation would leave the hidden screen holding app-level mouse
-        capture and swallow input on the newly active screen. Releasing on
-        suspend covers every screen (a modal covering a mid-drag screen had
-        the same latent hold); the view itself is kept -- the resume
-        reconcile above replays its state on return.
-        """
-        view = self._persona_buddy_view
-        if view is not None:
-            view.release_interaction_capture()
+    # TASK-24452 note: an `on_screen_suspend` override briefly lived here
+    # releasing a screen-owned Buddy view's mouse capture (Qodo #2402
+    # finding 3 -- reusable screens suspend instead of unmounting, so an
+    # unmount-time release stops covering them). PR #2407 then moved the
+    # Buddy overlay's lifetime to an app-level owner
+    # (`UI/Navigation/persona_buddy_overlay.py`): screens no longer hold a
+    # `_persona_buddy_view` at all, the owner's `is_current` fence rejects
+    # interaction the moment `app.screen` changes, its retire/invalid paths
+    # release capture per view, and Textual's own `switch_screen` calls
+    # `capture_mouse(None)` before every swap. The concern is covered at
+    # the owner; a screen-level hook would read an attribute that no
+    # longer exists.
 
     def on_unmount(self) -> None:
         """Called when the screen is unmounted."""

--- a/tldw_chatbook/UI/Navigation/screen_registry.py
+++ b/tldw_chatbook/UI/Navigation/screen_registry.py
@@ -20,6 +20,19 @@ class ScreenRoute:
     module_path: str
     class_name: str
     dependency_check: str | None = None
+    #: TASK-24452: opt-in screen-instance reuse. A reusable route's screen is
+    #: constructed once, installed (``App.install_screen``), and re-switched
+    #: to on every later visit -- Textual SUSPENDS an installed screen
+    #: instead of unmounting it, so the widget tree survives and warm visits
+    #: skip construction/mount entirely (measured: Home-class screens drop
+    #: from hundreds of ms of CPU per visit to tens). Opt-in per route
+    #: because reuse changes lifecycle semantics: ``on_mount``/``on_unmount``
+    #: fire once per app run instead of once per visit, so a route may only
+    #: set this after auditing that (a) per-visit refresh work runs from
+    #: ``on_screen_resume``, and (b) nothing load-bearing lives in
+    #: ``on_unmount`` teardown (see ``_create_navigation_screen``'s history
+    #: of why UNINSTALLED instances must never be reused).
+    reusable: bool = False
 
     def dependencies_available(self) -> bool:
         """Return whether optional dependencies for this route are available."""
@@ -54,7 +67,15 @@ class ScreenRoute:
 
 _SCREEN_ROUTES: dict[str, ScreenRoute] = {
     "home": ScreenRoute(
-        "home", "home", "tldw_chatbook.UI.Screens.home_screen", "HomeScreen"
+        "home",
+        "home",
+        "tldw_chatbook.UI.Screens.home_screen",
+        "HomeScreen",
+        # TASK-24452 first enablement: Home has no ``on_unmount`` teardown,
+        # no timers, and its per-visit refresh workers are re-triggered from
+        # ``on_screen_resume`` (all ``exclusive=True`` groups, so the
+        # first-visit mount+resume double-fire coalesces).
+        reusable=True,
     ),
     "chat": ScreenRoute(
         "chat", "chat", "tldw_chatbook.UI.Screens.chat_screen", "ChatScreen"

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -364,6 +364,20 @@ class HomeScreen(BaseAppScreen):
         self._refresh_home_content_snapshot()
         self._refresh_home_active_work_cache()
 
+    def on_screen_resume(self) -> None:
+        # No super().on_screen_resume(): same MRO contract as on_mount --
+        # Textual invokes BaseAppScreen's handler separately for this event.
+        #
+        # TASK-24452: Home is a reusable route (`ScreenRoute.reusable`), so
+        # `on_mount` fires once per app run and THIS hook is the per-visit
+        # seam -- without it, revisits would show the previous visit's
+        # dashboard. All three refreshers are `exclusive=True` worker
+        # groups, so the first visit's mount+resume double-fire coalesces
+        # instead of doing the work twice.
+        self._refresh_home_chatbook_artifact_snapshot()
+        self._refresh_home_content_snapshot()
+        self._refresh_home_active_work_cache()
+
     @work(exclusive=True, group="home-refresh-chatbook-artifact-snapshot", thread=True)
     def _refresh_home_chatbook_artifact_snapshot(self) -> None:
         adapter = getattr(self.app_instance, "home_active_work_adapter", None)

--- a/tldw_chatbook/UI/Screens/home_screen.py
+++ b/tldw_chatbook/UI/Screens/home_screen.py
@@ -357,23 +357,22 @@ class HomeScreen(BaseAppScreen):
         # the real seams.
         self._home_content_snapshot: HomeContentSnapshot | None = None
 
-    def on_mount(self) -> None:
-        # No super().on_mount(): the dispatcher already invokes
-        # BaseAppScreen.on_mount separately for this Mount event.
-        self._refresh_home_chatbook_artifact_snapshot()
-        self._refresh_home_content_snapshot()
-        self._refresh_home_active_work_cache()
-
     def on_screen_resume(self) -> None:
-        # No super().on_screen_resume(): same MRO contract as on_mount --
-        # Textual invokes BaseAppScreen's handler separately for this event.
-        #
-        # TASK-24452: Home is a reusable route (`ScreenRoute.reusable`), so
-        # `on_mount` fires once per app run and THIS hook is the per-visit
-        # seam -- without it, revisits would show the previous visit's
-        # dashboard. All three refreshers are `exclusive=True` worker
-        # groups, so the first visit's mount+resume double-fire coalesces
-        # instead of doing the work twice.
+        """Refresh the dashboard for this visit (initial and repeat alike).
+
+        TASK-24452: Home is a reusable route (`ScreenRoute.reusable`), so
+        `on_mount` fires once per app run and THIS hook is the per-visit
+        seam -- without it, revisits would show the previous visit's
+        dashboard. It is also the ONLY dispatch seam: Textual posts
+        ``ScreenResume`` on the initial push too, so dispatching from
+        ``on_mount`` as well double-ran the refreshers on every first
+        visit -- worker exclusivity cancels the superseded handle but
+        cannot undo synchronous provider calls already executing on its
+        thread (Qodo #2402 finding 4).
+
+        No super() call -- Textual's dispatcher invokes BaseAppScreen's
+        own handler separately for this event (the on_mount MRO contract).
+        """
         self._refresh_home_chatbook_artifact_snapshot()
         self._refresh_home_content_snapshot()
         self._refresh_home_active_work_cache()

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -12036,10 +12036,104 @@ class TldwCli(
         before it (executed: ``Docs/superpowers/plans/2026-08-14-headless-
         wake-task-0-report.md``, P3b). Screens still die on navigation;
         only the runtime survives.
+
+        Second documented exception, since TASK-24452: routes whose
+        ``ScreenRoute.reusable`` flag is set bypass this constructor on
+        warm visits entirely (``_reusable_navigation_screen``). That reuse
+        is safe ONLY because the instance is INSTALLED: Textual's
+        ``_replace_screen`` suspends an installed screen instead of
+        removing it, so the teardown race above never starts -- the
+        2026-07-11 freeze requires an unmount to be in flight, and an
+        installed screen is never unmounted mid-session.
         """
         if screen_name == TAB_RESEARCH_WORKSPACE:
             return self._create_research_workspace_screen(screen_class)
         return screen_class(self)
+
+    def _reusable_navigation_screen(
+        self,
+        current_tab_value: str,
+        runtime_identity: "RuntimeIdentity",
+    ) -> Any | None:
+        """Return the cached installed instance for a reusable route, if any.
+
+        TASK-24452. The cache is keyed by canonical route id and scoped to
+        the runtime identity that built the instance: an identity change
+        (the same scope ``ScreenStateStore`` keys its snapshots by) drops
+        and uninstalls the cached screen rather than leaking one identity's
+        live widget state into another's session.
+
+        Args:
+            current_tab_value: Canonical route id for the destination.
+            runtime_identity: The current snapshot scope.
+
+        Returns:
+            The still-valid installed instance, or ``None`` when the route
+            has not been visited yet (or its instance was invalidated).
+        """
+        cache = getattr(self, "_reusable_screen_instances", None)
+        if cache is None:
+            return None
+        entry = cache.get(current_tab_value)
+        if entry is None:
+            return None
+        cached_identity, screen = entry
+        if cached_identity == runtime_identity:
+            return screen
+        # Identity flipped (local <-> server): the cached instance carries
+        # the OLD identity's live widget state and must not be resumed under
+        # the new one. Drop it from the cache first -- that alone guarantees
+        # it is never reused -- then best-effort dispose. A screen still in
+        # the stack cannot be uninstalled (Textual raises); it stays
+        # installed-and-suspended until app exit: a bounded leak of one
+        # instance per identity flip, preferred over a teardown race on the
+        # rare path.
+        cache.pop(current_tab_value, None)
+        try:
+            if all(screen not in stack for stack in self._screen_stacks.values()):
+                self.uninstall_screen(screen)
+                screen.remove()
+        except Exception:
+            logger.debug(
+                "Could not dispose stale reusable screen (route=%s).",
+                current_tab_value,
+            )
+        return None
+
+    def _retain_reusable_navigation_screen(
+        self,
+        current_tab_value: str,
+        runtime_identity: "RuntimeIdentity",
+        screen: Any,
+    ) -> None:
+        """Install and cache a freshly built reusable screen (TASK-24452).
+
+        Installing is the load-bearing half: only installed screens survive
+        ``switch_screen`` without being unmounted. A failure to install
+        falls back silently to the fresh-instance lifecycle -- the screen
+        simply is not cached, and the next visit constructs again.
+        """
+        try:
+            # id() in the name: a stale same-route instance can legitimately
+            # outlive its cache entry (see the bounded-leak note in
+            # `_reusable_navigation_screen`), and `install_screen` raises on
+            # a duplicate name -- a lingering install must never block the
+            # replacement's.
+            self.install_screen(
+                screen, name=f"tldw-reusable:{current_tab_value}:{id(screen)}"
+            )
+        except Exception:
+            logger.warning(
+                "Could not install reusable screen; falling back to "
+                "per-visit construction (route=%s).",
+                current_tab_value,
+            )
+            return
+        cache = getattr(self, "_reusable_screen_instances", None)
+        if cache is None:
+            cache = {}
+            self._reusable_screen_instances = cache
+        cache[current_tab_value] = (runtime_identity, screen)
 
     def prepare_personal_context_interview_request(
         self,
@@ -13160,43 +13254,73 @@ class TldwCli(
                 )
 
         if screen_class:
-            try:
-                new_screen = self._create_navigation_screen(screen_name, screen_class)
-            except Exception as exc:
-                # A destination that cannot even be constructed is a broken
-                # destination, never a dead app. This ran unguarded until
-                # 2026-07-28: the MCP canvases read `Select.NULL` (Textual 8+)
-                # at construction time, so on an older Textual the
-                # AttributeError escaped this handler and Textual exited the
-                # whole app rather than the user simply failing to reach MCP.
-                logger.opt(exception=True).error(
-                    "Screen construction failed (route={}, exception_category={}).",
-                    screen_name,
-                    type(exc).__name__,
-                )
-                self._notify_navigation_failure(screen_name)
-                return False
-
-            restored_state = self.screen_state_store.restore(
-                current_tab_value,
-                runtime_identity,
+            # TASK-24452: a reusable route's screen survives navigation as an
+            # installed (suspended, never unmounted) instance; warm visits
+            # skip construction, mount, and snapshot-restore entirely.
+            route = resolve_screen_route(screen_name)
+            reusable_route = bool(route is not None and route.reusable)
+            new_screen = (
+                self._reusable_navigation_screen(current_tab_value, runtime_identity)
+                if reusable_route
+                else None
             )
-            restore_state = getattr(new_screen, "restore_state", None)
-            if restored_state is not None and callable(restore_state):
+            screen_reused = new_screen is not None
+            if new_screen is None:
                 try:
-                    restore_state(restored_state)
-                    logger.debug(
-                        "Restored screen snapshot for canonical route: %s",
-                        current_tab_value,
+                    new_screen = self._create_navigation_screen(
+                        screen_name, screen_class
                     )
                 except Exception as exc:
-                    self.screen_state_store.discard(current_tab_value)
-                    logger.warning(
-                        "Screen snapshot restore failed "
-                        "(route=%s, exception_category=%s).",
-                        current_tab_value,
+                    # A destination that cannot even be constructed is a broken
+                    # destination, never a dead app. This ran unguarded until
+                    # 2026-07-28: the MCP canvases read `Select.NULL` (Textual 8+)
+                    # at construction time, so on an older Textual the
+                    # AttributeError escaped this handler and Textual exited the
+                    # whole app rather than the user simply failing to reach MCP.
+                    logger.opt(exception=True).error(
+                        "Screen construction failed (route={}, exception_category={}).",
+                        screen_name,
                         type(exc).__name__,
                     )
+                    self._notify_navigation_failure(screen_name)
+                    return False
+                if reusable_route:
+                    self._retain_reusable_navigation_screen(
+                        current_tab_value, runtime_identity, new_screen
+                    )
+
+            if screen_reused:
+                # The live instance IS the state -- restoring an older
+                # snapshot over it would regress whatever the user last did
+                # there. The snapshot machinery still runs for the OUTGOING
+                # side above (projections published from `save_state` have
+                # consumers beyond restore).
+                logger.debug(
+                    "Reusing installed screen instance for canonical "
+                    "route: %s",
+                    current_tab_value,
+                )
+            else:
+                restored_state = self.screen_state_store.restore(
+                    current_tab_value,
+                    runtime_identity,
+                )
+                restore_state = getattr(new_screen, "restore_state", None)
+                if restored_state is not None and callable(restore_state):
+                    try:
+                        restore_state(restored_state)
+                        logger.debug(
+                            "Restored screen snapshot for canonical route: %s",
+                            current_tab_value,
+                        )
+                    except Exception as exc:
+                        self.screen_state_store.discard(current_tab_value)
+                        logger.warning(
+                            "Screen snapshot restore failed "
+                            "(route=%s, exception_category=%s).",
+                            current_tab_value,
+                            type(exc).__name__,
+                        )
 
             navigation_context = getattr(message, "screen_context", {}) or {}
             if not navigation_context:


### PR DESCRIPTION
## Summary

Owner call from the 2026-09-04 perf review: tackle task-24452 (screens re-minted from scratch on every visit — the biggest interactive lever in the app, root cause behind 24456/24457 as well).

**Mechanism (this PR):** `ScreenRoute.reusable` — an opt-in, per-route flag. A reusable route's screen is constructed once, **installed** (`App.install_screen`), suspended instead of unmounted on switch-away, and resumed on return. Installed screens are never torn down mid-session, so the root-caused 2026-07-11 freeze (re-mounting an instance whose teardown was still in flight) structurally cannot start. The instance cache is scoped to `RuntimeIdentity` (local↔server flips invalidate, guard-tested), and snapshot-restore is skipped on cache hits — the live instance is the state.

**Enabled here:** Home (no unmount teardown, no timers). Its per-visit dashboard refresh moved to `on_screen_resume` (mutation-tested: deleting the hook fails a guard).

**Deliberately NOT enabled here:** Console and Chat/Library — their `on_unmount` teardowns (a dozen subsystems on Console: timers, dictation, realtime, fleet ticks; six controllers' remount-invalidation on Library) must become suspend/resume-aware first or they'd keep running against a hidden screen. Filed as **task-31520** (Console) and **task-31521** (Library) with the audit checklists.

## Measurements (2026-09-04, interleaved arms, loaded machine)

- Installed-instance warm switches (bypass probe): **Chat 750–820 → 158 ms CPU (−80%); Library 340–1,540 → 33 ms (−95%)** — this is the headroom 31520/31521 collect.
- Typing CPU/key with a suspended screen mounted: 30.98 → 32.94 ms — **no regression** (the per-keystroke concern about resident widgets is empirically dismissed).
- Honest null result: Home arrivals through the real nav handler show **no** win — the arrival window is dominated by the *outgoing* screen's teardown, and Home was always cheap to build. Home is the proving ground for the mechanism, not the payoff.

## Verification

- `Tests/UI/test_screen_reuse.py` — 5 guard tests (same-instance resume + no re-mint, resume-refresh, identity invalidation, opt-in boundary pinning chat as fresh); the route flag and resume hook were each mutation-tested red
- home / dashboard-seams / triage-rail / master-shell / nav-failure-recovery suites: **142 passed**
- `test_screen_navigation.py`: 31 failed on this branch AND 31 failed on pristine `origin/dev` in the same run mode — failure-set diff is 3 names, each re-verified as pre-existing flakes failing solo on base too
- perf-guard suite (latency guardrails + boot ratchets + stall persist): 26 passed
- preflight: all derived-artifact checks passed; 3 new static diagnostics reviewed via `--statements` before `--write`; ruff error count identical to base (133 pre-existing)

Task-24452's ACs re-scoped in the task file per the workflow rule (mechanism ACs met here; Console/Library re-mint elimination tracked in 31520/31521).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ7TGpcXMtHqAwR34fNczp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in screen-instance reuse for TASK-24452: routes flagged `ScreenRoute.reusable` build their screen once, install it, and resume the same instance on return instead of unmounting and re-minting a fresh widget tree per visit. Installed screens are never torn down mid-session, which also structurally prevents the 2026-07-11 freeze class.

**Refactors**
- `ScreenRoute.reusable` defaults to `False`; only Home opts in, so every other route keeps its current fresh-instance lifecycle.
- The instance cache is scoped to `RuntimeIdentity`; a local↔server flip drops the cached screen, and cache hits skip snapshot-restore because the live instance is the state.
- Home's per-visit dashboard refresh moved to `on_screen_resume` as the only dispatch seam, since Textual posts `ScreenResume` on the initial push and dispatching from both `on_mount` and resume double-ran it.
- Console and Library enablement is deferred to TASK-31520 and TASK-31521 until their `on_unmount` teardowns become suspend/resume-aware; bypass probes measured −80% and −95% switch CPU there, while Home shows no win through the real nav path.
- A suspend-time Buddy mouse-capture release was tried and retired after dev's #2407 moved the overlay to an app-level owner.
- `Tests/UI/test_screen_reuse.py` (5 guard tests) and `Tests/UI/test_screen_reuse_helpers.py` (6 helper-unit contracts) cover reuse, identity invalidation, the opt-in boundary, and disposal fallbacks.

<sup>Written for commit 81be69bf0097f291595ba884d097b4d0a50ba9e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2402?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

