### PR TITLE
feat(console): bell and nav badge when a run blocks on the user off-screen (TASK-31385)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -368,6 +368,12 @@ marker stays the durable pointer to what finished.
   they never resolve themselves.
 - A background run that ends also toasts once: "Agent in <tab> (<workspace>)
   finished." (or "failed.").
+- A round that blocks on you — an approval, a skill or worktree confirm, or
+  a question — while you are on **another screen** (Library, Settings, …) or
+  Console has not been opened this launch rings the terminal bell once, and
+  the **Console** entry in the top navigation carries a `◆` badge until the
+  round resolves. `[console] interrupt_bell = false` silences the bell; the
+  badge stays. A round raised while Console is in front rings nothing.
 - The left rail pins a fleet summary line whenever other tabs are busy:
   "N other agents running, M waiting for approval."
 - Open session tabs show `Qn`, and open conversation rows show `Queue n`,

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -372,7 +372,8 @@ marker stays the durable pointer to what finished.
   a question — while you are on **another screen** (Library, Settings, …) or
   Console has not been opened this launch rings the terminal bell once, and
   the **Console** entry in the top navigation carries a `◆` badge until the
-  round resolves. `[console] interrupt_bell = false` silences the bell; the
+  round resolves. `[console] interrupt_bell = false` (or the
+  `TLDW_CONSOLE_INTERRUPT_BELL` environment variable) silences the bell; the
   badge stays. A round raised while Console is in front rings nothing.
 - The left rail pins a fleet summary line whenever other tabs are busy:
   "N other agents running, M waiting for approval."

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -278,8 +278,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 62,
-      "diagnostic_digest": "592be02944e2c1d0d772",
+      "call_count": 63,
+      "diagnostic_digest": "89be6c3f4de31869132b",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_controller.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -348,8 +348,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "34e4a03182256ca6bd34",
+      "call_count": 2,
+      "diagnostic_digest": "8e096c7f2fd6511a94e1",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_interrupt_rounds.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -11359,7 +11359,7 @@
     "owner_files": 574,
     "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
-    "task_492_calls": 1334,
+    "task_492_calls": 1336,
     "task_494_calls": 7599
   }
 }

--- a/Tests/Chat/test_console_interrupt_attention.py
+++ b/Tests/Chat/test_console_interrupt_attention.py
@@ -22,9 +22,16 @@ class _App:
         self.bells += 1
 
 
-def _controller(app, *, attached: bool):
+def _controller(app, *, attached: bool, pending: int = 0):
     controller = ConsoleChatController(store=ConsoleChatStore(), provider_gateway=None)
     controller.app = app
+    # The badge re-reads the host's truth on the UI thread, so a test that
+    # expects a count must have that many rounds registered.
+    with controller._interrupt_host.lock:
+        for index in range(pending):
+            controller._interrupt_host.registries["question"][f"r{index}"] = {
+                "event": threading.Event()
+            }
     if attached:
         controller.set_pending_approval = lambda payload: None
         controller.park_pending_approval = lambda session_id: None
@@ -36,38 +43,85 @@ def _controller(app, *, attached: bool):
 
 def test_a_round_raised_while_console_is_away_rings_once_and_badges():
     app = _App()
-    controller = _controller(app, attached=False)
+    controller = _controller(app, attached=False, pending=1)
     controller.on_pending_rounds_changed(1, "question", True)
     assert app.bells == 1 and getattr(app, CONSOLE_ATTENTION_ATTR) == 1
     # Teardown clears the badge and never rings.
+    with controller._interrupt_host.lock:
+        controller._interrupt_host.registries["question"].clear()
     controller.on_pending_rounds_changed(0, "question", False)
     assert app.bells == 1 and getattr(app, CONSOLE_ATTENTION_ATTR) == 0
 
 
 def test_a_round_raised_while_console_is_visible_badges_but_does_not_ring():
     app = _App()
-    controller = _controller(app, attached=True)
+    controller = _controller(app, attached=True, pending=2)
     controller.on_pending_rounds_changed(2, "approval", True)
     assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 2
 
 
-def test_the_setting_silences_the_bell_and_headless_never_rings(monkeypatch):
+def _config_bell(monkeypatch, value):
     import tldw_chatbook.Chat.console_chat_controller as ccc
 
     monkeypatch.setattr(
         ccc,
         "get_cli_setting",
-        lambda section, key, default=None: False
+        lambda section, key, default=None: value
         if (section, key) == ("console", "interrupt_bell")
         else default,
     )
+
+
+def _rings(monkeypatch, *, env, config) -> int:
+    from tldw_chatbook.Chat.console_chat_controller import INTERRUPT_BELL_ENV_VAR
+
+    if env is None:
+        monkeypatch.delenv(INTERRUPT_BELL_ENV_VAR, raising=False)
+    else:
+        monkeypatch.setenv(INTERRUPT_BELL_ENV_VAR, env)
+    _config_bell(monkeypatch, config)
     app = _App()
-    _controller(app, attached=False).on_pending_rounds_changed(1, "approval", True)
-    assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 1
-    monkeypatch.undo()
+    _controller(app, attached=False, pending=1).on_pending_rounds_changed(1, "approval", True)
+    return app.bells
+
+
+def test_bell_setting_precedence_is_environment_then_config_then_default(monkeypatch):
+    assert _rings(monkeypatch, env=None, config=None) == 1  # default on
+    assert _rings(monkeypatch, env=None, config=False) == 0  # config wins over default
+    assert _rings(monkeypatch, env="0", config=True) == 0  # env wins over config
+    assert _rings(monkeypatch, env="true", config=False) == 1
+    assert _rings(monkeypatch, env="   ", config=False) == 0  # blank env = unset
+    assert _rings(monkeypatch, env="maybe", config=None) == 0  # app-wide bool rule: not truthy -> off
+    assert _rings(monkeypatch, env="yes", config=None) == 1
+
+
+def test_headless_never_rings_and_a_zero_total_raise_never_rings(monkeypatch):
     headless = _App(headless=True)
     _controller(headless, attached=False).on_pending_rounds_changed(1, "approval", True)
     assert headless.bells == 0
+    app = _App()
+    _controller(app, attached=False).on_pending_rounds_changed(0, "approval", True)
+    assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 0
+
+
+def test_the_badge_shows_the_hosts_current_total_not_a_stale_dispatch():
+    app = _App()
+    controller = _controller(app, attached=True)
+    with controller._interrupt_host.lock:
+        controller._interrupt_host.registries["question"]["r1"] = {"event": threading.Event()}
+    # An older teardown dispatch (total 0) landing after a newer arm must not
+    # clear the badge while a round is still registered.
+    controller.on_pending_rounds_changed(0, "approval", False)
+    assert getattr(app, CONSOLE_ATTENTION_ATTR) == 1
+
+
+def test_a_raising_marshal_never_escapes_the_hook():
+    class _Broken(_App):
+        def call_from_thread(self, fn, *args, **kwargs):
+            raise RuntimeError("app is shutting down")
+
+    app = _Broken()
+    _controller(app, attached=False).on_pending_rounds_changed(1, "approval", True)  # must not raise
 
 
 def test_no_app_is_a_no_op():
@@ -100,3 +154,75 @@ def test_the_host_reports_arm_and_teardown_totals_through_the_seam():
         session_id="s1", owning_session_id="s1", deadline=None, is_parked=False,
     )
     assert seen == [(1, "question", True), (0, "question", False)]
+
+
+def _seams(seen, *, on_add=None):
+    class _Seams:
+        app = _App()
+        store = ConsoleChatStore()
+        set_pending_approval = None
+        park_pending_approval = None
+
+        @staticmethod
+        def _is_session_cancelled(session_id, *, cancel_event=None, visit_event=None):
+            return False
+
+        @staticmethod
+        def add_pending_round(session_id, round_id):
+            if on_add is not None:
+                on_add(round_id)
+
+        @staticmethod
+        def discard_pending_round(session_id, round_id):
+            return None
+
+        @staticmethod
+        def on_pending_rounds_changed(total, kind, raised):
+            seen.append((total, kind, raised))
+
+    return _Seams()
+
+
+def test_a_round_revoked_between_registration_and_announce_never_announces():
+    seen = []
+    host_box = {}
+    state = {"event": threading.Event(), "session_id": "s1", "run_id": "run-1", "revoked": False}
+
+    def _revoke(round_id):
+        # The sweep lands right after registration, before the arm is announced.
+        host_box["host"].revoke_for_run("run-1", {"question": lambda s: None})
+
+    host = InterruptRoundHost(_seams(seen, on_add=_revoke))
+    host_box["host"] = host
+    outcome = host.run_round(
+        "question", "r1", {"round_id": "r1", "session_id": "s1"}, state,
+        session_id="s1", owning_session_id="s1", deadline=None, is_parked=False,
+    )
+    assert outcome == "revoked"
+    assert all(raised is False for _total, _kind, raised in seen), seen
+    assert seen[-1][0] == 0
+
+
+def test_a_raising_attention_hook_never_skips_the_teardown():
+    class _Seams:
+        app = _App()
+        store = ConsoleChatStore()
+        set_pending_approval = None
+        park_pending_approval = None
+
+        @staticmethod
+        def _is_session_cancelled(session_id, *, cancel_event=None, visit_event=None):
+            return False
+
+        @staticmethod
+        def on_pending_rounds_changed(total, kind, raised):
+            raise RuntimeError("badge painter exploded")
+
+    host = InterruptRoundHost(_Seams())
+    state = {"event": threading.Event(), "session_id": "s1"}
+    state["event"].set()
+    assert host.run_round(
+        "question", "r1", {"round_id": "r1", "session_id": "s1"}, state,
+        session_id="s1", owning_session_id="s1", deadline=None, is_parked=False,
+    ) == "decided"
+    assert host.registries["question"] == {} and host.payloads["question"] == {}

--- a/Tests/Chat/test_console_interrupt_attention.py
+++ b/Tests/Chat/test_console_interrupt_attention.py
@@ -1,0 +1,102 @@
+"""task-31385: attention when a round blocks on the user off-screen."""
+
+from __future__ import annotations
+
+import threading
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_interrupt_rounds import InterruptRoundHost
+from tldw_chatbook.UI.Navigation.main_navigation import CONSOLE_ATTENTION_ATTR
+
+
+class _App:
+    def __init__(self, *, headless: bool = False) -> None:
+        self.is_headless = headless
+        self.bells = 0
+
+    def call_from_thread(self, fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    def bell(self) -> None:
+        self.bells += 1
+
+
+def _controller(app, *, attached: bool):
+    controller = ConsoleChatController(store=ConsoleChatStore(), provider_gateway=None)
+    controller.app = app
+    if attached:
+        controller.set_pending_approval = lambda payload: None
+        controller.park_pending_approval = lambda session_id: None
+    else:
+        controller.set_pending_approval = None
+        controller.park_pending_approval = None
+    return controller
+
+
+def test_a_round_raised_while_console_is_away_rings_once_and_badges():
+    app = _App()
+    controller = _controller(app, attached=False)
+    controller.on_pending_rounds_changed(1, "question", True)
+    assert app.bells == 1 and getattr(app, CONSOLE_ATTENTION_ATTR) == 1
+    # Teardown clears the badge and never rings.
+    controller.on_pending_rounds_changed(0, "question", False)
+    assert app.bells == 1 and getattr(app, CONSOLE_ATTENTION_ATTR) == 0
+
+
+def test_a_round_raised_while_console_is_visible_badges_but_does_not_ring():
+    app = _App()
+    controller = _controller(app, attached=True)
+    controller.on_pending_rounds_changed(2, "approval", True)
+    assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 2
+
+
+def test_the_setting_silences_the_bell_and_headless_never_rings(monkeypatch):
+    import tldw_chatbook.Chat.console_chat_controller as ccc
+
+    monkeypatch.setattr(
+        ccc,
+        "get_cli_setting",
+        lambda section, key, default=None: False
+        if (section, key) == ("console", "interrupt_bell")
+        else default,
+    )
+    app = _App()
+    _controller(app, attached=False).on_pending_rounds_changed(1, "approval", True)
+    assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 1
+    monkeypatch.undo()
+    headless = _App(headless=True)
+    _controller(headless, attached=False).on_pending_rounds_changed(1, "approval", True)
+    assert headless.bells == 0
+
+
+def test_no_app_is_a_no_op():
+    controller = _controller(None, attached=False)
+    controller.on_pending_rounds_changed(1, "approval", True)  # must not raise
+
+
+def test_the_host_reports_arm_and_teardown_totals_through_the_seam():
+    seen = []
+
+    class _Seams:
+        app = _App()
+        store = ConsoleChatStore()
+        set_pending_approval = None
+        park_pending_approval = None
+
+        @staticmethod
+        def _is_session_cancelled(session_id, *, cancel_event=None, visit_event=None):
+            return False
+
+        @staticmethod
+        def on_pending_rounds_changed(total, kind, raised):
+            seen.append((total, kind, raised))
+
+    host = InterruptRoundHost(_Seams())
+    state = {"event": threading.Event(), "session_id": "s1"}
+    state["event"].set()
+    host.run_round(
+        "question", "r1", {"round_id": "r1", "session_id": "s1"}, state,
+        session_id="s1", owning_session_id="s1", deadline=None, is_parked=False,
+    )
+    assert seen == [(1, "question", True), (0, "question", False)]

--- a/Tests/UI/test_nav_console_attention.py
+++ b/Tests/UI/test_nav_console_attention.py
@@ -1,0 +1,43 @@
+"""task-31385: the Console nav button carries a badge while interrupts pend."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Button
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.UI.Navigation.main_navigation import (
+    CONSOLE_ATTENTION_ATTR,
+    CONSOLE_ATTENTION_GLYPH,
+    MainNavigationBar,
+    set_console_attention,
+)
+
+
+class _App(ConsolidatedCSSApp):
+    def compose(self) -> ComposeResult:
+        yield MainNavigationBar(active="home")
+
+
+@pytest.mark.asyncio
+async def test_badge_appears_on_a_mounted_bar_and_clears_at_zero():
+    app = _App()
+    async with app.run_test(size=(140, 24)) as pilot:
+        await pilot.pause()
+        button = app.query_one("#nav-console", Button)
+        base = str(button.label)
+        assert CONSOLE_ATTENTION_GLYPH not in base
+        set_console_attention(app, 2)
+        assert str(button.label) == f"{base} {CONSOLE_ATTENTION_GLYPH}"
+        set_console_attention(app, 0)
+        assert str(button.label) == base
+
+
+@pytest.mark.asyncio
+async def test_a_bar_composed_after_the_round_armed_shows_the_badge_on_mount():
+    app = _App()
+    setattr(app, CONSOLE_ATTENTION_ATTR, 1)
+    async with app.run_test(size=(140, 24)) as pilot:
+        await pilot.pause()
+        assert str(app.query_one("#nav-console", Button).label).endswith(CONSOLE_ATTENTION_GLYPH)

--- a/backlog/tasks/task-31385 - Console-attention-when-away-notify-the-user-when-a-run-blocks-on-them-off-screen.md
+++ b/backlog/tasks/task-31385 - Console-attention-when-away-notify-the-user-when-a-run-blocks-on-them-off-screen.md
@@ -3,9 +3,11 @@ id: TASK-31385
 title: >-
   Console attention when away: notify the user when a run blocks on them
   off-screen
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-04 19:29'
+updated_date: '2026-09-05 01:25'
 labels:
   - console
   - ux
@@ -21,8 +23,30 @@ When an agent run blocks on the user -- an approval, a skill or worktree confirm
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A blocking round raised while Console is not the visible screen produces a terminal notification (bell or OSC 9/777) governed by a [console] setting that defaults on
-- [ ] #2 The Console entry in the app navigation shows a pending-interrupt badge until the round resolves
-- [ ] #3 A round raised while Console is visible produces no bell
-- [ ] #4 Headless and test runs never emit terminal control sequences
+- [x] #1 A blocking round raised while Console is not the visible screen produces a terminal notification (bell or OSC 9/777) governed by a [console] setting that defaults on
+- [x] #2 The Console entry in the app navigation shows a pending-interrupt badge until the round resolves
+- [x] #3 A round raised while Console is visible produces no bell
+- [x] #4 Headless and test runs never emit terminal control sequences
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Host: run_round notifies a late-bound seam on_pending_rounds_changed(total, kind, raised) after the mount/park step and after the teardown pop.
+2. Controller: marshal to the UI thread; nav badge = app-level pending count applied to the Console button on the content screen's MainNavigationBar; bell via App.bell() only when raised, the Console view seams are detached, the [console] interrupt_bell setting (default on) is set, and the app is not headless.
+3. MainNavigationBar.on_mount applies the app-level count so a screen composed after the round shows the badge.
+4. Config default + user-guide line; tests for host hook, controller gate matrix, nav badge.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Approach.** One hook on the interrupt host, two effects in the controller, one badge helper in the navigation module.
+
+- `InterruptRoundHost.run_round` calls the late-bound seam `on_pending_rounds_changed(total, kind, raised)` after a round mounts or parks (`raised=True`) and after its registry entry is popped in teardown (`raised=False`); `pending_total()` counts every kind. A controller or test double without the seam hears nothing.
+- `ConsoleChatController.on_pending_rounds_changed` marshals to the UI thread: `set_console_attention(app, total)` always; `App.bell()` only when the round is being raised, `[console] interrupt_bell` (default on) is set, no Console view is attached (`_approval_view_is_detached()` -- `detach_view` clears every slot together, so the approval pair stands for all five kinds; a Console never opened this launch counts as away), and the app is not headless (explicit `is_headless` gate; Textual's own `bell` also no-ops headless).
+- `UI/Navigation/main_navigation.py`: `set_console_attention` stores the count on the app and repaints the `#nav-console` button on every screen in the stack; `MainNavigationBar.on_mount` applies it, so a bar composed after the round armed (each screen composes its own) shows the `◆` badge too. The badge clears when the total returns to zero.
+- Bell only, no OSC 9/777: AC #1 allows either, the bell is one Textual call with no terminal detection.
+
+**Files.** `tldw_chatbook/Chat/console_interrupt_rounds.py`, `tldw_chatbook/Chat/console_chat_controller.py`, `tldw_chatbook/UI/Navigation/main_navigation.py`, `tldw_chatbook/config.py` (default), `Docs/User_Guide/console/agent-runs-and-tools.md`; tests `Tests/Chat/test_console_interrupt_attention.py` (gate matrix + host seam), `Tests/UI/test_nav_console_attention.py` (badge on a mounted bar, badge on a bar mounted later, clears at zero).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -346,6 +346,30 @@ from tldw_chatbook.Agents.builtin_tool_gate import (
     build_builtin_gate,
 )
 from tldw_chatbook.Agents.human_input_wait import use_human_input_wait
+#: task-31385: environment override for ``[console] interrupt_bell``
+#: (environment -> config.toml -> default, like every other setting).
+INTERRUPT_BELL_ENV_VAR = "TLDW_CONSOLE_INTERRUPT_BELL"
+
+
+def _bool_or_none(value: object) -> bool | None:
+    """Coerce a setting to bool with ``load_settings``' rules, or None when unset.
+
+    An unset source (None or an empty string) yields None so the next
+    source decides; any other value is read with the app-wide rule
+    (``coerce_bool_setting``: the usual truthy spellings are True and
+    everything else is False), so a present override always decides.
+
+    Args:
+        value: The raw environment or config value.
+
+    Returns:
+        The parsed bool, or None when ``value`` is None or empty.
+    """
+    if value is None or value == "":
+        return None
+    parsed = coerce_bool_setting(value, True)
+    return None if parsed is None else bool(parsed)
+
 # task-31384: `Chat.console_interrupt_rounds` is imported lazily (constructor
 # and shims) so the host module stays off the UI-ready census (ADR-097);
 # this module is boot-resident, the controller instance is not.
@@ -11832,26 +11856,47 @@ class ConsoleChatController:
         app = self.app
         if app is None:
             return
-        setting = get_cli_setting("console", "interrupt_bell", True)
-        bell_on = setting if isinstance(setting, bool) else True
         ring = (
             raised
-            and bell_on
+            and total > 0
+            and self._interrupt_bell_enabled()
             and self._approval_view_is_detached()
             and not bool(getattr(app, "is_headless", False))
         )
+        host = getattr(self, "_interrupt_host", None)
 
         def _apply() -> None:
             from tldw_chatbook.UI.Navigation.main_navigation import set_console_attention
 
-            set_console_attention(app, total)
+            # Re-read the total on the UI thread: two workers' updates may
+            # be marshalled out of order, and the badge must show the
+            # host's current truth, not whichever dispatch ran last.
+            current = host.pending_total() if host is not None else total
+            set_console_attention(app, current)
             bell = getattr(app, "bell", None) if ring else None
             if callable(bell):
                 bell()
 
         marshal = getattr(app, "call_from_thread", None)
-        if callable(marshal):
+        if not callable(marshal):
+            return
+        try:
             marshal(_apply)
+        except Exception:  # noqa: BLE001 -- attention is best-effort, never the round
+            logger.opt(exception=True).debug("Console attention marshal failed")
+
+    def _interrupt_bell_enabled(self) -> bool:
+        """Resolve ``[console] interrupt_bell``: environment, then config, then on.
+
+        Returns:
+            False only when ``TLDW_CONSOLE_INTERRUPT_BELL`` (a non-empty
+            value) or the config key coerces to False.
+        """
+        env_value = _bool_or_none(os.environ.get(INTERRUPT_BELL_ENV_VAR, "").strip())
+        if env_value is not None:
+            return env_value
+        config_value = _bool_or_none(get_cli_setting("console", "interrupt_bell", None))
+        return True if config_value is None else config_value
 
     def _announce_detached_approval(self, session_id: str) -> None:
         """Raise the app-wide toast for a round armed with no Console view.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -11807,6 +11807,52 @@ class ConsoleChatController:
         """
         return self.set_pending_approval is None and self.park_pending_approval is None
 
+    def on_pending_rounds_changed(self, total: int, kind: str, raised: bool) -> None:
+        """task-31385: attention when a round blocks on the user off-screen.
+
+        WORKER THREAD; the host calls this after every round arms (mounted
+        or parked) and after every teardown. Two effects, both on the UI
+        thread: the Console entry in the app navigation carries a
+        pending-interrupt badge while ``total`` is non-zero, and a round
+        that ARMS while no Console view is attached -- the user is on
+        another screen, or Console has not been opened this launch --
+        rings the terminal bell once. The bell is governed by
+        ``[console] interrupt_bell`` (default on) and never fires in a
+        headless app, so tests and embedded runs emit no control bytes.
+        Visibility is read from the view seams (``_approval_view_is_
+        detached``): ``detach_view`` clears every slot together, so the
+        approval pair stands for all five kinds.
+
+        Args:
+            total: Rounds of every kind registered after this change.
+            kind: The round kind that changed (unused; kept for callers
+                that want to specialise).
+            raised: True for an arm, False for a teardown.
+        """
+        app = self.app
+        if app is None:
+            return
+        setting = get_cli_setting("console", "interrupt_bell", True)
+        bell_on = setting if isinstance(setting, bool) else True
+        ring = (
+            raised
+            and bell_on
+            and self._approval_view_is_detached()
+            and not bool(getattr(app, "is_headless", False))
+        )
+
+        def _apply() -> None:
+            from tldw_chatbook.UI.Navigation.main_navigation import set_console_attention
+
+            set_console_attention(app, total)
+            bell = getattr(app, "bell", None) if ring else None
+            if callable(bell):
+                bell()
+
+        marshal = getattr(app, "call_from_thread", None)
+        if callable(marshal):
+            marshal(_apply)
+
     def _announce_detached_approval(self, session_id: str) -> None:
         """Raise the app-wide toast for a round armed with no Console view.
 

--- a/tldw_chatbook/Chat/console_interrupt_rounds.py
+++ b/tldw_chatbook/Chat/console_interrupt_rounds.py
@@ -274,6 +274,27 @@ class InterruptRoundHost:
 
         app.call_from_thread(_apply)
 
+    def pending_total(self) -> int:
+        """How many rounds of every kind are registered right now."""
+        with self.lock:
+            return sum(len(rounds) for rounds in self.registries.values())
+
+    def _note_pending(self, kind: str, *, raised: bool) -> None:
+        """task-31385: tell the seams the pending-round total changed.
+
+        Late-bound like every other seam: a controller (or test double)
+        without ``on_pending_rounds_changed`` hears nothing. ``raised`` is
+        True right after a round mounted or parked and False after its
+        registry entry was popped in teardown.
+
+        Args:
+            kind: The round kind that changed.
+            raised: Whether this is the arm (True) or the teardown (False).
+        """
+        hook = getattr(self._seams, "on_pending_rounds_changed", None)
+        if hook is not None:
+            hook(self.pending_total(), kind, raised)
+
     def revoke_for_run(
         self,
         run_id: str,
@@ -445,6 +466,7 @@ class InterruptRoundHost:
                 setter = self._setter(kind)
                 if app is not None and setter is not None:
                     app.call_from_thread(setter, payload)
+            self._note_pending(kind, raised=True)
             outcome = "decided"
             wait_cm = (
                 use_human_input_wait(human_wait_run_id)
@@ -483,6 +505,7 @@ class InterruptRoundHost:
         finally:
             with self.lock:
                 self.registries[kind].pop(round_id, None)
+            self._note_pending(kind, raised=False)
             # task-31384: a kind may RETAIN its payload past teardown (the
             # approvals bridge keeps a definitive-after-start batch mounted
             # in its "finishing" phase). The hook runs OUTSIDE the lock and

--- a/tldw_chatbook/Chat/console_interrupt_rounds.py
+++ b/tldw_chatbook/Chat/console_interrupt_rounds.py
@@ -275,7 +275,11 @@ class InterruptRoundHost:
         app.call_from_thread(_apply)
 
     def pending_total(self) -> int:
-        """How many rounds of every kind are registered right now."""
+        """How many rounds of every kind are registered right now.
+
+        Returns:
+            The number of registered interrupt rounds across all kinds.
+        """
         with self.lock:
             return sum(len(rounds) for rounds in self.registries.values())
 
@@ -292,8 +296,14 @@ class InterruptRoundHost:
             raised: Whether this is the arm (True) or the teardown (False).
         """
         hook = getattr(self._seams, "on_pending_rounds_changed", None)
-        if hook is not None:
+        if hook is None:
+            return
+        try:
             hook(self.pending_total(), kind, raised)
+        except Exception:  # noqa: BLE001 -- attention is best-effort; the round and its teardown are not
+            logger.opt(exception=True).debug(
+                f"Pending-round attention hook failed for {kind}"
+            )
 
     def revoke_for_run(
         self,
@@ -466,7 +476,16 @@ class InterruptRoundHost:
                 setter = self._setter(kind)
                 if app is not None and setter is not None:
                     app.call_from_thread(setter, payload)
-            self._note_pending(kind, raised=True)
+            # A sweep can revoke and pop the round between registration and
+            # here; a round that is no longer registered never announces
+            # itself (no bell for a dead round, no zero-total "raised").
+            with self.lock:
+                still_live = (
+                    self.registries[kind].get(round_id) is state
+                    and not bool(state.get("revoked"))
+                )
+            if still_live:
+                self._note_pending(kind, raised=True)
             outcome = "decided"
             wait_cm = (
                 use_human_input_wait(human_wait_run_id)

--- a/tldw_chatbook/UI/Navigation/main_navigation.py
+++ b/tldw_chatbook/UI/Navigation/main_navigation.py
@@ -1,12 +1,13 @@
 """Main navigation bar for screen-based navigation."""
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING, Any, Callable
 from loguru import logger
 
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
 from textual.events import DescendantFocus
 from textual.geometry import Region
+from textual.css.query import NoMatches
 from textual.widgets import Button, Static
 from textual.message import Message
 from textual import on
@@ -64,6 +65,32 @@ def nav_button_label(destination_id: str, label: str) -> str:
     if shortcut.startswith("ctrl+"):
         return f"{NAV_HOTKEY_GLYPH}{shortcut.removeprefix('ctrl+')} {label}"
     return f"{shortcut.upper()} {label}"
+
+
+#: task-31385: where the app remembers how many Console interrupt rounds
+#: are pending, so a navigation bar composed AFTER a round armed (every
+#: screen composes its own bar) still shows the badge on mount.
+CONSOLE_ATTENTION_ATTR = "_console_pending_interrupts"
+#: The pending-interrupt badge on the Console nav button; the same glyph
+#: the session tabs use for "needs approval".
+CONSOLE_ATTENTION_GLYPH = "◆"
+
+
+def set_console_attention(app: Any, pending: int) -> None:
+    """UI THREAD: remember ``pending`` on the app and repaint every mounted bar.
+
+    Args:
+        app: The running app (a test double is fine; it only needs to
+            accept the attribute).
+        pending: How many Console interrupt rounds are registered now.
+    """
+    setattr(app, CONSOLE_ATTENTION_ATTR, int(pending))
+    stack = getattr(app, "screen_stack", None)
+    if not isinstance(stack, (list, tuple)):
+        return
+    for screen in stack:
+        for bar in screen.query(MainNavigationBar):
+            bar.apply_console_attention()
 
 
 class NavigateToScreen(Message):
@@ -404,8 +431,21 @@ class MainNavigationBar(Container):
         overflow_hint.display = False
         yield overflow_hint
 
+    def apply_console_attention(self) -> None:
+        """task-31385: badge the Console button while interrupt rounds are pending."""
+        try:
+            button = self.query_one("#nav-console", Button)
+        except NoMatches:
+            return
+        base = nav_button_label("console", get_shell_destination("console").label)
+        pending = int(getattr(self.app, CONSOLE_ATTENTION_ATTR, 0) or 0)
+        label = f"{base} {CONSOLE_ATTENTION_GLYPH}" if pending else base
+        if str(button.label) != label:
+            button.label = label
+
     def on_mount(self) -> None:
         """Scroll the initially active destination's button into view."""
+        self.apply_console_attention()
         # Order matters: settle the overflow indicators (which change the
         # strip's width) before aligning the active button.
         self.call_after_refresh(self._update_overflow_hints)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3241,6 +3241,7 @@ rail_layout_scope = "global"  # Share Console rail disclosure across workspaces;
 assistant_library_access_default = false  # New Console sessions block assistant Library access
 paste_collapse_threshold = 50  # Collapse pasted/inserted chunks only when longer than this many characters
 local_tools_enabled = true      # workspace, web, and Watchlists agent tools; every call still uses MCP Ask/Allow/Off permissions
+interrupt_bell = true           # Ring the terminal bell when an agent blocks on you (approval, confirm, question) while Console is not the visible screen; the Console nav badge shows regardless
 # ask_user_timeout_seconds = 0  # ask_user question card auto-continue: 0 (default) waits for an answer indefinitely; e.g. 120 continues the run without an answer after 120s. Environment override: TLDW_CONSOLE_ASK_USER_TIMEOUT_SECONDS
 raw_cli_permitted = false       # Persisted unlock only; every app launch still starts unarmed
 # Root-source byte limit; allowed range is 1-1048576 (1 MiB).

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3241,7 +3241,7 @@ rail_layout_scope = "global"  # Share Console rail disclosure across workspaces;
 assistant_library_access_default = false  # New Console sessions block assistant Library access
 paste_collapse_threshold = 50  # Collapse pasted/inserted chunks only when longer than this many characters
 local_tools_enabled = true      # workspace, web, and Watchlists agent tools; every call still uses MCP Ask/Allow/Off permissions
-interrupt_bell = true           # Ring the terminal bell when an agent blocks on you (approval, confirm, question) while Console is not the visible screen; the Console nav badge shows regardless
+interrupt_bell = true           # Ring the terminal bell when an agent blocks on you (approval, confirm, question) while Console is not the visible screen; the Console nav badge shows regardless. Environment override: TLDW_CONSOLE_INTERRUPT_BELL
 # ask_user_timeout_seconds = 0  # ask_user question card auto-continue: 0 (default) waits for an answer indefinitely; e.g. 120 continues the run without an answer after 120s. Environment override: TLDW_CONSOLE_ASK_USER_TIMEOUT_SECONDS
 raw_cli_permitted = false       # Persisted unlock only; every app launch still starts unarmed
 # Root-source byte limit; allowed range is 1-1048576 (1 MiB).


### PR DESCRIPTION
## Summary

TASK-31385, sub-project D of the Console interaction PRD: when an agent run blocks on the user while Console is not the visible screen, the user now hears and sees it.

- **Terminal bell.** A blocking round (MCP approval, skill-install / skill-script / worktree-merge confirm, `ask_user` question) that arms while no Console view is attached (the user is on Library, Settings, …, or Console has not been opened this launch) rings `App.bell()` once. Governed by `[console] interrupt_bell` (default on). Never rings while Console is in front, and never in a headless app (explicit `is_headless` gate on top of Textual's own).
- **Cross-screen badge.** The Console entry in the top navigation carries a `◆` badge while any interrupt round is pending and clears when the last one resolves. `set_console_attention` stores the count on the app and repaints every mounted bar; `MainNavigationBar.on_mount` applies it, so a bar composed after the round armed (every screen composes its own) shows it too.
- **One seam.** `InterruptRoundHost.run_round` reports the pending total through the late-bound `on_pending_rounds_changed(total, kind, raised)` after every arm and teardown; the controller does the gating and marshals to the UI thread. A controller or test double without the seam hears nothing.

Bell only, no OSC 9/777: the AC allows either and the bell is one Textual call with no terminal detection.

## Evidence

- `Tests/Chat/test_console_interrupt_attention.py`: gate matrix (away → bell + badge; visible → badge only; setting off → no bell; headless → no bell; no app → no-op) and the host seam reporting `(1, kind, True)` then `(0, kind, False)`.
- `Tests/UI/test_nav_console_attention.py`: badge on a mounted bar, badge on a bar mounted after the count was set, clears at zero.
- Host suite 27/27, master-shell navigation suite green, ask_user and headless-approval suites unchanged (their two failures are the dev baseline). Preflight clean; census unchanged (no new module).
- User guide: `Docs/User_Guide/console/agent-runs-and-tools.md`, "Background & parked runs".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Alerts the user when an agent run blocks on them while Console is not the visible screen: the terminal rings once and the Console entry in the top navigation shows a `◆` badge until the round resolves.

- The bell fires only when the round arms while no Console view is attached, `[console] interrupt_bell` (default on) is set, and the app is not headless; the setting resolves `TLDW_CONSOLE_INTERRUPT_BELL` → config → default with the app-wide bool rule.
- The badge clears when the last pending round resolves; bars composed after the round armed show it on mount, and it re-reads the host's pending total on the UI thread so out-of-order dispatches can't leave a stale count.
- `InterruptRoundHost.run_round` reports the pending total through a late-bound `on_pending_rounds_changed(total, kind, raised)` seam after every arm and teardown; a round revoked between registration and announcement never rings or announces, a raise with total 0 never rings, and the hook and its UI marshal are best-effort so a failure can't skip the round's teardown.

<sup>Written for commit a7eb196fcf8728b9966695bf43ecb6dacb311160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2405?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

