### PR TITLE
test(db): pin the v66 character-conversation-search indexes in the census guard

### DIFF
--- a/Tests/ChaChaNotesDB/test_index_census.py
+++ b/Tests/ChaChaNotesDB/test_index_census.py
@@ -99,6 +99,27 @@ class IndexPin(NamedTuple):
 #: it only as part of a deliberate schema change, in the same commit as the
 #: migration that adds, drops, renames, or reshapes an index. Sorted by name.
 EXPECTED_CHACHANOTES_INDEXES: dict[str, IndexPin] = {
+    "character_conversation_search_dirty_authority_revision": IndexPin(
+        "character_conversation_search_dirty",
+        False,
+        ("data_authority_id", "source_revision"),
+    ),
+    "character_conversation_search_documents_character": IndexPin(
+        "character_conversation_search_documents",
+        False,
+        ("data_authority_id", "character_id", "generation_id", "conversation_id"),
+    ),
+    "character_conversation_search_documents_revision": IndexPin(
+        "character_conversation_search_documents",
+        False,
+        ("data_authority_id", "source_revision"),
+    ),
+    "character_conversation_search_generations_authority_status": IndexPin(
+        "character_conversation_search_generations", False, ("data_authority_id", "status")
+    ),
+    "character_conversation_search_one_ready_generation": IndexPin(
+        "character_conversation_search_generations", True, ("data_authority_id",)
+    ),
     "idx_actor_pack_persona_intents_state": IndexPin(
         "actor_pack_persona_intents", False, ("state", "created_at", "intent_id")
     ),


### PR DESCRIPTION
Post-merge repair for PR #2434 (merge `2b4973971e`): its migration `chachanotes_v65_to_v66_character_conversation_search.sql` creates five indexes, but `EXPECTED_CHACHANOTES_INDEXES` in `Tests/ChaChaNotesDB/test_index_census.py` was not updated in the same commit (the CLAUDE.md gotcha #1 rule). Both `test_no_unexpected_indexes` arms are red on dev tip, and no CI job runs this test — so without this, tomorrow's dev→main release ships with the index-census guard broken.

The five pins are exactly the failure message's paste-ready lines (name → table, uniqueness, key columns), inserted sorted. The plan-pin census (`scripts/index_plan_pin_census.tsv`) was already correctly updated by #2434 itself; this is the second, independent literal the author missed.

**Evidence:** on `2b4973971e`: `2 failed, 6 passed` → with this change: `8 passed`.

Found during tonight's release-gate review (reviewer verdict on #2434 otherwise: keep the merge — code is dormant, well-fenced, and migration-rule-compliant; this census pin was the one required fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the index-census test to include the five v66 character-conversation-search indexes from the migration, so `test_no_unexpected_indexes` passes again. The migration added these indexes but the expected list wasn't updated, breaking the test on dev tip.

<sup>Written for commit dd873c431478181c07150af8d150ea4a462c36ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2443?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

