### PR TITLE
fix(console): preserve durable trace ownership across sends and tool continuations

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -7085,6 +7085,132 @@ async def test_durable_capture_on_composes_exact_trace_request_through_real_agen
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("change_history", [False, True])
+async def test_two_saved_turns_keep_history_references_through_production_trace(
+    tmp_path,
+    monkeypatch,
+    change_history,
+):
+    """Ordinary history must extend the real trace surface on the next send."""
+    from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+    from tldw_chatbook.Chat.console_trace_provenance import SavedRevisionTraceProvenance
+    from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+
+    chat_db = CharactersRAGDB(tmp_path / "two-turn-trace.sqlite", "task31714")
+    runs_db = AgentRunsDB(tmp_path / "two-turn-runs.sqlite", client_id="task31714")
+    factory = ConsoleTraceBoundaryFactory(chat_db)
+    requests = []
+
+    def boundary(request, resolution, route):
+        result = factory(request, resolution, route)
+        requests.append(request)
+        return result
+
+    def adapter(**_kwargs):
+        return {"choices": [{"message": {"content": "Observations recorded."}}]}
+
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=adapter,
+        trace_call_boundary_factory=boundary,
+    )
+
+    async def resolve_for_send(_selection):
+        return ConsoleProviderResolution(
+            ready=True,
+            provider="openai",
+            model="test-model",
+            base_url="https://api.openai.com/v1",
+            execution_key="openai",
+            streaming=False,
+            resolved_destination=ConsoleResolvedDestination(
+                provider="openai",
+                model="test-model",
+                endpoint_identity="https://api.openai.com/v1",
+                egress_class=ConsoleEgressClass.PUBLIC_NETWORK,
+            ),
+        )
+
+    monkeypatch.setattr(gateway, "resolve_for_send", resolve_for_send)
+    original_preparation = controller_module.ConsoleTurnPreparation
+
+    def capture_on(**kwargs):
+        kwargs["capture_mode"] = ConsoleTraceCaptureMode.CAPTURE_ON
+        return original_preparation(**kwargs)
+
+    monkeypatch.setattr(controller_module, "ConsoleTurnPreparation", capture_on)
+    store = ConsoleChatStore(persistence=ChatPersistenceService(chat_db))
+    session = _arm_session(store)
+    session.settings = ConsoleSessionSettings(provider="openai", model="test-model")
+    bridge = ConsoleAgentBridge(
+        agent_runs_db=runs_db, store=store, provider_gateway=gateway
+    )
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider="openai",
+        model="test-model",
+        agent_runtime_enabled=True,
+        agent_bridge=bridge,
+    )
+    try:
+        first = await controller.submit_draft("Observe the sky.", session_id=session.id)
+        assert first.accepted
+        assert len(requests) == 1
+        cursor = chat_db.get_connection().cursor()
+        first_call = tuple(
+            cursor.execute("SELECT * FROM console_trace_calls").fetchone()
+        )
+        first_user_id = store.messages_for_session(session.id)[0].persisted_message_id
+        reader = ConsoleTraceNativeReader(chat_db)
+        first_trace = reader.read_calls(first_user_id)
+        assert len(first_trace) == 1
+        assert first_trace[0].capture.request.get("omitted") is None
+        if change_history:
+            substitute = controller._apply_skill_substitution
+
+            async def changed_history(rows):
+                result = await substitute(rows)
+                result[0][0] = {**result[0][0], "content": "Different history."}
+                return result
+
+            monkeypatch.setattr(
+                controller, "_apply_skill_substitution", changed_history
+            )
+        # Equal text is deliberate: different saved owners must remain distinct.
+        second = await controller.submit_draft(
+            "Observe the sky.", session_id=session.id
+        )
+        assert second.accepted
+        assert first_call in [
+            tuple(row) for row in cursor.execute("SELECT * FROM console_trace_calls")
+        ]
+        assert reader.read_calls(first_user_id) == first_trace
+        if change_history:
+            assert len(requests) == 1
+            assert (
+                controller.run_state_for(session.id).status is ConsoleRunStatus.BLOCKED
+            )
+            return
+        assert len(requests) == 2
+        assert controller.run_state_for(session.id).status is ConsoleRunStatus.COMPLETED
+        first_user = requests[0].provenance.messages_payload[-1]
+        assert isinstance(first_user, SavedRevisionTraceProvenance)
+        assert first_user in requests[1].provenance.messages_payload
+        second_user = requests[1].provenance.messages_payload[-1]
+        assert isinstance(second_user, SavedRevisionTraceProvenance)
+        assert first_user != second_user
+        assert all(
+            not any(key.startswith(("_native", "_tldw")) for key in row)
+            for request in requests
+            for row in request.messages_payload
+        )
+    finally:
+        runs_db.close()
+        await gateway.aclose()
+        chat_db.close_connection()
+
+
+@pytest.mark.asyncio
 async def test_run_agent_reply_without_factory_passes_no_library_provider():
     """Default construction (no factory) keeps the pre-task-1337 handoff:
     run_reply receives `library_provider=None`."""

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -7171,10 +7171,10 @@ async def test_two_saved_turns_keep_history_references_through_production_trace(
         first = await controller.submit_draft("Observe the sky.", session_id=session.id)
         assert first.accepted
         assert len(requests) == 1
-        cursor = chat_db.get_connection().cursor()
-        first_call = tuple(
-            cursor.execute("SELECT * FROM console_trace_calls").fetchone()
-        )
+        with chat_db.transaction() as connection:
+            first_call = tuple(
+                connection.execute("SELECT * FROM console_trace_calls").fetchone()
+            )
         first_user_id = store.messages_for_session(session.id)[0].persisted_message_id
         reader = ConsoleTraceNativeReader(chat_db)
         first_trace = reader.read_calls(first_user_id)
@@ -7196,9 +7196,11 @@ async def test_two_saved_turns_keep_history_references_through_production_trace(
             "Observe the sky.", session_id=session.id
         )
         assert second.accepted
-        assert first_call in [
-            tuple(row) for row in cursor.execute("SELECT * FROM console_trace_calls")
-        ]
+        with chat_db.transaction() as connection:
+            assert first_call in [
+                tuple(row)
+                for row in connection.execute("SELECT * FROM console_trace_calls")
+            ]
         assert reader.read_calls(first_user_id) == first_trace
         if change_history:
             assert len(requests) == 1

--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -6880,9 +6880,11 @@ async def test_run_agent_reply_threads_exact_admitted_trace_request_to_bridge():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("production_boundary", [False, True])
 async def test_durable_capture_on_composes_exact_trace_request_through_real_agent_path(
     tmp_path,
     monkeypatch,
+    production_boundary,
 ):
     """The durable production path owns provenance before the agent bridge."""
     from tldw_chatbook.Agents.agent_runtime import FENCE_OPEN
@@ -6904,6 +6906,9 @@ async def test_durable_capture_on_composes_exact_trace_request_through_real_agen
     runs_db = AgentRunsDB(tmp_path / "durable-agent-runs.sqlite", client_id="task12")
     repository = ConsoleTraceRepository()
     service = ConsoleTraceService(repository)
+    from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+
+    production_factory = ConsoleTraceBoundaryFactory(chat_db, repository=repository)
     with chat_db.transaction() as cursor:
         segment = repository.create_segment(cursor)
     owner_holder = []
@@ -6919,6 +6924,16 @@ async def test_durable_capture_on_composes_exact_trace_request_through_real_agen
         assert provenance is not None
         assert request.semantic.provenance is not None
         policy = request.semantic.provenance.capture_policy
+        if production_boundary:
+            boundary = production_factory(request, _resolution, route)
+            if not owner_holder:
+                owner_holder.append(
+                    SimpleNamespace(owner_id=boundary.identity.owner_id)
+                )
+            routes.append(route)
+            provenances.append(provenance)
+            policies.append(policy)
+            return boundary
         preparation_identity = new_opaque_id()
         with chat_db.transaction() as cursor:
             if not owner_holder:

--- a/Tests/Chat/test_console_trace_runtime.py
+++ b/Tests/Chat/test_console_trace_runtime.py
@@ -220,6 +220,7 @@ async def test_production_factory_persists_append_only_calls_through_real_gatewa
         "missing",
         "foreign_turn",
         "changed_policy",
+        "changed_actor",
         "stale_surface",
         "same_surface_new_run",
         "ambiguous",
@@ -277,6 +278,10 @@ async def test_tool_loop_uses_recorded_chain_and_rejects_changed_ownership(
             capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
         )
     ] == ["ok"]
+    with database.transaction() as cursor:
+        origin_run_id = cursor.execute(
+            "SELECT run_id FROM console_trace_calls WHERE call_sequence = 0"
+        ).fetchone()[0]
     if scenario == "missing":
         chain = new_opaque_id()
     elif scenario == "foreign_turn":
@@ -284,6 +289,8 @@ async def test_tool_loop_uses_recorded_chain_and_rejects_changed_ownership(
         _, revision = _saved_message(database, other, "calculate")
     elif scenario == "changed_policy":
         policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    elif scenario == "changed_actor":
+        actor = new_opaque_id()
     elif scenario == "ambiguous":
         other = database.add_conversation({"title": "colliding chain"})
         other_id, _ = _saved_message(database, other, "other turn")
@@ -297,7 +304,7 @@ async def test_tool_loop_uses_recorded_chain_and_rejects_changed_ownership(
                 owner_id=owner.owner_id,
                 segment_id=segment.segment_id,
                 turn_id=other_id,
-                run_id=chain,
+                run_id=origin_run_id,
                 call_sequence=0,
                 idempotency_key=new_opaque_id(),
                 policy_id=policy.policy_id,
@@ -383,7 +390,7 @@ async def test_tool_loop_uses_recorded_chain_and_rejects_changed_ownership(
             loop_prepared, resolution, ConsoleRequestRoute.TOOL_LOOP
         )
         assert boundary.identity.turn_id == user_id
-        assert boundary.identity.run_id == chain
+        assert boundary.identity.run_id == origin_run_id
         assert boundary.identity.call_sequence == 1
     else:
         with pytest.raises(ValueError, match="trace_tool_chain_unavailable"):

--- a/Tests/Chat/test_console_trace_runtime.py
+++ b/Tests/Chat/test_console_trace_runtime.py
@@ -213,6 +213,189 @@ async def test_production_factory_persists_append_only_calls_through_real_gatewa
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "valid",
+        "missing",
+        "foreign_turn",
+        "changed_policy",
+        "stale_surface",
+        "same_surface_new_run",
+        "ambiguous",
+    ],
+)
+async def test_tool_loop_uses_recorded_chain_and_rejects_changed_ownership(
+    tmp_path,
+    make_database,
+    make_gateway,
+    scenario,
+):
+    database = make_database(tmp_path / "tool-chain.sqlite", "tool-chain")
+    conversation_id = database.add_conversation({"title": "tool chain"})
+    user_id, revision = _saved_message(database, conversation_id, "calculate")
+    policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    actor, chain = new_opaque_id(), new_opaque_id()
+    factory = ConsoleTraceBoundaryFactory(database)
+    gateway = make_gateway(
+        chat_api_call_fn=lambda **kwargs: {"choices": [{"message": {"content": "ok"}}]},
+        trace_call_boundary_factory=factory,
+    )
+    resolution = ConsoleProviderResolution(
+        ready=True,
+        provider="openai",
+        model="gpt-test",
+        execution_key="openai",
+        base_url="https://api.openai.com/v1",
+        streaming=False,
+    )
+    messages = [{"role": "user", "content": "calculate"}]
+    initial = _semantic_request(
+        messages,
+        [revision],
+        policy,
+        route=ConsoleRequestRoute.AGENT_FIRST,
+        actor_id=actor,
+        chain_id=chain,
+    )
+    prepared = gateway.prepare_chat_request(
+        resolution,
+        initial,
+        route=ConsoleRequestRoute.AGENT_FIRST,
+        route_actor_id=actor,
+        route_chain_id=chain,
+        capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+    )
+    assert [
+        item
+        async for item in gateway.stream_chat(
+            resolution,
+            prepared,
+            route=ConsoleRequestRoute.AGENT_FIRST,
+            route_actor_id=actor,
+            route_chain_id=chain,
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
+    ] == ["ok"]
+    if scenario == "missing":
+        chain = new_opaque_id()
+    elif scenario == "foreign_turn":
+        other = database.add_conversation({"title": "foreign"})
+        _, revision = _saved_message(database, other, "calculate")
+    elif scenario == "changed_policy":
+        policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    elif scenario == "ambiguous":
+        other = database.add_conversation({"title": "colliding chain"})
+        other_id, _ = _saved_message(database, other, "other turn")
+        with database.transaction() as cursor:
+            segment = factory.repository.create_segment(cursor)
+            owner = factory.repository.attach_owner(
+                cursor, conversation_id=other, root_segment_id=segment.segment_id
+            )
+            factory.repository.reserve_call(
+                cursor,
+                owner_id=owner.owner_id,
+                segment_id=segment.segment_id,
+                turn_id=other_id,
+                run_id=chain,
+                call_sequence=0,
+                idempotency_key=new_opaque_id(),
+                policy_id=policy.policy_id,
+            )
+    elif scenario == "stale_surface":
+        _, later = _saved_message(database, conversation_id, "new turn")
+        next_request = _semantic_request(
+            messages + [{"role": "user", "content": "new turn"}],
+            [revision, later],
+            policy,
+        )
+        next_prepared = gateway.prepare_chat_request(
+            resolution,
+            next_request,
+            route=ConsoleRequestRoute.FRESH,
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
+        assert [
+            item
+            async for item in gateway.stream_chat(
+                resolution,
+                next_prepared,
+                route=ConsoleRequestRoute.FRESH,
+                capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+            )
+        ] == ["ok"]
+    elif scenario == "same_surface_new_run":
+        newer_chain = new_opaque_id()
+        newer_request = _semantic_request(
+            messages,
+            [revision],
+            policy,
+            route=ConsoleRequestRoute.AGENT_FIRST,
+            actor_id=actor,
+            chain_id=newer_chain,
+        )
+        newer_prepared = gateway.prepare_chat_request(
+            resolution,
+            newer_request,
+            route=ConsoleRequestRoute.AGENT_FIRST,
+            route_actor_id=actor,
+            route_chain_id=newer_chain,
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
+        assert [
+            item
+            async for item in gateway.stream_chat(
+                resolution,
+                newer_prepared,
+                route=ConsoleRequestRoute.AGENT_FIRST,
+                route_actor_id=actor,
+                route_chain_id=newer_chain,
+                capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+            )
+        ] == ["ok"]
+    tool_result = {"role": "tool", "content": "323", "tool_call_id": "call-1"}
+    loop_request = _semantic_request(
+        messages + [tool_result],
+        [
+            revision,
+            ProviderArtifactTraceProvenance(TraceProvenanceSource.TOOL_RESULT, policy),
+        ],
+        policy,
+        route=ConsoleRequestRoute.TOOL_LOOP,
+        actor_id=actor,
+        chain_id=chain,
+    )
+    loop_prepared = gateway.prepare_chat_request(
+        resolution,
+        loop_request,
+        route=ConsoleRequestRoute.TOOL_LOOP,
+        route_actor_id=actor,
+        route_chain_id=chain,
+        capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+    )
+    with database.transaction() as cursor:
+        before = cursor.execute("SELECT COUNT(*) FROM console_trace_calls").fetchone()[
+            0
+        ]
+    if scenario == "valid":
+        # A new factory must recover the chain from SQLite, not a process cache.
+        boundary = ConsoleTraceBoundaryFactory(database)(
+            loop_prepared, resolution, ConsoleRequestRoute.TOOL_LOOP
+        )
+        assert boundary.identity.turn_id == user_id
+        assert boundary.identity.run_id == chain
+        assert boundary.identity.call_sequence == 1
+    else:
+        with pytest.raises(ValueError, match="trace_tool_chain_unavailable"):
+            factory(loop_prepared, resolution, ConsoleRequestRoute.TOOL_LOOP)
+        with database.transaction() as cursor:
+            assert (
+                cursor.execute("SELECT COUNT(*) FROM console_trace_calls").fetchone()[0]
+                == before
+            )
+
+
+@pytest.mark.asyncio
 async def test_dual_write_legacy_capture_reuses_normalized_call_identity(
     tmp_path,
     make_database,

--- a/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+++ b/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
@@ -62,6 +62,13 @@ project-instruction bodies never enter default durable capture.
    abandoned generations remain distinct calls. No call stores a history array
    proportional to the conversation's age.
 
+   Agent run identity binds the stable opaque actor/chain pair carried by route
+   provenance, not the chain alone (PR2433 review, 2026-09-05). The existing
+   `run_id` stores `actor_uuid:chain_uuid`; both inputs are canonical UUIDv4
+   values, so this is an unambiguous content-free identity. No new schema,
+   content hash, or process-local ownership registry is introduced. Historical
+   chain-only runs remain readable, but cannot authorize a new continuation.
+
 5. **Store request headers only when their effective value changes.** A complete
    logical header records provider/model configuration, rendered system references,
    tool-schema references, response/reasoning controls, endpoint's credential-free

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11513,3 +11513,13 @@ Use the production factory for at least one multi-turn and tool-loop integration
 test; fake only inference. Compare native-reader reconstruction before/after a
 later turn, and keep a changed-history negative control. A completed call row or
 a mocked append boundary alone does not prove historical request reconstruction.
+
+Follow-up, TASK-31737: the real production-boundary tool test also exposed that
+response settlement is queued when the next model call begins; requiring a
+terminal `complete` row incorrectly blocked a valid `response_started` chain.
+Independent review then reproduced an old chain being admitted after a newer
+chain dispatched the identical prompt. Surface equality did not prove current
+call ownership. A failing same-surface/new-run test led to an atomic ordered
+call-boundary event and latest-call check. Use durable call order for supersession,
+not surface identity or timestamps, and exercise deferred settlement in the real
+agent path rather than forcing it synchronous in the test.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11496,3 +11496,20 @@ cancelled stream. Shielding only the callback did not make the stream wait.
 The regression now uses that actual gateway and waits for its worker's terminal
 acknowledgement; both callback and stream drain the same assistant-owned task
 before terminal settlement.
+
+## Trace integration tests must use the production boundary factory (TASK-31714, 2026-09-05)
+
+During mounted snapshot UAT, ordinary second sends failed even without any
+snapshot operations. Existing controller tests used a hand-built append-only
+trace boundary; lower-level factory tests supplied already-correct descriptors.
+Both missed private persisted-ID annotations surviving in semantic history but
+being removed from the wire, which caused saved descriptors to become artifacts
+at the real agent boundary. A real SQLite/controller/agent/gateway test using
+`ConsoleTraceBoundaryFactory` reproduced the failure before the correction.
+The same UAT then exposed a separate tool-loop `trace_turn_unavailable` rejection
+that the custom test boundary also bypasses.
+
+Use the production factory for at least one multi-turn and tool-loop integration
+test; fake only inference. Compare native-reader reconstruction before/after a
+later turn, and keep a changed-history negative control. A completed call row or
+a mocked append boundary alone does not prove historical request reconstruction.

--- a/backlog/docs/validation-31714-console-trace-snapshot-handoff.md
+++ b/backlog/docs/validation-31714-console-trace-snapshot-handoff.md
@@ -1,0 +1,112 @@
+# TASK-31714: Console trace fix and snapshot handoff validation
+
+Date: 2026-09-05. Base: `c14dadd77080be929d47e3acef41be790ee5d8d1` (`dev`).
+Branch: `codex/chatbook-snapshot-trace-fix` in an isolated temporary worktree.
+The dirty shared Chatbook checkout was not modified.
+Existing architecture: [ADR-097](../decisions/097-console-reference-backed-semantic-trace-ledger.md).
+No schema, trace ownership contract, capture policy or snapshot support gate changed.
+
+## Diagnosis and correction
+
+The ordinary second-send failure reproduced both after snapshot restoration and
+with no runtime lifecycle operations. The production trace service rejected
+`unsupported_surface_change`: a previously saved user reference arrived as an
+`ACTIVE_REQUEST` artifact alongside appended history.
+
+The native owner ID had not been lost. Saved history also carried the private
+`_tldw_persisted_message_id` and `_tldw_persisted_conversation_id` annotations.
+The durable trace builder retained them in semantic provider values, while
+serialization removed them. The agent request factory's exact row comparison
+therefore could not reuse the saved descriptor. `_build_durable_trace_request`
+now excludes all three private identity annotations from both compared visible
+rows and frozen provider values. Native owner lookup and exact content matching
+remain authoritative; no text-only owner inference or broader delta allowance
+was introduced.
+
+## Automated evidence
+
+- New regression uses real SQLite, persistence, controller, agent bridge, gateway
+  and production `ConsoleTraceBoundaryFactory`; only network inference is faked.
+  Before the fix, the second send never reached its second boundary. After the
+  fix it completes, even with identical text in two differently owned user rows.
+- Changed history remains explicitly blocked. Native-reader reconstruction of
+  the first trace is identical before and after either second-send outcome.
+- Final targeted run: **339 passed, 1 deselected, 1 warning, 37.74s** across
+  controller, trace runtime, service and native-reader modules.
+- The deselected tool-catalog count assertion expects 29 exclusions but current
+  dev has 26. It failed in the initial whole-module run and was independently
+  reproduced with the complete unchanged HEAD controller loaded before pytest.
+  It is not silently counted as passing or repaired by this trace fix.
+- Ruff 0.16.6 found **no introduced diagnostics**, including security rules:
+  controller 176 baseline/current, test module 16 baseline/current. Repository
+  lint debt remains; whole-file lint is not clean. Changed-range formatting and
+  `git diff --check` pass. No full-suite sweep or dependency installation.
+- Independent read-only review: no critical/important findings. Its suggested
+  historical reconstruction assertion was added and both cases passed again.
+
+Logs: `/private/tmp/chatbook-trace-{red,green,reconstruction,final-targeted}.log`,
+`/private/tmp/chatbook-catalog-baseline.log` and scoped Ruff output.
+
+## Real mounted Chatbook and native runtime
+
+Disposable fixture: `/private/tmp/llamacpp-chatbook-validation.3vIa7q`.
+Actual `TldwCli.run_test`, visible composer send action, production Admin HTTP
+snapshot routes, supervisor and native llama-server. This is mounted-app UAT,
+not physical-terminal input or a new browser walkthrough.
+
+Config/XDG/data paths were synthetic; an OS fence denied real-home writes and
+all outbound network except localhost ports 18584/18585. `HOME` was unchanged.
+Runtime: official macOS ARM64 b10816, supplied Gemma 4 26B/4A Q4_K_M,
+CPU, context 16384, one slot, explicit full-SWA cache, reasoning disabled.
+Only the fixture admitted its executable hash; production allowlist stays empty.
+
+Two ordinary sends first passed without lifecycle operations. Then:
+
+| Observation | Measured result |
+| --- | --- |
+| Save / Stop / Start / Restore | Saved and restored 6038 tokens |
+| Actual Chatbook follow-up | Reused 6031, processed 27 tokens |
+| Identical captured request, cold native control | Reused 0, processed 6058 tokens |
+| Lifecycle effects | No automatic send; messages, selected durable records and provider settings unchanged |
+| Pause / Resume | No snapshot operations or automatic sends; messages and selected durable records unchanged |
+
+The cold control is a direct request with the captured payload, not another
+Chatbook message. Each successful send required a fresh native response as well
+as a settled run state. The mounted app exited without an app exception.
+Payloads omit `id_slot`; this establishes single-slot reuse, not concurrent
+conversation-to-slot affinity. Prior stale-wait captures remain invalid.
+
+Evidence: `chatbook-fixed-lifecycle.log`, `chatbook-result.json`,
+`chatbook-wire.json`, `control-fixed.log`, and the mounted SVG screenshot.
+
+## Remaining tool-loop blocker
+
+The model requested exactly calculator `17 * 19`. The real approval card stayed
+pending across save/restart/restore (6085 tokens), with unchanged messages,
+durable state and settings and no automatic inference. The harness checked the
+single tool name, builtin server and arguments before pressing Approve once.
+Continuation then blocked **before another native request**:
+`console_trace_runtime.py:148`, `ValueError: trace_turn_unavailable`.
+
+The factory currently requires the final payload descriptor to identify the
+saved active turn (except its explicit direct-prefill case). A tool-loop tail
+is a provider-only tool artifact, so that rule does not establish its owning
+turn. Fixing this needs a separate, validated tool-chain ownership path, not
+loosening the guard or selecting an arbitrary earlier saved message.
+Tool execution/continuation and warm tool-loop cache reuse are **not validated**.
+A separate mounted calculator control with no snapshot or lifecycle operations
+reproduced the identical error before its continuation dispatch. This is an
+independent Chatbook tool-chain problem, not evidence of broken cache restoration.
+
+Evidence: `chatbook-tool-diagnostic.log`, `chatbook-tool-trace-errors.json`,
+`chatbook-tool-no-lifecycle.log`, `chatbook-tool-wire.json` and
+`chatbook-tool-pending.svg`. Server snapshot
+acceptance remains open; successful plain chat does not open production support.
+
+## Cleanup
+
+The owned native profile and API process were stopped. The two remaining
+synthetic tool-run cache copies (668,892,856 bytes combined) were permanently
+deleted; no saved copies remain. Ten completed operation receipts, synthetic
+databases and diagnostic logs were retained. Neither fixture port has a listener.
+Original model/executable assets and real user profiles were unchanged.

--- a/backlog/docs/validation-31737-tool-chain-snapshot-handoff.md
+++ b/backlog/docs/validation-31737-tool-chain-snapshot-handoff.md
@@ -107,3 +107,30 @@ control wire/exception captures and pending/after-restore mounted SVGs.
   Logs and synthetic databases are retained; user models, binaries and profiles
   were not changed.
   The owned native/API processes exited and both fixture ports have no listeners.
+
+## PR2433 rebase and Qodo review follow-up
+
+Rebased onto dev `66a1cbf8f`. The sole conflict was competing testing-lesson
+appendices; both were retained. Range-diff confirmed unchanged product patches.
+
+Qodo identified a missing actor binding, an unscoped test cursor, and a missing
+validation-exception docstring. A new changed-actor regression failed with
+`DID NOT RAISE ValueError`: the original chain accepted another actor. Durable
+agent `run_id` now encodes the canonical UUIDv4 pair `actor_uuid:chain_uuid`.
+The same pair recovers from SQLite across factory reconstruction; a changed
+actor finds no authoritative origin and fails before reservation. Existing
+opaque-string consumers and legacy shadow binding accept this identity. No
+new schema or cache was introduced; ADR097 decision4 records the clarification.
+Historical chain-only traces remain readable but cannot authorize continuations.
+
+Both integration reads now use separate shared transaction contexts, with no
+raw cursor retained across the awaited second send. `get_run_origin` documents
+its ValueError contract. Independent read-only review approved the follow-up
+with no findings. Fresh whole targeted modules: **375 passed, 1 known baseline
+catalog failure, 1 warning, 52.85s**. No introduced Ruff/security findings;
+changed-range formatting and diff checks pass. Earlier live native UAT above
+was not rerun for this review follow-up; the real controller/agent/factory
+regressions were rerun with inference replaced.
+
+Fresh post-review storage release gates: **2 passed, 4 deselected, 1 warning,
+89.42s**, preserving both append and replacement growth requirements.

--- a/backlog/docs/validation-31737-tool-chain-snapshot-handoff.md
+++ b/backlog/docs/validation-31737-tool-chain-snapshot-handoff.md
@@ -1,0 +1,109 @@
+# TASK-31737: Tool-chain ownership and snapshot approval validation
+
+Date: 2026-09-05. Base: `33a14b11c`, following the ordinary-send fix on
+`codex/chatbook-snapshot-trace-fix`. The shared dirty checkout was untouched.
+Architecture: [ADR-097](../decisions/097-console-reference-backed-semantic-trace-ledger.md),
+especially ordered call boundaries and conversation/turn/run/call ownership.
+No new schema, authority, capture policy or production build admission.
+
+## Failure and fix
+
+Mounted calculator approval previously failed with `trace_turn_unavailable`,
+both after restoration and without any snapshot operations. The factory assumed
+the final payload descriptor owned the saved user turn. Tool results are
+provider-only artifacts, so that assumption does not hold for tool loops.
+
+Tool continuations now validate their supplied saved-turn candidate against the
+unique recorded first agent call in the same chain. Owner, segment, turn and
+frozen policy must agree. The previous logical call must be response-bearing,
+and its surface must remain current. `response_started` is allowed because the
+agent intentionally queues response settlement; requiring `complete` races that
+existing handoff. Fresh-send unsaved-turn rejection is unchanged.
+
+Independent review reproduced an additional stale-run case: a newer run could
+use the identical surface. A new regression failed before the correction.
+Reservations now atomically append the already-defined `call_boundary` event,
+and continuation must follow the latest such event in its segment. This checks
+call order, not prompt equality or wall-clock timestamps. No history body is
+copied into the event. Missing, foreign, policy-mismatched, ambiguous and stale
+chains fail before a new reservation or provider dispatch.
+
+## Automated verification
+
+- The controller/agent/gateway regression uses real SQLite and the production
+  trace factory, with only inference replaced. It initially failed while the
+  older hand-built boundary passed. Both now pass, including distinct artifact
+  and saved-response links and completed call sequences 0 and 1.
+- Seven runtime scenarios cover valid continuation (including a new factory
+  recovering from SQLite), missing chain, foreign turn, changed policy,
+  changed surface, ambiguous origin and a newer run with the same surface.
+- Final whole-module run across controller, runtime, repository, service and
+  native reader: **374 passed, 1 baseline failure, 1 warning, 45.70s**.
+  The failure is the previously independently reproduced unchanged-dev catalog
+  count assertion (expects29, actual26), outside this fix. No full suite run.
+- Independent re-review approved the corrected ordering check; its targeted
+  verification passed20 tests with the existing requests-version warning.
+- Ruff 0.16.6 introduces no diagnostics: runtime2, repository4, runtime-test1
+  and controller-test16 inherited findings remain unchanged. Security rules
+  are included. Changed-range formatting and whitespace checks pass. Whole-file
+  lint debt is not reported as clean.
+- Production-factory storage release gates passed both append and replacement
+  scenarios (2 passed, 84.43s), five fresh databases each with200 turns.
+  Median trace-owned bytes were293,280 and316,591, below the2MiB cap.
+  Second-half/first-half byte ratios were0.9913 and0.9849; row ratios0.9929
+  and0.9920. The ordered event preserves the existing linear-growth contract.
+
+Evidence: `/private/tmp/chatbook-tool-{trace-red,chain-red,stale-run-red,order-green,chain-final-targeted}.log`.
+
+## Measured live approval handoff
+
+Fixture: `/private/tmp/llamacpp-chatbook-validation.3vIa7q`. Actual mounted
+`TldwCli`, visible composer action and approval card, real calculator, production
+Admin HTTP snapshot routes, supervisor/store and native llama-server. This is
+mounted-app UAT, not physical-terminal input or a new browser walkthrough.
+
+Official b10816 ARM64, supplied Gemma4 26B/4A Q4_K_M, CPU, context16384,
+one slot, full-SWA enabled, reasoning disabled, output cap128. The scratch config
+and all data paths were isolated before import. An OS fence denied real-home
+writes and all egress except the two fixture localhost ports. `HOME` was unchanged.
+
+1. The model requested calculator `17 * 19`; the actual card required approval.
+2. Save/restart/restore completed with **6085 tokens**, while the card remained
+   pending. Messages, selected durable records and provider settings stayed
+   unchanged; the lifecycle caused no inference request.
+3. The harness checked the sole builtin tool and exact arithmetic arguments,
+   then pressed **Approve once**. The real tool returned323 and the model
+   responded `The result of 17 * 19 is 323.`
+4. The continuation reused **6054 tokens / processed73**. An identical captured
+   payload sent directly to the cold native runtime reused0 / processed6127.
+   Native prompt processing was1193.579ms warm versus55812.482ms cold.
+5. Pause/Resume produced no snapshot operations or automatic send and preserved
+   messages and selected durable records. App teardown reported no exception.
+6. A separate actual calculator approval with **no lifecycle operations** passed.
+
+SQLite inspection verified the two UAT calls have the same recorded turn and
+run, sequences0/1, statescomplete, routesagent_first/tool_loop and two ordered
+call-boundary events. The final diagnostic exception list is empty.
+
+Evidence: `chatbook-tool-chain-final.log`, `chatbook-tool-chain-result.json`,
+`chatbook-tool-chain-wire.json`, `chatbook-tool-chain-control-final.log`, separate
+control wire/exception captures and pending/after-restore mounted SVGs.
+
+## Limits and cleanup
+
+- Production `TESTED_TEXT_BUILD_SHA256` remains empty. Only the disposable
+  fixture admitted this exact candidate executable. These results do not establish
+  general model, streaming, multimodal, concurrent-slot or fleet support.
+  Chatbook payloads still omit `id_slot`; one-slot observation is not affinity.
+- Pre-fix in-flight traces lack ordered call-boundary events. Their continuation
+  fails closed; this change does not backfill chronology or silently disable capture.
+- Origin uniqueness is a global scan; `LIMIT 2` bounds returned rows, not work.
+  A query-only in-memory clone of the actual table/index schema with100,000
+  synthetic calls measured100 samples: median2.199ms, p952.610ms, max3.516ms.
+  This is not disk or end-to-end reservation latency. Indexing remains a scaling
+  consideration; no schema expansion was made for this correction.
+- The harness permanently deleted its two synthetic saved copies across the
+  two successful lifecycle runs. Zero copies and14 historical receipts remain.
+  Logs and synthetic databases are retained; user models, binaries and profiles
+  were not changed.
+  The owned native/API processes exited and both fixture ports have no listeners.

--- a/backlog/tasks/task-31714 - Fix-Console-second-send-trace-surface-rejection-found-during-snapshot-UAT.md
+++ b/backlog/tasks/task-31714 - Fix-Console-second-send-trace-surface-rejection-found-during-snapshot-UAT.md
@@ -1,0 +1,46 @@
+---
+id: TASK-31714
+title: Fix Console second-send trace surface rejection found during snapshot UAT
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-05 19:24'
+updated_date: '2026-09-05 19:46'
+labels: []
+dependencies: []
+documentation:
+  - backlog/docs/validation-31714-console-trace-snapshot-handoff.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Restore ordinary multi-turn Chatbook sends with capture enabled after live validation found a pre-dispatch trace failure even without snapshot operations.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Two ordinary sends succeed through the real preparation and trace boundary with capture enabled.
+- [x] #2 Historical trace remains reconstructable and mismatched or unauthorized surface changes remain fail-closed.
+- [x] #3 Targeted regressions and disposable live snapshot and tool-approval handoff UAT are recorded without opening production snapshot support.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Capture the exact synthetic incoming versus durable trace-surface mismatch on current dev and trace it to its preparation/settlement owner. 2. Add a real SQLite and provider-boundary regression that fails before the smallest correction; retain negative provenance and ownership controls. 3. Run targeted trace/Console tests, lint/format and scoped security checks. 4. Re-run disposable two-send control, then Admin save/restart/restore and pending-tool approval UAT; record measured native reuse and cleanup. ADR required: no new ADR. ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md. Reason: restore existing reference-backed, fail-closed trace contract; do not widen its ownership/privacy boundaries or open production snapshot support.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Renumbered this newly created record from TASK-31701 before implementation: all-ref/worktree sweep found older unrelated owners of 31701 and maximum allocated ID 31713.
+
+Implemented the minimal visible-value correction in ConsoleChatController: omit native/persisted identity annotations from trace comparison and frozen provider rows, retaining native-owner lookup and exact content matching under ADR-097. Added a production SQLite/store/controller/gateway/agent trace regression with RED/GREEN evidence, equal-text distinct owners, changed-history fail-closed control, and native-reader before/after equality. Independent review has no blocking findings; its reconstruction suggestion was implemented. Targeted final339passed1deselected1warning; one catalog count assertion independently fails unchanged dev and remains out of scope. Ruff has zero introduced diagnostics against192 inherited findings; changed ranges are format-clean and git diff check passes. Actual mounted two-send control and save/restart/restore now demonstrate6031 cached/27processed versus cold0/6058, unchanged messages/durable state/settings, no autosends and unchanged Pause/Resume behavior. Tool approval survives restoration but continuation hits a separate trace_turn_unavailable error also reproduced without lifecycle operations; no tool-loop success or production enablement claimed. Evidence and exact limitations: backlog/docs/validation-31714-console-trace-snapshot-handoff.md. Added testing lesson about real factory coverage. Owned test runtime stopped and two disposable synthetic copies deleted; ten receipts retained. Shared dirty checkout untouched. No PR/push requested.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Ordinary capture-on multi-turn sends fixed and measured snapshot reuse verified. Production factory regression, negative controls and immutable reconstruction pass. Separate tool-chain ownership blocker documented; server snapshot acceptance and production allowlist remain gated.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/backlog/tasks/task-31737 - Fix-durable-trace-ownership-for-resumed-tool-loop-calls.md
+++ b/backlog/tasks/task-31737 - Fix-durable-trace-ownership-for-resumed-tool-loop-calls.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-05 19:50'
-updated_date: '2026-09-05 20:11'
+updated_date: '2026-09-05 21:43'
 labels: []
 dependencies: []
 documentation:
@@ -29,6 +29,8 @@ Allow approved tool continuations to preserve the active turn in durable capture
 
 <!-- SECTION:PLAN:BEGIN -->
 1. Reproduce the tool-loop failure with real SQLite, controller, agent, gateway and production boundary; trace existing chain metadata and call ownership. 2. Resolve continuation ownership from its recorded first agent call, verify the currently supplied saved turn and frozen policy/owner, and preserve fresh-send fail-closed rules. Add missing/foreign/stale-chain negative controls before implementation. 3. Run whole targeted trace/controller modules, scoped lint/format/security and independent review. 4. Rerun actual mounted calculator approval with and without save/restart/restore, measure native warm/cold reuse, document limits and clean owned fixtures. ADR required: no new ADR. ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md. Reason: implement existing turn/run/call-sequence ownership for tool calls using the durable ledger; no new schema, authority, or capture policy. Reassess if a new cross-module identity contract is necessary.
+
+PR2433 review follow-up: reproduce a changed actor under the original chain; bind the existing durable run_id to the canonical opaque actor/chain pair, recover it without process state, and reject changed actors before reservation. Scope test reads in separate transaction contexts and document the validation exception. Rerun whole targeted modules and storage gates, respond to each Qodo finding, and merge only after review and checks clear. ADR required: no new ADR; clarify ADR097 decision4 because the existing run-ownership field and authority remain unchanged.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -39,6 +41,10 @@ All remote refs (142) and worktrees swept before filing: maximum31736. CLI offer
 Independent review found stale-run admission when a newer chain used identical saved prompt surface. Added a failing same-surface/new-run regression, then atomically recorded the existing call_boundary event at reservation and required the prior logical call to be the latest boundary. This implements ADR097 ordered call ownership without schema changes. Re-review approved; pre-fix in-flight traces without boundaries remain fail-closed. Query-only100k-row schema-clone measurement: origin scan median2.199ms/p952.610ms; not an end-to-end/disk guarantee. New global index deferred as a scaling consideration, not claimed bounded by LIMIT2.
 
 Implemented recorded tool-chain ownership in console_trace_runtime plus bounded-result origin/latest-call lookups in repository. Existing call_boundary event now commits atomically with reservation; no schema change. Real controller/agent regression and seven runtime ownership scenarios cover valid/deferred settlement, missing/foreign/policy/ambiguous/stale chains, including newer same-surface runs. TDD failures observed before each correction. Final whole targeted modules374passed1knownbaselinefailure1warning; catalog count29vs26 was independently reproduced unchanged dev in TASK31714. Storage release gates2passed84.43s: five fresh databases/scenario,200turns, median293280/316591bytes, linear growth below2MiB. No introduced Ruff/security findings (23 inherited), touched-range format and diff checks pass. Independent re-review approved; old in-flight traces without ordered boundaries remain fail-closed and origin scan scaling is measured/documented. Final real mounted calculator approval across6085-token save/restart/restore completed323; warm6054reused/73processed versus cold0/6127. No-lifecycle approval control also passed. Messages/durable records/settings unchanged by lifecycle; Pause/Resume unchanged, no autosends. Actual trace calls complete on same turn/run seq0/1, exception list empty. Production allowlist empty. Both owned processes/ports clear; zero copies14receipts, synthetic evidence retained. Documentation: backlog/docs/validation-31737-tool-chain-snapshot-handoff.md and updated testing lesson. Existing ADR097 applies. No push/merge or dependency installation.
+
+PR2433 Qodo review: reproduce actor mismatch before fixing, scope integration reads in separate transactions, and document get_run_origin validation exception. ADR097 applies; clarify agent run ownership as the stable opaque actor/chain pair in the existing run_id field, without schema or authority expansion. No raw-content hash or in-memory-only actor registry.
+
+PR2433 rebased onto dev66a1cbf8f; retained both conflicting testing lessons. Addressed all three Qodo findings: RED changed-actor regression then durable actor_uuid:chain_uuid run binding; transaction-scoped integration reads; documented ValueError. ADR097 decision4 clarified, no schema change. Independent follow-up review approved. Fresh targeted375passed1knownbaselinefailure1warning52.85s; storage gates2passed89.42s; no introduced Ruff/security diagnostics, changed-range format and diff clean. Prior native UAT not rerun for this review correction; real controller/agent/factory regressions rerun. Production gate unchanged. Full evidence in validation-31737-tool-chain-snapshot-handoff.md.
 <!-- SECTION:NOTES:END -->
 
 ## Final Summary

--- a/backlog/tasks/task-31737 - Fix-durable-trace-ownership-for-resumed-tool-loop-calls.md
+++ b/backlog/tasks/task-31737 - Fix-durable-trace-ownership-for-resumed-tool-loop-calls.md
@@ -1,0 +1,48 @@
+---
+id: TASK-31737
+title: Fix durable trace ownership for resumed tool-loop calls
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-05 19:50'
+updated_date: '2026-09-05 20:11'
+labels: []
+dependencies: []
+documentation:
+  - backlog/docs/validation-31737-tool-chain-snapshot-handoff.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow approved tool continuations to preserve the active turn in durable capture without guessing an earlier message or weakening fresh-send ownership checks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Actual tool-loop calls and resumed calculator approval complete through the production trace boundary with the correct turn and chain.
+- [x] #2 Missing, mismatched and stale chain ownership fail closed before provider dispatch; ordinary fresh-send and historical reconstruction behavior remain intact.
+- [x] #3 Targeted regression and real mounted snapshot/approval validation are recorded with production support still gated.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the tool-loop failure with real SQLite, controller, agent, gateway and production boundary; trace existing chain metadata and call ownership. 2. Resolve continuation ownership from its recorded first agent call, verify the currently supplied saved turn and frozen policy/owner, and preserve fresh-send fail-closed rules. Add missing/foreign/stale-chain negative controls before implementation. 3. Run whole targeted trace/controller modules, scoped lint/format/security and independent review. 4. Rerun actual mounted calculator approval with and without save/restart/restore, measure native warm/cold reuse, document limits and clean owned fixtures. ADR required: no new ADR. ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md. Reason: implement existing turn/run/call-sequence ownership for tool calls using the durable ledger; no new schema, authority, or capture policy. Reassess if a new cross-module identity contract is necessary.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All remote refs (142) and worktrees swept before filing: maximum31736. CLI offered31715, so only this new untracked record was immediately moved to31737.
+
+Independent review found stale-run admission when a newer chain used identical saved prompt surface. Added a failing same-surface/new-run regression, then atomically recorded the existing call_boundary event at reservation and required the prior logical call to be the latest boundary. This implements ADR097 ordered call ownership without schema changes. Re-review approved; pre-fix in-flight traces without boundaries remain fail-closed. Query-only100k-row schema-clone measurement: origin scan median2.199ms/p952.610ms; not an end-to-end/disk guarantee. New global index deferred as a scaling consideration, not claimed bounded by LIMIT2.
+
+Implemented recorded tool-chain ownership in console_trace_runtime plus bounded-result origin/latest-call lookups in repository. Existing call_boundary event now commits atomically with reservation; no schema change. Real controller/agent regression and seven runtime ownership scenarios cover valid/deferred settlement, missing/foreign/policy/ambiguous/stale chains, including newer same-surface runs. TDD failures observed before each correction. Final whole targeted modules374passed1knownbaselinefailure1warning; catalog count29vs26 was independently reproduced unchanged dev in TASK31714. Storage release gates2passed84.43s: five fresh databases/scenario,200turns, median293280/316591bytes, linear growth below2MiB. No introduced Ruff/security findings (23 inherited), touched-range format and diff checks pass. Independent re-review approved; old in-flight traces without ordered boundaries remain fail-closed and origin scan scaling is measured/documented. Final real mounted calculator approval across6085-token save/restart/restore completed323; warm6054reused/73processed versus cold0/6127. No-lifecycle approval control also passed. Messages/durable records/settings unchanged by lifecycle; Pause/Resume unchanged, no autosends. Actual trace calls complete on same turn/run seq0/1, exception list empty. Production allowlist empty. Both owned processes/ports clear; zero copies14receipts, synthetic evidence retained. Documentation: backlog/docs/validation-31737-tool-chain-snapshot-handoff.md and updated testing lesson. Existing ADR097 applies. No push/merge or dependency installation.
+<!-- SECTION:NOTES:END -->
+
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Tool-loop ownership fixed under ADR097, with durable call-order supersession checks and fail-closed mismatches. Actual calculator approval now completes after restart/restore with measured cache reuse; production enablement remains gated. Targeted regressions, linear-storage gates and independent review completed; baseline catalog assertion and upgrade/scaling caveats documented.
+<!-- SECTION:FINAL_SUMMARY:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -8623,8 +8623,18 @@ class ConsoleChatController:
             raise TraceProvenancePersistenceError()
 
         def provider_row(row: Mapping[str, Any]) -> dict[str, Any]:
+            # History annotations identify saved owners, but are not provider
+            # values. Match and freeze the same visible shape that serialization
+            # sends; otherwise the agent bridge cannot reuse its saved descriptor.
             return {
-                key: value for key, value in row.items() if key != NATIVE_MESSAGE_ID_KEY
+                key: value
+                for key, value in row.items()
+                if key
+                not in {
+                    NATIVE_MESSAGE_ID_KEY,
+                    PERSISTED_MESSAGE_ID_KEY,
+                    PERSISTED_CONVERSATION_ID_KEY,
+                }
             }
 
         source_by_owner = {

--- a/tldw_chatbook/Chat/console_trace_repository.py
+++ b/tldw_chatbook/Chat/console_trace_repository.py
@@ -1977,6 +1977,9 @@ class ConsoleTraceRepository:
 
         Returns:
             The sole sequence-zero call, or None if missing or ambiguous.
+
+        Raises:
+            ValueError: If run_id is not a non-empty string.
         """
         _nonempty(run_id, "run_id")
         rows = cursor.execute(

--- a/tldw_chatbook/Chat/console_trace_repository.py
+++ b/tldw_chatbook/Chat/console_trace_repository.py
@@ -1966,6 +1966,45 @@ class ConsoleTraceRepository:
         ).fetchone()
         return None if row is None else self._call(row)
 
+    def get_run_origin(
+        self, cursor: sqlite3.Cursor, run_id: str
+    ) -> TraceCallRecord | None:
+        """Read a chain's unique first reservation, refusing ambiguous ownership.
+
+        Args:
+            cursor: Cursor for the caller-owned transaction.
+            run_id: Opaque provider-call chain identity.
+
+        Returns:
+            The sole sequence-zero call, or None if missing or ambiguous.
+        """
+        _nonempty(run_id, "run_id")
+        rows = cursor.execute(
+            self._call_select() + " WHERE run_id = ? AND call_sequence = 0 LIMIT 2",
+            (run_id,),
+        ).fetchall()
+        return self._call(rows[0]) if len(rows) == 1 else None
+
+    def get_latest_call_boundary(
+        self, cursor: sqlite3.Cursor, segment_id: str
+    ) -> TraceEventRecord | None:
+        """Read the latest reserved call in segment event order.
+
+        Args:
+            cursor: Cursor for the caller-owned transaction.
+            segment_id: Local trace segment, excluding inherited fork history.
+
+        Returns:
+            The latest call boundary, or None for a segment without one.
+        """
+        row = cursor.execute(
+            self._event_select()
+            + " WHERE segment_id = ? AND event_type = 'call_boundary'"
+            + " ORDER BY sequence DESC LIMIT 1",
+            (segment_id,),
+        ).fetchone()
+        return None if row is None else TraceEventRecord(*row)
+
     @staticmethod
     def _reconcile_call_reservation(
         expected: tuple[str, str, str, str, int, str, str],

--- a/tldw_chatbook/Chat/console_trace_runtime.py
+++ b/tldw_chatbook/Chat/console_trace_runtime.py
@@ -157,7 +157,13 @@ class ConsoleTraceBoundaryFactory:
         )
         policy = frozen_policy_from_provenance(semantic_provenance)
         preparation_identity = new_opaque_id()
-        run_id = route_record.chain_id or new_opaque_id()
+        # Both route identities are canonical UUIDv4 strings. Bind their pair
+        # durably, without a process cache or a second ownership table.
+        run_id = (
+            f"{route_record.actor_id}:{route_record.chain_id}"
+            if route_record.chain_id is not None
+            else new_opaque_id()
+        )
         idempotency_key = new_opaque_id()
         call_sequence = 0
         reserved = None

--- a/tldw_chatbook/Chat/console_trace_runtime.py
+++ b/tldw_chatbook/Chat/console_trace_runtime.py
@@ -8,7 +8,7 @@ from dataclasses import replace
 from datetime import datetime, timezone
 
 from tldw_chatbook.Chat.console_prepared_request import PreparedProviderRequest
-from tldw_chatbook.Chat.console_trace_models import new_opaque_id
+from tldw_chatbook.Chat.console_trace_models import TraceCallState, new_opaque_id
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
     DerivedTraceProvenance,
@@ -140,10 +140,14 @@ class ConsoleTraceBoundaryFactory:
             # preceding active user revision still owns the durable turn.
             active_descriptor_index = -2
         active_revision_ids = tuple(
-            _saved_revision_ids(
-                provenance.messages_payload[active_descriptor_index]
-            )
+            _saved_revision_ids(provenance.messages_payload[active_descriptor_index])
         )
+        tool_loop = route_record.route is ConsoleRequestRoute.TOOL_LOOP
+        if tool_loop:
+            # Tool results are provider artifacts, not a new saved user turn.
+            # This candidate must match the durable chain origin below; it is
+            # never sufficient on its own to admit continuation ownership.
+            active_revision_ids = message_revision_ids[-1:]
         if len(active_revision_ids) != 1:
             raise ValueError("trace_turn_unavailable")
         revision_ids = message_revision_ids + tuple(
@@ -179,17 +183,71 @@ class ConsoleTraceBoundaryFactory:
                             batch,
                         ).fetchall()
                     )
-                by_revision = {
-                    str(row[0]): (str(row[1]), str(row[2])) for row in rows
-                }
+                by_revision = {str(row[0]): (str(row[1]), str(row[2])) for row in rows}
                 if any(revision_id not in by_revision for revision_id in revision_ids):
                     raise ValueError("trace_revision_unavailable")
                 current_revision_id = active_revision_ids[0]
                 conversation_id, turn_id = by_revision[current_revision_id]
+                if route_record.chain_id is not None:
+                    call_sequence = self.repository.read_next_call_sequence(
+                        cursor, run_id
+                    )
                 owner = self.repository.get_attached_owner_by_conversation(
                     cursor,
                     conversation_id,
                 )
+                if tool_loop:
+                    origin = self.repository.get_run_origin(cursor, run_id)
+                    if (
+                        origin is None
+                        or owner is None
+                        or origin.route_identity
+                        != ConsoleRequestRoute.AGENT_FIRST.value
+                        or (
+                            origin.owner_id,
+                            origin.segment_id,
+                            origin.turn_id,
+                            origin.policy_id,
+                        )
+                        != (
+                            owner.owner_id,
+                            owner.root_segment_id,
+                            turn_id,
+                            policy.policy_id,
+                        )
+                    ):
+                        raise ValueError("trace_tool_chain_unavailable")
+                    previous = self.repository.get_call_by_logical_identity(
+                        cursor,
+                        owner_id=owner.owner_id,
+                        segment_id=owner.root_segment_id,
+                        turn_id=turn_id,
+                        run_id=run_id,
+                        call_sequence=call_sequence - 1,
+                    )
+                    tail = self.repository.get_surface_tail(
+                        cursor, owner.root_segment_id
+                    )
+                    latest_call = self.repository.get_latest_call_boundary(
+                        cursor, owner.root_segment_id
+                    )
+                    if (
+                        previous is None
+                        or latest_call is None
+                        or latest_call.call_id != previous.call_id
+                        # Agent response settlement may still be queued when
+                        # its next tool call begins; a response-bearing call
+                        # already provides durable ownership for that chain.
+                        or previous.state
+                        not in {
+                            TraceCallState.RESPONSE_STARTED,
+                            TraceCallState.COMPLETE,
+                        }
+                        or previous.policy_id != policy.policy_id
+                        or tail is None
+                        or previous.surface_node_id != tail.node_id
+                    ):
+                        raise ValueError("trace_tool_chain_unavailable")
                 if owner is None:
                     segment = self.repository.create_segment(cursor)
                     owner = self.repository.attach_owner(
@@ -201,20 +259,17 @@ class ConsoleTraceBoundaryFactory:
                 continuation_values = tuple(
                     group.checkpoint for group in request.continuation_groups
                 )
-                admission, surface_boundary = self.service.prepare_current_surface_delta(
-                    cursor,
-                    owner_id=owner.owner_id,
-                    segment_id=owner.root_segment_id,
-                    route_identity=route_identity,
-                    preparation_identity=preparation_identity,
-                    provenance=provenance,
-                    values=tuple(request.messages_payload) + continuation_values,
-                )
-                if route_record.chain_id is not None:
-                    call_sequence = self.repository.read_next_call_sequence(
+                admission, surface_boundary = (
+                    self.service.prepare_current_surface_delta(
                         cursor,
-                        run_id,
+                        owner_id=owner.owner_id,
+                        segment_id=owner.root_segment_id,
+                        route_identity=route_identity,
+                        preparation_identity=preparation_identity,
+                        provenance=provenance,
+                        values=tuple(request.messages_payload) + continuation_values,
                     )
+                )
                 reserved = self.repository.reserve_call(
                     cursor,
                     owner_id=owner.owner_id,
@@ -224,6 +279,19 @@ class ConsoleTraceBoundaryFactory:
                     call_sequence=call_sequence,
                     idempotency_key=idempotency_key,
                     policy_id=policy.policy_id,
+                )
+                # Surface identity alone cannot detect a newer run with the
+                # same prompt. Record the reservation in the existing ordered
+                # ledger, atomically with the call, before provider dispatch.
+                event_tail = self.repository.get_event_tail(
+                    cursor, owner.root_segment_id
+                )
+                self.repository.append_event(
+                    cursor,
+                    segment_id=owner.root_segment_id,
+                    sequence=0 if event_tail is None else event_tail.sequence + 1,
+                    event_type="call_boundary",
+                    call_id=reserved.call_id,
                 )
             assert reserved is not None
             return ConsoleTraceCallBoundary(


### PR DESCRIPTION
## Summary

- Preserve saved-message provenance across ordinary Console sends by excluding transport-private ID annotations at the durable trace boundary.
- Bind tool continuations to their recorded turn/run and durable call order, including deferred response settlement. Reject missing, foreign, policy-mismatched, ambiguous, and superseded chains before provider dispatch.
- Atomically record existing call-boundary events without schema changes, capture bypasses, or weakened fresh-send ownership checks (ADR-097).
- Include regression coverage, task records, and detailed snapshot/approval UAT evidence for TASK-31714 and TASK-31737.

## Verification

- Post-rebase Qodo fixes: 375 passed, 1 known baseline catalog failure, 1 warning (52.85s); both storage gates passed again (89.42s). All three findings addressed: durable actor/chain pair binding with a RED→GREEN changed-actor regression, transaction-scoped test reads, and exception docstring. Independent follow-up review approved. ADR097 clarifies pair identity and historical chain-only continuation failure; historical reads remain compatible.
- Fresh pre-PR run on `f82f5c6ea`: 374 passed, 1 explicitly deselected known baseline failure, 1 dependency warning in 45.38s (controller, trace runtime/repository/service/native reader modules).
- Prior complete targeted run: 374 passed, 1 independently reproduced baseline failure (catalog count expects 29, actual 26), 1 warning. No full-suite claim.
- Storage-growth release gates: 2 passed, five fresh databases per scenario, 200 turns; append/replacement medians 293,280/316,591 bytes, below the 2 MiB cap with linear growth.
- No introduced Ruff diagnostics, including configured security rules; 23 inherited findings remain. Changed-range formatting and diff checks passed.
- Independent review found and verified the fix for stale chains with identical prompt surfaces; final re-review approved.
- Actual mounted Chatbook UAT: calculator approval survives a 6,085-token save → stop/start → restore, then completes with result 323. Continuation reused 6,054 tokens and processed 73 versus cold control 0 reused / 6,127 processed. Separate no-lifecycle approval control passed.
- Messages, selected durable records, settings, and Pause/Resume semantics remained unchanged; no lifecycle autosend. Disposable services stopped and saved copies removed.

## Limits

- Production snapshot build admission remains empty; no server code or enablement change is included.
- Live evidence covers the supplied Gemma model and pinned llama.cpp ARM64 build, single-slot/nonstreaming only—not general model, streaming, multimodal, or concurrent-slot support.
- Pre-fix in-flight traces without ordered call boundaries fail closed; chronology is not backfilled.
- Origin lookup remains a global scan; the documented 100k-row measurement is query-only, not an end-to-end latency guarantee.
- Final rebase onto dev `4e904f54d`, head `82ba64a04`: all three reviewed patches unchanged by range-diff. Fresh targeted run: 375 passed, 1 known baseline catalog failure, 1 warning (51.73s). Qodo confirmed all three findings resolved before this patch-identical rebase.

## Evidence

- `backlog/docs/validation-31714-console-trace-snapshot-handoff.md`
- `backlog/docs/validation-31737-tool-chain-snapshot-handoff.md`
