### PR TITLE
fix(scheduling): UAT remediation — display, staleness, transfer honesty

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -550,7 +550,10 @@ button, and retrying resubmits the same task.
 A queued move can also be stranded rather than rejected — you point the
 app at a different server, or drop the connection entirely, while a
 local → server transfer is still waiting. That queued mutation can never
-be delivered, so the next sync settles it to *failed* with the reason
+be delivered, so the next time the Schedules screen opens (this check
+does not need a reachable server, or even a configured one — it is a
+local check, so it also covers the connection-dropped case, not only a
+sync-eligible server switch) settles it to *failed* with the reason
 *"The server this move was queued for is no longer configured."* rather
 than leaving the row reading "(Moving to server…)" with nothing behind
 it. The task is editable again and carries the usual **Retry

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -131,7 +131,7 @@ rows.
 | `space` | Enable or disable (reminders) |
 | `d` | Delete (reminders) |
 | `x` | Mark or unmark the row for a bulk action |
-| `Esc` | Clear marks — or, in a view opened over the list, close it |
+| `Esc` | Leave the filter box (when it has focus) — otherwise clear marks, or, in a view opened over the list, close it |
 | `s` | Sync now |
 | `a` | Mark every unread automation result read |
 
@@ -481,6 +481,17 @@ reason — no server connection, no server identity, a transfer already
 running, or, moving a `recurring_question` mirror to this device, the
 same local-health reason the automation's own pane reports.
 
+"Configured" and "reachable" are two different answers and the screen
+says which one it means. A profile with no scheduling server at all
+refuses with *"No server connection is configured."*; a server that is
+configured but has not answered refuses with *"The configured server is
+not reachable right now."* Nothing is offered on a hope: the answer
+comes from a real round trip (the same capabilities probe the sync
+layer uses), it is re-taken when you change the owner or press **s**,
+and until one has succeeded the create forms' `Runs on` dropdown lists
+only **This device** — the server option is omitted rather than offered
+and then refused.
+
 Picking the other owner opens a confirmation listing anything worth knowing before
 you commit: an imminent or already-passed one-time run time ("server
 behavior this close to run time is unverified"), and, for a reminder,
@@ -535,6 +546,15 @@ happened".
 **Retry transfer** appears only alongside a local → server move the
 server definitively rejected; the stored reason is shown beside the
 button, and retrying resubmits the same task.
+
+A queued move can also be stranded rather than rejected — you point the
+app at a different server, or drop the connection entirely, while a
+local → server transfer is still waiting. That queued mutation can never
+be delivered, so the next sync settles it to *failed* with the reason
+*"The server this move was queued for is no longer configured."* rather
+than leaving the row reading "(Moving to server…)" with nothing behind
+it. The task is editable again and carries the usual **Retry
+transfer** / **Cancel transfer** pair.
 
 **A disabled server reminder stays disabled** when it is released to this
 device — the release moves the task, not its on/off state.
@@ -718,6 +738,19 @@ example "the server has archived this automation") rather than the
 connection message — only genuine connectivity failures mention the
 network.
 
+**A server too old for this surface says so.** Before pulling, the app
+asks the server what it supports. A server that does not answer that
+question at all is not asked for automations or results — nothing is
+pulled, no error is invented, and the run-history pane reads *"This
+server does not support scheduled task automation (server too old)."* A
+server new enough to answer but not yet serving the results route
+reports *"This server does not provide the results inbox (server too
+old)."* — carried in the sync notice as *"Sync completed with issues —
+Automation results pull: …"*, so the missing route names itself instead
+of surfacing as a server-worded error about a task that was never the
+problem. The results view itself still reads "No results yet." when
+nothing has arrived; the sync notice is where the *why* lives.
+
 ## Execution timeouts
 
 A scheduled task's handler is bounded: if it is still running after its
@@ -733,6 +766,31 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules UAT remediation, Tasks 1/3/4 — live in
+the real TUI, 2026-09-05 (scratch profile, 235x52 and 80x24). Copy
+changed in three places, each because the behaviour behind it changed:
+**Moving a task…** now separates "no server is configured" from "the
+configured server is not reachable" — the offer is gated on a real probe
+rather than on a server profile merely existing, so the `Runs on`
+dropdown lists only **This device** when nothing answers (confirmed
+live: with nothing listening, both the create form's dropdown and a
+row's `m` dropdown offered exactly one option, and `s` refused with
+"Local only — nothing to sync (no server connection)"). The same
+section gained the stranded-transfer paragraph: a queued local -> server
+move whose server is no longer configured settles to *failed* with a
+stated reason instead of reading "(Moving to server…)" forever. **The
+results view** gained the server-too-old paragraph for the capabilities
+handshake. The keyboard table's `Esc` row now says it leaves the filter
+box first. Fixed without a copy change, re-verified live: the in-pane
+row editors and the queue filter paint their text while focused (they
+rendered as a bare top border before), and the detail pane scrolls to
+its `History` group while keeping the Edit/Run now/Enable/Disable/Delete
+row above the fold at both sizes. Pinned by
+`Tests/UI/test_schedules_responsive_floor.py`,
+`Tests/UI/test_schedules_workbench.py`,
+`Tests/Scheduling/test_scheduling_service.py` and
+`Tests/Scheduling/test_sync_engine.py`.*
 
 *Verified against the schedules UAT remediation, Task 2 (the stale-
 display cluster) — 2026-09-04. Two corrections to prior copy in this

--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -175,6 +175,14 @@ Local owner and no scheduling server connected, the bar collapses to a
 single line ("Local schedules — no scheduling server connected; sync is
 off"), and the **Clear** button only appears once a sync error exists.
 
+A sync cycle runs several independent phases (reminders, then automation
+review/definition pushback, definitions pull, results pull); one of them
+failing never overwrites the others' honest report. If your reminders
+synced cleanly but, say, an automation results pull hit a stale server,
+you get the success toast **and** a separate "Sync completed with
+issues — …" notice naming that one phase — never a blanket "Sync failed"
+that would make a genuinely successful push look lost.
+
 ## Scheduler liveness
 
 Below the sync bar, a one-line **scheduler liveness** indicator distinguishes
@@ -359,11 +367,13 @@ and its Next Run reads **— (disabled)** instead of a concrete time it
 will not honor, in both the detail pane and the queue row's subtitle.
 Enabling it restores the recorded last outcome and the real next run.
 
-This covers a one-time reminder that has already fired: running it
-disables it and clears its next run, so it reads **Disabled** in the
-detail badge with a Next Run of **— (disabled)** — the same as a task
-you disabled by hand. A fired one-time reminder shows the `✓` glyph in
-the queue and moves under the **Completed** chip.
+This does **not** cover a one-time reminder that has already fired:
+dispatching it also disables it and clears its next run internally, but
+the screen reads that specific shape as **finished**, not disabled —
+the detail badge and Next Run agree with the queue row: **Completed**,
+Next Run **—**, the `✓` glyph, and the **Completed** chip, everywhere at
+once. A task you disabled yourself (its next run is still armed
+underneath) is the only shape that reads **Disabled** / **— (disabled)**.
 
 ## Ran late — what happens to overdue reminders
 
@@ -723,6 +733,24 @@ The default bound is `handler_timeout_seconds` under `[scheduling]` in
 `config.toml` (**300** seconds). Set it to `0` (or negative) to disable the
 bound entirely — every handler may then run as long as it likes, and a
 wedged handler will wedge the scheduler, which is why the default is on.
+
+*Verified against the schedules UAT remediation, Task 2 (the stale-
+display cluster) — 2026-09-04. Two corrections to prior copy in this
+page, both fixed defects: the **Disabled tasks** section used to
+describe a fired one-time reminder as reading "Disabled" with a
+"— (disabled)" Next Run while simultaneously sitting under the
+**Completed** chip — that was the bug (badge and chip disagreeing on
+the same row), not a documented quirk; it now reads Completed
+everywhere. The **Sync bar honesty** section gained a paragraph on
+mixed-cycle sync (one phase fails, another succeeds): the toast now
+reports both truths separately rather than a blanket "Sync failed"
+masking a phase that actually succeeded. Also fixed without a copy
+change: a scheduler-fired reminder's row now repaints without
+navigating away and back, and the scheduler-liveness line refreshes
+every 5s instead of only alongside the 60s relative-time ticker.
+Pinned by `Tests/UI/test_schedules_disabled_state.py`,
+`Tests/UI/test_schedules_workbench.py`, and
+`Tests/Scheduling/test_sync_engine.py`/`test_scheduler_loop.py`.*
 
 *Verified against the schedules redesign PR-4 — 2026-09-04 (docs pass
 against shipped code/tests, live check pending the redesign program's

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1860,8 +1860,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 20,
-      "diagnostic_digest": "0a83b4c6ae83f35bc0a7",
+      "call_count": 21,
+      "diagnostic_digest": "9450b85145047577a813",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/scheduler/loop.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -1881,8 +1881,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 35,
-      "diagnostic_digest": "ddee18d094a5525b4b45",
+      "call_count": 38,
+      "diagnostic_digest": "573454591d581e995388",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Scheduling/services/sync_engine.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2924,8 +2924,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 27,
-      "diagnostic_digest": "c85dd7c9863c11936c42",
+      "call_count": 28,
+      "diagnostic_digest": "003ce5ef7309c52a87d3",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11392,6 +11392,6 @@
     "path_privacy_candidate_calls": 716,
     "persistent_sink_files": 11,
     "task_492_calls": 1336,
-    "task_494_calls": 7610
+    "task_494_calls": 7615
   }
 }

--- a/Tests/Scheduling/test_scheduler_loop.py
+++ b/Tests/Scheduling/test_scheduler_loop.py
@@ -819,3 +819,89 @@ async def test_scheduler_loop_dispatches_a_due_briefing_job(db):
     handler.assert_awaited_once()
     dispatched_task = handler.await_args.args[0]
     assert dispatched_task["id"] == "briefing:1"
+
+
+# ---------------------------------------------------------------------------
+# UAT finding 3a: dispatch -> UI fanout (`on_reminder_dispatched`)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_reminder_dispatched_fires_after_a_successful_fire(db):
+    """The callback must fire AFTER `mark_reminder_dispatched` commits, not
+    before -- a UI refresh triggered from it must see the row's NEW fired
+    state (enabled=False, next_run_at=None for a one-time reminder), never
+    the stale pre-fire snapshot."""
+    task_id = _create_reminder(db, "Test", "2026-01-01T00:00:00+00:00")
+    handler = AsyncMock()
+    calls: list[str] = []
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc),
+        on_reminder_dispatched=lambda tid: calls.append(tid),
+    )
+    loop.queue.load()
+    await loop.tick()
+
+    handler.assert_awaited_once()
+    assert calls == [task_id]
+    row = db.get_reminder_task(task_id)
+    assert row["enabled"] == 0, "the callback must fire AFTER the row's fired state lands"
+    assert row["next_run_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_on_reminder_dispatched_fires_after_a_failed_handler_too(db):
+    """A handler that raises still calls `mark_reminder_dispatched`
+    (recording the failed attempt) -- the row's bucket/status can still
+    change (e.g. its retry/missed state), so the UI must still hear
+    about it."""
+    task_id = _create_reminder(db, "Test", "2026-01-01T00:00:00+00:00")
+    handler = AsyncMock(side_effect=RuntimeError("boom"))
+    calls: list[str] = []
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc),
+        on_reminder_dispatched=lambda tid: calls.append(tid),
+    )
+    loop.queue.load()
+
+    with patch("tldw_chatbook.Scheduling.scheduler.loop.logger"):
+        await loop.tick()
+
+    assert calls == [task_id]
+
+
+@pytest.mark.asyncio
+async def test_on_reminder_dispatched_callback_failure_does_not_break_dispatch(db):
+    """Same tolerance as `on_queue_changed`: a broken callback must never
+    fail the dispatch itself."""
+    task_id = _create_reminder(db, "Test", "2026-01-01T00:00:00+00:00")
+    handler = AsyncMock()
+
+    def boom(_task_id):
+        raise RuntimeError("bad callback")
+
+    loop = SchedulerLoop(
+        db,
+        handlers={"reminder": handler},
+        clock=lambda: datetime(2026, 1, 1, tzinfo=timezone.utc),
+        on_reminder_dispatched=boom,
+    )
+    loop.queue.load()
+    await loop.tick()
+
+    handler.assert_awaited_once()
+    row = db.get_reminder_task(task_id)
+    assert row["enabled"] == 0, "the dispatch itself must still have succeeded"
+
+
+def test_on_reminder_dispatched_defaults_to_none_and_is_optional():
+    """Several existing tests build a `SchedulerLoop` via `__new__`,
+    bypassing `__init__` -- `_notify_reminder_dispatched` must tolerate a
+    missing attribute, not just a `None` one."""
+    loop = SchedulerLoop.__new__(SchedulerLoop)
+    # No `on_reminder_dispatched` attribute at all -- must not raise.
+    loop._notify_reminder_dispatched("some-id")

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -13,6 +13,7 @@ from tldw_chatbook.Scheduling.services import SchedulingServerClient, Scheduling
 from tldw_chatbook.Scheduling.services import scheduling_service as scheduling_service_module
 from tldw_chatbook.Scheduling.services.briefing_projection import BriefingProjection
 from tldw_chatbook.Scheduling.services.server_client import (
+    ServerClientConfig,
     ServerClientPolicyError,
     ServerClientValidationError,
     ServerUnavailableError,
@@ -2269,7 +2270,9 @@ async def test_refresh_server_reachability_no_client_stays_false(db):
 async def test_refresh_server_reachability_succeeds_when_capabilities_probe_lands(db):
     """Reuses the capabilities handshake's own round trip (ruling 5) as
     the reachability probe -- any successful response, present or absent
-    capabilities alike, proves the server actually answered."""
+    capabilities alike, proves the server actually answered. Also pins
+    the Qodo fix round finding 1 cache-bypass: the explicit probe always
+    passes `force=True` so it never answers from a stale cached verdict."""
     client = AsyncMock()
     client.notifications_service = object()
     client.get_capabilities.return_value = {"items": []}
@@ -2279,6 +2282,7 @@ async def test_refresh_server_reachability_succeeds_when_capabilities_probe_land
 
     assert result is True
     assert svc.server_reachable is True
+    client.get_capabilities.assert_awaited_once_with(force=True)
 
 
 @pytest.mark.asyncio
@@ -2298,29 +2302,17 @@ async def test_refresh_server_reachability_false_when_probe_raises(db):
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize(
-    "exc",
-    [
-        ServerClientPolicyError("scheduler.automations.list.server denied"),
-        ServerClientValidationError("401 unauthorized"),
-    ],
-)
-async def test_refresh_server_reachability_policy_denial_is_not_unreachable(
-    db, exc
-):
-    """Final review finding 7: a local policy denial (`ServerClientPolicy
-    Error`, refused before any network attempt) or a genuine 401/403 from
-    the server (`ServerClientValidationError`) is a PERMISSION problem,
-    not evidence the server is unreachable -- conflating either into
-    "unreachable" additionally blocked reminder transfer (unrelated to
-    the automations permission the probe is actually gated on) on a
-    permission gate that has nothing to do with it. Neither exception
-    establishes anything new about the network, so a PRIOR reachable
-    verdict must survive it, and `server_permission_denied` must record
-    the distinct signal."""
+async def test_refresh_server_reachability_policy_denial_leaves_reachable_as_is(db):
+    """A local `ServerClientPolicyError` refuses BEFORE any network
+    attempt -- no round trip happened, so it establishes nothing new
+    about the network either way. A PRIOR reachable verdict must
+    survive it, and `server_permission_denied` must record the distinct
+    signal (final review finding 7)."""
     client = AsyncMock()
     client.notifications_service = object()
-    client.get_capabilities.side_effect = exc
+    client.get_capabilities.side_effect = ServerClientPolicyError(
+        "scheduler.automations.list.server denied"
+    )
     svc = SchedulingService(db=db, server_client=client)
     svc._server_reachable = True  # a prior probe had succeeded
 
@@ -2349,6 +2341,80 @@ async def test_refresh_server_reachability_policy_denial_leaves_unprobed_as_unpr
     assert result is False  # bool(None) is False -- still "not confirmed"
     assert svc.server_reachable is None
     assert svc.server_permission_denied is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_401_proves_reachable_even_from_false(db):
+    """Qodo fix round finding 1 (ruling reversal), pin (b): a genuine
+    401/403 from the server (`ServerClientValidationError`) is the
+    server ACTUALLY ANSWERING -- that answer IS proof of network
+    reachability, so it is set `True` outright, even overriding a prior
+    `False` verdict. A reminder transfer needs no automations-list
+    permission at all -- only the automations affordance itself refuses,
+    with permission-naming copy via `server_permission_denied`, never
+    'server not reachable'."""
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.side_effect = ServerClientValidationError("401 unauthorized")
+    svc = SchedulingService(db=db, server_client=client)
+    svc._server_reachable = False  # a prior probe had failed
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is True, "a 401 answer proves the server is there, unlike a prior failure"
+    assert svc.server_reachable is True
+    assert svc.server_permission_denied is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_401_proves_reachable_even_unprobed(db):
+    """The FIRST-EVER probe landing a 401 still proves reachability --
+    unlike a policy denial, a `ServerClientValidationError` means the
+    server actually answered, so `server_reachable` becomes `True`
+    rather than staying `None`."""
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.side_effect = ServerClientValidationError("403 forbidden")
+    svc = SchedulingService(db=db, server_client=client)
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is True
+    assert svc.server_reachable is True
+    assert svc.server_permission_denied is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_bypasses_the_capabilities_cache(db):
+    """Qodo fix round finding 1, pin (a): a server that dies after an
+    earlier successful probe must be caught on the NEXT explicit probe,
+    not answered forever from `SchedulingServerClient`'s permanent
+    per-connection capabilities cache. Exercises the real
+    `SchedulingServerClient` (not a mock) so the cache-bypass wiring
+    itself is under test, not just the service's exception handling."""
+    service = MagicMock()
+    service.get_scheduled_automation_capabilities = AsyncMock(return_value={"items": []})
+    client = SchedulingServerClient(
+        notifications_service=service,
+        config=ServerClientConfig(max_retries=0, retry_delay=0),
+    )
+    svc = SchedulingService(db=db, server_client=client)
+
+    first = await svc.refresh_server_reachability()
+    assert first is True
+    assert svc.server_reachable is True
+
+    # The server dies; without a cache bypass, `get_capabilities()` would
+    # answer from the cached success forever and never notice.
+    service.get_scheduled_automation_capabilities = AsyncMock(
+        side_effect=ConnectionRefusedError("connection refused")
+    )
+
+    second = await svc.refresh_server_reachability()
+    assert second is False
+    assert svc.server_reachable is False, (
+        "the cache must not lie -- a dead server must flip reachability on the next probe"
+    )
 
 
 def test_transfer_refusal_names_permissions_not_the_network(db):

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -2066,12 +2066,25 @@ def _connected_server_client():
 def _transfer_service(db, *, server_client=None, active_server_id="1", **kwargs):
     app = _FakeApp(active_server_id) if active_server_id is not None else None
     kwargs.setdefault("runtime_source", "local")
-    return SchedulingService(
+    svc = SchedulingService(
         db=db,
         server_client=server_client,
         app_getter=(lambda: app) if app is not None else None,
         **kwargs,
     )
+    # task-3 (ruling 4): `transfer_refusal` now also gates on
+    # `server_reachable`, which only a real `refresh_server_reachability`
+    # probe sets -- these tests exercise everything ELSE `transfer_
+    # refusal` checks against an assumed-connected server, so pre-seed the
+    # same "a probe already succeeded" state `_connected_server_client()`
+    # implies, rather than making every caller await a probe just to
+    # reach the check it actually wants to test. A test that wants the
+    # unreachable-but-configured case instead sets `svc._server_reachable
+    # = False` back after calling this helper (see
+    # `test_transfer_refusal_configured_but_unreachable` below).
+    if server_client is not None:
+        svc._server_reachable = True
+    return svc
 
 
 def _make_reminder(db, **overrides):
@@ -2115,6 +2128,24 @@ def test_transfer_refusal_no_server_connection(db):
     for direction in ("to_server", "to_local"):
         reason = svc.transfer_refusal(row, direction)
         assert reason == "No server connection is configured."
+
+
+def test_transfer_refusal_configured_but_unreachable(db):
+    """task-3 (ruling 4, root-causes.md #5): a server IDENTITY being
+    configured is not proof anything ever answered it -- the three old
+    checks `_server_available`/`transfer_refusal` stopped at (client
+    object exists, an id string is set, `notifications_service` was
+    constructed) never contacted anything. `server_reachable` defaults
+    `False` until `refresh_server_reachability` actually probes and
+    succeeds; a configured-but-unreachable server must refuse with its
+    OWN reason, distinct from "not configured at all" (the UX-grammar
+    split ruling 4 calls for)."""
+    svc = _transfer_service(db, server_client=_connected_server_client())
+    svc._server_reachable = False  # no probe has succeeded (yet)
+    row = db.get_reminder_task(_make_reminder(db))
+    for direction in ("to_server", "to_local"):
+        reason = svc.transfer_refusal(row, direction)
+        assert reason == "The configured server is not reachable right now."
 
 
 def test_transfer_refusal_to_server_already_server_owned(db):
@@ -2210,6 +2241,56 @@ def test_transfer_refusal_allows_happy_path_both_directions(db, monkeypatch):
     to_local_def = _make_definition(db, owner_id="server:1", server_id="srv-def-1")
     to_local_row = db.get_automation_definition(to_local_def)
     assert svc.transfer_refusal(to_local_row, "to_local") is None
+
+
+# -- refresh_server_reachability (task-3, ruling 4) ------------------------
+
+
+def test_refresh_server_reachability_defaults_false_until_probed(db):
+    """`server_reachable` starts `False` -- ruling 4: "until a probe has
+    succeeded, the option must not be offered"."""
+    svc = SchedulingService(db=db, server_client=None)
+    assert svc.server_reachable is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_no_client_stays_false(db):
+    svc = SchedulingService(db=db, server_client=None)
+    result = await svc.refresh_server_reachability()
+    assert result is False
+    assert svc.server_reachable is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_succeeds_when_capabilities_probe_lands(db):
+    """Reuses the capabilities handshake's own round trip (ruling 5) as
+    the reachability probe -- any successful response, present or absent
+    capabilities alike, proves the server actually answered."""
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.return_value = {"items": []}
+    svc = SchedulingService(db=db, server_client=client)
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is True
+    assert svc.server_reachable is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_false_when_probe_raises(db):
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.side_effect = RuntimeError("connection refused")
+    svc = SchedulingService(db=db, server_client=client)
+    svc._server_reachable = True  # a prior probe had succeeded
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is False
+    assert svc.server_reachable is False, (
+        "a failed re-probe must not leave the stale 'reachable' verdict standing"
+    )
 
 
 # -- transfer_warnings -----------------------------------------------------

--- a/Tests/Scheduling/test_scheduling_service.py
+++ b/Tests/Scheduling/test_scheduling_service.py
@@ -2246,11 +2246,15 @@ def test_transfer_refusal_allows_happy_path_both_directions(db, monkeypatch):
 # -- refresh_server_reachability (task-3, ruling 4) ------------------------
 
 
-def test_refresh_server_reachability_defaults_false_until_probed(db):
-    """`server_reachable` starts `False` -- ruling 4: "until a probe has
-    succeeded, the option must not be offered"."""
+def test_refresh_server_reachability_defaults_none_until_probed(db):
+    """`server_reachable` starts `None` (unprobed, final review finding
+    2) -- distinct from `False` (probed and failed) so the header can
+    tell "haven't checked" apart from "checked and failed" -- but still
+    falsy, so ruling 4's "until a probe has succeeded, the option must
+    not be offered" still holds via `_server_available`'s `bool(...)`
+    wrap."""
     svc = SchedulingService(db=db, server_client=None)
-    assert svc.server_reachable is False
+    assert svc.server_reachable is None
 
 
 @pytest.mark.asyncio
@@ -2291,6 +2295,76 @@ async def test_refresh_server_reachability_false_when_probe_raises(db):
     assert svc.server_reachable is False, (
         "a failed re-probe must not leave the stale 'reachable' verdict standing"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "exc",
+    [
+        ServerClientPolicyError("scheduler.automations.list.server denied"),
+        ServerClientValidationError("401 unauthorized"),
+    ],
+)
+async def test_refresh_server_reachability_policy_denial_is_not_unreachable(
+    db, exc
+):
+    """Final review finding 7: a local policy denial (`ServerClientPolicy
+    Error`, refused before any network attempt) or a genuine 401/403 from
+    the server (`ServerClientValidationError`) is a PERMISSION problem,
+    not evidence the server is unreachable -- conflating either into
+    "unreachable" additionally blocked reminder transfer (unrelated to
+    the automations permission the probe is actually gated on) on a
+    permission gate that has nothing to do with it. Neither exception
+    establishes anything new about the network, so a PRIOR reachable
+    verdict must survive it, and `server_permission_denied` must record
+    the distinct signal."""
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.side_effect = exc
+    svc = SchedulingService(db=db, server_client=client)
+    svc._server_reachable = True  # a prior probe had succeeded
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is True, "a prior reachable verdict must survive a permission denial"
+    assert svc.server_reachable is True
+    assert svc.server_permission_denied is True
+
+
+@pytest.mark.asyncio
+async def test_refresh_server_reachability_policy_denial_leaves_unprobed_as_unprobed(
+    db,
+):
+    """The FIRST-EVER probe hitting a policy denial establishes nothing
+    about the network either way -- `server_reachable` must stay `None`
+    (unprobed), not flip to a confident `True` or `False` it hasn't
+    earned."""
+    client = AsyncMock()
+    client.notifications_service = object()
+    client.get_capabilities.side_effect = ServerClientPolicyError("denied")
+    svc = SchedulingService(db=db, server_client=client)
+
+    result = await svc.refresh_server_reachability()
+
+    assert result is False  # bool(None) is False -- still "not confirmed"
+    assert svc.server_reachable is None
+    assert svc.server_permission_denied is True
+
+
+def test_transfer_refusal_names_permissions_not_the_network(db):
+    """`transfer_refusal`'s copy must distinguish a permission problem
+    from "not reachable" -- final review finding 7's honest-refusal
+    grammar."""
+    svc = _transfer_service(db, server_client=_connected_server_client())
+    svc._server_reachable = False
+    svc._server_permission_denied = True
+    row = db.get_reminder_task(_make_reminder(db))
+
+    reason = svc.transfer_refusal(row, "to_server")
+
+    assert reason is not None
+    assert "permission" in reason.lower()
+    assert "not reachable" not in reason
 
 
 # -- transfer_warnings -----------------------------------------------------

--- a/Tests/Scheduling/test_server_client.py
+++ b/Tests/Scheduling/test_server_client.py
@@ -1,11 +1,27 @@
 import pytest
 
-from tldw_chatbook.Scheduling.services import SchedulingServerClient, ServerUnavailableError
+from tldw_chatbook.Scheduling.services import (
+    SchedulingServerClient,
+    ServerClientConfig,
+    ServerClientNotFoundError,
+    ServerClientServerError,
+    ServerUnavailableError,
+)
 
 
 class FakeNotificationsService:
     def __init__(self):
         self.calls = []
+        # task-3 (schedules UAT remediation ruling 5) capabilities
+        # handshake -- overridden per test below; defaults to "present".
+        self.capabilities_response = {"items": []}
+        self.capabilities_error = None
+
+    async def get_scheduled_automation_capabilities(self):
+        self.calls.append(("get_scheduled_automation_capabilities",))
+        if self.capabilities_error is not None:
+            raise self.capabilities_error
+        return self.capabilities_response
 
     async def create_reminder(self, **payload):
         self.calls.append(("create_reminder", payload))
@@ -100,3 +116,92 @@ async def test_unavailable_client_raises_server_unavailable_error(method_name, a
     method = getattr(client, method_name)
     with pytest.raises(ServerUnavailableError, match="server not available"):
         await method(*args, **kwargs)
+
+
+# -- get_capabilities (task-3, schedules UAT remediation ruling 5) --------
+# The handshake: probe once, cache the verdict for this connection. A 404
+# (the whole route is absent -- a server old enough to predate Scheduled
+# Tasks automation) degrades to `None`, never raised; anything else
+# re-raises uncached, so a transient blip is never misread as "too old".
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_returns_response_when_present(client, service):
+    result = await client.get_capabilities()
+
+    assert result == {"items": []}
+    assert service.calls == [("get_scheduled_automation_capabilities",)]
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_caches_a_successful_probe(client, service):
+    first = await client.get_capabilities()
+    second = await client.get_capabilities()
+
+    assert first == second == {"items": []}
+    assert service.calls == [("get_scheduled_automation_capabilities",)], (
+        "the second call must reuse the cached verdict, not re-probe"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_returns_none_when_route_absent(client, service):
+    service.capabilities_error = ServerClientNotFoundError("not found")
+
+    result = await client.get_capabilities()
+
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_caches_an_absent_verdict_too(client, service):
+    service.capabilities_error = ServerClientNotFoundError("not found")
+
+    first = await client.get_capabilities()
+    second = await client.get_capabilities()
+
+    assert first is None
+    assert second is None
+    assert service.calls == [("get_scheduled_automation_capabilities",)], (
+        "an 'absent' verdict is cached exactly like a 'present' one"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_transient_failure_is_not_cached(service):
+    # A no-retry-delay config: the "not cached" behavior under test is
+    # orthogonal to `_call_with_retry`'s own (separately tested) backoff.
+    fast_client = SchedulingServerClient(
+        notifications_service=service,
+        config=ServerClientConfig(max_retries=0, retry_delay=0),
+    )
+    service.capabilities_error = ServerClientServerError("503")
+
+    with pytest.raises(ServerClientServerError):
+        await fast_client.get_capabilities()
+    calls_after_failure = len(service.calls)
+
+    # The server recovers; a fresh probe must actually be attempted, not
+    # answered from a (nonexistent) cached failure.
+    service.capabilities_error = None
+    result = await fast_client.get_capabilities()
+    assert result == {"items": []}
+    assert len(service.calls) == calls_after_failure + 1, (
+        "the recovered probe must be a real second attempt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_notifications_service_clears_the_capabilities_cache(client, service):
+    """A reconnect (or a switch to a different server) may answer the
+    probe differently -- the cache must not survive it."""
+    await client.get_capabilities()
+    assert len(service.calls) == 1
+
+    other_service = FakeNotificationsService()
+    other_service.capabilities_response = {"items": [{"family": "agent_task"}]}
+    client.set_notifications_service(other_service)
+
+    result = await client.get_capabilities()
+    assert result == {"items": [{"family": "agent_task"}]}
+    assert other_service.calls == [("get_scheduled_automation_capabilities",)]

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -3739,6 +3739,49 @@ async def test_orphaned_reminder_transfer_mutation_settles_to_failed(tmp_path):
     )
 
 
+def test_orphaned_transfer_mutation_settles_when_no_server_is_configured(
+    tmp_path,
+):
+    """Final review finding 1: the removed-server/dead-server case, the
+    UAT's actual core symptom -- `target_owner=None` (nothing configured
+    at all) must settle every still-pending transfer_to_server mutation,
+    not just ones scoped to a DIFFERENT server. Calls the sweep directly
+    (it's a plain sync method, no network, no `sync_now()` round trip
+    needed) -- the workbench's `_settle_orphaned_transfers` calls it the
+    exact same way at mount, unconditionally, regardless of reachability.
+    """
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_reminder_task(
+        owner_id="local", title="Standup", schedule_kind="one_time"
+    )
+    db.set_transfer_state(
+        "reminder_task", local_id, "to_server_pending", expected=(None,)
+    )
+    db.record_pending_mutation(
+        local_id,
+        "reminder_task",
+        "server:removed-host",
+        {
+            "action": "transfer_to_server",
+            "task_payload": {"title": "Standup", "schedule_kind": "one_time"},
+        },
+    )
+    engine = SyncEngine(db, server_client=None, owner_id="local")
+
+    engine._settle_orphaned_transfer_mutations(None)
+
+    row = db.get_reminder_task(local_id)
+    assert row["transfer_state"] == "to_server_failed", (
+        "no server configured means nothing this mutation could still be "
+        "valid for -- it must settle, not hang forever"
+    )
+    pending = db.get_pending_mutations(
+        "server:removed-host", primitive="reminder_task"
+    )
+    assert len(pending) == 1
+    assert pending[0]["payload"]["transfer_errors"]
+
+
 @pytest.mark.asyncio
 async def test_orphaned_definition_transfer_mutation_settles_to_failed(tmp_path):
     db = ScheduledTasksDB(tmp_path / "db.db")

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1287,6 +1287,97 @@ async def test_sync_now_definition_noop_cycle_does_not_stamp_last_push_at(tmp_pa
     assert not state.get("last_push_at")
 
 
+def test_definition_push_success_outcomes_cover_every_return_value():
+    """Review round 1 finding 2: `_DEFINITION_PUSH_SUCCESS_OUTCOMES` is a
+    hand-maintained set with no automatic tie to the string vocabulary
+    `_push_definition_mutation` and its five helpers can actually return.
+    A new outcome added to any of those six functions (or to
+    `_replay_definition_mutations`'s own inline `"transfer_skipped"`)
+    without a matching classification here used to be silent: nothing
+    would fail, `last_push_at` would just never move for it. This walks
+    the AST of every one of those function bodies and asserts every
+    outcome string it can produce -- literal `return "..."` values, PLUS
+    `_push_definition_lifecycle`'s two dynamic shapes (`return action`
+    and `return f"{action}_not_found"`, both keyed on the three lifecycle
+    actions) -- is classified in EXACTLY ONE of `_DEFINITION_PUSH_
+    SUCCESS_OUTCOMES` / `_DEFINITION_PUSH_NON_SUCCESS_OUTCOMES`. An
+    unclassified new outcome fails this test instead of silently
+    freezing `last_push_at`.
+    """
+    import ast
+    import inspect
+
+    from tldw_chatbook.Scheduling.services import sync_engine as sync_engine_module
+    from tldw_chatbook.Scheduling.services.sync_engine import (
+        _DEFINITION_LIFECYCLE_ACTIONS,
+        _DEFINITION_PUSH_NON_SUCCESS_OUTCOMES,
+        _DEFINITION_PUSH_SUCCESS_OUTCOMES,
+    )
+
+    push_helper_names = {
+        "_push_definition_mutation",
+        "_push_definition_create",
+        "_push_definition_update",
+        "_push_definition_lifecycle",
+        "_push_definition_release",
+        "_push_definition_transfer",
+    }
+
+    source = inspect.getsource(sync_engine_module)
+    tree = ast.parse(source)
+
+    discovered: set[str] = set()
+    for node in ast.walk(tree):
+        if not (
+            isinstance(node, ast.AsyncFunctionDef) and node.name in push_helper_names
+        ):
+            continue
+        for sub in ast.walk(node):
+            if not (isinstance(sub, ast.Return) and sub.value is not None):
+                continue
+            value = sub.value
+            if isinstance(value, ast.Constant) and isinstance(value.value, str):
+                discovered.add(value.value)
+            elif node.name == "_push_definition_lifecycle" and isinstance(
+                value, ast.Name
+            ):
+                # `return action` -- dynamic, but only ever one of the
+                # three lifecycle actions this handler dispatches on.
+                discovered.update(_DEFINITION_LIFECYCLE_ACTIONS)
+            elif node.name == "_push_definition_lifecycle" and isinstance(
+                value, ast.JoinedStr
+            ):
+                # `return f"{action}_not_found"` -- same dynamic source.
+                discovered.update(
+                    f"{action}_not_found" for action in _DEFINITION_LIFECYCLE_ACTIONS
+                )
+            # A delegating `return await self._push_definition_X(...)`
+            # (from `_push_definition_mutation`'s own dispatch) contributes
+            # nothing itself -- the callee's own literal returns, walked
+            # separately above, already cover it.
+
+    # `_replay_definition_mutations`'s own pre-dispatch short-circuit --
+    # not a `return`, a `counts["transfer_skipped"] = ...` dict write --
+    # is a seventh real outcome this vocabulary must include.
+    discovered.add("transfer_skipped")
+
+    assert discovered, "the AST walk found nothing -- the helper names above drifted"
+
+    known = _DEFINITION_PUSH_SUCCESS_OUTCOMES | _DEFINITION_PUSH_NON_SUCCESS_OUTCOMES
+    unclassified = discovered - known
+    assert not unclassified, (
+        f"new/unclassified push outcome(s) {sorted(unclassified)} -- add each "
+        "to _DEFINITION_PUSH_SUCCESS_OUTCOMES (if it means a mutation reached "
+        "the server) or _DEFINITION_PUSH_NON_SUCCESS_OUTCOMES (if not) in "
+        "sync_engine.py"
+    )
+    stale = _DEFINITION_PUSH_SUCCESS_OUTCOMES - discovered
+    assert not stale, (
+        f"_DEFINITION_PUSH_SUCCESS_OUTCOMES claims outcome(s) {sorted(stale)} "
+        "that no longer exist in source -- prune it"
+    )
+
+
 @pytest.mark.asyncio
 async def test_sync_now_definition_create_orphan_clears_mutation_and_reports_both_ids(
     tmp_path,

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -1079,11 +1079,17 @@ async def test_sync_now_review_mutation_other_error_retains_it(tmp_path):
 
     outcome = await engine.sync_now()
 
-    # task-23105-review F2: the reminder phase itself succeeded, but a
-    # pushback phase failed -- that must surface as an error outcome, not
-    # a clean "ok" beside a fresh error badge.
-    assert outcome.status == "error"
-    assert "offline" in (outcome.error or "")
+    # UAT finding 3c (supersedes task-23105-review F2's "must surface as
+    # an error outcome" ruling): the reminder phase itself succeeded, and
+    # that must be reported honestly -- collapsing it to `status="error"`
+    # is exactly the "Sync failed" toast the UAT caught lying over a
+    # phase that had nothing to do with the failure. The pushback
+    # failure still reaches the caller, as its own labeled entry.
+    assert outcome.status == "ok"
+    assert outcome.error is None
+    assert len(outcome.phase_errors) == 1
+    assert "Automation review pushback" in outcome.phase_errors[0]
+    assert "offline" in outcome.phase_errors[0]
     pending = db.get_pending_mutations("server:1", primitive="automation_result_review")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     state = db.get_sync_state("server:1") or {}
@@ -1216,6 +1222,69 @@ async def test_sync_now_replays_definition_create_and_dedupes_same_cycle_pull(tm
     assert len(rows) == 1, "create replay + same-cycle pull must yield exactly one row"
     assert rows[0]["id"] == local_id
     assert rows[0]["server_id"] == "srv-def-1"
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_push_stamps_last_push_at(tmp_path):
+    """UAT finding 3c: `_sync_reminders` used to be the ONLY writer of
+    `last_push_at`, and only for its own reminder pushes -- a cycle that
+    pushed nothing on the reminder side but DID push a definition create
+    left the sync bar showing "Last push: -" forever, even though a push
+    genuinely happened this cycle."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_automation_definition(
+        "server:1", "recurring_question", "Draft"
+    )
+    db.record_pending_mutation(
+        local_id,
+        "automation_definition",
+        "server:1",
+        {
+            "action": "create",
+            "definition_payload": {"family": "recurring_question", "name": "Draft"},
+            "server_definition_id": None,
+        },
+    )
+    server_client = _empty_reminders_client()
+    server_client.preview_automation_definition.return_value = {
+        "id": "prev-1",
+        "status": "valid",
+        "validation_errors": [],
+    }
+    server_client.create_automation_definition.return_value = {
+        "id": "srv-def-1",
+        "family": "recurring_question",
+        "name": "Draft",
+        "lifecycle": "configured",
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    assert not (db.get_sync_state("server:1") or {}).get("last_push_at")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    assert outcome.pushed == 0, "nothing was pushed on the REMINDER side this cycle"
+    state = db.get_sync_state("server:1") or {}
+    assert state.get("last_push_at"), (
+        "a genuine definition push must stamp last_push_at even when the "
+        "reminder phase itself pushed nothing"
+    )
+
+
+@pytest.mark.asyncio
+async def test_sync_now_definition_noop_cycle_does_not_stamp_last_push_at(tmp_path):
+    """The other half of the same fix: a cycle with no pending definition
+    mutations at all must not fabricate a push timestamp."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    state = db.get_sync_state("server:1") or {}
+    assert not state.get("last_push_at")
 
 
 @pytest.mark.asyncio
@@ -1569,8 +1638,14 @@ async def test_sync_now_definition_create_retryable_error_retains_mutation(tmp_p
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "error"
-    assert "offline" in (outcome.error or "")
+    # UAT finding 3c: the reminder phase's own "ok" is no longer masked
+    # by this unrelated definition-push failure; the failure still
+    # reaches the caller as its own labeled `phase_errors` entry.
+    assert outcome.status == "ok"
+    assert outcome.error is None
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definition push" in outcome.phase_errors[0]
+    assert "offline" in outcome.phase_errors[0]
     pending = db.get_pending_mutations("server:1", primitive="automation_definition")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     row = db.get_automation_definition(local_id)
@@ -1918,8 +1993,13 @@ async def test_sync_now_definition_lifecycle_retryable_error_retains_mutation(tm
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "error"
-    assert "offline" in (outcome.error or "")
+    # UAT finding 3c: the reminder phase's own "ok" is no longer masked
+    # by this unrelated definition-push (lifecycle) failure.
+    assert outcome.status == "ok"
+    assert outcome.error is None
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definition push" in outcome.phase_errors[0]
+    assert "offline" in outcome.phase_errors[0]
     pending = db.get_pending_mutations("server:1", primitive="automation_lifecycle")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     assert db.get_automation_definition(local_id)["lifecycle"] == "configured"
@@ -2089,7 +2169,11 @@ async def test_sync_now_definition_transfer_timeout_retains_sent_and_mutation(
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "error"
+    # UAT finding 3c: the reminder phase's own "ok" is no longer masked
+    # by this unrelated definition-push (transfer) failure.
+    assert outcome.status == "ok"
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definition push" in outcome.phase_errors[0]
     row = db.get_automation_definition(local_id)
     assert row["transfer_state"] == "to_server_sent", (
         "disarm precedes the request -- an ambiguous failure leaves the "
@@ -2740,7 +2824,11 @@ async def test_sync_now_definition_release_retryable_error_keeps_copy_dormant(
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "error"
+    # UAT finding 3c: the reminder phase's own "ok" is no longer masked
+    # by this unrelated definition-push (release) failure.
+    assert outcome.status == "ok"
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definition push" in outcome.phase_errors[0]
     pending = db.get_pending_mutations("server:1", primitive="automation_definition")
     assert len(pending) == 1, "the mutation must be left queued for retry"
     copy_row = db.get_automation_definition(copy_id)
@@ -2994,13 +3082,18 @@ async def test_sync_now_definitions_phase_failure_does_not_abort_results_phase(t
 
     outcome = await engine.sync_now()
 
-    # task-23105-review F2: a failed automation phase must surface as an
-    # error outcome even though the reminder phase (and the later results
-    # phase) still ran to completion -- results are still pulled, but the
-    # workbench must not toast "Sync completed" next to a fresh error
-    # badge (the controller ruled the prior "ok" pin a plan artifact).
-    assert outcome.status == "error"
-    assert "down" in (outcome.error or "")
+    # UAT finding 3c (supersedes task-23105-review F2's "must surface as
+    # an error outcome" ruling): the reminder phase (and the later
+    # results phase) ran to completion -- that success must be reported
+    # honestly rather than collapsed into `status="error"` next to a
+    # fresh error badge, which is exactly the "Sync failed" toast the
+    # UAT caught misreporting an unrelated phase's failure. The
+    # definitions-phase failure still reaches the caller, labeled.
+    assert outcome.status == "ok"
+    assert outcome.error is None
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definitions pull" in outcome.phase_errors[0]
+    assert "down" in outcome.phase_errors[0]
     assert len(db.list_automation_results("server:1")) == 1
     state = db.get_sync_state("server:1") or {}
     assert state.get("sync_errors"), "the definitions-phase failure must be recorded"
@@ -3158,9 +3251,10 @@ async def test_sync_now_reminder_policy_refusal_does_not_mask_automation_error(
 ):
     """The reminder phase's own policy action can be refused
     (`not_applicable`) while a DIFFERENT policy action -- an automation
-    phase -- genuinely fails. The old `status == "ok"` guard only caught
-    this when the reminder phase was "ok"; "not_applicable" let the
-    automation failure through unreported."""
+    phase -- genuinely fails. UAT finding 3c: `status`/`error` now
+    describe ONLY the reminder phase (unconditionally, not just when it
+    was "ok") -- the automation failure must still reach the caller, via
+    `phase_errors`, never silently dropped."""
     from tldw_chatbook.Scheduling.services.server_client import (
         ServerClientPolicyError,
     )
@@ -3178,8 +3272,11 @@ async def test_sync_now_reminder_policy_refusal_does_not_mask_automation_error(
 
     outcome = await engine.sync_now()
 
-    assert outcome.status == "error"
-    assert "defs down" in (outcome.error or "")
+    assert outcome.status == "not_applicable"
+    assert outcome.error is None
+    assert len(outcome.phase_errors) == 1
+    assert "Automation definitions pull" in outcome.phase_errors[0]
+    assert "defs down" in outcome.phase_errors[0]
     assert len(db.list_automation_results("server:1")) == 1  # later phase still ran
     state = db.get_sync_state("server:1") or {}
     assert state.get("sync_errors"), "the definitions-phase failure must be recorded"

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -3577,6 +3577,77 @@ async def test_reminder_release_same_cycle_stale_pull_does_not_ghost_reinsert(
 
 
 @pytest.mark.asyncio
+async def test_two_reminder_releases_same_cycle_stale_pull_ghosts_neither(
+    tmp_path,
+):
+    """Fix round 1, finding 5: the single-release pin above doesn't
+    exercise `released_server_ids`' own construction, which is a SET
+    COMPREHENSION over every `staged_outcomes` entry -- correctly handles
+    more than one release per cycle as written, but nothing drove that
+    path. Two mirrors, both released, both still stale-listed in the SAME
+    pull: neither may ghost-reinsert."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+
+    mirror_a = db.create_reminder_task(
+        owner_id="server:1",
+        title="Standup",
+        schedule_kind="one_time",
+        server_id="srv-rem-a",
+    )
+    db.set_sync_mapping(mirror_a, "srv-rem-a", "reminder_task", "server:1")
+    copy_a = db.create_local_copy_from_mirror("reminder_task", mirror_a)
+    db.record_pending_mutation(
+        mirror_a,
+        "reminder_task",
+        "server:1",
+        {
+            "action": "release_from_server",
+            "server_task_id": "srv-rem-a",
+            "local_copy_id": copy_a,
+        },
+    )
+
+    mirror_b = db.create_reminder_task(
+        owner_id="server:1",
+        title="Retro",
+        schedule_kind="one_time",
+        server_id="srv-rem-b",
+    )
+    db.set_sync_mapping(mirror_b, "srv-rem-b", "reminder_task", "server:1")
+    copy_b = db.create_local_copy_from_mirror("reminder_task", mirror_b)
+    db.record_pending_mutation(
+        mirror_b,
+        "reminder_task",
+        "server:1",
+        {
+            "action": "release_from_server",
+            "server_task_id": "srv-rem-b",
+            "local_copy_id": copy_b,
+        },
+    )
+
+    server_client = AsyncMock()
+    # Both server rows still listed: neither release has run yet THIS
+    # cycle -- the same-cycle stale-payload window, for both at once.
+    server_client.list_reminders.return_value = {
+        "items": [
+            {"id": "srv-rem-a", "title": "Standup"},
+            {"id": "srv-rem-b", "title": "Retro"},
+        ]
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    all_rows = db.list_reminder_tasks(owner_id=None)
+    assert {row["id"] for row in all_rows} == {copy_a, copy_b}, (
+        f"neither released mirror may ghost-reinsert; rows: {all_rows!r}"
+    )
+    assert db.get_conflicts("server:1") == []
+
+
+@pytest.mark.asyncio
 async def test_rejected_reminder_release_settles_per_mutation(tmp_path):
     """L15: a definitively rejected release used to re-raise through
     `_push_mutation`'s blanket `except ServerClientError: raise`, aborting

--- a/Tests/Scheduling/test_sync_engine.py
+++ b/Tests/Scheduling/test_sync_engine.py
@@ -3518,6 +3518,65 @@ async def test_reminder_release_raises_no_conflict_while_the_mirror_is_listed(tm
 
 
 @pytest.mark.asyncio
+async def test_reminder_release_same_cycle_stale_pull_does_not_ghost_reinsert(
+    tmp_path,
+):
+    """root-causes.md #4 (Major 6, task-3 ghost row): `_network_phase`
+    pulls BEFORE it pushes, so the pull's `pulled_items` still lists the
+    mirror server-side row `_push_reminder_release` is about to
+    hard-delete in this SAME cycle. Applying that stale payload used to
+    re-insert the mirror under a brand-new local id no tombstone could
+    ever remove -- a permanent "deleted on server" conflict that survives
+    navigation, re-sync, and conflict resolution.
+
+    Fix: `_push_reminder_release` now returns `released_server_id`, and
+    `_sync_reminders` filters `pulled_items` by it before applying --
+    the exact twin of the `adopted_server_id` seen-set guard the opposite
+    direction (transfer_to_server) already had.
+    """
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    mirror_id = db.create_reminder_task(
+        owner_id="server:1",
+        title="Standup",
+        schedule_kind="one_time",
+        server_id="srv-rem-9",
+    )
+    db.set_sync_mapping(mirror_id, "srv-rem-9", "reminder_task", "server:1")
+    copy_id = db.create_local_copy_from_mirror("reminder_task", mirror_id)
+    db.record_pending_mutation(
+        mirror_id,
+        "reminder_task",
+        "server:1",
+        {
+            "action": "release_from_server",
+            "server_task_id": "srv-rem-9",
+            "local_copy_id": copy_id,
+        },
+    )
+    server_client = AsyncMock()
+    # The pull still lists the server row: the release hasn't run yet
+    # THIS cycle -- the exact same-cycle stale-payload window.
+    server_client.list_reminders.return_value = {
+        "items": [{"id": "srv-rem-9", "title": "Standup"}]
+    }
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    all_rows = db.list_reminder_tasks(owner_id=None)
+    assert len(all_rows) == 1, (
+        "the stale pull must not re-insert the mirror the release just "
+        f"tore down; rows: {all_rows!r}"
+    )
+    assert all_rows[0]["id"] == copy_id
+    assert db.get_conflicts("server:1") == [], (
+        "a re-inserted mirror with no tombstone would forever conflict "
+        "as 'deleted on server'"
+    )
+
+
+@pytest.mark.asyncio
 async def test_rejected_reminder_release_settles_per_mutation(tmp_path):
     """L15: a definitively rejected release used to re-raise through
     `_push_mutation`'s blanket `except ServerClientError: raise`, aborting
@@ -3554,3 +3613,211 @@ async def test_rejected_reminder_release_settles_per_mutation(tmp_path):
     )
     state = db.get_sync_state("server:1") or {}
     assert state.get("sync_errors"), "the refusal must be reported, not swallowed"
+
+
+# ----------------------------------------------------------------------
+# Orphaned transfer_to_server mutation settlement (task-3, root-causes.md
+# #5 / Major 9 / plan ruling 4). `_network_phase`'s mutation query is
+# scoped to the CURRENT target_owner, so a `transfer_to_server` mutation
+# recorded under a PRIOR server scope (the configured server's address
+# changed underneath it) is never selected, never attempted, and used to
+# hang `to_server_pending` forever -- no route to Retry/Cancel. `_settle_
+# orphaned_transfer_mutations` is the sweep that finds and settles one.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_orphaned_reminder_transfer_mutation_settles_to_failed(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_reminder_task(
+        owner_id="local", title="Standup", schedule_kind="one_time"
+    )
+    db.set_transfer_state(
+        "reminder_task", local_id, "to_server_pending", expected=(None,)
+    )
+    # Queued while "server:old-host" was the active server; the config
+    # has since moved to "server:1" (this test's SyncEngine owner).
+    db.record_pending_mutation(
+        local_id,
+        "reminder_task",
+        "server:old-host",
+        {
+            "action": "transfer_to_server",
+            "task_payload": {"title": "Standup", "schedule_kind": "one_time"},
+        },
+    )
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {"items": []}
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    # An orphaned mutation settles locally -- it must never be replayed
+    # against whatever server happens to be active now.
+    server_client.create_reminder.assert_not_awaited()
+    row = db.get_reminder_task(local_id)
+    assert row["transfer_state"] == "to_server_failed", (
+        "settled, not left hanging to_server_pending forever"
+    )
+    pending = db.get_pending_mutations("server:old-host", primitive="reminder_task")
+    assert len(pending) == 1
+    assert pending[0]["payload"]["transfer_errors"], (
+        "Retry/Cancel + 'Last transfer error:' both key off a truthy "
+        "transfer_errors entry"
+    )
+
+
+@pytest.mark.asyncio
+async def test_orphaned_definition_transfer_mutation_settles_to_failed(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    definition_id = db.create_automation_definition(
+        "local", "recurring_question", "Daily digest"
+    )
+    db.set_transfer_state(
+        "automation_definition", definition_id, "to_server_pending", expected=(None,)
+    )
+    db.record_pending_mutation(
+        definition_id,
+        "automation_definition",
+        "server:old-host",
+        {
+            "action": "transfer_to_server",
+            "definition_payload": {
+                "family": "recurring_question",
+                "name": "Daily digest",
+            },
+        },
+    )
+    server_client = _empty_reminders_client()
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.preview_automation_definition.assert_not_awaited()
+    row = db.get_automation_definition(definition_id)
+    assert row["transfer_state"] == "to_server_failed"
+    pending = db.get_pending_mutations(
+        "server:old-host", primitive="automation_definition"
+    )
+    assert len(pending) == 1
+    assert pending[0]["payload"]["transfer_errors"]
+
+
+@pytest.mark.asyncio
+async def test_transfer_mutation_still_scoped_to_active_server_is_not_orphaned(
+    tmp_path,
+):
+    """The non-regression twin: a mutation whose scope MATCHES the
+    current active server must replay normally, not get swept as
+    orphaned."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    local_id = db.create_reminder_task(
+        owner_id="local", title="Standup", schedule_kind="one_time"
+    )
+    db.set_transfer_state(
+        "reminder_task", local_id, "to_server_pending", expected=(None,)
+    )
+    db.record_pending_mutation(
+        local_id,
+        "reminder_task",
+        "server:1",
+        {
+            "action": "transfer_to_server",
+            "task_payload": {"title": "Standup", "schedule_kind": "one_time"},
+        },
+    )
+    server_client = AsyncMock()
+    server_client.list_reminders.return_value = {"items": []}
+    server_client.create_reminder.return_value = {"id": "srv-rem-1"}
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok"
+    server_client.create_reminder.assert_awaited_once()
+    row = db.get_reminder_task(local_id)
+    assert row["transfer_state"] is None, "converted to a server mirror, not failed"
+    assert row["server_id"] == "srv-rem-1"
+
+
+# ----------------------------------------------------------------------
+# Capabilities handshake (task-3, root-causes.md #7, plan ruling 5).
+# `get_capabilities` returning `None` means the server predates
+# Scheduled Tasks automation entirely -- `_pull_definitions`/`_pull_
+# results` must skip outright rather than page into a guaranteed 404.
+# `ServerClientNotFoundError` from the ACTUAL results call despite a
+# successful capabilities probe is the narrower, real UAT repro (a
+# mid-rollout server): that must degrade to the SAME honest copy family,
+# never a raw scheduled_task_not_found.
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_pull_results_skips_outright_when_capabilities_absent(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.get_capabilities = AsyncMock(return_value=None)
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    result = await engine._pull_results("server:1")
+
+    assert result == {}
+    server_client.list_automation_results.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pull_definitions_skips_outright_when_capabilities_absent(tmp_path):
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.get_capabilities = AsyncMock(return_value=None)
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    result = await engine._pull_definitions("server:1")
+
+    assert result == {}
+    server_client.list_automation_definitions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_pull_results_proceeds_when_capabilities_present(tmp_path):
+    """The non-regression twin: capabilities present -> the pull still
+    runs normally (the gate must not become a blanket skip)."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.get_capabilities = AsyncMock(return_value={"items": []})
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    result = await engine._pull_results("server:1")
+
+    assert result == {"inserted": 0, "updated": 0, "skipped_dedupe": 0}
+    server_client.list_automation_results.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_pull_results_reports_honest_copy_when_route_missing_despite_capabilities(
+    tmp_path,
+):
+    """The actual UAT repro (root-causes.md #7): capabilities ARE present
+    (a mid-rollout server), but `/results` specifically 404s -- a probe
+    alone cannot predict this, so the per-call catch is what turns it
+    into the same honest family of copy instead of a raw
+    scheduled_task_not_found poisoning the sync verdict (Minor 24 /
+    Major 7)."""
+    db = ScheduledTasksDB(tmp_path / "db.db")
+    server_client = _empty_reminders_client()
+    server_client.get_capabilities = AsyncMock(return_value={"items": []})
+    server_client.list_automation_results = AsyncMock(
+        side_effect=ServerClientNotFoundError("scheduled_task_not_found")
+    )
+    engine = SyncEngine(db, server_client, owner_id="server:1")
+
+    outcome = await engine.sync_now()
+
+    assert outcome.status == "ok", "the reminder phase is unaffected"
+    assert len(outcome.phase_errors) == 1
+    assert "does not provide the results inbox" in outcome.phase_errors[0]
+    assert "scheduled_task_not_found" not in outcome.phase_errors[0], (
+        "the raw server error code must not leak into the user-facing copy"
+    )

--- a/Tests/Scheduling/test_transfer_end_to_end.py
+++ b/Tests/Scheduling/test_transfer_end_to_end.py
@@ -197,6 +197,10 @@ async def test_local_reminder_transfer_to_server(tmp_path):
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     row_id = db.create_reminder_task(
         owner_id="local",
@@ -253,6 +257,10 @@ async def test_local_definition_transfer_to_server_uses_server_vocabulary(tmp_pa
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     def_id = db.create_automation_definition(
         "local",
@@ -312,6 +320,10 @@ async def test_server_definition_release_to_local(tmp_path, monkeypatch):
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     mirror_id = db.create_automation_definition(
         "server:1",
@@ -366,6 +378,10 @@ async def test_crash_recovery_reminder_ambiguous_timeout(tmp_path):
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     row_id = db.create_reminder_task(
         owner_id="local",
@@ -417,6 +433,10 @@ async def test_failed_definition_transfer_retries_and_succeeds(tmp_path):
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     def_id = db.create_automation_definition(
         "local",
@@ -479,6 +499,10 @@ async def test_offline_cancel_of_a_release_reaches_the_server_never(tmp_path):
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     mirror_id = db.create_reminder_task(
         owner_id="server:1",
@@ -520,6 +544,10 @@ async def test_offline_cancel_of_a_to_server_move_reaches_the_server_never(tmp_p
     svc = SchedulingService(
         db=db, server_client=fake, runtime_source="server:1", app_getter=lambda: app
     )
+    # task-3 (ruling 4): pre-seed the reachability probe verdict this
+    # always-connected fake implies -- see test_scheduling_service.py's
+    # `_transfer_service` for the same precedent.
+    svc._server_reachable = True
 
     row_id = db.create_reminder_task(
         owner_id="local",

--- a/Tests/Scheduling/test_transfer_invariant.py
+++ b/Tests/Scheduling/test_transfer_invariant.py
@@ -52,6 +52,17 @@ from tldw_chatbook.Scheduling.services.server_client import (
     ServerUnavailableError,
 )
 
+#: Fix round 1, finding 6: `begin_to_server`/`begin_to_local` below discard
+#: their `begin_transfer_to_*` outcome, so a regression that silently
+#: refuses every transfer (the exact vacuous-Hypothesis bug `_server_
+#: reachable = True` seeding just fixed) would again make `never_both_
+#: armed` "pass" unnoticed -- vacuously true because nothing ever armed.
+#: Counted at module level (not per-example) and reset/asserted once by
+#: `TestTransferInvariant.runTest` below, across the WHOLE property
+#: run's many generated examples -- a per-example assert would spuriously
+#: fail on Hypothesis's own minimal (zero-rule-call) examples.
+_successful_begins = 0
+
 
 class _FakeApp:
     """Only ``active_server_id`` is read by the transfer facade."""
@@ -181,7 +192,12 @@ class TransferInvariantMachine(RuleBasedStateMachine):
 
     @rule()
     def begin_to_server(self):
-        self._run(self.service.begin_transfer_to_server("reminder_task", self.row_id))
+        outcome = self._run(
+            self.service.begin_transfer_to_server("reminder_task", self.row_id)
+        )
+        if outcome.status == "pending":
+            global _successful_begins
+            _successful_begins += 1
 
     @rule(outcome=st.sampled_from(["success", "fail", "error", "ambiguous"]))
     def sync_push(self, outcome):
@@ -206,6 +222,8 @@ class TransferInvariantMachine(RuleBasedStateMachine):
         )
         if outcome.status == "pending" and outcome.row_id:
             self.copy_id = outcome.row_id
+            global _successful_begins
+            _successful_begins += 1
 
     @rule()
     def recover(self):
@@ -243,4 +261,31 @@ class TransferInvariantMachine(RuleBasedStateMachine):
         )
 
 
-TestTransferInvariant = TransferInvariantMachine.TestCase
+class TestTransferInvariant(TransferInvariantMachine.TestCase):
+    """Fix round 1, finding 6: wraps the generated `TestCase` to assert
+    the counter above ONCE, across the whole property run's many
+    generated examples -- not per-example (Hypothesis's own minimal
+    zero-rule-call examples would spuriously fail that).
+
+    Defined directly as `TestTransferInvariant` (not a separately-named
+    class aliased afterward): pytest's unittest collector walks every
+    module-level name and collects any `unittest.TestCase` subclass it
+    finds regardless of naming convention (`RuleBasedStateMachine.
+    TestCase` already is one) -- a `class _Foo(...): ...` +
+    `TestTransferInvariant = _Foo` alias left BOTH names as separate
+    module attributes pointing at the same class, so pytest collected
+    (and ran the whole Hypothesis property twice for) both `_Foo::
+    runTest` and `TestTransferInvariant::runTest`.
+    """
+
+    def runTest(self):
+        global _successful_begins
+        _successful_begins = 0
+        super().runTest()
+        assert _successful_begins > 0, (
+            "no begin_transfer_to_server/to_local ever succeeded across "
+            "the whole property run -- either the transfer machinery is "
+            "silently refusing every attempt again (the exact vacuous-"
+            "Hypothesis bug `_server_reachable = True` seeding above "
+            "fixed), or this counter itself broke"
+        )

--- a/Tests/Scheduling/test_transfer_invariant.py
+++ b/Tests/Scheduling/test_transfer_invariant.py
@@ -156,6 +156,13 @@ class TransferInvariantMachine(RuleBasedStateMachine):
             runtime_source="local",
             app_getter=lambda: _FakeApp(),
         )
+        # task-3 (ruling 4): `transfer_refusal` now also gates on a real
+        # `refresh_server_reachability` probe (default `False`) -- this
+        # fake models an always-connected server, so pre-seed the same
+        # verdict a probe would reach, or every `begin_to_server`/
+        # `begin_to_local` rule below silently refuses and the invariant
+        # stops exercising the transfer machinery it exists to stress.
+        self.service._server_reachable = True
         self.row_id = self.db.create_reminder_task(
             owner_id="local",
             title="t",

--- a/Tests/UI/schedules_test_helpers.py
+++ b/Tests/UI/schedules_test_helpers.py
@@ -339,6 +339,39 @@ def painted_at_own_center(host, widget) -> bool:
     return target is widget or widget in list(target.ancestors)
 
 
+def painted_glyphs_at(host, widget) -> str:
+    """Every glyph the compositor paints across ``widget``'s own rows,
+    restricted to its own x-range, row-joined.
+
+    The oracle the schedules-UAT-remediation root-causes doc used to
+    catch the ``Input``/``Select`` editor-clipping display blocker: a
+    focused compact editor's ONE content row IS its value, and the
+    `*:focus` outline (or an un-compacted 3-row border) can overwrite
+    that row while every structural attribute (``editor.value``,
+    ``row.query_one(...) is editor``) stays perfectly correct --
+    `test_detail_value_row.py`'s own module contract: "rendered output
+    only, never a stored attribute the widget might ignore." Restricting
+    to ``widget``'s own x-range (not just its y-rows) keeps a same-row
+    sibling -- e.g. a ``DetailValueRow``'s label -- from making a clipped
+    editor look painted when it is not.
+    """
+    region = widget.region
+    strips = host.screen._compositor.render_strips()
+    lines: list[str] = []
+    for y in range(region.y, region.bottom):
+        if not 0 <= y < len(strips):
+            continue
+        cursor = 0
+        chars: list[str] = []
+        for segment in strips[y]:
+            next_cursor = cursor + segment.cell_length
+            if cursor < region.right and next_cursor > region.x:
+                chars.append(segment.text)
+            cursor = next_cursor
+        lines.append("".join(chars))
+    return "\n".join(lines)
+
+
 def rendered_row_cells(table, row_index: int = 0) -> list[str]:
     """The cell text a `DataTable` will actually PAINT for one row.
 

--- a/Tests/UI/test_schedules_automations_tab.py
+++ b/Tests/UI/test_schedules_automations_tab.py
@@ -34,6 +34,7 @@ from Tests.UI.schedules_test_helpers import (
 )
 from tldw_chatbook.Scheduling.events import ViewDefinitionResultsRequested
 from tldw_chatbook.Scheduling.services.server_client import (
+    ServerClientNotFoundError,
     ServerClientValidationError,
 )
 from tldw_chatbook.Widgets.detail_value_row import DetailValueRow
@@ -64,6 +65,12 @@ class AutomationsServerClient:
 
     def __init__(self, notifications_service=None) -> None:
         self.notifications_service = notifications_service or object()
+        # task-3 (schedules UAT remediation ruling 5): the capabilities
+        # handshake -- defaults to "present" so every OTHER test in this
+        # file (which predate the handshake) keeps exercising the real
+        # audit call unhindered; the two `get_capabilities`-specific
+        # tests below override this per case.
+        self.get_capabilities = AsyncMock(return_value={"items": []})
         self.list_automation_definitions = AsyncMock(
             return_value={
                 "items": [
@@ -520,6 +527,56 @@ async def test_audit_view_shows_empty_state_without_events():
         notice = overlay.query_one("#scheduling-audit-view-notice")
         assert table.row_count == 0
         assert "No recorded events" in str(notice.content)
+
+
+@pytest.mark.asyncio
+async def test_audit_view_shows_notice_when_capabilities_absent():
+    """task-3 handshake, shape 1: the capabilities probe itself comes
+    back absent (`get_capabilities` returns `None`, root-causes.md #7's
+    "server predates Scheduled Tasks automation entirely") -- an honest
+    notice, and the real audit call is never even attempted."""
+    server_client = AutomationsServerClient()
+    server_client.get_capabilities = AsyncMock(return_value=None)
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await _settled_workbench(pilot)
+
+        overlay = await _push_audit_view(
+            pilot,
+            service,
+            {"id": "def-1", "name": "Morning brief", "owner_id": "server:server-1"},
+        )
+
+        server_client.list_automation_definition_audit.assert_not_awaited()
+        notice = overlay.query_one("#scheduling-audit-view-notice")
+        assert "does not support scheduled task automation" in str(notice.content)
+
+
+@pytest.mark.asyncio
+async def test_audit_view_shows_notice_when_audit_route_missing_despite_capabilities():
+    """task-3 handshake, shape 2 (the actual UAT repro): capabilities are
+    PRESENT (a mid-rollout server, new enough for the handshake, too old
+    for this one route) -- a probe alone can't predict this, so the
+    honest degrade comes from the real call's own 404 instead of a raw
+    `scheduled_task_not_found` (UAT Minor 24)."""
+    server_client = AutomationsServerClient()
+    server_client.list_automation_definition_audit = AsyncMock(
+        side_effect=ServerClientNotFoundError("scheduled_task_not_found")
+    )
+    service = AutomationsMockService(server_client)
+    app = AutomationsTestApp(service)
+    async with app.run_test() as pilot:
+        await _settled_workbench(pilot)
+
+        overlay = await _push_audit_view(
+            pilot,
+            service,
+            {"id": "def-1", "name": "Morning brief", "owner_id": "server:server-1"},
+        )
+
+        notice = overlay.query_one("#scheduling-audit-view-notice")
+        assert "does not provide run history" in str(notice.content)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_disabled_state.py
+++ b/Tests/UI/test_schedules_disabled_state.py
@@ -173,8 +173,15 @@ def test_waiting_projection_without_next_run_reads_dash():
     assert _format_next_run(projection) == "-"
 
 
-def test_real_dispatch_lifecycle_leaves_next_run_labelled_disabled(tmp_path):
-    """End-to-end over the REAL DB, not a hand-built post-dispatch model."""
+def test_real_dispatch_lifecycle_leaves_next_run_labelled_completed(tmp_path):
+    """End-to-end over the REAL DB, not a hand-built post-dispatch model.
+
+    UAT finding 3e: a fired one-time reminder used to read Disabled here
+    (this test's own former name/assertions pinned that bug) while the
+    Queue's `_reminder_bucket` bucketed the SAME row Completed -- the two
+    seams disagreeing on the same reminder, under a Completed chip. Now
+    reconciled: `_task_status` checks `reminder_has_fired` first.
+    """
     from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
     from tldw_chatbook.Scheduling.services.scheduling_service import (
         SchedulingService,
@@ -201,9 +208,33 @@ def test_real_dispatch_lifecycle_leaves_next_run_labelled_disabled(tmp_path):
     # The state the bug depended on, asserted rather than assumed.
     assert task.enabled is False
     assert task.next_run_at is None
+    assert task.last_run_at is not None
 
-    assert _task_status(task) is TaskStatus.DISABLED
-    assert _format_next_run(task) == "— (disabled)"
+    assert _task_status(task) is TaskStatus.COMPLETED
+    assert _format_next_run(task) == "—"
+
+
+def test_fired_reminder_status_agrees_with_the_queue_bucket():
+    """UAT finding 3e: the bucket seam (drives the Queue chip/glyph,
+    `unified_rows._reminder_bucket`) and the label seam (drives the
+    detail badge/next-run text, `task_detail._task_status`) must bucket
+    the SAME fired one-time reminder the same way -- a row simultaneously
+    "Completed" under the chip and "Disabled" in its own detail pane was
+    the exact defect."""
+    from tldw_chatbook.UI.Screens.scheduling.unified_rows import _reminder_bucket
+
+    fired = ReminderTask(
+        id="task-fired",
+        title="Backup",
+        schedule_kind=ScheduleKind.ONE_TIME,
+        run_at=_RUN_AT,
+        next_run_at=None,
+        last_run_at=_RUN_AT,
+        enabled=False,
+    )
+    assert _reminder_bucket(fired) == "completed"
+    assert _task_status(fired) is TaskStatus.COMPLETED
+    assert _format_next_run(fired) == "—"
 
 
 # --- review F5: behavior consumers use the underlying status --------------

--- a/Tests/UI/test_schedules_responsive_floor.py
+++ b/Tests/UI/test_schedules_responsive_floor.py
@@ -51,6 +51,14 @@ FLOOR = (80, 24)
 MID = (110, 40)
 WIDE = (220, 60)
 
+#: The exact tmux capture size the schedules-UAT-remediation root-causes
+#: doc measured the detail-pane clip against (finding 2): `TaskDetail`
+#: size.h=30 / virtual.h=51 there, tall enough for one plain reminder's
+#: Details/Frequency/collapsed-History groups to overflow the pane with
+#: no scroll route -- reused here so the pinning tests measure the same
+#: geometry the doc's probe did.
+TALL = (235, 52)
+
 
 class BundledCSSWorkbenchApp(ConsolidatedCSSApp):
     """Harness with the app CSS tier, where the `.compact` rules live.
@@ -575,6 +583,176 @@ async def test_the_full_width_layout_keeps_all_three_panes(tmp_path):
             assert workbench.query_one("#scheduling-list-header").region.height == 3
             assert workbench.query_one("#scheduling-chip-cycle", Button).display is False
             assert "Nightly check" in _painted(pilot.app)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Display blockers (schedules-UAT-remediation task 1): the rail filter's
+# typed text and the detail pane's scroll/lifecycle-row fold. Geometry
+# pins via `_painted()` (`app.screen._compositor.render_strips()`), never
+# a stored attribute -- `test_detail_value_row.py`'s own module contract.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_queue_filter_paints_typed_text_while_focused(tmp_path):
+    """Finding 1b: `#scheduling-queue-filter` is a 1-row `Input`; app CSS
+    (`_scheduling.tcss`) already wins its border, but not the app-wide
+    `*:focus { outline: solid ... }` (`core/_reset.tcss`), which painted
+    OVER the input's only content row -- what the user typed was on
+    screen but invisible, byte-identical to the live UAT capture the
+    root-causes doc quotes. `compact=True` opts the filter into Textual's
+    own `Input.-textual-compact:focus { outline: none; ... }` rule
+    (TASK-17961) the same way the row editors below do."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            filter_input = workbench.query_one("#scheduling-queue-filter", Input)
+            assert filter_input.has_class("-textual-compact"), (
+                "the queue filter was constructed without compact=True"
+            )
+
+            await pilot.click("#scheduling-queue-filter")
+            await pilot.pause()
+            await pilot.press("r", "o", "u", "n", "d", "u", "p")
+            await pilot.pause()
+
+            assert filter_input.value == "roundup"
+            assert "roundup" in _painted(pilot.app), (
+                "the filter's typed text is not painted while focused"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_escape_blurs_the_queue_filter_so_chip_keys_reach_the_screen(tmp_path):
+    """UAT Minor 21: with no blur, Escape fell through to the screen's
+    OWN `escape` -> `clear_marks` binding (a real, intentional binding --
+    `SchedulesWorkbench.BINDINGS`) while focus stayed on the filter, so
+    the very next `f`/`1`-`4` chip key landed in the still-focused
+    `Input` as literal text instead of cycling the chip. `_QueueFilterInput`
+    (schedules_workbench.py) binds `escape` on itself, which Textual
+    checks before the screen's own binding (`App._check_bindings` walks
+    the focus chain closest-first)."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        async with app.run_test(size=FLOOR) as pilot:
+            workbench = await _open_workbench(pilot)
+            filter_input = workbench.query_one("#scheduling-queue-filter", Input)
+            filter_input.focus()
+            await pilot.pause()
+            assert pilot.app.focused is filter_input
+
+            await pilot.press("escape")
+            await pilot.pause()
+            assert pilot.app.focused is not filter_input, (
+                "escape left the filter focused"
+            )
+
+            await pilot.press("f")
+            await pilot.pause()
+            assert workbench._chip == "active", (
+                "the chip key was swallowed by the still-focused filter "
+                "instead of reaching the screen binding"
+            )
+            assert filter_input.value == "", (
+                "the chip key landed in the filter as literal text"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_lifecycle_row_paints_without_scrolling_at_a_tall_docked_size(
+    tmp_path,
+):
+    """Finding 2: `#scheduling-task-detail-lifecycle` (Edit/Run now/
+    Enable/Disable/Delete) used to compose LAST in the pane, after the
+    History group -- past the fold at every measured width, including
+    this one (the doc's own probe: `painted 'Edit': False` at 235x52,
+    235x75, and 110x40 alike). It now composes FIRST, directly under
+    `#scheduling-task-detail-metadata`'s opening, so it must be visible
+    with NO scrolling at all."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=TALL) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+
+            painted = _painted(pilot.app)
+            assert "Edit" in painted, f"the Edit button is not painted: {painted!r}"
+            assert "Run now" in painted, (
+                f"the Run now button is not painted: {painted!r}"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_docked_task_detail_pane_scrolls_to_reveal_history_past_the_fold(
+    tmp_path,
+):
+    """Finding 2: `TaskDetail`/`DefinitionDetail` are plain `Vertical`
+    (`overflow: hidden hidden` by default) taller than their own box at
+    every measured width -- the History group was clipped with no
+    scrollbar, no wheel handling, no PageDown. `overflow-y: auto` +
+    `#scheduling-task-detail-groups { height: auto }` (the nested
+    `Vertical` that was ALSO clipping its own children, `height: 1fr` by
+    default) together open a real scroll route to it."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=TALL) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+
+            detail = pilot.app.screen.query_one("#scheduling-task-detail", TaskDetail)
+            assert detail.max_scroll_y > 0, (
+                "the docked TaskDetail pane has no scroll route at all"
+            )
+            assert "History" not in _painted(pilot.app), (
+                "History is already visible before scrolling -- this size "
+                "no longer reproduces the fold"
+            )
+
+            detail.scroll_end(animate=False)
+            await pilot.pause()
+
+            assert "History" in _painted(pilot.app), (
+                "History is still unreachable after scrolling to the end"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_the_lifecycle_row_paints_in_the_80x24_pushed_detail(tmp_path):
+    """Finding 2, the pushed-detail twin of the docked-pane pin above --
+    `WorkbenchHostScreen` mounts a FRESH `TaskDetail` instance (task 6's
+    own precedent), so the CSS fix and the compose-order move must both
+    apply there too, not just to the docked pane."""
+    app = BundledCSSWorkbenchApp()
+    db, _service = _real_service(tmp_path, app)
+    try:
+        _reminder(db, "Nightly check")
+        async with app.run_test(size=FLOOR) as pilot:
+            await _open_workbench(pilot)
+            await _select_row(pilot)
+            await _push_detail(pilot)
+
+            painted = _painted(pilot.app)
+            assert "Edit" in painted, f"the Edit button is not painted: {painted!r}"
+            assert "Run now" in painted, (
+                f"the Run now button is not painted: {painted!r}"
+            )
     finally:
         db.close()
 

--- a/Tests/UI/test_schedules_sync_surface.py
+++ b/Tests/UI/test_schedules_sync_surface.py
@@ -144,6 +144,40 @@ async def test_failed_sync_reports_failure_not_a_noop():
 
 
 @pytest.mark.asyncio
+async def test_failed_sync_also_surfaces_phase_errors():
+    """Final review finding 6: `_on_sync_failed` used to drop
+    `phase_errors` outright -- an automation phase (definition push/pull,
+    results pull) that failed in the SAME cycle as the reminder-phase
+    failure this toast already reports never reached the user at all on
+    THIS path (only `_on_sync_completed`'s success path read them)."""
+    app = _App(
+        _SyncService(
+            SyncOutcome(
+                "error",
+                error="connection refused",
+                phase_errors=("Automation results pull: scheduled_task_not_found",),
+            )
+        )
+    )
+    async with app.run_test(size=(160, 48)) as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+
+        await _sync_via_action(pilot, workbench)
+
+        notifications = list(pilot.app._notifications)
+        failure = [n for n in notifications if "Sync failed" in n.message]
+        assert failure and "connection refused" in failure[0].message
+        also = [n for n in notifications if "Automation results pull" in n.message]
+        assert also, [
+            (n.message, n.severity) for n in notifications
+        ]
+        assert also[0].severity == "warning"
+
+
+@pytest.mark.asyncio
 async def test_not_applicable_sync_says_so():
     app = _App(_SyncService(SyncOutcome("not_applicable")))
     async with app.run_test(size=(160, 48)) as pilot:

--- a/Tests/UI/test_schedules_sync_surface.py
+++ b/Tests/UI/test_schedules_sync_surface.py
@@ -75,7 +75,9 @@ class _App(ConsolidatedCSSApp):
 
 
 async def _sync_via_action(pilot, workbench):
-    workbench.action_sync_now()
+    # Fix round 1: action_sync_now is now async (it re-probes reachability
+    # before deciding, matching _run_owner_transfer/_on_owner_server).
+    await workbench.action_sync_now()
     await pilot.pause()
     await pilot.app.workers.wait_for_complete()
     await pilot.pause()

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -3480,7 +3480,7 @@ async def test_create_reminder_action_saves_new_reminder():
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
-        pilot.app.screen.action_create_reminder()
+        await pilot.app.screen.action_create_reminder()
         await pilot.pause()
 
         assert isinstance(pilot.app.screen, ReminderForm)
@@ -3577,7 +3577,7 @@ async def test_create_reminder_for_a_different_runs_on_owner_queues_a_mutation(
             await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
             await pilot.pause()
 
-            pilot.app.screen.action_create_reminder()
+            await pilot.app.screen.action_create_reminder()
             await pilot.pause()
             assert isinstance(pilot.app.screen, ReminderForm)
 
@@ -4695,6 +4695,91 @@ def _connected_service(tmp_path, app):
     return db, service
 
 
+# -- Final review finding 2: the header must not assert "not reachable"
+# before any probe has run. ---------------------------------------------
+
+
+class _SlowProbeServerClient:
+    """A server client whose `get_capabilities` blocks on a controllable
+    `asyncio.Event` -- lets a test observe the mount-time probe's
+    still-pending window deterministically instead of racing real time
+    (same idiom `test_schedules_notification_observer.py`'s own
+    `_GatedServerClient` uses)."""
+
+    def __init__(self) -> None:
+        self.notifications_service = object()
+        self.release = asyncio.Event()
+
+    async def get_capabilities(self):
+        await self.release.wait()
+        return {}
+
+
+@pytest.mark.asyncio
+async def test_header_paints_checking_not_a_false_unreachable_during_mount_probe(
+    tmp_path,
+):
+    """Final review finding 2: `on_mount` calls `_refresh_owner_select()`
+    one line before `_refresh_server_reachability()` kicks the probe
+    worker, and `server_reachable` used to default `False` (a two-state
+    bool with no "unprobed" value) -- so the header asserted "Server
+    configured but not reachable" (a negative network fact nothing had
+    established) for the whole still-pending window, then silently
+    corrected once the worker resolved. `server_reachable` is now
+    tri-state (`None` unprobed); the header must paint the existing
+    honest "Checking sync status…" copy instead, and correct to the true
+    state once the probe (blocked here on a controllable event, not real
+    time) actually resolves."""
+    from tldw_chatbook.Scheduling.db.scheduled_tasks_db import ScheduledTasksDB
+    from tldw_chatbook.Scheduling.services.scheduling_service import SchedulingService
+    from tldw_chatbook.UI.Workbench.workbench_widgets import DestinationHeader
+
+    app = WorkbenchTestApp()
+    db = ScheduledTasksDB(tmp_path / "scheduled_tasks.db")
+    app.active_server_id = "1"
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id="1")
+    )
+    server_client = _SlowProbeServerClient()
+    service = SchedulingService(
+        db=db,
+        server_client=server_client,
+        runtime_source="local",
+        app_getter=lambda: app,
+    )
+    app.scheduling_service = service
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            # No pause yet -- the mount-time probe worker has been
+            # scheduled but cannot possibly have resolved (it's blocked
+            # on `release`, which nothing has set).
+            header = pilot.app.screen.query_one(
+                "#schedules-destination-header", DestinationHeader
+            )
+            assert header.state.status_label == "Checking sync status…", (
+                f"got {header.state.status_label!r} -- must not assert "
+                "reachability nothing has established yet"
+            )
+            assert "not reachable" not in header.state.status_label
+
+            server_client.release.set()
+            await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
+
+            assert header.state.status_label == "Local schedules", (
+                f"got {header.state.status_label!r} -- must correct once "
+                "the probe actually resolves (owner stayed 'local' "
+                "throughout this test, so a resolved reachable server "
+                "reads 'Local schedules', not 'Synced with server' -- the "
+                "point under test is that it is no longer 'Server "
+                "configured but not reachable')"
+            )
+    finally:
+        db.close()
+
+
 # -- Fix round 1, finding 1: _on_owner_server / action_sync_now must
 # re-probe like _run_owner_transfer already did, not trust a stale
 # mount-time `server_reachable` while the background probe is still
@@ -4764,6 +4849,139 @@ async def test_action_sync_now_reprobes_during_the_mount_probe_window(tmp_path):
                 "the re-probe must resolve to reachable before deciding, "
                 "not refuse on the stale pending default"
             )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_action_create_reminder_reprobes_during_the_mount_probe_window(
+    tmp_path,
+):
+    """Final review finding 3: `_runs_on_options` (read by `action_
+    create_reminder`/`action_create_automation`) was the one gate site
+    fix round 1 did not re-probe -- a create during the mount probe's
+    still-pending window silently offered only "This device" in the
+    runs-on Select, with no notice and no correction while the form
+    stayed open."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            service._server_reachable = False  # simulate: probe still pending
+
+            await pilot.app.screen.action_create_reminder()
+            await pilot.pause()
+
+            form = pilot.app.screen
+            assert isinstance(form, ReminderForm)
+            runs_on = form.query_one("#reminder-runs-on", Select)
+            option_values = [value for _label, value in runs_on._options]
+            assert "server:1" in option_values, (
+                f"got {option_values!r} -- the re-probe must resolve to "
+                "reachable before building the runs-on options, not "
+                "silently offer only 'This device'"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_on_mount_settles_orphaned_transfer_without_any_sync_running(
+    tmp_path,
+):
+    """Final review finding 1's own pinned scenario: a reminder is queued
+    `to_server_pending` while a server was configured, then the server is
+    REMOVED entirely (`active_server_id -> None`) -- the UAT's actual
+    core symptom, not merely a switch to another reachable server.
+
+    The row must settle to `to_server_failed` from `on_mount` ALONE, with
+    no sync ever running: no server is configured, so `_server_
+    configured`/`_server_available` both read `False`, `_start_server_
+    notification_observer`/`_schedule_catch_up_results_pull` both no-op,
+    and nothing in this test ever calls `action_sync_now`/presses `s` --
+    `_settle_orphaned_transfers` (called directly from `on_mount`,
+    unconditionally) is the only mechanism that could possibly settle it.
+    """
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    local_id = db.create_reminder_task(
+        owner_id="local",
+        title="Standup",
+        schedule_kind="one_time",
+        run_at="2099-01-01T00:00:00+00:00",
+    )
+    db.set_transfer_state(
+        "reminder_task", local_id, "to_server_pending", expected=(None,)
+    )
+    db.record_pending_mutation(
+        local_id,
+        "reminder_task",
+        "server:1",  # the server _connected_service just configured
+        {
+            "action": "transfer_to_server",
+            "task_payload": {"title": "Standup", "schedule_kind": "one_time"},
+        },
+    )
+    # The server is removed entirely.
+    app.runtime_policy.state.active_server_id = None
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+
+            row = db.get_reminder_task(local_id)
+            assert row["transfer_state"] == "to_server_failed", (
+                "must settle from on_mount alone -- no server is "
+                "configured, so no sync could ever have run"
+            )
+            pending = db.get_pending_mutations(
+                "server:1", primitive="reminder_task"
+            )
+            assert len(pending) == 1
+            assert pending[0]["payload"]["transfer_errors"]
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_action_sync_now_splits_configured_unreachable_from_unconfigured(
+    tmp_path,
+):
+    """Final review finding 4: `action_sync_now`'s refusal used the
+    conflated "Local only -- nothing to sync (no server connection)."
+    copy even when a server WAS configured (merely unreachable) -- the
+    exact conflation the branch removed two surfaces away (the header's
+    own split, `transfer_refusal`'s own distinct reason). A configured-
+    but-unreachable server must name THAT, not "no server connection"."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    service._server_reachable = False  # confirmed unreachable, not unprobed
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            service._server_reachable = False  # re-assert after mount's probe
+
+            # `_FakeConnectedServerClient.get_capabilities` always
+            # succeeds, so force the re-probe itself to fail this once --
+            # a genuinely unreachable server, not merely an unprobed one.
+            async def _fail_reachability():
+                service._server_reachable = False
+                return False
+
+            service.refresh_server_reachability = _fail_reachability
+
+            workbench = pilot.app.screen
+            await workbench.action_sync_now()
+            await pilot.pause()
+
+            messages = [n.message for n in pilot.app._notifications]
+            assert any(
+                "Server configured but not reachable" in m for m in messages
+            ), messages
+            assert not any("no server connection" in m for m in messages), messages
     finally:
         db.close()
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -3834,10 +3834,11 @@ async def test_action_sync_now_notifies_when_no_service():
     app = WorkbenchTestApp()
     workbench = SchedulesWorkbench(app)
     # Should not crash and should not start a worker
-    workbench.action_sync_now()
+    await workbench.action_sync_now()
 
 
-def test_action_sync_now_guard_prevents_duplicate_workers():
+@pytest.mark.asyncio
+async def test_action_sync_now_guard_prevents_duplicate_workers():
     class FakeService:
         def __init__(self):
             self.owner_id = "local"
@@ -3849,7 +3850,10 @@ def test_action_sync_now_guard_prevents_duplicate_workers():
     app.scheduling_service = FakeService()
     workbench = SchedulesWorkbench(app)
     workbench._sync_running = True
-    workbench.action_sync_now()
+    # action_sync_now is now async (fix round 1) -- the _sync_running guard
+    # is the very first check, before any await, so this still exercises
+    # exactly what the test claims: the guard fires before anything else.
+    await workbench.action_sync_now()
     # The app should have received a warning notification.
     # Exact assertion depends on the test harness; at minimum it must not start a second worker.
 
@@ -4689,6 +4693,79 @@ def _connected_service(tmp_path, app):
     service._server_reachable = True
     app.scheduling_service = service
     return db, service
+
+
+# -- Fix round 1, finding 1: _on_owner_server / action_sync_now must
+# re-probe like _run_owner_transfer already did, not trust a stale
+# mount-time `server_reachable` while the background probe is still
+# pending. -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_on_owner_server_reprobes_during_the_mount_probe_window(tmp_path):
+    """A genuinely configured, about-to-be-confirmed server must not get a
+    false "No server connection" refusal during the on-mount probe's
+    still-pending window. `_connected_service` wires a REAL, working
+    probe (`_FakeConnectedServerClient.get_capabilities` succeeds) --
+    `server_reachable` is forced back to its honest pre-probe default
+    right before the click (the mount-time background worker may already
+    have resolved it by then; this isolates the handler's OWN re-probe as
+    what's under test). `_set_owner` itself is spied out: its downstream
+    runtime-policy write needs a real `RuntimePolicyContext` this test's
+    fixtures don't build, and that machinery is unrelated to what's under
+    test here -- whether `_on_owner_server` reaches `_set_owner` at all,
+    not whether the write it performs afterward succeeds."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            service._server_reachable = False  # simulate: probe still pending
+
+            workbench = pilot.app.screen
+            set_owner_calls: list[str] = []
+            workbench._set_owner = set_owner_calls.append
+            notify_calls: list[str] = []
+            app.notify = lambda message, **kwargs: notify_calls.append(message)
+
+            server_button = workbench.query_one("#scheduling-owner-server", Button)
+            server_button.press()
+            await pilot.pause()
+
+            assert set_owner_calls == ["server:1"], (
+                "the re-probe must resolve to reachable before deciding, "
+                "not refuse on the stale pending default"
+            )
+            assert notify_calls == [], (
+                f"must not show the false refusal notice, got {notify_calls!r}"
+            )
+    finally:
+        db.close()
+
+
+@pytest.mark.asyncio
+async def test_action_sync_now_reprobes_during_the_mount_probe_window(tmp_path):
+    """Same probe-window bug as `_on_owner_server`, for the `s` key --
+    `action_sync_now` used to refuse ("Local only -- nothing to sync")
+    off a stale `server_reachable=False` without re-probing first."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        async with app.run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+            service._server_reachable = False  # simulate: probe still pending
+            workbench = pilot.app.screen
+
+            await workbench.action_sync_now()
+
+            assert workbench._sync_running is True, (
+                "the re-probe must resolve to reachable before deciding, "
+                "not refuse on the stale pending default"
+            )
+    finally:
+        db.close()
 
 
 # -- bare-harness: widget mechanics, no service needed -----------------------

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from loguru import logger as _loguru_logger
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
@@ -25,6 +26,7 @@ from textual import on
 from tldw_chatbook.Scheduling.events import (
     DefinitionRunNowRequested,
     DeleteTaskRequested,
+    ReminderDispatched,
     ReminderFieldEditRequested,
     ReminderOwnerActionRequested,
     SyncCompleted,
@@ -45,9 +47,14 @@ from tldw_chatbook.UI.Screens.scheduling.definition_detail import (
 from tldw_chatbook.Scheduling.services import (
     scheduling_service as scheduling_service_module,
 )
+from tldw_chatbook.Scheduling.services.sync_engine import SyncOutcome
 from tldw_chatbook.UI.Screens.scheduling.forms.reminder_form import ReminderForm
 from tldw_chatbook.UI.Screens.scheduling.results_tab import ResultsHostScreen, ResultsTab
-from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
+from tldw_chatbook.UI.Screens.scheduling.schedules_workbench import (
+    NEXT_RUN_REFRESH_SECONDS,
+    SCHEDULER_LIVENESS_REFRESH_SECONDS,
+    SchedulesWorkbench,
+)
 from tldw_chatbook.UI.Screens.scheduling.sync_status_widget import SyncStatusWidget
 from tldw_chatbook.UI.Screens.scheduling.task_detail import (
     TaskDetail,
@@ -3034,15 +3041,24 @@ async def test_follow_console_ignored_when_disabled():
 
 @pytest.mark.asyncio
 async def test_load_tasks_service_error_notifies_and_uses_empty_state():
-    """A service failure surfaces an error notification and consistent empty copy."""
+    """A service failure surfaces an error notification; on the very
+    first (never-succeeded) load there is no prior state to preserve, so
+    the detail pane simply keeps its pre-load compose-time copy (UAT
+    Major 5: the fix is to stop DESTROYING good state on a later
+    failure, not to paint a bespoke first-failure copy)."""
     async with WorkbenchTestAppWithFailingService().run_test() as pilot:
+        notify_calls: list[tuple[str, str]] = []
+        pilot.app.notify = lambda message, severity="information", **_: (
+            notify_calls.append((severity, str(message)))
+        )
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
+        assert any(severity == "error" for severity, _ in notify_calls), notify_calls
         empty_state = pilot.app.screen.query_one(
             "#scheduling-task-detail-empty-state", Static
         )
-        assert "No scheduled tasks yet" in empty_state.visual.plain
+        assert "Select a task from the queue" in empty_state.visual.plain
 
 
 # redesign PR-2, Task 2: the four watchlist-row tests that used to live
@@ -3128,23 +3144,58 @@ class WorkbenchTestAppWithToggleFailingService(ConsolidatedCSSApp):
 
 
 @pytest.mark.asyncio
-async def test_load_tasks_service_error_clears_stale_rows():
-    """A service failure after data was loaded clears the table and internal task list."""
+async def test_load_tasks_service_error_keeps_the_last_good_rows():
+    """UAT Major 5: a service failure AFTER data was loaded must not
+    destroy the last-good display -- a read failure is not evidence the
+    queue is empty. This used to clear the table and the internal task
+    list on ANY exception here, with nothing short of a fresh mount able
+    to restore it; this test's own former name/assertions pinned that
+    bug."""
     async with WorkbenchTestAppWithToggleFailingService().run_test() as pilot:
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
         table = pilot.app.screen.query_one("#scheduling-task-table", DataTable)
         assert table.row_count == 1
+        workbench = pilot.app.screen
+        tasks_before = list(workbench._tasks)
+        rows_before = list(workbench._all_rows)
 
-        await pilot.app.screen.load_tasks()
+        notify_calls: list[tuple[str, str]] = []
+        pilot.app.notify = lambda message, severity="information", **_: (
+            notify_calls.append((severity, str(message)))
+        )
+        await workbench.load_tasks()
         await pilot.pause()
 
-        assert table.row_count == 0
-        empty_state = pilot.app.screen.query_one(
-            "#scheduling-task-detail-empty-state", Static
-        )
-        assert "No scheduled tasks yet" in empty_state.visual.plain
+        assert table.row_count == 1, "the table must keep the last-good rows"
+        assert workbench._tasks == tasks_before
+        assert workbench._all_rows == rows_before
+        assert any(severity == "error" for severity, _ in notify_calls), notify_calls
+
+
+@pytest.mark.asyncio
+async def test_load_tasks_failure_logs_which_step_raised():
+    """UAT Major 5's logging hook: a bare `logger.exception("Failed to
+    load tasks")` covering three distinct calls (reminders listing,
+    definitions listing, row build) left no way to pin the raiser
+    without reproducing it live. The log line must now name the step,
+    the exception type, and enough context to find it without a repro."""
+    records: list[str] = []
+    sink_id = _loguru_logger.add(
+        lambda message: records.append(message.record["message"]), level="ERROR"
+    )
+    try:
+        async with WorkbenchTestAppWithFailingService().run_test() as pilot:
+            await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+            await pilot.pause()
+    finally:
+        _loguru_logger.remove(sink_id)
+
+    assert any(
+        "listing tasks" in r and "RuntimeError" in r and "owner_id=" in r
+        for r in records
+    ), records
 
 
 class RecordingMockSchedulingService(_MockSchedulingServiceMixin):
@@ -3571,6 +3622,158 @@ def test_sync_failed_event():
     msg = SyncFailed("server:1", error="timeout")
     assert msg.owner_id == "server:1"
     assert msg.error == "timeout"
+
+
+@pytest.mark.asyncio
+async def test_mixed_sync_cycle_toasts_success_and_surfaces_the_phase_failure():
+    """UAT finding 3c pin: a cycle whose reminder phase succeeded (and,
+    per the same-cycle scenario, a definition push too) alongside an
+    UNRELATED phase's failure (a business 404) must never toast "Sync
+    failed" -- and must never silently drop the failure either. Both
+    truths, as separate notices."""
+    app = WorkbenchTestAppWithService()
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        notify_calls: list[tuple[str, str]] = []
+        pilot.app.notify = lambda message, severity="information", **_: (
+            notify_calls.append((severity, str(message)))
+        )
+        # Isolate the toast-mapping logic under test from the rest of
+        # this handler's refresh side effects (already covered by other
+        # tests in this file).
+        workbench._refresh_owner_select = lambda: None
+        workbench._request_tasks_refresh = lambda *a, **k: None
+        workbench._refresh_conflicts_badge = lambda: None
+        workbench._refresh_results_badge = lambda: None
+
+        outcome = SyncOutcome(
+            "ok",
+            pulled=0,
+            pushed=1,
+            phase_errors=("Automation results pull: business 404 (stale server)",),
+        )
+        workbench._on_sync_completed(SyncCompleted("local", conflict_count=0, outcome=outcome))
+
+        assert len(notify_calls) == 2, notify_calls
+        success_severity, success_message = notify_calls[0]
+        assert success_severity == "information"
+        assert "failed" not in success_message.lower(), (
+            "the success toast must never say 'failed'"
+        )
+        failure_severity, failure_message = notify_calls[1]
+        assert failure_severity == "warning"
+        assert "Automation results pull" in failure_message
+        assert "business 404" in failure_message
+
+
+def test_reminder_dispatched_relays_to_the_mounted_workbench():
+    """UAT finding 3a pin: `TldwCli.on_reminder_dispatched` (the `post_
+    message` fallback bridge -- `on_queue_changed` only reaches the
+    scheduler loop's own in-memory queue, never a screen) must find a
+    live `SchedulesWorkbench` on the screen stack and trigger a refresh,
+    the exact route a scheduled reminder fire otherwise has none of."""
+    from tldw_chatbook.app import TldwCli
+
+    workbench = SchedulesWorkbench(app_instance=SimpleNamespace(scheduling_service=None))
+    refresh_calls: list[bool] = []
+    workbench._request_tasks_refresh = lambda *, refresh_definitions=True: (
+        refresh_calls.append(refresh_definitions)
+    )
+    # A plain fake, not a real `App` -- `screen_stack` is a real Textual
+    # App's own read-only property, and this relay's only real contract
+    # is "reads `self.screen_stack`, finds the workbench, calls its
+    # refresh" -- no live app/message pump needed to pin that.
+    fake_app = SimpleNamespace(screen_stack=[object(), workbench])
+
+    TldwCli.on_reminder_dispatched(fake_app, ReminderDispatched("task-1"))
+
+    assert refresh_calls == [False], (
+        "a fired reminder must trigger a reminder-only refresh without navigating away and back"
+    )
+
+
+def test_reminder_dispatched_is_a_no_op_with_no_workbench_mounted():
+    """The relay must not raise when Schedules isn't the active screen."""
+    from tldw_chatbook.app import TldwCli
+
+    fake_app = SimpleNamespace(screen_stack=[object()])
+
+    TldwCli.on_reminder_dispatched(fake_app, ReminderDispatched("task-1"))
+
+
+def test_post_reminder_dispatched_posts_the_message():
+    """`SchedulerLoop.on_reminder_dispatched` is wired to this bound
+    method (`app.py`'s scheduler-loop construction) -- it must post a
+    real `ReminderDispatched` carrying the fired task's id."""
+    from tldw_chatbook.app import TldwCli
+
+    posted: list[object] = []
+    app = WorkbenchTestAppWithService()
+    app.post_message = lambda message: posted.append(message)
+
+    TldwCli._post_reminder_dispatched(app, "task-7")
+
+    assert len(posted) == 1
+    assert isinstance(posted[0], ReminderDispatched)
+    assert posted[0].task_id == "task-7"
+
+
+@pytest.mark.asyncio
+async def test_liveness_strip_gets_its_own_faster_interval_timer():
+    """UAT finding 3d pin: the scheduler-liveness strip used to be
+    repainted only as a side effect of the 60s next-run ticker, so a
+    0-30s value was static for up to a full minute between samples. It
+    must now be scheduled on its OWN interval, faster than that ticker,
+    calling `_refresh_scheduler_liveness` directly."""
+    app = WorkbenchTestAppWithService()
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        scheduled: list[tuple[float, object]] = []
+        real_set_interval = workbench.set_interval
+
+        def fake_set_interval(seconds, callback, *a, **k):
+            scheduled.append((seconds, callback))
+            return real_set_interval(seconds, callback, *a, **k)
+
+        workbench.set_interval = fake_set_interval
+
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        liveness_timers = [s for s, cb in scheduled if cb == workbench._refresh_scheduler_liveness]
+        next_run_timers = [s for s, cb in scheduled if cb == workbench._refresh_next_run_rendering]
+        assert liveness_timers == [SCHEDULER_LIVENESS_REFRESH_SECONDS]
+        assert next_run_timers == [NEXT_RUN_REFRESH_SECONDS]
+        assert SCHEDULER_LIVENESS_REFRESH_SECONDS < NEXT_RUN_REFRESH_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_suspend_and_resume_pause_and_restart_the_liveness_timer_too():
+    """The liveness timer must follow the same hidden-clock discipline
+    (TASK-23022) the next-run timer already has -- paused while covered,
+    resumed (and refreshed immediately) on uncover."""
+    app = WorkbenchTestAppWithService()
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+
+        paused = []
+        resumed = []
+        workbench._liveness_refresh_timer.pause = lambda: paused.append(True)
+        workbench._liveness_refresh_timer.resume = lambda: resumed.append(True)
+        refreshed = []
+        workbench._refresh_scheduler_liveness = lambda: refreshed.append(True)
+
+        workbench.on_screen_suspend()
+        assert paused == [True]
+
+        workbench.on_screen_resume()
+        assert resumed == [True]
+        assert refreshed == [True]
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -68,6 +68,7 @@ from Tests.UI.schedules_test_helpers import (
     MockSchedulingDB as _MockSchedulingDB,
     MockSchedulingServiceMixin as _MockSchedulingServiceMixin,
     MockServerClient as _MockServerClient,
+    painted_glyphs_at,
     rendered_row_cells,
     settle_schedules_workbench,
 )
@@ -490,6 +491,39 @@ async def test_repeat_row_editor_opens_with_current_preset_preselected():
 
 
 @pytest.mark.asyncio
+async def test_repeat_row_editor_paints_its_current_value_when_focused():
+    """Geometry pin (schedules-UAT-remediation, finding 1a): the test
+    above only proved ``editor.value`` -- a stored attribute the widget
+    can carry correctly while showing nothing at all. Uncompacted, a
+    `Select`'s own `border: tall` (3 rows) is clipped to 1 row by
+    `DetailValueRow`'s fixed-height line container
+    (`.detail-value-row-line { height: 1 }`), and the surviving row is
+    the border's TOP EDGE, not the label -- `editor.value` still reads
+    "monday" while the compositor paints only border glyphs. Fails
+    against the unfixed code (bare `Select(...)`, no `compact=True`) --
+    see the task-1 report's revert-check."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        detail.set_task(_frequency_reminder())
+        await pilot.pause()
+
+        repeat_row = detail._repeat_row
+        await pilot.click(repeat_row)
+        await pilot.pause()
+
+        editor = repeat_row.query_one(Select)
+        assert editor.value == "monday"
+        assert editor.has_class("-textual-compact"), (
+            "the Repeat row's Select editor was constructed without "
+            "compact=True"
+        )
+        painted = painted_glyphs_at(pilot.app, editor)
+        assert "Every Monday" in painted, (
+            f"the Repeat editor's own value is not painted: {painted!r}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_at_row_editor_opens_with_current_run_at_preselected():
     """A one-time reminder's At row opens an Input preloaded with the
     task's own `run_at.isoformat()` -- the same prefill shape the
@@ -514,6 +548,43 @@ async def test_at_row_editor_opens_with_current_run_at_preselected():
 
         editor = at_row.query_one(Input)
         assert editor.value == run_at.isoformat()
+
+
+@pytest.mark.asyncio
+async def test_at_row_editor_paints_its_current_value_when_focused():
+    """Geometry pin (schedules-UAT-remediation, finding 1a): an
+    uncompacted `Input`'s DEFAULT_CSS is `height: 3` (border + content +
+    border), clipped to 1 row by the same `.detail-value-row-line`
+    container -- the surviving row is the top border, so `editor.value`
+    reads the ISO timestamp correctly while the compositor paints only
+    border glyphs. Fails against the unfixed code (bare `Input(...)`, no
+    `compact=True`)."""
+    async with _BareTaskDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(TaskDetail)
+        run_at = datetime(2030, 1, 1, 9, 0, tzinfo=timezone.utc)
+        detail.set_task(
+            _frequency_reminder(
+                schedule_kind=ScheduleKind.ONE_TIME,
+                cron=None,
+                timezone=None,
+                run_at=run_at,
+            )
+        )
+        await pilot.pause()
+
+        at_row = detail._at_row
+        await pilot.click(at_row)
+        await pilot.pause()
+
+        editor = at_row.query_one(Input)
+        assert editor.value == run_at.isoformat()
+        assert editor.has_class("-textual-compact"), (
+            "the At row's Input editor was constructed without compact=True"
+        )
+        painted = painted_glyphs_at(pilot.app, editor)
+        assert run_at.isoformat() in painted, (
+            f"the At editor's own value is not painted: {painted!r}"
+        )
 
 
 @pytest.mark.asyncio
@@ -1099,6 +1170,34 @@ async def test_model_row_editor_preselects_provider_slash_model_and_is_blank_whe
 
 
 @pytest.mark.asyncio
+async def test_model_row_editor_paints_its_current_value_when_focused():
+    """Geometry pin (schedules-UAT-remediation, finding 1a), the
+    `DefinitionDetail` twin of `test_at_row_editor_paints_its_current_
+    value_when_focused` -- same `.detail-value-row-line { height: 1 }`
+    clip, a different pane class entirely, so the fix (`compact=True` at
+    this construction site) is pinned independently of `TaskDetail`'s
+    own."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())
+        await pilot.pause()
+
+        model_row = detail._model_row
+        await pilot.click(model_row)
+        await pilot.pause()
+        editor = model_row.query_one(Input)
+        assert editor.value == "openai/gpt-5"
+        assert editor.has_class("-textual-compact"), (
+            "the Model row's Input editor was constructed without "
+            "compact=True"
+        )
+        painted = painted_glyphs_at(pilot.app, editor)
+        assert "openai/gpt-5" in painted, (
+            f"the Model editor's own value is not painted: {painted!r}"
+        )
+
+
+@pytest.mark.asyncio
 async def test_generation_row_editor_preselects_current_value_defaulting_to_optional():
     async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
         detail = pilot.app.query_one(DefinitionDetail)
@@ -1121,6 +1220,30 @@ async def test_generation_row_editor_preselects_current_value_defaulting_to_opti
         await pilot.pause()
         editor = row.query_one(Select)
         assert editor.value == "optional"
+
+
+@pytest.mark.asyncio
+async def test_generation_row_editor_paints_its_current_value_when_focused():
+    """Geometry pin (schedules-UAT-remediation, finding 1a) -- the
+    `Select` case for `DefinitionDetail`, mirroring `TaskDetail`'s Repeat
+    row pin."""
+    async with _BareDefinitionDetailApp().run_test(size=(80, 60)) as pilot:
+        detail = pilot.app.query_one(DefinitionDetail)
+        detail.set_definition(_editable_definition())  # generation_mode="required"
+        await pilot.pause()
+        row = detail._generation_row
+        await pilot.click(row)
+        await pilot.pause()
+        editor = row.query_one(Select)
+        assert editor.value == "required"
+        assert editor.has_class("-textual-compact"), (
+            "the Generation row's Select editor was constructed without "
+            "compact=True"
+        )
+        painted = painted_glyphs_at(pilot.app, editor)
+        assert "Always generate a draft" in painted, (
+            f"the Generation editor's own value is not painted: {painted!r}"
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -4349,6 +4349,64 @@ async def test_conflicts_badge_pushes_conflicts_overlay_with_painted_content():
 
 
 @pytest.mark.asyncio
+async def test_conflict_resolution_buttons_click_target_is_already_3_rows():
+    """Finding 6/Major 10 (root-causes.md, task-3): root-causes' own
+    verdict already REFUTES "clicks don't work" (a real synthesized
+    mouse click lands fine). It also proposed a residual worth-fixing
+    claim -- the buttons are "1 row tall... a 1-row-tall target at a
+    screen edge" (`btn.size == Size(16, 1)`, and its own report also
+    states `region: height=1`) -- and recommended widening via
+    `min-height: 3`.
+
+    Direct measurement against the CURRENT real bundle REFUTES that
+    residual claim too: `.size.height` is indeed 1 (content box only),
+    but `.region.height` -- the compositor's actual laid-out click
+    target, the attribute that matters for "does a click land" -- is
+    ALREADY 3 at every screen size probed (80x24, 120x40, 235x52,
+    verified interactively). The reason: Textual's own `Button.-style-
+    default` DEFAULT_CSS sets `border-top: tall` + `border-bottom: tall`
+    (1 row each) around the 1-row content, giving 3 laid-out rows
+    regardless of this app's CSS. Adding `min-height: 3` here was
+    therefore a no-op (confirmed by toggling it and rebuilding the CSS
+    bundle both ways -- `.region.height` stayed 3 either way), so no
+    source change was made; this test pins the ACTUAL state (a
+    comfortable click target) as a regression guard, not a fix."""
+    app = _RailTestApp(
+        _RailService(
+            conflicts=[{"id": "c1", "local_state": {"title": "Digest"}}]
+        )
+    )
+    async with app.run_test() as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await pilot.pause()
+
+        badge = pilot.app.screen.query_one("#scheduling-conflicts-badge", Button)
+        badge.press()
+        await pilot.pause()
+
+        overlay_tab = pilot.app.screen.query_one(
+            "#scheduling-conflicts-overlay", ConflictsTab
+        )
+        use_server = overlay_tab.query_one("#scheduling-use-server", Button)
+        use_local = overlay_tab.query_one("#scheduling-use-local", Button)
+
+        # `.region`, not `.size`: a click's screen coordinates land in
+        # `.region` (the laid-out box including border chrome), which is
+        # what actually determines "does this click hit the button".
+        assert use_server.region.height >= 3, f"got {use_server.region.height}"
+        assert use_local.region.height >= 3, f"got {use_local.region.height}"
+
+        # Post-compositor confirmation (root-causes.md's own oracle): both
+        # buttons' labels are actually painted, not merely sized on paper.
+        strips = pilot.app.screen._compositor.render_strips()
+        painted = "\n".join(
+            "".join(seg.text for seg in strip) for strip in strips
+        )
+        assert "Use server" in painted
+        assert "Use local" in painted
+
+
+@pytest.mark.asyncio
 async def test_conflicts_badge_defaults_to_no_count():
     app = _RailTestApp(_RailService())
     async with app.run_test() as pilot:
@@ -4593,6 +4651,15 @@ class _FakeConnectedServerClient:
     def __init__(self) -> None:
         self.notifications_service = object()
 
+    async def get_capabilities(self):
+        """task-3 (ruling 4/5): `SchedulesWorkbench.on_mount` kicks a real
+        `refresh_server_reachability` probe, which calls this -- without
+        it, the mount-time worker's `AttributeError` gets caught as
+        "unreachable" and silently overwrites this fixture's whole
+        "looks connected" premise (`_server_reachable` back to `False`)
+        moments after `_connected_service` pre-seeds it `True`."""
+        return {}
+
 
 def _connected_service(tmp_path, app):
     """A real `ScheduledTasksDB` + `SchedulingService`, wired to LOOK
@@ -4614,6 +4681,12 @@ def _connected_service(tmp_path, app):
         runtime_source="local",
         app_getter=lambda: app,
     )
+    # task-3 (ruling 4): `transfer_refusal`/`_server_available` now also
+    # gate on a real `refresh_server_reachability` probe (default
+    # `False`) -- this fixture's whole point is "look connected", so
+    # pre-seed the same verdict a probe would reach (same precedent as
+    # `test_scheduling_service.py`'s `_transfer_service`).
+    service._server_reachable = True
     app.scheduling_service = service
     return db, service
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -3045,7 +3045,9 @@ async def test_load_tasks_service_error_notifies_and_uses_empty_state():
     first (never-succeeded) load there is no prior state to preserve, so
     the detail pane simply keeps its pre-load compose-time copy (UAT
     Major 5: the fix is to stop DESTROYING good state on a later
-    failure, not to paint a bespoke first-failure copy)."""
+    failure, not to paint a bespoke first-failure copy). Review round 1
+    finding 1: the toast text itself must not claim a "last-loaded
+    queue" that never existed."""
     async with WorkbenchTestAppWithFailingService().run_test() as pilot:
         notify_calls: list[tuple[str, str]] = []
         pilot.app.notify = lambda message, severity="information", **_: (
@@ -3054,7 +3056,12 @@ async def test_load_tasks_service_error_notifies_and_uses_empty_state():
         await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
         await pilot.pause()
 
-        assert any(severity == "error" for severity, _ in notify_calls), notify_calls
+        errors = [message for severity, message in notify_calls if severity == "error"]
+        assert errors, notify_calls
+        assert "last-loaded queue" not in errors[0], (
+            "the first-ever load has no last-good queue to claim it is showing"
+        )
+        assert "Could not load tasks" in errors[0]
         empty_state = pilot.app.screen.query_one(
             "#scheduling-task-detail-empty-state", Static
         )
@@ -3171,7 +3178,11 @@ async def test_load_tasks_service_error_keeps_the_last_good_rows():
         assert table.row_count == 1, "the table must keep the last-good rows"
         assert workbench._tasks == tasks_before
         assert workbench._all_rows == rows_before
-        assert any(severity == "error" for severity, _ in notify_calls), notify_calls
+        errors = [message for severity, message in notify_calls if severity == "error"]
+        assert errors, notify_calls
+        assert "last-loaded queue" in errors[0], (
+            "a failure AFTER a real load must say so -- there IS a last-good queue"
+        )
 
 
 @pytest.mark.asyncio
@@ -3719,6 +3730,48 @@ def test_post_reminder_dispatched_posts_the_message():
     assert len(posted) == 1
     assert isinstance(posted[0], ReminderDispatched)
     assert posted[0].task_id == "task-7"
+
+
+@pytest.mark.asyncio
+async def test_reminder_dispatched_message_reaches_the_workbench_through_a_live_pump():
+    """Review round 1 finding 3: the three other fanout tests each pin
+    one hop in isolation via direct calls (the loop's callback fires;
+    `TldwCli.on_reminder_dispatched` called directly against a fake app;
+    `_post_reminder_dispatched` checked to call `post_message`) -- none
+    of them actually run a message through a live Textual pump. This
+    posts a REAL `ReminderDispatched` on a RUNNING app and confirms
+    Textual's naming-convention dispatch (`on_reminder_dispatched`, no
+    `@on` decorator -- `Message.handler_name` resolves it purely by
+    class-name convention) really connects `TldwCli`'s production method
+    to a mounted `SchedulesWorkbench` at runtime, not just in theory."""
+    from tldw_chatbook.app import TldwCli
+
+    class _FanoutTestApp(WorkbenchTestAppWithService):
+        # The REAL production method, unbound onto this lightweight test
+        # app -- if Textual's dispatch did not route by name convention,
+        # this handler would simply never run.
+        on_reminder_dispatched = TldwCli.on_reminder_dispatched
+
+    app = _FanoutTestApp()
+    async with app.run_test() as pilot:
+        workbench = SchedulesWorkbench(app_instance=pilot.app)
+        refresh_calls: list[bool] = []
+        workbench._request_tasks_refresh = lambda *, refresh_definitions=True: (
+            refresh_calls.append(refresh_definitions)
+        )
+        await pilot.app.push_screen(workbench)
+        await pilot.pause()
+        # `on_mount` itself calls `_request_tasks_refresh()` (default
+        # True) as part of normal mounting -- irrelevant to this pin.
+        refresh_calls.clear()
+
+        pilot.app.post_message(ReminderDispatched("task-1"))
+        await pilot.pause()
+
+        assert refresh_calls == [False], (
+            "the live message pump must dispatch ReminderDispatched to "
+            "TldwCli.on_reminder_dispatched by naming convention alone"
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -4655,13 +4655,15 @@ class _FakeConnectedServerClient:
     def __init__(self) -> None:
         self.notifications_service = object()
 
-    async def get_capabilities(self):
+    async def get_capabilities(self, *, force: bool = False):
         """task-3 (ruling 4/5): `SchedulesWorkbench.on_mount` kicks a real
         `refresh_server_reachability` probe, which calls this -- without
         it, the mount-time worker's `AttributeError` gets caught as
         "unreachable" and silently overwrites this fixture's whole
         "looks connected" premise (`_server_reachable` back to `False`)
-        moments after `_connected_service` pre-seeds it `True`."""
+        moments after `_connected_service` pre-seeds it `True`. Accepts
+        `force` (Qodo fix round finding 1) since the real probe always
+        passes it -- this fake has no cache to bypass."""
         return {}
 
 
@@ -4710,7 +4712,7 @@ class _SlowProbeServerClient:
         self.notifications_service = object()
         self.release = asyncio.Event()
 
-    async def get_capabilities(self):
+    async def get_capabilities(self, *, force: bool = False):
         await self.release.wait()
         return {}
 
@@ -4901,8 +4903,10 @@ async def test_on_mount_settles_orphaned_transfer_without_any_sync_running(
     configured`/`_server_available` both read `False`, `_start_server_
     notification_observer`/`_schedule_catch_up_results_pull` both no-op,
     and nothing in this test ever calls `action_sync_now`/presses `s` --
-    `_settle_orphaned_transfers` (called directly from `on_mount`,
-    unconditionally) is the only mechanism that could possibly settle it.
+    `_settle_orphaned_transfers` (kicked unconditionally from `on_mount`,
+    running on its own deferred worker since the Qodo fix round finding 2
+    fix -- `wait_for_complete()` below lets it actually finish) is the
+    only mechanism that could possibly settle it.
     """
     app = WorkbenchTestApp()
     db, service = _connected_service(tmp_path, app)
@@ -4930,6 +4934,8 @@ async def test_on_mount_settles_orphaned_transfer_without_any_sync_running(
         async with app.run_test() as pilot:
             await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
             await pilot.pause()
+            await pilot.app.workers.wait_for_complete()
+            await pilot.pause()
 
             row = db.get_reminder_task(local_id)
             assert row["transfer_state"] == "to_server_failed", (
@@ -4941,6 +4947,41 @@ async def test_on_mount_settles_orphaned_transfer_without_any_sync_running(
             )
             assert len(pending) == 1
             assert pending[0]["payload"]["transfer_errors"]
+    finally:
+        db.close()
+
+
+def test_settle_orphaned_transfers_defers_to_a_worker_not_inline(tmp_path):
+    """Qodo fix round finding 2 (MEDIUM) pin: `_settle_orphaned_transfers`
+    must hand the actual local-DB sweep to a worker and return
+    immediately, never run it inline on the calling (UI) thread --
+    `run_worker` itself is substituted here so the assertion holds
+    regardless of when a real worker would actually get scheduled to
+    run (the concern the app-level test above can only prove after the
+    fact, via `wait_for_complete()`)."""
+    app = WorkbenchTestApp()
+    db, service = _connected_service(tmp_path, app)
+    try:
+        workbench = SchedulesWorkbench(app_instance=app)
+
+        calls: list[str | None] = []
+        service.sync_engine._settle_orphaned_transfer_mutations = (
+            lambda target_owner: calls.append(target_owner)
+        )
+
+        captured = {}
+
+        def _fake_run_worker(work, *, exclusive=False, group=None, **_kwargs):
+            captured["work"] = work
+            captured["group"] = group
+
+        workbench.run_worker = _fake_run_worker
+
+        workbench._settle_orphaned_transfers()
+
+        assert calls == [], "must not run the sweep inline before returning"
+        assert captured["group"] == "schedules-orphan-sweep"
+        assert captured["work"] is not None
     finally:
         db.close()
 

--- a/Tests/tldw_api/test_scheduled_tasks_automation_client.py
+++ b/Tests/tldw_api/test_scheduled_tasks_automation_client.py
@@ -8,6 +8,7 @@ import pytest
 
 from tldw_chatbook.tldw_api.client import TLDWAPIClient
 from tldw_chatbook.tldw_api.scheduled_tasks_automation_schemas import (
+    ScheduledTaskAutomationCapabilities,
     ScheduledTaskAutomationDefinition,
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
@@ -643,3 +644,92 @@ async def test_reopen_forwards_target_lifecycle_and_reason(monkeypatch):
         "target_lifecycle": "configured",
         "reason": "False positive",
     }
+
+
+# -- capabilities handshake (task-3, schedules UAT remediation ruling 5) ---
+# Mirrors client.py:16269's `/sync/capabilities` precedent
+# (`get_sync_v2_capabilities`): a per-session probe whose response this
+# client must parse without crashing regardless of which automation
+# families/actions a given server happens to advertise.
+
+
+@pytest.mark.asyncio
+async def test_get_capabilities_routes_and_parses_a_realistic_response(monkeypatch):
+    client = TLDWAPIClient("http://localhost:8000")
+    # Shape mirrors the server's own `ScheduledTaskAutomationCapabilitiesResponse`
+    # (tldw_Server_API/app/api/v1/schemas/scheduled_tasks_automation_schemas.py).
+    mocked = AsyncMock(
+        return_value={
+            "items": [
+                {
+                    "family": "recurring_question",
+                    "family_availability": "available",
+                    "actions": {
+                        "run_now": {"status": "available"},
+                        "execute_tools": {
+                            "status": "planned",
+                            "reason": "recurring_question has no tool surface",
+                        },
+                    },
+                    "missing_dependencies": [],
+                    "related_capabilities": {"rag": {"status": "not_checked"}},
+                },
+                {
+                    "family": "agent_task",
+                    "family_availability": "unavailable",
+                    "actions": {
+                        "run_now": {
+                            "status": "unavailable",
+                            "reason": "agent_execution_requires_certification",
+                        },
+                    },
+                    "reason": "agent_execution_requires_certification",
+                },
+            ]
+        }
+    )
+    monkeypatch.setattr(client, "_request", mocked)
+
+    result = await client.get_scheduled_task_automation_capabilities()
+
+    assert mocked.await_args.args[:2] == (
+        "GET",
+        "/api/v1/scheduled-tasks/capabilities",
+    )
+    assert isinstance(result, ScheduledTaskAutomationCapabilities)
+    assert len(result.items) == 2
+    recurring, agent = result.items
+    assert recurring.family == "recurring_question"
+    assert recurring.family_availability == "available"
+    assert recurring.actions["run_now"].status == "available"
+    assert recurring.actions["execute_tools"].status == "planned"
+    assert agent.family_availability == "unavailable"
+    assert agent.reason == "agent_execution_requires_certification"
+
+
+def test_capabilities_schema_tolerates_an_unknown_family_and_missing_fields():
+    """The server owns the family/action vocabularies (same forward-compat
+    contract `test_definition_schema_tolerates_unknown_enum_values_and_
+    missing_policies` pins for definitions) -- a future family or a bare
+    minimum response must not break this client."""
+    capabilities = ScheduledTaskAutomationCapabilities.model_validate(
+        {
+            "items": [
+                {
+                    "family": "some_future_family",
+                    "family_availability": "degraded",
+                    "actions": {},
+                }
+            ]
+        }
+    )
+    assert capabilities.items[0].family == "some_future_family"
+    assert capabilities.items[0].actions == {}
+    assert capabilities.items[0].reason is None
+
+
+def test_capabilities_schema_defaults_to_an_empty_item_list():
+    """An empty ``{}`` response (or one missing ``items`` entirely) is a
+    valid, if useless, answer -- must not raise."""
+    capabilities = ScheduledTaskAutomationCapabilities.model_validate({})
+    assert capabilities.items == []

--- a/backlog/docs/plan-2026-09-04-schedules-uat-remediation.md
+++ b/backlog/docs/plan-2026-09-04-schedules-uat-remediation.md
@@ -1,0 +1,34 @@
+# Schedules UAT Remediation
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Fix the UAT's 2 confirmed Blockers + 7 confirmed Majors (finding 10 refuted; the 404s were an environment artifact whose keepable fix is a capabilities handshake), per the root-cause report — `.superpowers/sdd/uat-remediation/root-causes.md` is the mechanism authority; deviate only with probe evidence.
+
+**Spec/authority:** the root-cause report + `backlog/docs/spec-2026-09-02-schedules-screen-redesign.md`. Rulings:
+1. Blocker 2: NO kebab — move the existing `#scheduling-task-detail-lifecycle` row above the groups (the report's recommendation; spec §5's kebab is formally superseded, note it in the commit).
+2. Stale-cluster (a): the scheduler loop fans out on the existing `on_queue_changed` seam (a real push beats making the ticker load — the ticker stays paint-only per its contract) — but if the seam trace shows it unreachable from the workbench, the fallback is a lightweight `post_message` bridge; document the choice.
+3. Major 5: the destructive `except` in `load_tasks` becomes non-destructive (keep the last-good rows + an error notice) + a logging hook naming the raiser — the honest fix for an unpinned symptom.
+4. Major 9: connectedness gates BOTH `_server_available` and `transfer_refusal` (the header's readiness probe is the source); an unreplayable orphaned mutation settles to `to_server_failed` (Retry/Cancel + "Last transfer error" already exist).
+5. Capabilities handshake: probe `GET /scheduled-tasks/capabilities` per the `client.py:16269` precedent; missing routes surface honestly (kills Minor 24/Polish 31).
+6. TEST DISCIPLINE (the blindness lesson): every display fix pins via the `render_strips()` geometry oracle (already imported in both test files for colour — now used for geometry); content-only assertions are insufficient for visibility claims.
+
+## Global Constraints
+Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook-uat-fix`, branch `fix/schedules-uat-remediation` off f01cad196e. NEVER stash (git show / throwaway worktree for baselines); no pkill beyond own PIDs; FOREGROUND pytest; EXACT tail lines; tmp_path DBs; diagnostics pin SCRIPT on logger changes; class-targeted CSS + bundle rebuilds; census/ratchet parity; escape/Text discipline; commit trailer:
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
+Claude-Session: https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv
+
+### Task 1: Display blockers (findings 1+2 + minor 18)
+compact=True at the 12 begin_edit sites + `#scheduling-queue-filter` (+ Escape blurs the filter); `TaskDetail, DefinitionDetail { overflow-y: auto }` + `#scheduling-task-detail-groups { height: auto }`; the lifecycle row moves above the groups (both panes' equivalents — check DefinitionDetail's ordering too). Tests: render_strips GEOMETRY pins for an open editor (its strip carries the value), the filter (typed text visible), the pane scroll (max_scroll_y > 0 on tall content), the lifecycle row painted at 235×52 AND 80×24-pushed.
+
+### Task 2: The stale-display cluster (findings 3a/3c/3d/3e + Major 5 hardening)
+(a) dispatch→UI fanout per ruling 2 — a fired reminder repaints within a tick, pinned; (c) `SyncOutcome.phase_errors` + per-phase toast truth + `last_push_at` stamped by the definition-push phase; (d) the liveness strip on its own 5s interval; (e) the one-line COMPLETED label; Major 5: non-destructive except + logging hook. Tests per item incl. the sync-success-never-toasts-failure pin.
+
+### Task 3: Sync/transfer state (findings 4+5 + the handshake + finding 6's target)
+Ghost row: `released_server_id` filtering of pulled_items (the adopted_server_id twin, 12 lines below); Major 9 per ruling 4; the capabilities handshake per ruling 5; conflict buttons: widen the click target (a container-level click or min-height 3 — smallest honest fix; finding 10 itself REFUTED, cite it). Tests: release→pull same-cycle → ONE row; no-server transfer refused with reason; orphaned mutation settles to failed w/ Retry visible; handshake gates the results affordances honestly.
+
+### Task 4: Gates + scoped live re-verification
+Full `Tests/Scheduling/ -q` + the schedules UI set + floor pins; census/ratchets/pin/bundle with attributions; then a SCOPED live tmux re-check of exactly the fixed legs (editor visible + typed text painted; pane scrolls to History; a fired reminder repaints without navigation; sync toast truth; the lifecycle row on screen) under a scratch profile — the UAT charter's evidence style, cleanup confirmed. Docs: User Guide touch-ups where fixes changed copy/behavior.
+
+## After
+Final whole-branch review (opus) → wave → PR `fix(scheduling): UAT remediation — display, staleness, transfer honesty` → bot round → in-loop merge → memory + file the refuted/deferred UAT minors to backlog.

--- a/tldw_chatbook/Notifications/server_notifications_service.py
+++ b/tldw_chatbook/Notifications/server_notifications_service.py
@@ -259,6 +259,23 @@ class ServerNotificationsService:
         self._enforce("notifications.reminders.configure.server")
         return self._dump(await self._require_client().delete_reminder_task(task_id))
 
+    async def get_scheduled_automation_capabilities(self) -> dict[str, Any]:
+        """Probe server-advertised Scheduled Tasks automation capabilities.
+
+        task-3 (schedules UAT remediation ruling 5) capabilities
+        handshake: a 404 here means the server predates Scheduled Tasks
+        automation entirely, which `SchedulingServerClient.get_capabilities`
+        turns into an honest degrade rather than a crash.
+
+        Returns:
+            The capabilities response (``items``, one entry per
+            automation family) as a JSON-mode dict.
+        """
+        self._enforce("scheduler.automations.list.server")
+        return self._dump(
+            await self._require_client().get_scheduled_task_automation_capabilities()
+        )
+
     async def list_scheduled_automations(
         self,
         *,

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -315,9 +315,21 @@ class SyncFailed(Message):
         error: Human-readable failure text for the UI. Sourced either
             from a raised exception or from the error the engine recorded
             on a ``SyncOutcome`` whose status is ``"error"``.
+        outcome: The engine's ``SyncOutcome`` for the attempt, when one
+            exists (a raised exception outside the engine has none) --
+            final review finding 6: without it, an automation-phase
+            failure in the SAME cycle as the reminder-phase failure this
+            event already reports (`SyncOutcome.phase_errors`) had no
+            route to the UI at all on the failed path, only the
+            succeeded-reminder-phase path (`SyncCompleted`). Typed
+            ``object`` to keep this event module free of a
+            service-layer import, same as ``SyncCompleted.outcome``.
     """
 
-    def __init__(self, owner_id: str, error: str) -> None:
+    def __init__(
+        self, owner_id: str, error: str, outcome: object | None = None
+    ) -> None:
         super().__init__()
         self.owner_id = owner_id
         self.error = error
+        self.outcome = outcome

--- a/tldw_chatbook/Scheduling/events.py
+++ b/tldw_chatbook/Scheduling/events.py
@@ -287,6 +287,26 @@ class SyncCompleted(Message):
         self.outcome = outcome
 
 
+class ReminderDispatched(Message):
+    """Posted (to the App) after the scheduler loop dispatches a reminder.
+
+    UAT finding 3a: nothing outside the workbench's own user-initiated
+    actions ever re-read the DB while the screen was open, so a fired
+    reminder kept painting "Waiting" until the next 60s ticker or a
+    navigation away and back. `SchedulerLoop` has no route to a screen
+    (it is UI-agnostic by design), so it fires this through the app
+    (`TldwCli.on_reminder_dispatched`), which relays it to the
+    `SchedulesWorkbench` if one is currently mounted. Carries only the
+    task id, informational only for now -- the handler does a full
+    `_request_tasks_refresh()` rather than a targeted repaint, since a
+    fired one-time reminder's bucket/next-run text both change together.
+    """
+
+    def __init__(self, task_id: str) -> None:
+        super().__init__()
+        self.task_id = task_id
+
+
 class SyncFailed(Message):
     """Posted when a sync attempt fails.
 

--- a/tldw_chatbook/Scheduling/scheduler/loop.py
+++ b/tldw_chatbook/Scheduling/scheduler/loop.py
@@ -82,10 +82,23 @@ class SchedulerLoop:
         handler_timeout_seconds: float | None = HANDLER_TIMEOUT_SECONDS,
         heartbeat_path: Path | None = None,
         emergency_stop_path: Path | None = None,
+        on_reminder_dispatched: Callable[[str], None] | None = None,
     ) -> None:
         self.db = db
         self.handlers = handlers
         self.poll_interval = poll_interval
+        # UAT finding 3a: the only route from "a reminder just fired" to
+        # "the workbench's row repaints" -- `mark_reminder_dispatched`
+        # below is where the row's own fired/enabled/next_run_at state
+        # actually changes, so this fires AFTER that write, on both the
+        # handler-succeeded and handler-failed branches (both call it).
+        # Posting from `ReminderHandler.handle` instead (which also has
+        # an `app_getter`) would race the DB write: that call returns
+        # before `mark_reminder_dispatched` runs, so a UI refresh
+        # triggered there could reload the pre-fire row. Guarded the same
+        # way `on_queue_changed` is guarded elsewhere in this package --
+        # a broken callback must never fail a dispatch.
+        self.on_reminder_dispatched = on_reminder_dispatched
         # TASK-26025: durable liveness. None uses the default user-data
         # path; injectable for tests. last_success/error persist across
         # ticks so a stalled loop's last state is inspectable.
@@ -676,6 +689,7 @@ class SchedulerLoop:
                     False,
                     grace_seconds=self.missed_fire_grace_seconds,
                 )
+                self._notify_reminder_dispatched(task_id)
             return False
 
         await self._finish_run_ledger(
@@ -693,7 +707,33 @@ class SchedulerLoop:
                 grace_seconds=self.missed_fire_grace_seconds,
                 timed_out=timed_out,
             )
+            self._notify_reminder_dispatched(task_id)
         return not timed_out
+
+    def _notify_reminder_dispatched(self, task_id: Any) -> None:
+        """Tell the app a reminder's row just changed (finding 3a).
+
+        Called once `mark_reminder_dispatched` has actually committed, on
+        both the success/timed-out and handler-failed paths -- either
+        one can flip the row's bucket (fired, or still armed for retry).
+        Never allowed to fail the dispatch: same tolerance
+        `SchedulingService.on_queue_changed` already applies to its own
+        callback. `getattr` (not `self.on_reminder_dispatched` directly):
+        several existing tests build a `SchedulerLoop` via
+        `SchedulerLoop.__new__(...)` and hand-set only the attributes
+        they need, bypassing `__init__` entirely -- this must not raise
+        `AttributeError` for those.
+        """
+        callback = getattr(self, "on_reminder_dispatched", None)
+        if callback is None:
+            return
+        try:
+            callback(task_id)
+        except Exception:  # noqa: BLE001 -- a broken callback must not break dispatch
+            logger.exception(
+                "on_reminder_dispatched callback failed for task {task_id}",
+                task_id=task_id,
+            )
 
     async def _begin_run_ledger(
         self, task: dict[str, Any], task_type: str, task_id: Any, now: datetime

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -361,6 +361,52 @@ class SchedulingService:
         #: the periodic ~30-minute reload (task-18937). Kept optional and
         #: exception-guarded: a broken callback must never fail the mutation.
         self.on_queue_changed = on_queue_changed
+        #: task-3 (schedules UAT remediation ruling 4): whether the last
+        #: `refresh_server_reachability` probe actually reached the
+        #: configured server. Defaults `False` -- "until a probe has
+        #: succeeded, the option must not be offered" (root-causes.md #5)
+        #: -- so a fresh service never asserts a server is usable before
+        #: anything has confirmed it. `_server_available`/`transfer_
+        #: refusal` read this instead of merely checking that a client
+        #: object was constructed (the bug root-causes.md #5 found: none
+        #: of the old checks ever contacted anything).
+        self._server_reachable = False
+
+    async def refresh_server_reachability(self) -> bool:
+        """Probe the configured server for actual reachability.
+
+        task-3 (schedules UAT remediation ruling 4): reuses the
+        capabilities handshake's own round trip (`SchedulingServerClient.
+        get_capabilities`, ruling 5) as the reachability probe rather than
+        a second one -- any response (capabilities present OR a clean
+        "route absent" answer) proves the server is actually there; only
+        an exception (timeout, connection refused, 5xx, or no client
+        configured at all) means it is not. Cheap to call repeatedly: the
+        underlying probe is itself cached per connection, so this mostly
+        just re-reads that cache except right after a reconnect.
+
+        Returns:
+            The freshly probed reachability, also cached on ``self`` for
+            `_server_available`/`transfer_refusal` (sync callers) to read.
+        """
+        if (
+            self.server_client is None
+            or getattr(self.server_client, "notifications_service", None) is None
+        ):
+            self._server_reachable = False
+            return False
+        try:
+            await self.server_client.get_capabilities()
+        except Exception:  # noqa: BLE001
+            self._server_reachable = False
+            return False
+        self._server_reachable = True
+        return True
+
+    @property
+    def server_reachable(self) -> bool:
+        """The last `refresh_server_reachability` probe's answer."""
+        return self._server_reachable
 
     def _notify_queue_changed(self) -> None:
         """Invoke the queue-changed callback, tolerating a broken one.
@@ -1114,6 +1160,15 @@ class SchedulingService:
             or getattr(self.server_client, "notifications_service", None) is None
         ):
             return "No server connection is configured."
+        # task-3 (schedules UAT remediation ruling 4): the check above is
+        # CONFIGUREDNESS, not connectivity -- it passes for any
+        # syntactically valid server profile whether or not anything ever
+        # answered it (root-causes.md #5's exact bug). `server_reachable`
+        # is the actual probe's answer (`refresh_server_reachability`);
+        # a configured-but-unreachable server gets its OWN reason, distinct
+        # from "not configured at all" (ruling 4's UX-grammar note).
+        if not self.server_reachable:
+            return "The configured server is not reachable right now."
 
         owner_id = str(row.get("owner_id") or "")
         if direction == "to_server":

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -363,14 +363,24 @@ class SchedulingService:
         self.on_queue_changed = on_queue_changed
         #: task-3 (schedules UAT remediation ruling 4): whether the last
         #: `refresh_server_reachability` probe actually reached the
-        #: configured server. Defaults `False` -- "until a probe has
-        #: succeeded, the option must not be offered" (root-causes.md #5)
-        #: -- so a fresh service never asserts a server is usable before
-        #: anything has confirmed it. `_server_available`/`transfer_
-        #: refusal` read this instead of merely checking that a client
-        #: object was constructed (the bug root-causes.md #5 found: none
-        #: of the old checks ever contacted anything).
-        self._server_reachable = False
+        #: configured server. Tri-state: `None` (never probed yet) is
+        #: NOT the same as `False` (a probe ran and failed) -- final
+        #: review finding 2: the workbench header used to read the old
+        #: two-state default (`False`) as "confirmed unreachable" during
+        #: the on-mount probe's still-pending window and asserted a
+        #: negative network fact nothing had established, the same class
+        #: of dishonesty ruling 4 targeted, inverted. `_server_available`
+        #: (`bool(...)`-wrapped, so `None` still reads as unavailable --
+        #: "until a probe has succeeded, the option must not be offered",
+        #: root-causes.md #5) and `transfer_refusal` both still refuse on
+        #: anything falsy; only the HEADER'S DISPLAY COPY needs to tell
+        #: "haven't checked" apart from "checked and failed".
+        self._server_reachable: bool | None = None
+        #: Whether the LAST `refresh_server_reachability` probe hit a
+        #: policy denial or a genuine 401/403 from the server -- final
+        #: review finding 7: distinct from `server_reachable` itself, so
+        #: a caller can say "permission denied", not "not reachable".
+        self._server_permission_denied = False
 
     async def refresh_server_reachability(self) -> bool:
         """Probe the configured server for actual reachability.
@@ -385,6 +395,21 @@ class SchedulingService:
         underlying probe is itself cached per connection, so this mostly
         just re-reads that cache except right after a reconnect.
 
+        Final review finding 7: `get_capabilities` is `_enforce`-gated on
+        the AUTOMATIONS list permission (`scheduler.automations.list.
+        server`), a permission unrelated to reminder transfer -- treating
+        a `ServerClientPolicyError` (a local runtime-policy gate refusing
+        BEFORE any network attempt) or a `ServerClientValidationError`
+        that is really a 401/403 (the server responded and refused,
+        which is itself proof of reachability, not evidence against it)
+        as "unreachable" conflated a permission problem with a network
+        one, and additionally blocked an unrelated feature on a
+        permission gate that has nothing to do with it. Neither branch
+        establishes anything new about the network, so `server_
+        reachable` is left AT WHATEVER IT ALREADY WAS rather than
+        overwritten to `False` -- `server_permission_denied` records the
+        distinct signal for honest, separate copy.
+
         Returns:
             The freshly probed reachability, also cached on ``self`` for
             `_server_available`/`transfer_refusal` (sync callers) to read.
@@ -394,19 +419,34 @@ class SchedulingService:
             or getattr(self.server_client, "notifications_service", None) is None
         ):
             self._server_reachable = False
+            self._server_permission_denied = False
             return False
         try:
             await self.server_client.get_capabilities()
+        except (ServerClientPolicyError, ServerClientValidationError):
+            self._server_permission_denied = True
+            return bool(self._server_reachable)
         except Exception:  # noqa: BLE001
             self._server_reachable = False
+            self._server_permission_denied = False
             return False
         self._server_reachable = True
+        self._server_permission_denied = False
         return True
 
     @property
-    def server_reachable(self) -> bool:
-        """The last `refresh_server_reachability` probe's answer."""
+    def server_reachable(self) -> bool | None:
+        """The last `refresh_server_reachability` probe's answer, or
+        `None` when no probe has run yet (final review finding 2)."""
         return self._server_reachable
+
+    @property
+    def server_permission_denied(self) -> bool:
+        """Whether the last `refresh_server_reachability` probe hit a
+        policy denial or a 401/403 (final review finding 7) -- read this
+        BEFORE treating a falsy `server_reachable` as "not reachable";
+        when this is `True` the honest copy names permissions instead."""
+        return self._server_permission_denied
 
     def _notify_queue_changed(self) -> None:
         """Invoke the queue-changed callback, tolerating a broken one.
@@ -1168,6 +1208,16 @@ class SchedulingService:
         # a configured-but-unreachable server gets its OWN reason, distinct
         # from "not configured at all" (ruling 4's UX-grammar note).
         if not self.server_reachable:
+            # Final review finding 7: a policy denial / 401 / 403 on the
+            # reachability probe is a PERMISSION problem, not a network
+            # one -- the copy must not tell the user "not reachable" when
+            # the server (or the local policy gate) is right there and
+            # simply refused this specific request.
+            if self.server_permission_denied:
+                return (
+                    "Permission denied while checking the server -- ask "
+                    "an admin about the automations permission."
+                )
             return "The configured server is not reachable right now."
 
         owner_id = str(row.get("owner_id") or "")

--- a/tldw_chatbook/Scheduling/services/scheduling_service.py
+++ b/tldw_chatbook/Scheduling/services/scheduling_service.py
@@ -388,27 +388,36 @@ class SchedulingService:
         task-3 (schedules UAT remediation ruling 4): reuses the
         capabilities handshake's own round trip (`SchedulingServerClient.
         get_capabilities`, ruling 5) as the reachability probe rather than
-        a second one -- any response (capabilities present OR a clean
-        "route absent" answer) proves the server is actually there; only
-        an exception (timeout, connection refused, 5xx, or no client
-        configured at all) means it is not. Cheap to call repeatedly: the
-        underlying probe is itself cached per connection, so this mostly
-        just re-reads that cache except right after a reconnect.
+        a second one -- any response (capabilities present, a clean
+        "route absent" answer, OR a 4xx refusal) proves the server is
+        actually there; only an exception that never got an HTTP answer
+        at all (timeout, connection refused, 5xx, or no client configured)
+        means it is not. The probe always bypasses the capabilities cache
+        (`force=True`) so a server that dies after an earlier successful
+        probe is caught on the next explicit check instead of answering
+        forever from a stale cached verdict (Qodo fix round, finding 1
+        pin (a)).
 
-        Final review finding 7: `get_capabilities` is `_enforce`-gated on
-        the AUTOMATIONS list permission (`scheduler.automations.list.
-        server`), a permission unrelated to reminder transfer -- treating
-        a `ServerClientPolicyError` (a local runtime-policy gate refusing
-        BEFORE any network attempt) or a `ServerClientValidationError`
-        that is really a 401/403 (the server responded and refused,
-        which is itself proof of reachability, not evidence against it)
-        as "unreachable" conflated a permission problem with a network
-        one, and additionally blocked an unrelated feature on a
-        permission gate that has nothing to do with it. Neither branch
-        establishes anything new about the network, so `server_
-        reachable` is left AT WHATEVER IT ALREADY WAS rather than
-        overwritten to `False` -- `server_permission_denied` records the
-        distinct signal for honest, separate copy.
+        Qodo fix round (finding 1, HIGH -- ruling reversal over the prior
+        "final review finding 7" text below): `get_capabilities` is
+        `_enforce`-gated on the AUTOMATIONS list permission (`scheduler.
+        automations.list.server`), a permission unrelated to reminder
+        transfer. Two distinct failure shapes hit this gate differently:
+
+        * `ServerClientPolicyError` -- a local runtime-policy gate that
+          refuses BEFORE any network attempt. No round trip happened, so
+          this establishes nothing new either way; `server_reachable` is
+          left AT WHATEVER IT ALREADY WAS.
+        * `ServerClientValidationError` (a genuine 401/403/4xx) -- the
+          server ACTUALLY ANSWERED and refused. That answer IS proof of
+          network reachability (a reminder transfer needs no
+          automations-list permission at all -- the scenario that
+          reversed this call), so `server_reachable` is set `True`
+          outright, even overriding a prior `False`/`None` (pin (b)).
+
+        Either way `server_permission_denied` records the distinct
+        signal, so per-action copy can refuse with permission wording
+        instead of misreporting "server not reachable".
 
         Returns:
             The freshly probed reachability, also cached on ``self`` for
@@ -422,10 +431,14 @@ class SchedulingService:
             self._server_permission_denied = False
             return False
         try:
-            await self.server_client.get_capabilities()
-        except (ServerClientPolicyError, ServerClientValidationError):
+            await self.server_client.get_capabilities(force=True)
+        except ServerClientPolicyError:
             self._server_permission_denied = True
             return bool(self._server_reachable)
+        except ServerClientValidationError:
+            self._server_reachable = True
+            self._server_permission_denied = True
+            return True
         except Exception:  # noqa: BLE001
             self._server_reachable = False
             self._server_permission_denied = False

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -105,7 +105,7 @@ class SchedulingServerClient:
         # across it (task-3 handshake caching discipline).
         self._capabilities_cache = _CAPABILITIES_UNSET
 
-    async def get_capabilities(self) -> dict[str, Any] | None:
+    async def get_capabilities(self, *, force: bool = False) -> dict[str, Any] | None:
         """Probe Scheduled Tasks automation capabilities, cached per connection.
 
         task-3 (schedules UAT remediation ruling 5) capabilities handshake
@@ -119,6 +119,21 @@ class SchedulingServerClient:
         connection (reset by `set_notifications_service`), so repeated
         callers (every sync cycle) don't re-probe.
 
+        Qodo fix round (finding 1, HIGH): the cache is permanent for the
+        life of a connection, which is right for affordance-gating reads
+        but wrong for an explicit reachability probe -- a server that
+        died after a successful first probe would otherwise answer every
+        later probe from the stale cached verdict forever. ``force=True``
+        bypasses the cache READ (still writing a successful result back
+        to it, so ordinary callers keep benefiting) so
+        `SchedulingService.refresh_server_reachability` always makes a
+        real network attempt.
+
+        Args:
+            force: Skip the cached verdict and re-probe the server. Used
+                by explicit reachability checks; affordance-gating reads
+                should leave this ``False``.
+
         Returns:
             The parsed capabilities dict once fetched successfully (cached
             from then on), or ``None`` when the server does not expose the
@@ -130,7 +145,7 @@ class SchedulingServerClient:
             class) -- a blip must never be permanently misread as "this
             server is too old".
         """
-        if self._capabilities_cache is not _CAPABILITIES_UNSET:
+        if not force and self._capabilities_cache is not _CAPABILITIES_UNSET:
             return self._capabilities_cache  # type: ignore[return-value]
         try:
             result = await self._call_with_retry(

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -109,10 +109,15 @@ class SchedulingServerClient:
         """Probe Scheduled Tasks automation capabilities, cached per connection.
 
         task-3 (schedules UAT remediation ruling 5) capabilities handshake
-        -- mirrors `client.py`'s `/sync/capabilities` probe-and-cache shape
-        (`get_sync_v2_capabilities`). Fetched at most once per connection
-        (reset by `set_notifications_service`), so repeated callers (every
-        sync cycle) don't re-probe.
+        -- the PROBE construction mirrors `client.py`'s `/sync/
+        capabilities` route (`get_sync_v2_capabilities`), but that method
+        itself does not cache (it's a plain probe, called fresh each time
+        by `Sync_Interop/server_sync_service.py`). The per-connection
+        CACHING shape here instead mirrors `Prompt_Management/prompt_
+        scope_service.py`'s `_server_capabilities_cache` (fix round 1,
+        finding 3 -- corrected citation): fetched at most once per
+        connection (reset by `set_notifications_service`), so repeated
+        callers (every sync cycle) don't re-probe.
 
         Returns:
             The parsed capabilities dict once fetched successfully (cached

--- a/tldw_chatbook/Scheduling/services/server_client.py
+++ b/tldw_chatbook/Scheduling/services/server_client.py
@@ -58,6 +58,12 @@ class ServerClientConfig:
     retry_delay: float = 1.0
 
 
+#: Sentinel distinguishing "capabilities never probed this connection"
+#: from a probed-and-absent (``None``) result -- `get_capabilities`'s
+#: caching discipline (task-3, schedules UAT remediation ruling 5).
+_CAPABILITIES_UNSET = object()
+
+
 class SchedulingServerClient:
     """Async client that delegates scheduling operations to a notifications service.
 
@@ -82,6 +88,9 @@ class SchedulingServerClient:
         """
         self.notifications_service = notifications_service
         self.config = config or ServerClientConfig()
+        self._capabilities_cache: dict[str, Any] | None | object = (
+            _CAPABILITIES_UNSET
+        )
 
     def set_notifications_service(self, notifications_service: Any | None) -> None:
         """Inject or refresh the underlying notifications service.
@@ -91,6 +100,42 @@ class SchedulingServerClient:
                 operations, or ``None`` to disconnect the server.
         """
         self.notifications_service = notifications_service
+        # A reconnect (or a switch to a different server) may answer the
+        # capabilities probe differently -- never carry a stale verdict
+        # across it (task-3 handshake caching discipline).
+        self._capabilities_cache = _CAPABILITIES_UNSET
+
+    async def get_capabilities(self) -> dict[str, Any] | None:
+        """Probe Scheduled Tasks automation capabilities, cached per connection.
+
+        task-3 (schedules UAT remediation ruling 5) capabilities handshake
+        -- mirrors `client.py`'s `/sync/capabilities` probe-and-cache shape
+        (`get_sync_v2_capabilities`). Fetched at most once per connection
+        (reset by `set_notifications_service`), so repeated callers (every
+        sync cycle) don't re-probe.
+
+        Returns:
+            The parsed capabilities dict once fetched successfully (cached
+            from then on), or ``None`` when the server does not expose the
+            capabilities route at all -- a server old enough to predate
+            Scheduled Tasks automation entirely, degraded honestly here
+            instead of raised (root-causes.md #7). A transient failure
+            (timeout/5xx/other) is deliberately NOT cached and re-raises
+            (same error-mapping contract as every other method on this
+            class) -- a blip must never be permanently misread as "this
+            server is too old".
+        """
+        if self._capabilities_cache is not _CAPABILITIES_UNSET:
+            return self._capabilities_cache  # type: ignore[return-value]
+        try:
+            result = await self._call_with_retry(
+                "get_scheduled_automation_capabilities", is_read=True
+            )
+        except ServerClientNotFoundError:
+            self._capabilities_cache = None
+            return None
+        self._capabilities_cache = result
+        return result
 
     @staticmethod
     def _strip_local_only_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -63,6 +63,17 @@ _SYNC_MAX_PAGES = 4
 #: them (final review I4).
 _TRANSFER_ACTIONS = ("transfer_to_server", "release_from_server")
 
+#: `_push_definition_mutation`'s outcome vocabulary that means "a mutation
+#: actually reached the server this cycle" (UAT finding 3c) -- everything
+#: else (`invalid`/`orphaned`/`unsynced`/`transfer_skipped`/
+#: `transfer_cas_skipped`/`transfer_failed`/`transfer_orphaned`/
+#: `unknown`/`{action}_not_found`) settled without a real push. Read by
+#: `_replay_definition_mutations`, the only other writer of
+#: `last_push_at` besides `_sync_reminders`'s own reminder-scoped one.
+_DEFINITION_PUSH_SUCCESS_OUTCOMES = frozenset(
+    {"created", "updated", "released", "transferred", "pause", "resume", "archive"}
+)
+
 
 @dataclass(frozen=True)
 class SyncOutcome:
@@ -81,12 +92,26 @@ class SyncOutcome:
       pulled or pushed; not an error.
     - ``error``: the attempt failed. ``error`` carries the message that
       was also recorded as a persisted sync error.
+
+    ``status``/``error`` describe ONLY the reminder phase (`_sync_
+    reminders`) -- the automation phases (review pushback, definition
+    push, definitions pull, results pull) are independently contained by
+    `_run_phase` and run regardless of the reminder phase's own outcome.
+    UAT finding 3c: `sync_now` used to collapse any later phase's error
+    into `status="error"` + `error=phase_errors[0]`, so a cycle whose
+    definition push succeeded still toasted "Sync failed" over an
+    unrelated results-pull 404. ``phase_errors`` carries those phases'
+    own LABELED failures (e.g. ``"Automation results pull: ..."``)
+    instead, so a caller can report the reminder outcome honestly *and*
+    surface the rest as its own notice -- never silently dropped, never
+    misreported as the whole cycle failing.
     """
 
     status: str
     pulled: int = 0
     pushed: int = 0
     error: str | None = None
+    phase_errors: tuple[str, ...] = ()
 
 
 def now_utc_iso() -> str:
@@ -223,7 +248,7 @@ class SyncEngine:
             target_owner, "Automation review pushback", self._replay_review_mutations
         )
         if error:
-            phase_errors.append(error)
+            phase_errors.append(f"Automation review pushback: {error}")
         if pushed_review_ids:
             logger.info(
                 f"Automation review pushback for {target_owner}: "
@@ -248,7 +273,7 @@ class SyncEngine:
             self._replay_definition_mutations,
         )
         if error:
-            phase_errors.append(error)
+            phase_errors.append(f"Automation definition push: {error}")
         definition_push_counts, pushed_lifecycle_server_ids = (
             definition_push_result
             if definition_push_result is not None
@@ -271,7 +296,7 @@ class SyncEngine:
             skip_lifecycle_server_ids=pushed_lifecycle_server_ids,
         )
         if error:
-            phase_errors.append(error)
+            phase_errors.append(f"Automation definitions pull: {error}")
         if counts:
             logger.info(f"Automation definitions pull for {target_owner}: {counts}")
 
@@ -282,7 +307,7 @@ class SyncEngine:
             skip_review_server_ids=skip_review_server_ids,
         )
         if error:
-            phase_errors.append(error)
+            phase_errors.append(f"Automation results pull: {error}")
         if counts:
             logger.info(f"Automation results pull for {target_owner}: {counts}")
 
@@ -301,8 +326,15 @@ class SyncEngine:
         # already carries its own message and is left alone. Results/
         # definitions already pulled by an earlier phase this round are
         # not rolled back.
-        if reminder_outcome.status in ("ok", "not_applicable") and phase_errors:
-            return replace(reminder_outcome, status="error", error=phase_errors[0])
+        #
+        # UAT finding 3c: this used to collapse ANY later-phase error into
+        # `status="error"` (masking a genuinely successful reminder/
+        # definition-push phase behind "Sync failed"). `status`/`error`
+        # now describe ONLY the reminder phase; `phase_errors` carries
+        # the labeled rest so a caller can report both honestly instead
+        # of picking one truth to tell.
+        if phase_errors:
+            return replace(reminder_outcome, phase_errors=tuple(phase_errors))
 
         return reminder_outcome
 
@@ -603,6 +635,17 @@ class SyncEngine:
                 and server_definition_id
             ):
                 pushed_lifecycle_server_ids.add(server_definition_id)
+        if any(outcome in _DEFINITION_PUSH_SUCCESS_OUTCOMES for outcome in counts):
+            # UAT finding 3c: `_sync_reminders` is the ONLY existing
+            # `last_push_at` writer, and only for its own reminder
+            # pushes -- a definition edit/lifecycle push (with nothing
+            # on the reminder side this cycle) left the header showing
+            # "Last push: -" forever. Direct call, not
+            # `asyncio.to_thread`, matching every other `self.db.*` call
+            # in this method. Only stamped on a genuine push (not
+            # `invalid`/`unsynced`/`transfer_skipped`/etc.) so an
+            # all-noop cycle can never move it.
+            self.db.update_sync_state(owner_id, last_push_at=now_utc_iso())
         return counts, frozenset(pushed_lifecycle_server_ids)
 
     async def _push_definition_mutation(self, mutation: dict, owner_id: str) -> str:

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -170,7 +170,9 @@ class SyncEngine:
         self.server_client = server_client
         self.owner_id = owner_id
 
-    def _settle_orphaned_transfer_mutations(self, target_owner: str) -> None:
+    def _settle_orphaned_transfer_mutations(
+        self, target_owner: str | None
+    ) -> None:
         """Settle a `transfer_to_server` mutation whose scope no longer
         matches the active server (task-3, root-causes.md #5 / ruling 4).
 
@@ -187,6 +189,18 @@ class SyncEngine:
         per-primitive exception-guarded shape, run once per sync cycle
         (not startup-only) so a mid-session reconfiguration settles on
         the very next sync rather than waiting for a restart.
+
+        `target_owner=None` (final review finding 1): the workbench's
+        mount/refresh path also calls this directly -- pure local DB
+        work, so it must run even when NO server is configured/reachable
+        at all, the UAT's actual "removed the server / it went down"
+        core symptom that gating this behind a live `sync_now()` (which
+        `action_sync_now`/the mount-time probe both refuse without a
+        reachable server) never reaches. `None` never equals a real
+        `mutation_owner` string, so every still-pending transfer_to_
+        server mutation is correctly swept as orphaned when nothing is
+        configured -- exactly right, since there is no server left it
+        could still be valid for.
 
         Only a still-unattempted mutation (`to_server_pending`) is
         touched -- an ambiguous `to_server_sent` row belongs to

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -74,6 +74,31 @@ _DEFINITION_PUSH_SUCCESS_OUTCOMES = frozenset(
     {"created", "updated", "released", "transferred", "pause", "resume", "archive"}
 )
 
+#: Review round 1 finding 2: the complement of the set above, so a
+#: drift-guard test can assert every outcome `_push_definition_mutation`
+#: (+ its five `_push_definition_*` helpers, + `_replay_definition_
+#: mutations`'s own `"transfer_skipped"`) can actually return is
+#: CLASSIFIED as one or the other -- an unclassified new outcome fails
+#: that test instead of silently never moving `last_push_at`.
+#: `{action}_not_found` is `_push_definition_lifecycle`'s dynamic
+#: NotFoundError outcome (`action` is always one of the three lifecycle
+#: actions below).
+_DEFINITION_PUSH_NON_SUCCESS_OUTCOMES = frozenset(
+    {
+        "unknown",
+        "invalid",
+        "orphaned",
+        "unsynced",
+        "transfer_cas_skipped",
+        "transfer_orphaned",
+        "transfer_failed",
+        "transfer_skipped",
+        "pause_not_found",
+        "resume_not_found",
+        "archive_not_found",
+    }
+)
+
 
 @dataclass(frozen=True)
 class SyncOutcome:

--- a/tldw_chatbook/Scheduling/services/sync_engine.py
+++ b/tldw_chatbook/Scheduling/services/sync_engine.py
@@ -170,12 +170,91 @@ class SyncEngine:
         self.server_client = server_client
         self.owner_id = owner_id
 
+    def _settle_orphaned_transfer_mutations(self, target_owner: str) -> None:
+        """Settle a `transfer_to_server` mutation whose scope no longer
+        matches the active server (task-3, root-causes.md #5 / ruling 4).
+
+        `_network_phase`'s mutation query is deliberately scoped to
+        `target_owner` (`get_pending_mutations(target_owner, ...)`), so a
+        mutation recorded under a PRIOR server scope -- the configured
+        server's address changed underneath it -- is never selected,
+        never attempted, and the row hangs `to_server_pending` forever
+        with no route to Retry/Cancel (the UAT's permanent "Moving to
+        server..."). This is the one place that looks ACROSS every owner
+        scope (`get_pending_mutations(owner_id=None, ...)`, the same
+        all-owners mode `cancel_transfer`'s own lookup already relies on)
+        to find one -- mirrors `recover_inflight_transfers`'s per-row,
+        per-primitive exception-guarded shape, run once per sync cycle
+        (not startup-only) so a mid-session reconfiguration settles on
+        the very next sync rather than waiting for a restart.
+
+        Only a still-unattempted mutation (`to_server_pending`) is
+        touched -- an ambiguous `to_server_sent` row belongs to
+        `recover_inflight_transfers`, not this sweep (same division of
+        labor that method's own docstring draws for other stuck states).
+        The CAS's own `expected=` guard makes the read-and-write atomic;
+        no separate row fetch is needed first.
+        """
+        for primitive in (_REMINDER_PRIMITIVE, _DEFINITION_PRIMITIVE):
+            try:
+                mutations = self.db.get_pending_mutations(
+                    owner_id=None, primitive=primitive
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    f"Orphaned-transfer sweep failed to list mutations "
+                    f"for {primitive}"
+                )
+                continue
+            for mutation in mutations:
+                payload = mutation.get("payload") or {}
+                if payload.get("action") != "transfer_to_server":
+                    continue
+                if payload.get("transfer_errors"):
+                    continue  # already settled
+                mutation_owner = mutation.get("owner_id")
+                if mutation_owner == target_owner:
+                    continue  # still valid for the active server
+                local_id = mutation.get("local_id")
+                try:
+                    settled = self.db.set_transfer_state(
+                        primitive,
+                        local_id,
+                        "to_server_failed",
+                        expected=("to_server_pending",),
+                        pending_mutation={
+                            "primitive": primitive,
+                            "owner_id": mutation_owner,
+                            "payload": {
+                                **payload,
+                                "transfer_errors": [
+                                    "The server this move was queued for "
+                                    "is no longer configured."
+                                ],
+                            },
+                        },
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        f"Failed to settle orphaned transfer mutation for "
+                        f"{primitive} {local_id}"
+                    )
+                    continue
+                if settled:
+                    logger.warning(
+                        f"Orphaned transfer_to_server mutation settled to "
+                        f"to_server_failed for {primitive} {local_id} "
+                        f"(queued for {mutation_owner!r}; active server "
+                        f"is {target_owner!r})"
+                    )
+
     async def pull(self, owner_id: str | None = None) -> None:
         """Public entry point to pull server reminders for the given owner."""
         target_owner = owner_id if owner_id is not None else self.owner_id
         if self.server_client is None:
             return
 
+        self._settle_orphaned_transfer_mutations(target_owner)
         await self._pull_reminders(target_owner)
 
         # Automation mirrors run regardless of reminder-phase health (review
@@ -257,6 +336,7 @@ class SyncEngine:
         if self.server_client is None:
             return SyncOutcome("not_applicable")
 
+        self._settle_orphaned_transfer_mutations(target_owner)
         reminder_outcome = await self._sync_reminders(target_owner)
 
         # Automation mirrors, appended after the reminder phase (task 4) and
@@ -389,6 +469,28 @@ class SyncEngine:
 
         try:
             with self.db.transaction() as conn:
+                # UAT finding 4 / root-causes.md #4 (ghost row): `_network_
+                # phase` pulls BEFORE it pushes, so a reminder released THIS
+                # cycle is still listed in `pulled_items` from the
+                # pre-release snapshot. Applying that stale item would
+                # re-insert the mirror `_push_reminder_release` just tore
+                # down, with a brand-new local id no tombstone can remove --
+                # it then reads as "deleted on server" forever. Exact twin
+                # of the `adopted_server_id` seen-set guard below (this
+                # method, further down): filter what this cycle just
+                # released out of the stale payload before applying it.
+                released_server_ids = {
+                    outcome["released_server_id"]
+                    for outcome in staged_outcomes
+                    if outcome.get("released_server_id")
+                }
+                if released_server_ids:
+                    pulled_items = [
+                        item
+                        for item in pulled_items
+                        if item.get("id") not in released_server_ids
+                    ]
+
                 # Ensure pulled items have safe defaults before the DB helper
                 # copies fields verbatim.
                 for item in pulled_items:
@@ -1211,6 +1313,30 @@ class SyncEngine:
         )
         self.db.delete_pending_mutation(mutation_id)
 
+    async def _automation_capabilities_available(self) -> bool:
+        """Whether the server still exposes Scheduled Tasks automation at all.
+
+        task-3 (schedules UAT remediation ruling 5) capabilities
+        handshake: `SchedulingServerClient.get_capabilities` returns
+        ``None`` only for a definitive "the capabilities route itself
+        does not exist" answer (a server old enough to predate Scheduled
+        Tasks automation entirely) -- that is the ONE case this returns
+        ``False`` for, so `_pull_definitions`/`_pull_results` can skip
+        outright rather than let every page 404 (root-causes.md #7).
+        Fails OPEN on any other outcome (a transient probe failure must
+        not silently stop pulling automations that otherwise work fine --
+        the per-call `ServerClientNotFoundError` handling below is what
+        catches the narrower "capabilities exist, this ONE route doesn't
+        yet" case a probe alone cannot distinguish).
+        """
+        assert self.server_client is not None
+        try:
+            return await self.server_client.get_capabilities() is not None
+        except ServerClientError:
+            return True
+        except Exception:  # noqa: BLE001
+            return True
+
     async def _pull_definitions(
         self,
         owner_id: str,
@@ -1229,8 +1355,14 @@ class SyncEngine:
         forwarded unchanged to every page's upsert call -- see the design
         comment on
         `ScheduledTasksDB.upsert_automation_definitions_from_server`.
+
+        task-3 capabilities handshake: returns an empty (no-op) result
+        outright when the server does not expose Scheduled Tasks
+        automation at all, rather than paging into a guaranteed 404.
         """
         assert self.server_client is not None
+        if not await self._automation_capabilities_available():
+            return {}
         totals: dict[str, int] = {}
         offset = 0
         for _page_num in range(_SYNC_MAX_PAGES):
@@ -1271,14 +1403,34 @@ class SyncEngine:
         ``skip_review_server_ids`` (Task 5 same-cycle echo) is forwarded
         unchanged to every page's upsert call -- see the design comment on
         `ScheduledTasksDB.upsert_automation_results_from_server`.
+
+        task-3 capabilities handshake: returns an empty (no-op) result
+        outright when the server does not expose Scheduled Tasks
+        automation at all (rather than paging into a guaranteed 404). A
+        server whose capabilities probe DOES succeed but whose `/results`
+        route specifically is missing (root-causes.md #7's actual UAT
+        repro -- a mid-rollout server new enough for capabilities, too
+        old for the results-inbox surface) cannot be told apart by that
+        probe alone; the `ServerClientNotFoundError` below is what turns
+        THAT case into the same honest copy instead of a raw
+        ``scheduled_task_not_found`` poisoning the sync verdict (UAT
+        Minor 24 / Major 7).
         """
         assert self.server_client is not None
+        if not await self._automation_capabilities_available():
+            return {}
         totals: dict[str, int] = {}
         offset = 0
         for _page_num in range(_SYNC_MAX_PAGES):
-            response = await self.server_client.list_automation_results(
-                limit=_RESULTS_PAGE_SIZE, offset=offset
-            )
+            try:
+                response = await self.server_client.list_automation_results(
+                    limit=_RESULTS_PAGE_SIZE, offset=offset
+                )
+            except ServerClientNotFoundError as exc:
+                raise ServerClientNotFoundError(
+                    "This server does not provide the results inbox "
+                    "(server too old)."
+                ) from exc
             if not isinstance(response, dict):
                 response = {}
             page = list(response.get("items") or [])
@@ -1594,10 +1746,18 @@ class SyncEngine:
         genuine double execution. Deleting the mirror on the ack is what
         makes the ADR's "the mirror is torn down" claim true.
 
-        Returns a plain ``{"local_id": ...}`` outcome, same shape and same
-        reasoning as `_push_reminder_transfer`'s: this action does its own
-        DB writes immediately, so `_sync_reminders`'s batched apply has
-        nothing left to do with it.
+        Returns ``{"local_id": ..., "released_server_id": ...}`` once the
+        mirror is actually torn down (no ``server_id``/``delete_local``/
+        ``mutation_id`` keys, same shape family as `_push_reminder_transfer`'s
+        `adopted_server_id`): this action does its own DB writes
+        immediately, so `_sync_reminders`'s batched apply has nothing left
+        to do with it. ``released_server_id`` exists so `_sync_reminders`
+        can filter this cycle's already-stale `pulled_items` (`_network_
+        phase` pulls BEFORE it pushes) -- otherwise the pre-release pull
+        payload re-inserts the mirror this call just deleted, with a new
+        local id no tombstone can remove (root-causes.md #4 / UAT finding
+        4). Exact twin of `adopted_server_id`'s seen-set guard 12 lines
+        below `_sync_reminders`'s own apply call.
         """
         server_task_id = payload.get("server_task_id")
         local_copy_id = payload.get("local_copy_id")
@@ -1649,7 +1809,7 @@ class SyncEngine:
         self.db.delete_reminder_task(local_id)
         self.db.delete_sync_mapping(local_id, _REMINDER_PRIMITIVE, owner_id)
         self.db.delete_pending_mutation(mutation_id)
-        return {"local_id": local_id}
+        return {"local_id": local_id, "released_server_id": server_task_id}
 
     async def _push_tombstone(
         self, tombstone: dict, owner_id: str

--- a/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
@@ -43,9 +43,9 @@ from loguru import logger
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Vertical
+from textual.widgets import DataTable, Static
 
 from tldw_chatbook.Scheduling.services.server_client import ServerClientNotFoundError
-from textual.widgets import DataTable, Static
 
 
 @dataclass

--- a/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_audit_view.py
@@ -43,6 +43,8 @@ from loguru import logger
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Vertical
+
+from tldw_chatbook.Scheduling.services.server_client import ServerClientNotFoundError
 from textual.widgets import DataTable, Static
 
 
@@ -109,10 +111,39 @@ async def fetch_definition_audit(
         return DefinitionAuditFetch(
             notice_override="Run history needs a connected server."
         )
+    # task-3 (schedules UAT remediation ruling 5) capabilities handshake:
+    # a server that doesn't expose Scheduled Tasks automation at all
+    # can't have a run-history route either -- say so honestly instead of
+    # attempting a call guaranteed to 404 (root-causes.md #7). Fails open
+    # (attempts the call anyway) on a probe blip -- only a DEFINITIVE
+    # "capabilities route absent" answer short-circuits here.
+    try:
+        capabilities_absent = (
+            await server_client.get_capabilities() is None
+        )
+    except Exception:  # noqa: BLE001
+        capabilities_absent = False
+    if capabilities_absent:
+        return DefinitionAuditFetch(
+            notice_override=(
+                "This server does not support scheduled task automation "
+                "(server too old)."
+            )
+        )
     definition_id = str(definition.get("id") or "")
     try:
         response = await server_client.list_automation_definition_audit(
             definition_id
+        )
+    except ServerClientNotFoundError:
+        # The narrower case a capabilities probe alone can't predict: this
+        # server IS new enough to advertise capabilities but doesn't (yet)
+        # serve THIS route -- same honest family of copy, not a raw
+        # scheduled_task_not_found (UAT Minor 24).
+        return DefinitionAuditFetch(
+            notice_override=(
+                "This server does not provide run history (server too old)."
+            )
         )
     except Exception:  # noqa: BLE001
         logger.exception(

--- a/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/definition_detail.py
@@ -1159,6 +1159,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current_owner,
                     id=_RUNS_ON_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._model_row:
@@ -1182,6 +1183,7 @@ class DefinitionDetail(Vertical):
                     value=initial,
                     placeholder="provider/model — blank for auto",
                     id=_MODEL_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._generation_row:
@@ -1197,6 +1199,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current,
                     id=_GENERATION_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._finding_policy_row:
@@ -1212,6 +1215,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current,
                     id=_FINDING_POLICY_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._sources_row:
@@ -1224,6 +1228,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current,
                     id=_NOTIFICATIONS_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._repeat_row:
@@ -1240,6 +1245,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current_preset,
                     id=_REPEAT_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._at_row:
@@ -1260,7 +1266,12 @@ class DefinitionDetail(Vertical):
                 "2026-08-28 09:00" if field == "run_at" else DEFAULT_TIME_OF_DAY
             )
             row.begin_edit(
-                Input(value=initial, placeholder=placeholder, id=_AT_EDITOR_ID)
+                Input(
+                    value=initial,
+                    placeholder=placeholder,
+                    id=_AT_EDITOR_ID,
+                    compact=True,
+                )
             )
         elif row is self._timezone_row:
             schedule = (
@@ -1277,6 +1288,7 @@ class DefinitionDetail(Vertical):
                     allow_blank=False,
                     value=current_tz,
                     id=_TIMEZONE_EDITOR_ID,
+                    compact=True,
                 )
             )
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -127,6 +127,15 @@ QUEUE_FILTER_DEBOUNCE_SECONDS = 0.2
 #: not current, per the hidden-progress-clock rule (TASK-23022).
 NEXT_RUN_REFRESH_SECONDS = 60.0
 
+#: Cadence for the scheduler-liveness strip (UAT finding 3d). It used to
+#: be repainted only as a side effect of the 60s ticker above, so a
+#: 0-30s "last tick Ns ago" value was visibly static for up to a full
+#: minute between samples. `scheduler_liveness_line` is one JSON-file
+#: read plus a string compare -- cheap enough for its own faster,
+#: independent cadence. Also paused while the screen is not current
+#: (same rule, TASK-23022).
+SCHEDULER_LIVENESS_REFRESH_SECONDS = 5.0
+
 #: Defensive cap for the server definitions' follow-the-pages load -- the
 #: loop exists so the tail of a large definition list is never silently
 #: hidden, not to render unbounded rows.
@@ -437,6 +446,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._filter_text = ""
         self._filter_debounce_timer: Timer | None = None
         self._next_run_refresh_timer: Timer | None = None
+        self._liveness_refresh_timer: Timer | None = None
         # task-15476: the task id currently shown in the detail/inspector
         # panes, tracked independently of row index so a filter keystroke
         # can restore the same selection instead of always jumping to row 0.
@@ -724,6 +734,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._next_run_refresh_timer = self.set_interval(
             NEXT_RUN_REFRESH_SECONDS, self._refresh_next_run_rendering
         )
+        # UAT finding 3d: its own faster, independent cadence -- it used
+        # to be repainted only as a side effect of the timer above, so a
+        # 0-30s value was static for up to a full minute between samples.
+        self._liveness_refresh_timer = self.set_interval(
+            SCHEDULER_LIVENESS_REFRESH_SECONDS, self._refresh_scheduler_liveness
+        )
         self._request_tasks_refresh()
         self._refresh_scheduler_liveness()
         self._start_server_notification_observer()
@@ -1005,8 +1021,10 @@ class SchedulesWorkbench(BaseAppScreen):
     def _refresh_next_run_rendering(self) -> None:
         """Re-render the queue so relative next-run text stays honest.
 
-        Also refreshes the scheduler-liveness line (TASK-26025) so a loop
-        that dies while the screen is open turns visibly stale.
+        UAT finding 3d: the scheduler-liveness line used to be refreshed
+        only as a side effect of this 60s ticker -- it now has its own
+        faster `_liveness_refresh_timer` (started alongside this one in
+        `on_mount`), so this method no longer touches it.
 
         Skips unless this screen is the top of the stack. (Textual's
         ``is_current`` also counts screens behind the top one --
@@ -1019,9 +1037,6 @@ class SchedulesWorkbench(BaseAppScreen):
         """
         if self.app.screen is not self:
             return
-        # TASK-26025: refresh liveness even on an empty queue -- a stall
-        # with nothing queued is exactly the case AC#2 must distinguish.
-        self._refresh_scheduler_liveness()
         # redesign PR-2, Task 2: `_visible_rows`, not the reminder-only
         # `_visible_tasks` -- a Queue showing only definition rows still
         # has relative next-run text that must not go stale.
@@ -1030,16 +1045,18 @@ class SchedulesWorkbench(BaseAppScreen):
         self._render_table(tick=True)
 
     def on_screen_suspend(self) -> None:
-        """Stop the relative-time refresh while another screen covers this.
+        """Stop the relative-time and liveness refreshes while covered.
 
         Hidden clocks must not tick unseen (TASK-23022); the resume
         handler refreshes immediately so no stale text is ever shown.
         """
         if self._next_run_refresh_timer is not None:
             self._next_run_refresh_timer.pause()
+        if self._liveness_refresh_timer is not None:
+            self._liveness_refresh_timer.pause()
 
     def on_screen_resume(self) -> None:
-        """Refresh relative times and restart the cadence when uncovered.
+        """Refresh relative times/liveness and restart both cadences.
 
         No ``super().on_screen_resume()``: Textual's dispatcher invokes
         every handler along the MRO for one event (see BaseAppScreen's
@@ -1047,7 +1064,13 @@ class SchedulesWorkbench(BaseAppScreen):
         """
         if self._next_run_refresh_timer is not None:
             self._next_run_refresh_timer.resume()
+        if self._liveness_refresh_timer is not None:
+            self._liveness_refresh_timer.resume()
         self._refresh_next_run_rendering()
+        # UAT finding 3d: `_refresh_next_run_rendering` no longer covers
+        # this (its own decoupled timer does) -- refresh it immediately
+        # on uncover too, same "no stale text is ever shown" rule.
+        self._refresh_scheduler_liveness()
         # redesign PR-4 task 5: the retired Queue-tab `TabActivated`
         # staleness consumer's new home -- see `_consume_definitions_stale`.
         self._consume_definitions_stale()
@@ -1168,6 +1191,13 @@ class SchedulesWorkbench(BaseAppScreen):
             await self._refresh_console_context()
             return
 
+        # UAT Major 5 (unpinned): names WHICH step raised, since a bare
+        # `logger.exception("Failed to load tasks")` covering three
+        # distinct calls (reminders listing, definitions listing, row
+        # build) left no way to pin the raiser without reproducing it
+        # live. Updated before each step so the except below always
+        # names the one in flight when it failed.
+        stage = "listing tasks"
         try:
             combined = await service.list_tasks(
                 owner_id=None, include_projections=False
@@ -1175,6 +1205,7 @@ class SchedulesWorkbench(BaseAppScreen):
             # Defensive, not load-bearing: `include_projections=False`
             # already guarantees every row is a `ReminderTask`.
             reminders = [task for task in combined if isinstance(task, ReminderTask)]
+            stage = "loading automation definitions"
             do_full_definitions_fetch = refresh_definitions or self._definitions_stale
             definitions = (
                 await self._load_queue_definitions(service)
@@ -1183,6 +1214,8 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             if do_full_definitions_fetch:
                 self._definitions_stale = False
+
+            stage = "building unified rows"
 
             def _build_rows() -> list[UnifiedRow]:
                 results = service.db.list_automation_results(
@@ -1196,24 +1229,28 @@ class SchedulesWorkbench(BaseAppScreen):
                 )
 
             all_rows = await asyncio.to_thread(_build_rows)
-        except Exception:  # noqa: BLE001
-            logger.exception("Failed to load tasks")
+        except Exception as exc:  # noqa: BLE001
+            # UAT Major 5: a read failure is not evidence the queue is
+            # empty. This used to reset `_tasks`/`_all_rows`, clear the
+            # table, and blank every detail/inspector pane on ANY
+            # exception here -- destroying the last-good display over a
+            # transient read error, with nothing short of a fresh mount
+            # able to restore it. Now it keeps whatever was already on
+            # screen and only reports the failure.
+            logger.exception(
+                "Failed to load tasks while {stage} (owner_id={owner_id}, "
+                "refresh_definitions={refresh_definitions}): {exc_type}: {exc}",
+                stage=stage,
+                owner_id=getattr(service, "owner_id", None),
+                refresh_definitions=refresh_definitions,
+                exc_type=type(exc).__name__,
+                exc=exc,
+            )
             self.app_instance.notify(
-                "Could not load tasks. Check the scheduling service and retry.",
+                "Could not refresh tasks (showing the last-loaded queue). "
+                "Check the scheduling service and retry.",
                 severity="error",
             )
-            self._tasks = []
-            self._all_rows = []
-            self._update_mark_all_read_visibility()
-            table = self.query_one("#scheduling-task-table", DataTable)
-            table.clear()
-            self.query_one("#scheduling-task-detail", TaskDetail).set_task(
-                None, queue_empty=True
-            )
-            self.query_one("#scheduling-task-inspector", TaskInspector).set_task(None)
-            self.query_one(
-                "#scheduling-queue-definition-detail", DefinitionDetail
-            ).set_definition(None)
             await self._refresh_console_context()
             return
 
@@ -4344,6 +4381,19 @@ class SchedulesWorkbench(BaseAppScreen):
         else:
             message = "Sync finished — nothing to pull or push."
         self.app_instance.notify(message, severity="information")
+        # UAT finding 3c: `outcome.status`/`.error` now describe ONLY the
+        # reminder phase -- an automation phase (definition push/pull,
+        # results pull) that failed in the same cycle no longer collapses
+        # this into a `SyncFailed` "Sync failed: ..." toast (that would
+        # lie about a reminder phase, or an unrelated definition push,
+        # that genuinely succeeded). Its own truth still has to reach the
+        # user, as its own notice rather than silently dropped.
+        phase_errors = tuple(getattr(outcome, "phase_errors", ()) or ())
+        if phase_errors:
+            self.app_instance.notify(
+                "Sync completed with issues — " + "; ".join(phase_errors),
+                severity="warning",
+            )
         self._refresh_owner_select()
         self._request_tasks_refresh()
         self._refresh_conflicts_badge()

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -3138,17 +3138,8 @@ class SchedulesWorkbench(BaseAppScreen):
             )
             return
         # task-3 (ruling 4): re-probe right before deciding, rather than
-        # trust whatever the mount-time background probe last cached --
-        # `refresh_server_reachability`'s own probe is itself cached
-        # per-connection, so this is a no-op round trip once a verdict is
-        # already known and only actually re-checks a genuinely stale
-        # (errored) prior attempt. Guarded with getattr, same reasoning as
-        # `_refresh_server_reachability`: a test double that models
-        # `transfer_refusal` but not this newer probe method must not
-        # crash the worker over a method it was never asked to implement.
-        refresh_reachability = getattr(service, "refresh_server_reachability", None)
-        if refresh_reachability is not None:
-            await refresh_reachability()
+        # trust whatever the mount-time background probe last cached.
+        await self._reprobe_server_reachability(service)
         reason = service.transfer_refusal(row_dict, direction)
         if reason is not None:
             row.show_error(reason)
@@ -4329,6 +4320,28 @@ class SchedulesWorkbench(BaseAppScreen):
             _probe, exclusive=True, group="schedules-server-reachability"
         )
 
+    @staticmethod
+    async def _reprobe_server_reachability(service: Any) -> None:
+        """Re-probe reachability right before a decision that gates on it.
+
+        Fix round 1, finding 1: `_run_owner_transfer` already did this
+        inline; `_on_owner_server` and `action_sync_now` did not, so a
+        press during the on-mount probe window (`_refresh_server_
+        reachability`'s background worker hasn't resolved yet) saw the
+        honest default -- `server_reachable=False` -- and refused a
+        genuinely configured, about-to-be-confirmed server. `refresh_
+        server_reachability`'s own probe is cached per-connection, so
+        this is a no-op round trip once a verdict is already known and
+        only actually re-checks a still-pending mount-time probe or a
+        genuinely stale (errored) prior attempt. Guarded with getattr: a
+        test double that models `server_reachable`/`transfer_refusal`
+        but not this newer probe method must not crash a worker over a
+        method it was never asked to implement.
+        """
+        refresh_reachability = getattr(service, "refresh_server_reachability", None)
+        if refresh_reachability is not None:
+            await refresh_reachability()
+
     def _sync_header_status(self, status: WorkbenchStatus, label: str) -> None:
         """Reflect real sync health in the destination header chip."""
         try:
@@ -4443,10 +4456,14 @@ class SchedulesWorkbench(BaseAppScreen):
         self._set_owner("local")
 
     @on(Button.Pressed, "#scheduling-owner-server")
-    def _on_owner_server(self) -> None:
+    async def _on_owner_server(self) -> None:
         service = self._service()
         if service is None:
             return
+        # Fix round 1, finding 1: re-probe rather than trust whatever the
+        # mount-time background probe last cached -- same reasoning as
+        # `_run_owner_transfer`'s own re-probe.
+        await self._reprobe_server_reachability(service)
         active_server_id = self._active_server_id()
         if not self._server_available(service, active_server_id):
             self.app_instance.notify("No server connection", severity="warning")
@@ -4908,7 +4925,7 @@ class SchedulesWorkbench(BaseAppScreen):
             group="schedules-bulk-toggle",
         )  # type: ignore[arg-type]
 
-    def action_sync_now(self) -> None:
+    async def action_sync_now(self) -> None:
         """Sync schedule state now."""
         if self._sync_running:
             self.app_instance.notify("Sync already in progress", severity="warning")
@@ -4920,6 +4937,10 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="warning",
             )
             return
+        # Fix round 1, finding 1: re-probe rather than trust whatever the
+        # mount-time background probe last cached -- same reasoning as
+        # `_run_owner_transfer`'s own re-probe.
+        await self._reprobe_server_reachability(service)
         if not self._server_available(service, self._active_server_id()):
             # Honest no-op: never claim "Sync completed" when nothing can
             # sync. Same predicate as the sync bar's collapse (review F10):

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -1246,11 +1246,19 @@ class SchedulesWorkbench(BaseAppScreen):
                 exc_type=type(exc).__name__,
                 exc=exc,
             )
-            self.app_instance.notify(
-                "Could not refresh tasks (showing the last-loaded queue). "
-                "Check the scheduling service and retry.",
-                severity="error",
-            )
+            # Review round 1 finding 1: "showing the last-loaded queue"
+            # is only true once something HAS loaded -- on the very
+            # first (never-succeeded) load, `_all_rows` is still its
+            # `__init__` empty-list default, and that copy would assert
+            # a last-good display that never existed.
+            if self._all_rows:
+                message = (
+                    "Could not refresh tasks (showing the last-loaded "
+                    "queue). Check the scheduling service and retry."
+                )
+            else:
+                message = "Could not load tasks. Check the scheduling service and retry."
+            self.app_instance.notify(message, severity="error")
             await self._refresh_console_context()
             return
 

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -300,6 +300,21 @@ def _row_subtitle(row: UnifiedRow, now: datetime) -> str:
     return f"{row.schedule_summary} · {next_text}"
 
 
+class _QueueFilterInput(Input):
+    """The rail search box -- `escape` blurs it (UAT Minor 21) instead of
+    falling through to `SchedulesWorkbench`'s own `escape` -> clear_marks
+    binding. Textual checks a focused widget's own BINDINGS before its
+    ancestors' (`App._check_bindings` walks the focus chain closest-first),
+    so this in-area binding wins without touching the screen's binding at
+    all; unblurred, the filter kept focus and swallowed the single-letter
+    chip keys (`f`, `1`-`4`) as literal text instead of routing them."""
+
+    BINDINGS = [Binding("escape", "blur_filter", "Unfocus filter", show=False)]
+
+    def action_blur_filter(self) -> None:
+        self.blur()
+
+
 class SchedulesWorkbench(BaseAppScreen):
     """Main workbench for managing scheduled runs, reminders, and jobs.
 
@@ -612,7 +627,7 @@ class SchedulesWorkbench(BaseAppScreen):
                             id="scheduling-chip-cycle",
                             tooltip="Cycle the queue filter (f).",
                         )
-                    yield Input(
+                    yield _QueueFilterInput(
                         # Says what ruling 5's search actually
                         # matches -- title + question/body (final
                         # review F6: the Type/Status columns are
@@ -621,6 +636,15 @@ class SchedulesWorkbench(BaseAppScreen):
                         # already documents).
                         placeholder="Filter: title or question…",
                         id="scheduling-queue-filter",
+                        # UAT display blocker (finding 1b): a 1-row Input
+                        # from app CSS height never carries Textual's own
+                        # `.-textual-compact` class, so the existing
+                        # `Input.-textual-compact:focus` outline opt-out
+                        # (TASK-17961) missed it -- `*:focus`'s outline
+                        # painted over the only content row, hiding
+                        # whatever was typed. `compact=True` joins that
+                        # family instead of adding a bespoke opt-out.
+                        compact=True,
                     )
                     yield DataTable(
                         id="scheduling-task-table", cursor_type="row"

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -321,6 +321,12 @@ class _QueueFilterInput(Input):
     BINDINGS = [Binding("escape", "blur_filter", "Unfocus filter", show=False)]
 
     def action_blur_filter(self) -> None:
+        """Unfocus the search filter.
+
+        Bound to escape (see `BINDINGS` above) so single-letter chip keys
+        (`f`, `1`-`4`) route to their bindings again instead of being
+        swallowed as literal text while the filter still has focus.
+        """
         self.blur()
 
 
@@ -4341,16 +4347,38 @@ class SchedulesWorkbench(BaseAppScreen):
         orphaned_transfer_mutations` treats that as "every still-pending
         transfer_to_server mutation is orphaned", which is exactly right
         (nothing configured means nothing it could still be valid for).
+
+        Qodo fix round (finding 2, MEDIUM): this used to run the local DB
+        work inline and synchronously from `on_mount`, blocking mount on
+        it. Deferred onto the same fire-and-forget worker path
+        `SchedulingService.recover_inflight_transfers` rides at app
+        startup -- `on_mount` kicks it and returns immediately; the
+        sweep's own idempotence (a rerun is a no-op once every row has
+        settled) makes the exact ordering against other mount-time work
+        forgiving.
         """
         service = self._service()
         if service is None:
             return
         active_server_id = self._active_server_id()
         target_owner = f"server:{active_server_id}" if active_server_id else None
-        try:
-            service.sync_engine._settle_orphaned_transfer_mutations(target_owner)
-        except Exception:  # noqa: BLE001
-            logger.exception("Orphaned-transfer sweep failed at mount")
+
+        async def _settle() -> None:
+            try:
+                service.sync_engine._settle_orphaned_transfer_mutations(target_owner)
+            except Exception:  # noqa: BLE001
+                # Qodo fix round (finding 3, LOW): name the active target
+                # and owner this sweep was settling against -- never the
+                # mutation payload, which carries the user's own reminder/
+                # definition text on this path.
+                logger.exception(
+                    "Orphaned-transfer sweep failed at mount "
+                    "(target_owner={target_owner}, owner_id={owner_id})",
+                    target_owner=target_owner,
+                    owner_id=service.owner_id,
+                )
+
+        self.run_worker(_settle, exclusive=True, group="schedules-orphan-sweep")
 
     def _refresh_server_reachability(self) -> None:
         """Kick a background probe of server reachability (task-3, ruling 4).

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -513,17 +513,22 @@ class SchedulesWorkbench(BaseAppScreen):
         server_reachable` is `refresh_server_reachability`'s actual probe
         result, not mere configuredness (root-causes.md #5's bug -- the
         three checks this method used to stop at never contacted
-        anything). Until a probe has succeeded this reads `False` (the
-        real service's own default), so a fresh workbench never offers a
-        server destination before anything has confirmed it is there.
-        Read via `getattr(..., True)` rather than a direct attribute
-        access: many test doubles across this test suite model "a
-        connected service" without also modeling reachability, and were
-        never meant to exercise this NEW gate -- they get the old
+        anything). It is tri-state (`None` unprobed / `True` / `False`,
+        final review finding 2) -- `bool(...)`-wrapped here so `None`
+        (never probed) still reads as unavailable, same as `False`:
+        "until a probe has succeeded, the option must not be offered"
+        (root-causes.md #5) covers BOTH "hasn't checked" and "checked and
+        failed" identically for this method's callers (the transfer
+        dropdown, `transfer_refusal`'s callers). Only the header's own
+        DISPLAY COPY (`_refresh_owner_select`) needs to tell those two
+        apart. Read via `getattr(..., True)` rather than a direct
+        attribute access: many test doubles across this test suite model
+        "a connected service" without also modeling reachability, and
+        were never meant to exercise this NEW gate -- they get the old
         available-if-configured behavior; a fake that wants to test the
         unreachable case sets `server_reachable = False` explicitly.
         """
-        return (
+        return bool(
             service is not None
             and bool(active_server_id)
             and service.server_client.notifications_service is not None
@@ -759,6 +764,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._register_footer_shortcuts()
         self._refresh_owner_select()
         self._refresh_server_reachability()
+        self._settle_orphaned_transfers()
         self._refresh_conflicts_badge()
         self._refresh_results_badge()
         self._sync_chip_cycle_label()
@@ -1568,8 +1574,11 @@ class SchedulesWorkbench(BaseAppScreen):
         gate above still keeps the stale pane from being re-fed.
 
         Only `load_tasks`'s SUCCESS path reaches `_render_table` -- its
-        `except` branch empties `_all_rows` and returns early -- so a
-        transient service failure never closes an open pane.
+        `except` branch returns early before ever calling it (Major 5's
+        fix made that branch non-destructive -- it no longer empties
+        `_all_rows` either, final review finding 5 -- but it still never
+        reaches `_render_table`) -- so a transient service failure never
+        closes an open pane.
         """
         host = self._pushed_host
         row_id = self._pushed_row_id
@@ -2549,8 +2558,19 @@ class SchedulesWorkbench(BaseAppScreen):
             options.append((owner_id, owner_id))
         return options, owner_id
 
-    def action_create_reminder(self) -> None:
-        """Open the create-reminder form."""
+    async def action_create_reminder(self) -> None:
+        """Open the create-reminder form.
+
+        Final review finding 3: re-probes reachability first (same
+        pattern `_run_owner_transfer`/`_on_owner_server`/`action_sync_
+        now` already follow) -- without it, a create during the mount
+        probe's still-pending window (or any time after one failed
+        probe) silently offered only "This device" in `_runs_on_options`,
+        with no notice and no correction while the form stayed open.
+        """
+        service = self._service()
+        if service is not None:
+            await self._reprobe_server_reachability(service)
         options, default_owner = self._runs_on_options()
         self.app.push_screen(
             ReminderForm(
@@ -2561,8 +2581,12 @@ class SchedulesWorkbench(BaseAppScreen):
             callback=self._on_reminder_form_result,
         )
 
-    def action_create_automation(self) -> None:
-        """Open the create-recurring-question-automation form (task-5)."""
+    async def action_create_automation(self) -> None:
+        """Open the create-recurring-question-automation form (task-5).
+
+        Final review finding 3: same re-probe as `action_create_
+        reminder` above, for the same reason.
+        """
         service = self._scheduling_service
         if service is None:
             self.app_instance.notify(
@@ -2570,6 +2594,7 @@ class SchedulesWorkbench(BaseAppScreen):
                 severity="warning",
             )
             return
+        await self._reprobe_server_reachability(service)
         options, default_owner = self._runs_on_options()
         self.app.push_screen(
             AutomationDefinitionForm(
@@ -2582,11 +2607,11 @@ class SchedulesWorkbench(BaseAppScreen):
         """Ask which kind of scheduled task to create (task-5)."""
         self.app.push_screen(NewTaskChoiceModal(), callback=self._on_new_task_choice)
 
-    def _on_new_task_choice(self, choice: str | None) -> None:
+    async def _on_new_task_choice(self, choice: str | None) -> None:
         if choice == "reminder":
-            self.action_create_reminder()
+            await self.action_create_reminder()
         elif choice == "recurring_question":
-            self.action_create_automation()
+            await self.action_create_automation()
 
     def _on_automation_form_result(
         self, outcome: Any | None, *, was_edit: bool = False
@@ -4274,22 +4299,58 @@ class SchedulesWorkbench(BaseAppScreen):
                 "error", f"{count} sync error{'s' if count != 1 else ''}"
             )
         elif not server_available:
-            # task-3 (ruling 4): distinct copy for "nothing configured" vs
-            # "configured but the reachability probe hasn't succeeded" --
-            # the header must not assert a server as a fact it hasn't
-            # confirmed (UAT leg A defect, root-causes.md #5).
-            if active_server_id:
-                self._sync_header_status(
-                    "empty", "Server configured but not reachable"
-                )
-            else:
+            # task-3 (ruling 4) / final review finding 2: three distinct
+            # copies, not two -- "nothing configured" / "configured, the
+            # probe hasn't resolved yet" (must NOT assert "not reachable",
+            # a negative fact nothing has established -- the same class of
+            # dishonesty ruling 4 targeted, inverted, root-causes.md #5) /
+            # "configured, confirmed unreachable".
+            if not active_server_id:
                 self._sync_header_status(
                     "empty", "Local only — no server connection"
+                )
+            elif getattr(service, "server_reachable", True) is None:
+                self._sync_header_status("loading", "Checking sync status…")
+            else:
+                self._sync_header_status(
+                    "empty", "Server configured but not reachable"
                 )
         elif service.owner_id.startswith("server:"):
             self._sync_header_status("ready", "Synced with server")
         else:
             self._sync_header_status("ready", "Local schedules")
+
+    def _settle_orphaned_transfers(self) -> None:
+        """Local-DB-only orphaned-transfer sweep, independent of server
+        reachability (final review finding 1).
+
+        `SyncEngine._settle_orphaned_transfer_mutations` only ran INSIDE
+        `sync_now()`, which `action_sync_now`/the mount-time probe both
+        refuse to even start without a reachable server -- so the UAT's
+        actual core symptom (the configured server removed, or simply
+        dead, not merely switched to another reachable one) never
+        settled: no sync ever runs, so the sweep never runs, and the row
+        keeps reading "Moving to server..." forever with no Retry/
+        Cancel. This is pure local DB work (`get_pending_mutations`/
+        `set_transfer_state`, no network), so it runs unconditionally on
+        every mount -- the in-`sync_now()` call stays too (idempotent):
+        a mid-session reconfiguration onto a still-reachable OTHER server
+        settles on the very next sync without waiting for a re-mount.
+
+        `target_owner=None` when no server is configured at all -- `_settle_
+        orphaned_transfer_mutations` treats that as "every still-pending
+        transfer_to_server mutation is orphaned", which is exactly right
+        (nothing configured means nothing it could still be valid for).
+        """
+        service = self._service()
+        if service is None:
+            return
+        active_server_id = self._active_server_id()
+        target_owner = f"server:{active_server_id}" if active_server_id else None
+        try:
+            service.sync_engine._settle_orphaned_transfer_mutations(target_owner)
+        except Exception:  # noqa: BLE001
+            logger.exception("Orphaned-transfer sweep failed at mount")
 
     def _refresh_server_reachability(self) -> None:
         """Kick a background probe of server reachability (task-3, ruling 4).
@@ -4535,6 +4596,17 @@ class SchedulesWorkbench(BaseAppScreen):
     def _on_sync_failed(self, event: SyncFailed) -> None:
         self._sync_running = False
         self.app_instance.notify(f"Sync failed: {event.error}", severity="error")
+        # Final review finding 6: an automation phase (definition push/
+        # pull, results pull) that failed in the SAME cycle as the
+        # reminder-phase failure this toast already reports must not be
+        # silently dropped -- symmetric with `_on_sync_completed`'s own
+        # `phase_errors` handling just below its success toast.
+        phase_errors = tuple(getattr(event.outcome, "phase_errors", ()) or ())
+        if phase_errors:
+            self.app_instance.notify(
+                "Also: " + "; ".join(phase_errors),
+                severity="warning",
+            )
         self._refresh_owner_select()
         self._request_tasks_refresh()
         self._refresh_conflicts_badge()
@@ -4941,14 +5013,26 @@ class SchedulesWorkbench(BaseAppScreen):
         # mount-time background probe last cached -- same reasoning as
         # `_run_owner_transfer`'s own re-probe.
         await self._reprobe_server_reachability(service)
-        if not self._server_available(service, self._active_server_id()):
+        active_server_id = self._active_server_id()
+        if not self._server_available(service, active_server_id):
             # Honest no-op: never claim "Sync completed" when nothing can
             # sync. Same predicate as the sync bar's collapse (review F10):
             # the bar and the s key must agree on whether sync is possible.
-            self.app_instance.notify(
-                "Local only — nothing to sync (no server connection).",
-                severity="information",
-            )
+            # Final review finding 4: split copy, not the conflated "no
+            # server connection" for both cases -- matches the header's
+            # own split (`:4272`-ish, "Server configured but not
+            # reachable" vs "Local only") and `transfer_refusal`'s own
+            # distinct reason (`scheduling_service.py`).
+            if active_server_id:
+                self.app_instance.notify(
+                    "Server configured but not reachable — nothing to sync.",
+                    severity="information",
+                )
+            else:
+                self.app_instance.notify(
+                    "Local only — nothing to sync (no server connection).",
+                    severity="information",
+                )
             return
         self._sync_running = True
         self.run_worker(self._run_sync, exclusive=True, group="schedules-sync-now")
@@ -4970,7 +5054,9 @@ class SchedulesWorkbench(BaseAppScreen):
             if outcome is not None and getattr(outcome, "status", None) == "error":
                 self.post_message(
                     SyncFailed(
-                        owner_id, getattr(outcome, "error", None) or "sync error"
+                        owner_id,
+                        getattr(outcome, "error", None) or "sync error",
+                        outcome=outcome,
                     )
                 )
                 return

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -507,7 +507,48 @@ class SchedulesWorkbench(BaseAppScreen):
 
     @staticmethod
     def _server_available(service: Any, active_server_id: str | None) -> bool:
-        """Return whether Schedules can switch ownership to a live server."""
+        """Return whether Schedules can switch ownership to a live server.
+
+        task-3 (schedules UAT remediation ruling 4): `service.
+        server_reachable` is `refresh_server_reachability`'s actual probe
+        result, not mere configuredness (root-causes.md #5's bug -- the
+        three checks this method used to stop at never contacted
+        anything). Until a probe has succeeded this reads `False` (the
+        real service's own default), so a fresh workbench never offers a
+        server destination before anything has confirmed it is there.
+        Read via `getattr(..., True)` rather than a direct attribute
+        access: many test doubles across this test suite model "a
+        connected service" without also modeling reachability, and were
+        never meant to exercise this NEW gate -- they get the old
+        available-if-configured behavior; a fake that wants to test the
+        unreachable case sets `server_reachable = False` explicitly.
+        """
+        return (
+            service is not None
+            and bool(active_server_id)
+            and service.server_client.notifications_service is not None
+            and getattr(service, "server_reachable", True)
+        )
+
+    @staticmethod
+    def _server_configured(service: Any, active_server_id: str | None) -> bool:
+        """Return whether a server identity is merely CONFIGURED.
+
+        Unlike `_server_available`, this does NOT require `refresh_
+        server_reachability`'s probe to have succeeded -- it is
+        `_server_available`'s OLD body, pre-task-3, kept for call sites
+        that only need "is there anything to even attempt a network call
+        against" (starting the SSE observer, scheduling a catch-up pull,
+        deciding whether to also fetch server automations for the Queue
+        list), not "should this be offered as a confirmed-live transfer/
+        switch destination" (`_server_available`'s job, ruling 4). Those
+        call sites run at `on_mount`, synchronously, before `_refresh_
+        server_reachability`'s background probe has had a chance to
+        resolve -- gating them on `_server_available` made every fresh
+        mount silently skip its first catch-up pull/observer start (a
+        real regression this method exists to avoid, caught by this
+        task's own test suite, not merely a fixture-compat concern).
+        """
         return (
             service is not None
             and bool(active_server_id)
@@ -717,6 +758,7 @@ class SchedulesWorkbench(BaseAppScreen):
         self._sync_responsive_workbench()
         self._register_footer_shortcuts()
         self._refresh_owner_select()
+        self._refresh_server_reachability()
         self._refresh_conflicts_badge()
         self._refresh_results_badge()
         self._sync_chip_cycle_label()
@@ -771,13 +813,19 @@ class SchedulesWorkbench(BaseAppScreen):
         `ServerNotificationEventObserver.observe()` --
         `NotificationsScopeService.observe_server_feed_events` has existed
         since 18940 slice 3 with nothing invoking it (survey §3).
+
+        `_server_configured`, not `_server_available`: this runs at
+        `on_mount`, synchronously, before `_refresh_server_reachability`'s
+        background probe has had any chance to resolve -- gating a
+        mount-time start on the reachability verdict raced it and
+        silently skipped starting the observer on every fresh mount.
         """
         service = self._service()
         scope_service = getattr(self.app_instance, "notifications_scope_service", None)
         if (
             service is None
             or scope_service is None
-            or not self._server_available(service, self._active_server_id())
+            or not self._server_configured(service, self._active_server_id())
         ):
             return
         self._notification_cancel_event = asyncio.Event()
@@ -916,9 +964,11 @@ class SchedulesWorkbench(BaseAppScreen):
         pull. Gated on a configured server for the same reason
         `_start_server_notification_observer` is: with no server there is
         nothing to pull and `_run_phase` would only record a sync error.
+        `_server_configured`, not `_server_available`, for the same
+        mount-time-race reason that method's own docstring gives.
         """
         service = self._service()
-        if service is None or not self._server_available(
+        if service is None or not self._server_configured(
             service, self._active_server_id()
         ):
             return
@@ -1304,7 +1354,12 @@ class SchedulesWorkbench(BaseAppScreen):
         self._queue_local_definitions = local_rows
         local_items = self._device_only_automations(local_rows)
         server_client = getattr(service, "server_client", None)
-        server_available = server_client is not None and self._server_available(
+        # `_server_configured`, not `_server_available`: this runs from
+        # `_request_tasks_refresh`'s worker, kicked at `on_mount` roughly
+        # alongside `_refresh_server_reachability`'s own probe -- gating
+        # on the reachability verdict raced it and could silently skip
+        # merging server automations into the FIRST Queue-list load.
+        server_available = server_client is not None and self._server_configured(
             service, self._active_server_id()
         )
         if not server_available:
@@ -3082,6 +3137,18 @@ class SchedulesWorkbench(BaseAppScreen):
                 "Scheduling service is unavailable; cannot start a transfer."
             )
             return
+        # task-3 (ruling 4): re-probe right before deciding, rather than
+        # trust whatever the mount-time background probe last cached --
+        # `refresh_server_reachability`'s own probe is itself cached
+        # per-connection, so this is a no-op round trip once a verdict is
+        # already known and only actually re-checks a genuinely stale
+        # (errored) prior attempt. Guarded with getattr, same reasoning as
+        # `_refresh_server_reachability`: a test double that models
+        # `transfer_refusal` but not this newer probe method must not
+        # crash the worker over a method it was never asked to implement.
+        refresh_reachability = getattr(service, "refresh_server_reachability", None)
+        if refresh_reachability is not None:
+            await refresh_reachability()
         reason = service.transfer_refusal(row_dict, direction)
         if reason is not None:
             row.show_error(reason)
@@ -4216,11 +4283,51 @@ class SchedulesWorkbench(BaseAppScreen):
                 "error", f"{count} sync error{'s' if count != 1 else ''}"
             )
         elif not server_available:
-            self._sync_header_status("empty", "Local only — no server connection")
+            # task-3 (ruling 4): distinct copy for "nothing configured" vs
+            # "configured but the reachability probe hasn't succeeded" --
+            # the header must not assert a server as a fact it hasn't
+            # confirmed (UAT leg A defect, root-causes.md #5).
+            if active_server_id:
+                self._sync_header_status(
+                    "empty", "Server configured but not reachable"
+                )
+            else:
+                self._sync_header_status(
+                    "empty", "Local only — no server connection"
+                )
         elif service.owner_id.startswith("server:"):
             self._sync_header_status("ready", "Synced with server")
         else:
             self._sync_header_status("ready", "Local schedules")
+
+    def _refresh_server_reachability(self) -> None:
+        """Kick a background probe of server reachability (task-3, ruling 4).
+
+        `_server_available`/`transfer_refusal` read `service.
+        server_reachable`, which defaults `False` until a probe succeeds
+        -- this is what actually runs one, then repaints the header/owner
+        state so the honest answer appears as soon as it's known rather
+        than only at the next unrelated refresh.
+
+        A no-op for a test double that doesn't implement `refresh_
+        server_reachability` at all (`_server_available`'s own `getattr`
+        fallback already reads such a fake as available) -- there is
+        nothing to probe and no worker crash to risk over it.
+        """
+        service = self._service()
+        if service is None:
+            return
+        probe = getattr(service, "refresh_server_reachability", None)
+        if probe is None:
+            return
+
+        async def _probe() -> None:
+            await probe()
+            self._refresh_owner_select()
+
+        self.run_worker(
+            _probe, exclusive=True, group="schedules-server-reachability"
+        )
 
     def _sync_header_status(self, status: WorkbenchStatus, label: str) -> None:
         """Reflect real sync health in the destination header chip."""

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -605,6 +605,56 @@ class TaskDetail(Vertical):
             id="scheduling-task-detail-empty-state",
         )
         with Vertical(id="scheduling-task-detail-metadata"):
+            # UAT display-blocker fix: this row used to be the LAST thing
+            # in the pane, after History -- past the fold at every
+            # measured width (`_scheduling_uat_remediation` root-causes
+            # doc, finding 2). It carries the one Edit-in-full affordance
+            # this pane has (no kebab -- plan ruling 1), so it now composes
+            # FIRST, mirroring `DefinitionDetail`'s own Pause/Run-now row.
+            yield Horizontal(
+                Button(
+                    "Edit",
+                    id="scheduling-edit-task",
+                    variant="primary",
+                    tooltip="Edit this scheduled task.",
+                ),
+                Button(
+                    "Acknowledge incident",
+                    id="scheduling-ack-incident",
+                    tooltip="Silence notifications for the current failure "
+                    "incident until it recurs after a success. Does not disable "
+                    "the task.",
+                ),
+                Button(
+                    "Run now",
+                    id="scheduling-run-now",
+                    variant="primary",
+                    tooltip="Dispatch this scheduled task immediately, without "
+                    "waiting for its schedule. A real dispatch: a recurring "
+                    "task's next occurrence is computed from now, a one-time "
+                    "task is consumed. Works on disabled tasks without enabling "
+                    "them.",
+                ),
+                Button(
+                    "Enable",
+                    id="scheduling-enable-task",
+                    variant="success",
+                    tooltip="Enable this scheduled task.",
+                ),
+                Button(
+                    "Disable",
+                    id="scheduling-disable-task",
+                    variant="warning",
+                    tooltip="Disable this scheduled task.",
+                ),
+                Button(
+                    "Delete",
+                    id="scheduling-delete-task",
+                    variant="error",
+                    tooltip="Delete this scheduled task.",
+                ),
+                id="scheduling-task-detail-lifecycle",
+            )
             yield Horizontal(
                 Static("Title:", classes="scheduling-detail-label"),
                 Static(
@@ -772,50 +822,6 @@ class TaskDetail(Vertical):
                 id="scheduling-task-detail-incidents",
                 classes="scheduling-detail-value",
             )
-        yield Horizontal(
-            Button(
-                "Edit",
-                id="scheduling-edit-task",
-                variant="primary",
-                tooltip="Edit this scheduled task.",
-            ),
-            Button(
-                "Acknowledge incident",
-                id="scheduling-ack-incident",
-                tooltip="Silence notifications for the current failure "
-                "incident until it recurs after a success. Does not disable "
-                "the task.",
-            ),
-            Button(
-                "Run now",
-                id="scheduling-run-now",
-                variant="primary",
-                tooltip="Dispatch this scheduled task immediately, without "
-                "waiting for its schedule. A real dispatch: a recurring "
-                "task's next occurrence is computed from now, a one-time "
-                "task is consumed. Works on disabled tasks without enabling "
-                "them.",
-            ),
-            Button(
-                "Enable",
-                id="scheduling-enable-task",
-                variant="success",
-                tooltip="Enable this scheduled task.",
-            ),
-            Button(
-                "Disable",
-                id="scheduling-disable-task",
-                variant="warning",
-                tooltip="Disable this scheduled task.",
-            ),
-            Button(
-                "Delete",
-                id="scheduling-delete-task",
-                variant="error",
-                tooltip="Delete this scheduled task.",
-            ),
-            id="scheduling-task-detail-lifecycle",
-        )
         # redesign PR-4, task 4 (ruling 2): the legacy Move/Retry/Cancel
         # button row that lived here (schedules-handoff spec §6, PR-5
         # task 7) is RETIRED -- the Runs-on row's own dropdown + mini-bar
@@ -1153,6 +1159,7 @@ class TaskDetail(Vertical):
                     allow_blank=False,
                     value=current_owner,
                     id=_RUNS_ON_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._repeat_row:
@@ -1163,11 +1170,12 @@ class TaskDetail(Vertical):
                     allow_blank=False,
                     value=current_preset,
                     id=_REPEAT_EDITOR_ID,
+                    compact=True,
                 )
             )
         elif row is self._at_row:
             initial = task.run_at.isoformat() if task.run_at is not None else ""
-            row.begin_edit(Input(value=initial, id=_AT_EDITOR_ID))
+            row.begin_edit(Input(value=initial, id=_AT_EDITOR_ID, compact=True))
         elif row is self._timezone_row:
             # task.timezone is guaranteed set here: this row's affordance
             # is only ever True while `task.schedule_kind` is RECURRING,
@@ -1179,6 +1187,7 @@ class TaskDetail(Vertical):
                     allow_blank=False,
                     value=task.timezone,
                     id=_TIMEZONE_EDITOR_ID,
+                    compact=True,
                 )
             )
 

--- a/tldw_chatbook/UI/Screens/scheduling/task_detail.py
+++ b/tldw_chatbook/UI/Screens/scheduling/task_detail.py
@@ -54,6 +54,7 @@ from .unified_rows import (
     _humanize_schedule,
     definition_cron_expression,  # noqa: F401  (re-export: definition_detail.py imports this from here)
     owner_display_label,
+    reminder_has_fired,
 )
 
 
@@ -201,6 +202,13 @@ def _format_next_run(
     # badge said "Disabled" (Qodo review). Suppression is a property of the
     # status, not of whether a stale timestamp happens to survive.
     display_status = _task_status(task)
+    # UAT finding 3e: a fired one-time reminder is COMPLETED (not
+    # DISABLED, since `_task_status` above now checks `reminder_has_
+    # fired` first) -- its own branch, not the generic "nothing
+    # scheduled" fallback below, so "Completed" never explains itself as
+    # "— (disabled)".
+    if display_status == TaskStatus.COMPLETED:
+        return "—"
     if display_status == TaskStatus.DISABLED:
         return "— (disabled)"
     if display_status == TaskStatus.PAUSED:
@@ -288,7 +296,18 @@ def _task_status(task: ReminderTask | ScheduledTask) -> TaskStatus:
     left disabled rows showing "Waiting" (task-23101). Enabling restores
     the recorded last outcome. Consumers that need the recorded outcome
     itself use ``_underlying_status`` (review F5).
+
+    UAT finding 3e: this predated the Queue's Completed bucket
+    (`unified_rows._reminder_bucket`) and was never reconciled with it.
+    Dispatching a one-time reminder sets ``enabled=False`` AND clears
+    ``next_run_at`` -- so a fired reminder's row was bucketed Completed
+    (drives the chip/glyph) while this method still said Disabled (drives
+    the badge/next-run text) for the exact same row. Checking
+    ``reminder_has_fired`` first, BEFORE the ``enabled`` override, makes
+    the two seams share the one rule instead of quietly disagreeing.
     """
+    if isinstance(task, ReminderTask) and reminder_has_fired(task):
+        return TaskStatus.COMPLETED
     if isinstance(task, ReminderTask) and not task.enabled:
         return TaskStatus.DISABLED
     return _underlying_status(task)

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -10427,6 +10427,12 @@ class TldwCli(
             handler_timeout_seconds=get_cli_setting(
                 "scheduling", "handler_timeout_seconds", HANDLER_TIMEOUT_SECONDS
             ),
+            # UAT finding 3a: `on_queue_changed` (above) only reloads the
+            # loop's OWN in-memory queue -- it never reaches a screen.
+            # This is the fallback the plan calls for: a lightweight
+            # `post_message` bridge so a fired reminder's row repaints
+            # without navigating away and back.
+            on_reminder_dispatched=self._post_reminder_dispatched,
         )
         # The report demo is opt-in. Keep its audio stack off first paint and
         # let the property above build it on the first demo entry-point read.
@@ -11003,6 +11009,39 @@ class TldwCli(
             )
             self._automation_definition_handler = handler
         return handler
+
+    def _post_reminder_dispatched(self, task_id: str) -> None:
+        """`SchedulerLoop.on_reminder_dispatched` callback (finding 3a).
+
+        Lazy import: `Scheduling.events` pulls in `Widgets.
+        detail_value_row` (ADR-097 boot-census ratchet), and this only
+        runs once a reminder has actually fired -- long after boot.
+        Posting to `self` (the App) is the only route available: the
+        loop is UI-agnostic and holds no screen reference, so
+        `on_reminder_dispatched` below relays this to whichever
+        `SchedulesWorkbench` is currently on the screen stack, if any.
+        """
+        from .Scheduling.events import ReminderDispatched
+
+        self.post_message(ReminderDispatched(task_id))
+
+    def on_reminder_dispatched(self, message: Any) -> None:
+        """Relay a scheduler-fired reminder into the live Schedules
+        workbench, if one is mounted (finding 3a).
+
+        A purely local scheduler fire has no other route to the UI --
+        the only existing push path is the server SSE observer, which
+        requires a server. Same `screen_stack` scan idiom as
+        `_mounted_chat_screen` above; a full `_request_tasks_refresh()`
+        rather than a targeted repaint, since the fired row's own
+        bucket/next-run text both change together.
+        """
+        from .UI.Screens.scheduling.schedules_workbench import SchedulesWorkbench
+
+        for screen in reversed(tuple(getattr(self, "screen_stack", ()))):
+            if isinstance(screen, SchedulesWorkbench):
+                screen._request_tasks_refresh(refresh_definitions=False)
+                return
 
     def _backfill_subscription_items_fts(self) -> None:
         """Worker body: index subscription_items rows that predate the FTS

--- a/tldw_chatbook/css/features/_scheduling.tcss
+++ b/tldw_chatbook/css/features/_scheduling.tcss
@@ -50,6 +50,27 @@
 #scheduling-detail-pane { width: 4fr; min-width: 52; border: solid $ds-grid-line; padding: 1; }
 #scheduling-inspector-pane { width: 2fr; min-width: 34; border: solid $ds-grid-line; padding: 1; }
 
+/* UAT display blocker (finding 2): both detail panes are a plain
+ * `Vertical` (`overflow: hidden hidden` by default) taller than their
+ * own box at every measured width -- History and the lifecycle action
+ * row were clipped with no scrollbar, no wheel handling, no PageDown.
+ * `overflow-y: auto` alone is not enough: `#scheduling-task-detail-
+ * groups` is itself a plain `Vertical` (`height: 1fr` by default), which
+ * clips ITS OWN children a second time before `TaskDetail` ever gets a
+ * chance to scroll them -- `height: auto` lets it size to its real
+ * content instead. `DefinitionDetail` nests one level shallower (no
+ * separate groups wrapper -- its DetailGroups are direct children of
+ * `#scheduling-automation-detail-body`), so that container gets the
+ * same treatment. */
+TaskDetail, DefinitionDetail {
+    overflow-y: auto;
+}
+
+#scheduling-task-detail-groups,
+#scheduling-automation-detail-body {
+    height: auto;
+}
+
 /* The queue table must fill its pane, or empty queues collapse to a single
  * clipped row at short heights (80x24). */
 #scheduling-task-table {

--- a/tldw_chatbook/css/screen_feature_scheduling.tcss
+++ b/tldw_chatbook/css/screen_feature_scheduling.tcss
@@ -130,6 +130,11 @@ $ds-library-source-browser-width: 31;
 #scheduling-detail-pane { width: 4fr; min-width: 52; border: solid $ds-grid-line; padding: 1; }
 #scheduling-inspector-pane { width: 2fr; min-width: 34; border: solid $ds-grid-line; padding: 1; }
 
+#scheduling-task-detail-groups,
+#scheduling-automation-detail-body {
+    height: auto;
+}
+
 /* The queue table must fill its pane, or empty queues collapse to a single
  * clipped row at short heights (80x24). */
 #scheduling-task-table {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -12711,6 +12711,22 @@ Button.error:hover {
 
 /* ===== MODULE: features/_scheduling.tcss ===== */
 
+/* UAT display blocker (finding 2): both detail panes are a plain
+ * `Vertical` (`overflow: hidden hidden` by default) taller than their
+ * own box at every measured width -- History and the lifecycle action
+ * row were clipped with no scrollbar, no wheel handling, no PageDown.
+ * `overflow-y: auto` alone is not enough: `#scheduling-task-detail-
+ * groups` is itself a plain `Vertical` (`height: 1fr` by default), which
+ * clips ITS OWN children a second time before `TaskDetail` ever gets a
+ * chance to scroll them -- `height: auto` lets it size to its real
+ * content instead. `DefinitionDetail` nests one level shallower (no
+ * separate groups wrapper -- its DetailGroups are direct children of
+ * `#scheduling-automation-detail-body`), so that container gets the
+ * same treatment. */
+TaskDetail, DefinitionDetail {
+    overflow-y: auto;
+}
+
 /* Compact mode: the filter's margin row goes to the table (80x24 has
  * exactly one spare row; without this the queue shows only the filter). */
 #scheduling-workbench.compact #scheduling-queue-filter {

--- a/tldw_chatbook/tldw_api/client.py
+++ b/tldw_chatbook/tldw_api/client.py
@@ -981,6 +981,7 @@ from .server_notifications_schemas import (
     ServerNotificationStreamEvent,
 )
 from .scheduled_tasks_automation_schemas import (
+    ScheduledTaskAutomationCapabilities,
     ScheduledTaskAutomationDefinition,
     ScheduledTaskAutomationDefinitionList,
     ScheduledTaskAutomationRunNowResponse,
@@ -8077,6 +8078,25 @@ class TLDWAPIClient:
     async def delete_reminder_task(self, task_id: str) -> ReminderTaskDeleteResponse:
         response = await self._request("DELETE", f"/api/v1/tasks/{task_id}")
         return ReminderTaskDeleteResponse.model_validate(response)
+
+    async def get_scheduled_task_automation_capabilities(
+        self,
+    ) -> ScheduledTaskAutomationCapabilities:
+        """Probe server-advertised Scheduled Tasks automation capabilities.
+
+        Mirrors `get_sync_v2_capabilities`'s probe-and-validate shape
+        (task-3, schedules UAT remediation ruling 5). The caller
+        (`SchedulingServerClient.get_capabilities`) treats a 404 here as
+        "this server predates Scheduled Tasks automation entirely" -- an
+        honest degrade, never a crash (root-causes.md #7).
+
+        Returns:
+            The parsed capabilities response.
+        """
+        response = await self._request(
+            "GET", "/api/v1/scheduled-tasks/capabilities"
+        )
+        return ScheduledTaskAutomationCapabilities.model_validate(response)
 
     async def list_scheduled_task_automation_definitions(
         self,

--- a/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
+++ b/tldw_chatbook/tldw_api/scheduled_tasks_automation_schemas.py
@@ -216,3 +216,44 @@ class ScheduledTaskAuditList(BaseModel):
     offset: int = Field(default=0, ge=0)
     has_more: bool = False
     next_offset: int | None = Field(default=None, ge=0)
+
+
+class ScheduledTaskAutomationCapabilityAction(BaseModel):
+    """One action's capability status within a family capability report.
+
+    Mirrors the server's ``ScheduledTaskActionCapability`` (schemas file
+    of the same name), trimmed to the fields this client reads.
+    """
+
+    status: str
+    reason: str | None = None
+
+
+class ScheduledTaskAutomationCapability(BaseModel):
+    """One automation family's capability report.
+
+    Mirrors the server's ``ScheduledTaskAutomationCapability``, trimmed to
+    the fields this client reads.
+    """
+
+    family: str
+    family_availability: str
+    actions: dict[str, ScheduledTaskAutomationCapabilityAction] = Field(
+        default_factory=dict
+    )
+    reason: str | None = None
+
+
+class ScheduledTaskAutomationCapabilities(BaseModel):
+    """``GET /api/v1/scheduled-tasks/capabilities`` response.
+
+    Mirrors the server's ``ScheduledTaskAutomationCapabilitiesResponse``
+    (task-3, schedules UAT remediation ruling 5 -- the capabilities
+    handshake per the ``client.py``'s ``/sync/capabilities`` precedent).
+    A 404 on the request this backs means the server predates Scheduled
+    Tasks automation entirely; that is the caller's job to interpret
+    (``SchedulingServerClient.get_capabilities``), not this model's --
+    this model only describes a SUCCESSFUL response's shape.
+    """
+
+    items: list[ScheduledTaskAutomationCapability] = Field(default_factory=list)


### PR DESCRIPTION
Remediation of the schedules single-surface UAT (plan tracked in this PR; root-cause report drove every fix — two UAT findings were REFUTED with probe evidence along the way).

## What this fixes (the UAT's Blockers + Majors)
- **Blind typing (Blocker)**: inline editors and the rail search rendered only a top border — `compact` editors joining the established opt-out family; 8 compositor-geometry pins now assert PAINTED strips (the old content-only assertions were structurally blind — the lesson is encoded in the tests).
- **Unreachable detail content (Blocker)**: the pane now scrolls, and the Edit/Run-now/Enable/Disable/Delete row — which existed but had painted invisible at every width — sits above the fold (spec §5's kebab formally superseded).
- **The stale-display cluster (5 Majors)**: a fired reminder's row repaints within a tick via a real dispatch→UI fanout (live-verified: fire→repaint in 7s, no navigation); sync toasts tell per-phase truth (`SyncOutcome.phase_errors` — a successful push never toasts "Sync failed" for an unrelated business-404, both directions pinned); the liveness strip ticks on its own 5s cadence; fired one-time reminders read "Completed" not "Disabled"; the blank-list path hardened (a load failure keeps last-good rows + an honest notice — branch-aware copy for the first-load case).
- **Ghost row (Major)**: a release's same-cycle stale pull re-inserted the just-deleted mirror — the `released_server_id` guard (the exact twin of the adoption guard beside it).
- **Transfer honesty (Major)**: transfers gate on CONNECTEDNESS (tri-state, with an honest checking state and permission-vs-network refusal copy), orphaned mutations settle to failed-with-Retry via a reachability-free local sweep (mount + in-sync), and "Moving to server…" can no longer be a forever-lie.
- **Capabilities handshake**: the client probes `/scheduled-tasks/capabilities` (the UAT's 404s were an environment artifact — its server was 3,759 commits behind on a non-ancestor branch — but the handshake makes any version skew surface honestly instead of as raw 404s).
- **Refuted with evidence**: the conflict-button click-target theory (region already 3 rows — regression-guarded) and the missing-endpoints blocker (above).

## Verification
4 SDD tasks, each reviewed with fix rounds; final whole-branch review (opus) + one wave, scoped re-review 7/7 resolved with spot-reverted pins. **All 7 originally-failing UAT legs re-driven LIVE in the real TUI and VERIFIED** (scratch profile, both widths, cleanup confirmed). Gates: 1061 Scheduling + 409 schedules-UI green; preflight clean; diagnostics pin exact; CSS bundle byte-identical; the 3 ratchet reds reproduce identically at the branch base (pre-existing dev debt, attributed).

## Not this PR
The UAT's 13 minors + 7 polish items (filed to backlog at close-out); the dev-baseline ratchet reds (boot-css snapshot refresh tracked by task-24459; two diagnostic-inventory reds name files this branch never touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WocisXw6SEEG6nb1aKFHtv

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the schedules screen's UAT blockers: clipped display, stale rows, and dishonest sync/transfer status. Detail panes now scroll, fired reminders repaint immediately, and status messaging tells per-phase truth.

**Bug Fixes**
- Compact editors and the rail filter paint their typed text; the lifecycle action row stays above the fold.
- A `ReminderDispatched` event bridges the scheduler loop to the UI; the liveness strip ticks on its own 5s cadence.
- Fired one-time reminders read "Completed" instead of "Disabled"; a load failure keeps last-good rows with an honest notice.
- The same-cycle stale pull no longer re-inserts a just-deleted mirror (`released_server_id` guard).

**Sync & transfer honesty**
- Sync toasts carry labeled per-phase errors instead of collapsing a successful phase into a blanket failure.
- Transfers gate on a real reachability probe (tri-state, with honest checking and permission-vs-network refusal copy).
- Reachability probes bypass the capabilities cache, so a dead server is caught on the next explicit probe; a 401/403 counts as proof of reachability.
- Orphaned transfer mutations settle to failed-with-Retry on mount without blocking the screen, and again each sync cycle.
- The client probes `/scheduled-tasks/capabilities` so a too-old server degrades honestly instead of raw 404s.

<sup>Written for commit f81a30605dc630dbcc89887014244e3a622afd3f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2422?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

