### PR TITLE
feat(console): fleet activity in the reply row and a per-call abandon (TASK-31386)

### DIFF
--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -57,8 +57,14 @@ tool finished and the model is composing the next round, and `Generating…`
 is the wait for the model's first response of the turn. The elapsed figure
 advances while you watch. The line is live-only — it vanishes the moment
 the reply's own text arrives, and a conversation you reopen later shows the
-completed `Tool` rows below instead. A sub-agent's work never appears here;
-it belongs to the **Sub-agents** panel in the left rail.
+completed `Tool` rows below instead. During a fleet turn, while the primary
+waits on its children, the line reads `2 sub-agents · ⚙ grep_files · 12s`
+(the count of running sub-agents and their longest-running tool) instead of
+`Thinking…`; each child's full step list stays in the **Sub-agents** panel
+in the left rail. Once a tool call has run for five seconds the line grows
+a `✕ abandon call` link: clicking it abandons that one call (the model sees
+it fail as "tool call cancelled") and the turn continues, unlike **Stop**,
+which ends the run.
 
 **In the transcript** — inline `Tool` rows appear between your message and the
 reply:

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -64,7 +64,8 @@ waits on its children, the line reads `2 sub-agents · ⚙ grep_files · 12s`
 in the left rail. Once a tool call has run for five seconds the line grows
 a `✕ abandon call` link: clicking it abandons that one call (the model sees
 it fail as "tool call cancelled") and the turn continues, unlike **Stop**,
-which ends the run.
+which ends the run. A tool that must finish once started (a Watchlists
+mutation, for example) cannot be abandoned and shows no link.
 
 **In the transcript** — inline `Tool` rows appear between your message and the
 reply:

--- a/Tests/Agents/test_tool_call_abandon.py
+++ b/Tests/Agents/test_tool_call_abandon.py
@@ -1,0 +1,54 @@
+"""task-31386: abandon one in-flight tool call and let the turn continue."""
+
+from __future__ import annotations
+
+import threading
+
+from tldw_chatbook.Agents.agent_models import TOOL_OUTCOME_CANCELLED
+from tldw_chatbook.Agents.agent_service import (
+    _call_with_timeout,
+    _clear_tool_call_inflight,
+    _mark_tool_call_inflight,
+    inflight_tool_call,
+    request_tool_call_abandon,
+    tool_call_abandon_requested,
+)
+
+
+def test_a_request_with_no_call_in_flight_is_refused_and_never_queued():
+    _clear_tool_call_inflight("run-x")
+    assert request_tool_call_abandon("run-x") is None
+    assert tool_call_abandon_requested("run-x") is False
+    _mark_tool_call_inflight("run-x", "c1", "grep_files")
+    assert inflight_tool_call("run-x") == ("c1", "grep_files")
+    assert tool_call_abandon_requested("run-x") is False  # the refusal left nothing behind
+    _clear_tool_call_inflight("run-x")
+
+
+def test_an_abandon_request_cancels_only_the_wrapped_call_and_is_cleared_after():
+    run_id = "run-abandon"
+    release = threading.Event()
+
+    def _hung():
+        release.wait(10)
+        return None
+
+    _mark_tool_call_inflight(run_id, "c1", "slow_tool")
+    try:
+        assert request_tool_call_abandon(run_id) == "slow_tool"
+        run_wide_stop = False
+        result = _call_with_timeout(
+            _hung,
+            seconds=30.0,
+            tool_name="slow_tool",
+            should_cancel=lambda: run_wide_stop or tool_call_abandon_requested(run_id),
+        )
+    finally:
+        _clear_tool_call_inflight(run_id)
+        release.set()
+    assert result.ok is False and result.outcome == TOOL_OUTCOME_CANCELLED
+    assert "cancelled" in (result.error or "")
+    # The run itself was never asked to stop, and the flag did not outlive the call.
+    assert run_wide_stop is False
+    assert tool_call_abandon_requested(run_id) is False
+    assert inflight_tool_call(run_id) is None

--- a/Tests/Agents/test_tool_call_abandon.py
+++ b/Tests/Agents/test_tool_call_abandon.py
@@ -52,3 +52,52 @@ def test_an_abandon_request_cancels_only_the_wrapped_call_and_is_cleared_after()
     assert run_wide_stop is False
     assert tool_call_abandon_requested(run_id) is False
     assert inflight_tool_call(run_id) is None
+
+
+def test_the_screen_action_reaches_the_service_and_cancels_only_the_call():
+    """The action -> controller -> service chain, with a hung call in flight."""
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    session.persisted_conversation_id = "conv-1"
+    controller = ConsoleChatController(store=store, provider_gateway=None)
+    controller._agent_bridge = SimpleNamespace(
+        live_primary_run_id=lambda conversation_id: "run-ui" if conversation_id == "conv-1" else None
+    )
+    notices = []
+    screen = SimpleNamespace(
+        _ensure_console_chat_controller=lambda: controller,
+        app_instance=SimpleNamespace(notify=lambda message, **kw: notices.append(message)),
+    )
+    # Nothing in flight: the click is refused, not queued.
+    ChatScreen.action_abandon_console_tool_call(screen)
+    assert notices == ["No tool call is running."]
+    assert tool_call_abandon_requested("run-ui") is False
+
+    release = threading.Event()
+
+    def _hung():
+        release.wait(10)
+        return None
+
+    _mark_tool_call_inflight("run-ui", "c1", "slow_tool")
+    try:
+        ChatScreen.action_abandon_console_tool_call(screen)
+        assert notices[-1] == "Abandoning slow_tool… the turn continues."
+        run_wide_stop = False
+        result = _call_with_timeout(
+            _hung,
+            seconds=30.0,
+            tool_name="slow_tool",
+            should_cancel=lambda: run_wide_stop or tool_call_abandon_requested("run-ui"),
+        )
+    finally:
+        _clear_tool_call_inflight("run-ui")
+        release.set()
+    assert result.ok is False and result.outcome == TOOL_OUTCOME_CANCELLED
+    assert run_wide_stop is False and inflight_tool_call("run-ui") is None

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -38,13 +38,17 @@ from tldw_chatbook.Chat.console_chat_models import (
     ConsoleRunStatus,
 )
 from tldw_chatbook.UI.Console_Modules.agent import (
+    CONSOLE_TURN_ACTIVITY_ABANDON_ACTION,
+    CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS,
     CONSOLE_TURN_ACTIVITY_SEPARATOR,
     CONSOLE_TURN_ACTIVITY_THINKING,
     ConsoleAgentController,
+    console_turn_activity_abandon_action,
     console_turn_activity_text,
 )
 from tldw_chatbook.Widgets.Console.console_transcript import (
     CONSOLE_GENERATING_PLACEHOLDER,
+    CONSOLE_TURN_ACTIVITY_ABANDON_COPY,
     ConsoleMarkdownMessage,
     ConsoleTranscript,
 )
@@ -871,14 +875,6 @@ async def test_an_ineffective_activity_never_repaints_an_idle_transcript():
 # offers "abandon call".
 # --------------------------------------------------------------------------
 
-from tldw_chatbook.UI.Console_Modules.agent import (  # noqa: E402
-    CONSOLE_TURN_ACTIVITY_ABANDON_ACTION,
-    CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS,
-    console_turn_activity_abandon_action,
-)
-from tldw_chatbook.Widgets.Console.console_transcript import (  # noqa: E402
-    CONSOLE_TURN_ACTIVITY_ABANDON_COPY,
-)
 
 
 def _child(*steps):
@@ -896,6 +892,9 @@ def test_a_fleet_turn_names_the_children_and_their_longest_running_tool():
     assert text == f"3 sub-agents{CONSOLE_TURN_ACTIVITY_SEPARATOR}⚙ grep_files{CONSOLE_TURN_ACTIVITY_SEPARATOR}12s"
     # No child inside a tool call: the count still replaces "Thinking…".
     assert console_turn_activity_text(primary, now=110.0, children=[thinking]) == "1 sub-agent working"
+    # A child whose run has not attached (no live feed yet) still counts.
+    assert console_turn_activity_text(primary, now=110.0, children=[None, slow]).startswith("2 sub-agents")
+    assert console_turn_activity_text(primary, now=110.0, children=[None]) == "1 sub-agent working"
 
 
 def test_a_primary_tool_call_still_wins_over_the_fleet_and_single_agent_turns_are_unchanged():

--- a/Tests/UI/test_console_turn_activity_line.py
+++ b/Tests/UI/test_console_turn_activity_line.py
@@ -864,3 +864,81 @@ async def test_an_ineffective_activity_never_repaints_an_idle_transcript():
     await ChatScreen._sync_native_console_transcript(screen)
 
     assert transcript.refresh_messages.await_count == 1
+
+
+# --------------------------------------------------------------------------
+# task-31386: fleet turns read as their children, and a long tool call
+# offers "abandon call".
+# --------------------------------------------------------------------------
+
+from tldw_chatbook.UI.Console_Modules.agent import (  # noqa: E402
+    CONSOLE_TURN_ACTIVITY_ABANDON_ACTION,
+    CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS,
+    console_turn_activity_abandon_action,
+)
+from tldw_chatbook.Widgets.Console.console_transcript import (  # noqa: E402
+    CONSOLE_TURN_ACTIVITY_ABANDON_COPY,
+)
+
+
+def _child(*steps):
+    return AgentLiveSnapshot(status="running", step=len(steps), steps=tuple(steps))
+
+
+def test_a_fleet_turn_names_the_children_and_their_longest_running_tool():
+    primary = _snapshot(
+        AgentLiveStep(kind=STEP_TOOL_RESULT, text="spawn", agent_kind=AGENT_KIND_PRIMARY, started_at=100.0),
+    )
+    quick = _child(AgentLiveStep(kind=STEP_TOOL_CALL, text="read_file", agent_kind=AGENT_KIND_SUBAGENT, started_at=108.0))
+    slow = _child(AgentLiveStep(kind=STEP_TOOL_CALL, text="grep_files", agent_kind=AGENT_KIND_SUBAGENT, started_at=98.0))
+    thinking = _child(AgentLiveStep(kind=STEP_MODEL, text="…", agent_kind=AGENT_KIND_SUBAGENT, started_at=105.0))
+    text = console_turn_activity_text(primary, now=110.0, children=[quick, slow, thinking])
+    assert text == f"3 sub-agents{CONSOLE_TURN_ACTIVITY_SEPARATOR}⚙ grep_files{CONSOLE_TURN_ACTIVITY_SEPARATOR}12s"
+    # No child inside a tool call: the count still replaces "Thinking…".
+    assert console_turn_activity_text(primary, now=110.0, children=[thinking]) == "1 sub-agent working"
+
+
+def test_a_primary_tool_call_still_wins_over_the_fleet_and_single_agent_turns_are_unchanged():
+    running_tool = _snapshot(
+        AgentLiveStep(kind=STEP_TOOL_CALL, text="fs_write", agent_kind=AGENT_KIND_PRIMARY, started_at=100.0),
+    )
+    child = _child(AgentLiveStep(kind=STEP_TOOL_CALL, text="grep_files", agent_kind=AGENT_KIND_SUBAGENT, started_at=90.0))
+    assert console_turn_activity_text(running_tool, now=103.0, children=[child]).startswith("⚙ fs_write")
+    between = _snapshot(
+        AgentLiveStep(kind=STEP_TOOL_RESULT, text="x", agent_kind=AGENT_KIND_PRIMARY, started_at=100.0),
+    )
+    assert console_turn_activity_text(between, now=103.0).startswith(CONSOLE_TURN_ACTIVITY_THINKING)
+    assert console_turn_activity_text(between, now=103.0, children=[]) == console_turn_activity_text(between, now=103.0)
+
+
+def test_the_abandon_action_appears_only_for_a_primary_tool_call_that_has_run_long_enough():
+    step = AgentLiveStep(kind=STEP_TOOL_CALL, text="slow", agent_kind=AGENT_KIND_PRIMARY, started_at=100.0)
+    snapshot = _snapshot(step)
+    before = 100.0 + CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS - 0.1
+    after = 100.0 + CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS
+    assert console_turn_activity_abandon_action(snapshot, now=before) == ""
+    assert console_turn_activity_abandon_action(snapshot, now=after) == CONSOLE_TURN_ACTIVITY_ABANDON_ACTION
+    child_only = _snapshot(AgentLiveStep(kind=STEP_TOOL_CALL, text="c", agent_kind=AGENT_KIND_SUBAGENT, started_at=1.0))
+    assert console_turn_activity_abandon_action(child_only, now=after) == ""
+    thinking = _snapshot(AgentLiveStep(kind=STEP_MODEL, text="m", agent_kind=AGENT_KIND_PRIMARY, started_at=1.0))
+    assert console_turn_activity_abandon_action(thinking, now=after) == ""
+    assert console_turn_activity_abandon_action(_snapshot(step, status="done"), now=after) == ""
+
+
+@pytest.mark.asyncio
+async def test_the_row_offers_abandon_call_only_while_the_action_is_set():
+    app = _ActivityHarness()
+    async with app.run_test(size=(120, 24)) as pilot:
+        await pilot.pause()
+        transcript = app.query_one(ConsoleTranscript)
+        row = _in_flight_assistant()
+        transcript.set_messages([_user(), row])
+        transcript.apply_turn_activity("⚙ slow · 6s", action=CONSOLE_TURN_ACTIVITY_ABANDON_ACTION)
+        await transcript.refresh_messages()
+        await pilot.pause()
+        assert CONSOLE_TURN_ACTIVITY_ABANDON_COPY in _rendered_row_text(transcript, row.id)
+        transcript.apply_turn_activity("⚙ slow · 7s")
+        await transcript.refresh_messages()
+        await pilot.pause()
+        text = _rendered_row_text(transcript, row.id)
+        assert "⚙ slow · 7s" in text and CONSOLE_TURN_ACTIVITY_ABANDON_COPY not in text

--- a/backlog/tasks/task-31386 - Console-live-progress-sub-agent-activity-and-an-adjacent-cancel-during-long-tool-calls.md
+++ b/backlog/tasks/task-31386 - Console-live-progress-sub-agent-activity-and-an-adjacent-cancel-during-long-tool-calls.md
@@ -3,9 +3,11 @@ id: TASK-31386
 title: >-
   Console live progress: sub-agent activity and an adjacent cancel during long
   tool calls
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-04 19:29'
+updated_date: '2026-09-05 01:41'
 labels:
   - console
   - ux
@@ -21,7 +23,28 @@ Sub-project E of the design spec (2026-08-19-console-user-interaction-design.md 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 During a fleet turn the activity line reflects the running child agents (count and the longest-running tool) rather than reading idle
-- [ ] #2 A long-running tool call exposes a cancel adjacent to the activity line that abandons that call and lets the turn continue, using the existing per-call abandon path
-- [ ] #3 Single-agent turns are unchanged
+- [x] #1 During a fleet turn the activity line reflects the running child agents (count and the longest-running tool) rather than reading idle
+- [x] #2 A long-running tool call exposes a cancel adjacent to the activity line that abandons that call and lets the turn continue, using the existing per-call abandon path
+- [x] #3 Single-agent turns are unchanged
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Activity line: console_turn_activity_text gains children= (the running sub-agents' own live snapshots via bridge.live_run_snapshot); when the primary is between tools it renders the child count and the longest-running child tool instead of Thinking….
+2. Per-call abandon: a module-level in-flight registry in Agents/agent_service.py; the dispatch marks the call before _call_with_timeout and ORs tool_call_abandon_requested(run_id) into that wrapper's cancel probe only, so the loop continues with the existing 'tool call cancelled' result.
+3. Affordance: after CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS the tick passes a click action (Style meta, not markup) that the row header renders as '✕ abandon call'; ChatScreen.action_abandon_console_tool_call -> ConsoleChatController.abandon_active_tool_call -> request_tool_call_abandon(latest unanchored primary run).
+4. Tests: pure fleet/abandon-action cases, mounted row affordance, service registry + wrapper cancel; user-guide paragraph.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Fleet activity (AC #1).** `console_turn_activity_text(snapshot, *, now, children=())` in `UI/Console_Modules/agent.py`: when the primary's latest step is not a tool call and `children` (the running sub-agents' own live snapshots, read through `ConsoleAgentBridge.live_run_snapshot`, the one live source of a working child's steps) is non-empty, the line renders `N sub-agent(s) · ⚙ <tool> · <elapsed>` for the child tool that has run longest, or `N sub-agent(s) working` when no child is inside a tool call. A primary tool call still wins, and a turn with no children renders exactly as before (AC #3).
+
+**Per-call abandon (AC #2).** `Agents/agent_service.py` keeps a module-level in-flight registry (`_mark_tool_call_inflight` / `_clear_tool_call_inflight` around the existing `_call_with_timeout` call) and `request_tool_call_abandon(run_id) -> tool name | None`. The request is ORed into that wrapper's cancel probe only, so the wrapper returns the existing "tool call cancelled" result on its next poll slice and abandons the worker thread exactly as a run-wide Stop does, while the run's own `should_cancel` stays False and the loop hands the failed result to the model. A request with nothing in flight is refused, never queued; the flag is cleared with the mark when the call ends. Calls dispatched without a timeout (`max_tool_call_seconds = 0`) bypass the wrapper and cannot be abandoned, as before.
+
+**Affordance.** Once the primary's tool call has run `CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS` (5 s), the 0.2 s transcript tick passes `action=CONSOLE_TURN_ACTIVITY_ABANDON_ACTION` to `ConsoleTranscript.apply_turn_activity`; the row header appends `✕ abandon call` carrying the action in a `Style.from_meta({"@click": ...})` (the same mechanism Textual's Markdown links use), so the line's text still renders literally. `ChatScreen.action_abandon_console_tool_call` -> `ConsoleChatController.abandon_active_tool_call` (viewed session's durable conversation -> newest unanchored primary run, the stop path's lookup) -> `request_tool_call_abandon`, with a notice either way. The plain (non-markdown) renderer shows the line without the link.
+
+**Files.** `tldw_chatbook/Agents/agent_service.py`, `tldw_chatbook/UI/Console_Modules/agent.py`, `tldw_chatbook/Widgets/Console/console_transcript.py`, `tldw_chatbook/Chat/console_chat_models.py` (`live_activity_action`), `tldw_chatbook/Chat/console_chat_controller.py`, `tldw_chatbook/UI/Screens/chat_screen.py`, `Docs/User_Guide/console/agent-runs-and-tools.md`; tests in `Tests/UI/test_console_turn_activity_line.py` (fleet line, primary-wins, action threshold, mounted affordance) and `Tests/Agents/test_tool_call_abandon.py` (refused when idle, wrapper cancels only the call and clears).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -1630,13 +1630,29 @@ def _clear_tool_call_inflight(run_id: str) -> None:
 
 
 def inflight_tool_call(run_id: str) -> tuple[str, str] | None:
-    """Return ``(call_key, tool_name)`` for ``run_id``'s in-flight call, or None."""
+    """Return the tool call ``run_id`` has in flight through the timeout wrapper.
+
+    Args:
+        run_id: The run to look up.
+
+    Returns:
+        ``(call_key, tool_name)`` while such a call is running, else None.
+        Calls dispatched outside the wrapper (no timeout, or a definitive-
+        after-start tool) are never registered and never abandonable.
+    """
     with _TOOL_CALL_ABANDON_LOCK:
         return _INFLIGHT_TOOL_CALLS.get(run_id)
 
 
 def tool_call_abandon_requested(run_id: str) -> bool:
-    """Whether the user asked to abandon ``run_id``'s in-flight tool call."""
+    """Whether the user asked to abandon ``run_id``'s in-flight tool call.
+
+    Args:
+        run_id: The run to look up.
+
+    Returns:
+        True while an abandon request is pending for the run's current call.
+    """
     with _TOOL_CALL_ABANDON_LOCK:
         return run_id in _TOOL_CALL_ABANDON_REQUESTS
 

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -1602,6 +1602,62 @@ def _usage_total_tokens(resp) -> int | None:
 
 _CANCEL_POLL_SECONDS = 0.5
 
+# task-31386: the one tool call a run has in flight, and the user's request
+# to abandon it. `request_tool_call_abandon(run_id)` is honoured by the very
+# next `_call_with_timeout` poll slice (<= `_CANCEL_POLL_SECONDS`), which
+# then returns the existing "tool call cancelled" result and leaves the
+# worker to die, exactly as a run-wide Stop does -- but the run's own
+# `should_cancel` stays False, so the loop hands the failed result back to
+# the model and the turn continues. A request with no call in flight is
+# refused (never queued against a future call), and the flag is cleared
+# with the in-flight mark when the call ends.
+_TOOL_CALL_ABANDON_LOCK = threading.Lock()
+_INFLIGHT_TOOL_CALLS: dict[str, tuple[str, str]] = {}
+_TOOL_CALL_ABANDON_REQUESTS: set[str] = set()
+
+
+def _mark_tool_call_inflight(run_id: str, call_key: str, tool_name: str) -> None:
+    """Record ``run_id``'s in-flight tool call for ``request_tool_call_abandon``."""
+    with _TOOL_CALL_ABANDON_LOCK:
+        _INFLIGHT_TOOL_CALLS[run_id] = (call_key, tool_name)
+
+
+def _clear_tool_call_inflight(run_id: str) -> None:
+    """Forget ``run_id``'s in-flight call and any abandon request against it."""
+    with _TOOL_CALL_ABANDON_LOCK:
+        _INFLIGHT_TOOL_CALLS.pop(run_id, None)
+        _TOOL_CALL_ABANDON_REQUESTS.discard(run_id)
+
+
+def inflight_tool_call(run_id: str) -> tuple[str, str] | None:
+    """Return ``(call_key, tool_name)`` for ``run_id``'s in-flight call, or None."""
+    with _TOOL_CALL_ABANDON_LOCK:
+        return _INFLIGHT_TOOL_CALLS.get(run_id)
+
+
+def tool_call_abandon_requested(run_id: str) -> bool:
+    """Whether the user asked to abandon ``run_id``'s in-flight tool call."""
+    with _TOOL_CALL_ABANDON_LOCK:
+        return run_id in _TOOL_CALL_ABANDON_REQUESTS
+
+
+def request_tool_call_abandon(run_id: str) -> str | None:
+    """Ask ``run_id`` to abandon its in-flight tool call and continue the turn.
+
+    Args:
+        run_id: The run whose current tool call should be abandoned.
+
+    Returns:
+        The abandoned tool's name, or None when the run has no call in
+        flight (nothing is queued for a later call).
+    """
+    with _TOOL_CALL_ABANDON_LOCK:
+        inflight = _INFLIGHT_TOOL_CALLS.get(run_id)
+        if inflight is None:
+            return None
+        _TOOL_CALL_ABANDON_REQUESTS.add(run_id)
+        return inflight[1]
+
 
 def _effective_tool_timeout(
     configured: float,
@@ -3124,17 +3180,24 @@ class AgentService:
                         ),
                         outcome=TOOL_OUTCOME_TIMEOUT,
                     )
-                return _call_with_timeout(
-                    _invoke,
-                    timeout,
-                    call.name,
-                    should_cancel,
-                    # ADR-067: pause the per-call clock while a human
-                    # decision is pending for THIS run, so an approval/
-                    # confirm wait inside the invoke outlives the ceiling.
-                    pauses_deadline=lambda: human_input_wait_active(run_id),
-                    clamped_by_wall_budget=clamped_by_wall_budget,
-                )
+                # task-31386: a per-call abandon request rides the same
+                # poll as the run-wide Stop, but only inside this wrapper --
+                # `should_cancel` itself stays False, so the loop continues.
+                _mark_tool_call_inflight(run_id, call.call_id or call.name, call.name)
+                try:
+                    return _call_with_timeout(
+                        _invoke,
+                        timeout,
+                        call.name,
+                        lambda: should_cancel() or tool_call_abandon_requested(run_id),
+                        # ADR-067: pause the per-call clock while a human
+                        # decision is pending for THIS run, so an approval/
+                        # confirm wait inside the invoke outlives the ceiling.
+                        pauses_deadline=lambda: human_input_wait_active(run_id),
+                        clamped_by_wall_budget=clamped_by_wall_budget,
+                    )
+                finally:
+                    _clear_tool_call_inflight(run_id)
             return _invoke()
 
         if self.post_tool_dispatch is None:

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -4316,6 +4316,11 @@ class ConsoleAgentBridge:
         #: line reads; a child's slot is reachable through
         #: `live_run_snapshot` and is never the summary.
         self._live: dict[str, dict[str, AgentLiveSnapshot]] = {}
+        #: task-31386: the primary run currently (or most recently) stepping
+        #: in each conversation, memoised from `on_step` so the 0.2s poll
+        #: and the "abandon call" click can find the run's in-flight tool
+        #: call without a DB lookup.
+        self._live_primary_runs: dict[str, str] = {}
         #: Which `_live[conversation_id]` key holds the rail's summary --
         #: the newest turn's primary run. Only `run_reply` writes it.
         self._live_primary_keys: dict[str, str] = {}
@@ -5422,6 +5427,8 @@ class ConsoleAgentBridge:
         planning_deriver = _PendingPrimaryPlanningDeriver()
 
         def on_step(step: AgentStep, agent_kind: str, run_id: str) -> None:
+            if agent_kind == AGENT_KIND_PRIMARY and run_id:
+                self._live_primary_runs[conversation_id] = run_id
             # PR 2a (task-3): AgentService now attributes every step to its
             # run id so a fleet of concurrent children can be told apart.
             # PR3a-1 Task 6b (audit F1): that attribution is finally USED.
@@ -7137,6 +7144,20 @@ class ConsoleAgentBridge:
         return coordinator.snapshot() if coordinator is not None else []
 
     # -- rail reads -----------------------------------------------------
+
+    def live_primary_run_id(self, conversation_id: str) -> str | None:
+        """task-31386: the primary run last seen stepping in ``conversation_id``.
+
+        In-memory only (memoised by ``on_step``), so a run from a previous
+        process is unknown here; callers fall back to the durable lookup.
+
+        Args:
+            conversation_id: The conversation to look up.
+
+        Returns:
+            The run id, or None when no primary step has been seen.
+        """
+        return self._live_primary_runs.get(conversation_id)
 
     def live_snapshot(self, conversation_id: str) -> AgentLiveSnapshot:
         """The rail's view of this conversation's agent activity.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -14047,7 +14047,10 @@ class ConsoleChatController:
                 break
         if not conversation_id:
             return None
-        run_id = self._latest_unanchored_primary_run_id(conversation_id)
+        find_run = getattr(self._agent_bridge, "live_primary_run_id", None)
+        run_id = find_run(conversation_id) if callable(find_run) else None
+        if not run_id:
+            run_id = self._latest_unanchored_primary_run_id(conversation_id)
         if not run_id:
             return None
         from tldw_chatbook.Agents.agent_service import request_tool_call_abandon

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -14024,6 +14024,36 @@ class ConsoleChatController:
             return "no active run to redirect — plain messages queue for the next turn"
         return redirect(text)
 
+    def abandon_active_tool_call(self) -> str | None:
+        """task-31386: abandon the active run's in-flight tool call; keep the turn.
+
+        UI THREAD. Resolves the viewed session's durable conversation to its
+        newest unanchored primary run (the run in flight, the same lookup
+        the stop path uses) and asks ``agent_service`` to abandon that run's
+        current tool call. The call's ``_call_with_timeout`` wrapper honours
+        the request on its next poll slice and returns the existing
+        "tool call cancelled" result; the run's own cancel probe stays
+        False, so the loop hands that result to the model and continues.
+
+        Returns:
+            The abandoned tool's name, or None when no tool call is in
+            flight for the viewed session (nothing is queued).
+        """
+        session_id = self.store.active_session_id or ""
+        conversation_id = ""
+        for session in self.store.sessions():
+            if session.id == session_id:
+                conversation_id = str(getattr(session, "persisted_conversation_id", "") or "")
+                break
+        if not conversation_id:
+            return None
+        run_id = self._latest_unanchored_primary_run_id(conversation_id)
+        if not run_id:
+            return None
+        from tldw_chatbook.Agents.agent_service import request_tool_call_abandon
+
+        return request_tool_call_abandon(run_id)
+
     def stop_active_run(self, *, record_user_stop: bool = True) -> bool:
         """Request the ACTIVE (viewed) session's stream to stop at the next
         safe boundary.

--- a/tldw_chatbook/Chat/console_chat_models.py
+++ b/tldw_chatbook/Chat/console_chat_models.py
@@ -1116,6 +1116,11 @@ class ConsoleChatMessage:
     #: 0.2s Console poll re-derives every tick. It is therefore always
     #: ``""`` on every message the rest of the app ever sees.
     live_activity: str = ""
+    #: task-31386: render-only companion to ``live_activity`` -- the Textual
+    #: action a click on the row's "abandon call" affordance runs, set only
+    #: while the primary's tool call has run long enough to offer it. Same
+    #: ownership and lifetime rules as ``live_activity``.
+    live_activity_action: str = ""
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -134,7 +134,7 @@ straight from `ConsoleAgentBridge.fleet_snapshot`/`historical_snapshot`.
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from dataclasses import replace
 from functools import partial
 from typing import Any, Dict, Iterable, TYPE_CHECKING
@@ -252,10 +252,17 @@ CONSOLE_TURN_ACTIVITY_TOOL_GLYPH = "⚙"
 CONSOLE_TURN_ACTIVITY_THINKING = "Thinking…"
 #: Separator between the state and its elapsed segment.
 CONSOLE_TURN_ACTIVITY_SEPARATOR = " · "
+#: task-31386: a primary tool call that has run at least this long offers
+#: the "abandon call" affordance next to the activity line.
+CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS = 5.0
+#: The Textual action that affordance runs (a `ChatScreen` action).
+CONSOLE_TURN_ACTIVITY_ABANDON_ACTION = "screen.abandon_console_tool_call"
 
 __all__ = [
     "ConsoleAgentController",
     "CONSOLE_AGENT_FLEET_SECTION_ID",
+    "CONSOLE_TURN_ACTIVITY_ABANDON_ACTION",
+    "CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS",
     "CONSOLE_TURN_ACTIVITY_SEPARATOR",
     "CONSOLE_TURN_ACTIVITY_THINKING",
     "CONSOLE_TURN_ACTIVITY_TOOL_GLYPH",
@@ -294,7 +301,77 @@ def _format_fleet_elapsed(seconds: float | None) -> str:
     return f"{minutes}m {secs}s"
 
 
-def console_turn_activity_text(snapshot: Any, *, now: float) -> str:
+def _fleet_turn_activity(children: Sequence[Any], *, now: float) -> str:
+    """task-31386: the line for a primary that is waiting on its children.
+
+    Args:
+        children: The RUNNING sub-agents' own live snapshots (duck-typed:
+            a ``steps`` sequence), as the parent's ``subagents`` summary
+            lists them.
+        now: ``time.monotonic()`` reading for this poll tick.
+
+    Returns:
+        ``"N sub-agent(s) · ⚙ <tool> · <elapsed>"`` naming the child tool
+        that has run longest, ``"N sub-agent(s) working"`` when no child is
+        inside a tool call, or ``""`` when nothing is running.
+    """
+    running = [child for child in children if child is not None]
+    if not running:
+        return ""
+    count = len(running)
+    label = f"{count} sub-agent{'s' if count != 1 else ''}"
+    tool_steps = []
+    for child in running:
+        steps = tuple(getattr(child, "steps", ()) or ())
+        last = steps[-1] if steps else None
+        if last is not None and getattr(last, "kind", "") == STEP_TOOL_CALL:
+            tool_steps.append(last)
+    if not tool_steps:
+        return f"{label} working"
+    longest = min(
+        tool_steps,
+        key=lambda step: (
+            step.started_at if getattr(step, "started_at", None) is not None else now
+        ),
+    )
+    line = f"{label}{CONSOLE_TURN_ACTIVITY_SEPARATOR}{CONSOLE_TURN_ACTIVITY_TOOL_GLYPH} {longest.text}"
+    started_at = getattr(longest, "started_at", None)
+    elapsed = _format_fleet_elapsed(max(0.0, now - started_at)) if started_at is not None else ""
+    return f"{line}{CONSOLE_TURN_ACTIVITY_SEPARATOR}{elapsed}" if elapsed else line
+
+
+def console_turn_activity_abandon_action(snapshot: Any, *, now: float) -> str:
+    """task-31386: the action to offer next to the line, or ``""``.
+
+    Only the PRIMARY's own in-flight tool call qualifies, and only once it
+    has run ``CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS``; a child's call
+    (its own run, its own budget) and the model's thinking never do.
+
+    Args:
+        snapshot: The conversation's ``AgentLiveSnapshot`` (duck-typed).
+        now: ``time.monotonic()`` reading for this poll tick.
+
+    Returns:
+        ``CONSOLE_TURN_ACTIVITY_ABANDON_ACTION`` or ``""``.
+    """
+    if getattr(snapshot, "status", "idle") != "running":
+        return ""
+    steps = tuple(getattr(snapshot, "steps", ()) or ())
+    step = next(
+        (s for s in reversed(steps) if getattr(s, "agent_kind", "") == AGENT_KIND_PRIMARY),
+        None,
+    )
+    if step is None or step.kind != STEP_TOOL_CALL:
+        return ""
+    started_at = getattr(step, "started_at", None)
+    if started_at is None or now - started_at < CONSOLE_TURN_ACTIVITY_ABANDON_AFTER_SECONDS:
+        return ""
+    return CONSOLE_TURN_ACTIVITY_ABANDON_ACTION
+
+
+def console_turn_activity_text(
+    snapshot: Any, *, now: float, children: Sequence[Any] = ()
+) -> str:
     """Return the live activity line for one in-flight Console turn.
 
     **Live-only, by construction.** There is no resumed counterpart and
@@ -333,11 +410,17 @@ def console_turn_activity_text(snapshot: Any, *, now: float) -> str:
     text -- mid-turn that is the tool-call fence itself -- so the state, not
     the summary, is what the user sees.
 
+    task-31386: during a fleet turn the primary is between tools while its
+    children work, which used to read as ``Thinking…``; with ``children``
+    (the running sub-agents' own live snapshots) that state renders their
+    count and longest-running tool instead. A primary tool call still wins.
+
     Args:
         snapshot: The conversation's ``AgentLiveSnapshot`` (duck-typed:
             ``status`` plus a ``steps`` sequence).
         now: ``time.monotonic()`` reading for this poll tick, injected so
             the elapsed segment is testable without sleeping.
+        children: Live snapshots of the RUNNING sub-agents, if any.
 
     Returns:
         The line to render, or ``""`` when nothing is live.
@@ -352,6 +435,10 @@ def console_turn_activity_text(snapshot: Any, *, now: float) -> str:
         ),
         None,
     )
+    if step is None or step.kind != STEP_TOOL_CALL:
+        fleet = _fleet_turn_activity(children, now=now)
+        if fleet:
+            return fleet
     if step is None:
         # Pre-first-token: the model has not come back once yet, so there is
         # no step to name and no honest base to time from.
@@ -758,7 +845,45 @@ class ConsoleAgentController:
         read_snapshot = getattr(bridge, "live_snapshot", None)
         if read_snapshot is None:
             return ""
-        return console_turn_activity_text(
+        snapshot = read_snapshot(conversation_id)
+        # task-31386: a running child's steps live in its OWN run feed
+        # (`live_run_snapshot`, the one live source of a working child's
+        # steps); `getattr` because bare bridge doubles lack it.
+        read_run = getattr(bridge, "live_run_snapshot", None)
+        children = (
+            [
+                read_run(conversation_id, summary.run_id)
+                for summary in (getattr(snapshot, "subagents", ()) or ())
+                if getattr(summary, "run_id", "")
+                and getattr(summary, "status", "") == "running"
+            ]
+            if read_run is not None
+            else []
+        )
+        return console_turn_activity_text(snapshot, now=time.monotonic(), children=children)
+
+    def console_turn_activity_abandon_action(self) -> str:
+        """task-31386: the "abandon call" action for the live line, or ``""``.
+
+        Same guards as ``console_turn_activity``: no active run, no bridge
+        or no snapshot reader means no affordance.
+
+        Returns:
+            ``CONSOLE_TURN_ACTIVITY_ABANDON_ACTION`` while the primary's
+            tool call has run long enough, else ``""``.
+        """
+        from ..Screens.chat_screen import CONSOLE_ACTIVE_RUN_STATUSES
+
+        controller = self._console_chat_controller
+        run_state = getattr(controller, "run_state", None) if controller else None
+        if run_state is None or run_state.status not in CONSOLE_ACTIVE_RUN_STATUSES:
+            return ""
+        bridge = self._console_agent_bridge
+        read_snapshot = getattr(bridge, "live_snapshot", None) if bridge else None
+        if read_snapshot is None:
+            return ""
+        conversation_id = self._current_console_rail_conversation_id() or ""
+        return console_turn_activity_abandon_action(
             read_snapshot(conversation_id), now=time.monotonic()
         )
 

--- a/tldw_chatbook/UI/Console_Modules/agent.py
+++ b/tldw_chatbook/UI/Console_Modules/agent.py
@@ -315,13 +315,17 @@ def _fleet_turn_activity(children: Sequence[Any], *, now: float) -> str:
         that has run longest, ``"N sub-agent(s) working"`` when no child is
         inside a tool call, or ``""`` when nothing is running.
     """
-    running = [child for child in children if child is not None]
-    if not running:
+    # Every running child counts, even one whose run has not attached or
+    # published a step yet (its entry is None); only children WITH a live
+    # feed can name a tool.
+    count = len(children)
+    if not count:
         return ""
-    count = len(running)
     label = f"{count} sub-agent{'s' if count != 1 else ''}"
     tool_steps = []
-    for child in running:
+    for child in children:
+        if child is None:
+            continue
         steps = tuple(getattr(child, "steps", ()) or ())
         last = steps[-1] if steps else None
         if last is not None and getattr(last, "kind", "") == STEP_TOOL_CALL:
@@ -850,16 +854,15 @@ class ConsoleAgentController:
         # (`live_run_snapshot`, the one live source of a working child's
         # steps); `getattr` because bare bridge doubles lack it.
         read_run = getattr(bridge, "live_run_snapshot", None)
-        children = (
-            [
+        children = [
+            (
                 read_run(conversation_id, summary.run_id)
-                for summary in (getattr(snapshot, "subagents", ()) or ())
-                if getattr(summary, "run_id", "")
-                and getattr(summary, "status", "") == "running"
-            ]
-            if read_run is not None
-            else []
-        )
+                if read_run is not None and getattr(summary, "run_id", "")
+                else None
+            )
+            for summary in (getattr(snapshot, "subagents", ()) or ())
+            if getattr(summary, "status", "") == "running"
+        ]
         return console_turn_activity_text(snapshot, now=time.monotonic(), children=children)
 
     def console_turn_activity_abandon_action(self) -> str:
@@ -883,9 +886,19 @@ class ConsoleAgentController:
         if read_snapshot is None:
             return ""
         conversation_id = self._current_console_rail_conversation_id() or ""
-        return console_turn_activity_abandon_action(
+        action = console_turn_activity_abandon_action(
             read_snapshot(conversation_id), now=time.monotonic()
         )
+        if not action:
+            return ""
+        # Only a call the service registered through its timeout wrapper
+        # can be abandoned; a definitive-after-start tool (or a call with
+        # no timeout) runs outside it and must not advertise the action.
+        from tldw_chatbook.Agents.agent_service import inflight_tool_call
+
+        find_run = getattr(bridge, "live_primary_run_id", None)
+        run_id = find_run(conversation_id) if find_run is not None else None
+        return action if run_id and inflight_tool_call(run_id) is not None else ""
 
     def _console_agent_section_lines(self) -> tuple[str, str, str]:
         """Return the Agent rail's (status, steps, sub-agents) line text.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -1914,6 +1914,22 @@ class ChatScreen(BaseAppScreen):
             )
         return super().check_action(action, parameters)
 
+    def action_abandon_console_tool_call(self) -> None:
+        """task-31386: the activity line's "abandon call" click.
+
+        Abandons the viewed session's in-flight tool call and lets the turn
+        continue (``ConsoleChatController.abandon_active_tool_call``); a
+        stale click -- the call already ended -- is a no-op with a notice.
+        """
+        controller = self._ensure_console_chat_controller()
+        tool_name = controller.abandon_active_tool_call()
+        if tool_name:
+            self.app_instance.notify(
+                f"Abandoning {tool_name}… the turn continues.", severity="warning"
+            )
+        else:
+            self.app_instance.notify("No tool call is running.", severity="information")
+
     def action_exit_console_hands_free(self) -> None:
         """Priority Esc: exit the hands-free loop from any point (task-5
         review I2) -- see `check_action`'s gate and the `BINDINGS` entry's
@@ -15916,7 +15932,8 @@ class ChatScreen(BaseAppScreen):
             # is what joins the refresh key below -- so an idle transcript
             # can never repaint once a second off a stale run snapshot.
             turn_activity = transcript.apply_turn_activity(
-                self._agent.console_turn_activity()
+                self._agent.console_turn_activity(),
+                action=self._agent.console_turn_activity_abandon_action(),
             )
             visible_citation_counts = {
                 message_id: count

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -145,6 +145,9 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
 # fixed 200-dash string stopped short on very wide terminals.
 CONSOLE_TRANSCRIPT_RULE = ""
 CONSOLE_GENERATING_PLACEHOLDER = "Generating…"
+#: task-31386: the click affordance next to a long-running tool call's
+#: activity line (the action it runs is `CONSOLE_TURN_ACTIVITY_ABANDON_ACTION`).
+CONSOLE_TURN_ACTIVITY_ABANDON_COPY = "✕ abandon call"
 #: Console selection phase 3: run statuses during which review feedback
 #: (Request changes / LGTM) can be queued behind the active run via the
 #: prompt-queue seam. Anything else (or a screen without the run-status
@@ -1320,6 +1323,20 @@ def _assistant_markdown_header(
             )
     elif message.status in {"stopped", "failed"}:
         suffix = f"  {_MESSAGE_STATUS_LINES[message.status]}"
+    if suffix and message.live_activity_action and suffix.endswith(message.live_activity):
+        # task-31386: a click on the affordance runs the screen action that
+        # abandons the primary's current tool call; the turn continues.
+        # A Style carries the action (not markup), so the line's text --
+        # including a bracketed tool name -- still renders literally.
+        return Content.assemble(
+            role_label,
+            (suffix, "dim"),
+            (
+                f"  {CONSOLE_TURN_ACTIVITY_ABANDON_COPY}",
+                Style(dim=True, underline=True)
+                + Style.from_meta({"@click": message.live_activity_action}),
+            ),
+        )
     return Content.assemble(role_label, (suffix, "dim"))
 
 
@@ -3037,6 +3054,9 @@ class ConsoleTranscript(VerticalScroll):
         #: never derived here and never stored on the message the store
         #: owns (see `_with_turn_activity`).
         self._turn_activity: str = ""
+        #: task-31386: the click action offered next to the line ("abandon
+        #: call"), or "" -- same lifetime as `_turn_activity`.
+        self._turn_activity_action: str = ""
         # TASK-259: per-message render-signature cache. Maps message id ->
         # (cheap change-token, expensive row signature). `_transcript_rows`
         # re-derives the render payload (Content assembly) only when the
@@ -7519,7 +7539,7 @@ class ConsoleTranscript(VerticalScroll):
                 return message.id if not content.strip() else None
         return None
 
-    def apply_turn_activity(self, activity: str) -> str:
+    def apply_turn_activity(self, activity: str, *, action: str = "") -> str:
         """Store this poll tick's live activity line; return what will show.
 
         Returns the EFFECTIVE value -- ``""`` whenever no row is eligible --
@@ -7543,6 +7563,8 @@ class ConsoleTranscript(VerticalScroll):
         # exactly where a retained line would sit forever, frozen at its
         # last elapsed -- the frozen look this feature exists to remove.
         self._turn_activity = effective
+        # task-31386: the affordance only ever rides a live line.
+        self._turn_activity_action = action if effective else ""
         return effective
 
     def _with_turn_activity(
@@ -7578,7 +7600,11 @@ class ConsoleTranscript(VerticalScroll):
         """
         if target_id is None or message.id != target_id:
             return message
-        return replace(message, live_activity=self._turn_activity)
+        return replace(
+            message,
+            live_activity=self._turn_activity,
+            live_activity_action=self._turn_activity_action,
+        )
 
     def _with_expanded_tool_output(
         self, message: ConsoleChatMessage

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -7553,6 +7553,9 @@ class ConsoleTranscript(VerticalScroll):
         Args:
             activity: The derived line (``console_turn_activity_text``), or
                 ``""`` when nothing is live.
+            action: task-31386: the Textual action the row's "abandon
+                call" affordance runs, or ``""`` for no affordance. Kept
+                only while ``activity`` is live.
 
         Returns:
             The line that will actually render, or ``""``.


### PR DESCRIPTION
## Summary

TASK-31386, the residual of sub-project E of the Console interaction PRD, re-scoped against what already shipped (the live activity line and the run-wide Stop).

- **Fleet turns read as their children (AC #1).** While the primary waits on its sub-agents, the unfinished Assistant row's activity line reads `N sub-agents · ⚙ <tool> · <elapsed>` (running children and their longest-running tool, read from each child's own live run feed via `ConsoleAgentBridge.live_run_snapshot`) or `N sub-agents working`, instead of `Thinking…`. A primary tool call still wins. A turn with no children renders exactly as before (AC #3).
- **Per-call abandon (AC #2).** `Agents/agent_service.py` keeps a per-run in-flight tool call registry around the existing `_call_with_timeout` call; `request_tool_call_abandon(run_id)` is ORed into that wrapper's cancel probe only, so the wrapper returns the existing "tool call cancelled" result on its next poll slice and abandons the worker thread exactly as a run-wide Stop does, while the run's own cancel probe stays False and the loop hands the failed result to the model. A request with nothing in flight is refused, never queued; the flag is cleared with the mark when the call ends. Calls dispatched with no timeout bypass the wrapper and cannot be abandoned, as before.
- **Affordance.** Once the primary's tool call has run five seconds, the line grows `✕ abandon call`. The action rides `Style.from_meta({"@click": …})` on the row header (the same mechanism Textual's Markdown links use), so the line's text still renders literally. `ChatScreen.action_abandon_console_tool_call` → `ConsoleChatController.abandon_active_tool_call` (viewed session's durable conversation → newest unanchored primary run, the stop path's own lookup) → `request_tool_call_abandon`, with a notice either way.

## Evidence

- `Tests/UI/test_console_turn_activity_line.py`: fleet line with the longest-running child tool, "working" fallback, primary-wins, single-agent unchanged, action threshold, mounted row shows and drops the affordance. The three transcript-sync tests in that file fail on clean dev too (bare-stub shape), unchanged here.
- `Tests/Agents/test_tool_call_abandon.py`: refused when nothing is in flight; a request cancels only the wrapped call and is cleared afterwards.
- Run-budget, agent-bridge, and headless-approval suites unchanged against the dev baseline. Preflight clean; census unchanged.
- User guide: `Docs/User_Guide/console/agent-runs-and-tools.md`, "In the reply row itself".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements TASK-31386: when the primary agent is waiting on sub-agents, the reply row's activity line now reads as the running children instead of `Thinking…`, and a long-running primary tool call gains a per-call abandon action. Single-agent turns and primary tool calls render exactly as before.

- The line shows `N sub-agents · ⚙ <tool> · <elapsed>` with the longest-running child tool, or `N sub-agents working` when no child is in a tool call; every running child counts, even before its run has attached.
- After five seconds the line appends `✕ abandon call`; clicking it cancels only that call, the model sees `tool call cancelled`, and the turn continues—unlike **Stop**, which ends the run.
- The affordance is offered only while the service has the run's call registered through its timeout wrapper, so a definitive-after-start tool never advertises the action; an abandon request with nothing in flight is refused, never queued.

<sup>Written for commit 996a7a6e93f7797b12fa26fd510eaac7fdbc04a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2406?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

