### PR TITLE
refactor(persona-buddy): move overlay lifetime to app owner

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -3974,8 +3974,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 379,
-      "diagnostic_digest": "485a82edd120eeda66f9",
+      "call_count": 378,
+      "diagnostic_digest": "6925a6612538de10d8a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11360,6 +11360,6 @@
     "path_privacy_candidate_calls": 715,
     "persistent_sink_files": 10,
     "task_492_calls": 1334,
-    "task_494_calls": 7599
+    "task_494_calls": 7598
   }
 }

--- a/Docs/superpowers/plans/2026-09-04-task-21123-buddy-overlay-owner.md
+++ b/Docs/superpowers/plans/2026-09-04-task-21123-buddy-overlay-owner.md
@@ -1,0 +1,41 @@
+# Persona Buddy presentation ownership implementation plan
+
+**Goal:** One app-owned coordinator manages Buddy presentation across navigation,
+screen rebuilds, controller changes, and shutdown, with the existing UI contract.
+**Architecture:** Native screen-change signal plus generic ContentsRebuilt messages;
+thread-safe generation notifications; one coalescing reconciliation worker.
+**Tech stack:** Existing Python, Textual 8, asyncio, pytest/Pilot.
+**ADR required:** yes, amendment to backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md.
+**Reason:** Presentation lifetime and cross-module ownership change.
+**Spec:** ../specs/2026-09-04-task-21123-buddy-overlay-owner.md
+
+## Steps
+
+- [x] Read current task, ADR-074, lifecycle code, and relevant Textual/testing lessons;
+  confirm TASK-21122 merged and no relocation PR is active.
+- [x] Run the existing lifecycle and disabled-import baseline (21 passed).
+- [x] Add failing behavior tests: no Buddy reconciliation workers while disabled,
+  controller changes from a worker thread mount without a manual reconcile, and
+  screen rebuilds retain exactly one current view without per-screen Buddy state.
+- [x] Add UI/Navigation/persona_buddy_overlay.py: content-free change message and
+  app-owned coordinator. Keep all mount/currentness/cleanup ownership here.
+- [x] In UI/Navigation/base_app_screen.py replace Buddy fields and methods with a
+  generic post-recompose ContentsRebuilt notification; retain unrelated mouse safety.
+- [x] Wire app.py screen-change subscription, generation message handler, lazy owner,
+  unavailable confirmation, and geometry drain. Keep App's public reconcile entry point.
+- [x] Add the optional content-free controller generation callback. Its production
+  target posts a message; it must never await or enter UI logic under the controller lock.
+- [x] Wire widget unavailable callbacks to the app-owned boundary. Retain widget
+  timers, render authority, geometry persistence, style, and input behavior.
+- [x] Adapt existing lifecycle tests to the owner; verify cancellation, stale mounts,
+  modal resume, unavailable fences, and shutdown durability on the production path.
+- [x] Run targeted Buddy widget/controller/lifecycle/Workbench/import guards, Ruff,
+  compilation, diff checks, and derived-artifact preflight. Inspect any failures before
+  widening the run. No full repository test sweep.
+- [x] Review final diff; record exact results, complete task criteria, and prepare the verified commit.
+
+Commands use the shared interpreter from the isolated worktree:
+`/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest -q <target files>`.
+Use unique /private/tmp/task21123-* basetemp directories.
+Expected failing tests must demonstrate the missing behavior before implementation;
+existing lifecycle regressions must pass after adapting ownership references.

--- a/Docs/superpowers/specs/2026-09-04-task-21123-buddy-overlay-owner.md
+++ b/Docs/superpowers/specs/2026-09-04-task-21123-buddy-overlay-owner.md
@@ -1,0 +1,62 @@
+# TASK-21123: App-owned Persona Buddy presentation
+
+The approved scope is an ownership refactor preserving the current pet-only appearance,
+controls, geometry, modal behavior, persistence, and unavailable-state fences.
+Base: dev 68f9d865fa. TASK-21122 and the import half of TASK-21123 have merged.
+
+## Decision
+
+One lazy app-owned coordinator holds the current disposable view, its screen,
+generation, and reconciliation lock. It mounts the existing widget on the active
+primary BaseAppScreen, preserving Textual screen-overlay rendering and input routing.
+The controller remains independent of Textual and never owns a screen or widget.
+
+Textual's screen_change_signal covers push, switch, pop, and mode changes.
+BaseAppScreen posts a generic ContentsRebuilt message after its existing recompose
+and mouse-capture cleanup finish. The app consumes that notification only for the
+current screen. This retains recompose awareness without per-screen Buddy state,
+workers, or Buddy-specific mount/resume/recompose hooks.
+
+Controller generation changes invoke an optional notification callback whose only
+production action is posting a content-free message to the app. Textual post_message
+is thread-safe; no UI work runs under the controller lock. The app coalesces requests
+behind one reconciliation worker and re-reads current state after await boundaries.
+An entirely disabled Buddy with no view to retire starts no reconciliation worker
+and imports no widget, controller, visual runtime, or PIL as a consequence of navigation.
+
+## Lifecycle
+
+- Primary navigation retires the previous view and mounts one view on the current screen.
+- A modal leaves the underlying view suspended; its currentness predicate rejects
+  interaction and resolution commits until its owning screen becomes active again.
+  Dismissal resumes resolution. Modal/splash/authentication surfaces never host Buddy.
+- Recompose removes the old view normally; ContentsRebuilt triggers replacement.
+  Queued notifications for old screens never mount into a newer screen's ownership.
+- Disable/close removes a retained view even while its screen is covered.
+- Exact current screen, view object, generation, controller, and visual identity gate
+  unavailable confirmation; an old view cannot hide a replacement.
+- Reconciliation cancellation cleans only its own candidate. Coalescing must not
+  repeatedly cancel an in-progress mount or a geometry flush.
+- Shutdown closes presentation admission, drains pending geometry before controller
+  shutdown, and prevents queued notifications from mounting another view.
+- Workbench affordances still refresh after reconciliation, including when no view
+  is desired. No default selection, visibility, rendering, or keyboard changes.
+
+## Alternatives
+
+Keeping all lifecycle state in BaseAppScreen leaves the duplicated ownership in place.
+Reacting only to screen changes loses Buddy after recompose. Marking the widget as a
+private Textual system child relies on an internal retention convention and changes
+its lifecycle. The generic post-rebuild notification uses the existing teardown flow.
+
+## Verification
+
+Extend the current real-CSS lifecycle harness to bind the production owner.
+Pin recompose replacement, navigation, modal resume, stale delayed mount/cancellation,
+unavailable recovery, disabled zero-worker/import behavior, worker-thread generation
+notifications, coalescing, and geometry durability across shutdown.
+Retain the existing widget/UAT tests for unchanged appearance and controls.
+Run targeted suites and static/derived-artifact checks; no full repository sweep.
+
+ADR required: yes, amend ADR-074 with the presentation ownership clarification.
+No schema, dependency, provider, or persistence-format change.

--- a/Tests/Live/persona_buddy_terminal_probe.py
+++ b/Tests/Live/persona_buddy_terminal_probe.py
@@ -278,6 +278,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
         PersonaBuddyWidget,
     )
     from tldw_chatbook.css import build_css
+    from tldw_chatbook.app import TldwCli
 
     if preferences_path.exists():
         raw = json.loads(preferences_path.read_text(encoding="utf-8"))
@@ -368,6 +369,20 @@ def _child(preferences_path: Path, report_path: Path) -> int:
     screen_scoped, screen_self = build_css.screen_css_paths(css_dir)
 
     class ProbeApp(App):
+        reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+        _start_persona_buddy_overlay = TldwCli._start_persona_buddy_overlay
+        _schedule_persona_buddy_overlay = TldwCli._schedule_persona_buddy_overlay
+        _notify_persona_buddy_changed = TldwCli._notify_persona_buddy_changed
+        on_persona_buddy_changed = TldwCli.on_persona_buddy_changed
+        on_base_app_screen_contents_rebuilt = (
+            TldwCli.on_base_app_screen_contents_rebuilt
+        )
+        _persona_buddy_authority = staticmethod(TldwCli._persona_buddy_authority)
+        is_persona_buddy_confirmed_unavailable = (
+            TldwCli.is_persona_buddy_confirmed_unavailable
+        )
+        confirm_persona_buddy_unavailable = TldwCli.confirm_persona_buddy_unavailable
+
         CSS_PATH = [
             str(screen_scoped),
             str(css_dir / "tldw_cli_modular.tcss"),
@@ -386,7 +401,9 @@ def _child(preferences_path: Path, report_path: Path) -> int:
             self.persona_buddy_controller = PersonaBuddyController(
                 preferences=preferences,
                 preference_writer=write_preferences,
+                on_change=self._notify_persona_buddy_changed,
             )
+            self._persona_buddy_unavailable_authority = None
 
             self.resolution_calls = 0
 
@@ -446,12 +463,8 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 build_css.widget_defaults_sources(css_dir) + super()._get_default_css()
             )
 
-        async def reconcile_persona_buddy_view(self) -> None:
-            screen = self.screen
-            if isinstance(screen, BaseAppScreen) and screen.is_active:
-                await screen.reconcile_persona_buddy_view()
-
         async def on_mount(self) -> None:
+            self._start_persona_buddy_overlay()
             await self.push_screen(ProbeScreen(self, "first"))
             asyncio.get_running_loop().add_signal_handler(
                 signal.SIGUSR1,
@@ -735,7 +748,7 @@ def _child(preferences_path: Path, report_path: Path) -> int:
                 ),
                 "view_present": buddy is not None,
                 "viewport": {"width": self.size.width, "height": self.size.height},
-                "screen_generation": screen.persona_buddy_view_generation,
+                "screen_generation": self._persona_buddy_overlay.generation,
                 "viewport_clamped": (
                     region is not None
                     and region.x >= 0

--- a/Tests/Performance/test_boot_worker_census.py
+++ b/Tests/Performance/test_boot_worker_census.py
@@ -93,7 +93,6 @@ ALLOWED_BOOT_WORKERS: frozenset[tuple[str, str]] = frozenset(
         ("_refresh_workspace_files_availability_snapshot", "console-workspace-files-availability"),
         ("build_worker", "console-changed-files"),
         ("load", "console-prompt-history"),
-        ("reconcile_persona_buddy_view", "persona-buddy-view-reconcile"),
         # Rail-preference persistence: observed on the FIRST boot of a fresh
         # profile (initial state write); allowlisted, not asserted present.
         ("_save_console_rail_preferences", "default"),

--- a/Tests/UI/test_persona_buddy_app_mount.py
+++ b/Tests/UI/test_persona_buddy_app_mount.py
@@ -48,6 +48,11 @@ class _BuddyModal(ModalScreen[None]):
 class _BuddyApp(ConsolidatedCSSApp):
     CSS_PATH = BUNDLED_STYLESHEET
     reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+    _start_persona_buddy_overlay = TldwCli._start_persona_buddy_overlay
+    _schedule_persona_buddy_overlay = TldwCli._schedule_persona_buddy_overlay
+    _notify_persona_buddy_changed = TldwCli._notify_persona_buddy_changed
+    on_persona_buddy_changed = TldwCli.on_persona_buddy_changed
+    on_base_app_screen_contents_rebuilt = TldwCli.on_base_app_screen_contents_rebuilt
     _persona_buddy_authority = staticmethod(TldwCli._persona_buddy_authority)
     is_persona_buddy_confirmed_unavailable = (
         TldwCli.is_persona_buddy_confirmed_unavailable
@@ -64,6 +69,7 @@ class _BuddyApp(ConsolidatedCSSApp):
         self.persona_buddy_controller = PersonaBuddyController(
             preferences=preferences,
             preference_writer=lambda _preferences: True,
+            on_change=self._notify_persona_buddy_changed,
         )
         self._persona_buddy_unavailable_authority = None
         if not production_resolution:
@@ -77,6 +83,7 @@ class _BuddyApp(ConsolidatedCSSApp):
         self.initial_screen = _BuddyScreen(self)
 
     async def on_mount(self) -> None:
+        self._start_persona_buddy_overlay()
         await self.push_screen(self.initial_screen)
 
 
@@ -85,6 +92,60 @@ def _enabled_preferences() -> PersonaBuddyPreferences:
         enabled=True,
         selection=PersonaBuddySelection("local", "persona-1"),
     )
+
+
+@pytest.mark.asyncio
+async def test_threaded_controller_changes_reconcile_without_manual_ui_calls():
+    app = _BuddyApp(PersonaBuddyPreferences())
+    controller = app.persona_buddy_controller
+    controller._on_change = app._notify_persona_buddy_changed
+    async with app.run_test(size=(100, 30)):
+        await asyncio.to_thread(
+            controller.apply_preferences_patch,
+            enabled=True,
+            selection=PersonaBuddySelection("local", "persona-1"),
+        )
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        await asyncio.to_thread(controller.apply_preferences_patch, enabled=False)
+        await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
+
+
+@pytest.mark.asyncio
+async def test_disabled_navigation_and_recompose_start_no_buddy_workers(monkeypatch):
+    app = _BuddyApp(PersonaBuddyPreferences())
+    calls = []
+    from textual.dom import DOMNode
+
+    original = DOMNode.run_worker
+
+    def counted(node, *args, **kwargs):
+        if "persona-buddy" in kwargs.get("group", ""):
+            calls.append(kwargs["group"])
+        return original(node, *args, **kwargs)
+
+    monkeypatch.setattr(DOMNode, "run_worker", counted)
+    async with app.run_test(size=(100, 30)) as pilot:
+        await app.screen.recompose()
+        await app.switch_screen(_BuddyScreen(app, "replacement"))
+        await pilot.pause()
+        assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_rebuild_replaces_view_without_screen_owned_buddy_state():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)):
+        await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
+        before = app.screen.query_one(PersonaBuddyWidget)
+        await app.screen.recompose()
+        await _wait_until(
+            lambda: (
+                len(list(app.screen.query(PersonaBuddyWidget))) == 1
+                and app.screen.query_one(PersonaBuddyWidget) is not before
+            )
+        )
+        assert "_persona_buddy_view" not in vars(app.screen)
+        assert "_persona_buddy_reconcile_lock" not in vars(app.screen)
 
 
 @pytest.mark.asyncio
@@ -116,13 +177,13 @@ async def test_close_removes_only_current_generation():
     async with app.run_test(size=(100, 30)):
         await _wait_until(lambda: len(list(app.screen.query(PersonaBuddyWidget))) == 1)
         stale = app.screen.query_one(PersonaBuddyWidget)
-        await app.screen.reconcile_persona_buddy_view()
+        await app.reconcile_persona_buddy_view()
         current = app.screen.query_one(PersonaBuddyWidget)
         assert current is stale
 
         await stale.close_and_persist()
         await _wait_until(lambda: not list(app.screen.query(PersonaBuddyWidget)))
-        assert stale.view_generation < app.screen.persona_buddy_view_generation
+        assert stale.view_generation < app._persona_buddy_overlay.generation
 
 
 @pytest.mark.asyncio
@@ -188,6 +249,8 @@ async def test_navigation_replaces_screen_local_view_generation():
 @pytest.mark.asyncio
 async def test_cancelled_delayed_mount_cleans_only_the_created_view(monkeypatch):
     app = _BuddyApp(PersonaBuddyPreferences())
+    # This case controls/cancels the explicit reconcile caller, not the worker.
+    app.persona_buddy_controller._on_change = None
     async with app.run_test(size=(100, 30)):
         screen = app.screen
         preferences = _enabled_preferences()
@@ -202,14 +265,14 @@ async def test_cancelled_delayed_mount_cleans_only_the_created_view(monkeypatch)
             return await original_mount(widget, *args, **kwargs)
 
         monkeypatch.setattr(screen, "mount", delayed_mount)
-        reconcile = asyncio.create_task(screen.reconcile_persona_buddy_view())
+        reconcile = asyncio.create_task(app.reconcile_persona_buddy_view())
         await asyncio.wait_for(started.wait(), timeout=1)
         reconcile.cancel()
         release.set()
         with pytest.raises(asyncio.CancelledError):
             await reconcile
         assert not list(screen.query(PersonaBuddyWidget))
-        assert screen._persona_buddy_view is None
+        assert app._persona_buddy_overlay.view is None
 
 
 @pytest.mark.asyncio
@@ -217,6 +280,7 @@ async def test_delayed_mount_with_superseded_generation_removes_stale_created_vi
     monkeypatch,
 ):
     app = _BuddyApp(PersonaBuddyPreferences())
+    app.persona_buddy_controller._on_change = None
     async with app.run_test(size=(100, 30)):
         screen = app.screen
         await app.persona_buddy_controller.update_preferences(_enabled_preferences())
@@ -230,13 +294,13 @@ async def test_delayed_mount_with_superseded_generation_removes_stale_created_vi
             return await original_mount(widget, *args, **kwargs)
 
         monkeypatch.setattr(screen, "mount", delayed_mount)
-        reconcile = asyncio.create_task(screen.reconcile_persona_buddy_view())
+        reconcile = asyncio.create_task(app.reconcile_persona_buddy_view())
         await asyncio.wait_for(started.wait(), timeout=1)
-        screen._persona_buddy_view_generation += 1
+        app._persona_buddy_overlay.generation += 1
         release.set()
         await reconcile
         assert not list(screen.query(PersonaBuddyWidget))
-        assert screen._persona_buddy_view is None
+        assert app._persona_buddy_overlay.view is None
 
 
 @pytest.mark.asyncio
@@ -412,7 +476,7 @@ async def test_app_owned_preference_write_drains_once_before_new_owner_starts():
         replacement = _BuddyScreen(app, "replacement")
         await app.switch_screen(replacement)
         app.persona_buddy_controller.apply_preferences_patch(open=True)
-        await replacement.reconcile_persona_buddy_view()
+        await app.reconcile_persona_buddy_view()
         await _wait_until(lambda: len(list(replacement.query(PersonaBuddyWidget))) == 1)
         replacement.query_one(PersonaBuddyWidget).action_move_left()
         await asyncio.sleep(0.1)
@@ -516,10 +580,13 @@ async def test_blocked_close_and_stale_geometry_merge_immediately_and_durably():
             app.persona_buddy_controller.current_preferences().geometry
         )
 
-        view.action_close()
-        assert app.persona_buddy_controller.current_preferences().open is False
-        await _wait_until(entered.is_set)
-        view.action_move_left()
+        # Keep the view current while two admitted edits race with persistence.
+        # Once the owner retires a closed view, input must correctly be ignored.
+        async with app._persona_buddy_overlay._lock:
+            view.action_close()
+            assert app.persona_buddy_controller.current_preferences().open is False
+            await _wait_until(entered.is_set)
+            view.action_move_left()
 
         current = app.persona_buddy_controller.current_preferences()
         assert current.open is False
@@ -531,6 +598,124 @@ async def test_blocked_close_and_stale_geometry_merge_immediately_and_durably():
         assert persisted[-1] == final
         assert final.open is False
         assert final.geometry == current.geometry
+
+
+@pytest.mark.asyncio
+async def test_change_burst_keeps_one_inflight_mount_worker(monkeypatch):
+    app = _BuddyApp(PersonaBuddyPreferences())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        entered = asyncio.Event()
+        release = asyncio.Event()
+        original_mount = app.screen.mount
+        mounts = []
+
+        async def blocked_mount(view):
+            mounts.append(view)
+            entered.set()
+            await release.wait()
+            return await original_mount(view)
+
+        monkeypatch.setattr(app.screen, "mount", blocked_mount)
+        app.persona_buddy_controller.apply_preferences_patch(
+            enabled=True, selection=PersonaBuddySelection("local", "persona-1")
+        )
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        owner = app._persona_buddy_overlay
+        worker = owner._worker
+        for _ in range(20):
+            app.persona_buddy_controller.invalidate_profile()
+        await pilot.pause()
+        assert owner._worker is worker
+        assert not worker.is_cancelled
+        release.set()
+        await _wait_until(lambda: worker.is_finished)
+        assert len(mounts) == 1
+        assert owner.is_current(owner.view)
+
+
+@pytest.mark.asyncio
+async def test_disable_behind_modal_removes_retained_view():
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        owner = app._persona_buddy_overlay
+        previous = owner.view
+        await app.push_screen(_BuddyModal())
+        app.persona_buddy_controller.apply_preferences_patch(enabled=False)
+        await _wait_until(lambda: owner.view is None)
+        assert not previous.is_attached
+        assert not list(app.screen.query(PersonaBuddyWidget))
+        await app.pop_screen()
+        await pilot.pause()
+        assert not list(app.screen.query(PersonaBuddyWidget))
+
+
+@pytest.mark.asyncio
+async def test_cancelled_retirement_replaces_invalidated_view_on_reenable(monkeypatch):
+    app = _BuddyApp(_enabled_preferences())
+    app.persona_buddy_controller._on_change = None
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        owner = app._persona_buddy_overlay
+        previous = owner.view
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocked_flush():
+            entered.set()
+            await release.wait()
+
+        monkeypatch.setattr(previous, "flush_pending_geometry_persist", blocked_flush)
+        app.persona_buddy_controller.apply_preferences_patch(enabled=False)
+        retire = asyncio.create_task(app.reconcile_persona_buddy_view())
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        retire.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await retire
+        release.set()
+        app.persona_buddy_controller.apply_preferences_patch(enabled=True)
+        await app.reconcile_persona_buddy_view()
+        assert owner.is_current(owner.view)
+        assert owner.view is not previous
+        assert not previous.is_attached
+
+
+@pytest.mark.asyncio
+async def test_shutdown_during_retirement_admits_no_replacement_mount(monkeypatch):
+    app = _BuddyApp(_enabled_preferences())
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        owner = app._persona_buddy_overlay
+        entered = asyncio.Event()
+        release = asyncio.Event()
+
+        async def blocked_flush():
+            entered.set()
+            await release.wait()
+
+        monkeypatch.setattr(owner.view, "flush_pending_geometry_persist", blocked_flush)
+        replacement = _BuddyScreen(app, "shutdown-replacement")
+        mounts = []
+        original_mount = replacement.mount
+
+        def record_mount(*widgets, **kwargs):
+            mounts.extend(
+                widget for widget in widgets if isinstance(widget, PersonaBuddyWidget)
+            )
+            return original_mount(*widgets, **kwargs)
+
+        monkeypatch.setattr(replacement, "mount", record_mount)
+        await app.push_screen(replacement)
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        shutdown = asyncio.create_task(owner.shutdown())
+        try:
+            await _wait_until(lambda: owner.closed)
+        finally:
+            release.set()
+        await asyncio.wait_for(shutdown, timeout=2)
+        assert mounts == []
+        assert owner.view is None
 
 
 class _ShutdownOrderBuddyApp(_BuddyApp):

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -261,6 +261,11 @@ class PersonaBuddyWorkbenchApp(PersonasTestApp):
     """Workbench harness using the real app-to-screen Buddy reconciliation."""
 
     reconcile_persona_buddy_view = TldwCli.reconcile_persona_buddy_view
+    _start_persona_buddy_overlay = TldwCli._start_persona_buddy_overlay
+    _schedule_persona_buddy_overlay = TldwCli._schedule_persona_buddy_overlay
+    _notify_persona_buddy_changed = TldwCli._notify_persona_buddy_changed
+    on_persona_buddy_changed = TldwCli.on_persona_buddy_changed
+    on_base_app_screen_contents_rebuilt = TldwCli.on_base_app_screen_contents_rebuilt
     _persona_buddy_authority = staticmethod(TldwCli._persona_buddy_authority)
     is_persona_buddy_confirmed_unavailable = (
         TldwCli.is_persona_buddy_confirmed_unavailable
@@ -270,6 +275,11 @@ class PersonaBuddyWorkbenchApp(PersonasTestApp):
     def __init__(self, mock_app_instance) -> None:
         super().__init__(mock_app_instance)
         self._persona_buddy_unavailable_authority = None
+        self._persona_buddy_overlay = None
+        self._persona_buddy_overlay_started = False
+
+    def on_mount(self) -> None:
+        self._start_persona_buddy_overlay()
 
 
 def _row_text(item) -> str:
@@ -13514,7 +13524,7 @@ async def test_stale_personas_screen_reconcile_skips_screen_local_buddy_hook(
         hook = Mock(wraps=stale.sync_persona_buddy_reconciled_state)
         stale.sync_persona_buddy_reconciled_state = hook
 
-        await stale.reconcile_persona_buddy_view()
+        await app.reconcile_persona_buddy_view()
 
         hook.assert_not_called()
 

--- a/Tests/Utils/test_optional_import_deferral.py
+++ b/Tests/Utils/test_optional_import_deferral.py
@@ -444,10 +444,8 @@ print(json.dumps({"imported": SwarmUIClient is not None}))
 
 # --- 4. Persona Buddy reconcile: no widget/PIL import while disabled -------
 #
-# TASK-21123 (partial). `BaseAppScreen.reconcile_persona_buddy_view` runs on
-# EVERY screen mount, screen resume and screen recompose, as a coroutine on
-# the event loop (`run_worker` with no `thread=True`) right after first
-# paint. Importing `persona_buddy_widget` pulls
+# TASK-21123. The app-owned overlay preserves the disabled import guard
+# originally added to BaseAppScreen. Importing `persona_buddy_widget` pulls
 # `Persona_Buddy.controller` -> `Persona_Visual.repository`/`runtime` ->
 # `PIL`. On routes that do not already carry PIL (Home, Settings) that was a
 # measured ~25 ms of loop-blocking work per process for a feature that is
@@ -459,10 +457,9 @@ import json
 import sys
 import types
 
-# The production import route: a screen module, then the base screen that
-# owns the reconcile. Neither may drag the Buddy widget in on its own.
+# Screen imports and the lightweight app owner must not pull in rendering.
 import tldw_chatbook.UI.Screens.home_screen  # noqa: F401
-from tldw_chatbook.UI.Navigation.base_app_screen import BaseAppScreen
+from tldw_chatbook.UI.Navigation.persona_buddy_overlay import PersonaBuddyOverlay
 
 BUDDY_WIDGET = "tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget"
 BUDDY_CONTROLLER = "tldw_chatbook.Persona_Buddy.controller"
@@ -488,10 +485,7 @@ class _Screen:
     \"\"\"
 
     def __init__(self, controller):
-        self.app_instance = types.SimpleNamespace(persona_buddy_controller=controller)
-        self._persona_buddy_reconcile_lock = asyncio.Lock()
-        self._persona_buddy_view = None
-        self._persona_buddy_view_generation = 0
+        self.persona_buddy_controller = controller
         self.is_attached = True
         self.synced = 0
 
@@ -525,7 +519,7 @@ async def _main():
     # feature was turned off at runtime.
     for name, controller in (("no_controller", None), ("disabled", _DisabledController())):
         screen = _Screen(controller)
-        returned = await BaseAppScreen.reconcile_persona_buddy_view(screen)
+        returned = await PersonaBuddyOverlay(screen).reconcile()
         results["cases"][name] = {
             "returned": returned,
             "synced": screen.synced,

--- a/backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+++ b/backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
@@ -116,6 +116,22 @@ until review, validation, and activation all succeed.
 
 ## Consequences
 
+### Buddy presentation ownership (TASK-21123, 2026-09-04)
+
+The app owns one disposable Buddy presentation coordinator as well as the domain
+controller. The coordinator mounts the native view on the current primary screen;
+screens carry no Buddy-specific view or reconciliation state. Screen-change signals
+and a generic post-recompose notification keep the view current, including when a
+screen rebuilds without navigation. Controller generation notifications cross to
+the UI through thread-safe app messages. Covered views preserve their existing modal
+behavior, stale view generations cannot publish unavailable state, and geometry
+flushes before controller shutdown. The controller still owns no Textual object.
+
+The implementation must preserve the existing pet-only visual and interaction
+contract. This clarifies ADR-074's app ownership; it does not introduce a general
+overlay framework or use private Textual system-child retention conventions.
+See [the design](../../Docs/superpowers/specs/2026-09-04-task-21123-buddy-overlay-owner.md).
+
 - Actor Pack import/export and Buddy operate only on profile-local actors; server
   Personas require an explicit local copy.
 - The portable envelope can carry both visual systems without coupling their models or

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11274,3 +11274,20 @@ quiescence/registry boundary rather than a single-thread `close()`. Diagnose a
 session FD warning by splitting test files, classifying descriptors with
 `lsof`, and inspecting live owners after finalizers; GC or a higher threshold
 cannot establish ownership or fix a registered worker handle.
+
+## Lifecycle relocation tests must include production change notifications
+
+**TASK-21123, 2026-09-04.** Moving Buddy ownership to the app initially passed
+the old mount harness, which manually reconciled state and omitted the new
+controller notification callback. Wiring the production callback exposed tests
+that installed mount gates after enable had already mounted the view, and a
+close/geometry test that sent input after the view had retired. Explicit caller
+cancellation tests now isolate their caller; the merge test gates owner retirement
+while admitting both edits. Independent review also reproduced late mounts after
+shutdown during a geometry flush and reuse of a generation-invalidated view after
+canceled retirement. Both received failing-then-passing regression tests.
+
+**What to do.** Bind production lifecycle notifications in integration harnesses.
+Gate the specific await boundary a race test intends to exercise; a persistence
+writer starting does not prove the originating view is still current. Check
+shutdown and generation authority again after teardown awaits, before reuse/mount.

--- a/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
+++ b/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
@@ -126,3 +126,14 @@ delta before regenerating the pin, with no new diagnostics or persistent sinks.
 
 Task status and criteria use the documented direct-file workaround for the broken
 five-digit Backlog CLI, rather than generating a malformed TASK-TASK- record.
+
+### PR #2407 review follow-up
+
+Rebased onto dev `b52080fee0`; the sole conflict was the diagnostic-inventory
+aggregate, resolved by retaining dev's TASK-492 changes and this PR's TASK-494
+decrement. Qodo reported zero bugs and one Google-style docstring violation:
+documented `is_current`'s argument and return value, plus the new owner's
+constructor argument and reconciliation result. No runtime behavior changed.
+Rebased verification: 256 targeted tests passed (374 deselected, one inherited
+RequestsDependencyWarning), 123.89 seconds; all derived-artifact preflight checks
+and the overlay's Ruff/format checks passed.

--- a/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
+++ b/backlog/tasks/task-21123 - Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner.md
@@ -2,10 +2,11 @@
 id: TASK-21123
 title: >-
   Relocate the Persona Buddy hook from BaseAppScreen to an app-level overlay owner
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-08-22'
-updated_date: '2026-08-23'
+updated_date: '2026-09-04'
 labels:
   - performance
   - architecture
@@ -29,9 +30,23 @@ controller is app-owned, and the widget floats via overlay: screen.
 
 ## Acceptance Criteria
 
-- [ ] A single app-level overlay owner reacts to screen-change events and controller generation bumps; the per-screen recompose/mount/resume hooks and per-screen buddy state are removed
-- [x] Short-term (or as part of the move): no widget module imported when the feature is disabled (shipped separately, see Progress note below); the worker half is still open
-- [ ] Buddy behavior when enabled (placement, persistence, unavailable-fence) is unchanged - existing buddy tests green
+- [x] A single app-level overlay owner reacts to screen-change events and controller generation bumps; the per-screen recompose/mount/resume hooks and per-screen buddy state are removed
+- [x] No widget module imported or Buddy worker started when the feature is disabled (import half shipped separately; worker half completed in this move)
+- [x] Buddy behavior when enabled (placement, persistence, unavailable-fence) is unchanged - existing buddy tests green
+
+## Implementation Plan
+
+1. Preserve the accepted pet-only UI and existing modal, navigation, persistence, and unavailable behavior.
+2. Move disposable view ownership into one app-owned coordinator. Subscribe to Textual screen changes and a generic screen-rebuilt message so recomposition cannot silently lose the view.
+3. Deliver controller generation changes to the app through thread-safe, content-free messages; coalesce reconciliation and skip workers when disabled with no view to remove.
+4. Replace per-screen Buddy state and methods with app/owner authority checks; retain the Workbench affordance refresh.
+5. Run targeted Buddy lifecycle, widget, controller, Workbench, import-closure, and shutdown checks. No full test sweep.
+
+ADR required: yes (existing decision amendment)
+ADR path: backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md
+Reason: Clarify the app-owned presentation boundary and recompose-aware lifecycle without changing the controller/runtime or user experience.
+
+Design: Docs/superpowers/specs/2026-09-04-task-21123-buddy-overlay-owner.md
 
 ## Progress note (2026-08-23) - the import half shipped separately
 
@@ -61,7 +76,7 @@ already imported, then timing the buddy-widget import):
 the ~1.28 s an earlier task recorded for the cold chain -- that figure did not reproduce on a
 warm filesystem here.
 
-### What remains open, and why the relocation is deferred
+### Historical deferral (resolved by the 2026-09-04 implementation)
 
 Everything else: the app-level overlay owner, removing the per-screen recompose/mount/resume
 hooks, and removing the per-screen state. An independent review of the relocation found it
@@ -72,3 +87,42 @@ Any relocation therefore needs a recompose-aware re-mount signal designed in fir
 design is out of scope for a perf burn-down slice. Do not treat AC-2's import half being ticked
 as licence to ship the move without it.
 
+## Implementation Notes
+
+Relocated disposable Buddy presentation to one lazy `PersonaBuddyOverlay` owned by
+the app. Native screen-change signals, generic post-recompose messages, and
+thread-safe content-free controller notifications feed one coalescing worker.
+BaseAppScreen no longer owns Buddy fields, methods, or mount/resume workers.
+The widget keeps its rendering, controls, timers, and persistence behavior, with
+unavailable confirmation now injected from the app-owned boundary.
+
+ADR-074 was amended (no new dependency, schema, or preference format). The disabled
+path retains the fresh-process import guard and starts zero Buddy workers; removed
+the old worker from the real-app boot census allowlist. Geometry drains before
+controller shutdown. Review found and regression-tested two await-boundary races:
+shutdown during retirement now prevents late mounts, and canceled retirement cannot
+reuse a generation-invalidated view. Production-notification harness wiring and
+explicit race gates are documented in `backlog/docs/lessons-testing-evidence.md`.
+
+Verification includes the Buddy domain/widget/lifecycle suites, Workbench Buddy
+cases, architecture and fresh-process import guards, real-app boot census, and
+terminal-probe tests. The standalone POSIX PTY probe passed all 22 interactions,
+including pet-only normal display, alerts, fold, constrained controls, mouse and
+keyboard interactions, modal resume, navigation, and persisted geometry restore.
+No full repository test sweep was run.
+
+Final combined targeted run: **256 passed, 374 deselected**, 119.35 seconds,
+with one inherited RequestsDependencyWarning. Command: shared-venv Python
+`-m pytest -q Tests/Persona_Buddy Tests/UI/test_persona_buddy_widget.py Tests/UI/test_persona_buddy_app_mount.py Tests/UI/test_personas_workbench.py Tests/Utils/test_optional_import_deferral.py Tests/Architecture/test_persona_buddy_boundary.py Tests/Packaging/test_persona_buddy_import_closure.py Tests/Live/test_persona_buddy_terminal_probe.py Tests/Performance/test_boot_worker_census.py -k 'buddy or boot_worker' --basetemp=/private/tmp/task21123-verification-final`.
+Independent lifecycle review confirmed both regression fixes with 2 passing tests
+and reported no remaining blocking findings.
+
+Static checks: modified-code Ruff passes with the 133 pre-existing app.py E402
+findings excluded (the same 133 reproduce at HEAD); changed formatting, compilation,
+and diff whitespace checks pass. All derived-artifact preflight checks pass.
+The diagnostic inventory changed only for removal of the old screen-traversal
+fallback's fixed `persona_buddy_geometry_flush_failed` log; reviewed the statement
+delta before regenerating the pin, with no new diagnostics or persistent sinks.
+
+Task status and criteria use the documented direct-file workaround for the broken
+five-digit Backlog CLI, rather than generating a malformed TASK-TASK- record.

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -334,6 +334,7 @@ class PersonaBuddyController:
             persist_persona_buddy_preferences
         ),
         scheduler: Callable[[Callable[[], None]], object] | None = None,
+        on_change: Callable[[], None] | None = None,
         phase_barrier: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
         if selection is not None and type(selection) is not PersonaBuddySelection:
@@ -364,6 +365,7 @@ class PersonaBuddyController:
         self._repository_factory = repository_factory
         self._portrait_loader = portrait_loader
         self._preference_writer = preference_writer
+        self._on_change = on_change
         self._scheduler = scheduler
         self._phase_barrier = phase_barrier
         self._operation_lock = asyncio.Lock()
@@ -473,7 +475,7 @@ class PersonaBuddyController:
                 self._selection = selection
                 self._preferences = replace(self._preferences, selection=selection)
                 self._preferences_generation += 1
-                self._generation += 1
+                self._advance_generation_locked()
             return self._generation
 
     def invalidate_profile(self) -> int:
@@ -481,7 +483,7 @@ class PersonaBuddyController:
 
         with self._lock:
             self._profile_generation += 1
-            self._generation += 1
+            self._advance_generation_locked()
             return self._profile_generation
 
     def set_viewport_generation(self, generation: int) -> int:
@@ -492,7 +494,7 @@ class PersonaBuddyController:
         with self._lock:
             if generation != self._viewport_generation:
                 self._viewport_generation = generation
-                self._generation += 1
+                self._advance_generation_locked()
             return self._viewport_generation
 
     def observe_persona(self, *, source: str, persona_id: object) -> int:
@@ -537,7 +539,7 @@ class PersonaBuddyController:
                 token=token,
                 kind=_lease_kind(normalized_source, normalized_state),
             )
-            self._generation += 1
+            self._advance_generation_locked()
             return token
 
     def release_state(
@@ -569,7 +571,7 @@ class PersonaBuddyController:
                 if current is None:
                     return False
             del self._leases[key]
-            self._generation += 1
+            self._advance_generation_locked()
             return True
 
     def set_timed_state(
@@ -888,7 +890,7 @@ class PersonaBuddyController:
 
         self._shutdown_requested = True
         with self._lock:
-            self._generation += 1
+            self._advance_generation_locked()
         task = self._shutdown_task
         if task is None:
             task = asyncio.create_task(
@@ -999,7 +1001,7 @@ class PersonaBuddyController:
         self._preferences = preferences
         self._selection = preferences.selection
         self._preferences_generation += 1
-        self._generation += 1
+        self._advance_generation_locked()
 
     async def _after_phase(self, phase: str, ticket: _ResolutionTicket) -> bool:
         barrier = self._phase_barrier
@@ -1237,6 +1239,17 @@ class PersonaBuddyController:
             frames=(),
         )
 
+    def _advance_generation_locked(self) -> None:
+        """Advance authority and enqueue a content-free notification.
+
+        The optional callback must only enqueue work; it may run under the
+        controller lock on a producer thread. The app uses thread-safe
+        post_message, never a synchronous UI callback.
+        """
+        self._generation += 1
+        if self._on_change is not None:
+            self._on_change()
+
     def _discard_expired_locked(self) -> None:
         now = self._clock()
         expired = [
@@ -1248,7 +1261,7 @@ class PersonaBuddyController:
             return
         for key in expired:
             del self._leases[key]
-        self._generation += 1
+        self._advance_generation_locked()
 
     def _resolve_locked(self) -> _StateLease | None:
         leases = tuple(self._leases.values())

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -1,9 +1,9 @@
 """Base screen class for all application screens."""
 
-import asyncio
 from typing import TYPE_CHECKING, Optional, Dict, Any
 from loguru import logger
 
+from textual.message import Message
 from textual.app import ComposeResult
 from textual.geometry import Region
 from textual.screen import Screen
@@ -21,6 +21,13 @@ class BaseAppScreen(Screen):
     Base screen class for all application screens.
     Provides common functionality like navigation bar and state management.
     """
+
+    class ContentsRebuilt(Message):
+        """Report completion of a primary screen's child reconstruction."""
+
+        def __init__(self, screen: "BaseAppScreen") -> None:
+            super().__init__()
+            self.screen = screen
 
     BUNDLED_CSS = """
     BaseAppScreen {
@@ -55,9 +62,6 @@ class BaseAppScreen(Screen):
         #: search aliases, screen routing) -- only this screen's OWN composed
         #: nav bar's highlight is affected.
         self.nav_bar_active: str = screen_name
-        self._persona_buddy_view = None
-        self._persona_buddy_view_generation = 0
-        self._persona_buddy_reconcile_lock = asyncio.Lock()
 
         logger.debug(f"Initializing {self.__class__.__name__} screen: {screen_name}")
 
@@ -166,7 +170,7 @@ class BaseAppScreen(Screen):
         self.release_mouse_capture_for_teardown()
         await super().recompose()
         self.sweep_stale_mouse_capture()
-        await self.reconcile_persona_buddy_view()
+        self.post_message(self.ContentsRebuilt(self))
 
     def release_mouse_capture_for_teardown(self) -> None:
         """Release any mouse capture before removing widgets.
@@ -367,191 +371,7 @@ class BaseAppScreen(Screen):
         carries a legacy ``super().on_mount()`` call.
         """
         logger.info(f"Screen {self.screen_name} mounted")
-        self.call_after_refresh(self._schedule_persona_buddy_reconcile)
-
-    def on_screen_resume(self) -> None:
-        """Replay app-owned Buddy state after this screen is uncovered."""
-
-        self.call_after_refresh(self._schedule_persona_buddy_reconcile)
 
     def on_unmount(self) -> None:
         """Called when the screen is unmounted."""
-        self._persona_buddy_view_generation += 1
-        view = self._persona_buddy_view
-        self._persona_buddy_view = None
-        if view is not None:
-            view.release_interaction_capture()
         logger.info(f"Screen {self.screen_name} unmounted")
-
-    @property
-    def persona_buddy_view_generation(self) -> int:
-        """Return this screen's current disposable Buddy-view generation."""
-
-        return self._persona_buddy_view_generation
-
-    def confirm_persona_buddy_unavailable(
-        self,
-        *,
-        view: Any,
-        controller: Any,
-        snapshot: Any,
-        visual: Any,
-    ) -> bool:
-        """Publish unavailable through the app's exact screen/view fence."""
-
-        confirm = getattr(self.app_instance, "confirm_persona_buddy_unavailable", None)
-        return bool(
-            callable(confirm)
-            and confirm(
-                screen=self,
-                view=view,
-                view_generation=view.view_generation,
-                controller=controller,
-                snapshot=snapshot,
-                visual=visual,
-            )
-        )
-
-    def is_persona_buddy_confirmed_unavailable(
-        self, controller: Any, snapshot: Any
-    ) -> bool:
-        """Query the app-owned marker for this exact controller authority."""
-
-        unavailable = getattr(
-            self.app_instance, "is_persona_buddy_confirmed_unavailable", None
-        )
-        return bool(callable(unavailable) and unavailable(controller, snapshot))
-
-    def _schedule_persona_buddy_reconcile(self) -> None:
-        """Schedule one idempotent mount reconciliation after screen paint."""
-
-        if not self.is_attached:
-            return
-        self.run_worker(
-            self.reconcile_persona_buddy_view,
-            group="persona-buddy-view-reconcile",
-            exclusive=True,
-        )
-
-    def sync_persona_buddy_reconciled_state(self) -> None:
-        """Refresh screen-local Buddy affordances after view reconciliation."""
-
-        return None
-
-    async def flush_persona_buddy_geometry(self) -> None:
-        """Drain this screen's mounted Buddy view of debounced geometry.
-
-        TASK-21122: geometry writes are coalesced behind a short debounce on
-        the view. The app calls this at exit before Buddy admission closes,
-        so a nudge inside that window still reaches disk.
-        """
-
-        view = self._persona_buddy_view
-        if view is None:
-            return
-        flush = getattr(view, "flush_pending_geometry_persist", None)
-        if callable(flush):
-            await flush()
-
-    async def reconcile_persona_buddy_view(self) -> bool:
-        """Reconcile one generation; return whether no current view remains.
-
-        TASK-21123 (partial): the ``PersonaBuddyWidget`` import lives at the
-        one branch that constructs the widget, NOT at the top of this method.
-        Every screen mount and every screen recompose reaches this reconcile,
-        including with the Buddy disabled (the default), and importing that
-        widget pulls ``Persona_Buddy.controller`` ->
-        ``Persona_Visual.repository``/``runtime`` -> ``PIL`` -- 10 modules /
-        ~6.9k LOC, plus 10 PIL modules on the routes that do not already carry
-        them. This coroutine runs ON the event loop (``run_worker`` without
-        ``thread=True``), right after first paint, so the import blocked the
-        loop for ~25 ms on Home and Settings for a feature that was off.
-        ``app.py``'s ``persona_buddy_controller`` docstring already claimed
-        the disabled early-out was free of that cost; with the import moved,
-        it is.
-        """
-
-        async with self._persona_buddy_reconcile_lock:
-            controller = getattr(self.app_instance, "persona_buddy_controller", None)
-            active = self.is_attached and self.app.screen is self
-            snapshot = controller.snapshot() if controller is not None else None
-            confirmed_unavailable = bool(
-                snapshot is not None
-                and self.is_persona_buddy_confirmed_unavailable(controller, snapshot)
-            )
-            desired = bool(
-                active
-                and snapshot is not None
-                and snapshot.enabled
-                and snapshot.open
-                and snapshot.selection is not None
-                and not confirmed_unavailable
-            )
-
-            current = self._persona_buddy_view
-            if current is not None and not current.is_attached:
-                current = None
-                self._persona_buddy_view = None
-
-            if not desired:
-                self._persona_buddy_view_generation += 1
-                if current is not None:
-                    current.release_interaction_capture()
-                    await current.remove()
-                    if self._persona_buddy_view is current:
-                        self._persona_buddy_view = None
-                if self.is_attached and self.app.screen is self:
-                    self.sync_persona_buddy_reconciled_state()
-                return True
-
-            if current is not None:
-                current.refresh_from_controller()
-                current.resume_resolution()
-                self.sync_persona_buddy_reconciled_state()
-                return False
-
-            # Only reached when the Buddy is enabled, open, has a selection
-            # and no view is mounted yet -- the one branch that needs the
-            # widget class (and therefore the Persona_Visual/PIL chain).
-            from ...Widgets.Persona_Widgets.persona_buddy_widget import (  # noqa: PLC0415
-                PersonaBuddyWidget,
-            )
-
-            self._persona_buddy_view_generation += 1
-            generation = self._persona_buddy_view_generation
-            view = PersonaBuddyWidget(
-                controller=controller,
-                view_generation=generation,
-                reconcile=self.app_instance.reconcile_persona_buddy_view,
-                is_current=lambda candidate: bool(
-                    generation == self._persona_buddy_view_generation
-                    and self._persona_buddy_view is candidate
-                    and self.is_attached
-                    and self.app.screen is self
-                ),
-            )
-            self._persona_buddy_view = view
-            try:
-                await self.mount(view)
-            except BaseException:
-                if self._persona_buddy_view is view:
-                    self._persona_buddy_view = None
-                if view.is_attached:
-                    view.release_interaction_capture()
-                    await view.remove()
-                raise
-            still_current = bool(
-                generation == self._persona_buddy_view_generation
-                and self._persona_buddy_view is view
-                and self.is_attached
-                and self.app.screen is self
-            )
-            if not still_current:
-                view.release_interaction_capture()
-                if view.is_attached:
-                    await view.remove()
-                if self._persona_buddy_view is view:
-                    self._persona_buddy_view = None
-                return True
-            self.sync_persona_buddy_reconciled_state()
-            return False

--- a/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
+++ b/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
@@ -20,6 +20,11 @@ class PersonaBuddyOverlay:
     """Own one presentation generation across primary screens and rebuilds."""
 
     def __init__(self, app: Any) -> None:
+        """Create the presentation owner.
+
+        Args:
+            app: Textual app providing Buddy authority and reconciliation hooks.
+        """
         self.app = app
         self.view: Any = None
         self.screen: Any = None
@@ -30,7 +35,15 @@ class PersonaBuddyOverlay:
         self.closed = False
 
     def is_current(self, view: Any) -> bool:
-        """Return whether a view may interact with the active primary screen."""
+        """Return whether a view may interact with the active primary screen.
+
+        Args:
+            view: Candidate Buddy view whose presentation authority is checked.
+
+        Returns:
+            True when the attached view owns the current generation on the
+            active primary screen and presentation admission remains open.
+        """
         return bool(
             not self.closed
             and view is self.view
@@ -82,7 +95,12 @@ class PersonaBuddyOverlay:
             self.screen = None
 
     async def reconcile(self) -> bool:
-        """Reconcile current authority; return whether the current view is absent."""
+        """Reconcile current presentation authority.
+
+        Returns:
+            True if the view is absent or presentation admission is closed;
+            False if a view is retained or the active screen cannot host it.
+        """
         from .base_app_screen import BaseAppScreen
 
         async with self._lock:

--- a/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
+++ b/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
@@ -1,0 +1,191 @@
+"""App-owned lifetime for disposable Persona Buddy views.
+
+This module stays lightweight while Buddy is disabled. Rendering imports belong
+only to the branch that mounts an enabled view.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from textual.message import Message
+
+
+class PersonaBuddyChanged(Message):
+    """Notify the app of a controller generation change without carrying content."""
+
+
+class PersonaBuddyOverlay:
+    """Own one presentation generation across primary screens and rebuilds."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self.view: Any = None
+        self.screen: Any = None
+        self.generation = 0
+        self._lock = asyncio.Lock()
+        self._worker: Any = None
+        self._pending = False
+        self.closed = False
+
+    def is_current(self, view: Any) -> bool:
+        """Return whether a view may interact with the active primary screen."""
+        return bool(
+            not self.closed
+            and view is self.view
+            and view.view_generation == self.generation
+            and view.is_attached
+            and self.screen is self.app.screen
+            and self.screen.is_attached
+        )
+
+    def request(self) -> None:
+        """Coalesce changes without cancelling mounts or geometry writes."""
+        if self.closed:
+            return
+        self._pending = True
+        if self._worker is None or self._worker.is_finished:
+            self._worker = self.app.run_worker(
+                self._run_pending,
+                group="persona-buddy-view-reconcile",
+                exclusive=True,
+            )
+
+    async def _run_pending(self) -> None:
+        while self._pending and not self.closed:
+            self._pending = False
+            await self.reconcile()
+
+    def _sync_affordances(self, screen: Any) -> None:
+        if screen is self.app.screen and screen.is_attached:
+            sync = getattr(screen, "sync_persona_buddy_reconciled_state", None)
+            if callable(sync):
+                sync()
+
+    async def flush_geometry(self) -> None:
+        """Drain geometry before the controller closes write admission."""
+        if self.view is not None:
+            await self.view.flush_pending_geometry_persist()
+
+    async def _retire(self) -> None:
+        current = self.view
+        self.generation += 1
+        if current is None:
+            return
+        current.release_interaction_capture()
+        await current.flush_pending_geometry_persist()
+        if current.is_attached:
+            await current.remove()
+        if self.view is current:
+            self.view = None
+            self.screen = None
+
+    async def reconcile(self) -> bool:
+        """Reconcile current authority; return whether the current view is absent."""
+        from .base_app_screen import BaseAppScreen
+
+        async with self._lock:
+            if self.closed:
+                return True
+            screen = self.app.screen
+            controller = getattr(self.app, "persona_buddy_controller", None)
+            snapshot = controller.snapshot() if controller is not None else None
+            desired = bool(
+                snapshot is not None
+                and snapshot.enabled
+                and snapshot.open
+                and snapshot.selection is not None
+                and not self.app.is_persona_buddy_confirmed_unavailable(
+                    controller, snapshot
+                )
+            )
+            if not desired:
+                await self._retire()
+                self._sync_affordances(screen)
+                return True
+            if not isinstance(screen, BaseAppScreen) or not screen.is_active:
+                # A modal covers the retained primary view. Its is_current fence
+                # suspends interaction and resolution until the primary resumes.
+                return False
+            if not screen.is_attached:
+                return False
+            if self.view is not None and (
+                self.screen is not screen
+                or not self.view.is_attached
+                or self.view.view_generation != self.generation
+                or self.view._controller is not controller
+            ):
+                await self._retire()
+            # Geometry flushing / removal can yield to shutdown or navigation.
+            if self.closed:
+                return True
+            if screen is not self.app.screen or not screen.is_attached:
+                self._pending = True
+                return True
+            latest = controller.snapshot()
+            if latest != snapshot:
+                self._pending = True
+                return self.view is None
+            if self.view is not None:
+                self.view.refresh_from_controller()
+                self.view.resume_resolution()
+                self._sync_affordances(screen)
+                return False
+
+            from ...Widgets.Persona_Widgets.persona_buddy_widget import (
+                PersonaBuddyWidget,
+            )
+
+            self.generation += 1
+            generation = self.generation
+            view = PersonaBuddyWidget(
+                controller=controller,
+                view_generation=generation,
+                reconcile=self.app.reconcile_persona_buddy_view,
+                is_current=self.is_current,
+                confirm_unavailable=lambda **kwargs: (
+                    self.app.confirm_persona_buddy_unavailable(
+                        screen=screen, view_generation=generation, **kwargs
+                    )
+                ),
+                is_confirmed_unavailable=self.app.is_persona_buddy_confirmed_unavailable,
+            )
+            self.view = view
+            self.screen = screen
+            try:
+                await screen.mount(view)
+                current = controller.snapshot()
+                valid = bool(
+                    self.is_current(view)
+                    and controller
+                    is getattr(self.app, "persona_buddy_controller", None)
+                    and current.enabled
+                    and current.open
+                    and current.selection is not None
+                )
+                if not valid:
+                    view.release_interaction_capture()
+                    if view.is_attached:
+                        await view.remove()
+                    if self.view is view:
+                        self.view = None
+                        self.screen = None
+                    return True
+            except BaseException:
+                if self.view is view:
+                    self.view = None
+                    self.screen = None
+                view.release_interaction_capture()
+                if view.is_attached:
+                    await view.remove()
+                raise
+            self._sync_affordances(screen)
+            return False
+
+    async def shutdown(self) -> None:
+        """Close presentation admission and drain geometry before domain shutdown."""
+        self.closed = True
+        self._pending = False
+        async with self._lock:
+            await self.flush_geometry()

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -215,12 +215,16 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         view_generation: int,
         reconcile: Callable[[], Awaitable[None] | None],
         is_current: Callable[["PersonaBuddyWidget"], bool] | None = None,
+        confirm_unavailable: Callable[..., bool] | None = None,
+        is_confirmed_unavailable: Callable[..., bool] | None = None,
     ) -> None:
         super().__init__(id="persona-buddy-widget")
         self._controller = controller
         self.view_generation = view_generation
         self._reconcile = reconcile
         self._current_view = is_current
+        self._confirm_unavailable = confirm_unavailable
+        self._is_confirmed_unavailable = is_confirmed_unavailable
         self._snapshot: Any = None
         self._painted_visual_identity: object | None = None
         self._accepted_render: _AcceptedRender | None = None
@@ -374,7 +378,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self.refresh_from_controller(schedule_resolution=False)
             current_visual = current_snapshot.visual
             if visual is not None and not visual.available and current_visual is visual:
-                confirm = getattr(
+                confirm = self._confirm_unavailable or getattr(
                     self.screen, "confirm_persona_buddy_unavailable", None
                 )
                 if not callable(confirm) or not confirm(
@@ -401,7 +405,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
                 if removed or not self._is_current_view():
                     return
                 current_snapshot = self._controller.snapshot()
-                confirmed = getattr(
+                confirmed = self._is_confirmed_unavailable or getattr(
                     self.screen, "is_persona_buddy_confirmed_unavailable", None
                 )
                 if callable(confirmed) and confirmed(

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8389,6 +8389,7 @@ class TldwCli(
                     get_cli_setting("appearance", "reduce_motion", False)
                 ),
                 scheduler=self.call_after_refresh,
+                on_change=self._notify_persona_buddy_changed,
             )
             return self._persona_buddy_controller
 
@@ -11921,8 +11922,9 @@ class TldwCli(
             controller is not current_controller
             or current_screen is not screen
             or not screen.is_attached
-            or screen._persona_buddy_view is not view
-            or screen.persona_buddy_view_generation != view_generation
+            or getattr(self, "_persona_buddy_overlay", None) is None
+            or not self._persona_buddy_overlay.is_current(view)
+            or self._persona_buddy_overlay.generation != view_generation
             or not view.is_attached
         ):
             return False
@@ -11951,7 +11953,55 @@ class TldwCli(
             return False
         if not isinstance(screen, BaseAppScreen) or not screen.is_active:
             return False
-        return await screen.reconcile_persona_buddy_view()
+        owner = getattr(self, "_persona_buddy_overlay", None)
+        if owner is None:
+            from .UI.Navigation.persona_buddy_overlay import PersonaBuddyOverlay
+
+            owner = self._persona_buddy_overlay = PersonaBuddyOverlay(self)
+        return await owner.reconcile()
+
+    def _start_persona_buddy_overlay(self) -> None:
+        """Subscribe once to native screen changes and reconcile after mount."""
+        if getattr(self, "_persona_buddy_overlay_started", False):
+            return
+        self._persona_buddy_overlay_started = True
+        self.screen_change_signal.subscribe(self, self._schedule_persona_buddy_overlay)
+        self.call_after_refresh(self._schedule_persona_buddy_overlay)
+
+    def _notify_persona_buddy_changed(self) -> None:
+        """Post a content-free notification safely from any controller thread."""
+        from .UI.Navigation.persona_buddy_overlay import PersonaBuddyChanged
+
+        self.post_message(PersonaBuddyChanged())
+
+    def on_persona_buddy_changed(self, message: Any) -> None:
+        """Reconcile the latest controller generation on the app event loop."""
+        self._schedule_persona_buddy_overlay()
+
+    def on_base_app_screen_contents_rebuilt(self, message: Any) -> None:
+        """Restore app-owned presentation after the active screen rebuilds."""
+        if message.screen is self.screen:
+            self._schedule_persona_buddy_overlay()
+
+    def _schedule_persona_buddy_overlay(self, _screen: Any = None) -> None:
+        """Skip disabled work and coalesce presentation updates on the app."""
+        owner = getattr(self, "_persona_buddy_overlay", None)
+        if owner is not None and owner.closed:
+            return
+        controller = getattr(self, "persona_buddy_controller", None)
+        snapshot = controller.snapshot() if controller is not None else None
+        if (snapshot is None or not snapshot.enabled) and (
+            owner is None or owner.view is None
+        ):
+            sync = getattr(self.screen, "sync_persona_buddy_reconciled_state", None)
+            if callable(sync):
+                sync()
+            return
+        if owner is None:
+            from .UI.Navigation.persona_buddy_overlay import PersonaBuddyOverlay
+
+            owner = self._persona_buddy_overlay = PersonaBuddyOverlay(self)
+        owner.request()
 
     def _create_navigation_screen(self, screen_name: str, screen_class: type):
         """Build a FRESH screen instance for every navigation.
@@ -14196,6 +14246,7 @@ class TldwCli(
 
     def on_mount(self) -> None:
         """Configure logging and schedule post-mount setup."""
+        self._start_persona_buddy_overlay()
         self.watchlists_operation_coordinator = WatchlistsOperationCoordinator(
             local_service=self.local_watchlists_service,
             briefing_db=self.subscriptions_db,
@@ -16813,42 +16864,10 @@ class TldwCli(
         await asyncio.shield(task)
 
     async def _flush_persona_buddy_geometry(self) -> None:
-        """Land any debounced Buddy geometry before admission closes.
-
-        TASK-21122: the mounted view coalesces geometry writes behind a
-        250 ms debounce. Because `_shutdown_persona_buddy` ends the
-        controller BEFORE Textual unmounts screens, a nudge inside that
-        window would reach `persist_preferences_revision` after admission
-        closed and be refused -- silently losing the user's last move.
-        Draining every mounted view here, while the controller is still
-        accepting writes, is what keeps it durable.
-        """
-        screens: list[Any] = []
-        stacks = getattr(self, "_screen_stacks", None)
-        if isinstance(stacks, dict):
-            for stack in stacks.values():
-                screens.extend(stack or ())
-        else:
-            try:
-                screens.extend(self.screen_stack)
-            except Exception:
-                return
-        seen: set[int] = set()
-        for screen in screens:
-            if id(screen) in seen:
-                continue
-            seen.add(id(screen))
-            flush = getattr(screen, "flush_persona_buddy_geometry", None)
-            if not callable(flush):
-                continue
-            try:
-                pending = flush()
-                if inspect.isawaitable(pending):
-                    await pending
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.debug("persona_buddy_geometry_flush_failed")
+        """Close presentation admission and drain the app-owned view."""
+        owner = getattr(self, "_persona_buddy_overlay", None)
+        if owner is not None:
+            await owner.shutdown()
 
     async def _shutdown_persona_buddy(self) -> None:
         """Drain the app-owned Buddy before profile database teardown.


### PR DESCRIPTION
## Summary

- Complete TASK-21123 by moving disposable Persona Buddy presentation from BaseAppScreen to one lazy app-owned overlay coordinator.
- React to native screen changes, generic post-recompose messages, and thread-safe controller generation notifications through a coalescing worker. Disabled Buddy starts no workers and retains the rendering-import guard.
- Preserve the pet-only UI, controls, modal behavior, geometry persistence, and unavailable-state fences. Cover shutdown-during-retirement and canceled-retirement races found during independent review.
- Amend ADR-074 and update task notes, lifecycle lessons, boot-worker census, and the reviewed diagnostic inventory.

## Verification

- [x] Combined targeted verification: 256 passed, 374 deselected (Buddy domain, widget, lifecycle, Workbench cases, import/architecture guards, terminal-probe tests, and real-app boot census).
- [x] Fresh pre-push lifecycle run on this commit: 27 passed.
- [x] Standalone POSIX PTY probe: all 22 interaction checks passed, including pet-only/alert/folded/constrained display, mouse and keyboard actions, modal resume, navigation, and persisted geometry restoration.
- [x] All derived-artifact preflight checks passed.
- [x] Modified-code Ruff, changed formatting, compilation, and diff whitespace checks passed. The 133 pre-existing app.py E402 findings were verified unchanged and excluded from scoped lint.
- [x] Independent lifecycle review: both findings fixed and regression-tested; no remaining blocking findings.

No full repository test sweep was run. Tests emit one inherited RequestsDependencyWarning. No new dependency, schema, preference format, or visual redesign.

Task: TASK-21123
Design: Docs/superpowers/specs/2026-09-04-task-21123-buddy-overlay-owner.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors Persona Buddy overlay lifetime so a single app-owned coordinator manages the view across navigation, screen rebuilds, and controller changes, instead of per-screen state in `BaseAppScreen`. This prevents screen rebuilds from silently losing the view and fixes two races found during review: shutdown during retirement now prevents late mounts, and canceled retirement reuses only generation-valid views.

**Refactors**
- `BaseAppScreen` now posts a generic `ContentsRebuilt` message after recompose; all Buddy-specific fields and workers are removed, and the derived diagnostic pin plus boot-worker census reflect the deleted screen-local fallback.
- New `PersonaBuddyOverlay` owns the current view, screen, generation, and reconciliation lock, reacting to screen changes, rebuilds, and thread-safe controller notifications.
- Controller generation changes notify the app through a content-free message; disabled Buddy starts no workers and keeps the rendering import guard.
- Amends ADR-074, adds the implementation plan and design spec docs, updates lifecycle lessons and task notes, and revises the overlay's public API docstrings after review feedback.

<sup>Written for commit f8523f8a70ff7916dc9c816b5c9f4b0aa5fe283a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

