### PR TITLE
chore(release): bump version to 0.2.0 so the dev→main publish actually fires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to Some kind of Versioning
     
+## [0.2.0] - 2026-09-06
+
+First minor release cut from eight weeks of dev work since 0.1.8.x. Highlights:
+
+### Added
+- Console: durable agent runs, git modes, Inspect rail, conversation inspector,
+  environment panel, cost ticker, voice dictation, turn file cards
+- Library: unified Notes/Prompts/Search workbench, ingest jobs pipeline, reader
+- Agents runtime: native tool-calls, MCP bridge, supervisor fleet, tool gates
+- Personal context profiles (`tldw_profile_core`), conversation canvases
+- Video generation foundation; expanded TTS/STT stacks
+- First-run setup wizard
+
+### Changed
+- Database schema v17 → v65 (existing databases migrate automatically at first boot)
+- Screen navigation rebuilt around a shared registry with screen-instance reuse
+
+### Fixed
+- Fresh-install boot no longer depends on an undeclared `packaging` module
+- Wheel/sdist now package every DB migration (task-19860)
+
 ## [0.1.8.1] - 2026-09-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ machine by default.
 
 ## Alpha status
 
-tldw_chatbook is **Alpha** software. The current package version is `0.1.8.1`.
+tldw_chatbook is **Alpha** software. The current package version is `0.2.0`.
 The core application is usable, but the project is moving quickly: interfaces
 can change, advanced integrations vary in maturity, and older data may
 occasionally need migration or recovery.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tldw_chatbook"
-version = "0.1.8.1"
+version = "0.2.0"
 authors = [
   { name="Robert Musser", email="contact@rmusser.net" },
 ]

--- a/tldw_chatbook/__init__.py
+++ b/tldw_chatbook/__init__.py
@@ -91,13 +91,13 @@ def _install_textual_compatibility_shims() -> None:
 
 _install_textual_compatibility_shims()
 
-__version__ = "0.1.8.1"
+__version__ = "0.2.0"
 __author__ = "Robert Musser"
 __email__ = "contact@rmusser.net"
 __license__ = "AGPLv3+"
 
 # Version tuple for programmatic comparison
-VERSION_TUPLE = (0, 1, 8, 1)
+VERSION_TUPLE = (0, 2, 0)
 
 # Export key components when package is imported
 __all__ = [


### PR DESCRIPTION
## Why

PyPI already has **0.1.8.1** (published 2026-09-03 from a dev snapshot). `Packaging/check_pypi_release.py` returns `publish_release=false` when the version already exists, so tomorrow's dev→main release merge would build fine and then **silently skip the PyPI publish** — the release would never reach package users.

## What

- `pyproject.toml`: `0.1.8.1` → `0.2.0`
- `tldw_chatbook/__init__.py`: `__version__` + `VERSION_TUPLE` (lockstep-pinned by `test_release_metadata`)
- `CHANGELOG.md`: 0.2.0 entry summarizing the release headline areas

0.2.0 chosen because this cut ships ~8 weeks of feature work (schema v17→v65); if you prefer 0.1.9 say so and I'll retitle.

## Verification

`Tests/Packaging/test_release_metadata.py` — 24 passed.
Release-gate context: wheel+sdist built from dev verified to contain all 58 migrations + tldw_profile_core; installed-wheel import chain green; live v17→v65 upgrade test with canary data passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `tldw_chatbook` from 0.1.8.1 to 0.2.0 so the next dev→main merge actually publishes to PyPI. PyPI already has 0.1.8.1, and the release check skips publishing when the version already exists, so without this bump the build would succeed but the publish would silently never happen.

Updates the version in `pyproject.toml`, `__version__`, `VERSION_TUPLE`, and `README.md` in lockstep, and adds a 0.2.0 `CHANGELOG.md` entry covering eight weeks of work (schema v17→v65, new console and library features, agents runtime additions). Existing databases migrate automatically at first boot, so no manual migration steps are needed. Release metadata tests pass (24), and a live v17→v65 upgrade test with canary data passed.

<sup>Written for commit 6afddadcf1a6912fc0d70dabdf2d6cd34733328b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2436?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

