### PR TITLE
Veto navigation while a queue-manager edit is unsaved (TASK-31701)

### DIFF
--- a/Tests/UI/test_console_prompt_queue.py
+++ b/Tests/UI/test_console_prompt_queue.py
@@ -631,3 +631,138 @@ async def test_dirty_queue_edit_vetoes_navigation_and_preserves_text() -> None:
         assert console.flush_pending_work() is True, (
             "a saved edit loses nothing; navigation must be allowed again"
         )
+
+
+def _bare_modal_for_dirty_check(
+    *, editing: str | None, edit_text: str, baseline: str | None, read_result
+):
+    """A ConsolePromptQueueModal with only the dirty-check's seams stubbed.
+
+    Args:
+        editing: Value for ``_editing_entry_id``.
+        edit_text: Text the stubbed edit TextArea reports.
+        baseline: Value for ``_editing_baseline_text``.
+        read_result: What the stubbed controller's ``read_waiting_text``
+            returns.
+
+    Returns:
+        The bare modal instance.
+    """
+    modal = ConsolePromptQueueModal.__new__(ConsolePromptQueueModal)
+    modal._editing_entry_id = editing
+    modal._editing_baseline_text = baseline
+    modal._revision = 7
+    modal.session_id = "session-1"
+    modal._queue_controller = SimpleNamespace(
+        read_waiting_text=lambda *args, **kwargs: read_result
+    )
+    modal.query_one = lambda selector, widget_type=None: SimpleNamespace(
+        text=edit_text
+    )
+    return modal
+
+
+def test_has_unsaved_edit_unit_states() -> None:
+    """Isolated decision table for the dirty check (Qodo #2425).
+
+    The race states (STALE_REVISION / LOCKED / NOT_FOUND) must judge
+    against the edit-time baseline: the save path refuses them too, so
+    the veto is the user's only copy of the modified text.
+    """
+    from tldw_chatbook.Chat.console_prompt_queue import QueueMutationStatus
+
+    applied = SimpleNamespace(status=QueueMutationStatus.APPLIED, text="queued")
+
+    # No edit open: never dirty.
+    assert (
+        _bare_modal_for_dirty_check(
+            editing=None, edit_text="anything", baseline=None, read_result=applied
+        ).has_unsaved_edit()
+        is False
+    )
+    # Edit open, text matches the current queue: clean.
+    assert (
+        _bare_modal_for_dirty_check(
+            editing="e1", edit_text="queued", baseline="queued", read_result=applied
+        ).has_unsaved_edit()
+        is False
+    )
+    # Edit open, text diverges from the current queue: dirty.
+    assert (
+        _bare_modal_for_dirty_check(
+            editing="e1", edit_text="typed", baseline="queued", read_result=applied
+        ).has_unsaved_edit()
+        is True
+    )
+    # Race states: current unreadable -> judge against the baseline.
+    for status in (
+        QueueMutationStatus.STALE_REVISION,
+        QueueMutationStatus.LOCKED,
+        QueueMutationStatus.NOT_FOUND,
+    ):
+        raced = SimpleNamespace(status=status, text=None)
+        assert (
+            _bare_modal_for_dirty_check(
+                editing="e1", edit_text="typed", baseline="queued", read_result=raced
+            ).has_unsaved_edit()
+            is True
+        ), f"{status}: modified text must stay protected through the race"
+        assert (
+            _bare_modal_for_dirty_check(
+                editing="e1", edit_text="queued", baseline="queued", read_result=raced
+            ).has_unsaved_edit()
+            is False
+        ), f"{status}: an unmodified edit protects nothing"
+    # Defensive: no baseline at all -> any typed text is protected.
+    raced = SimpleNamespace(status=QueueMutationStatus.NOT_FOUND, text=None)
+    assert (
+        _bare_modal_for_dirty_check(
+            editing="e1", edit_text="typed", baseline=None, read_result=raced
+        ).has_unsaved_edit()
+        is True
+    )
+    assert (
+        _bare_modal_for_dirty_check(
+            editing="e1", edit_text="", baseline=None, read_result=raced
+        ).has_unsaved_edit()
+        is False
+    )
+
+
+def test_flush_pending_work_unit_stack_walk() -> None:
+    """Isolated contract for the screen hook (Qodo #2425).
+
+    Vetoes (with one warning notification) when any stacked screen
+    reports an unsaved edit; allows when none does or none provides the
+    probe.
+    """
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    class _App:
+        def __init__(self, stack):
+            self.screen_stack = stack
+
+    class _Host(ChatScreen):
+        # Textual's `app` is a read-only property; the bare unit needs a
+        # stubbed stack, so the subclass overrides the lookup.
+        _stub_app = None
+
+        @property
+        def app(self):
+            return self._stub_app
+
+    screen = _Host.__new__(_Host)
+    notes: list[str] = []
+    screen.notify = lambda message, **kwargs: notes.append(str(message))
+
+    plain = SimpleNamespace()  # no has_unsaved_edit at all
+    clean = SimpleNamespace(has_unsaved_edit=lambda: False)
+    dirty = SimpleNamespace(has_unsaved_edit=lambda: True)
+
+    screen._stub_app = _App([plain, clean])
+    assert ChatScreen.flush_pending_work(screen) is True
+    assert notes == []
+
+    screen._stub_app = _App([plain, clean, dirty])
+    assert ChatScreen.flush_pending_work(screen) is False
+    assert len(notes) == 1 and "Unsaved queue edit" in notes[0]

--- a/Tests/UI/test_console_prompt_queue.py
+++ b/Tests/UI/test_console_prompt_queue.py
@@ -572,3 +572,62 @@ async def test_use_current_context_rejects_an_epoch_that_changed_after_review() 
 
     assert result.status is QueueMutationStatus.INVALID
     assert "changed since review" in result.detail
+
+
+@pytest.mark.asyncio
+async def test_dirty_queue_edit_vetoes_navigation_and_preserves_text() -> None:
+    """TASK-31701: the one lossy Console navigation is guarded again.
+
+    A queue-manager edit whose text diverges from the queued entry vetoes
+    `flush_pending_work` (the seam app.py consults before dismissing
+    overlays), preserving the modal, the typed text, and focus. Saving
+    the edit clears the veto -- navigation is lossless again.
+    """
+    _app, host = _ready_host()
+    async with host.run_test(size=(100, 30)) as pilot:
+        console = await _mounted_console(host, pilot)
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        snapshot = controller.prompt_queue_registry.snapshot(session_id)
+        snapshot = controller.prompt_queue_registry.begin_chain(
+            session_id,
+            context_epoch=controller.store.conversation_context_epoch(session_id),
+            expected_revision=snapshot.revision,
+        ).snapshot
+        controller.prompt_queue_registry.admit(
+            session_id,
+            text="original queued text",
+            expected_revision=snapshot.revision,
+        )
+        controller.prompt_queue_coordinator.publish_registry_change(session_id)
+        await console._sync_native_console_chat_ui()
+        await pilot.pause()
+        await pilot.click("#console-prompt-queue-manage")
+        await pilot.pause()
+        modal = host.screen_stack[-1]
+        assert isinstance(modal, ConsolePromptQueueModal)
+
+        # No edit open: nothing to protect.
+        assert console.flush_pending_work() is True
+
+        await pilot.click("#console-prompt-queue-edit")
+        edit = modal.query_one("#console-prompt-queue-edit-input", TextArea)
+        # Edit open but text unchanged: still lossless, still allowed.
+        assert console.flush_pending_work() is True
+
+        edit.text = "edited but not yet saved"
+        assert console.flush_pending_work() is False, (
+            "a dirty edit must veto -- the navigation seam would dismiss "
+            "the modal and discard the typed text"
+        )
+        assert isinstance(host.screen_stack[-1], ConsolePromptQueueModal), (
+            "the veto must not disturb the open manager"
+        )
+        assert edit.text == "edited but not yet saved"
+
+        # Saving resolves the veto.
+        await pilot.click("#console-prompt-queue-save")
+        await pilot.pause()
+        assert console.flush_pending_work() is True, (
+            "a saved edit loses nothing; navigation must be allowed again"
+        )

--- a/backlog/tasks/task-31701 - Veto-navigation-while-a-queue-manager-edit-is-unsaved.md
+++ b/backlog/tasks/task-31701 - Veto-navigation-while-a-queue-manager-edit-is-unsaved.md
@@ -1,0 +1,63 @@
+---
+id: TASK-31701
+title: Veto navigation while a queue-manager edit is unsaved
+status: Done
+assignee: []
+created_date: '2026-09-05 12:10'
+labels:
+  - console
+  - ux
+dependencies:
+  - task-31520
+priority: medium
+---
+
+## Description (the why)
+
+TASK-31520 made Console navigation lossless and retired the busy-fleet
+confirmation dialog -- but that dialog had been the ACCIDENTAL protection
+for one genuinely lossy case: an unsaved edit in the prompt-queue manager
+modal. The navigation seam dismisses pushed screens before switching, so
+navigating with a dirty queue edit open silently discards the user's
+typed text (it always did when the fleet was idle; the busy-fleet dialog
+merely happened to intercept some of those journeys). The repo's
+convention for exactly this shape is the outgoing screen's
+`flush_pending_work` veto -- Library's note editor already blocks
+navigation on an unresolved dirty state and lets the user resolve and
+retry.
+
+## Acceptance Criteria (the what)
+
+- [x] Navigating away from Console with a DIRTY queue-manager edit open is vetoed: the user stays, the modal and typed text are untouched, and a notification says why
+- [x] A clean edit view, a saved edit, or no modal never vetoes -- navigation stays instant and lossless
+- [x] The veto goes through the existing `flush_pending_work` seam (no new dialog, no confirm_navigation revival)
+- [x] Guard tests cover the veto, the allow paths, and are mutation-tested (disabling the veto loop fails the guard)
+
+## Implementation Plan (the how)
+
+1. `ConsolePromptQueueModal.has_unsaved_edit()`: True only when an edit
+   view is open AND its text diverges from the queued entry's current
+   text (an unchanged view or a changed/vanished entry protects nothing).
+2. `ChatScreen.flush_pending_work()`: walk the app screen stack for a
+   `has_unsaved_edit` provider; veto with a warning notification.
+3. One journey guard test covering no-modal / clean-edit / dirty-edit /
+   saved-edit; mutation-test the veto.
+
+## Implementation Notes
+
+Implemented exactly per plan. The dirty check lives ON the modal (it
+owns the controller, session id, and revision), so the screen hook stays
+a generic stack walk -- any future modal with recoverable typed state
+opts in by defining `has_unsaved_edit`. The veto fires through the same
+`flush_pending_work` seam Library's note editor uses: app.py consults it
+BEFORE dismissing overlays, so a veto leaves the modal, text, and focus
+untouched. Quit is deliberately out of scope (confirm_quit already
+warns, and quit cancels everything regardless).
+
+Verified: the journey guard passes (no-modal allow, clean-edit allow,
+dirty veto with modal/text preserved, save-then-allow); disabling the
+veto loop fails it; prompt-queue + console reuse + suspend-contract +
+parallel-runs suites 58 passed; ruff clean.
+
+Files: `Widgets/Console/console_prompt_queue_modal.py`,
+`UI/Screens/chat_screen.py`, `Tests/UI/test_console_prompt_queue.py`.

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -15318,6 +15318,33 @@ class ChatScreen(BaseAppScreen):
                 )
             self.app_instance.notify(copy, severity="information")
 
+    def flush_pending_work(self) -> bool:
+        """Veto navigation while a dirty queue-manager edit is open.
+
+        TASK-31701: the one genuinely lossy Console navigation left after
+        TASK-31520 made switches lossless. The navigation seam dismisses
+        pushed screens before switching, so a queue-manager edit whose
+        text diverges from the queued entry would be silently discarded
+        -- the retired busy-fleet dialog had been its accidental
+        protection. Same convention as Library's note-editor dirty guard:
+        veto, tell the user why, let them save or cancel and retry.
+        A clean edit view, a saved edit, or no modal never vetoes.
+
+        Returns:
+            ``False`` to veto while a dirty edit is open; ``True``
+            otherwise.
+        """
+        for screen in reversed(self.app.screen_stack):
+            checker = getattr(screen, "has_unsaved_edit", None)
+            if callable(checker) and checker():
+                self.notify(
+                    "Unsaved queue edit -- save or cancel it before "
+                    "leaving Console.",
+                    severity="warning",
+                )
+                return False
+        return True
+
     async def confirm_navigation(self) -> bool:
         """Allow tab switches: leaving Console no longer cancels anything.
 

--- a/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
@@ -481,6 +481,37 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
                 "Use current now adopts that reviewed version."
             )
 
+    def has_unsaved_edit(self) -> bool:
+        """Report whether the open edit view holds text the queue does not.
+
+        TASK-31701: consumed by ``ChatScreen.flush_pending_work`` to veto
+        navigation while a dirty edit is open -- the navigation seam
+        dismisses pushed screens before switching, which would silently
+        discard the typed text. Only a REAL divergence counts: an edit
+        view showing the entry's current text loses nothing when
+        dismissed, and an entry that changed or vanished under the edit
+        has nothing recoverable to protect (the modal's own save path
+        already refuses it with a feedback line).
+
+        Returns:
+            ``True`` when an edit is open and its text differs from the
+            queued entry's current text.
+        """
+        if self._editing_entry_id is None:
+            return False
+        try:
+            edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
+        except NoMatches:
+            return False
+        result = self._queue_controller.read_waiting_text(
+            self.session_id,
+            self._editing_entry_id,
+            expected_revision=self._revision,
+        )
+        if result.status is not QueueMutationStatus.APPLIED or result.text is None:
+            return False
+        return edit.text != result.text
+
     def _begin_edit(self) -> None:
         entry_id = self._selected_entry_id
         if entry_id is None:

--- a/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_prompt_queue_modal.py
@@ -147,6 +147,14 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
             self._snapshot.entries[0].entry_id if self._snapshot.entries else None
         )
         self._editing_entry_id: str | None = None
+        #: The queued text as it was when the edit began (TASK-31701, Qodo
+        #: #2425 finding 2): the dirtiness baseline when the CURRENT queue
+        #: text cannot be re-read -- queue processing can move the
+        #: revision, claim, or remove the entry while the modal is open,
+        #: and a failed read must not make a genuinely modified edit look
+        #: clean (navigation would discard text the save path also
+        #: refuses, leaving the user no copy).
+        self._editing_baseline_text: str | None = None
         self._reviewed_context_epoch: int | None = None
         self._render_key: tuple[Any, ...] | None = None
 
@@ -489,13 +497,17 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
         dismisses pushed screens before switching, which would silently
         discard the typed text. Only a REAL divergence counts: an edit
         view showing the entry's current text loses nothing when
-        dismissed, and an entry that changed or vanished under the edit
-        has nothing recoverable to protect (the modal's own save path
-        already refuses it with a feedback line).
+        dismissed. When the current queue text cannot be re-read (queue
+        processing moved the revision, claimed, or removed the entry
+        while the modal was open -- Qodo #2425 finding 2), dirtiness is
+        judged against the baseline captured when the edit began: the
+        save path refuses those states too, so navigation is the user's
+        ONLY copy of the modified text.
 
         Returns:
             ``True`` when an edit is open and its text differs from the
-            queued entry's current text.
+            queued entry's current text (or, when that is unreadable,
+            from the edit's opening baseline).
         """
         if self._editing_entry_id is None:
             return False
@@ -508,9 +520,13 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
             self._editing_entry_id,
             expected_revision=self._revision,
         )
-        if result.status is not QueueMutationStatus.APPLIED or result.text is None:
-            return False
-        return edit.text != result.text
+        if result.status is QueueMutationStatus.APPLIED and result.text is not None:
+            return edit.text != result.text
+        if self._editing_baseline_text is not None:
+            return edit.text != self._editing_baseline_text
+        # No readable current text and no baseline (defensive; _begin_edit
+        # always records one): protect any typed text rather than lose it.
+        return bool(edit.text)
 
     def _begin_edit(self) -> None:
         entry_id = self._selected_entry_id
@@ -530,6 +546,7 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
             return
         edit = self.query_one("#console-prompt-queue-edit-input", TextArea)
         self._editing_entry_id = entry_id
+        self._editing_baseline_text = result.text
         edit.text = result.text
         edit.add_class("-visible")
         self.query_one("#console-prompt-queue-save", Button).disabled = False
@@ -560,6 +577,7 @@ class ConsolePromptQueueModal(SafeModalDismissMixin, ModalScreen[None]):
             QueueMutationStatus.UNCHANGED,
         }:
             self._editing_entry_id = None
+            self._editing_baseline_text = None
             edit.text = ""
             edit.remove_class("-visible")
         self._accept_mutation(result)


### PR DESCRIPTION
## Summary

Follow-up flagged in #2420: with Console navigation now lossless and the busy-fleet dialog retired, the one genuinely lossy journey left was navigating with a **dirty** queue-manager edit open — the navigation seam dismisses pushed screens before switching, silently discarding the typed text (the old dialog had been its accidental protection on busy fleets; idle fleets always lost it silently).

**Fix, via the repo's existing convention** (Library's note-editor dirty guard): `ConsolePromptQueueModal.has_unsaved_edit()` reports a real divergence only — an edit view showing the entry's current text loses nothing, and an entry that changed/vanished under the edit has nothing recoverable (the modal's own save path already refuses it). `ChatScreen.flush_pending_work()` walks the screen stack and vetoes with a warning notification. app.py consults this seam **before** overlay dismissal, so a veto leaves the modal, the typed text, and focus untouched — the user saves or cancels and retries. No new dialog; `confirm_navigation` stays always-allow.

## Verification

- One journey guard test: no modal → allow; edit open but unchanged → allow; dirty → veto with modal/text preserved; saved → allow again. **Mutation-tested**: disabling the veto loop fails it.
- Prompt-queue + console-reuse + suspend-contract + parallel-runs suites: 58 passed; ruff clean; preflight all green.

Closes task-31701.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JZ7TGpcXMtHqAwR34fNczp

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents silent data loss when navigating away from Console with an unsaved queue-manager edit open. The switch is now vetoed via the `flush_pending_work` seam before overlays are dismissed, keeping the modal, typed text, and focus intact; the user saves or cancels and retries. Clean, saved, or no edit never vetoes.

- Adds `ConsolePromptQueueModal.has_unsaved_edit()` that reports only real text divergences from the queued entry; when queue processing makes the current text unreadable, dirtiness is judged against the baseline captured when the edit began, so a modified edit stays protected through revision, claim, and removal races.
- Walks the screen stack in `flush_pending_work` and shows a warning notification when a dirty edit is open.
- Adds a journey guard test plus isolated unit tests covering the race-state decision table and the stack-walk contract, mutation-tested so disabling the veto loop fails them.

<sup>Written for commit a7299b6891693f275fc5fb5b2a8facb2a4a855ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2425?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

