### PR TITLE
Reduce Personal Context database connections on send

### DIFF
--- a/Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md
+++ b/Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md
@@ -1,0 +1,17 @@
+# Personal Context send performance
+
+Goal: complete TASK-31504 without weakening per-request authorization.
+
+ADR required: yes (amend existing decision)
+ADR path: backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md
+Reason: record connection lifetime and negative-cache invalidation boundaries.
+
+## Implementation
+
+1. Add failing regressions in `Tests/Personal_Context/` for configured operation connection counts, unchanged absent status, local/external setup invalidation (including WAL commits), failure cleanup, nested calls, and concurrent thread isolation. Preserve existing authority-race and export-concurrency tests. Use actual SQLite with call counters, not mocked authority behavior.
+2. In `tldw_chatbook/Personal_Context/repository.py`, introduce bounded operation-scoped autocommit connection reuse. Keep the existing short export transaction and all live checks after it; never surround authorization with one read transaction or a write lock. Close the connection on success and exceptions, and never share it across threads. Retain hardened opens and reject path/owner replacement between operations; assess replacements during reuse so stale file identity cannot authorize context.
+3. Scope reuse around authorized view construction and the Console provider-composition operation in `tldw_chatbook/Personal_Context/context_service.py` and `tldw_chatbook/Chat/console_chat_controller.py` as appropriate. Keep the double authorized-view fence because separately read identity and authority must be revalidated; document this owner note instead of changing the authorized-view contract. Live agent calls remain freshly checked.
+4. In the Personal Context service, cache only proven absent state using content-free database/WAL identity and change metadata. Any signature change, error, setup/start-fresh, service replacement, or uncertain validity requires a hardened read. Never cache READY authority. Existing locked facades need no SQLite; unlock replaces the facade. Test symlink/owner replacement rejection and failed setup.
+5. Amend ADR-102 and task notes with the bounded lifetime, invalidation contract and retained double-build rationale. Run targeted context/repository/export/agent/Console tests, provenance checks and affected-file static checks. Compare configured global/workspace hardened-open counts against measured 44/68 baseline. Do not claim latency gains from instrumented counts. Request spec then quality review and address findings before completion.
+
+Verification uses the repository root `.venv/bin/python` from this isolated worktree, confirming imports resolve here. No full-suite sweep, new dependency, persistent ready-state cache, schema change, or new authorization contract.

--- a/Tests/Personal_Context/test_send_performance.py
+++ b/Tests/Personal_Context/test_send_performance.py
@@ -1,0 +1,290 @@
+"""Real SQLite evidence for bounded send reads and absent-state invalidation."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+import tldw_chatbook.Personal_Context.repository as repository_module
+from tldw_chatbook.Chat.console_chat_controller import _compose_profile_tool_provider
+from tldw_chatbook.Personal_Context.repository import PersonalContextRepository
+from tldw_chatbook.Personal_Context.runtime_policy import PersonalContextAuthorityError
+from tldw_chatbook.Personal_Context.service import (
+    PersonalContextService,
+    ProfileOperationalState,
+)
+
+
+@pytest.fixture
+def profile(tmp_path, memory_protector):
+    repository = PersonalContextRepository(
+        tmp_path / "context.db", key_protector=memory_protector
+    )
+    return repository, PersonalContextService(repository)
+
+
+@pytest.fixture
+def opens(monkeypatch):
+    connections = []
+    original = repository_module.connect_private_sqlite
+
+    def track(*args, **kwargs):
+        connection = original(*args, **kwargs)
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(repository_module, "connect_private_sqlite", track)
+    return connections
+
+
+def compose(service, workspace_id=None):
+    return _compose_profile_tool_provider(
+        service,
+        workspace_id=workspace_id,
+        ephemeral=False,
+        run_id="run",
+        session_id="session",
+        current_user_message=None,
+        kill_switch=lambda: False,
+    )
+
+
+@pytest.mark.parametrize("workspace", [False, True])
+def test_configured_composition_uses_one_hardened_open(profile, opens, workspace):
+    repository, service = profile
+    service.create_profile()
+    service.set_runtime_enabled(True)
+    if workspace:
+        service.create_workspace_scope("workspace", "Project")
+    opens.clear()
+
+    assert compose(service, "workspace" if workspace else None) is not None
+    assert len(opens) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        opens[0].execute("SELECT 1")
+
+
+@pytest.mark.parametrize("wal", [False, True])
+def test_absent_composition_reuses_only_unchanged_negative_status(profile, opens, wal):
+    repository, service = profile
+    if wal:
+        with sqlite3.connect(repository.db_path) as connection:
+            connection.execute("PRAGMA journal_mode=WAL")
+        connection.close()
+    assert compose(service) is None
+    assert opens
+    opens.clear()
+    assert compose(service) is None
+    assert service.status().state is ProfileOperationalState.ABSENT
+    assert opens == []
+    service.create_profile()
+    service.set_runtime_enabled(True)
+    opens.clear()
+    assert compose(service) is not None
+    assert len(opens) == 1
+
+
+def test_absent_status_invalidates_on_external_wal_setup(
+    profile, opens, memory_protector
+):
+    repository, service = profile
+    external = PersonalContextRepository(
+        repository.db_path, key_protector=memory_protector
+    )
+    with sqlite3.connect(repository.db_path) as writer:
+        writer.execute("PRAGMA journal_mode=WAL")
+        assert service.status().state is ProfileOperationalState.ABSENT
+        assert service.status().state is ProfileOperationalState.ABSENT
+        opens.clear()
+        assert service.status().state is ProfileOperationalState.ABSENT
+        assert opens == []
+        # Pin an older reader so setup commits remain exclusively in WAL.
+        writer.execute("BEGIN")
+        writer.execute("SELECT * FROM profile_meta").fetchall()
+        prior_db = repository.db_path.stat()
+        other_service = PersonalContextService(external)
+        other_service.create_profile()
+        other_service.set_runtime_enabled(True)
+        assert repository.db_path.stat().st_mtime_ns == prior_db.st_mtime_ns
+        opens.clear()
+        assert service.status().state is ProfileOperationalState.READY
+        assert opens
+
+
+def test_nested_operations_close_after_failure_and_next_operation_is_fresh(
+    profile, opens
+):
+    repository, service = profile
+    service.create_profile()
+    opens.clear()
+    with pytest.raises(RuntimeError, match="failure"):
+        with repository.operation():
+            repository.get_manifest()
+            with repository.operation():
+                repository.list_scopes()
+            raise RuntimeError("failure")
+    assert len(opens) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        opens[0].execute("SELECT 1")
+    with repository.operation():
+        assert repository.get_manifest() is not None
+    assert len(opens) == 2
+
+
+def test_operations_are_thread_local(profile, opens):
+    repository, service = profile
+    service.create_profile()
+    opens.clear()
+    barrier = threading.Barrier(2)
+
+    def read():
+        with repository.operation():
+            first = repository.get_manifest()
+            barrier.wait(timeout=5)
+            assert repository.get_manifest() == first
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        futures = [pool.submit(read) for _ in range(2)]
+        for future in futures:
+            future.result(timeout=10)
+    assert len(opens) == 2
+
+
+@pytest.mark.parametrize("replacement", ["file", "symlink", "permissions", "parent"])
+def test_scoped_read_rejects_mid_operation_path_authority_change(profile, replacement):
+    repository, service = profile
+    service.create_profile()
+    with repository.operation():
+        repository.get_manifest()
+        path = repository.db_path
+        if replacement in {"file", "symlink"}:
+            saved = path.with_suffix(".saved")
+            path.rename(saved)
+            if replacement == "file":
+                path.write_bytes(saved.read_bytes())
+                path.chmod(0o600)
+            else:
+                path.symlink_to(saved)
+        elif replacement == "permissions":
+            path.chmod(0o644)
+        else:
+            path.parent.chmod(0o777)
+        with pytest.raises((OSError, repository_module.ProfileIntegrityError)):
+            repository.get_manifest()
+
+
+def test_authorized_absent_view_still_fails_closed_without_connects(profile, opens):
+    repository, service = profile
+    with pytest.raises(PersonalContextAuthorityError):
+        service.authorized_context_view()
+    opens.clear()
+    with pytest.raises(PersonalContextAuthorityError):
+        service.authorized_context_view()
+    assert opens == []
+
+
+def test_failed_setup_does_not_retain_absent_cache(profile, opens, monkeypatch):
+    repository, service = profile
+    assert service.status().state is ProfileOperationalState.ABSENT
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("setup failure")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(repository, "create_profile_with_global_scope", fail)
+        with pytest.raises(RuntimeError, match="setup failure"):
+            service.create_profile()
+    opens.clear()
+    assert service.status().state is ProfileOperationalState.ABSENT
+    assert opens
+    service.create_profile()
+    assert service.status().profile_present
+
+
+def test_storage_error_discards_cached_absence(profile, opens, monkeypatch):
+    repository, service = profile
+    assert service.status().state is ProfileOperationalState.ABSENT
+    original = repository.storage_signature
+
+    def fail():
+        raise OSError("metadata unavailable")
+
+    with monkeypatch.context() as patch:
+        patch.setattr(repository, "storage_signature", fail)
+        assert compose(service) is None
+    opens.clear()
+    assert service.status().state is ProfileOperationalState.ABSENT
+    assert opens
+    assert repository.storage_signature() == original()
+
+
+def test_same_path_replacement_invalidates_absence_and_fresh_operation(profile, opens):
+    repository, service = profile
+    assert service.status().state is ProfileOperationalState.ABSENT
+    copied = repository.db_path.with_suffix(".replacement")
+    copied.write_bytes(repository.db_path.read_bytes())
+    copied.chmod(0o600)
+    copied.replace(repository.db_path)
+    opens.clear()
+    assert service.status().state is ProfileOperationalState.ABSENT
+    assert opens
+    service.create_profile()
+    service.set_runtime_enabled(True)
+    assert compose(service) is not None
+    repository.db_path.rename(copied)
+    repository.db_path.symlink_to(copied)
+    opens.clear()
+    assert compose(service) is None
+    assert opens == []
+
+
+def test_ready_authority_is_never_cached_and_locked_facade_never_connects(
+    profile, opens
+):
+    repository, service = profile
+    service.create_profile()
+    service.set_runtime_enabled(True)
+    assert compose(service) is not None
+    service.set_runtime_enabled(False)
+    opens.clear()
+    assert compose(service) is None
+    assert opens
+    locked = PersonalContextService.locked(profile_present=True)
+    opens.clear()
+    assert compose(locked) is None
+    assert compose(locked) is None
+    assert opens == []
+    # Unlock installs a fresh unlocked service over repository/key custody.
+    service.set_runtime_enabled(True)
+    assert compose(PersonalContextService(repository)) is not None
+
+
+def test_connection_setup_failure_closes_and_does_not_poison_next_operation(
+    profile, opens, monkeypatch
+):
+    repository, service = profile
+    service.create_profile()
+    service.set_runtime_enabled(True)
+    original = repository.storage_signature
+    calls = 0
+
+    def fail_post_open_validation():
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise OSError("path changed during open")
+        return original()
+
+    opens.clear()
+    with monkeypatch.context() as patch:
+        patch.setattr(repository, "storage_signature", fail_post_open_validation)
+        with pytest.raises(OSError, match="path changed"):
+            with repository.operation():
+                repository.get_manifest()
+    assert len(opens) == 1
+    with pytest.raises(sqlite3.ProgrammingError, match="closed"):
+        opens[0].execute("SELECT 1")
+    assert compose(service) is not None

--- a/backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md
+++ b/backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md
@@ -218,6 +218,38 @@ the Persona/User Profile inversion rejected by ADR-037.
   canaries; this is regression evidence, not proof that plaintext never
   existed in process memory or external snapshots.
 
+## Send-read lifetime amendment (2026-09-05, TASK-31504)
+
+Chatbook may reuse one lazily opened, hardened SQLite read connection for a
+synchronous authorized-view or Console tool-provider composition operation.
+The lifetime is thread-local, nested scopes borrow it, and the outer scope
+closes it on success or failure. Reuse stays in autocommit mode except for the
+existing short export snapshot transaction. Mutations retain independent write
+transactions. Every final manifest, policy, binding, and revocation fence still
+reads live state after the export snapshot ends.
+
+Every reused repository read retains trusted-directory verification and checks
+database identity, owner, permissions, and link count. Sidecar ownership and
+privacy are checked too. Replacing a database or its parent during the operation
+fails closed; a later operation starts with a new hardened open. This removes
+repeated SQLite opens and PRAGMAs, not the trusted-directory security walk.
+
+Only proven ABSENT status may be retained between sends. Its cache contains
+content-free database/WAL/journal identity and change metadata, never profile
+content or READY authority. Changed metadata, uncertain reads, setup (including
+failed setup), and Start Fresh discard the cached absence. External commits in
+WAL invalidate it even when the database file has not changed. SHM is validated
+for ownership/privacy but holds coordination rather than committed content;
+empty WAL/journal creation and retirement are equivalent to their absence.
+Locked facades continue to need no SQLite access; unlock installs an unlocked
+service with a fresh cache.
+
+The Console keeps both authorized views: its second view fences the identity
+and scope authority read between them. Removing that view would require a
+different authorization contract. Live tool invocations still obtain fresh
+authority; a connection lifetime is neither a permission cache nor a whole-run
+read transaction. No schema or dependency changes are involved.
+
 ## Migration/rollback
 
 tldw_server migrates one user at a time behind a legacy-write fence. It creates

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -745,6 +745,21 @@ shredding test obtained by changing journal mode is not sufficient evidence.
 
 ---
 
+## An empty WAL reader can invalidate a content-free negative cache forever
+
+**TASK-31504, 2026-09-05.** Personal Context's first absent-status cache compared
+all DB/WAL/SHM metadata. A real WAL-mode regression closed the last SQLite reader
+between sends: opening recreated an empty WAL and SHM, and closing retired them.
+Every send therefore invalidated the cache even though no profile had been set up.
+Normalizing empty WAL/journal artifacts and excluding SHM coordination metadata
+from the change token fixed the regression while retaining sidecar owner/privacy
+checks. A second test pinned a reader while another service created the profile;
+the main DB mtime stayed unchanged and the WAL change correctly invalidated absence.
+
+**What to do.** Test negative caches with both last-reader cleanup and committed
+WAL-only writes. Coordination-file churn is not a committed-data change, but
+database-only metadata misses real committed state.
+
 ## An outer SQLite rollback cannot undo a write committed by another database
 
 **TASK-19900.1 fix review, 2026-08-22.** Console temporary promotion wrapped

--- a/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
+++ b/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-04 19:30'
-updated_date: '2026-09-06 00:04'
+updated_date: '2026-09-06 00:18'
 labels:
   - performance
   - personal-context
@@ -34,6 +34,12 @@ ADR required: yes (amend existing decision). ADR path: backlog/decisions/102-per
 Independent spec review and code-quality review approved with no findings. Primary independently reran the nine-file targeted set: 169 passed, 2 dependency warnings (6.56s); quality reviewer separately ran 17 new regressions, all passed. Primary Ruff checks for repository/service/new tests, new-test formatting and diff check passed. Pytest emitted cleanup warnings for protected pre-existing garbage directories after exit 0; those unrelated directories were not modified. Implementation plan: Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md. No schema or dependency changes, no full sweep, no PR or merge. Both authorized views remain intentionally per the documented owner note. Legacy unnumbered acceptance criteria were checked in the task source after CLI reported their indexes unavailable; Done status set through CLI.
 
 Publication: opened https://github.com/rmusser01/tldw_chatbook/pull/2439 against dev from reviewed source 0e3bcd1366. Fresh send-performance regression run: 17 passed, exit 0, two existing dependency warnings and pre-existing protected pytest garbage cleanup warnings; diff check passed. No rebase or merge. Current dev has advanced including Console changes; latest-base integration remains a pre-merge step.
+
+PR review round: rebase onto current dev, document public metadata/context-manager return contracts and name the storage identity slice boundary. Verify Qodo path/transaction recommendations against approved ADR-102 before changing authorization semantics. Run targeted Personal Context/Console tests and source checks, review the diff, then publish. Existing ADR-102 governs unchanged behavior; no new ADR required.
+
+Review evidence: rebased onto Chatbook dev 2b4973971e. Added public return contracts and named the identity-field count without changing checks. Retained operation-scoped autocommit per ADR-102: spanning live fences with a read transaction could hide revocation. Retained trusted lexical descriptor walk per private_paths.verify_trusted_directory security contract; path normalization before that walk would follow aliases before authority checks and reject supported root-owned macOS links. Fresh seven-file repository/service/context/export/inventory/Console selection: 151 passed, 2 dependency warnings, exit 0; protected pre-existing pytest cleanup warnings left unchanged. Ruff and changed-range formatting/diff checks passed; whole-file formatter has existing unrelated drift, not bulk-rewritten. Independent scoped review and derived preflight pending.
+
+Independent scoped spec and quality review approved the fixes and path/transaction rationale with no actionable findings. Full derived-artifact preflight passed (stylesheets, path census, diagnostic inventory, task IDs, table allowlist, index pins). All four Qodo items have a fix or evidence-backed disposition; publishing this reviewed round, not merging.
 <!-- SECTION:NOTES:END -->
 
 ## Description (the why)

--- a/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
+++ b/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-04 19:30'
-updated_date: '2026-09-05 20:06'
+updated_date: '2026-09-06 00:04'
 labels:
   - performance
   - personal-context
@@ -32,6 +32,8 @@ ADR required: yes (amend existing decision). ADR path: backlog/decisions/102-per
 - Self-review complete. Status/AC finalization awaits independent spec and quality review; no full suite, commit, or publication performed by the implementing subagent.
 
 Independent spec review and code-quality review approved with no findings. Primary independently reran the nine-file targeted set: 169 passed, 2 dependency warnings (6.56s); quality reviewer separately ran 17 new regressions, all passed. Primary Ruff checks for repository/service/new tests, new-test formatting and diff check passed. Pytest emitted cleanup warnings for protected pre-existing garbage directories after exit 0; those unrelated directories were not modified. Implementation plan: Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md. No schema or dependency changes, no full sweep, no PR or merge. Both authorized views remain intentionally per the documented owner note. Legacy unnumbered acceptance criteria were checked in the task source after CLI reported their indexes unavailable; Done status set through CLI.
+
+Publication: opened https://github.com/rmusser01/tldw_chatbook/pull/2439 against dev from reviewed source 0e3bcd1366. Fresh send-performance regression run: 17 passed, exit 0, two existing dependency warnings and pre-existing protected pytest garbage cleanup warnings; diff check passed. No rebase or merge. Current dev has advanced including Console changes; latest-base integration remains a pre-merge step.
 <!-- SECTION:NOTES:END -->
 
 ## Description (the why)

--- a/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
+++ b/backlog/tasks/task-31504 - Personal-Context-pays-repeated-hardened-connects-on-every-send.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31504
 title: Personal Context pays repeated hardened connects on every send
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@codex'
 created_date: '2026-09-04 19:30'
+updated_date: '2026-09-05 20:06'
 labels:
   - performance
   - personal-context
@@ -11,6 +13,26 @@ labels:
 dependencies: []
 priority: medium
 ---
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes (amend existing decision). ADR path: backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md. Reason: document operation-scoped autocommit connection reuse and fail-closed negative-cache validity without changing authority. Add failing connection-count, invalidation, closure, thread isolation and authority-race regressions. Reuse one hardened connection per scoped operation while preserving short export snapshots and live fences; retain the Console double-build consistency fence with an owner note. Cache only unchanged absent state using content-free filesystem identity/change metadata and invalidate on setup, replacement, WAL change or errors. Never cache ready authority. Verify targeted Personal Context and agent/Console suites and record measured counts, not speculative latency.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Added lazy, thread-local repository read operations and service/Console scopes. Nested reads reuse one autocommit connection and close it on success or failure; mutations keep their existing transactions. The export transaction and final live manifest, policy, binding, and revocation reads remain intact.
+- Owner note: both Console authorized views remain because the second fences separately read scope identity and authority. Every reused read retains trusted-directory verification plus database identity/owner/mode/link and sidecar privacy checks.
+- Cache only proven absent status using content-free DB/WAL/journal metadata. Setup, failed setup, Start Fresh, storage changes/errors and service replacement invalidate it. SHM ownership remains checked; empty WAL/journal creation/retirement cannot hide committed changes and is normalized to absent. Locked facades retain zero-connect behavior.
+- Measured production composition on real SQLite: configured global **44 → 1** hardened opens; configured workspace **68 → 1**. Unchanged absent composition performs **0** opens after its first read, including WAL mode. These are connection counts, not latency claims.
+- ADR required: yes, amended `backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md`; no schema/dependency change. Changed repository/service and Console composition; added `Tests/Personal_Context/test_send_performance.py`.
+- Verification: targeted repository, service, context-service, export, durable-owner inventory, agent-provider, Console integration and import-provenance run: **169 passed, 2 existing dependency warnings**. New regressions cover count reduction, negative-cache invalidation (including external WAL-only setup), lifecycle/errors, replacement rejection, nesting, closure and threads. Ruff passes for repository/service/new tests; changed source ranges and new test formatting pass; `git diff --check` passes. Console whole-file lint has the same 27 pre-existing findings as HEAD.
+- Self-review complete. Status/AC finalization awaits independent spec and quality review; no full suite, commit, or publication performed by the implementing subagent.
+
+Independent spec review and code-quality review approved with no findings. Primary independently reran the nine-file targeted set: 169 passed, 2 dependency warnings (6.56s); quality reviewer separately ran 17 new regressions, all passed. Primary Ruff checks for repository/service/new tests, new-test formatting and diff check passed. Pytest emitted cleanup warnings for protected pre-existing garbage directories after exit 0; those unrelated directories were not modified. Implementation plan: Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md. No schema or dependency changes, no full sweep, no PR or merge. Both authorized views remain intentionally per the documented owner note. Legacy unnumbered acceptance criteria were checked in the task source after CLI reported their indexes unavailable; Done status set through CLI.
+<!-- SECTION:NOTES:END -->
 
 ## Description (the why)
 
@@ -30,6 +52,6 @@ export-snapshot decrypts per send, scaling with profile size. Evidence:
 
 ## Acceptance Criteria (the what)
 
-- [ ] A send with Personal Context unconfigured/locked performs zero Personal Context DB connects after the first (the locked/absent status is cached with a correct invalidation story for setup/unlock)
-- [ ] A send with a configured profile builds the authorized view once and reuses one connection across the operation (or an owner note records why the double-build consistency check must stay)
-- [ ] Security semantics unchanged: fail-closed behavior and owner checks still hold (existing Personal Context authority tests stay green)
+- [x] A send with Personal Context unconfigured/locked performs zero Personal Context DB connects after the first (the locked/absent status is cached with a correct invalidation story for setup/unlock)
+- [x] A send with a configured profile builds the authorized view once and reuses one connection across the operation (or an owner note records why the double-build consistency check must stay)
+- [x] Security semantics unchanged: fail-closed behavior and owner checks still hold (existing Personal Context authority tests stay green)

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2818,24 +2818,27 @@ def _compose_profile_tool_provider(
         None if workspace_id == CONSOLE_GLOBAL_WORKSPACE_ID else workspace_id
     )
     try:
-        first_view = service.authorized_context_view(
-            active_workspace_id=active_workspace_id
-        )
-        scopes = service.list_scopes()
-        scope_id = first_view.workspace_scope_id or next(
-            scope.scope_id for scope in scopes if scope.kind.value == "global"
-        )
-        authority = service.get_scope_authority(scope_id)
-        stable_view = service.authorized_context_view(
-            active_workspace_id=active_workspace_id
-        )
-        if (
-            stable_view.generation != first_view.generation
-            or stable_view.authority_revision != first_view.authority_revision
-            or stable_view.workspace_scope_id != first_view.workspace_scope_id
-        ):
-            return None
-        manifest = service.get_manifest()
+        with service.read_operation():
+            first_view = service.authorized_context_view(
+                active_workspace_id=active_workspace_id
+            )
+            scopes = service.list_scopes()
+            scope_id = first_view.workspace_scope_id or next(
+                scope.scope_id for scope in scopes if scope.kind.value == "global"
+            )
+            authority = service.get_scope_authority(scope_id)
+            # Both views stay: the second fences the separately read scope and
+            # authority. Reusing a connection must not turn this into a snapshot.
+            stable_view = service.authorized_context_view(
+                active_workspace_id=active_workspace_id
+            )
+            if (
+                stable_view.generation != first_view.generation
+                or stable_view.authority_revision != first_view.authority_revision
+                or stable_view.workspace_scope_id != first_view.workspace_scope_id
+            ):
+                return None
+            manifest = service.get_manifest()
     except Exception:  # noqa: BLE001 - optional profile tools fail soft
         return None
 

--- a/tldw_chatbook/Personal_Context/repository.py
+++ b/tldw_chatbook/Personal_Context/repository.py
@@ -56,6 +56,8 @@ _WRAP_NONCE_BYTES = 12
 _PEER_ENVELOPE = "chatbook-local-v1"
 MAX_UNRESOLVED_PROPOSALS = 200
 _COLLECTION_PAGE_SIZE = 128
+# Device, inode, owner, mode and link count; size/timestamps track content only.
+_STORAGE_IDENTITY_FIELD_COUNT = 5
 _REBASELINE_TABLES = ("local_runtime_policy", "local_scope_bindings")
 _PROFILE_CONTENT_TABLES = (
     "encrypted_outbox",
@@ -447,6 +449,10 @@ class PersonalContextRepository:
 
         This can invalidate an absent-state cache; it never grants profile access.
         SQLite sidecars may be created or retired by another connection.
+
+        Returns:
+            Parent identity followed by DB, WAL, SHM and journal metadata tuples.
+            Missing or content-neutral sidecars are represented by None.
         """
 
         verify_trusted_directory(self.db_path.parent, allow_shared_sticky=False)
@@ -500,6 +506,10 @@ class PersonalContextRepository:
 
         Nested operations borrow the outer lifetime. Mutations retain their own
         transactions; no read snapshot spans the live authorization fences.
+
+        Returns:
+            A context manager yielding None and closing its owned read connection
+            when the outermost operation exits, including on errors.
         """
 
         if getattr(self._read_operation, "state", None) is not None:
@@ -523,12 +533,12 @@ class PersonalContextRepository:
             return
         signature = self.storage_signature()
         # Content/WAL changes are expected: final fences must observe them live.
-        identity = signature[0], signature[1][:5]
+        identity = signature[0], signature[1][:_STORAGE_IDENTITY_FIELD_COUNT]
         if state["connection"] is None:
             state["connection"] = self._connect()
             state["identity"] = identity
             signature = self.storage_signature()
-            identity = signature[0], signature[1][:5]
+            identity = signature[0], signature[1][:_STORAGE_IDENTITY_FIELD_COUNT]
         if identity != state["identity"]:
             raise ProfileIntegrityError("Personal Context storage identity changed.")
         yield state["connection"]

--- a/tldw_chatbook/Personal_Context/repository.py
+++ b/tldw_chatbook/Personal_Context/repository.py
@@ -7,6 +7,7 @@ import hmac
 import json
 import os
 import sqlite3
+import stat
 import uuid
 from collections.abc import Iterator, Mapping
 from contextlib import closing, contextmanager
@@ -14,6 +15,7 @@ from contextvars import ContextVar
 from dataclasses import dataclass
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
+from threading import local
 from typing import Any
 
 from cryptography.exceptions import InvalidTag
@@ -35,6 +37,7 @@ from tldw_profile_core.canonical import canonical_json_bytes
 
 from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
 from tldw_chatbook.DB.sql_validation import validate_identifier
+from tldw_chatbook.Utils.private_paths import verify_trusted_directory
 
 from .crypto import EncryptedEnvelope, EnvelopeCipher
 from .key_protector import (
@@ -361,6 +364,7 @@ class PersonalContextRepository:
         )
         self._protector = key_protector or KeyringProfileKeyProtector()
         self._keys: ProfileKeyMaterial | None = None
+        self._read_operation = local()
 
         with self._transaction() as connection:
             is_new = self._inspect_schema(connection)
@@ -438,6 +442,97 @@ class PersonalContextRepository:
             connection.close()
             raise
 
+    def storage_signature(self) -> tuple:
+        """Read content-free identity/change metadata under the trusted path guard.
+
+        This can invalidate an absent-state cache; it never grants profile access.
+        SQLite sidecars may be created or retired by another connection.
+        """
+
+        verify_trusted_directory(self.db_path.parent, allow_shared_sticky=False)
+        parent = self.db_path.parent.stat()
+        metadata = [(parent.st_dev, parent.st_ino, parent.st_uid, parent.st_mode)]
+        for suffix in ("", "-wal", "-shm", "-journal"):
+            try:
+                observed = Path(f"{self.db_path}{suffix}").lstat()
+            except FileNotFoundError:
+                if not suffix:
+                    raise
+                metadata.append(None)
+                continue
+            if (
+                not stat.S_ISREG(observed.st_mode)
+                or observed.st_nlink != 1
+                or (
+                    os.name == "posix"
+                    and (
+                        observed.st_uid != os.geteuid()
+                        or stat.S_IMODE(observed.st_mode) != 0o600
+                    )
+                )
+            ):
+                raise ProfileIntegrityError(
+                    "Personal Context storage authority changed."
+                )
+            # SHM contains coordination, not committed data. Opening a WAL reader
+            # creates SHM and an empty WAL; their retirement must not defeat an
+            # absent cache. Still validate their ownership/privacy above.
+            if suffix == "-shm" or (suffix and observed.st_size == 0):
+                metadata.append(None)
+                continue
+            metadata.append(
+                (
+                    observed.st_dev,
+                    observed.st_ino,
+                    observed.st_uid,
+                    observed.st_mode,
+                    observed.st_nlink,
+                    observed.st_size,
+                    observed.st_mtime_ns,
+                    observed.st_ctime_ns,
+                )
+            )
+        return tuple(metadata)
+
+    @contextmanager
+    def operation(self) -> Iterator[None]:
+        """Reuse one lazy autocommit read connection within this synchronous thread.
+
+        Nested operations borrow the outer lifetime. Mutations retain their own
+        transactions; no read snapshot spans the live authorization fences.
+        """
+
+        if getattr(self._read_operation, "state", None) is not None:
+            yield
+            return
+        state = {"connection": None, "identity": None}
+        self._read_operation.state = state
+        try:
+            yield
+        finally:
+            del self._read_operation.state
+            if state["connection"] is not None:
+                state["connection"].close()
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        state = getattr(self._read_operation, "state", None)
+        if state is None:
+            with closing(self._connect()) as connection:
+                yield connection
+            return
+        signature = self.storage_signature()
+        # Content/WAL changes are expected: final fences must observe them live.
+        identity = signature[0], signature[1][:5]
+        if state["connection"] is None:
+            state["connection"] = self._connect()
+            state["identity"] = identity
+            signature = self.storage_signature()
+            identity = signature[0], signature[1][:5]
+        if identity != state["identity"]:
+            raise ProfileIntegrityError("Personal Context storage identity changed.")
+        yield state["connection"]
+
     def _iter_head_rows(self, object_type: str) -> Iterator[sqlite3.Row]:
         """Yield one complete head set through bounded, stable keyset pages."""
 
@@ -445,7 +540,7 @@ class PersonalContextRepository:
             raise ValueError("Unsupported collection object type.")
         after_object_id = ""
         while True:
-            with closing(self._connect()) as connection:
+            with self._connection() as connection:
                 rows = connection.execute(
                     "SELECT encrypted_objects.* FROM object_heads "
                     "JOIN encrypted_objects USING (object_type, object_id, version_id) "
@@ -469,7 +564,7 @@ class PersonalContextRepository:
     def is_destroyed(self) -> bool:
         """Return the content-free durable local-removal marker."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT destroyed FROM profile_meta WHERE singleton = 1"
             ).fetchone()
@@ -678,7 +773,7 @@ class PersonalContextRepository:
         """Release WAL history that a completed repository snapshot had pinned."""
 
         try:
-            with closing(self._connect()) as connection:
+            with self._connection() as connection:
                 self._truncate_wal_if_possible(connection)
         except (OSError, sqlite3.Error, ProfileIntegrityError):
             return
@@ -811,7 +906,7 @@ class PersonalContextRepository:
     def first_link_freeze_plan_id(self) -> str | None:
         """Return the content-free durable freeze owner for restart recovery."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT plan_id FROM first_link_freeze WHERE singleton = 1"
             ).fetchone()
@@ -820,7 +915,7 @@ class PersonalContextRepository:
     def first_link_rebaseline_commit_plan_id(self) -> str | None:
         """Return the durable rebaseline-marker owner without key material."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT plan_id FROM first_link_rebaseline_commit WHERE singleton = 1"
             ).fetchone()
@@ -837,7 +932,7 @@ class PersonalContextRepository:
     ) -> bool:
         """Return whether the exact v7 marker still lacks key-record identity."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT 1 FROM first_link_rebaseline_commit "
                 "WHERE singleton = 1 AND target_key_record_id IS NULL "
@@ -872,7 +967,7 @@ class PersonalContextRepository:
     ) -> tuple[str, int | None]:
         """Classify an interrupted apply using only exact content-free evidence."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             marker = connection.execute(
                 "SELECT * FROM first_link_rebaseline_commit WHERE singleton = 1"
             ).fetchone()
@@ -998,7 +1093,7 @@ class PersonalContextRepository:
     def first_link_reconciliation_writes(self, *, plan_id: str) -> Iterator[None]:
         """Authorize only dedicated reconciliation writes under the exact freeze."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT plan_id FROM first_link_freeze WHERE singleton = 1"
             ).fetchone()
@@ -1172,7 +1267,7 @@ class PersonalContextRepository:
         return plaintext
 
     def _head_row(self, object_type: str, object_id: str) -> sqlite3.Row | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             return connection.execute(
                 """
                 SELECT encrypted_objects.*
@@ -1417,7 +1512,7 @@ class PersonalContextRepository:
         """Return the current authenticated manifest, if one exists."""
 
         self._require_keys()
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             meta = connection.execute(
                 "SELECT profile_id, current_manifest_version FROM profile_meta WHERE singleton = 1"
             ).fetchone()
@@ -2229,7 +2324,7 @@ class PersonalContextRepository:
     def first_link_head_rows(self) -> tuple[tuple[str, str, str], ...]:
         """Return content-free canonical head identities for convergence checks."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT object_type, object_id, version_id FROM object_heads "
                 "WHERE object_type IN ('manifest', 'scope', 'record', 'proposal') "
@@ -2295,7 +2390,7 @@ class PersonalContextRepository:
             for domain, objects in heads.items()
             for object_id, version_id in objects.items()
         }
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             lineage.update(
                 (
                     f"personal_context.{row['object_type']}",
@@ -2894,7 +2989,7 @@ class PersonalContextRepository:
     def get_record_derivation(self, record_id: str) -> str | None:
         """Return the encrypted peer-local source identity for a private record."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             metadata = connection.execute(
                 "SELECT encrypted_link_version FROM local_record_links "
                 "WHERE record_id = ?",
@@ -3208,7 +3303,10 @@ class PersonalContextRepository:
     ]:
         """Read all canonical export heads from one SQLite snapshot."""
 
-        connection = self._connect()
+        with self._connection() as connection:
+            return self._read_export_snapshot(connection)
+
+    def _read_export_snapshot(self, connection: sqlite3.Connection) -> tuple:
         try:
             connection.execute("BEGIN")
             meta = connection.execute(
@@ -3262,7 +3360,6 @@ class PersonalContextRepository:
             connection.rollback()
             raise
         finally:
-            connection.close()
             self._checkpoint_after_snapshot()
 
     def resolve_proposal(
@@ -3665,7 +3762,7 @@ class PersonalContextRepository:
     def is_scope_explicitly_unlinked(self, scope_id: str) -> bool:
         """Return whether first-link review retained this workspace as local-only."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT 1 FROM local_unlinked_scopes WHERE scope_id = ?",
                 (scope_id,),
@@ -3686,7 +3783,7 @@ class PersonalContextRepository:
         )
 
     def list_scope_bindings(self) -> dict[str, dict[str, Any]]:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT scope_id FROM local_scope_bindings ORDER BY scope_id"
             ).fetchall()
@@ -3724,7 +3821,7 @@ class PersonalContextRepository:
     def list_validated_scope_bindings(self) -> dict[str, dict[str, Any]]:
         """Return only authenticated exact-v1 workspace mappings."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             scope_ids = [
                 row["scope_id"]
                 for row in connection.execute(
@@ -3740,7 +3837,7 @@ class PersonalContextRepository:
     def _get_local_version(
         self, table: str, version_column: str, scope_id: str
     ) -> str | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 f"SELECT {version_column} FROM {table} WHERE scope_id = ?",
                 (scope_id,),
@@ -3985,7 +4082,7 @@ class PersonalContextRepository:
         object_type: str,
         scope_id: str,
     ) -> dict[str, Any] | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             version = connection.execute(
                 f"SELECT {version_column} FROM {table} WHERE scope_id = ?", (scope_id,)
             ).fetchone()
@@ -4120,7 +4217,7 @@ class PersonalContextRepository:
             )
 
     def get_outbox_body(self, outbox_id: str) -> dict[str, Any] | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             outbox = connection.execute(
                 "SELECT envelope_version FROM encrypted_outbox WHERE outbox_id = ?",
                 (outbox_id,),
@@ -4141,7 +4238,7 @@ class PersonalContextRepository:
 
         if type(limit) is not int or not 1 <= limit <= 500:
             raise ValueError("Outbox limit must be between 1 and 500.")
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT outbox_id, object_type, object_id, version_id, status, "
                 "created_at FROM encrypted_outbox WHERE status = 'pending' "
@@ -4176,7 +4273,7 @@ class PersonalContextRepository:
         if ordered_scope_ids:
             placeholders = ",".join("?" for _ in ordered_scope_ids)
             scope_filter = f"canonical.scope_id IN ({placeholders})"
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT outbox.outbox_id, outbox.object_type, outbox.object_id, "
                 "outbox.version_id, outbox.status, outbox.created_at "
@@ -4250,7 +4347,7 @@ class PersonalContextRepository:
             )
 
     def get_outbox_receipt(self, outbox_id: str) -> str | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT destination_envelope_id FROM encrypted_outbox WHERE outbox_id = ?",
                 (outbox_id,),
@@ -4258,7 +4355,7 @@ class PersonalContextRepository:
         return None if row is None else row["destination_envelope_id"]
 
     def get_outbox_quarantine_reason(self, outbox_id: str) -> str | None:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             row = connection.execute(
                 "SELECT quarantine_reason FROM encrypted_outbox WHERE outbox_id = ?",
                 (outbox_id,),
@@ -4313,7 +4410,7 @@ class PersonalContextRepository:
     def _is_quarantined(
         self, object_type: str, object_id: str, version_id: str | None
     ) -> bool:
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             return (
                 connection.execute(
                     "SELECT 1 FROM quarantine WHERE object_type = ? AND object_id = ? "
@@ -4326,7 +4423,7 @@ class PersonalContextRepository:
     def list_quarantine(self) -> list[QuarantineEntry]:
         """Return content-free quarantine metadata."""
 
-        with closing(self._connect()) as connection:
+        with self._connection() as connection:
             rows = connection.execute(
                 "SELECT * FROM quarantine ORDER BY created_at, quarantine_id"
             ).fetchall()

--- a/tldw_chatbook/Personal_Context/service.py
+++ b/tldw_chatbook/Personal_Context/service.py
@@ -174,7 +174,12 @@ class PersonalContextService:
 
     @contextmanager
     def read_operation(self) -> Iterator[None]:
-        """Bound synchronous read reuse without caching live agent authority."""
+        """Bound synchronous read reuse without caching live agent authority.
+
+        Returns:
+            A context manager yielding None within the repository read lifetime,
+            or a no-op context when this service is unavailable or locked.
+        """
 
         if self._repository is None or self._locked_reason is not None:
             yield

--- a/tldw_chatbook/Personal_Context/service.py
+++ b/tldw_chatbook/Personal_Context/service.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterator, Mapping
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from enum import StrEnum
@@ -151,6 +152,7 @@ class PersonalContextService:
         self._locked_reason = locked_reason
         self._profile_present_hint = profile_present_hint
         self._destructive_lifecycle_lock = Lock()
+        self._absent_storage_signature: tuple | None = None
 
     @classmethod
     def locked(
@@ -169,6 +171,16 @@ class PersonalContextService:
         if self._repository is None or self._locked_reason is not None:
             raise ProfileLockedError("Personal Context profile is locked.")
         return self._repository
+
+    @contextmanager
+    def read_operation(self) -> Iterator[None]:
+        """Bound synchronous read reuse without caching live agent authority."""
+
+        if self._repository is None or self._locked_reason is not None:
+            yield
+            return
+        with self._repository.operation():
+            yield
 
     def _new_profile_id(self, label: str) -> str:
         """Issue a canonical identity for one service-owned collaborator."""
@@ -306,6 +318,14 @@ class PersonalContextService:
                 False,
                 self._locked_reason or "profile_locked",
             )
+        cached_signature = self._absent_storage_signature
+        self._absent_storage_signature = None
+        signature = self._repository.storage_signature()
+        if cached_signature == signature:
+            self._absent_storage_signature = signature
+            return ProfileOperationalStatus(
+                ProfileOperationalState.ABSENT, False, False, False, "profile_absent"
+            )
         if self._repository.is_destroyed():
             return ProfileOperationalStatus(
                 ProfileOperationalState.REMOVED,
@@ -323,6 +343,8 @@ class PersonalContextService:
                 ProfileOperationalState.LOCKED, True, True, False, "profile_locked"
             )
         if manifest is None:
+            if signature == self._repository.storage_signature():
+                self._absent_storage_signature = signature
             return ProfileOperationalStatus(
                 ProfileOperationalState.ABSENT, False, False, False, "profile_absent"
             )
@@ -349,6 +371,7 @@ class PersonalContextService:
         )
 
     def create_profile(self) -> ProfileManifest:
+        self._absent_storage_signature = None
         repository = self._repo()
         if repository.is_destroyed():
             raise ValueError(
@@ -527,6 +550,7 @@ class PersonalContextService:
     def start_fresh_profile(self) -> ProfileManifest:
         """Create a new profile only after an explicit local-removal transition."""
 
+        self._absent_storage_signature = None
         with self._destructive_lifecycle_lock:
             repository = self._repo()
             if not repository.is_destroyed():
@@ -1538,6 +1562,18 @@ class PersonalContextService:
         view.
         """
 
+        with self.read_operation():
+            return self._authorized_context_view(
+                active_workspace_id=active_workspace_id,
+                active_workspace_scope_id=active_workspace_scope_id,
+            )
+
+    def _authorized_context_view(
+        self,
+        *,
+        active_workspace_id: str | None,
+        active_workspace_scope_id: str | None,
+    ) -> AuthorizedProfileContextView:
         if active_workspace_id is not None and active_workspace_scope_id is not None:
             raise ValueError("Specify one active workspace identity, not both.")
         status = self.status()


### PR DESCRIPTION
## Summary

- Resolve TASK-31504 by reusing one lazy, thread-local, autocommit read connection within a Personal Context send operation. Nested reads share it; success and failure both close it.
- Preserve both authorized views and live authority/path checks: the second view fences separately read scope and authorization state.
- Cache only proven, unchanged ABSENT status using content-free filesystem metadata, including WAL invalidation. Never cache READY authority or profile content.
- Measured hardened connection counts: configured global 44 to 1; workspace 68 to 1; unchanged absent composition 0 after its first read. These are connection counts, not end-user latency measurements.
- Amend ADR-102 with these boundaries; no schema or dependency change.

## Validation

- Latest review-fix round: rebased onto dev 2b4973971e; head e656dadae4. Seven-file targeted Personal Context/Console selection: 151 passed. Ruff, changed-range formatting, diff checks and all six derived-artifact preflight gates passed. Independent scoped spec/quality review approved. Added public return contracts and a named storage-identity field count; all four existing Qodo findings received fixes or evidence-backed replies. Existing dependency and protected-temp cleanup warnings remain disclosed below.
- Additional same-head checks: agent profile-provider and Console provider integration, 27 passed; import provenance and prompt routing, 4 passed. The latter also emitted an existing invalid-escape SyntaxWarning in patch_tool_impls.py; no unrelated cleanup performed.

- Fresh pre-publication run on commit 0e3bcd1366: all 17 send-performance regressions passed, with 2 existing dependency warnings. Existing protected pytest garbage directories produced cleanup warnings after successful tests; they were left alone. Diff check passed.
- Earlier implementation verification on the same commit: 169 targeted repository/service/context/export/inventory/agent/Console/provenance tests passed. Independent spec and quality reviews approved.
- Ruff passed for repository/service/new tests and changed-range formatting passed. The Console file had 27 unchanged baseline lint findings at review time.
- No full repository sweep or live latency benchmark.

## Integration and risk

- Base: dev, rebased onto the fetched 2b4973971e snapshot including the intervening Console changes; targeted integration and derived preflight passed. Recheck dev and CI before merge.
- Main risks are stale authorization and missed external database changes. The tests exercise authority races, external WAL-only setup, replacement rejection, lifecycle/errors, closure and thread isolation.
- Rollback: revert this PR; no data migration is involved.

Tracking: TASK-31504; `Docs/superpowers/plans/2026-09-05-personal-context-send-performance.md`; `backlog/decisions/102-personal-context-profile-authority-sync-and-encryption.md`.
