### PR TITLE
fix(research): Runs view rendered collapsed to one squashed row (TASK-31795)

### DIFF
--- a/Docs/User_Guide/research_workspace.md
+++ b/Docs/User_Guide/research_workspace.md
@@ -186,7 +186,9 @@ Grounded Chat exposes a canonical message owner.
   records the authority, canonical-owner, overlay, and unlink boundaries.
 
 —
-*Verified against `fix/task-23024` — 2026-08-27. Targeted Research
-Workspace verification was run (source rows and operation receipts now
-mount as data arrives rather than as pre-built empty pools — no visible
-behavior change); the full pytest suite was not run.*
+*Verified against `fix/research-runs-collapsed-layout` — 2026-09-05
+(TASK-31795: the Runs screen previously rendered collapsed to one
+squashed row; it now lays out toolbar, create-run row, run list and
+detail panel vertically — verified live in tmux plus production-CSS
+geometry tests). Previous stamp: `fix/task-23024` — 2026-08-27; the full
+pytest suite was not run.*

--- a/Tests/UI/test_research_workspace_geometry.py
+++ b/Tests/UI/test_research_workspace_geometry.py
@@ -232,3 +232,102 @@ async def test_wide_chat_uses_grid_except_two_fixed_reveal_handles() -> None:
         assert sources_handle.region.width == 4
         assert studio_handle.region.width == 4
         assert chat.region.width == grid.content_region.width - 8
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(220, 50), (120, 30), (80, 24)])
+async def test_production_runs_view_lays_out_vertically_with_usable_regions(
+    size: tuple[int, int],
+) -> None:
+    """TASK-31795 regression: the global ``.window`` rule forces
+    ``layout: horizontal``, which crushed the (Vertical-subclassing)
+    ResearchWindow's five sections into one squashed row -- toolbar and
+    create-row at width 1, ``#research-body`` pushed off-screen entirely.
+    The Runs view must stack vertically and give the run list + detail
+    body the remaining height."""
+    app = _ProductionRunsHarness()
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        screen = app.screen_stack[-1]
+        content = screen.query_one("#screen-content")
+        window = screen.query_one("#research-window")
+        toolbar = screen.query_one("#research-toolbar")
+        create_row = screen.query_one("#research-create-row")
+        body = screen.query_one("#research-body")
+        run_list = screen.query_one("#research-run-list")
+        detail = screen.query_one("#research-detail-panel")
+
+        # Vertical stacking: each section starts below the previous one.
+        assert create_row.region.y >= toolbar.region.bottom, (size, create_row.region)
+        assert body.region.y >= create_row.region.bottom, (size, body.region)
+
+        # Full-width rows with usable heights -- the bug left them 1 cell wide.
+        for section in (toolbar, create_row, body):
+            assert section.region.width == window.content_region.width, (
+                size,
+                section.region,
+            )
+            assert section.region.height > 0, (size, section.region)
+        assert content.content_region.contains_region(body.region), (
+            size,
+            content.content_region,
+            body.region,
+        )
+
+        # The list/detail split owns the remaining height and stays on screen
+        # (the bug parked #research-body at x=239 on a 220-column terminal).
+        assert body.region.height >= 5, (size, body.region)
+        assert run_list.region.width > 0 and detail.region.width > 0, (
+            size,
+            run_list.region,
+            detail.region,
+        )
+        assert detail.region.x >= run_list.region.right, (
+            size,
+            run_list.region,
+            detail.region,
+        )
+
+
+@pytest.mark.asyncio
+async def test_production_runs_view_paints_create_and_detail_controls() -> None:
+    """TASK-31795 regression: with the collapsed layout nothing was
+    reachable. Assert the create-run controls and the detail-panel action
+    rows paint on screen with clickable regions at a roomy size."""
+    app = _ProductionRunsHarness()
+    async with app.run_test(size=(220, 50)) as pilot:
+        await pilot.pause()
+        screen = app.screen_stack[-1]
+        painted = _painted_text(app.export_screenshot(simplify=True))
+        for text in (
+            "Research Sessions",
+            "Refresh",
+            "Research question",
+            "Create Run",
+            "No research run selected",
+            "Resume",
+            "Approve Checkpoint",
+        ):
+            assert text in painted, (text, painted)
+
+        content_region = screen.query_one("#screen-content").content_region
+        for widget_id in (
+            "research-source-select",
+            "research-refresh-runs",
+            "research-query-input",
+            "research-create-run",
+            "research-run-list",
+            "research-run-detail",
+            "research-resume-run",
+            "research-followup-input",
+        ):
+            widget = screen.query_one(f"#{widget_id}")
+            assert widget.region.width > 0 and widget.region.height > 0, (
+                widget_id,
+                widget.region,
+            )
+            assert content_region.contains_region(widget.region), (
+                widget_id,
+                content_region,
+                widget.region,
+            )

--- a/backlog/tasks/task-31795 - Research-Runs-view-renders-collapsed-blank-—-missing-layout-CSS.md
+++ b/backlog/tasks/task-31795 - Research-Runs-view-renders-collapsed-blank-—-missing-layout-CSS.md
@@ -1,0 +1,94 @@
+---
+id: TASK-31795
+title: Research Runs view renders collapsed/blank — missing layout CSS
+status: Done
+assignee: []
+created_date: '2026-09-06 00:12'
+labels:
+  - bug
+  - ui
+  - research
+dependencies: []
+priority: high
+---
+
+## Description (the why)
+
+Live UAT on dev tip (fresh profile) reproduced twice: Research tab →
+"Runs" chip in the Research mode strip → the whole content area collapses
+to ~1 squashed line. Nothing renders, nothing is reachable, no traceback
+(silent layout failure). Only ~8 non-blank rows appear in a 52-row
+terminal. This is a release blocker for the dev→main cut: the durable
+Research Runs surface is unusable.
+
+## Acceptance Criteria (the what)
+
+- [x] Opening Research → Runs renders the full Runs view (toolbar,
+      create-run row, status line, run list and detail panel) with
+      nonzero, on-screen geometry at common terminal sizes.
+- [x] Every Runs control (source select, refresh, create inputs/buttons,
+      run actions, checkpoint/follow-up controls) is painted inside the
+      screen content area, not pushed off-screen.
+- [x] A regression test with production CSS asserts the Runs view's key
+      containers lay out vertically with usable heights/widths.
+- [x] CSS bundle stays in sync with its sources (preflight passes) and
+      within the boot CSS byte ratchet.
+
+## Implementation Plan (the how)
+
+1. Reproduce with a production-CSS Textual harness and dump the Runs
+   view's widget regions to find the collapse mechanism.
+2. Root-cause: check git history for lost research CSS vs never-authored
+   styles; inspect the global `.window` rules.
+3. Fix in `css/features/_research_workspace.tcss` (already a CSS_MODULES
+   entry): force `layout: vertical` on the Runs window (the global
+   `.window` rule imposes horizontal) and author the missing internal
+   layout rules (rows auto-height, body 1fr, list/detail split,
+   input/select widths, scrollable detail panel). Rebuild the bundle
+   with `build_css.py`.
+4. Add a production-CSS regression test asserting the vertical stacking
+   and on-screen geometry of the Runs containers and controls.
+5. Verify live in tmux with an isolated scratch config (before/after
+   captures), run targeted UI tests, `./scripts/preflight.sh`, PR to dev.
+
+## Implementation Notes
+
+Root cause: never-authored CSS, not a lost file. `ResearchWindow`
+(UI/Research_Window.py, born unstyled in 7a6129009b) subclasses
+`Vertical`, but ResearchScreen mounts it with `classes="window"` and the
+global `.window` rule (css/layout/_windows.tcss) sets
+`layout: horizontal`. App-tier class rules beat widget DEFAULT_CSS, so
+the window's five vertical sections were laid out side-by-side: toolbar
+and create-row collapsed to width 1 and `#research-body` was parked at
+x=239 on a 220-column terminal (production-CSS harness region dump).
+Git history shows no research layout tcss was ever deleted; the only
+Runs rule ever authored was the mode-strip-era height override.
+
+Fix (app tier, mirroring the `#logs-window { layout: vertical; }`
+precedent): extended `css/features/_research_workspace.tcss` (already a
+CSS_MODULES entry) with `layout: vertical` on
+`ResearchScreen #research-window.window` plus the missing internal
+layout — toolbar/create/action rows auto-height, `#research-body` 1fr,
+run-list/detail split (30%/1fr), input/select widths, scrollable detail
+panel, fixed-height checkpoint TextArea. Bundle regenerated with
+`build_css.py` (+80 lines; boot CSS byte ratchet passes with ~23KB
+headroom). A widget-tier DEFAULT_CSS baseline was considered and
+rejected: the offending `.window` rule is app-tier, which beats any
+DEFAULT_CSS regardless of specificity, so only an app-tier rule can fix
+it; keeping one authority avoids a second drift surface.
+
+Verification: live tmux on a scratch TLDW_CONFIG_PATH profile — before
+(pristine dev bundle): 8 non-blank rows, exactly the UAT capture; after:
+48 non-blank rows, every control painted, Refresh click round-trips
+("Loaded 0 local research run(s)."), Workspace→Runs roundtrip stays
+rendered. New production-CSS regression tests in
+Tests/UI/test_research_workspace_geometry.py (vertical stacking +
+usable regions at 220x50/120x30/80x24; painted-control containment)
+fail 4/4 against the pristine bundle and pass with the fix. Research UI
+test files: 150 passed, 1 pre-existing failure
+(test_research_sources_region.py sort test, fails identically on the
+pristine bundle). preflight.sh all green.
+
+Files: css/features/_research_workspace.tcss, css/tldw_cli_modular.tcss
+(generated), Tests/UI/test_research_workspace_geometry.py,
+Docs/User_Guide/research_workspace.md (stamp), this task file.

--- a/tldw_chatbook/css/features/_research_workspace.tcss
+++ b/tldw_chatbook/css/features/_research_workspace.tcss
@@ -11,8 +11,12 @@
 
 /* Runs adds the shared one-row mode strip above the legacy 100%-high window.
  * Claim only the remaining screen-content height so its footer stays contained.
+ * layout: vertical -- ResearchWindow subclasses Vertical, but the global
+ * `.window` rule (layout/_windows.tcss) forces layout: horizontal, which
+ * crushed the whole Runs view into one squashed row (release P1).
  */
 ResearchScreen #research-window.window {
+    layout: vertical;
     height: 1fr;
     min-height: 0;
 }
@@ -798,4 +802,80 @@ ResearchNoteSwitchRecoveryModal {
     margin-top: 1;
     color: $accent;
     text-style: bold;
+}
+
+/* --- Runs window internal layout ------------------------------------------
+ * ResearchWindow's containers had no styles at all: the toolbar/create/body
+ * rows fell back to Horizontal's 1fr height and Input/Select's 100% width,
+ * so nothing usable rendered. Rows hug their content; the run list + detail
+ * body claims the rest.
+ */
+#research-toolbar,
+#research-create-row {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+}
+
+#research-source-select {
+    width: 16;
+}
+
+#research-create-row Input {
+    width: 1fr;
+}
+
+#research-policy-select {
+    width: 20;
+}
+
+#research-rounds-select {
+    width: 14;
+}
+
+#research-status {
+    width: 100%;
+    height: auto;
+    min-height: 1;
+    padding: 0 1;
+    color: $text-muted;
+}
+
+#research-body {
+    width: 100%;
+    height: 1fr;
+    min-height: 0;
+}
+
+#research-run-list {
+    width: 30%;
+    min-width: 24;
+    height: 100%;
+    border-right: solid $surface-lighten-1;
+}
+
+#research-detail-panel {
+    width: 1fr;
+    height: 100%;
+    min-height: 0;
+    padding: 0 1;
+    overflow-y: auto;
+}
+
+#research-run-actions,
+#research-observe-actions,
+#research-checkpoint-actions,
+#research-followup-row {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+}
+
+#research-observe-actions Input,
+#research-followup-row Input {
+    width: 1fr;
+}
+
+#research-checkpoint-patch {
+    height: 6;
 }

--- a/tldw_chatbook/css/features/_research_workspace.tcss
+++ b/tldw_chatbook/css/features/_research_workspace.tcss
@@ -821,7 +821,12 @@ ResearchNoteSwitchRecoveryModal {
     width: 16;
 }
 
-#research-create-row Input {
+/* ID subjects, not `<row> Input`: the ancestor-scoped bare-type ratchet
+ * (test_textual_css_fastpath, ADR-097) taxes bare-type-subject rules.
+ */
+#research-query-input,
+#research-limits-input,
+#research-providers-input {
     width: 1fr;
 }
 
@@ -871,8 +876,8 @@ ResearchNoteSwitchRecoveryModal {
     min-height: 0;
 }
 
-#research-observe-actions Input,
-#research-followup-row Input {
+#research-artifact-name,
+#research-followup-input {
     width: 1fr;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -17816,7 +17816,12 @@ ResearchNoteSwitchRecoveryModal {
     width: 16;
 }
 
-#research-create-row Input {
+/* ID subjects, not `<row> Input`: the ancestor-scoped bare-type ratchet
+ * (test_textual_css_fastpath, ADR-097) taxes bare-type-subject rules.
+ */
+#research-query-input,
+#research-limits-input,
+#research-providers-input {
     width: 1fr;
 }
 
@@ -17866,8 +17871,8 @@ ResearchNoteSwitchRecoveryModal {
     min-height: 0;
 }
 
-#research-observe-actions Input,
-#research-followup-row Input {
+#research-artifact-name,
+#research-followup-input {
     width: 1fr;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -17006,8 +17006,12 @@ VllmSetupView.vllm-compact.vllm-two-actions #vllm-mode-summary {
 
 /* Runs adds the shared one-row mode strip above the legacy 100%-high window.
  * Claim only the remaining screen-content height so its footer stays contained.
+ * layout: vertical -- ResearchWindow subclasses Vertical, but the global
+ * `.window` rule (layout/_windows.tcss) forces layout: horizontal, which
+ * crushed the whole Runs view into one squashed row (release P1).
  */
 ResearchScreen #research-window.window {
+    layout: vertical;
     height: 1fr;
     min-height: 0;
 }
@@ -17793,6 +17797,82 @@ ResearchNoteSwitchRecoveryModal {
     margin-top: 1;
     color: $accent;
     text-style: bold;
+}
+
+/* --- Runs window internal layout ------------------------------------------
+ * ResearchWindow's containers had no styles at all: the toolbar/create/body
+ * rows fell back to Horizontal's 1fr height and Input/Select's 100% width,
+ * so nothing usable rendered. Rows hug their content; the run list + detail
+ * body claims the rest.
+ */
+#research-toolbar,
+#research-create-row {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+}
+
+#research-source-select {
+    width: 16;
+}
+
+#research-create-row Input {
+    width: 1fr;
+}
+
+#research-policy-select {
+    width: 20;
+}
+
+#research-rounds-select {
+    width: 14;
+}
+
+#research-status {
+    width: 100%;
+    height: auto;
+    min-height: 1;
+    padding: 0 1;
+    color: $text-muted;
+}
+
+#research-body {
+    width: 100%;
+    height: 1fr;
+    min-height: 0;
+}
+
+#research-run-list {
+    width: 30%;
+    min-width: 24;
+    height: 100%;
+    border-right: solid $surface-lighten-1;
+}
+
+#research-detail-panel {
+    width: 1fr;
+    height: 100%;
+    min-height: 0;
+    padding: 0 1;
+    overflow-y: auto;
+}
+
+#research-run-actions,
+#research-observe-actions,
+#research-checkpoint-actions,
+#research-followup-row {
+    width: 100%;
+    height: auto;
+    min-height: 0;
+}
+
+#research-observe-actions Input,
+#research-followup-row Input {
+    width: 1fr;
+}
+
+#research-checkpoint-patch {
+    height: 6;
 }
 
 /* ===== MODULE: features/_logs.tcss ===== */


### PR DESCRIPTION
## P1 (release blocker for the dev→main cut)

Live UAT on dev tip, fresh profile, reproduced twice: Research → "Runs" chip in the mode strip → the whole content area collapses to ~1 squashed line (8 non-blank rows on a 52-row screen), nothing reachable, no traceback.

## Root cause — never-authored layout CSS + the global `.window` rule

`ResearchWindow` subclasses `Vertical`, but `ResearchScreen` mounts it with `classes="window"`, and `layout/_windows.tcss` declares `.window { layout: horizontal; }`. An app-tier class rule beats the widget's `DEFAULT_CSS` type rule regardless of specificity, so the window's five vertical sections were laid out **side-by-side**: toolbar and create-row crushed to width 1, `#research-body` parked off-screen at x=239 on a 220-column terminal (production-CSS harness region dump). Git history confirms no research layout tcss was ever deleted — `ResearchWindow` was born unstyled (`7a6129009b`); the only Runs rule ever authored was the mode-strip-era height override. Not a decomposition/rename loss.

## Fix (app tier, mirroring the `#logs-window { layout: vertical; }` precedent)

- `css/features/_research_workspace.tcss` (already a `CSS_MODULES` entry): `layout: vertical` on `ResearchScreen #research-window.window`, plus the missing internal layout — toolbar/create/action rows hug content, `#research-body` takes `1fr`, 30%/1fr run-list/detail split, input/select widths, scrollable detail panel, fixed-height checkpoint TextArea.
- `css/tldw_cli_modular.tcss` regenerated via `build_css.py` (+80 lines). Boot CSS byte ratchet passes with ~23KB headroom.
- A widget-tier `DEFAULT_CSS` baseline was considered and rejected: the offending `.window` rule is app-tier, which beats any `DEFAULT_CSS`, so only an app-tier rule can fix this; one authority avoids a second drift surface.

## Verification

**Live tmux (scratch `TLDW_CONFIG_PATH` profile, 220x50):**
- Before (pristine dev bundle): `Research Sessions▊▊Rounds: 2. Each extra round…` — 8 non-blank rows, identical to the UAT capture.
- After: 48 non-blank rows; toolbar, create-run row, status, run list and full detail panel all painted; **Refresh click round-trips** ("Loaded 0 local research run(s)."); Workspace→Runs roundtrip stays rendered.

**Tests:**
- New production-CSS regression tests in `Tests/UI/test_research_workspace_geometry.py`: vertical stacking + usable regions at 220x50/120x30/80x24, painted-control containment. Negative control: all 4 fail against the pre-fix bundle.
- Research UI test files: 150 passed, 1 pre-existing failure (`test_research_sources_region.py` sort test — fails identically on the pristine bundle, unrelated).
- `Tests/Performance/test_boot_css_byte_budget.py` passes; `./scripts/preflight.sh` all green (CSS bundle sync included).

Backlog: TASK-31795 (Done, with implementation notes). User Guide stamp updated (`Docs/User_Guide/research_workspace.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Research Runs view collapsing into a single squashed row. The global `.window` rule forced a horizontal layout on the window, which subclasses `Vertical`, so its toolbar, create-run row, and body were laid out side-by-side and pushed off-screen. The fix forces `layout: vertical` on the Runs window at the app tier and authors the missing internal layout CSS (auto-height rows, 1fr body, 30%/1fr run-list/detail split, scrollable detail panel). The CSS bundle was regenerated, and production-CSS regression tests assert vertical stacking and on-screen geometry at 220x50, 120x30, and 80x24.

**Bug Fixes**
- Runs-window width rules target widget IDs directly instead of ancestor-scoped bare types to stay within the ADR-097 CSS ratchet.
- TASK-31795 is tracked with acceptance criteria and verification steps; the pre-existing `test_research_sources_region.py` sort failure is unrelated and fails identically on the pristine bundle.

<sup>Written for commit 935e69a78f690b38cedd975041e8c6e2bf1e4417. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2444?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

