### PR TITLE
Fix Migu Buddy dragging, publication and speech lifecycle

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2568,7 +2568,7 @@
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "a50acef38af041324bbf",
+      "diagnostic_digest": "868dbc1c5a3b51e12cec",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/LLM_Management_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2568,7 +2568,7 @@
     },
     {
       "call_count": 14,
-      "diagnostic_digest": "d8707e1647f69223e115",
+      "diagnostic_digest": "a50acef38af041324bbf",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/LLM_Management_Window.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2820,7 +2820,7 @@
     },
     {
       "call_count": 104,
-      "diagnostic_digest": "bc23f0ee6b49abb5b080",
+      "diagnostic_digest": "11c7244cedd22151a5b3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-09-04-console-current-and-next-send-spend.md
+++ b/Docs/superpowers/plans/2026-09-04-console-current-and-next-send-spend.md
@@ -2,7 +2,7 @@
 
 The approved [design](../specs/2026-09-04-console-current-and-next-send-spend-design.md) shipped in [PR #2397](https://github.com/rmusser01/tldw_chatbook/pull/2397), merged into `dev` as `c418d4516c` on 2026-09-05 UTC.
 
-This record supersedes the unmerged local implementation checklist. [TASK-31585](../../../backlog/tasks/task-31585%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md) owns documentation reconciliation and the six pre-existing context-control test repairs. The original local TASK-31382 collided with dev's unrelated ask_user-attribution task; that existing task is unchanged. The closeout itself was renumbered from TASK-31568 after the older Library Reader task landed during CI; its task record preserves that provenance.
+This record supersedes the unmerged local implementation checklist. [TASK-31591](../../../backlog/tasks/task-31591%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md) owns documentation reconciliation and the six pre-existing context-control test repairs. The original local TASK-31382 collided with dev's unrelated ask_user-attribution task; that existing task is unchanged. The closeout itself was renumbered from TASK-31568 after the older Library Reader task landed during CI; its task record preserves that provenance.
 
 ## Completed scope
 
@@ -32,7 +32,7 @@ Reason: bug fixes and display/test refinements inside accepted ownership and pol
 - Scoped Ruff lint/format, compilation, CSS reproduction, and diff checks passed. Reviewed diagnostic changes were recorded in the generated inventory.
 - Qodo reported zero bugs and zero rule violations on final head `24bffc3f40`; all review threads were resolved.
 - GitHub fast-lane, derived-artifact, CSS, platform-import, and performance checks passed before merge.
-- The additional context-control suite had 25 passes and six failures identical to clean dev. Those stale fixtures/assertions are the follow-up work in TASK-31585, not a feature regression.
+- The additional context-control suite had 25 passes and six failures identical to clean dev. Those stale fixtures/assertions are the follow-up work in TASK-31591, not a feature regression.
 - The full repository suite was not run; repository policy requires explicit opt-in.
 
 ## Cleanup scope

--- a/Docs/superpowers/specs/2026-09-04-console-current-and-next-send-spend-design.md
+++ b/Docs/superpowers/specs/2026-09-04-console-current-and-next-send-spend-design.md
@@ -2,7 +2,7 @@
 
 Status: implemented in [PR #2397](https://github.com/rmusser01/tldw_chatbook/pull/2397), merged into `dev` as `c418d4516c`.
 
-Closeout: [TASK-31585](../../../backlog/tasks/task-31585%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md).
+Closeout: [TASK-31591](../../../backlog/tasks/task-31591%20-%20Close-Console-context-spend-workstream-and-repair-context-control-tests.md).
 
 ## User-facing contract
 

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -176,7 +176,6 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
     },
     "tldw_chatbook/UI/Screens/library_screen.py": {
         "Pending Library lifecycle write failed during unmount.": (),
-        "canvas sync failed": ("kind",),
         "Library entry canvas repair attempt failed": (),
         "Strict Library entry shell synchronization failed": (),
         "Strict Library entry canvas removal failed": (),
@@ -189,7 +188,6 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
             "operation",
             "type(exc).__name__",
         ),
-        "Failed to load Library conversations page.": (),
         "in bulk delete": (),
         "Failed to restore a Library media item in bulk-delete undo": (
             "type(exc).__name__",
@@ -197,7 +195,13 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Failed to persist the Library ingest backend": (),
         "Failed to persist Library ingest options": (),
         "Failed to restore a Library note": (),
-        "Failed to restore a Library Collection": (),
+        # Removed by 5dd1077df6 when generic Collection restore was retired.
+    },
+    "tldw_chatbook/UI/Library_Modules/canvas_sync.py": {
+        "canvas sync failed": ("kind",),
+    },
+    "tldw_chatbook/UI/Library_Modules/library_conversations_controller.py": {
+        "Failed to load Library conversations page.": (),
     },
     "tldw_chatbook/UI/Console_Modules/image.py": {
         "Console image edit cleanup failed": (
@@ -994,7 +998,15 @@ def test_task_15743_exception_types_survive_loguru_forwarding() -> None:
             if "exception_type={}" not in message:
                 failures.append(f"{relative}: {label!r} does not render exception_type")
             positional = [ast.unparse(argument) for argument in call.args[1:]]
-            if "type(exc).__name__" not in positional:
+            # Receipt degradation also supports a missing exception. Only its
+            # literal fallback is safe; arbitrary conditional payloads are not.
+            if not any(
+                value in {
+                    "type(exc).__name__",
+                    "type(exc).__name__ if exc is not None else 'invalid_state'",
+                }
+                for value in positional
+            ):
                 failures.append(f"{relative}: {label!r} is not positional metadata")
             if any(keyword.arg == "exception_type" for keyword in call.keywords):
                 failures.append(f"{relative}: {label!r} leaves exception_type in extra")

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -175,6 +175,7 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "stream resolution failed": ("type(exc).__name__",),
     },
     "tldw_chatbook/UI/Screens/library_screen.py": {
+        "Pending Library lifecycle write failed during unmount.": (),
         "canvas sync failed": ("kind",),
         "Library entry canvas repair attempt failed": (),
         "Strict Library entry shell synchronization failed": (),
@@ -217,6 +218,7 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Image generation batch raised": ("type(exc).__name__",),
     },
     "tldw_chatbook/UI/LLM_Management_Window.py": {
+        "Lazy LLM view mount failed": (),
         "Managed GGUF inventory load failed": (),
     },
     "tldw_chatbook/UI/Screens/llm_screen.py": {
@@ -3395,3 +3397,55 @@ def test_task_15103_review_ledger_semantic_atom_digest_is_scope_independent() ->
     moved = {**atom, "qualified_scope": "Another.place"}
 
     assert moved["semantic_digest"] == atom["semantic_digest"]
+
+
+@pytest.mark.parametrize("environment_name", [".venv", "developer-python"])
+def test_inventory_excludes_nested_virtualenv_but_keeps_application_sources(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, environment_name: str
+) -> None:
+    """Local dependency installations must not become application owners/sinks."""
+    package = tmp_path / "tldw_chatbook"
+    package.mkdir()
+    environment = package / environment_name
+    dependency = environment / "lib/python3.13/site-packages/foreign.py"
+    dependency.parent.mkdir(parents=True)
+    (environment / "pyvenv.cfg").write_text("home = /local/python\n")
+    dependency.write_text("logger.error('foreign')\nlogger.add('foreign.log')\n")
+    # A similarly named application module is still in scope.
+    application = package / "venv"
+    application.mkdir()
+    (application / "owner.py").write_text(
+        "logger.warning('owned')\nlogger.add('owned.log')\n"
+    )
+    monkeypatch.setattr(diagnostic_inventory, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(diagnostic_inventory, "PACKAGE_ROOT", package)
+
+    inventory = diagnostic_inventory.build_inventory()
+
+    assert [row["path"] for row in inventory["owners"]] == [
+        "tldw_chatbook/venv/owner.py"
+    ]
+    assert [row["path"] for row in inventory["persistent_sink_topology"]] == [
+        "tldw_chatbook/venv/owner.py"
+    ]
+    assert inventory["summary"] == {
+        "owner_files": 1,
+        "persistent_sink_files": 1,
+        "task_492_calls": 0,
+        "task_494_calls": 1,
+        "path_privacy_candidate_calls": 0,
+    }
+
+
+def test_buddy_uat_lifecycle_diagnostics_do_not_capture_private_errors(monkeypatch):
+    owners = {
+        "tldw_chatbook/UI/LLM_Management_Window.py": {"Lazy LLM view mount failed": ()},
+        "tldw_chatbook/UI/Screens/library_screen.py": {
+            "Pending Library lifecycle write failed during unmount.": ()
+        },
+    }
+    for owner, labels in owners.items():
+        for label, fields in labels.items():
+            assert REVIEWED_METADATA_ONLY_DIAGNOSTICS[owner][label] == fields
+    monkeypatch.setitem(globals(), "REVIEWED_METADATA_ONLY_DIAGNOSTICS", owners)
+    test_reviewed_diagnostic_changes_are_metadata_only()

--- a/Tests/Architecture/test_persistent_diagnostic_inventory.py
+++ b/Tests/Architecture/test_persistent_diagnostic_inventory.py
@@ -222,7 +222,7 @@ REVIEWED_METADATA_ONLY_DIAGNOSTICS = {
         "Image generation batch raised": ("type(exc).__name__",),
     },
     "tldw_chatbook/UI/LLM_Management_Window.py": {
-        "Lazy LLM view mount failed": (),
+        "Lazy LLM view mount failed: view={}": ("safe_view",),
         "Managed GGUF inventory load failed": (),
     },
     "tldw_chatbook/UI/Screens/llm_screen.py": {
@@ -3451,7 +3451,7 @@ def test_inventory_excludes_nested_virtualenv_but_keeps_application_sources(
 
 def test_buddy_uat_lifecycle_diagnostics_do_not_capture_private_errors(monkeypatch):
     owners = {
-        "tldw_chatbook/UI/LLM_Management_Window.py": {"Lazy LLM view mount failed": ()},
+        "tldw_chatbook/UI/LLM_Management_Window.py": {"Lazy LLM view mount failed: view={}": ("safe_view",)},
         "tldw_chatbook/UI/Screens/library_screen.py": {
             "Pending Library lifecycle write failed during unmount.": ()
         },

--- a/Tests/Chat/test_console_agent_project_instructions.py
+++ b/Tests/Chat/test_console_agent_project_instructions.py
@@ -266,7 +266,11 @@ def test_token_omission_notice_keeps_content_free_source_metadata(
             or "proceed"
         ),
     )
-    monkeypatch.setattr(agent_service, "get_model_token_limit", lambda *_a, **_k: 1)
+    # The base request fits; only the optional instruction row exceeds budget.
+    monkeypatch.setattr(agent_service, "get_model_token_limit", lambda *_a, **_k: 100)
+    monkeypatch.setattr(agent_service, "_count_model_messages", lambda *_a, **_k: 95)
+    monkeypatch.setattr(agent_service, "count_tokens_messages", lambda *_a, **_k: 20)
+    monkeypatch.setattr(agent_service, "estimate_tokens", lambda *_a, **_k: 0)
     service.run_turn(
         conversation_id="c",
         messages=[{"role": "user", "content": "question"}],
@@ -1217,7 +1221,10 @@ def test_disabled_session_does_not_consult_registry(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_project_instruction_disable_terminalizes_and_allows_retry(tmp_path):
+@pytest.mark.parametrize("ephemeral", [True, False])
+async def test_project_instruction_disable_terminalizes_and_allows_retry(
+    tmp_path, ephemeral
+):
     """Disabling unavailable instructions must not strand the Console run."""
 
     registry = LocalWorkspaceRegistryService(
@@ -1227,7 +1234,7 @@ async def test_project_instruction_disable_terminalizes_and_allows_retry(tmp_pat
     store = persisted_console_store(
         db_path=tmp_path / "chat.db", workspace_registry=registry
     )
-    session = store.create_session(workspace_id="w1")
+    session = store.create_session(workspace_id="w1", ephemeral=ephemeral)
     store.set_session_project_instruction_state(
         session.id,
         ProjectInstructionControlState(
@@ -1278,13 +1285,26 @@ async def test_project_instruction_disable_terminalizes_and_allows_retry(tmp_pat
 
     first = await controller.submit_draft("first")
 
-    assert first.accepted is False
-    assert first.visible_copy == "project_instructions_disabled"
+    assert first.accepted is (not ephemeral)
+    assert first.visible_copy == (
+        "project_instructions_disabled"
+        if ephemeral
+        else "Accepted turn is retained for recovery."
+    )
     assert session.project_instruction_state == (
         ProjectInstructionControlState.legacy_disabled()
     )
     assert controller.run_state_for(session.id).status is ConsoleRunStatus.BLOCKED
     assert bridge_calls == []
+
+    if not ephemeral:
+        # Durable acceptance owns the pending response until explicit recovery.
+        blocked = await controller.submit_draft("premature retry")
+        assert blocked.accepted is False
+        assert bridge_calls == []
+        assert store.dispatch_recovery_for_session(session.id) is not None
+        await controller.discard_dispatch_recovery(session.id)
+        assert store.dispatch_recovery_for_session(session.id) is None
 
     second = await controller.submit_draft("second")
 

--- a/Tests/Chat/test_console_project_setup_refusal.py
+++ b/Tests/Chat/test_console_project_setup_refusal.py
@@ -1,0 +1,117 @@
+"""Recovery decisions release a real Console send without provider dispatch."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.console_provider_doubles import persisted_console_store, with_destination
+from tldw_chatbook.Agents.agent_models import RUN_DONE, RunOutcome
+from tldw_chatbook.Chat.console_chat_controller import (
+    ConsoleChatController,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_project_instructions import (
+    ProjectInstructionControlState,
+)
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("decision", ["disable", "cancel", "unavailable"])
+@pytest.mark.parametrize("ephemeral", [True, False])
+async def test_setup_recovery_releases_run_and_excludes_unsent_echo(
+    tmp_path, decision, ephemeral
+):
+    """Disabling unavailable instructions must not strand the Console run."""
+
+    registry = LocalWorkspaceRegistryService(
+        WorkspaceDB(tmp_path / "workspaces.db", client_id="instruction-disable")
+    )
+    registry.create_workspace(workspace_id="w1", name="Workspace 1")
+    store = persisted_console_store(
+        db_path=tmp_path / "chat.db", workspace_registry=registry
+    )
+    session = store.create_session(workspace_id="w1", ephemeral=ephemeral)
+    store.set_session_project_instruction_state(
+        session.id,
+        ProjectInstructionControlState(
+            project_instructions_enabled=True,
+            working_folder_binding_id="removed-binding",
+            working_folder_locator_fingerprint="f" * 64,
+        ),
+    )
+    provider_calls = []
+    bridge_calls = []
+
+    class Gateway:
+        async def resolve_for_send(self, _selection):
+            provider_calls.append(True)
+            return with_destination(
+                ConsoleProviderResolution(
+                    provider="OpenAI",
+                    base_url="http://127.0.0.1:18991/v1",
+                    model="gpt-4o-mini",
+                    ready=True,
+                    readiness_key="openai",
+                    execution_key="openai",
+                    max_tokens=128,
+                )
+            )
+
+    class Bridge:
+        def run_reply(self, **_kwargs):
+            bridge_calls.append(True)
+            return "run-1", RunOutcome(status=RUN_DONE, steps=[], final_text="done")
+
+    async def disable(_session_id, _options, _recovery_code):
+        return decision, None
+
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=Gateway(),
+        provider="openai",
+        model="gpt-4o-mini",
+        agent_bridge=Bridge(),
+        agent_runtime_enabled=True,
+        select_project_instruction_binding=None
+        if decision == "unavailable"
+        else disable,
+    )
+    controller.app = SimpleNamespace(
+        workspace_registry_service=registry,
+        call_from_thread=lambda callback: callback(),
+    )
+
+    first = await controller.submit_draft("first")
+
+    assert controller.run_state_for(session.id).status is ConsoleRunStatus.BLOCKED
+    assert bridge_calls == []
+
+    messages = store.messages_for_session(session.id)
+    assert not controller.activity_for(session.id).occupies_slot
+    if decision == "disable":
+        assert not session.project_instruction_state.project_instructions_enabled
+
+    if ephemeral:
+        assert (
+            next(m for m in messages if m.role is ConsoleMessageRole.ASSISTANT).status
+            == "failed"
+        )
+        assert not first.accepted
+        assert not first.should_clear_draft
+        assert (
+            next(m for m in messages if m.role is ConsoleMessageRole.USER).status
+            == "failed"
+        )
+        assert all(
+            m["content"] != "first"
+            for m in controller._provider_messages_for_session(session.id)
+        )
+    else:
+        # Current dev retains durably accepted turns for recovery rather than
+        # refunding them into a composer that could submit a duplicate.
+        assert first.accepted
+        assert store.dispatch_recovery_for_session(session.id) is not None

--- a/Tests/Persona_Visual/test_persona_visual_publication.py
+++ b/Tests/Persona_Visual/test_persona_visual_publication.py
@@ -445,22 +445,10 @@ def test_final_file_content_mutation_inside_authority_guard_is_rejected(
     assert repository.get_active_persona_pack(snapshot.persona_id) is None
 
 
-@pytest.mark.parametrize(
-    "layout", ("same", "profile_inside_source", "source_inside_profile")
-)
-def test_profile_and_package_root_overlap_is_rejected(
-    tmp_path: Path, layout: str
-) -> None:
-    root = tmp_path / "root"
-    root.mkdir()
-    if layout == "same":
-        source_root = profile_root = root
-    elif layout == "profile_inside_source":
-        source_root, profile_root = root, root / "profile"
-        profile_root.mkdir()
-    else:
-        profile_root, source_root = root, root / "source"
-        source_root.mkdir()
+def test_profile_inside_external_source_is_rejected(tmp_path: Path) -> None:
+    source_root = tmp_path / "source"
+    profile_root = source_root / "profile"
+    profile_root.mkdir(parents=True)
     db = CharactersRAGDB(tmp_path / "overlap.db", "overlap")
     repository = PersonaVisualRepository(db)
     try:
@@ -1038,3 +1026,153 @@ def test_publication_and_cleanup_fail_closed_without_posix_descriptor_guards(
             "persona_visual/packs/" + "a" * 32 + "/versions/" + "b" * 32,
             profile_root=profile_root,
         )
+
+
+@pytest.mark.parametrize("layout", ("profile", "import_staging"))
+def test_profile_owned_sources_publish_without_mutating_originals(environment, layout):
+    repository, _external, profile = environment
+    source = (
+        profile if layout == "profile" else profile / "persona_visual/imports/review"
+    )
+    source.mkdir(parents=True, exist_ok=True)
+    key = (
+        "persona_visual/drafts/review/idle.png"
+        if layout == "profile"
+        else "assets/idle.png"
+    )
+    snapshot = _snapshot(source, source_storage_key=key)
+    original = (source / key).read_bytes()
+
+    result = publish_persona_visual(
+        repository,
+        snapshot,
+        source_root=source,
+        profile_root=profile,
+        authority_guard=lambda: True,
+    )
+
+    active = repository.get_active_persona_pack(snapshot.persona_id)
+    assert active.identity == result.new_identity
+    stored = (
+        repository.db.get_connection()
+        .execute("SELECT storage_relpath FROM persona_visual_assets")
+        .fetchone()[0]
+    )
+    assert (profile / stored).read_bytes() == original
+    assert (source / key).read_bytes() == original
+
+
+def test_edit_republishes_profile_owned_active_version_without_mutation(environment):
+    repository, external, profile = environment
+    snapshot = _snapshot(external)
+    first = _publish(environment, snapshot)
+    storage_key = (
+        repository.db.get_connection()
+        .execute("SELECT storage_relpath FROM persona_visual_assets")
+        .fetchone()[0]
+    )
+    original = (profile / storage_key).read_bytes()
+    updated = replace(
+        snapshot,
+        expected_identity=first.new_identity,
+        manifest_json=json.dumps(
+            _manifest(frame_rate=2), sort_keys=True, separators=(",", ":")
+        ),
+        assets=(replace(snapshot.assets[0], source_storage_key=storage_key),),
+    )
+
+    second = publish_persona_visual(
+        repository,
+        updated,
+        source_root=profile,
+        profile_root=profile,
+        authority_guard=lambda: True,
+    )
+
+    active = repository.get_active_persona_pack(snapshot.persona_id)
+    assert active.identity == second.new_identity
+    assert second.new_identity != first.new_identity
+    assert (profile / storage_key).read_bytes() == original
+    stored_assets = (
+        repository.db.get_connection()
+        .execute("SELECT storage_relpath FROM persona_visual_assets")
+        .fetchall()
+    )
+    assert len(stored_assets) == 2
+    assert all((profile / row[0]).read_bytes() == original for row in stored_assets)
+
+
+@pytest.mark.parametrize("mutation", ("directory", "file", "symlink"))
+def test_profile_owned_source_substitution_cannot_activate(environment, mutation):
+    repository, _source_root, profile_root = environment
+    source_key = "persona_visual/drafts/review/assets/idle.png"
+    snapshot = _snapshot(profile_root, source_storage_key=source_key)
+    original = profile_root / source_key
+    original_data = original.read_bytes()
+    changed = False
+
+    def substitute_source():
+        nonlocal changed
+        if not changed:
+            changed = True
+            if mutation == "directory":
+                original.parent.rename(original.parent.with_name("displaced"))
+                original.parent.mkdir()
+                original.write_bytes(original_data)
+            elif mutation == "file":
+                original.unlink()
+                original.write_bytes(_png_bytes((7, 8, 9)))
+            else:
+                original.rename(original.with_suffix(".old"))
+                original.symlink_to(original.with_suffix(".old").name)
+        return True
+
+    with pytest.raises(PersonaVisualPublicationError, match="publication_denied"):
+        publish_persona_visual(
+            repository,
+            snapshot,
+            source_root=profile_root,
+            profile_root=profile_root,
+            authority_guard=substitute_source,
+        )
+    assert changed  # Ensure the rejection reached the source revalidation guard.
+    assert repository.get_active_persona_pack(snapshot.persona_id) is None
+
+
+@pytest.mark.parametrize("alias", ("source_root", "source_component", "destination"))
+def test_profile_owned_publication_rejects_symlink_escape(environment, alias):
+    repository, outside, profile = environment
+    source_key = "persona_visual/drafts/review/idle.png"
+    snapshot = _snapshot(profile, source_storage_key=source_key)
+    source = profile
+    (outside / "sentinel").write_bytes(b"unchanged")
+    if alias == "source_root":
+        source = profile.parent / "profile-alias"
+        source.symlink_to(profile, target_is_directory=True)
+    elif alias == "source_component":
+        directory = (profile / source_key).parent
+        directory.rename(outside / "review")
+        directory.symlink_to(outside / "review", target_is_directory=True)
+    else:
+        (profile / "persona_visual/packs").symlink_to(outside, target_is_directory=True)
+    before = {
+        str(path.relative_to(outside)): path.read_bytes()
+        for path in outside.rglob("*")
+        if path.is_file()
+    }
+    with pytest.raises(PersonaVisualPublicationError) as caught:
+        publish_persona_visual(
+            repository,
+            snapshot,
+            source_root=source,
+            profile_root=profile,
+            authority_guard=lambda: True,
+        )
+    assert str(profile) not in str(caught.value)
+    assert str(outside) not in str(caught.value)
+    assert repository.get_active_persona_pack(snapshot.persona_id) is None
+    assert {
+        str(path.relative_to(outside)): path.read_bytes()
+        for path in outside.rglob("*")
+        if path.is_file()
+    } == before

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -55,7 +55,10 @@ _BUNDLED_STYLESHEET = _REPO_ROOT / "tldw_chatbook/css/tldw_cli_modular.tcss"
 class _ComposerCSSApp(ConsolidatedCSSApp):
     """Mount the composer with the production stylesheet for visual assertions."""
 
-    CSS_PATH = str(_BUNDLED_STYLESHEET)
+    CSS_PATH = [
+        str(_BUNDLED_STYLESHEET),
+        str(_REPO_ROOT / "tldw_chatbook/css/screen_agentic_console.tcss"),
+    ]
 
     def compose(self) -> ComposeResult:
         yield ConsoleComposerBar(id="console-native-composer")
@@ -363,6 +366,9 @@ async def test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns(
             console = await _mounted_console(host, pilot)
             composer = console.query_one("#console-native-composer", ConsoleComposerBar)
 
+            reason_was_visible = composer.query_one(
+                "#console-send-disabled-reason"
+            ).display
             await pilot.click("#console-dictation")
             deadline = time.monotonic() + 4
             while (
@@ -375,10 +381,10 @@ async def test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns(
 
             actions = composer.query_one("#console-composer-actions")
             mic = composer.query_one("#console-dictation", Button)
-            assert "Local transcription busy — dictation will run next." in _painted(
+            assert "Local transcription busy — queued." in _painted(
                 composer.query_one("#console-voice-status", Static)
             )
-            assert actions.region.width == 25
+            assert actions.region.width == 33
             assert actions.region.right <= composer.region.right <= host.size.width
             assert mic.region.right <= composer.region.right
             assert mic.visible
@@ -408,7 +414,10 @@ async def test_busy_parakeet_mic_stays_reachable_and_cancels_at_80_columns(
             assert composer.query_one("#console-composer-collapse").display
             assert composer.query_one("#console-composer-menu").display
             assert composer.query_one("#console-command-visible-text").display
-            assert composer.query_one("#console-send-disabled-reason").display
+            assert (
+                composer.query_one("#console-send-disabled-reason").display
+                == reason_was_visible
+            )
     finally:
         service.start_gate.set()
 
@@ -444,7 +453,7 @@ async def test_busy_parakeet_mic_stays_reachable_with_staged_attachments(
             assert "2 files" in _painted(indicator)
             assert clear_button.display
             assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
-            assert actions.region.width == 29
+            assert actions.region.width == 37
 
             mic = composer.query_one("#console-dictation", Button)
             mic.press()
@@ -460,12 +469,12 @@ async def test_busy_parakeet_mic_stays_reachable_with_staged_attachments(
             console._sync_console_composer_action_state(can_save_chatbook=False)
             await pilot.pause()
 
-            assert "Local transcription busy — dictation will run next." in _painted(
+            assert "Local transcription busy — queued." in _painted(
                 composer.query_one("#console-voice-status", Static)
             )
             assert not indicator.display
             assert not clear_button.display
-            assert actions.region.width == 25
+            assert actions.region.width == 33
             assert actions.region.right <= composer.region.right <= host.size.width
             assert mic.region.right <= composer.region.right
             click_offset = (
@@ -488,7 +497,7 @@ async def test_busy_parakeet_mic_stays_reachable_with_staged_attachments(
             assert indicator.display
             assert clear_button.display
             assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
-            assert actions.region.width == 29
+            assert actions.region.width == 37
     finally:
         service.start_gate.set()
 

--- a/Tests/UI/test_console_dictation_streaming.py
+++ b/Tests/UI/test_console_dictation_streaming.py
@@ -3098,7 +3098,7 @@ async def test_read_that_back_speaks_the_last_completed_assistant_reply(monkeypa
                 await pilot.pause(0.01)
             # Blocked mid-flight: nothing must have been spoken yet.
             assert not any(
-                call.args[0].__class__.__name__ == "TTSRequestEvent"
+                call.args[0].__class__.__name__ == "TTSMessageSpeechRequestEvent"
                 for call in app.post_message.call_args_list
             )
 
@@ -3112,13 +3112,14 @@ async def test_read_that_back_speaks_the_last_completed_assistant_reply(monkeypa
                     (
                         call.args[0]
                         for call in app.post_message.call_args_list
-                        if call.args[0].__class__.__name__ == "TTSRequestEvent"
+                        if call.args[0].__class__.__name__
+                        == "TTSMessageSpeechRequestEvent"
                     ),
                     None,
                 )
 
             assert spoken_event is not None
-            assert spoken_event.text == "The answer is 42."
+            assert spoken_event.snapshot.raw_content == "The answer is 42."
             assert spoken_event.message_id == message.id
             assert console._console_speaking_message_id == message.id
     finally:
@@ -3927,7 +3928,11 @@ async def test_read_that_back_speech_is_unaffected_by_spoken_feedback_toggle_on(
         spoken: list[str] = []
         while time.monotonic() < deadline and not spoken:
             await pilot.pause(0.01)
-            spoken = _spoken_texts(app.post_message)
+            spoken = [
+                call.args[0].snapshot.raw_content
+                for call in app.post_message.call_args_list
+                if call.args[0].__class__.__name__ == "TTSMessageSpeechRequestEvent"
+            ]
 
         assert spoken == ["The answer is 42."]
         assert console._console_speaking_message_id == message.id

--- a/Tests/UI/test_console_readback_lifecycle.py
+++ b/Tests/UI/test_console_readback_lifecycle.py
@@ -1,0 +1,40 @@
+"""Read-back must use the same trusted lifecycle as manual Console Speak."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from Tests.UI.test_console_dictation import _mounted_console, _ready_host
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSMessageSpeechRequestEvent,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_state", ["stopped", "failed"])
+async def test_readback_settles_console_speaking_with_owned_playback(terminal_state):
+    app, host = _ready_host()
+    app.post_message = Mock()
+    async with host.run_test(size=(140, 42)) as pilot:
+        screen = await _mounted_console(host, pilot)
+        store = screen._ensure_console_chat_store()
+        message = store.append_message(
+            store.active_session_id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="The blue notebook is ready.",
+        )
+        await screen._console_read_last_response_back()
+        events = [call.args[0] for call in app.post_message.call_args_list]
+        requests = [
+            event for event in events if isinstance(event, TTSMessageSpeechRequestEvent)
+        ]
+        assert len(requests) == 1, "Read-back bypassed trusted message speech"
+        request = requests[0]
+        assert request.validator(request.snapshot) == message.content
+        assert request.snapshot.message_id == message.id
+        assert screen._console_speaking_message_id == message.id
+        assert request.playback_lifecycle.report("playing")
+        assert request.playback_lifecycle.report(terminal_state)
+        assert screen._console_speaking_message_id is None
+        assert screen._message._console_speech_states[message.id] == terminal_state

--- a/Tests/UI/test_console_readback_lifecycle.py
+++ b/Tests/UI/test_console_readback_lifecycle.py
@@ -9,12 +9,18 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSMessageSpeechRequestEvent,
 )
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
 
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("terminal_state", ["stopped", "failed"])
-async def test_readback_settles_console_speaking_with_owned_playback(terminal_state):
+@pytest.mark.parametrize("stale_context", [False, True])
+async def test_readback_settles_console_speaking_with_owned_playback(
+    terminal_state, stale_context
+):
     app, host = _ready_host()
+    buddy = PersonaBuddyController()
+    app.persona_buddy_controller = buddy
     app.post_message = Mock()
     async with host.run_test(size=(140, 42)) as pilot:
         screen = await _mounted_console(host, pilot)
@@ -34,7 +40,19 @@ async def test_readback_settles_console_speaking_with_owned_playback(terminal_st
         assert request.validator(request.snapshot) == message.content
         assert request.snapshot.message_id == message.id
         assert screen._console_speaking_message_id == message.id
+        assert buddy.snapshot().state == "idle"
         assert request.playback_lifecycle.report("playing")
-        assert request.playback_lifecycle.report(terminal_state)
-        assert screen._console_speaking_message_id is None
-        assert screen._message._console_speech_states[message.id] == terminal_state
+        assert buddy.snapshot().state == "speaking"
+        if stale_context:
+            store.switch_session(store.create_session().id)
+            sink = app.console_runtime.persona_buddy_sink
+            sink.voice_state("other-session", 42, "listening")
+            assert not request.playback_lifecycle.is_current()
+            assert request.playback_lifecycle.report_terminal(terminal_state)
+            assert buddy.snapshot().state == "listening"
+            sink.release_voice("other-session", 42)
+        else:
+            assert request.playback_lifecycle.report(terminal_state)
+            assert screen._console_speaking_message_id is None
+            assert screen._message._console_speech_states[message.id] == terminal_state
+        assert buddy.snapshot().state == "idle"

--- a/Tests/UI/test_console_send_draft_snapshot.py
+++ b/Tests/UI/test_console_send_draft_snapshot.py
@@ -603,3 +603,47 @@ async def test_setup_refusal_does_not_restore_consumed_stash_into_other_visible_
         monkeypatch.setattr(controller, "run_prompt_chain", refuse_after_setup)
         await console._submit_console_native_draft("A private draft", session.id)
         assert composer.draft_text() == "B private draft"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("keyboard", [False, True])
+@pytest.mark.parametrize("accepted", [False, True])
+async def test_post_acceptance_refusal_restores_undo_redo_only_for_unsent_draft(
+    monkeypatch, keyboard, accepted
+):
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        controller = console._ensure_console_chat_controller()
+        session = controller.store.ensure_session()
+        console._session._sync_console_session_draft()
+        composer.insert_text("original")
+        composer.insert_text(" draft")
+        composer.insert_text(" extra")
+        assert composer.undo()
+        assert composer.draft_text() == "original draft"
+        if keyboard:
+            console._console_inflight_send_stashes[session.id] = (
+                composer.stash_draft_for_send()
+            )
+
+        async def finish_after_setup(draft, *, session_id=None):
+            controller.on_submission_accepted()
+            return ConsoleSubmitResult(accepted, False, "Setup result")
+
+        monkeypatch.setattr(controller, "run_prompt_chain", finish_after_setup)
+        await console._submit_console_native_draft("original draft", session.id)
+        if accepted:
+            assert composer.draft_text() == ""
+            assert not composer.undo()
+            assert not composer.redo()
+        else:
+            assert composer.draft_text() == "original draft"
+            assert composer.redo()
+            assert composer.draft_text() == "original draft extra"
+            assert composer.undo()
+            assert composer.undo()
+            assert composer.draft_text() == "original"

--- a/Tests/UI/test_console_send_draft_snapshot.py
+++ b/Tests/UI/test_console_send_draft_snapshot.py
@@ -522,3 +522,77 @@ async def test_console_send_watchdog_is_a_noop_once_the_stash_is_consumed():
         # Nothing resurrected: the composer stays exactly as the normal
         # accept/refuse path already left it.
         assert composer.draft_text() == ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "keyboard,late_text",
+    [(False, ""), (False, "new draft"), (True, ""), (True, "new draft")],
+)
+async def test_setup_refusal_after_acceptance_preserves_draft(
+    monkeypatch, keyboard, late_text
+):
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        controller = console._ensure_console_chat_controller()
+        session = controller.store.ensure_session()
+        console._session._sync_console_session_draft()
+        composer.load_draft("original draft")
+        if keyboard:
+            console._console_inflight_send_stashes[session.id] = (
+                composer.stash_draft_for_send()
+            )
+
+        async def refuse_after_setup(draft, *, session_id=None):
+            controller.on_submission_accepted()
+            if late_text:
+                composer.insert_text(late_text)
+            return ConsoleSubmitResult(False, False, "Setup cancelled")
+
+        monkeypatch.setattr(controller, "run_prompt_chain", refuse_after_setup)
+        await console._submit_console_native_draft("original draft", session.id)
+        expected = (
+            "original draft" + late_text
+            if keyboard
+            else (late_text or "original draft")
+        )
+        assert composer.draft_text() == expected
+
+
+@pytest.mark.asyncio
+async def test_setup_refusal_does_not_restore_consumed_stash_into_other_visible_draft(
+    monkeypatch,
+):
+    from unittest.mock import AsyncMock
+
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-composer")
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        controller = console._ensure_console_chat_controller()
+        session = controller.store.ensure_session()
+        console._session._sync_console_session_draft()
+        composer.load_draft("A private draft")
+        console._console_inflight_send_stashes[session.id] = (
+            composer.stash_draft_for_send()
+        )
+
+        async def refuse_after_setup(draft, *, session_id=None):
+            controller.on_submission_accepted()
+            # A remains store-active while the composer already presents B.
+            composer.load_draft("B private draft")
+            console._console_visible_draft_session_id = "other-session"
+            return ConsoleSubmitResult(False, False, "Setup cancelled")
+
+        # Hold the session-switch presentation gap while observing the refusal;
+        # the ordinary final sync would finish that transition and replace B.
+        monkeypatch.setattr(console, "_sync_native_console_chat_ui", AsyncMock())
+        monkeypatch.setattr(controller, "run_prompt_chain", refuse_after_setup)
+        await console._submit_console_native_draft("A private draft", session.id)
+        assert composer.draft_text() == "B private draft"

--- a/Tests/UI/test_console_send_draft_snapshot.py
+++ b/Tests/UI/test_console_send_draft_snapshot.py
@@ -45,6 +45,13 @@ async def _wait_for_text(console, pilot, needle: str, tries: int = 40) -> None:
 
 def _ready_openai_app(monkeypatch, reply: str):
     app = _build_console_send_test_app()
+    # This in-memory composer harness has no durable trace repository.
+    # Exercise ordinary sending with the supported capture-off setting.
+    from tldw_chatbook import config as config_module
+
+    assert config_module.save_settings_to_cli_config(
+        {"console": {"exchange_capture": False}}
+    )
     _persist_console_provider_config(
         app,
         provider="openai",

--- a/Tests/UI/test_console_voice_chip.py
+++ b/Tests/UI/test_console_voice_chip.py
@@ -25,12 +25,10 @@ class ComposerApp(App):
 class ProductionCssComposerApp(ComposerApp):
     """Mount the composer with the generated production stylesheet."""
 
-    CSS_PATH = str(
-        Path(__file__).resolve().parents[2]
-        / "tldw_chatbook"
-        / "css"
-        / "tldw_cli_modular.tcss"
-    )
+    CSS_PATH = [
+        str(Path(__file__).resolve().parents[2] / "tldw_chatbook/css" / name)
+        for name in ("tldw_cli_modular.tcss", "screen_agentic_console.tcss")
+    ]
 
 
 def _visible(widget) -> bool:
@@ -224,17 +222,19 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
         mic = composer.query_one("#console-dictation")
         idle_action_width = actions.region.width
         idle_mic_width = mic.region.width
-        assert all(_visible(widget) for widget in presentation)
+        visibility_before = tuple(_visible(widget) for widget in presentation)
+        assert all(visibility_before[:3])
 
         composer.sync_dictation_state("starting")
         composer.set_voice_preparing_message(message)
         await pilot.pause()
         chip = composer.query_one("#console-voice-status", Static)
 
-        assert message in _painted(chip)
+        assert "Local transcription busy — queued." in _painted(chip)
+        assert str(chip.tooltip) == message
         assert _visible(chip)
         assert all(not _visible(widget) for widget in presentation)
-        assert idle_action_width == 25
+        assert idle_action_width == 33
         assert actions.region.width == idle_action_width
         assert mic.region.width == idle_mic_width
         assert actions.region.right <= composer.region.right <= app.size.width
@@ -245,13 +245,14 @@ async def test_busy_dictation_copy_uses_the_existing_chip_and_clears_at_idle():
         # An ordinary control-bar refresh must not erase the busy status.
         composer.sync_dictation_state("starting")
         await pilot.pause()
-        assert message in _painted(chip)
+        assert "Local transcription busy — queued." in _painted(chip)
+        assert str(chip.tooltip) == message
 
         composer.sync_dictation_state("idle")
         await pilot.pause()
         assert chip.styles.width.value == 0
         assert _painted(chip) == ""
-        assert all(_visible(widget) for widget in presentation)
+        assert tuple(_visible(widget) for widget in presentation) == visibility_before
 
 
 @pytest.mark.asyncio
@@ -308,7 +309,7 @@ async def test_busy_presentation_suppresses_and_restores_staged_attachment():
         assert _visible(indicator)
         assert _visible(clear_button)
         assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
-        assert actions.region.width == 29
+        assert actions.region.width == 37
 
         composer.set_voice_status(
             STATE_PREPARING,
@@ -321,7 +322,7 @@ async def test_busy_presentation_suppresses_and_restores_staged_attachment():
 
         assert not _visible(indicator)
         assert not _visible(clear_button)
-        assert actions.region.width == 25
+        assert actions.region.width == 33
         assert "2 files" in str(indicator.renderable)
         assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
 
@@ -340,13 +341,13 @@ async def test_busy_presentation_suppresses_and_restores_staged_attachment():
         assert _visible(indicator)
         assert _visible(clear_button)
         assert str(clear_button.tooltip) == "Remove all 2 pending attachments."
-        assert actions.region.width == 29
+        assert actions.region.width == 37
 
         composer.set_pending_attachment_label(None)
         await pilot.pause()
         assert not _visible(indicator)
         assert not _visible(clear_button)
-        assert actions.region.width == 25
+        assert actions.region.width == 33
 
 
 @pytest.mark.asyncio
@@ -363,8 +364,9 @@ async def test_production_css_busy_status_stays_meaningful_at_narrow_width():
 
         chip = composer.query_one("#console-voice-status", Static)
         painted = _painted(chip)
-        assert painted.startswith("Local trans")
-        assert painted.endswith("…")
+        assert painted == "Queued"
+        assert str(chip.tooltip) == "Local transcription busy — dictation will run next."
+        assert composer.query_one("#console-dictation").region.right <= app.size.width
         assert _visible(chip)
         assert chip.region.x + chip.region.width <= composer.region.right
 

--- a/Tests/UI/test_llm_deferred_views.py
+++ b/Tests/UI/test_llm_deferred_views.py
@@ -272,3 +272,33 @@ async def test_inactive_view_compose_cannot_stall_models_navigation(monkeypatch)
         assert screen.query_one("#llamacpp-start-server-button").is_mounted
         assert gaps
         assert max(gaps) < 0.25, f"event loop stalled for {max(gaps):.3f}s"
+
+
+@pytest.mark.parametrize(
+    "view_name,expected", [("ollama", "ollama"), ("private-view-token", "unknown")]
+)
+async def test_lazy_mount_failure_logs_only_bounded_view_context(
+    monkeypatch, view_name, expected
+):
+    from loguru import logger
+
+    window = LLMManagementWindow(_build_test_app())
+    records = []
+
+    async def fail_mount(_view_name):
+        raise RuntimeError("private-provider-secret")
+
+    monkeypatch.setattr(window, "_mount_deferred_views", fail_mount)
+    sink = logger.add(lambda message: records.append(message.record))
+    try:
+        await window._activate_deferred_view(view_name)
+    finally:
+        logger.remove(sink)
+    failures = [
+        r for r in records if r["message"].startswith("Lazy LLM view mount failed")
+    ]
+    assert len(failures) == 1
+    assert failures[0]["message"].endswith("view=" + expected)
+    assert failures[0]["exception"] is None
+    assert "private-provider-secret" not in str(failures[0])
+    assert "private-view-token" not in str(failures[0])

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -2398,3 +2398,50 @@ async def test_pending_geometry_write_is_flushed_on_unmount():
         await buddy.remove()
         await _wait_until(lambda: controller.persisted)
         assert controller.persisted[-1].geometry == expected
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mode", ("drag", "resize"))
+@pytest.mark.parametrize("intermediate_move", (False, True))
+async def test_native_mouse_release_commits_final_geometry(mode, intermediate_move):
+    """The terminal may report a newer release position than its last move."""
+    from textual._xterm_parser import XTermParser
+
+    controller = _FakeController()
+    controller.preferences = replace(
+        controller.preferences,
+        geometry=PersonaBuddyGeometry(x=10, y=5, width=28, height=12),
+    )
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(100, 36)) as pilot:
+        await pilot.pause()
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        parser = XTermParser()
+        if mode == "drag":
+            x, y = buddy.content_region.x + 5, buddy.content_region.y + 3
+            dx, dy = -4, -2
+            expected = PersonaBuddyGeometry(x=6, y=3, width=28, height=12)
+        else:
+            x, y = buddy.region.right - 1, buddy.region.bottom - 1
+            dx, dy = 4, 2
+            expected = PersonaBuddyGeometry(x=10, y=5, width=32, height=14)
+
+        async def forward(buttons, px, py, suffix):
+            event = parser.parse_mouse_code(
+                f"\x1b[<{buttons};{px + 1};{py + 1}{suffix}"
+            )
+            assert event is not None and event.widget is None
+            app.screen._forward_event(event)
+            await pilot.pause()
+
+        await forward(0, x, y, "M")
+        assert app.mouse_captured is buddy
+        if intermediate_move:
+            await forward(32, x + dx // 2, y + dy // 2, "M")
+        assert controller.persisted == []
+        await forward(0, x + dx, y + dy, "m")
+        await _wait_until(lambda: len(controller.persisted) == 1)
+        assert app.mouse_captured is None
+        assert controller.persisted[0].geometry == expected
+        if mode == "drag":
+            assert (buddy.region.x, buddy.region.y) == (6, 3)

--- a/Tests/Utils/test_path_validation.py
+++ b/Tests/Utils/test_path_validation.py
@@ -296,3 +296,41 @@ class TestValidatePathAllowHidden:
 
         with pytest.raises(ValueError, match="outside"):
             validate_path("../escape", tmp_path, allow_hidden=True)
+
+
+class TestCanonicalDirectory:
+    def test_accepts_existing_hidden_canonical_directory(self, tmp_path):
+        from tldw_chatbook.Utils.path_validation import validate_canonical_directory
+
+        root = tmp_path.resolve() / ".private"
+        root.mkdir()
+        assert validate_canonical_directory(root) == root
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["relative", "dotdot", "symlink", "file", "missing", "null", "trailing-slash"],
+    )
+    def test_rejects_noncanonical_or_nondirectory_roots_without_path_content(
+        self, tmp_path, kind
+    ):
+        from tldw_chatbook.Utils.path_validation import validate_canonical_directory
+
+        root = tmp_path.resolve()
+        target = root / "private-token"
+        target.mkdir()
+        alias = root / "alias"
+        alias.symlink_to(target, target_is_directory=True)
+        file = root / "file"
+        file.write_text("fixture")
+        value = {
+            "relative": "private-token",
+            "dotdot": str(target) + "/../private-token",
+            "symlink": str(alias),
+            "file": str(file),
+            "missing": str(root / "missing-private-token"),
+            "null": "private-token\x00",
+            "trailing-slash": str(target) + "/",
+        }[kind]
+        with pytest.raises(ValueError) as error:
+            validate_canonical_directory(value)
+        assert "private-token" not in str(error.value)

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -2003,3 +2003,18 @@ app-tests with a stubbed resolver and generator instead, and the PR body says so
 - Do not kill other sessions' runs to free the semaphores. Either wait for them to finish
   or reboot; until then, substitute app-tests and state the gap in the PR — never report a
   live verification you could not run.
+
+## Playback cleanup does not prove the Buddy received playback state
+
+**PR #2404 / TASK-31585, 2026-09-05.** After rebasing onto dev, trusted
+readback lifecycle tests passed and real Kokoro drained 128,000 PCM bytes, but
+Migu stayed idle throughout. Manual Speak correctly tracked its own presentation
+while only the realtime loop published Buddy voice leases. Connecting the
+existing trusted playback callbacks to a unique request-owned lease produced
+idle → speaking → idle in the real replay; stale-session terminal tests also
+proved that cleanup preserves another voice owner.
+
+**What to do.** Observe the actual Buddy controller and rendered availability
+alongside audio completion. A successful sink and cleared speaking-message ID
+prove audio ownership, not delivery to a separate visual state consumer. Re-run
+from the current PR tree: older live evidence can exercise a superseded host.

--- a/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
+++ b/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
@@ -1,0 +1,40 @@
+---
+id: TASK-31585
+title: Close remaining Migu Buddy UAT interaction and voice gaps
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-05 03:32'
+updated_date: '2026-09-05 03:48'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Port the remaining reproducible Buddy UAT fixes onto current dev while preserving its newer Buddy, Console, and governance architecture.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Native Buddy move and resize commit final release coordinates when mouse-move events are coalesced.
+- [x] #2 Read-back uses trusted Console speech and clears presentation after playback completion or failure.
+- [x] #3 Project-instruction recovery refusal releases the run and preserves the unsent draft without replacing newer edits.
+- [x] #4 Diagnostic inventory excludes nested virtual environments while retaining application modules.
+- [x] #5 Persona Visual import and edit publication succeeds without weakening file identity and containment checks.
+- [ ] #6 Targeted tests and scoped static checks pass on the actual PR tree; earlier live evidence and remaining OpenAI credential limitation are clearly distinguished.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+Compare older UAT changes with current dev, port only unsuperseded fixes with failing seam regressions, run targeted tests and governance checks, review the final diff, and create a PR against dev. ADR required: no new ADR. Existing ADR-074 Persona Visual/Buddy, ADR-037 trusted speech, ADR-069 project instructions, and ADR-029 private diagnostics govern the repairs; no new ownership boundary or storage schema.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Ported only remaining UAT fixes onto dev 68f9d865: final-release Buddy geometry, profile-owned publication, trusted readback lifecycle, setup terminalization and transient echo exclusion, visible-owner-fenced draft restoration, nested environment pruning, and two metadata-only lifecycle diagnostics. Existing ADR-074/037/069/029 apply. Native/publication/importer 171 passed; independent focused review 15 passed; final focused selection 23 passed. Broader targeted runs have 6 Console and 2 diagnostic failures, all reproduced on pristine base, alongside the existing Library Iterable F821; retain AC6 and In Progress status and publish draft PR. Evidence, exact limits and earlier hardware provenance: qa/buddy-uat-2026-09-05/README.md. No unrelated dirty-checkout work included.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
+++ b/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-05 03:32'
-updated_date: '2026-09-05 04:29'
+updated_date: '2026-09-05 04:56'
 labels: []
 dependencies: []
 priority: high
@@ -28,6 +28,8 @@ Port the remaining reproducible Buddy UAT fixes onto current dev while preservin
 - [x] #7 Real Manual Speak and readback playback makes Buddy speaking only during playback, releases on terminal acknowledgement after context changes, and preserves another voice owner.
 - [x] #8 At 80 columns a busy local transcription keeps the microphone reachable for cancel and preserves attachments; unavailable microphone state is visually distinct and remains clickable to retry.
 - [ ] #9 Final native dragging and OpenAI realtime UAT are verified on the PR branch with an application-configured credential.
+- [x] #10 Post-acceptance refusal preserves undo and redo for unchanged visible drafts without making successfully sent content undoable.
+- [x] #11 Publication roots use centralized path validation with existing canonical-directory and descriptor safeguards preserved, and lazy mount errors retain safe view context only.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -40,10 +42,16 @@ Rebased first onto dev b52080fee0. Investigate and repair the eight baseline ver
 Rebased live Kokoro playback exposed a missing Manual Speak-to-Buddy event. Bind a content-free, request-unique voice lease to existing trusted playback start/terminal callbacks, releasing exact ownership even after session invalidation; verify state transitions and concurrent voice ownership. Existing ADR-074 lifecycle leases and ADR-037 trusted playback govern this repair.
 
 Broader mounted voice checks exposed 80-column clipping after the Send width stabilization and an overridden unavailable-mic CSS rule. Budget the busy chip against current action width, retain the stable Send control, and strengthen the unavailable selector; preserve click-to-reprobe behavior. These are bounded layout repairs under existing Console UX conventions; no new ADR.
+
+Qodo review follow-up: reproduce history loss for keyboard and mouse sends; restore captured history under session/edit ownership guards; extract the existing strict root check into central path validation; add bounded view context without exception capture. Run targeted undo, publication, path and diagnostic tests plus preflight. ADR required: no new ADR; existing ADR-074/069/029 govern unchanged root authority, recovery and privacy contracts.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Rebased first onto dev b52080fee0. Repaired all eight baseline verification failures without disabling privacy checks, and restored the missing Library Iterable import. Real rebased Kokoro UAT exposed a missing Buddy speech lease: actual Manual Speak playback now owns a request-unique lease with exact terminal cleanup, including stale contexts. Real Kokoro drained 128000 bytes with idle/speaking/idle; DeepSeek returned the expected synthetic reply with thinking/speaking/idle. Normal settings unchanged. Fixed actual 80-column busy microphone clipping while retaining stable Send width; compact copy and full tooltip preserve meaning at narrow widths. Investigation found unavailable-mic failures came from bare test harnesses missing the split Console stylesheet; no production CSS change was needed. Final voice UI 103 passed; speech/autoplay/Buddy adapters 102 passed; diagnostic suite 69 passed and 1 historical-object skip; all six preflight guards and scoped fatal lint pass. Independent review has no actionable findings. Existing ADR-074/037/069/029 apply. Evidence: qa/buddy-uat-2026-09-05/README.md and rebased-live-evidence.json. Keep In Progress/draft until physical macOS dragging is confirmed with Terminal foreground and OpenAI realtime UAT has a configured credential.
+Rebased first onto dev b52080fee0. Repaired all eight baseline verification failures without disabling privacy checks, and restored the missing Library Iterable import. Real rebased Kokoro UAT exposed a missing Buddy speech lease: actual Manual Speak playback now owns a request-unique lease with exact terminal cleanup, including stale contexts. Real Kokoro drained 128000 bytes with idle/speaking/idle; DeepSeek returned the expected synthetic reply with thinking/speaking/idle. Normal settings unchanged. Fixed actual 80-column busy microphone clipping while retaining stable Send width; compact copy and full tooltip preserve meaning at narrow widths. Investigation found unavailable-mic failures came from bare test harnesses missing the split Console stylesheet; no production CSS change was needed. Final voice UI 103 passed; speech/autoplay/Buddy adapters 102 passed; diagnostic suite 69 passed and 1 historical-object skip; all six preflight guards and scoped fatal lint pass. Independent review has no actionable findings. Existing ADR-074/037/069/029 apply. Evidence: qa/buddy-uat-2026-09-05/README.md and rebased-live-evidence.json. Keep In Progress until physical macOS dragging is confirmed with Terminal foreground and OpenAI realtime UAT has a configured credential. User subsequently authorized review and merge of the verified fixes with these UAT limits recorded.
+
+Qodo review: restore captured undo/redo on post-acceptance refusal only for the unchanged visible draft, preserving successful-send history barriers and newer edits. Centralized the existing canonical-directory root policy in Utils/path_validation.py; publication and cleanup consume its returned paths while retaining descriptor/identity/containment checks. Lazy mount failure records only an allowlisted view key (unknown otherwise), with no exception capture. 174 focused undo/draft/LLM/publication/path tests and two diagnostic privacy guards passed. Diagnostic statement review: exactly one 14-call LLM owner signature changed to add safe_view, with unchanged sink topology. Existing ADR-074/069/029 apply; no new ADR.
+
+Qodo follow-up final checks: all six derived-artifact preflight gates and scoped fatal-rule Ruff checks pass. Physical dragging/OpenAI realtime AC9 remains open as explicitly documented.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
+++ b/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-05 03:32'
-updated_date: '2026-09-05 03:48'
+updated_date: '2026-09-05 04:29'
 labels: []
 dependencies: []
 priority: high
@@ -24,17 +24,26 @@ Port the remaining reproducible Buddy UAT fixes onto current dev while preservin
 - [x] #3 Project-instruction recovery refusal releases the run and preserves the unsent draft without replacing newer edits.
 - [x] #4 Diagnostic inventory excludes nested virtual environments while retaining application modules.
 - [x] #5 Persona Visual import and edit publication succeeds without weakening file identity and containment checks.
-- [ ] #6 Targeted tests and scoped static checks pass on the actual PR tree; earlier live evidence and remaining OpenAI credential limitation are clearly distinguished.
+- [x] #6 Targeted tests and scoped static checks pass on the actual PR tree; earlier live evidence and remaining OpenAI credential limitation are clearly distinguished.
+- [x] #7 Real Manual Speak and readback playback makes Buddy speaking only during playback, releases on terminal acknowledgement after context changes, and preserves another voice owner.
+- [x] #8 At 80 columns a busy local transcription keeps the microphone reachable for cancel and preserves attachments; unavailable microphone state is visually distinct and remains clickable to retry.
+- [ ] #9 Final native dragging and OpenAI realtime UAT are verified on the PR branch with an application-configured credential.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
 Compare older UAT changes with current dev, port only unsuperseded fixes with failing seam regressions, run targeted tests and governance checks, review the final diff, and create a PR against dev. ADR required: no new ADR. Existing ADR-074 Persona Visual/Buddy, ADR-037 trusted speech, ADR-069 project instructions, and ADR-029 private diagnostics govern the repairs; no new ownership boundary or storage schema.
+
+Rebased first onto dev b52080fee0. Investigate and repair the eight baseline verification failures and Library annotation import before final UAT; preserve durable admission and privacy contracts, updating fixtures only where production boundaries demonstrably changed. ADR required: no; existing ADR-037/069/074/029 apply, and test-owner corrections introduce no runtime boundary.
+
+Rebased live Kokoro playback exposed a missing Manual Speak-to-Buddy event. Bind a content-free, request-unique voice lease to existing trusted playback start/terminal callbacks, releasing exact ownership even after session invalidation; verify state transitions and concurrent voice ownership. Existing ADR-074 lifecycle leases and ADR-037 trusted playback govern this repair.
+
+Broader mounted voice checks exposed 80-column clipping after the Send width stabilization and an overridden unavailable-mic CSS rule. Budget the busy chip against current action width, retain the stable Send control, and strengthen the unavailable selector; preserve click-to-reprobe behavior. These are bounded layout repairs under existing Console UX conventions; no new ADR.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Ported only remaining UAT fixes onto dev 68f9d865: final-release Buddy geometry, profile-owned publication, trusted readback lifecycle, setup terminalization and transient echo exclusion, visible-owner-fenced draft restoration, nested environment pruning, and two metadata-only lifecycle diagnostics. Existing ADR-074/037/069/029 apply. Native/publication/importer 171 passed; independent focused review 15 passed; final focused selection 23 passed. Broader targeted runs have 6 Console and 2 diagnostic failures, all reproduced on pristine base, alongside the existing Library Iterable F821; retain AC6 and In Progress status and publish draft PR. Evidence, exact limits and earlier hardware provenance: qa/buddy-uat-2026-09-05/README.md. No unrelated dirty-checkout work included.
+Rebased first onto dev b52080fee0. Repaired all eight baseline verification failures without disabling privacy checks, and restored the missing Library Iterable import. Real rebased Kokoro UAT exposed a missing Buddy speech lease: actual Manual Speak playback now owns a request-unique lease with exact terminal cleanup, including stale contexts. Real Kokoro drained 128000 bytes with idle/speaking/idle; DeepSeek returned the expected synthetic reply with thinking/speaking/idle. Normal settings unchanged. Fixed actual 80-column busy microphone clipping while retaining stable Send width; compact copy and full tooltip preserve meaning at narrow widths. Investigation found unavailable-mic failures came from bare test harnesses missing the split Console stylesheet; no production CSS change was needed. Final voice UI 103 passed; speech/autoplay/Buddy adapters 102 passed; diagnostic suite 69 passed and 1 historical-object skip; all six preflight guards and scoped fatal lint pass. Independent review has no actionable findings. Existing ADR-074/037/069/029 apply. Evidence: qa/buddy-uat-2026-09-05/README.md and rebased-live-evidence.json. Keep In Progress/draft until physical macOS dragging is confirmed with Terminal foreground and OpenAI realtime UAT has a configured credential.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
+++ b/backlog/tasks/task-31585 - Close-remaining-Migu-Buddy-UAT-interaction-and-voice-gaps.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-05 03:32'
-updated_date: '2026-09-05 04:56'
+updated_date: '2026-09-05 05:24'
 labels: []
 dependencies: []
 priority: high
@@ -54,4 +54,6 @@ Rebased first onto dev b52080fee0. Repaired all eight baseline verification fail
 Qodo review: restore captured undo/redo on post-acceptance refusal only for the unchanged visible draft, preserving successful-send history barriers and newer edits. Centralized the existing canonical-directory root policy in Utils/path_validation.py; publication and cleanup consume its returned paths while retaining descriptor/identity/containment checks. Lazy mount failure records only an allowlisted view key (unknown otherwise), with no exception capture. 174 focused undo/draft/LLM/publication/path tests and two diagnostic privacy guards passed. Diagnostic statement review: exactly one 14-call LLM owner signature changed to add safe_view, with unchanged sink topology. Existing ADR-074/069/029 apply; no new ADR.
 
 Qodo follow-up final checks: all six derived-artifact preflight gates and scoped fatal-rule Ruff checks pass. Physical dragging/OpenAI realtime AC9 remains open as explicitly documented.
+
+Latest-dev CI exposed TASK-31585 collision with PR #2403 Console closeout. Applied the TASK-19601 older-created-date rule: Buddy at 03:32 retains TASK-31585; Console closeout at 03:40 moves to TASK-31591 with provenance and both plan/spec references updated. This is metadata-only; no new ADR. Local backlog guard rerun before publication.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31591 - Close-Console-context-spend-workstream-and-repair-context-control-tests.md
+++ b/backlog/tasks/task-31591 - Close-Console-context-spend-workstream-and-repair-context-control-tests.md
@@ -1,11 +1,11 @@
 ---
-id: TASK-31585
+id: TASK-31591
 title: Close Console context spend workstream and repair context control tests
 status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-05 03:40'
-updated_date: '2026-09-05 03:51'
+updated_date: '2026-09-05 05:24'
 labels:
   - console
   - tests
@@ -58,4 +58,6 @@ Published the corrected Current/On next send design and completed implementation
 Validation: 158 focused tests passed across context controls, rail/popover settings, and the real settings-default persistence service, including after rebasing onto dev's interrupt-host change. Scoped Ruff lint/format, diff whitespace checks, and the backlog ID/path guard passed. The subsequent Library follow-up merge changes documentation only; its task-ID collision is reconciled above. The full suite was not run. Pytest emitted a Requests dependency-version warning and temporary-directory cleanup warnings; neither was a test failure.
 
 Cleanup after merge is limited to the Console spend feature/port/baseline/closeout worktrees and topic/backup refs. Preserve the conflicted port and branch history in a verified recovery archive first. The original records in the shared main checkout are tracked on an unrelated branch and remain untouched; the authoritative dev replacements above supersede them.
+
+Renumbering provenance (PR #2404, 2026-09-05): moved this Console closeout from TASK-31585 to TASK-31591 after PR #2403 merged alongside the older Buddy task. Buddy created_date is 03:32; this closeout is 03:40. TASK-19601 gives the older task the ID regardless of Done status. A fresh sweep of 334 refs and 63 worktrees found max TASK-31590. Updated both spend plan/spec links; earlier TASK-31568-to-31585 provenance is retained as history. No implementation or acceptance status changed.
 <!-- SECTION:NOTES:END -->

--- a/qa/buddy-uat-2026-09-05/README.md
+++ b/qa/buddy-uat-2026-09-05/README.md
@@ -1,0 +1,97 @@
+# Migu Buddy UAT fixes on current dev
+
+PR base: `68f9d865fad623db6ec02e19632090c1140b3c89`.
+Work branch: `codex/migu-buddy-uat-fixes`. Task: TASK-31585.
+
+## Scope
+
+Current dev already contains the Buddy implementation and realtime/fleet
+extractions (PRs #1927, #1939, #1970 and #2094). This patch carries only the
+remaining UAT defects forward; it preserves the newer Buddy widget, controller
+boundaries, durable turn admission and diagnostic inventory format.
+
+- Apply final native mouse-release coordinates for move and resize. Existing
+  coordinate-based hit testing already handles XTerm events with no widget.
+- Permit profile-owned Persona Visual imports, drafts and active-version edits.
+  Pin directory device/inode while retaining file metadata, digest, descriptor,
+  containment and symlink checks. Publication may change ancestor metadata.
+- Route readback through trusted Manual Speak snapshots and playback ownership,
+  so terminal playback clears the speaking presentation.
+- Terminalize cancelled/unavailable project-instruction recovery. Refused
+  transient echoes are excluded from provider history; already durably accepted
+  turns retain recovery ownership under current dev's existing contract.
+- Restore refused drafts after the acceptance callback consumed them, only when
+  the composer still owns the same visible session. Preserve newer edits.
+- Prune nested Python environments from diagnostic scanning, preserving
+  serialized POSIX ordering and application modules merely named `venv`.
+- Remove exception capture from lazy LLM mount and Library lifecycle failures.
+  Reviewed inventory changes are exactly two diagnostic digests: 14 LLM-window
+  calls and 104 Library-screen calls remain. No owners or sinks were added.
+
+ADR required: no new ADR. Existing ADR-074 (Persona Visual/Buddy), ADR-037
+(trusted speech), ADR-069 (project instructions), and ADR-029 (private diagnostic
+boundary) govern these repairs. No new schema, dependency or provider transport.
+
+## Verification
+
+Tests import the actual PR tree using `PYTHONPATH` and `python -m pytest`.
+The existing development Python environment supplies dependencies only.
+No full repository suite was run.
+
+- Native Buddy widget + publication + importer: **171 passed**.
+- Independent review: **15 focused regressions passed**, covering readback,
+  setup recovery, draft ownership and nested environments.
+- Final focused setup, readback, draft, voice-guard and diagnostic regressions:
+  **23 passed**; the final diagnostic registry assertion also passed separately.
+- Broader Console/speech selection: **140 passed, 6 failed**. All six failures
+  reproduce on the pristine base with the same environment.
+- Broader diagnostic selection: **66 passed, 2 failed, 1 skipped**. Both failures
+  reproduce on the pristine base; the skip needs unavailable pinned Git objects.
+- Diagnostic inventory: 573 owners, 1,338 TASK-492 calls, 7,599 TASK-494
+  calls, 10 sink files. Statement-level review confirms exactly two changed
+  constant-message signatures; no call counts changed. Final rebuild reports
+  no drift.
+- New files pass Ruff; changed ranges were checked for formatting. Fatal-rule
+  checks retain a pre-existing `F821` (`Iterable`) in `library_screen.py:36855`,
+  reproduced on the pristine base. Existing broad lint debt is not represented
+  as clean.
+
+Born-red tests demonstrated final release position loss, profile-owned
+publication rejection, stale readback ownership, recovery stuck in validating,
+consumed draft loss, cross-session draft restoration, dependency inventory
+contamination and exception capture before their respective fixes.
+Independent review found and corrected decorator placement and visible-composer
+ownership during the port.
+
+### Base failures retained for follow-up
+
+- `test_console_enter_snapshots_draft_before_late_keystrokes`
+- `test_console_double_enter_sends_once_and_loses_nothing`
+- `test_console_fresh_profile_first_send_resolves_real_session_not_sentinel`
+- `test_console_enter_no_op_press_restores_draft_and_unblocks_next_send`
+- `test_token_omission_notice_keeps_content_free_source_metadata`
+- `test_project_instruction_disable_terminalizes_and_allows_retry`
+- `test_reviewed_diagnostic_changes_are_metadata_only`
+- `test_task_15743_exception_types_survive_loguru_forwarding`
+
+The last two concern stale moved diagnostic labels and an existing activity
+receipt metadata assertion. The draft PR does not waive these checks or claim
+complete repository governance sign-off.
+
+## Earlier live evidence and limits
+
+`prior-live-evidence.json` contains minimized synthetic-fixture results from the
+older working checkout. It is historical live evidence, not a claim that those
+hardware runs were repeated on this PR tree. Real Terminal move/resize, a real
+DeepSeek reply, a five-second microphone/local-transcription check, and local
+Kokoro playback were exercised there. Kokoro drained 128,000 PCM bytes with
+Migu idle → speaking → idle; microphone capture stopped after 5.02 seconds,
+recognized the known phrase, released the device, and returned to idle.
+Normal configuration remained unchanged. Microphone content was neither saved
+nor sent to a provider. Temporary speech dependencies/model were not added to
+the project or enabled in the user's normal profile.
+
+Before final sign-off: resolve or classify the base failures and CI, then run
+live OpenAI realtime UAT with a credential configured in the application's
+settings. That provider was not configured during this UAT. Local speech success
+does not validate the OpenAI realtime transport.

--- a/qa/buddy-uat-2026-09-05/README.md
+++ b/qa/buddy-uat-2026-09-05/README.md
@@ -1,6 +1,7 @@
 # Migu Buddy UAT fixes on current dev
 
-PR base: `68f9d865fad623db6ec02e19632090c1140b3c89`.
+Rebased before follow-up repairs onto `dev` at `b52080fee0`.
+Original PR verification base: `68f9d865fad623db6ec02e19632090c1140b3c89`.
 Work branch: `codex/migu-buddy-uat-fixes`. Task: TASK-31585.
 
 ## Scope
@@ -16,7 +17,9 @@ boundaries, durable turn admission and diagnostic inventory format.
   Pin directory device/inode while retaining file metadata, digest, descriptor,
   containment and symlink checks. Publication may change ancestor metadata.
 - Route readback through trusted Manual Speak snapshots and playback ownership,
-  so terminal playback clears the speaking presentation.
+  so terminal playback clears the speaking presentation. Actual playback also
+  owns an exact Buddy voice lease; stale terminal callbacks release only their
+  own lease and preserve concurrent voice owners.
 - Terminalize cancelled/unavailable project-instruction recovery. Refused
   transient echoes are excluded from provider history; already durably accepted
   turns retain recovery ownership under current dev's existing contract.
@@ -32,51 +35,65 @@ ADR required: no new ADR. Existing ADR-074 (Persona Visual/Buddy), ADR-037
 (trusted speech), ADR-069 (project instructions), and ADR-029 (private diagnostic
 boundary) govern these repairs. No new schema, dependency or provider transport.
 
+- Preserve the stable Send width while bounding the busy transcription chip,
+  keeping the cancel-capable microphone reachable at 80 columns. Narrow copy
+  reads “Local transcription busy — queued.” or “Queued”; the full explanation
+  stays in its tooltip. Ordinary listening layout is unchanged.
+
 ## Verification
 
 Tests import the actual PR tree using `PYTHONPATH` and `python -m pytest`.
 The existing development Python environment supplies dependencies only.
 No full repository suite was run.
 
-- Native Buddy widget + publication + importer: **171 passed**.
-- Independent review: **15 focused regressions passed**, covering readback,
-  setup recovery, draft ownership and nested environments.
-- Final focused setup, readback, draft, voice-guard and diagnostic regressions:
-  **23 passed**; the final diagnostic registry assertion also passed separately.
-- Broader Console/speech selection: **140 passed, 6 failed**. All six failures
-  reproduce on the pristine base with the same environment.
-- Broader diagnostic selection: **66 passed, 2 failed, 1 skipped**. Both failures
-  reproduce on the pristine base; the skip needs unavailable pinned Git objects.
-- Diagnostic inventory: 573 owners, 1,338 TASK-492 calls, 7,599 TASK-494
-  calls, 10 sink files. Statement-level review confirms exactly two changed
-  constant-message signatures; no call counts changed. Final rebuild reports
-  no drift.
-- New files pass Ruff; changed ranges were checked for formatting. Fatal-rule
-  checks retain a pre-existing `F821` (`Iterable`) in `library_screen.py:36855`,
-  reproduced on the pristine base. Existing broad lint debt is not represented
-  as clean.
+- Initial rebased targeted run: **414 passed, 3 failed**. All three remaining
+  voice failures were investigated and repaired; see the follow-up below.
+- Rebased diagnostic suite: **69 passed, 1 skipped**. The skip requires unavailable
+  historical Git objects; current-source and metadata assertions remain enabled.
+- Speech ownership, autoplay and Buddy adapter gate: **102 passed**.
+- Final complete voice-chip and mounted dictation selection: **103 passed**.
+- Focused narrow-chip/mounted-microphone regression selection: **13 passed**.
+- Independent final chip review: **15 passed**; no actionable review findings.
+- Diagnostic inventory rebuilt without drift: 574 owners, 1,334 TASK-492 calls,
+  7,599 TASK-494 calls and 10 sink files. The changed counts come from rebased dev.
+- All six derived-artifact preflight checks passed: CSS, path inventory,
+  diagnostic inventory, task IDs, schema allowlist and index pins.
+- Changed Python files pass fatal-rule checks; the missing Library `Iterable`
+  annotation import is repaired. New readback tests pass Ruff, changed ranges
+  were formatted, and `git diff --check` passes. No full repository sweep.
 
-Born-red tests demonstrated final release position loss, profile-owned
-publication rejection, stale readback ownership, recovery stuck in validating,
-consumed draft loss, cross-session draft restoration, dependency inventory
-contamination and exception capture before their respective fixes.
-Independent review found and corrected decorator placement and visible-composer
-ownership during the port.
+### Verification repairs
 
-### Base failures retained for follow-up
+The original eight failures reproduced after the rebase. Four composer fixtures
+needed the supported capture-off setting because their in-memory harness has no
+durable trace repository. The token-omission fixture now permits the base request
+to fit while the optional instruction row exceeds its budget. Setup retry covers
+both transient refusal and durable acceptance: a durable pending response blocks
+new sends until explicit discard, after which a fresh send succeeds.
 
-- `test_console_enter_snapshots_draft_before_late_keystrokes`
-- `test_console_double_enter_sends_once_and_loses_nothing`
-- `test_console_fresh_profile_first_send_resolves_real_session_not_sentinel`
-- `test_console_enter_no_op_press_restores_draft_and_unblocks_next_send`
-- `test_token_omission_notice_keeps_content_free_source_metadata`
-- `test_project_instruction_disable_terminalizes_and_allows_retry`
-- `test_reviewed_diagnostic_changes_are_metadata_only`
-- `test_task_15743_exception_types_survive_loguru_forwarding`
+The metadata registry now follows two extracted Library diagnostics and removes
+one retired by `5dd1077df6`. The exception-type forwarding guard admits only the
+existing safe conditional type-name/literal fallback. No privacy check was disabled.
 
-The last two concern stale moved diagnostic labels and an existing activity
-receipt metadata assertion. The draft PR does not waive these checks or claim
-complete repository governance sign-off.
+The broader voice gate exposed a real 80-column clipping regression after Send
+width stabilization, plus stale fixed-width/reason-visibility expectations. Bare
+composer harnesses also omitted the split Console stylesheet, causing false
+visual failures. They now load the production Console sheet; production CSS did
+not need changing.
+
+### Rebased live evidence
+
+`rebased-live-evidence.json` records actual runs from this PR worktree:
+
+- **Kokoro:** 128,000 PCM bytes drained; Migu idle → speaking → idle; speech
+  presentation cleared, no app exception, normal configuration unchanged.
+- **DeepSeek:** expected synthetic reply received; run completed; Migu
+  idle → thinking → speaking → idle; normal configuration unchanged.
+- The first rebased Kokoro replay exposed the missing Buddy playback lease;
+  regression tests failed before the repair and the real replay passed afterward.
+- Physical macOS dragging is still awaiting a foreground Terminal window. The
+  background gesture did not change geometry, so this replay is not a pass.
+- OpenAI realtime is blocked because no credential is configured.
 
 ## Earlier live evidence and limits
 
@@ -91,7 +108,7 @@ Normal configuration remained unchanged. Microphone content was neither saved
 nor sent to a provider. Temporary speech dependencies/model were not added to
 the project or enabled in the user's normal profile.
 
-Before final sign-off: resolve or classify the base failures and CI, then run
-live OpenAI realtime UAT with a credential configured in the application's
-settings. That provider was not configured during this UAT. Local speech success
+Before final sign-off: finish physical dragging on the final branch, review
+updated CI, then run live OpenAI realtime UAT with a credential configured in
+the application's settings. That provider was not configured during this UAT. Local speech success
 does not validate the OpenAI realtime transport.

--- a/qa/buddy-uat-2026-09-05/README.md
+++ b/qa/buddy-uat-2026-09-05/README.md
@@ -1,6 +1,7 @@
 # Migu Buddy UAT fixes on current dev
 
-Rebased before follow-up repairs onto `dev` at `b52080fee0`.
+Latest review rebase: `dev` at `d9e2e3d507`.
+Earlier follow-up repairs were rebased onto `b52080fee0`.
 Original PR verification base: `68f9d865fad623db6ec02e19632090c1140b3c89`.
 Work branch: `codex/migu-buddy-uat-fixes`. Task: TASK-31585.
 
@@ -112,3 +113,22 @@ Before final sign-off: finish physical dragging on the final branch, review
 updated CI, then run live OpenAI realtime UAT with a credential configured in
 the application's settings. That provider was not configured during this UAT. Local speech success
 does not validate the OpenAI realtime transport.
+
+
+## Qodo review follow-up
+
+All three initial Qodo findings were addressed: refusal restores captured
+undo/redo only when the same visible draft has not been edited; successful
+sends remain history barriers. Publication and cleanup now consume the shared
+`validate_canonical_directory` result, preserving the existing strict spelling,
+symlink, descriptor, identity and containment policy. Lazy mount errors retain
+an allowlisted view identifier (unknown otherwise) without exception capture.
+
+The latest-dev rebase passed 74 Console regressions and 150 Buddy/publication/
+setup regressions. Review fixes passed 174 undo/draft/LLM/publication/path tests
+and two diagnostic privacy guards. The diagnostic statement change is exactly
+one safe-view argument on the existing 14-call LLM owner; no sink changed.
+Live provider/playback records above predate these review-only follow-ups and
+retain their original source digests. TASK-31585 remains In Progress for the
+explicit native-dragging and OpenAI realtime UAT gaps; the user authorized
+review and merge of the verified fixes with those follow-ups recorded.

--- a/qa/buddy-uat-2026-09-05/prior-live-evidence.json
+++ b/qa/buddy-uat-2026-09-05/prior-live-evidence.json
@@ -1,0 +1,72 @@
+{
+  "provenance": "Historical live UAT on the older working checkout, not a replay on this PR tree. PR-tree verification uses the targeted regressions documented in README.md.",
+  "live-hardware-voice.json": {
+    "capture_seconds_limit": 5,
+    "capture_stop_requested_after_seconds": 5.02,
+    "captured_bytes": 90240,
+    "known_phrase_recognized": true,
+    "known_words_recognized": {
+      "voice": true,
+      "check": true,
+      "blue": true,
+      "notebook": true,
+      "ready": true
+    },
+    "final_dictation_state": "idle",
+    "audio_device_released": true,
+    "final_buddy_state": "idle",
+    "normal_config_unchanged": true,
+    "microphone_audio_sent_to_provider": false,
+    "audio_saved": false
+  },
+  "live-kokoro-voice.json": {
+    "provider": "kokoro",
+    "voice": "af_heart",
+    "fixture": "Migu voice check. The blue notebook is ready.",
+    "entry_point": "Console read last response back",
+    "sink_result": {
+      "outcome": "drained",
+      "bytes_fed": 128000,
+      "final_state": "stopped",
+      "terminal_reason": "drained"
+    },
+    "buddy_states": [
+      "idle",
+      "speaking",
+      "idle"
+    ],
+    "final_buddy_state": "idle",
+    "elapsed_seconds": 5.18,
+    "final_speaking_message_id": null,
+    "app_exception": null,
+    "normal_config_unchanged": true
+  },
+  "native-move-evidence.json": {
+    "before": {
+      "x": 203,
+      "y": 3,
+      "width": 28,
+      "height": 19
+    },
+    "after": {
+      "x": 171,
+      "y": 11,
+      "width": 28,
+      "height": 19
+    }
+  },
+  "native-resize-evidence.json": {
+    "before": {
+      "x": 171,
+      "y": 11,
+      "width": 28,
+      "height": 19
+    },
+    "after": {
+      "x": 171,
+      "y": 11,
+      "width": 37,
+      "height": 23
+    }
+  }
+}

--- a/qa/buddy-uat-2026-09-05/rebased-live-evidence.json
+++ b/qa/buddy-uat-2026-09-05/rebased-live-evidence.json
@@ -1,0 +1,55 @@
+{
+  "base_commit": "b52080fee0",
+  "provenance": "Live rebased-app UAT including the follow-up speech lease repair; synthetic fixtures only. Production source digests pin the tested code.",
+  "source_sha256": {
+    "tldw_chatbook/UI/Console_Modules/message.py": "348a94d6659e8cba25580672e955c7d957a74209fe0dda25758453cdebfda313",
+    "tldw_chatbook/UI/Screens/chat_screen.py": "f8be325c9ab35ef7a7e80df898756218880b4feee883d2775294bf8c0dd54224",
+    "tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py": "ab244bb7ae1c4f9140dd78f80bf5d9dea037e9ebac539cc129c4fdf6a2667588"
+  },
+  "kokoro": {
+    "provider": "kokoro",
+    "microphone_opened": false,
+    "visual_before": true,
+    "visual_reason": null,
+    "sink": {
+      "outcome": "drained",
+      "bytes_fed": 128000,
+      "terminal_reason": "drained"
+    },
+    "buddy_states": [
+      "idle",
+      "speaking",
+      "idle"
+    ],
+    "elapsed_seconds": 5.6,
+    "speaking_cleared": true,
+    "app_exception": null,
+    "normal_config_unchanged": true
+  },
+  "deepseek": {
+    "provider": "deepseek",
+    "microphone_opened": false,
+    "fixture": "Reply exactly: Migu live check passed.",
+    "run_status": "completed",
+    "visible_copy": "Response complete.",
+    "buddy_states": [
+      "idle",
+      "thinking",
+      "speaking",
+      "idle"
+    ],
+    "final_buddy_state": "idle",
+    "expected_reply": true,
+    "elapsed_seconds": 2.09,
+    "app_exception": null,
+    "normal_config_unchanged": true
+  },
+  "physical_dragging": {
+    "status": "waiting_for_foreground_window",
+    "reason": "Background macOS drag was delivered to Terminal but no geometry changed; no pass claimed."
+  },
+  "openai_realtime": {
+    "status": "blocked",
+    "reason": "No OpenAI credential configured."
+  }
+}

--- a/scripts/check_persistent_diagnostic_inventory.py
+++ b/scripts/check_persistent_diagnostic_inventory.py
@@ -1035,7 +1035,19 @@ def build_inventory() -> dict[str, Any]:
     path_privacy_candidates: list[dict[str, Any]] = []
     # Path ordering is case-folded on Windows. Sort by the serialized POSIX
     # spelling so every host produces the same ordered inventory lists.
-    for path in sorted(PACKAGE_ROOT.rglob("*.py"), key=_inventory_path_sort_key):
+    sources: list[Path] = []
+    for directory, subdirectories, filenames in os.walk(PACKAGE_ROOT):
+        # Installed dependencies under a virtualenv are not application owners.
+        # Detect the environment marker rather than assuming a directory name.
+        if "pyvenv.cfg" in filenames:
+            subdirectories.clear()
+            continue
+        sources.extend(
+            Path(directory) / filename
+            for filename in filenames
+            if filename.endswith(".py")
+        )
+    for path in sorted(sources, key=_inventory_path_sort_key):
         relative = path.relative_to(REPO_ROOT).as_posix()
         diagnostics, sinks, candidates = _scan_file(path)
         if diagnostics:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -8333,6 +8333,11 @@ class ConsoleChatController:
                     else None
                 ),
             )
+            if (
+                not stream_result.accepted
+                and origin is not ConsoleSubmissionOrigin.AGENT_WAKE
+            ):
+                self._mark_transient_echo_blocked(echoed_user.id)
             result = replace(
                 stream_result,
                 session_id=session.id,
@@ -21478,6 +21483,16 @@ class ConsoleChatController:
             selected_body=selected.selected_body,
         )
 
+    def _refuse_project_instruction_setup(
+        self, session_id: str, assistant_message_id: str, visible_copy: str
+    ) -> ConsoleSubmitResult:
+        """Release setup recovery using the existing disable decision contract."""
+        try:
+            self.store.mark_message_failed(assistant_message_id)
+        except KeyError:
+            return self._session_closed_result(session_id=session_id)
+        return self._block(session_id, visible_copy)
+
     @_retire_generation_before_agent_handoff
     async def _run_agent_reply(
         self,
@@ -21584,7 +21599,9 @@ class ConsoleChatController:
                 else:
                     callback = self._select_project_instruction_binding
                     if callback is None:
-                        return ConsoleSubmitResult(False, False, str(exc))
+                        return self._refuse_project_instruction_setup(
+                            session_id, assistant_message_id, str(exc)
+                        )
                     action, binding_id = await callback(session_id, options, str(exc))
                     action, project_selection = (
                         commit_project_instruction_setup_decision(
@@ -21599,14 +21616,16 @@ class ConsoleChatController:
                     )
                     if action == "disable":
                         self._clear_project_instruction_delivery(session_id)
-                        try:
-                            self.store.mark_message_failed(assistant_message_id)
-                        except KeyError:
-                            return self._session_closed_result(session_id=session_id)
-                        return self._block(session_id, "project_instructions_disabled")
+                        return self._refuse_project_instruction_setup(
+                            session_id,
+                            assistant_message_id,
+                            "project_instructions_disabled",
+                        )
                     if action != "select" or project_selection is None:
                         self._clear_project_instruction_delivery(session_id)
-                        return ConsoleSubmitResult(False, False, str(exc))
+                        return self._refuse_project_instruction_setup(
+                            session_id, assistant_message_id, str(exc)
+                        )
             if project_selection is not None:
                 state = session.project_instruction_state
                 if state.working_folder_binding_id is None:

--- a/tldw_chatbook/Persona_Visual/publication.py
+++ b/tldw_chatbook/Persona_Visual/publication.py
@@ -16,6 +16,7 @@ from typing import Any
 from uuid import uuid4
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDBError
+from tldw_chatbook.Utils.path_validation import validate_canonical_directory
 from tldw_chatbook.Utils.private_paths import secure_private_directory
 
 from . import assets as asset_boundary
@@ -443,7 +444,7 @@ def cleanup_persona_visual_publication_candidate(
     cleanup_path, cleanup_secret = capability
     _require_idle_repository(repository)
     try:
-        profile_path = _canonical_root(profile_root, must_exist=True)
+        profile_path = validate_canonical_directory(profile_root)
     except (OSError, TypeError, ValueError):
         raise PersonaVisualPublicationError("persona_visual_cleanup_denied") from None
     candidate_path = profile_path / cleanup_path
@@ -777,8 +778,8 @@ def _publication_roots(
     profile_root: os.PathLike[str] | str,
 ) -> tuple[Path, Path]:
     try:
-        source = _canonical_root(source_root, must_exist=True)
-        profile = _canonical_root(profile_root, must_exist=True)
+        source = validate_canonical_directory(source_root)
+        profile = validate_canonical_directory(profile_root)
         # Authoring sources live inside the profile, including existing versions.
         # Publication copies pinned files into a fresh immutable directory; it
         # never renames or recursively copies the source root itself.
@@ -789,22 +790,6 @@ def _publication_roots(
         raise PersonaVisualPublicationError(
             "persona_visual_publication_denied"
         ) from None
-
-
-def _canonical_root(value: os.PathLike[str] | str, *, must_exist: bool) -> Path:
-    raw = os.fspath(value)
-    if type(raw) is not str or not raw or "\x00" in raw:
-        raise ValueError
-    path = Path(raw)
-    if not path.is_absolute() or str(path) != raw:
-        raise ValueError
-    resolved = path.resolve(strict=must_exist)
-    if resolved != path:
-        raise ValueError
-    metadata = os.lstat(path)
-    if not stat.S_ISDIR(metadata.st_mode):
-        raise ValueError
-    return path
 
 
 def _open_absolute_directory_chain(path: Path) -> list[int]:

--- a/tldw_chatbook/Persona_Visual/publication.py
+++ b/tldw_chatbook/Persona_Visual/publication.py
@@ -102,7 +102,7 @@ class PersonaVisualPublicationResult:
 @dataclass(frozen=True, slots=True)
 class _PinnedSource:
     parts: tuple[str, ...]
-    directory_identities: tuple[tuple[int, int, int, int, int], ...]
+    directory_identities: tuple[tuple[int, int], ...]
     identity: tuple[int, int, int, int, int]
     byte_count: int
     sha256: str
@@ -132,7 +132,8 @@ def publish_persona_visual(
     Args:
         repository: Idle Persona Visual repository that owns the activation.
         snapshot: Fully bounded manifest, provenance, asset, and authority snapshot.
-        source_root: Absolute root containing the snapshotted source assets.
+        source_root: Absolute root containing the snapshotted source assets;
+            may be the profile itself or its private import/workspace directory.
         profile_root: Absolute profile root receiving immutable pack storage.
         authority_guard: Side-effect-free callback checked before and inside the
             repository transaction.
@@ -778,11 +779,10 @@ def _publication_roots(
     try:
         source = _canonical_root(source_root, must_exist=True)
         profile = _canonical_root(profile_root, must_exist=True)
-        if (
-            source == profile
-            or source.is_relative_to(profile)
-            or profile.is_relative_to(source)
-        ):
+        # Authoring sources live inside the profile, including existing versions.
+        # Publication copies pinned files into a fresh immutable directory; it
+        # never renames or recursively copies the source root itself.
+        if source != profile and profile.is_relative_to(source):
             raise ValueError
         return source, profile
     except Exception:
@@ -855,7 +855,7 @@ def _pin_source_asset(
     parts = tuple(source.split("/"))
     current = source_root_fd
     opened_directories: list[int] = []
-    directory_identities: list[tuple[int, int, int, int, int]] = []
+    directory_identities: list[tuple[int, int]] = []
     file_fd = -1
     try:
         for component in parts[:-1]:
@@ -867,8 +867,13 @@ def _pin_source_asset(
             opened_directories.append(child)
             named = os.stat(component, dir_fd=current, follow_symlinks=False)
             opened = os.fstat(child)
-            identity = _file_identity(opened)
-            if not stat.S_ISDIR(named.st_mode) or _file_identity(named) != identity:
+            # Publishing changes shared ancestors' timestamps and sizes. Pin
+            # directory identity; files retain full metadata and digest checks.
+            identity = (opened.st_dev, opened.st_ino)
+            if (
+                not stat.S_ISDIR(named.st_mode)
+                or (named.st_dev, named.st_ino) != identity
+            ):
                 raise ValueError
             directory_identities.append(identity)
             current = child
@@ -947,8 +952,8 @@ def _source_entry_current(source_root_fd: int, source: _PinnedSource) -> bool:
             opened = os.fstat(child)
             if (
                 not stat.S_ISDIR(named.st_mode)
-                or _file_identity(named) != expected
-                or _file_identity(opened) != expected
+                or (named.st_dev, named.st_ino) != expected
+                or (opened.st_dev, opened.st_ino) != expected
             ):
                 return False
             current = child

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -1134,8 +1134,28 @@ class ConsoleMessageController:
                 return False
             return True
 
+        from tldw_chatbook.Persona_Buddy.console_adapter import BuddyLifecycleEvent
+
+        runtime = getattr(self.app_instance, "console_runtime", None)
+        buddy_sink = getattr(runtime, "persona_buddy_sink", None)
+        buddy_owner = f"speech:{uuid.uuid4().hex}"
+
         def report_playback(state: str) -> None:
-            if playback_is_current():
+            current = playback_is_current()
+            if buddy_sink is not None and (
+                (current and state == "playing") or state in {"stopped", "failed"}
+            ):
+                # Exact playback ownership outlives the visible session. A stale
+                # stop acknowledgement releases only this request's voice lease.
+                buddy_sink.publish(
+                    BuddyLifecycleEvent(
+                        source="voice",
+                        owner=buddy_owner,
+                        state="speaking" if state == "playing" else "idle",
+                        terminal=state in {"stopped", "failed"},
+                    )
+                )
+            if current:
                 self._settle_console_speech_presentation(
                     message_id,
                     request_generation,

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -2174,7 +2174,7 @@ class LLMManagementWindow(Container):
         try:
             await self._mount_deferred_views(view_name)
         except Exception:
-            logger.exception("Lazy LLM view mount failed: {}", view_name)
+            logger.error("Lazy LLM view mount failed")
             return
         finally:
             self._populating_views.discard(view_name)

--- a/tldw_chatbook/UI/LLM_Management_Window.py
+++ b/tldw_chatbook/UI/LLM_Management_Window.py
@@ -2174,7 +2174,8 @@ class LLMManagementWindow(Container):
         try:
             await self._mount_deferred_views(view_name)
         except Exception:
-            logger.error("Lazy LLM view mount failed")
+            safe_view = view_name if view_name in self.view_mapping else "unknown"
+            logger.error("Lazy LLM view mount failed: view={}", safe_view)
             return
         finally:
             self._populating_views.discard(view_name)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9691,11 +9691,10 @@ class ChatScreen(BaseAppScreen):
     async def _console_read_last_response_back(self) -> None:
         """Speak the last completed assistant reply for "Console, read that back."
 
-        Mirrors `handle_console_message_action`'s "speak" branch (task-559)
-        exactly rather than inventing a second TTS path: post
-        `TTSRequestEvent`, track the message as the one currently driving
-        speech, and resync so the transcript's action row reflects it. Only
-        the completed target selection and the two ack cases are new here.
+        Use Manual Speak's trusted snapshot and playback lifecycle so
+        authority checks and terminal speech cleanup also apply to voice
+        commands. The completed target selection and acknowledgements stay
+        local to this entry point.
         """
         # Own-guard for the microphone/speaker mutual-exclusion invariant.
         # The one caller already reaches here at `idle`, so this is defensive
@@ -9721,15 +9720,7 @@ class ChatScreen(BaseAppScreen):
             self.app_instance.notify("Nothing to read yet.", severity="warning")
             self._speak_status("Nothing to read yet.")
             return
-        from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
-            TTSRequestEvent,
-        )
-
-        self.app_instance.post_message(
-            TTSRequestEvent(text=message.content, message_id=message.id)
-        )
-        self._console_speaking_message_id = message.id
-        await self._sync_native_console_chat_ui()
+        await self._message.request_console_message_speech(message.id)
 
     # ------------------------------------------------------------------
     # V3 pipeline hands-free conversation loop: moved to
@@ -16458,6 +16449,12 @@ class ChatScreen(BaseAppScreen):
         if session_id is None:
             session_id = controller.store.active_session_id or ""
         dispatch_composer = self._console_composer_or_none()
+        dispatch_snapshot = (
+            dispatch_composer.capture_draft_snapshot()
+            if dispatch_composer is not None
+            and self._console_visible_draft_session_id == session_id
+            else None
+        )
         dispatch_draft_revision = (
             (
                 dispatch_composer.edit_serial,
@@ -16535,12 +16532,29 @@ class ChatScreen(BaseAppScreen):
             composer is not None
             and self._console_visible_draft_session_id == session_id
         )
-        stash = self._console_inflight_send_stashes.pop(session_id, None)
-        if not result.accepted and stash is not None and composer_reflects_session:
+        stash = (
+            self._console_inflight_send_stashes.pop(session_id, None) or inflight_stash
+        )
+        if (
+            not result.accepted
+            and stash is not None
+            and composer_reflects_session
+            and composer_visible_for_session
+        ):
             # Controller-level refusal of a keyboard send: the composer was
             # cleared at the keypress, so hand the draft back (ahead of any
             # keystrokes typed since).
             composer.restore_stashed_draft(stash)
+        elif (
+            not result.accepted
+            and composer_visible_for_session
+            and dispatch_snapshot is not None
+            and composer.edit_serial == dispatch_snapshot.edit_serial
+            and not composer.draft_text()
+        ):
+            # Setup may refuse after the accepted hook cleared this draft.
+            # A newer edit or another visible session retains ownership.
+            composer.restore_snapshot(dispatch_snapshot)
         if result.session_closed:
             # Task 4 (D2 fix wave): `_session_closed_result` is `accepted`
             # (see its own docstring) so the restore above never fires, and

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -16455,6 +16455,11 @@ class ChatScreen(BaseAppScreen):
             and self._console_visible_draft_session_id == session_id
             else None
         )
+        dispatch_history = (
+            dispatch_composer.export_undo_history()
+            if dispatch_snapshot is not None
+            else None
+        )
         dispatch_draft_revision = (
             (
                 dispatch_composer.edit_serial,
@@ -16544,6 +16549,11 @@ class ChatScreen(BaseAppScreen):
             # Controller-level refusal of a keyboard send: the composer was
             # cleared at the keypress, so hand the draft back (ahead of any
             # keystrokes typed since).
+            if (
+                dispatch_snapshot is not None
+                and composer.edit_serial == dispatch_snapshot.edit_serial
+            ):
+                composer.restore_undo_history(dispatch_history)
             composer.restore_stashed_draft(stash)
         elif (
             not result.accepted
@@ -16555,6 +16565,7 @@ class ChatScreen(BaseAppScreen):
             # Setup may refuse after the accepted hook cleared this draft.
             # A newer edit or another visible session retains ownership.
             composer.restore_snapshot(dispatch_snapshot)
+            composer.restore_undo_history(dispatch_history)
         if result.session_closed:
             # Task 4 (D2 fix wave): `_session_closed_result` is `accepted`
             # (see its own docstring) so the restore above never fires, and

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9729,7 +9729,7 @@ class LibraryScreen(BaseAppScreen):
             try:
                 await lifecycle_worker.wait()
             except Exception:
-                logger.opt(exception=True).warning(
+                logger.warning(
                     "Pending Library lifecycle write failed during unmount."
                 )
         if self._library_lifecycle_pending_persist is not None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -14,7 +14,7 @@ import time
 import tomllib
 import uuid
 import webbrowser
-from collections.abc import Awaitable, Callable, Mapping, Sequence
+from collections.abc import Awaitable, Callable, Iterable, Mapping, Sequence
 from datetime import datetime, timezone
 from enum import Enum
 from contextlib import closing

--- a/tldw_chatbook/Utils/path_validation.py
+++ b/tldw_chatbook/Utils/path_validation.py
@@ -6,6 +6,7 @@ escape allowed directories.
 """
 
 import os
+import stat
 import time
 from pathlib import Path
 from typing import Optional, Sequence, Union
@@ -51,6 +52,37 @@ ROOT_DENIAL_RECOVERY_HINT = (
     "private scratch, bind that folder in Settings > Workspaces and use a "
     "chat in that Workspace."
 )
+
+
+def validate_canonical_directory(value: os.PathLike[str] | str) -> Path:
+    """Validate an existing absolute directory without normalizing aliases.
+
+    Args:
+        value: Directory spelling that must already be canonical, including
+            every ancestor. Hidden profile directories are permitted.
+
+    Returns:
+        The validated canonical directory. Callers must still pin descriptors
+        and enforce their own authority and containment during filesystem use.
+
+    Raises:
+        ValueError: If the value is not an existing canonical directory. The
+            error contains no path content.
+    """
+    try:
+        raw = os.fspath(value)
+        if type(raw) is not str or not raw or "\x00" in raw:
+            raise ValueError
+        path = Path(raw)
+        if not path.is_absolute() or str(path) != raw:
+            raise ValueError
+        if path.resolve(strict=True) != path:
+            raise ValueError
+        if not stat.S_ISDIR(os.lstat(path).st_mode):
+            raise ValueError
+        return path
+    except (OSError, TypeError, ValueError, RuntimeError):
+        raise ValueError("Canonical directory required") from None
 
 
 def validate_path(

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -5836,19 +5836,33 @@ class ConsoleComposerBar(Horizontal):
             body = message or state
             width = min(width, len(body) + 2)
 
+        # The busy preparation row hides optional chrome. Reserve the actual
+        # stable action width plus the chip's three surrounding layout cells.
+        full_width_preparing = (
+            state == STATE_PREPARING and cell_len(body) + 2 >= self.VOICE_CHIP_MAX_WIDTH
+        )
+        if full_width_preparing:
+            width = min(
+                width,
+                max(
+                    1,
+                    total_width - self._actions_row_width(attachment_visible=False) - 3,
+                ),
+            )
+            chip.tooltip = body
+            if (
+                cell_len(body) + 1 > width
+                and body == "Local transcription busy — dictation will run next."
+            ):
+                compact = "Local transcription busy — queued."
+                body = compact if cell_len(compact) + 1 <= width else "Queued"
+        else:
+            chip.tooltip = None
         chip.styles.display = "block"
         chip.styles.width = max(width, 1)
         chip.styles.min_width = 0
         chip.styles.height = 1
         chip.styles.min_height = 1
-        # Production CSS resolves the 53-cell ceiling to 52 cells here. The
-        # 51-cell executor-wait copy therefore gives back its trailing padding,
-        # keeps the normal one-cell right margin, and temporarily hides only
-        # presentation chrome; every ordinary repaint restores both padding
-        # and chrome without touching draft/editor state.
-        full_width_preparing = (
-            state == STATE_PREPARING and cell_len(body) + 2 >= self.VOICE_CHIP_MAX_WIDTH
-        )
         self._sync_full_width_voice_presentation(full_width_preparing)
         if full_width_preparing:
             chip.styles.padding = (0, 0, 0, 1)

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -978,6 +978,13 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if not self._is_current_view():
             self.release_interaction_capture()
             return
+        self._apply_interaction_position(event)
+        event.stop()
+
+    def _apply_interaction_position(self, event: events.MouseEvent) -> None:
+        """Apply the latest pointer sample while the interaction is still armed."""
+        if self._interaction is None:
+            return
         mode, origin_x, origin_y, original = self._interaction
         screen_x = int(event.screen_x if event.screen_x is not None else event.x)
         screen_y = int(event.screen_y if event.screen_y is not None else event.y)
@@ -998,7 +1005,6 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self._working_preferences, geometry=preferred
         )
         self._apply_geometry(preferred)
-        event.stop()
 
     def on_mouse_up(self, event: events.MouseUp) -> None:
         """Finish one interaction, release capture, and persist exactly once."""
@@ -1009,7 +1015,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if not self._is_current_view():
             self.release_interaction_capture()
             return
-        self._interaction = None
+        # Terminals may coalesce moves or report the last position only on release.
+        self._apply_interaction_position(event)
         self.release_interaction_capture()
         self._schedule_geometry_persist(self._working_preferences.geometry)
         event.stop()


### PR DESCRIPTION
Migu Buddy can lose final native move/resize coordinates, reject valid profile-owned visual drafts, or remain idle during real speech playback. This PR repairs those remaining UAT defects and the Console voice/recovery regressions exposed while verifying them.

Rebased again onto latest `dev` at `9b272bde04` after review fixes; the only conflict was two appended lessons entries, both preserved. All three PR commits are unchanged after the latest rebase. The new dev changes touched Console tests/docs only; 109 Console context/rail/draft/readback tests passed on the resulting head `40d4fb1319`. The earlier follow-up fixes were first rebased onto `b52080fee0`.

- Apply final native release coordinates and support profile-owned Persona Visual publication while preserving file identity, digest, containment and symlink checks.
- Route readback through trusted Manual Speak, and connect actual playback to a unique Buddy voice lease. Terminal callbacks release only their request, including after a session change.
- Terminalize setup refusal and restore unsent drafts for their visible owner. Preserve durable pending-response ownership and explicit recovery.
- Keep the microphone reachable during busy transcription at 80 columns, preserving stable Send width and attachments. Narrow status has a complete concise label and full tooltip.
- Exclude nested Python environments from diagnostics; remove exception capture from two lifecycle errors; repair moved/retired diagnostic assertions and the missing Library annotation import.
- Repair stale verification fixtures: explicit capture-off for in-memory composer harnesses, realistic instruction-omission budget, transient/durable retry coverage, and the production split Console stylesheet for visual tests.

Existing ADR-074, ADR-037, ADR-069 and ADR-029 govern these repairs; no new schema or dependency. Tracks TASK-31585.

### Validation

Tests imported the actual PR tree. No full repository sweep was run.

Latest-dev rebase (`7c3c83809b`): **74** Console voice/draft/project-instruction regressions and **150** Buddy/publication/setup regressions passed; all six derived-artifact checks passed. Git range-diff confirms the rebase preserved both fix commits unchanged.

- Initial rebased targeted run: **414 passed, 3 voice failures**, subsequently repaired and reverified below.
- Diagnostic suite: **69 passed, 1 skipped** (unavailable historical Git objects; live assertions remain enabled).
- Speech ownership, autoplay and Buddy adapters: **102 passed**.
- Complete voice-chip and mounted dictation selection: **103 passed**.
- Focused mounted microphone/chip regressions: **13 passed**; independent chip review **15 passed**.
- All six derived-artifact preflight checks passed (CSS, paths, diagnostics, task IDs, schema allowlist and index pins).
- Original eight baseline failures all repaired; privacy checks remain enforced.
- Changed Python files pass fatal-rule checks; new readback tests pass Ruff; changed ranges formatted and `git diff --check` passes.

### Live UAT

- **Kokoro:** real local playback drained 128,000 PCM bytes; Migu idle → speaking → idle; speech presentation cleared.
- **DeepSeek:** expected synthetic reply received; Migu idle → thinking → speaking → idle; run completed.
- Both ran from the rebased PR worktree with isolated profile data, no application exceptions, and normal settings unchanged. No microphone content was sent.

Known UAT limits: physical macOS dragging awaits the dedicated Terminal window being brought to the front (the background gesture changed no geometry), and OpenAI realtime UAT requires a configured credential. Earlier hardware/native evidence is explicitly historical. TASK-31585 remains In Progress for these acceptance checks. The user requested review and merge of the verified fixes; Qodo feedback and final-head CI must be addressed before merge.

[Evidence and exact verification limits](https://github.com/rmusser01/tldw_chatbook/blob/codex/migu-buddy-uat-fixes/qa/buddy-uat-2026-09-05/README.md) include minimized live records and production source digests.


### Qodo review fixes

Addressed all three initial findings: preserve undo/redo after post-acceptance refusal under visible-session/edit guards, centralize strict canonical-directory validation used by publication and cleanup, and add an allowlisted view key to lazy mount diagnostics without exception capture. **174** targeted undo/draft/LLM/publication/path tests and **2** diagnostic privacy checks passed. The diagnostic pin changes one existing 14-call owner signature, with no new sink. Live UAT evidence predates these bounded review follow-ups and keeps its original source digests.


### Latest-dev task collision

The PR #2403 merge introduced another TASK-31585. Following TASK-19601, Buddy (created 03:32) retains its ID; the younger Console closeout (03:40) moves to TASK-31591 with provenance and both plan/spec links updated. A fresh sweep covered 334 refs and 63 worktrees; the backlog guard now passes across 3,260 files. This is a metadata-only correction.


Latest Buddy-overlay integration rebase (`ca0140fbea`): all four PR commits are preserved unchanged. **151** Buddy app-mount/widget/readback/adapter/import-deferral tests passed against the newly merged app-level overlay owner; all six local preflight checks passed.


Final scheduler-base rebase (`32dfe76088`): all four PR commits preserved unchanged; **61** scheduler heartbeat/loop and readback tests plus all six preflight checks passed. This incorporates PR #2399, which landed after the prior head had passed every CI check.
