### PR TITLE
ci: unbreak the publish check job and UI-test collection before the release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -150,6 +150,13 @@ jobs:
         id: check
         env:
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
+          # `python Packaging/check_pypi_release.py` puts Packaging/ (not the
+          # repo root) at sys.path[0], and the job never installs the package,
+          # so the script's `from tldw_chatbook.Utils...` import needs the repo
+          # root on PYTHONPATH. Broke main's first two publish runs on
+          # 2026-09-04; hotfixed there as 943a0ef1f4 — this is that same line,
+          # backported so the dev→main merge hunk resolves without losing it.
+          PYTHONPATH: ${{ github.workspace }}
         run: python Packaging/check_pypi_release.py "$RELEASE_VERSION"
 
   publish-pypi:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,6 +206,13 @@ jobs:
         pip install -r requirements.txt
         pip install -r requirements-test.txt
         pip install pytest-json-report
+        # The vendored tldw_profile_core package (packages/tldw_profile_core/
+        # src, mapped via pyproject package-dir) is importable only when the
+        # distribution is installed; requirements.txt alone leaves every UI
+        # shard dead at collection (ModuleNotFoundError via
+        # Sync_Interop/sync_readiness.py) — the other jobs already install
+        # the project.
+        pip install -e .
         # Install textual dev tools for better debugging
         pip install textual-dev
 


### PR DESCRIPTION
Two one-line pipeline fixes, both release-gating for tomorrow's dev→main merge:

## 1. `publish-pypi.yml`: backport main's `PYTHONPATH` hotfix

Dev's `check_pypi_release` job is missing `PYTHONPATH: ${{ github.workspace }}` (main hotfix `943a0ef1f4`). Without it the job crashes with `ModuleNotFoundError: No module named 'tldw_chatbook'` — production-proven on main runs 33824240119/33824822823 (2026-09-04) — which skips `publish-pypi` entirely. Worse: the file is an **add/add conflict** in the dev→main merge and dev's side of that hunk is empty, so resolving the merge toward dev (the natural choice everywhere else) would silently delete the fix from main. Backporting makes the hunk vanish.

## 2. `test.yml` ui-tests: `pip install -e .`

All 12 UI shards on dev die at collection with `ModuleNotFoundError: No module named 'tldw_profile_core'` (run 33894387395) because the vendored package (`packages/tldw_profile_core/src`) is only importable when the distribution is installed, and ui-tests was the one job installing only requirements files. Fix verified on PR #2427's branch CI (same line): shard 0 goes from collection-dead to 1557 passed / 24 failed (those 24 are pre-existing failures this merely unmasks).

## Release-merge note

`git merge-tree origin/main origin/dev` still conflicts across the publish path (MANIFEST.in, check_pypi_release.py, Packaging docs/scripts, test_release_metadata.py, input_validation.py, nightly-deep.yml). With this PR landed, **every publish-path conflict should be resolved toward dev** — main's only load-bearing divergence was the PYTHONPATH line. Recommend a `workflow_dispatch` of the publish workflow's build job on the merge result before trusting the push-triggered publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two CI failures that would block the dev→main release: the publish check job now sets `PYTHONPATH` so it stops crashing with `ModuleNotFoundError: No module named 'tldw_chatbook'`, and UI tests now run `pip install -e .` so all 12 shards stop dying at collection (`ModuleNotFoundError: No module named 'tldw_profile_core'`).

**Notes**
- The UI test fix unmasks 24 pre-existing failures on shard 0; they're not new regressions.
- When merging to main, resolve publish-path conflicts toward dev — with this backport, the conflicting `PYTHONPATH` hunk disappears.

<sup>Written for commit 7b11a1cf6da9ce5376ea9feb248583b5407ff02a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2440?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

