### PR TITLE
docs(backlog): file the schedules-UAT minor findings

### DIFF
--- a/backlog/tasks/task-31710 - Schedules-copy-and-vocabulary-pass.md
+++ b/backlog/tasks/task-31710 - Schedules-copy-and-vocabulary-pass.md
@@ -1,0 +1,47 @@
+---
+id: TASK-31710
+title: >-
+  Schedules copy/vocabulary pass
+status: To Do
+assignee: []
+created_date: '2026-09-05 12:05'
+labels: [scheduling, ux, copy]
+priority: low
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Minor/polish copy findings from the schedules single-surface UAT
+(`qa/schedules-uat-single-surface` session, findings Minor 14 and Polish
+28/29), still present at dev tip `da2fbdbc2` (post the #2422 remediation).
+The workbench mixes multiple names for the same concept, describes itself
+inaccurately, and renders one literal double-hyphen where the copy meant an
+em dash.
+
+Concrete findings:
+- Three vocabularies for one list of things — *scheduled task* / *automation*
+  / *task* / *definition* — appear across the `Create ▾` chooser, toasts,
+  and pane titles; most visibly the two detail panes are titled `"Task
+  Detail"` (`tldw_chatbook/UI/Screens/scheduling/task_detail.py:618`) and
+  `"Definition Detail"` (`tldw_chatbook/UI/Screens/scheduling/
+  definition_detail.py:607`) for what the rest of the screen calls one
+  unified queue.
+- The screen's header subtitle reads `"When jobs, watchlists, and
+  workflows run."` (`schedules_workbench.py:584` and `:4443`) — none of
+  those three nouns names what the screen actually lists (reminders +
+  recurring questions), and watchlist projections are explicitly out of
+  scope per the redesign spec.
+- The server-transfer confirm dialog's own body text renders a literal
+  `--` where an em dash was intended: `"...the transfer -- nothing goes
+  dark while this is only queued."` (`schedules_workbench.py:2243`).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The two detail-pane titles, the `Create ▾` chooser copy, and save toasts converge on one consistent vocabulary for "the thing in the queue" (or the split is intentional and stated once, not scattered across 3+ wordings)
+- [ ] #2 The header subtitle names what the screen actually lists (reminders and recurring questions), not watchlists or workflows
+- [ ] #3 The transfer confirm dialog's body text renders a real em dash instead of a literal `--`, and any other schedules-screen user-facing string with the same double-hyphen pattern is corrected
+<!-- AC:END -->

--- a/backlog/tasks/task-31711 - Schedules-timestamp-and-timezone-display-pass.md
+++ b/backlog/tasks/task-31711 - Schedules-timestamp-and-timezone-display-pass.md
@@ -1,0 +1,57 @@
+---
+id: TASK-31711
+title: >-
+  Schedules timestamp/timezone display pass
+status: To Do
+assignee: []
+created_date: '2026-09-05 12:05'
+labels: [scheduling, ux, timezone]
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Minor timestamp/timezone display findings from the schedules single-surface
+UAT (findings Minor 13, 15, 19, 20), still present at dev tip `da2fbdbc2`
+(post the #2422 remediation, which fixed the display-staleness and sync-
+honesty defects but did not touch these formatting/field gaps).
+
+Concrete findings:
+- A definition row's subtitle shows a second, **absolute** next-run
+  timestamp alongside the relative text, and that absolute value is
+  rendered in UTC with **no `UTC` suffix**
+  (`_row_subtitle` in `tldw_chatbook/UI/Screens/scheduling/
+  schedules_workbench.py:290-303`: `absolute =
+  row.next_run_at.strftime("%Y-%m-%d %H:%M")` with no timezone label) —
+  hours or a day away from the local time the user actually typed.
+- The reminder create/edit form has no visible Timezone field for a
+  one-time reminder (the default schedule kind): `reminder_form.py`'s
+  `#reminder-timezone-group` is explicitly hidden whenever
+  `schedule_kind == ONE_TIME` (`_update_schedule_field_visibility`,
+  `reminder_form.py:650-661`), and `_save()` then hard-codes
+  `form_data["timezone"] = None` for that kind
+  (`reminder_form.py:846`) regardless of the machine's detected zone —
+  it later displays back as `UTC`.
+- Raw microsecond ISO-8601 strings appear in user-facing chrome: the sync
+  status strip's `Last pull:` / `Last push:` values are passed through
+  unformatted (`sync_status_widget.py:184-187`, fed by
+  `state.get("last_pull_at")` in `schedules_workbench.py:4297-4298`), and
+  the same raw strings appear in the Conflicts pushed view.
+- A hard-coded example date, `2026-08-28 09:00`, sits in the past relative
+  to the current date and appears as placeholder/example copy at 12 sites
+  across `forms/reminder_form.py`, `forms/automation_definition_form.py`,
+  `task_detail.py`, `definition_detail.py`,
+  `Scheduling/schedule_input_parsing.py`, and
+  `Scheduling/services/scheduling_service.py`.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 A definition row's absolute next-run timestamp (when shown) carries an explicit timezone label (UTC or the zone it is actually in), never a bare `YYYY-MM-DD HH:MM`
+- [ ] #2 A one-time reminder captures and persists a real timezone (the machine's detected zone, matching the recurring form's own default) instead of storing `None` and later displaying `UTC`
+- [ ] #3 `Last pull:` / `Last push:` and the Conflicts view render a human-readable local timestamp, not a raw microsecond ISO-8601 string
+- [ ] #4 The hard-coded example/placeholder date used across the schedules forms and detail panes is a date that is never in the past relative to "today", at all 12 known sites
+<!-- AC:END -->

--- a/backlog/tasks/task-31712 - Schedules-form-and-detail-pane-polish.md
+++ b/backlog/tasks/task-31712 - Schedules-form-and-detail-pane-polish.md
@@ -1,0 +1,64 @@
+---
+id: TASK-31712
+title: >-
+  Schedules form/detail-pane polish
+status: To Do
+assignee: []
+created_date: '2026-09-05 12:05'
+labels: [scheduling, ux, polish]
+priority: low
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Minor/polish form and detail-pane findings from the schedules
+single-surface UAT (findings Minor 16, 22, 23, Polish 25, 26, 27), still
+present at dev tip `da2fbdbc2` (post the #2422 remediation, which fixed the
+inline-editor/scroll blockers but not these smaller inconsistencies).
+
+Concrete findings:
+- A reminder's `Repeat` / `Timezone` rows are only ever editable for the
+  kind they apply to (`recurring = task.schedule_kind ==
+  ScheduleKind.RECURRING`, `task_detail.py:1003-1011`) — reasonable per
+  se, but `Notifications` stays **permanently** read-only for a reminder
+  ("Notifications has no backing field at all... stays permanently
+  read-only", same file) while a definition's own Notifications toggle
+  (On/Off) is editable in place. The net effect a user sees is still: two
+  primitives on the same screen with different, unexplained editability
+  rules for a same-named field.
+- The recurring-question form (`automation_definition_form.py:333`) always
+  preselects `Schedule Kind: One Time` even though the form's whole purpose
+  is authoring a *recurring* question — the user must switch it every time.
+- Spec §5's kebab menu (Duplicate / View runs / View results / Edit in
+  full… / Delete-Archive) was deliberately deferred, not delivered — the
+  Task Detail pane's lifecycle row only carries `Edit | Acknowledge
+  incident | Run now | Enable | Disable | Delete`
+  (`task_detail.py:615-673`, comment: "no kebab -- plan ruling 1"). No
+  Duplicate and no View-runs/View-results shortcut exists from either
+  detail pane.
+- Each `DetailGroup` (a thin `Collapsible` subclass,
+  `Widgets/detail_value_row.py:333`) still carries several rows of blank
+  padding from Textual's own `Collapsible` body chrome — the direct cause
+  of the now-fixed scrolling blocker, but the wasted vertical space itself
+  was not trimmed.
+- The reminder detail pane's "Recent runs:" / "Run history: See list
+  below" labels (`task_detail.py:810-833`) sit in a narrow column and can
+  wrap across two lines at ordinary widths; the "See list below" value
+  reads like a link but has no affordance (`▾`/click) of its own.
+- The Inspector column (third pane) still renders every row as `-` in the
+  empty state, giving no visual distinction between "nothing selected yet"
+  and "this row simply has no sync/run data."
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 The reminder/definition Notifications row's editability (or permanent read-only-ness) is either made consistent between the two primitives, or the difference is explained in the row itself (a tooltip/helper line) rather than silently inconsistent
+- [ ] #2 The recurring-question ("Create automation") form defaults `Schedule Kind` to `Recurring`, not `One Time`
+- [ ] #3 Either the spec §5 kebab (or an equivalent Duplicate/View-runs/View-results affordance) is available from a detail pane, or the deferral is formally re-scoped as its own follow-up rather than left implicit
+- [ ] #4 A `DetailGroup`'s body no longer wastes multiple blank rows of padding when expanded at ordinary terminal heights
+- [ ] #5 "Recent runs:"/"Run history" labels do not wrap across two lines at the detail pane's normal column width, and any pseudo-link value text either becomes a real affordance or reads as plain text
+- [ ] #6 The Inspector pane's empty state is visually distinguishable from "no task selected" vs. "task selected, nothing to report"
+<!-- AC:END -->

--- a/backlog/tasks/task-31713 - Schedules-owner-label-and-remaining-action-honesty-gaps.md
+++ b/backlog/tasks/task-31713 - Schedules-owner-label-and-remaining-action-honesty-gaps.md
@@ -1,0 +1,59 @@
+---
+id: TASK-31713
+title: >-
+  Schedules owner-label consistency + remaining action-honesty gaps
+status: To Do
+assignee: []
+created_date: '2026-09-05 12:05'
+labels: [scheduling, ux, honesty]
+priority: medium
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Minor/polish findings from the schedules single-surface UAT (findings
+Minor 12, 17, 24 (narrowed), Polish 30), still present at dev tip
+`da2fbdbc2`. The #2422 remediation PR fixed the sync-pull path's honest
+copy (a server missing `/results` now says so instead of surfacing
+`scheduled_task_not_found`, `sync_engine.py:1403-1449`) and the invisible-
+editor/escape-focus/blank-Select-on-activation defects — this task is the
+residue that survives that fix.
+
+Concrete findings:
+- Three owner-label formats coexist in one list, none of them the
+  spec's dim `⇅ server` suffix: definition rows get a bracket PREFIX
+  (`"[This device] <name>"` / `"[<server id>] <name>"`,
+  `automation_name_cell` in `definition_detail.py:340-359`), reminder rows
+  get a parenthetical SUFFIX only when server-scoped
+  (`" (server: <id>)"`, `_queue_owner_suffix` in `task_detail.py:431-451`)
+  and **no label at all** for a local reminder.
+- The 60-second next-run ticker's re-render calls `table.clear()` then
+  repopulates every row (`schedules_workbench.py:1436-1449`) — Textual's
+  `DataTable.clear()` resets the table's horizontal scroll to column 0,
+  so a user reading a truncated subtitle is yanked back to column 0 once
+  a minute.
+- A definition's server-side `Run now` still surfaces the server client's
+  raw exception text on failure — `_run_automation_now_server`
+  (`schedules_workbench.py:3888-3920`) catches `ServerClientError`
+  generically and notifies `f"Failed to run '{name}': {exc}"` with no
+  capabilities gate beforehand, unlike the (now-fixed) results-pull path
+  which checks `_automation_capabilities_available()` first and turns a
+  missing-endpoint 404 into "This server does not provide the results
+  inbox (server too old)." A server too old for
+  `/definitions/{id}/run` still surfaces its raw 404 text through
+  Run-now.
+- The Conflicts and Results pushed views still carry large amounts of dead
+  vertical space relative to their content (a handful of rows in a
+  full-height pane).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+
+<!-- AC:BEGIN -->
+- [ ] #1 Reminder and definition rows use the same owner-label format (prefix or suffix, not both), and a local row's labeling behavior is consistent between the two primitives
+- [ ] #2 The 60-second (or any periodic) row re-render preserves the DataTable's current horizontal scroll position instead of resetting it to column 0
+- [ ] #3 A server-side `Run now` against a server that does not implement the run endpoint reports honest copy (e.g. "This server does not support running automations on demand") instead of the raw client exception text, mirroring the results-pull fix
+- [ ] #4 The Conflicts and Results pushed views make reasonable use of vertical space instead of leaving most of the pane empty for a handful of rows
+<!-- AC:END -->


### PR DESCRIPTION
## Summary
- Files the still-open Minor (12-24) and Polish (25-31) findings from the schedules single-surface UAT report as four grouped backlog tasks (TASK-31710..31713), cross-checked against dev tip `da2fbdbc2` (post the #2422 UAT-remediation PR).
- Dropped as already-fixed (confirmed in code, not just re-asserted): Minor 18 (Select-border blank-on-activate), Minor 21 (Escape not releasing search-box focus), the sync-pull half of Minor 24 (raw `scheduled_task_not_found`), Polish 31 (silent results pull). Minor 24's Run-now half (a server missing `/definitions/{id}/run` still surfaces a raw client exception) survives, narrowed, inside TASK-31713.
- Groups: TASK-31710 copy/vocabulary, TASK-31711 timestamp/timezone display, TASK-31712 form/detail-pane polish, TASK-31713 owner-label consistency + remaining action-honesty gaps.

## Test plan
- [x] N/A — docs-only change (new task files under `backlog/tasks/`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files the still-open Minor/Polish findings from the schedules single-surface UAT as four grouped backlog tasks (TASK-31710–31713), dropping the findings already fixed in code (Minor 18, 21, the sync-pull half of 24, and Polish 31). Docs-only change; no test plan needed.

- Groups findings by area: copy/vocabulary, timestamp/timezone display, form/detail-pane polish, and owner-label consistency plus remaining action-honesty gaps.
- Minor 24's Run-now half (a raw server exception on a missing `/definitions/{id}/run` endpoint) survives, narrowed, in TASK-31713.

<sup>Written for commit cc02a45a479a4831faac25b93ba7d21588ce9217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2426?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

