### PR TITLE
test(console): repair context-control tests and close spend workstream

### DIFF
--- a/Docs/superpowers/plans/2026-09-04-console-current-and-next-send-spend.md
+++ b/Docs/superpowers/plans/2026-09-04-console-current-and-next-send-spend.md
@@ -1,0 +1,40 @@
+# Console Current and Next-Send Spend — Completed Implementation Record
+
+The approved [design](../specs/2026-09-04-console-current-and-next-send-spend-design.md) shipped in [PR #2397](https://github.com/rmusser01/tldw_chatbook/pull/2397), merged into `dev` as `c418d4516c` on 2026-09-05 UTC.
+
+This record supersedes the unmerged local implementation checklist. [TASK-31585](../../../backlog/tasks/task-31585%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md) owns documentation reconciliation and the six pre-existing context-control test repairs. The original local TASK-31382 collided with dev's unrelated ask_user-attribution task; that existing task is unchanged. The closeout itself was renumbered from TASK-31568 after the older Library Reader task landed during CI; its task record preserves that provenance.
+
+## Completed scope
+
+- [x] Preserve inherited compaction settings and persist deliberate Off → Automatic reselection.
+- [x] Show context fullness, settled Current spend, and estimated additional On next send input charge with exact full/compact labels.
+- [x] Separate draft/staged inputs from settled spend, preserving independent price and context fallbacks.
+- [x] Handle dispatch/preparation/recovery ownership, including persisted versus transient IDs and provider-reported usage replacing local user estimates.
+- [x] Filter historical media through canonical provider admission, capabilities, and image budgeting without serializing bytes.
+- [x] Coalesce idle draft refreshes, cancel during active sends/teardown, and update labels on resize.
+- [x] Address all six Qodo findings and the introduced startup import regression.
+- [x] Verify required CI and merge the implementation into `dev`.
+
+## Final implementation decisions
+
+Pure formatting/history logic lives in `UI/Console_Modules/console_spend_projection.py` and the existing cost/context builders. Controller wiring owns the refresh timer. ChatScreen supplies captured live inputs and uses metadata-only provider rows for media admission.
+
+The initial plan's raw historical-attachment scan was corrected during review: excluded media must not suppress available text estimates. Capturing send configuration for an empty chat was also removed after the UI-ready census exposed eager RAG imports. Neither correction changed the approved additional-input-charge semantics.
+
+ADR required: no.
+ADR paths: [ADR-052](../../../backlog/decisions/052-console-conversation-memory-and-compaction-policy.md), [ADR-095](../../../backlog/decisions/095-conversation-owned-console-generation-settings.md).
+Reason: bug fixes and display/test refinements inside accepted ownership and policy boundaries.
+
+## Verification at PR #2397 merge
+
+- 204 focused cost, status-chip, wiring, projection, rail, and mounted-screen tests passed.
+- After the startup fix, 10 UI-ready census/media regressions passed at 972/972 modules with the existing limit unchanged.
+- Scoped Ruff lint/format, compilation, CSS reproduction, and diff checks passed. Reviewed diagnostic changes were recorded in the generated inventory.
+- Qodo reported zero bugs and zero rule violations on final head `24bffc3f40`; all review threads were resolved.
+- GitHub fast-lane, derived-artifact, CSS, platform-import, and performance checks passed before merge.
+- The additional context-control suite had 25 passes and six failures identical to clean dev. Those stale fixtures/assertions are the follow-up work in TASK-31585, not a feature regression.
+- The full repository suite was not run; repository policy requires explicit opt-in.
+
+## Cleanup scope
+
+After the closeout PR merges, remove only this workstream's temporary worktrees and topic/backup branches. Preserve a recoverable copy of the abandoned conflicted port and any superseded local task/design records before removing them. The shared main checkout and all unrelated worktrees, edits, branches, and task records remain outside cleanup scope.

--- a/Docs/superpowers/specs/2026-09-04-console-current-and-next-send-spend-design.md
+++ b/Docs/superpowers/specs/2026-09-04-console-current-and-next-send-spend-design.md
@@ -1,0 +1,46 @@
+# Console Current and Next-Send Spend Design
+
+Status: implemented in [PR #2397](https://github.com/rmusser01/tldw_chatbook/pull/2397), merged into `dev` as `c418d4516c`.
+
+Closeout: [TASK-31585](../../../backlog/tasks/task-31585%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md).
+
+## User-facing contract
+
+The context/spend button shows request-context fullness first, followed by money with explicit timing:
+
+- Wide: `Context 45% · Current $0.48 · On next send ~+$0.13`
+- Narrow: `Ctx 45% · Now $0.48 · Next ~+$0.13`
+
+`Current` is settled conversation spend, using reported provider usage when available and clearly marked local transcript estimates otherwise. It excludes the active draft, staged evidence, and unfinished turn owners. A user's local estimate is not counted again when the following assistant's actual usage covers that turn. Unpriced fleet tokens remain disclosed separately; they do not fabricate a dollar contribution.
+
+`On next send` is the estimated **additional input charge** for the next request. It includes the represented history, active composer draft, and staged evidence. It uses the selected model's uncached input rate. Output cost is added after completion; cache reads may lower the input charge and cache writes may raise it. This is a baseline estimate, not a total conversation projection or maximum bill.
+
+Context occupancy is estimated request usage relative to safe input capacity, not cumulative billed tokens. The tooltip explains request usage, safe capacity, conversation budget, compaction timing, cache status, and spend. Activating the button opens Conversation Inspector.
+
+## States and ownership
+
+- Current pricing and next-send pricing may be unavailable independently. A missing price or token estimate is `unavailable`, never invented zero spend.
+- Known zero input pricing can produce `~+$0.00`. A clean empty draft with known pricing and context produces `On next send —`.
+- Invalid drafts are unavailable until corrected.
+- Pending media or historical media admitted by the provider makes the forecast unavailable, with text-token detail retained. Failed echoes, assistant attachments, missing bytes, lifecycle-excluded rows, and images omitted by capability/budget rules do not suppress an otherwise available text forecast.
+- Accepted recovery owners remain request context but are excluded from Current. Quarantined/unaccepted owners are excluded from both. Durable checkpoints use persisted message IDs; local preparation uses transient IDs.
+- Unavailable snapshots remain distinguishable from a truly empty conversation.
+- Cache details and alerts remain in the tooltip/style without an extra unexplained amount or trailing cache glyph in the approved labels.
+
+## Automatic compaction
+
+Applying untouched quick settings preserves the sparse inherited compaction setting. A deliberate Off → Automatic edit persists an explicit Automatic choice, even when Automatic was the initial effective value. Existing compaction policy and failure handling remain owned by ADR-052.
+
+## Refresh and performance
+
+The chip reuses the shared context token estimate. Idle draft edits use one coalesced refresh owned by `ConsoleDraftSpendRefresh` in the canonical controller wiring; active sends and teardown cancel the pending refresh. Width changes reapply full/compact labels even if spend has not changed.
+
+Media checks reuse the provider's metadata-only admission path and never serialize attachments. Full send configuration is resolved only when admitted user attachments require capability/budget filtering, keeping RAG work off text-only refreshes and startup.
+
+The separate Send-button price tooltip retains its existing contract; this chip's forecast remains the input-only additional charge described above.
+
+## Architecture and verification
+
+ADR required: no. [ADR-052](../../../backlog/decisions/052-console-conversation-memory-and-compaction-policy.md) and [ADR-095](../../../backlog/decisions/095-conversation-owned-console-generation-settings.md) already define context/compaction policy and conversation-owned settings.
+
+See the [completed implementation record](../plans/2026-09-04-console-current-and-next-send-spend.md) for tested behavior and merge evidence.

--- a/Tests/UI/test_console_context_controls.py
+++ b/Tests/UI/test_console_context_controls.py
@@ -4,12 +4,12 @@ from __future__ import annotations
 
 import threading
 from dataclasses import replace
-from pathlib import Path
 
 import pytest
-from textual.app import App
 from textual.widgets import Button, OptionList, Select, Static
 
+from Tests.UI.consolidated_css import APP_STYLESHEETS, ConsolidatedCSSApp
+from Tests.UI.test_console_rail_sections import _test_popover
 from tldw_chatbook.Chat.console_context_compaction import (
     EffectiveMemoryKind,
     EffectiveMemoryResult,
@@ -35,16 +35,18 @@ from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
     ConsoleSettingsContextEstimate,
 )
+from tldw_chatbook.Chat.console_settings_apply import (
+    FULL_MODEL_DEFAULT_FIELDS,
+    ConsoleSettingsAction,
+    ConsoleSettingsCommittedSubmission,
+)
+from tldw_chatbook.Chat.console_settings_defaults import build_console_default_intent
 from tldw_chatbook.Widgets.Console.console_context_controls import (
     build_console_context_control_state,
 )
-from tldw_chatbook.Widgets.Console.console_model_popover import (
-    ConsoleModelPopover,
-    ConsoleModelPopoverResult,
-)
+from tldw_chatbook.Widgets.Console.console_model_popover import ConsoleModelPopover
 from tldw_chatbook.Widgets.Console.console_settings_modal import (
     ConsoleSettingsModal,
-    ConsoleSettingsResult,
 )
 import tldw_chatbook.Widgets.Console.console_transcript as transcript_module
 
@@ -130,15 +132,9 @@ def _generated_effective(
             coverage_kind=coverage,
             origin_kind=origin,
             selection_anchor_message_id=(
-                anchor
-                if origin is MemoryOriginKind.MANUAL_REWIND
-                else None
+                anchor if origin is MemoryOriginKind.MANUAL_REWIND else None
             )
-            or (
-                "message-8"
-                if origin is MemoryOriginKind.MANUAL_REWIND
-                else None
-            ),
+            or ("message-8" if origin is MemoryOriginKind.MANUAL_REWIND else None),
         ),
     )
 
@@ -336,13 +332,8 @@ def test_invalid_effective_memory_derives_no_banner(case: str) -> None:
     assert _derive_banner(effective, rows) is None
 
 
-class _ContextHarness(App[None]):
-    CSS_PATH = str(
-        Path(__file__).resolve().parents[2]
-        / "tldw_chatbook"
-        / "css"
-        / "tldw_cli_modular.tcss"
-    )
+class _ContextHarness(ConsolidatedCSSApp):
+    CSS_PATH = [str(path) for path in APP_STYLESHEETS]
 
     def __init__(self) -> None:
         super().__init__()
@@ -372,7 +363,7 @@ async def test_quick_popover_separates_request_conversation_and_policy() -> None
     app = _ContextHarness()
     async with app.run_test(size=(90, 34)) as pilot:
         await app.push_screen(
-            ConsoleModelPopover(
+            _test_popover(
                 settings=_settings(),
                 providers_models={"llama_cpp": ["model-a"]},
                 context_state=_state(),
@@ -399,12 +390,20 @@ async def test_quick_popover_separates_request_conversation_and_policy() -> None
         assert not app.screen.query("#console-popover-custom-budget")
         app.screen.query_one(
             "#console-popover-compaction-mode", Select
+        ).value = ContextCompactionMode.OFF.value
+        await pilot.pause()
+        app.screen.query_one(
+            "#console-popover-compaction-mode", Select
         ).value = ContextCompactionMode.AUTOMATIC.value
         await pilot.click("#console-popover-apply")
         await pilot.pause()
 
-    assert isinstance(app.result, ConsoleModelPopoverResult)
-    assert app.result.compaction_mode is ContextCompactionMode.AUTOMATIC
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    assert app.result.submission.action is ConsoleSettingsAction.APPLY_TO_CHAT
+    assert (
+        app.result.live_commit.context_policy_overrides.compaction_mode
+        is ContextCompactionMode.AUTOMATIC
+    )
 
 
 @pytest.mark.asyncio
@@ -436,11 +435,9 @@ async def test_full_modal_has_stable_views_and_saves_conversation_policy() -> No
             "#console-settings-save-default",
             Button,
         )
-        assert str(save_defaults.label) == "Save model defaults"
+        assert str(save_defaults.label) == "Save as provider defaults"
         assert save_defaults.display is False
-        scope = str(
-            app.screen.query_one("#console-settings-scope", Static).renderable
-        )
+        scope = str(app.screen.query_one("#console-settings-scope", Static).renderable)
         assert "this conversation" in scope
         assert "F9 Settings > Console behavior" in scope
         context_labels = {
@@ -478,13 +475,16 @@ async def test_full_modal_has_stable_views_and_saves_conversation_policy() -> No
         await pilot.click("#console-settings-save")
         await pilot.pause()
 
-    assert isinstance(app.result, ConsoleSettingsResult)
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    assert app.result.submission.action is ConsoleSettingsAction.APPLY_TO_CHAT
     assert (
-        app.result.context_policy_overrides.compaction_mode
+        app.result.live_commit.context_policy_overrides.compaction_mode
         is ContextCompactionMode.AUTOMATIC
     )
-    assert app.result.context_policy_overrides.custom_budget_tokens == 70_000
-    assert app.result.thinking_history_policy == "auto"
+    assert (
+        app.result.live_commit.context_policy_overrides.custom_budget_tokens == 70_000
+    )
+    assert not app.result.submission.default_field_mask
 
 
 @pytest.mark.asyncio
@@ -628,15 +628,15 @@ async def test_visual_representation_choices_enable_for_vision_model() -> None:
         await pilot.click("#console-settings-save")
         await pilot.pause()
 
-    assert isinstance(app.result, ConsoleSettingsResult)
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
     assert (
-        app.result.context_policy_overrides.compaction_representation
+        app.result.live_commit.context_policy_overrides.compaction_representation
         is ContextCompactionRepresentation.HYBRID
     )
 
 
 @pytest.mark.asyncio
-async def test_provider_defaults_write_excludes_memory_and_prompt_ownership(
+async def test_provider_default_submission_excludes_memory_and_prompt_ownership(
     monkeypatch,
 ) -> None:
     from tldw_chatbook.Widgets.Console import console_settings_modal as modal_module
@@ -671,18 +671,29 @@ async def test_provider_defaults_write_excludes_memory_and_prompt_ownership(
         await pilot.click("#console-settings-save-default")
         await pilot.pause()
 
-    assert len(writes) == 1
-    assert set(writes[0]) <= {
-        "api_settings.llama_cpp",
-        "console.provider_defaults.llama_cpp",
-        "chat_defaults",
-    }
-    serialized_keys = " ".join(
-        f"{section} {' '.join(values)}" for section, values in writes[0].items()
-    ).lower()
-    assert "memory" not in serialized_keys
-    assert "prompt" not in serialized_keys
-    assert app.result.context_policy_overrides.compaction_mode is (
+    # The modal emits intent; the defaults service owns configuration writes.
+    assert writes == []
+    assert isinstance(app.result, ConsoleSettingsCommittedSubmission)
+    submission = app.result.submission
+    assert submission.action is ConsoleSettingsAction.SAVE_MODEL_DEFAULT
+    assert submission.default_field_mask == FULL_MODEL_DEFAULT_FIELDS
+    intent = build_console_default_intent(
+        generation=1,
+        action=submission.action,
+        provider_config_key=submission.draft.settings.provider,
+        literal_model_id=submission.draft.settings.model,
+        field_drafts=submission.draft.field_drafts,
+        field_mask=submission.default_field_mask,
+        endpoint=submission.draft.endpoint_draft,
+    )
+    assert set(intent.values) == FULL_MODEL_DEFAULT_FIELDS
+    assert all(
+        owner not in key
+        for key in intent.values
+        for owner in ("memory", "prompt", "compaction", "thinking_history")
+    )
+    assert intent.endpoint_patch is None
+    assert app.result.live_commit.context_policy_overrides.compaction_mode is (
         ContextCompactionMode.AUTOMATIC
     )
 
@@ -696,9 +707,7 @@ async def test_provider_defaults_write_excludes_memory_and_prompt_ownership(
             "provenance unavailable",
         ),
         (
-            _generated_effective(
-                _memory(), origin=MemoryOriginKind.MANUAL_REWIND
-            ),
+            _generated_effective(_memory(), origin=MemoryOriginKind.MANUAL_REWIND),
             "Manual prefix memory",
             "provenance unavailable",
         ),
@@ -750,9 +759,7 @@ async def test_current_memory_uses_typed_effective_display(
         )
         await pilot.pause()
         rendered = str(
-            app.screen.query_one(
-                "#console-context-memory-metadata", Static
-            ).renderable
+            app.screen.query_one("#console-context-memory-metadata", Static).renderable
         )
         assert metadata in rendered
         assert forbidden not in rendered
@@ -936,9 +943,9 @@ def test_context_controls_add_no_forbidden_keybindings() -> None:
             *ConsoleModelPopover.BINDINGS,
             *ConsoleSettingsModal.BINDINGS,
         )
-        for key in str(
-            binding.key if hasattr(binding, "key") else binding[0]
-        ).split(",")
+        for key in str(binding.key if hasattr(binding, "key") else binding[0]).split(
+            ","
+        )
     }
     assert keys.isdisjoint(forbidden)
 
@@ -986,7 +993,7 @@ async def test_quick_popover_keeps_actions_visible_and_marks_the_narrow_fold() -
     app = _ContextHarness()
     async with app.run_test(size=(72, 24)) as pilot:
         await app.push_screen(
-            ConsoleModelPopover(
+            _test_popover(
                 settings=_settings(),
                 providers_models={"llama_cpp": ["model-a"]},
                 context_state=_state(),
@@ -996,7 +1003,7 @@ async def test_quick_popover_keeps_actions_visible_and_marks_the_narrow_fold() -
         await pilot.pause()
 
         hint = app.screen.query_one("#console-popover-fold-hint", Static)
-        actions = app.screen.query_one("#console-popover-actions")
+        actions = app.screen.query_one("#console-popover-main-actions")
         context_button = app.screen.query_one(
             "#console-popover-full-settings",
             Button,
@@ -1073,7 +1080,7 @@ async def test_quick_popover_mounts_with_no_model_selected() -> None:
     app = _ContextHarness()
     async with app.run_test(size=(90, 34)) as pilot:
         await app.push_screen(
-            ConsoleModelPopover(
+            _test_popover(
                 settings=ConsoleSessionSettings(
                     provider="llama_cpp",
                     model=None,

--- a/Tests/UI/test_console_rail_sections.py
+++ b/Tests/UI/test_console_rail_sections.py
@@ -44,6 +44,7 @@ from tldw_chatbook.Widgets.Console.console_model_popover import (
     ConsoleModelPopover,
 )
 from tldw_chatbook.Widgets.Console.console_context_controls import (
+    ConsoleContextControlState,
     build_console_context_control_state,
 )
 from tldw_chatbook.Widgets.Console.console_settings_summary import (
@@ -919,6 +920,7 @@ def _test_popover(
     *,
     overrides: ConsoleContextPolicyOverrides | None = None,
     global_overrides: ConsoleContextPolicyOverrides | None = None,
+    context_state: ConsoleContextControlState | None = None,
 ) -> ConsoleModelPopover:
     origin = ConsoleSettingsOrigin("popover-session", None, 0)
     draft = ConsoleSettingsDraftState(
@@ -971,7 +973,8 @@ def _test_popover(
         },
         initial_draft=draft,
         providers_models=providers_models,
-        context_state=build_console_context_control_state(
+        context_state=context_state
+        or build_console_context_control_state(
             settings=settings,
             estimate=ConsoleSettingsContextEstimate(
                 used_tokens=None, token_limit=None, label="unavailable"

--- a/backlog/tasks/task-31585 - Close-Console-context-spend-workstream-and-repair-context-control-tests.md
+++ b/backlog/tasks/task-31585 - Close-Console-context-spend-workstream-and-repair-context-control-tests.md
@@ -1,0 +1,61 @@
+---
+id: TASK-31585
+title: Close Console context spend workstream and repair context control tests
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-05 03:40'
+updated_date: '2026-09-05 03:51'
+labels:
+  - console
+  - tests
+  - documentation
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the merged automatic-compaction and context/spend workstream with authoritative records and current settings-contract test coverage.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 The six pre-existing context-control failures pass using the current settings submission and provider-default ownership contracts.
+- [x] #2 The merged compaction and Current/On next send behavior is documented with accurate validation evidence and a unique task ID.
+- [x] #3 Focused test and static checks pass, with the workstream cleanup targets documented separately from unrelated user work.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the six failures on merged dev and compare their fixtures and assertions with the current settings submission/default-persistence contracts.
+2. Reuse the mounted popover fixture and migrate assertions to committed submissions while retaining provider-default isolation and geometry coverage.
+3. Publish the corrected context/spend design and completed implementation record, including PR #2397 evidence and the local TASK-31382 collision provenance.
+4. Run focused context-control, popover, and settings-default tests plus scoped formatting/lint and documentation checks; review, merge into dev, then clean up only this workstream's branches/worktrees with recoverable preservation of its conflicted attempt.
+
+ADR required: no
+ADR path: backlog/decisions/095-conversation-owned-console-generation-settings.md
+Reason: test and documentation repair within the existing settings ownership and merged context/spend contracts; no production interface or policy changes.
+
+## Task ID provenance
+
+The CLI initially offered TASK-31430. A remote-ref and worktree census found IDs through TASK-31567, so this task was assigned TASK-31568 before implementation. The original local context/spend task used TASK-31382, which belongs to the unrelated ask_user attribution task on dev. This closeout record references the original work by PR #2397 and does not replace dev's TASK-31382.
+
+## Renumbering provenance
+
+PR #2401 landed while PR #2403 was completing CI and introduced the older Library Reader TASK-31568 (created 2026-09-05 03:22, versus this task at 03:40). Following the older-keeps-ID rule, this closeout moved from TASK-31568 to TASK-31585. A fresh sweep across all remote refs and worktrees found a maximum of TASK-31584; the spec and completed implementation record were updated together. The existing Library task remains unchanged.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Reproduced the six stale failures on merged dev (25 passed, 6 failed), then updated the context-control tests to the conversation-owned settings submission contract. Reused the existing popover fixture, asserted explicit Automatic reselection, retained the provider-default ownership exclusion through the defaults intent builder, and corrected the action-row selector. The mounted harness now loads the same consolidated and split stylesheets as production. No application behavior changed.
+
+Published the corrected Current/On next send design and completed implementation record, preserving the feature PR's evidence separately from this follow-up. ADR-095 already governs the tested boundary; no new ADR was required. The existing testing lessons already describe the stale-fixture and consolidated-CSS traps, so no duplicate lesson was added.
+
+Validation: 158 focused tests passed across context controls, rail/popover settings, and the real settings-default persistence service, including after rebasing onto dev's interrupt-host change. Scoped Ruff lint/format, diff whitespace checks, and the backlog ID/path guard passed. The subsequent Library follow-up merge changes documentation only; its task-ID collision is reconciled above. The full suite was not run. Pytest emitted a Requests dependency-version warning and temporary-directory cleanup warnings; neither was a test failure.
+
+Cleanup after merge is limited to the Console spend feature/port/baseline/closeout worktrees and topic/backup refs. Preserve the conflicted port and branch history in a verified recovery archive first. The original records in the shared main checkout are tracked on an unrelated branch and remain untouched; the authoritative dev replacements above supersede them.
+<!-- SECTION:NOTES:END -->


### PR DESCRIPTION
## Summary
- Repair six pre-existing context-control failures against the current conversation-owned settings submission and default-intent contracts.
- Reuse the mounted popover fixture and load production consolidated/split stylesheets for geometry coverage. No production-code changes.
- Publish the reconciled compaction and Current/On next send records for merged #2397, under unique TASK-31585. Preserve dev’s unrelated TASK-31382.

## Validation
- Baseline: 25 passed, 6 failed in Tests/UI/test_console_context_controls.py.
- Updated: 158 passed across context controls, rail/popover settings, and real settings-default persistence tests.
- Scoped Ruff lint/format, git diff --check, and backlog ID/path guard passed.
- Independent review: no blocking code findings; task marker nit corrected.
- Full suite not run. Requests dependency-version and temporary-directory cleanup warnings are environmental.

## Follow-through
Wait for Qodo and CI, address actionable findings, merge into dev, then remove only this workstream’s temporary worktrees/refs after making a recoverable archive of the abandoned conflicted port. The shared main checkout stays untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes six pre-existing console context-control test failures so the suite matches the conversation-owned settings submission and provider-default ownership contracts. Closes TASK-31585 by adding the reconciled design and implementation records for the merged #2397 spend workstream; no production code changes.

**Tests**
- Context-control assertions now use `ConsoleSettingsCommittedSubmission` and the defaults intent builder.
- Geometry coverage reuses the mounted popover fixture and production consolidated/split stylesheets.

<sup>Written for commit ad7ebcd3804f0de62eb53f45a7cc04febcfae87a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

