### PR TITLE
fix(library): Trash mutation claim released when the guarded seam fails; real-DB test hygiene (task-31220 follow-up, wave 5 PR E2)

### DIFF
--- a/Tests/UI/test_library_media_bulk_delete_real_db.py
+++ b/Tests/UI/test_library_media_bulk_delete_real_db.py
@@ -19,11 +19,11 @@ import sqlite3
 
 import pytest
 from loguru import logger
+from textual.widgets import Button, Static
 
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase
 from tldw_chatbook.Media import LocalMediaReadingService, MediaReadingScopeService
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
-
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_library_shell import (
     LibraryHarness,
@@ -31,7 +31,6 @@ from Tests.UI.test_library_shell import (
     _wait_for_condition,
     _wait_for_library_shell,
 )
-from textual.widgets import Button, Static
 
 
 def _seed(db: MediaDatabase, count: int) -> list[int]:
@@ -195,9 +194,15 @@ async def test_contended_write_never_paints_a_success_receipt(tmp_path):
     house DEFERRED ``BEGIN``, and SQLite cannot park a read transaction
     waiting to upgrade to a writer (it would deadlock), so the promotion
     returns ``SQLITE_BUSY`` at once rather than honouring ``busy_timeout``.
+
+    Qodo on #2412: the writer slot is reserved through the project's own
+    ``transaction(immediate=True)`` on a SECOND independent
+    ``MediaDatabase`` -- the contention a user actually hits is between two
+    app instances, not between the app and a hand-rolled connection, and
+    the context manager's exit releases the lock on every path.
     """
     host, screen, db, db_path = _real_media_host(tmp_path, items=2)
-    other = sqlite3.connect(db_path, isolation_level=None)
+    other = MediaDatabase(db_path=db_path, client_id="other-instance")
     warnings: list[dict] = []
     sink = logger.add(
         lambda message: warnings.append(dict(message.record)),
@@ -205,34 +210,42 @@ async def test_contended_write_never_paints_a_success_receipt(tmp_path):
         filter=lambda record: record["name"].endswith("library_screen"),
     )
     try:
-        other.execute("BEGIN IMMEDIATE")
-        async with host.run_test(size=(235, 52)) as pilot:
-            await _browse_media(screen, pilot)
-            ids = screen_media_ids(screen)
-            target = ids[0]
+        with other.transaction(immediate=True) as held:
+            # The lock is genuinely held, not merely requested: only the
+            # IMMEDIATE begin reserves the writer slot (control run: with
+            # ``immediate=False`` the app's delete succeeds and paints
+            # ``('local:media:2',)``).
+            assert held.in_transaction is True
+            async with host.run_test(size=(235, 52)) as pilot:
+                await _browse_media(screen, pilot)
+                ids = screen_media_ids(screen)
+                target = ids[0]
 
-            await _run_bulk_delete(screen, (target,))
-            await pilot.pause()
+                await _run_bulk_delete(screen, (target,))
+                await pilot.pause()
 
-            assert screen._library_media_delete_receipt_ids == ()
-            assert screen._library_media_bulk_delete_in_flight is False
-            assert _fresh_is_trash(db_path, _backing(target)) == 0
-            notified = host.app_instance.library_media_notifications
-            assert [message for message, _ in notified] == [
-                "Could not delete 1 of 1 selected media item."
-            ]
-            assert all(kwargs.get("severity") == "warning" for _, kwargs in notified)
-            # The per-item failure itself, not just its aggregate side
-            # effects: the delete loop's own warning must have been raised.
-            assert "Failed to delete Library media item in bulk delete." in [
-                record["message"] for record in warnings
-            ]
+                assert screen._library_media_delete_receipt_ids == ()
+                assert screen._library_media_bulk_delete_in_flight is False
+                assert _fresh_is_trash(db_path, _backing(target)) == 0
+                notified = host.app_instance.library_media_notifications
+                assert [message for message, _ in notified] == [
+                    "Could not delete 1 of 1 selected media item."
+                ]
+                assert all(
+                    kwargs.get("severity") == "warning" for _, kwargs in notified
+                )
+                # The per-item failure itself, not just its aggregate side
+                # effects: the delete loop's own warning must have been raised.
+                assert "Failed to delete Library media item in bulk delete." in [
+                    record["message"] for record in warnings
+                ]
+        # The interlock the contention raised is released with the lock: a
+        # fresh writer succeeds where the contended one was refused.
+        with other.transaction(immediate=True):
+            pass
     finally:
         logger.remove(sink)
-        try:
-            other.execute("ROLLBACK")
-        finally:
-            other.close()
+        other.close_connection()
         db.close_connection()
 
 

--- a/Tests/UI/test_library_media_trash.py
+++ b/Tests/UI/test_library_media_trash.py
@@ -3825,6 +3825,126 @@ async def test_media_trash_permanent_failure_keeps_fresh_row_and_skips_refresh()
     assert fake._library_media_bulk_delete_in_flight is False
 
 
+async def _trash_screen_over_a_real_controller(
+    *, begin_raises=None, worker_raises=None
+):
+    """A Trash screen fake whose controller is REAL and whose claim seam refuses.
+
+    ``claim_mutation`` advances the controller generation and publishes
+    ``mutation_pending=True`` BEFORE the shared claim seam fences and
+    schedules, so a fence/scheduling failure is only observable against the
+    real reducer -- ``mutation_pending`` is what disables every Trash control
+    and blocks every subsequent refresh.
+    """
+    item = _canonical_trash_items(1)[0]
+
+    class ControllerScreen:
+        def __init__(self):
+            self.pending = []
+
+        def run_worker(self, work, **_kwargs):
+            self.pending.append(work)
+            return work
+
+    class ListService:
+        async def list_library_media_trash(self, **_kwargs):
+            return {
+                "items": [item],
+                "total": 1,
+                "limit": 20,
+                "offset": 0,
+                "types": [str(item["media_type"])],
+            }
+
+    async def call_service(fn, **kwargs):
+        kwargs.pop("isolate_in_worker", None)
+        return await fn(**kwargs)
+
+    controller_screen = ControllerScreen()
+    controller = LibraryMediaTrashBrowseController(
+        screen=controller_screen,
+        run_service_call=lambda: call_service,
+        media_service=lambda: ListService(),
+        sync_view=lambda: lambda _focus: None,
+        request_is_active=lambda: True,
+    )
+    controller.request(MediaTrashScope(), origin="entry", focus_identity=None)
+    await controller_screen.pending.pop()
+
+    def _refuse_worker(work, **_kwargs):
+        if worker_raises is not None:
+            raise worker_raises
+        pytest.fail("no worker may start on a refused claim")
+
+    fake = SimpleNamespace(
+        _library_media_bulk_delete_in_flight=False,
+        _library_media_trash_browse_controller=controller,
+        _library_media_trash_focus_identity="#library-media-trash-row-0",
+        _library_notes_focus_intent_generation=0,
+        is_mounted=False,
+        refresh=lambda **_kwargs: None,
+        call_after_refresh=lambda fn, *_args: None,
+        run_worker=_refuse_worker,
+        _focus_library_media_trash_entry=lambda: None,
+    )
+    _bind_trash_mutation_seams(fake)
+    # The real worker bodies: the seam is handed the production coroutine
+    # (and must close it), never a stand-in that would not warn if leaked.
+    fake._permanently_delete_library_media_from_trash = types.MethodType(
+        LibraryScreen._permanently_delete_library_media_from_trash, fake
+    )
+    fake._restore_library_media_from_trash = types.MethodType(
+        LibraryScreen._restore_library_media_from_trash, fake
+    )
+    if begin_raises is not None:
+        def _begin():
+            raise begin_raises
+
+        fake._begin_library_media_mutation = _begin
+    return fake
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action", ("delete", "restore"))
+@pytest.mark.parametrize("failure_kind", ("fence", "schedule"))
+async def test_trash_claim_is_rolled_back_when_the_mutation_never_reaches_a_worker(
+    action, failure_kind
+):
+    """Qodo #3: the Trash claim outlives a refused shared claim.
+
+    Both Trash handlers claim the controller (generation advanced,
+    ``mutation_pending=True``) before ``_claim_library_media_mutation``
+    fences and schedules. Its failure path released only the shared screen
+    interlock, so a fence/scheduling error left Trash pending forever --
+    every control disabled and every refresh request dropped, for the rest
+    of the session.
+    """
+    boom = RuntimeError("fence/scheduling refused")
+    fake = await _trash_screen_over_a_real_controller(
+        begin_raises=boom if failure_kind == "fence" else None,
+        worker_raises=boom if failure_kind == "schedule" else None,
+    )
+    controller = fake._library_media_trash_browse_controller
+    event = SimpleNamespace(stop=lambda: None)
+    if action == "delete":
+        assert controller.open_delete_confirmation() is not None
+        handler = LibraryScreen.handle_library_media_trash_delete_confirm
+    else:
+        handler = LibraryScreen.handle_library_media_trash_restore
+
+    with pytest.raises(RuntimeError, match="refused"):
+        handler(fake, event)
+
+    assert controller.state.mutation_pending is False
+    assert fake._library_media_bulk_delete_in_flight is False
+    # The row survives an attempt that never touched the database, and the
+    # surface says so rather than sitting silently disabled.
+    assert controller.state.retained_items == (_canonical_trash_items(1)[0],)
+    assert controller.state.error_copy != ""
+    # A rolled-back claim is a fresh claim opportunity, not a dead surface.
+    assert controller.claim_mutation() is not None
+
+
 def test_escape_gate_only_passes_in_trash_view():
     """check_action: ``library_media_trash_back`` fires only while the
     media canvas genuinely shows its Trash view; the viewer's own gate is

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -750,6 +750,13 @@ _ANALYZE_ITEM_FAILED_REASON = "analysis did not persist"
 # analyze_outcome`` (``library_ingest_state.py``) reads this to paint
 # "already analyzed" instead of the generic "analyzed" receipt.
 _ANALYZE_AUTO_SKIP_REASON = "already analyzed"
+# task-31220 (Qodo review round, PR #2412 #3): the copy each Trash mutation
+# releases its controller claim with. Named once because both the worker
+# body's own pre-commit failure and the claim seam's rollback (a fence or
+# ``run_worker`` that refused before any worker ran) mean the same thing to
+# the person looking at the row: nothing happened to it.
+_TRASH_PERMANENT_DELETE_FAILURE_COPY = "Could not delete this media item permanently."
+_TRASH_RESTORE_FAILURE_COPY = "Could not restore this media item."
 #
 # _INGEST_OPTIONS_CACHE_ATTR, _read_library_ingest_options_from_config, and
 # _library_ingest_options_for (just above) STAY here rather than moving to
@@ -15646,7 +15653,10 @@ class LibraryScreen(BaseAppScreen):
         return (None, *self._library_media_browse_controller.type_options)
 
     def _claim_library_media_mutation(
-        self, work: Coroutine[Any, Any, None]
+        self,
+        work: Coroutine[Any, Any, None],
+        *,
+        on_failure: Callable[[], object] | None = None,
     ) -> None:
         """Claim the shared write interlock, fence reads, and schedule ``work``.
 
@@ -15662,6 +15672,15 @@ class LibraryScreen(BaseAppScreen):
 
         Args:
             work: The mutation coroutine to run under the interlock.
+            on_failure: Roll back a SURFACE-level claim the caller took
+                before this seam (Qodo on #2412: both Trash handlers claim
+                their controller -- generation advanced,
+                ``mutation_pending=True`` published -- before calling here,
+                and releasing only the shared flag left Trash's own
+                controls disabled and its refreshes dropped for the rest of
+                the session). Runs after the shared release, mirroring the
+                worker bodies' own ``finally`` order, and can never replace
+                the fence/scheduling error the caller needs.
 
         Returns:
             None.
@@ -15684,6 +15703,9 @@ class LibraryScreen(BaseAppScreen):
             # not replace the fence/scheduling error the caller needs.
             with suppress(Exception):
                 self._complete_library_media_mutation()
+            if on_failure is not None:
+                with suppress(Exception):
+                    on_failure()
             raise
 
     def _begin_library_media_mutation(self) -> MediaBrowseScope:
@@ -25102,7 +25124,10 @@ class LibraryScreen(BaseAppScreen):
         if claim is None or claim.target != captured:
             return
         self._claim_library_media_mutation(
-            self._permanently_delete_library_media_from_trash(claim)
+            self._permanently_delete_library_media_from_trash(claim),
+            on_failure=lambda: controller.finish_mutation_failure(
+                claim, _TRASH_PERMANENT_DELETE_FAILURE_COPY
+            ),
         )
 
     async def _permanently_delete_library_media_from_trash(
@@ -25134,7 +25159,7 @@ class LibraryScreen(BaseAppScreen):
                 result,
                 media_id=target.backing_media_id,
             ):
-                failure_copy = "Could not delete this media item permanently."
+                failure_copy = _TRASH_PERMANENT_DELETE_FAILURE_COPY
                 return
 
             title = LibraryScreen._bounded_library_media_trash_title(target.title)
@@ -25188,11 +25213,15 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         if self._library_media_bulk_delete_in_flight:
             return
-        claim = self._library_media_trash_browse_controller.claim_mutation()
+        controller = self._library_media_trash_browse_controller
+        claim = controller.claim_mutation()
         if claim is None:
             return
         self._claim_library_media_mutation(
-            self._restore_library_media_from_trash(claim)
+            self._restore_library_media_from_trash(claim),
+            on_failure=lambda: controller.finish_mutation_failure(
+                claim, _TRASH_RESTORE_FAILURE_COPY
+            ),
         )
 
     async def _restore_library_media_from_trash(
@@ -25251,7 +25280,7 @@ class LibraryScreen(BaseAppScreen):
                         type(exc).__name__,
                     )
             if restored_record is None:
-                failure_copy = "Could not restore this media item."
+                failure_copy = _TRASH_RESTORE_FAILURE_COPY
                 return
 
             title = LibraryScreen._bounded_library_media_trash_title(target.title)


### PR DESCRIPTION
Follow-up to #2412 carrying its Qodo round, which landed after that PR merged under the strict dev gate.

- **Bug (Qodo #3):** Trash restore and permanent delete claimed the Trash controller's mutation (`claim_mutation()`, `mutation_pending=True`) BEFORE the guarded `_claim_library_media_mutation` seam, so a fence or `run_worker` raise released the shared Library interlock but left Trash permanently mutation-pending. The seam gains an optional `on_failure` callback, run after the shared release under `suppress`; both Trash handlers pass the controller's existing `finish_mutation_failure`. Regression tests: both handlers × both failure points (RED then GREEN, +4 in `test_library_media_trash.py`). The other four claim sites take no pre-seam surface claim.
- **Rule (Qodo #2):** the contention test in `test_library_media_bulk_delete_real_db.py` now holds the write lock through a second `MediaDatabase` instance's `transaction(immediate=True)` instead of a raw `sqlite3` connection; an executed `immediate=False` control proves the lock is really held.
- **Rule (Qodo #1):** import groups in that test file.

Verification: trash 85 passed, bulk_delete_real_db 5, multiselect 95, browse_controller 30, side_by_side 34 (separate processes, vs base); diagnostic inventory exit 0; one flag / one worker group invariant green. Same class of defect as the storage wedge root-caused in #2412, one layer down.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Trash mutation claim leaking when the shared media-mutation seam fails, so a refused fence or worker schedule no longer leaves Trash permanently pending. Also tightens the real-DB contention test to hold its writer lock through a second `MediaDatabase` instance.

- The claim seam now takes an optional `on_failure` callback run after the shared release; both Trash handlers pass the controller's existing `finish_mutation_failure`.
- Adds regression coverage for both Trash handlers over both failure points (fence and schedule) against a real controller, verifying the claim, row, and error copy recover.
- The contention test replaces raw `sqlite3` with `transaction(immediate=True)` on a second `MediaDatabase`; an `immediate=False` control run confirms the lock is genuinely held.
- The real-DB test's import groups are split cleanly into stdlib, third-party, and project-local.

<sup>Written for commit 04722ad03dcfc8498e40a6b821c04af02f8c1e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

