### PR TITLE
backlog: file the 12 remaining pre-release UAT findings

### DIFF
--- a/backlog/tasks/task-31796 - Library notes list keeps stale note title after rename until a filter re-query.md
+++ b/backlog/tasks/task-31796 - Library notes list keeps stale note title after rename until a filter re-query.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31796
+title: Library notes list keeps stale note title after rename until a filter re-query
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - library
+  - notes
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). Create a blank note (autosaves as 'Untitled'), set its title in the editor, wait for 'Saved', Esc back to the list: the Unfiled entry still reads 'Untitled', and stays stale even after reopening the note. Only typing a filter query and pressing Enter re-queries and shows the real title. DB row confirmed correct throughout, so this is purely the list widget not refreshing on save. With several new notes, every one shows as 'Untitled' in the primary nav surface.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Renaming a note updates its row in the notes list on save (or at latest on returning to the list), without requiring a filter re-query.
+- [ ] #2 A regression test covers title propagation from editor save to the list row.
+<!-- AC:END -->

--- a/backlog/tasks/task-31797 - Library items pane empty ('0 of 0 - Total unavailable') after 'Open in Library' deep-link from the import queue.md
+++ b/backlog/tasks/task-31797 - Library items pane empty ('0 of 0 - Total unavailable') after 'Open in Library' deep-link from the import queue.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31797
+title: Library items pane empty ('0 of 0 - Total unavailable') after 'Open in Library' deep-link from the import queue
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - library
+  - ingest
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). Import a local .md via the Library import flow, wait for the job's done state, click 'Open in Library': the reader opens the item correctly but the middle Items pane shows '0 of 0 - type: None' / 'No page loaded - Total unavailable / Page boundary is unknown' and never recovers on its own. Clicking 'Media (1)' in the left rail populates it. A user arriving via the deep-link sees an apparently empty library beside their open item.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The 'Open in Library' deep-link lands with the items list populated (at minimum the opened item's page loaded).
+- [ ] #2 Regression test for the deep-link path asserting a non-empty items page.
+<!-- AC:END -->

--- a/backlog/tasks/task-31798 - Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured.md
+++ b/backlog/tasks/task-31798 - Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31798
+title: Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - schedules
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). With no scheduling server, the Schedules DestinationHeader keeps its compose-time seed 'Checking sync status...' indefinitely (verified 20+ minutes and across navigations) while the same screen's footer correctly says 'Local schedules - no scheduling server connected; sync is off.' Source lead: UI/Screens/scheduling/schedules_workbench.py:586 seeds the label; the refresh at ~line 4315 that would set 'Local only - no server connection' never runs on this path.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The header resolves to the local-only status (matching the footer) shortly after mount when no server is configured.
+- [ ] #2 Test covering the no-server header path.
+<!-- AC:END -->

--- a/backlog/tasks/task-31799 - Schedule Queue table truncates the first-inserted row to header-width columns.md
+++ b/backlog/tasks/task-31799 - Schedule Queue table truncates the first-inserted row to header-width columns.md
@@ -1,0 +1,24 @@
+---
+id: TASK-31799
+title: Schedule Queue table truncates the first-inserted row to header-width columns
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - schedules
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). Creating the first reminder renders the queue row with Title clipped to 5 chars and Details to 7 ('UAT f' / 'One-tim') despite ample free width; any filter keystroke re-renders with correct widths and it stays correct. Columns are auto-sized before the first content insert and not re-measured on row add.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The first row added to an empty Schedule Queue renders with correctly measured column widths.
+<!-- AC:END -->

--- a/backlog/tasks/task-31800 - Reminder form 'Run at' placeholder and examples hardcode a past datetime.md
+++ b/backlog/tasks/task-31800 - Reminder form 'Run at' placeholder and examples hardcode a past datetime.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31800
+title: Reminder form 'Run at' placeholder and examples hardcode a past datetime
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - schedules
+  - copy
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). The 'Run at' placeholder and helper/error copy use the literal '2026-08-28 09:00' (already in the past): UI/Screens/scheduling/forms/reminder_form.py:513, definition_detail.py:1266 and :1606. A user copying the example gets an already-due run time. Generate the example relative to now, or use an obviously-future fixed date.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The run-at example shown to users is always a future datetime (or clearly synthetic).
+- [ ] #2 All three literal sites updated consistently.
+<!-- AC:END -->

--- a/backlog/tasks/task-31801 - Daily Brief failure toast says 'run the demo again' but the demo CTA disappears once a failed report exists.md
+++ b/backlog/tasks/task-31801 - Daily Brief failure toast says 'run the demo again' but the demo CTA disappears once a failed report exists.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31801
+title: Daily Brief failure toast says 'run the demo again' but the demo CTA disappears once a failed report exists
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ux
+  - artifacts
+  - watchlists
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). With no API key, Artifacts > 'Create Your First Daily Report' seeds the watchlist, fetches RSS, fails at the LLM stage, and the toast instructs fixing the key then 'run the demo again' - but once the failed report row exists, the CTA button is no longer rendered anywhere on the Artifacts screen, so the advertised retry path is gone (user must discover Watchlists to regenerate).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 After a failed demo brief, a retry affordance for the demo remains reachable from the Artifacts screen (or the toast copy points at a path that exists).
+- [ ] #2 Test covering the failed-demo retry affordance.
+<!-- AC:END -->

--- a/backlog/tasks/task-31802 - Artifacts empty-state copy tells users to 'import an artifact' while the Import button is permanently disabled.md
+++ b/backlog/tasks/task-31802 - Artifacts empty-state copy tells users to 'import an artifact' while the Import button is permanently disabled.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31802
+title: Artifacts empty-state copy tells users to 'import an artifact' while the Import button is permanently disabled
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ux
+  - artifacts
+  - copy
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). The Artifacts empty state instructs importing an artifact, but the only Import button is disabled with no explanation of how to enable it. Either enable the path, explain the precondition, or change the copy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Empty-state guidance matches an action the user can actually take.
+<!-- AC:END -->

--- a/backlog/tasks/task-31803 - Daily Brief report rows and preview show raw microsecond-precision UTC ISO timestamps.md
+++ b/backlog/tasks/task-31803 - Daily Brief report rows and preview show raw microsecond-precision UTC ISO timestamps.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31803
+title: Daily Brief report rows and preview show raw microsecond-precision UTC ISO timestamps
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ux
+  - artifacts
+  - copy
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). Report list rows and the preview header render timestamps like '2026-09-05T23:10:2...' raw. Format for humans (local time, minute precision) in list and preview surfaces.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Brief timestamps render in a human-readable local format in the list and preview.
+<!-- AC:END -->

--- a/backlog/tasks/task-31804 - Roleplay Inspector shows the previous character's avatar while reporting 'Selected - none'.md
+++ b/backlog/tasks/task-31804 - Roleplay Inspector shows the previous character's avatar while reporting 'Selected - none'.md
@@ -1,0 +1,24 @@
+---
+id: TASK-31804
+title: Roleplay Inspector shows the previous character's avatar while reporting 'Selected: none'
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - roleplay
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). After deselecting (or when selection clears), the Inspector's status line says 'Selected: none' but the previously selected character's avatar stays rendered - contradictory state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When selection is none, the Inspector shows no stale avatar.
+<!-- AC:END -->

--- a/backlog/tasks/task-31805 - Home 'Model - Ready' and Settings Overview overstate readiness with no credential present.md
+++ b/backlog/tasks/task-31805 - Home 'Model - Ready' and Settings Overview overstate readiness with no credential present.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31805
+title: Home 'Model - Ready' and Settings Overview overstate readiness with no credential present
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ux
+  - settings
+  - home
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). On a fresh profile with no API key anywhere, Home reports 'Model: Ready' and Settings Overview shows an OpenAI status implying usability; an actual send then fails with the key-required error. Readiness surfaces should reflect the same resolve_provider_api_key check the send path uses (see the CLAUDE.md configuration notes on readiness/spend agreement).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Home and Settings Overview report not-ready when no valid credential resolves for the selected provider.
+- [ ] #2 Readiness surfaces and the send path share one credential check.
+<!-- AC:END -->

--- a/backlog/tasks/task-31806 - 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter.md
+++ b/backlog/tasks/task-31806 - 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter.md
@@ -1,0 +1,24 @@
+---
+id: TASK-31806
+title: 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - logs
+  - boot
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev tip 8e9d1128d4, real tmux-driven app). Every fresh boot emits 13 'No handler found for worker ...' WARNING lines, drowning the Warnings+ filter's signal. Either register handlers, downgrade to debug, or fix the worker wiring.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A fresh boot emits zero spurious 'No handler found for worker' warnings.
+<!-- AC:END -->

--- a/backlog/tasks/task-31807 - First-run wizard intermittently self-dismisses to Home with zero input when splash is enabled.md
+++ b/backlog/tasks/task-31807 - First-run wizard intermittently self-dismisses to Home with zero input when splash is enabled.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31807
+title: First-run wizard intermittently self-dismisses to Home with zero input when splash is enabled
+status: To Do
+assignee: []
+created_date: '2026-09-05 19:15'
+labels:
+  - bug
+  - ui
+  - wizard
+  - flaky
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Observed twice on origin/dev during the 2026-09-05 release-gate work (by the TASK-31741 fix agent): with the splash screen enabled, the first-run wizard occasionally mounts and then self-dismisses to Home with no input, persisting setup_started. Intermittent; likely a race between splash teardown and the wizard's screen push. Needs a reproducer and fix; related surface: TASK-31226 (cancel routing) and TASK-31741 (exit-dialog settle guard).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Root cause identified with a deterministic reproducer or instrumented evidence.
+- [ ] #2 Wizard never dismisses without user input.
+<!-- AC:END -->


### PR DESCRIPTION
Files one task per remaining finding from tonight's live UAT sweep (fresh scratch profiles, real tmux-driven app, dev tip `8e9d1128d4`), run ahead of tomorrow's release. The two P1s are already fixed in PR #2444 (Research Runs collapsed layout) and PR #2445 (wizard exit-dialog settle guard); this PR records the rest so they survive the release without living only in a chat transcript.

| Task | Sev | Area | Finding |
|---|---|---|---|
| 31796 | P2 | Library | Notes list keeps stale title after rename until a filter re-query |
| 31797 | P3 | Library | Items pane empty after 'Open in Library' deep-link |
| 31798 | P3 | Schedules | Header stuck 'Checking sync status…' (contradicts footer) |
| 31799 | P3 | Schedules | Queue table truncates first-inserted row |
| 31800 | P3 | Schedules | 'Run at' examples hardcode a past datetime |
| 31801 | P2 | Artifacts | Failure toast points at a CTA that disappears |
| 31802 | P3 | Artifacts | Empty-state copy vs permanently disabled Import |
| 31803 | P3 | Artifacts | Raw microsecond ISO timestamps in report rows |
| 31804 | P3 | Roleplay | Inspector stale avatar with 'Selected: none' |
| 31805 | P2 | Settings/Home | Readiness overstated with no credential |
| 31806 | P3 | Logs | 13 spurious worker warnings per boot |
| 31807 | P2 | Wizard | Intermittent self-dismiss to Home with splash on |

IDs start at 31796, above the swept in-use max (31795), to dodge the in-flight-branch ID collisions hit twice today. Preflight green (duplicate-ID check included).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files the 12 remaining P2/P3 findings from the 2026-09-05 pre-release UAT sweep as one backlog task per finding, so they survive the release without living only in the chat transcript. The two P1s found (Research Runs collapsed layout, wizard exit-dialog settle guard) are already fixed in separate PRs; task IDs start at 31796, above the swept in-use max (31795), to avoid branch-ID collisions.

<sup>Written for commit 05949f7eacdab4e2af91422801a8634b5e0070b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2448?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

