### PR TITLE
style(chat): clean general Chat formatter debt (TASK-26951)

### DIFF
--- a/Docs/superpowers/plans/2026-09-05-task-26951-ruff-chat-general.md
+++ b/Docs/superpowers/plans/2026-09-05-task-26951-ruff-chat-general.md
@@ -1,0 +1,21 @@
+# TASK-26951 general Chat formatter cleanup
+
+Spec: `Docs/superpowers/specs/2026-08-30-task-26000-ruff-formatter-debt-design.md` and TASK-26951's owner-approved test-only exception.
+
+ADR required: no
+ADR path: N/A
+Reason: mechanical formatting under the existing TASK-26000 contract, with three explicitly approved test-only lint corrections.
+
+## Global Constraints
+
+Only the 19 Python paths in TASK-26951 may change. Use Python 3.12.11 and Ruff 0.15.22. Preserve AST structure (including type comments), ordered comments, directive anchors, and fmt intervals, except the three exact owner-approved test corrections. No hand-written production behavior changes. No full suite: use all 15 assigned test modules with identical before/after bounded commands. Record inherited failures honestly, not as passing tests. Do not absorb other failures or paths. Root owns task documentation and integration.
+
+## Task 1: Apply and verify the assigned batch
+
+Read TASK-26951 for the complete 19-path list and precise approved exceptions. Capture original structural evidence using `/tmp/task26947_format_guard.py` and run all 15 assigned test modules before editing, using the main checkout's `.venv/bin/python`, `-q --timeout=10 --timeout-method=signal --timeout-disable-debugger-detection --show-capture=no --tb=short`, and `/tmp/task26951_before.xml`. Preserve output and exact commands in the report. Report baseline failures; do not fix unrelated behavior.
+
+Apply only the three approved test corrections using apply_patch; prove that exact AST delta against original files, then capture a corrected pre-format baseline. Run Ruff format on all assigned paths, prove structural parity against the corrected baseline and comment preservation against original, and verify deterministic Ruff byte replay from corrected base blobs. Run Ruff check and format check on all assigned paths and repeat the exact focused suite to `/tmp/task26951_after.xml`; compare every test identity/outcome, not just counts. Commit only assigned Python changes after self-review. Return report with command evidence, tool versions, changed paths, hashes, and concerns.
+
+## Task 2: Review and integrate
+
+Root reconciles authority cut `e555df102c950c29beed5e7119f433d35eee1f3c` with integration base `c0fa6639a1fd294bf2bfbdc043c0dcb70782a689`, verifies governance and diagnostic inventory, and records complete evidence in TASK-26951. Independent task review and final branch review precede PR publication. Rebase if needed, reverify affected gates, request Qodo review, wait for CI, then merge and remove only this clean merged worktree and its branch.

--- a/Tests/Chat/test__zz_probe2.py
+++ b/Tests/Chat/test__zz_probe2.py
@@ -1,4 +1,6 @@
-import threading, time, json
+import threading
+import time
+import json
 import Tests.Chat.test_console_agent_bridge as T
 
 
@@ -17,15 +19,21 @@ def test_probe_two_children(tmp_path):
     store = T.ConsoleChatStore()
     session = store.ensure_session()
     store.append_message(session.id, role=T.ConsoleMessageRole.USER, content="hi")
-    assistant = store.append_message(session.id, role=T.ConsoleMessageRole.ASSISTANT, content="")
-    bridge = T.ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
+    assistant = store.append_message(
+        session.id, role=T.ConsoleMessageRole.ASSISTANT, content=""
+    )
+    bridge = T.ConsoleAgentBridge(
+        agent_runs_db=db, store=store, provider_gateway=gateway
+    )
     captured = {}
     bridge._teardown_fleet_service = lambda cid, svc: captured.setdefault("svc", svc)
     result = {}
     marks = []
 
     def do_run():
-        result["outcome"] = T._run(bridge, store, session, assistant.id, conversation_id="conv-two-children")
+        result["outcome"] = T._run(
+            bridge, store, session, assistant.id, conversation_id="conv-two-children"
+        )
         marks.append(("run_returned", time.monotonic()))
 
     runner = threading.Thread(target=do_run)
@@ -47,6 +55,11 @@ def test_probe_two_children(tmp_path):
             if snap and all(h.status != "running" for h in snap):
                 break
             time.sleep(0.0005)
-        marks.append(("ms_until_all_terminal", round((time.monotonic() - t0) * 1000, 2)))
-    out = [(m[0], (round((m[1]-t_start)*1000, 2) if isinstance(m[1], float) else m[1])) for m in marks]
+        marks.append(
+            ("ms_until_all_terminal", round((time.monotonic() - t0) * 1000, 2))
+        )
+    out = [
+        (m[0], (round((m[1] - t_start) * 1000, 2) if isinstance(m[1], float) else m[1]))
+        for m in marks
+    ]
     print("PROBE2", json.dumps(out))

--- a/Tests/Chat/test_anthropic_caching_degrade.py
+++ b/Tests/Chat/test_anthropic_caching_degrade.py
@@ -78,9 +78,7 @@ def test_degrade_is_visible_to_metrics(mock_post):
     bad = _bad_response('{"error": {"message": "cache_control is not supported"}}')
     mock_post.side_effect = [bad, _ok_response()]
 
-    with patch(
-        "tldw_chatbook.LLM_Calls.LLM_API_Calls.log_counter"
-    ) as mock_log_counter:
+    with patch("tldw_chatbook.LLM_Calls.LLM_API_Calls.log_counter") as mock_log_counter:
         chat_api_call(
             "anthropic",
             messages_payload=[{"role": "user", "content": "hi"}],
@@ -154,12 +152,18 @@ def test_caching_enabled_defaults_true_and_warns_on_config_read_failure():
 
 def test_without_cache_control_strips_recursively():
     data = {
-        "system": [{"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}],
+        "system": [
+            {"type": "text", "text": "s", "cache_control": {"type": "ephemeral"}}
+        ],
         "messages": [
             {
                 "role": "user",
                 "content": [
-                    {"type": "text", "text": "hi", "cache_control": {"type": "ephemeral"}}
+                    {
+                        "type": "text",
+                        "text": "hi",
+                        "cache_control": {"type": "ephemeral"},
+                    }
                 ],
             }
         ],

--- a/Tests/Chat/test_change_notes_db.py
+++ b/Tests/Chat/test_change_notes_db.py
@@ -5,6 +5,7 @@ Persistence foundation for the turn-file-card annotate/feedback loop
 §1). Tests run against a real FILE-BACKED ``AgentRunsDB`` — never
 ``:memory:`` (thread-affinity trap, V1 lesson carried into this spec).
 """
+
 from __future__ import annotations
 
 import sqlite3
@@ -118,12 +119,22 @@ def test_add_change_note_file_note_round_trips_sentinels(db):
 def test_notes_for_run_oldest_first(db):
     run_id = _make_run(db)
     first = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="first",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="first",
     )
     second = db.add_change_note(
-        run_id=run_id, root="/r", path="b.py", hunk_index=1,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="second",
+        run_id=run_id,
+        root="/r",
+        path="b.py",
+        hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="second",
     )
     ids = [row["id"] for row in db.notes_for_run(run_id)]
     assert ids == [first, second]
@@ -135,16 +146,31 @@ def test_pending_notes_for_conversation_joins_both_runs_oldest_first(db):
     other_conv_run = _make_run(db, conversation_id="conv2")
 
     note_a = db.add_change_note(
-        run_id=run_a, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note-a",
+        run_id=run_a,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="note-a",
     )
     note_b = db.add_change_note(
-        run_id=run_b, root="/r", path="b.py", hunk_index=0,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="note-b",
+        run_id=run_b,
+        root="/r",
+        path="b.py",
+        hunk_index=0,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="note-b",
     )
     db.add_change_note(
-        run_id=other_conv_run, root="/r", path="c.py", hunk_index=0,
-        hunk_header="@@ -3,1 +3,1 @@", hunk_excerpt="z", note="note-other-conv",
+        run_id=other_conv_run,
+        root="/r",
+        path="c.py",
+        hunk_index=0,
+        hunk_header="@@ -3,1 +3,1 @@",
+        hunk_excerpt="z",
+        note="note-other-conv",
     )
 
     pending = db.pending_notes_for_conversation("conv1")
@@ -155,8 +181,13 @@ def test_pending_notes_for_conversation_joins_both_runs_oldest_first(db):
 def test_pending_notes_for_conversation_excludes_delivered(db):
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="note",
     )
     db.mark_notes_delivered([note_id])
     assert db.pending_notes_for_conversation("conv1") == []
@@ -165,12 +196,22 @@ def test_pending_notes_for_conversation_excludes_delivered(db):
 def test_mark_notes_delivered_stamps_only_given_ids_and_sets_timestamp(db):
     run_id = _make_run(db)
     note_1 = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="one",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="one",
     )
     note_2 = db.add_change_note(
-        run_id=run_id, root="/r", path="b.py", hunk_index=1,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
+        run_id=run_id,
+        root="/r",
+        path="b.py",
+        hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="two",
     )
 
     stamped = db.mark_notes_delivered([note_1])
@@ -190,12 +231,22 @@ def test_mark_notes_delivered_returns_only_actually_stamped_ids(db):
     """
     run_id = _make_run(db)
     note_1 = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="one",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="one",
     )
     note_2 = db.add_change_note(
-        run_id=run_id, root="/r", path="b.py", hunk_index=1,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
+        run_id=run_id,
+        root="/r",
+        path="b.py",
+        hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="two",
     )
 
     # Simulate a lost race: note_2 gets delivered by someone else first.
@@ -223,8 +274,13 @@ def test_mark_notes_delivered_stamps_delivered_by_run_id_when_given(db):
     run_a = _make_run(db, conversation_id="conv1")
     run_b = _make_run(db, conversation_id="conv1")
     note_id = db.add_change_note(
-        run_id=run_a, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="anchored-to-a",
+        run_id=run_a,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="anchored-to-a",
     )
 
     db.mark_notes_delivered([note_id], delivered_by_run_id=run_b)
@@ -241,8 +297,13 @@ def test_mark_notes_delivered_leaves_delivered_by_run_id_null_when_omitted(db):
     column NULL, exactly like a pre-migration stamp would read."""
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="no-deliverer",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="no-deliverer",
     )
     db.mark_notes_delivered([note_id])
     row = db.notes_for_run(run_id)[0]
@@ -258,18 +319,35 @@ def test_delivered_notes_for_conversation_joins_both_runs_oldest_first(db):
     other_conv_run = _make_run(db, conversation_id="conv2")
 
     note_a = db.add_change_note(
-        run_id=run_a, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="note-a",
+        run_id=run_a,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="note-a",
     )
     note_b = db.add_change_note(
-        run_id=run_b, root="/r", path="b.py", hunk_index=0,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="note-b",
+        run_id=run_b,
+        root="/r",
+        path="b.py",
+        hunk_index=0,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="note-b",
     )
     other_conv_note = db.add_change_note(
-        run_id=other_conv_run, root="/r", path="c.py", hunk_index=0,
-        hunk_header="@@ -3,1 +3,1 @@", hunk_excerpt="z", note="note-other-conv",
+        run_id=other_conv_run,
+        root="/r",
+        path="c.py",
+        hunk_index=0,
+        hunk_header="@@ -3,1 +3,1 @@",
+        hunk_excerpt="z",
+        note="note-other-conv",
     )
-    db.mark_notes_delivered([note_a, note_b, other_conv_note], delivered_by_run_id=run_b)
+    db.mark_notes_delivered(
+        [note_a, note_b, other_conv_note], delivered_by_run_id=run_b
+    )
 
     delivered = db.delivered_notes_for_conversation("conv1")
     assert [row["id"] for row in delivered] == [note_a, note_b]
@@ -280,8 +358,13 @@ def test_delivered_notes_for_conversation_joins_both_runs_oldest_first(db):
 def test_delivered_notes_for_conversation_excludes_pending(db):
     run_id = _make_run(db)
     db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="still-pending",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="still-pending",
     )
     assert db.delivered_notes_for_conversation("conv1") == []
 
@@ -295,8 +378,13 @@ def test_mark_notes_delivered_mid_run_race_leaves_later_note_pending(db):
     """
     run_id = _make_run(db)
     note_1 = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="captured-before-run",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="captured-before-run",
     )
 
     # Attach seam captures the pending id list at this instant.
@@ -305,8 +393,13 @@ def test_mark_notes_delivered_mid_run_race_leaves_later_note_pending(db):
 
     # A note lands on an older turn's card while the run is in flight.
     note_2 = db.add_change_note(
-        run_id=run_id, root="/r", path="b.py", hunk_index=1,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="mid-run-race",
+        run_id=run_id,
+        root="/r",
+        path="b.py",
+        hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="mid-run-race",
     )
 
     # Completion stamps exactly the captured list, not "all pending now".
@@ -323,8 +416,13 @@ def test_mark_notes_delivered_mid_run_race_leaves_later_note_pending(db):
 def test_delete_change_note_deletes_pending_note(db):
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="deleteme",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="deleteme",
     )
     assert db.delete_change_note(note_id) is True
     assert db.notes_for_run(run_id) == []
@@ -333,8 +431,13 @@ def test_delete_change_note_deletes_pending_note(db):
 def test_delete_change_note_returns_false_for_delivered(db):
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="delivered",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="delivered",
     )
     db.mark_notes_delivered([note_id])
     assert db.delete_change_note(note_id) is False
@@ -348,9 +451,14 @@ def test_delete_change_note_returns_false_for_missing(db):
 
 def test_mark_notes_delivered_empty_list_is_noop(db):
     run_id = _make_run(db)
-    note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="untouched",
+    db.add_change_note(
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="untouched",
     )
     stamped = db.mark_notes_delivered([])
     assert stamped == []
@@ -369,24 +477,49 @@ def test_change_note_counts_for_conversation_groups_by_root_path_across_runs(db)
     other_conv_run = _make_run(db, conversation_id="conv2")
 
     note_1 = db.add_change_note(
-        run_id=run_a, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="one",
+        run_id=run_a,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="one",
     )
     db.add_change_note(
-        run_id=run_a, root="/r", path="a.py", hunk_index=1,
-        hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="two",
+        run_id=run_a,
+        root="/r",
+        path="a.py",
+        hunk_index=1,
+        hunk_header="@@ -2,1 +2,1 @@",
+        hunk_excerpt="y",
+        note="two",
     )
     db.add_change_note(
-        run_id=run_b, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -3,1 +3,1 @@", hunk_excerpt="z", note="three",
+        run_id=run_b,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -3,1 +3,1 @@",
+        hunk_excerpt="z",
+        note="three",
     )
     db.add_change_note(
-        run_id=run_b, root="/r", path="b.py", hunk_index=0,
-        hunk_header="@@ -4,1 +4,1 @@", hunk_excerpt="w", note="four",
+        run_id=run_b,
+        root="/r",
+        path="b.py",
+        hunk_index=0,
+        hunk_header="@@ -4,1 +4,1 @@",
+        hunk_excerpt="w",
+        note="four",
     )
     db.add_change_note(
-        run_id=other_conv_run, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -5,1 +5,1 @@", hunk_excerpt="v", note="other-conv",
+        run_id=other_conv_run,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -5,1 +5,1 @@",
+        hunk_excerpt="v",
+        note="other-conv",
     )
     # Delivered notes still count -- "ALL the conversation's notes".
     db.mark_notes_delivered([note_1])
@@ -434,7 +567,8 @@ def test_migration_creates_table_and_appends_audit_version_8(tmp_path):
         }
         assert "change_notes" not in tables
         versions = {
-            row[0] for row in raw.execute("SELECT version FROM schema_version").fetchall()
+            row[0]
+            for row in raw.execute("SELECT version FROM schema_version").fetchall()
         }
         assert 8 not in versions
     finally:
@@ -463,8 +597,13 @@ def test_migration_creates_table_and_appends_audit_version_8(tmp_path):
         # freshly-recreated table.
         run_id = reopened.create_run(conversation_id="c", agent_kind="primary")
         note_id = reopened.add_change_note(
-            run_id=run_id, root="/r", path="a.py", hunk_index=0,
-            hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="post-migration",
+            run_id=run_id,
+            root="/r",
+            path="a.py",
+            hunk_index=0,
+            hunk_header="@@ -1,1 +1,1 @@",
+            hunk_excerpt="x",
+            note="post-migration",
         )
         assert reopened.notes_for_run(run_id)[0]["id"] == note_id
     finally:
@@ -487,8 +626,13 @@ def test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9(
     first = AgentRunsDB(db_path, client_id="t")
     run_id = first.create_run(conversation_id="c", agent_kind="primary")
     pre_migration_note_id = first.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="pre-existing",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="pre-existing",
     )
     first.close()
 
@@ -545,9 +689,7 @@ def test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9(
     try:
         raw = sqlite3.connect(str(db_path))
         try:
-            columns = {
-                row[1] for row in raw.execute("PRAGMA table_info(change_notes)")
-            }
+            columns = {row[1] for row in raw.execute("PRAGMA table_info(change_notes)")}
             assert "delivered_by_run_id" in columns
             versions = {
                 row[0] for row in raw.execute("SELECT version FROM schema_version")
@@ -563,8 +705,13 @@ def test_migration_adds_delivered_by_run_id_column_and_appends_audit_version_9(
         assert pre_row["delivered_by_run_id"] is None
 
         post_note_id = reopened.add_change_note(
-            run_id=run_id, root="/r", path="b.py", hunk_index=1,
-            hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="post-migration",
+            run_id=run_id,
+            root="/r",
+            path="b.py",
+            hunk_index=1,
+            hunk_header="@@ -2,1 +2,1 @@",
+            hunk_excerpt="y",
+            note="post-migration",
         )
         reopened.mark_notes_delivered([post_note_id], delivered_by_run_id=run_id)
         post_row = {r["id"]: r for r in reopened.notes_for_run(run_id)}[post_note_id]
@@ -585,8 +732,13 @@ def test_migration_adds_snapshot_id_column_and_appends_audit_version_10(tmp_path
     first = AgentRunsDB(db_path, client_id="t")
     run_id = first.create_run(conversation_id="c", agent_kind="primary")
     pre_migration_note_id = first.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="pre-existing",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="pre-existing",
     )
     first.close()
 
@@ -645,9 +797,7 @@ def test_migration_adds_snapshot_id_column_and_appends_audit_version_10(tmp_path
     try:
         raw = sqlite3.connect(str(db_path))
         try:
-            columns = {
-                row[1] for row in raw.execute("PRAGMA table_info(change_notes)")
-            }
+            columns = {row[1] for row in raw.execute("PRAGMA table_info(change_notes)")}
             assert "snapshot_id" in columns
             versions = {
                 row[0] for row in raw.execute("SELECT version FROM schema_version")
@@ -663,8 +813,13 @@ def test_migration_adds_snapshot_id_column_and_appends_audit_version_10(tmp_path
         assert pre_row["snapshot_id"] is None
 
         post_note_id = reopened.add_change_note(
-            run_id=run_id, root="/r", path="b.py", hunk_index=1,
-            hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="post-migration",
+            run_id=run_id,
+            root="/r",
+            path="b.py",
+            hunk_index=1,
+            hunk_header="@@ -2,1 +2,1 @@",
+            hunk_excerpt="y",
+            note="post-migration",
             snapshot_id=42,
         )
         post_row = {r["id"]: r for r in reopened.notes_for_run(run_id)}[post_note_id]
@@ -689,8 +844,13 @@ def test_migration_adds_anchor_kind_and_diff_line_columns_and_appends_audit_vers
     first = AgentRunsDB(db_path, client_id="t")
     run_id = first.create_run(conversation_id="c", agent_kind="primary")
     pre_migration_note_id = first.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="pre-existing",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="pre-existing",
     )
     first.close()
 
@@ -753,9 +913,7 @@ def test_migration_adds_anchor_kind_and_diff_line_columns_and_appends_audit_vers
     try:
         raw = sqlite3.connect(str(db_path))
         try:
-            columns = {
-                row[1] for row in raw.execute("PRAGMA table_info(change_notes)")
-            }
+            columns = {row[1] for row in raw.execute("PRAGMA table_info(change_notes)")}
             assert "anchor_kind" in columns
             assert "diff_line_index" in columns
             assert "diff_line_text" in columns
@@ -777,9 +935,16 @@ def test_migration_adds_anchor_kind_and_diff_line_columns_and_appends_audit_vers
         assert pre_row["diff_line_text"] is None
 
         post_note_id = reopened.add_change_note(
-            run_id=run_id, root="/r", path="b.py", hunk_index=1,
-            hunk_header="@@ -2,1 +2,1 @@", hunk_excerpt="y", note="post-migration",
-            anchor_kind="diff_line", diff_line_index=3, diff_line_text="+z",
+            run_id=run_id,
+            root="/r",
+            path="b.py",
+            hunk_index=1,
+            hunk_header="@@ -2,1 +2,1 @@",
+            hunk_excerpt="y",
+            note="post-migration",
+            anchor_kind="diff_line",
+            diff_line_index=3,
+            diff_line_text="+z",
         )
         post_row = {r["id"]: r for r in reopened.notes_for_run(run_id)}[post_note_id]
         assert post_row["anchor_kind"] == "diff_line"
@@ -808,8 +973,13 @@ def test_migration_adds_anchor_kind_and_diff_line_columns_and_appends_audit_vers
 def test_add_change_note_snapshot_id_defaults_to_none(db):
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="no snapshot id",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="no snapshot id",
     )
     assert db.notes_for_run(run_id)[0]["id"] == note_id
     assert db.notes_for_run(run_id)[0]["snapshot_id"] is None
@@ -818,8 +988,13 @@ def test_add_change_note_snapshot_id_defaults_to_none(db):
 def test_add_change_note_round_trips_snapshot_id(db):
     run_id = _make_run(db)
     note_id = db.add_change_note(
-        run_id=run_id, root="/r", path="a.py", hunk_index=0,
-        hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="with snapshot id",
+        run_id=run_id,
+        root="/r",
+        path="a.py",
+        hunk_index=0,
+        hunk_header="@@ -1,1 +1,1 @@",
+        hunk_excerpt="x",
+        note="with snapshot id",
         snapshot_id=7,
     )
     assert db.notes_for_run(run_id)[0]["id"] == note_id
@@ -858,8 +1033,13 @@ def test_migration_reopening_twice_is_idempotent(tmp_path):
         # And the API still works normally on the third open.
         run_id = second.create_run(conversation_id="c", agent_kind="primary")
         note_id = second.add_change_note(
-            run_id=run_id, root="/r", path="a.py", hunk_index=0,
-            hunk_header="@@ -1,1 +1,1 @@", hunk_excerpt="x", note="third-open",
+            run_id=run_id,
+            root="/r",
+            path="a.py",
+            hunk_index=0,
+            hunk_header="@@ -1,1 +1,1 @@",
+            hunk_excerpt="x",
+            note="third-open",
         )
         assert note_id
     finally:

--- a/Tests/Chat/test_change_turn_tracking.py
+++ b/Tests/Chat/test_change_turn_tracking.py
@@ -5,6 +5,7 @@ The bridge tests drive the real run loop with a scripted gateway whose
 streaming callback writes files mid-turn: that is literally the run-window
 side effect the feature exists to catch.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -72,9 +73,7 @@ def root(tmp_path) -> Path:
 
 @pytest.fixture()
 def tracker(tmp_path) -> ChangeTurnTracker:
-    return ChangeTurnTracker(
-        service=ShadowRepoService(data_dir=tmp_path / "appdata")
-    )
+    return ChangeTurnTracker(service=ShadowRepoService(data_dir=tmp_path / "appdata"))
 
 
 # -- tracker level ----------------------------------------------------------
@@ -133,9 +132,7 @@ def test_snapshot_preserves_a_new_ordinary_symlink(tracker, root):
     assert repo.last_oversize_excluded == ()
 
 
-def test_snapshot_drops_a_gitlink_that_appears_after_scan(
-    tracker, root, monkeypatch
-):
+def test_snapshot_drops_a_gitlink_that_appears_after_scan(tracker, root, monkeypatch):
     import subprocess as _sp
 
     handle = tracker.begin_turn([root])
@@ -253,9 +250,7 @@ def test_snapshot_drops_a_gitlink_replacing_a_tip_regular_file_after_scan(
     assert str(repo._run("ls-files", "--stage", "--", child.name).stdout) == ""
 
 
-def test_snapshot_removes_tip_entries_when_directory_becomes_nested_repo(
-    tracker, root
-):
+def test_snapshot_removes_tip_entries_when_directory_becomes_nested_repo(tracker, root):
     import subprocess as _sp
 
     child = root / "child"
@@ -298,15 +293,12 @@ def test_final_index_validation_uses_nul_delimited_force_removals(
 ):
     repo = tracker.service.repo_for_root(root)
     ordinary_paths = tuple(
-        f"nested/dir-{index:05d}/{'x' * 180}-{index:05d}.txt"
-        for index in range(20_000)
+        f"nested/dir-{index:05d}/{'x' * 180}-{index:05d}.txt" for index in range(20_000)
     )
     overlong = f"nested/{'y' * 5_000}"
     paths = (*ordinary_paths[:10_000], overlong, *ordinary_paths[10_000:])
     object_id = "a" * 40
-    stage_entries = tuple(
-        f"100644 {object_id} 0\t{path}" for path in paths
-    )
+    stage_entries = tuple(f"100644 {object_id} 0\t{path}" for path in paths)
     calls: list[tuple[tuple[str, ...], dict]] = []
 
     def fake_z_tokens(*args):
@@ -347,8 +339,7 @@ def test_exact_force_add_paths_use_nul_delimited_stdin(
     repo = tracker.service.repo_for_root(root)
     repo.snapshot("initial")
     ordinary_paths = tuple(
-        f"ignored/dir-{index:05d}/{'x' * 180}-{index:05d}.txt"
-        for index in range(2_000)
+        f"ignored/dir-{index:05d}/{'x' * 180}-{index:05d}.txt" for index in range(2_000)
     )
     overlong = f"ignored/{'y' * 5_000}"
     paths = (*ordinary_paths[:1_000], overlong, *ordinary_paths[1_000:])
@@ -417,9 +408,7 @@ def test_force_add_refreshes_ignored_executable_bytes_and_mode(tracker, root):
     target.chmod(0o755)
     repo = tracker.service.repo_for_root(root)
     first = repo.snapshot("first executable", force_paths=[target.name])
-    first_mode = str(
-        repo._run("ls-tree", first, "--", target.name).stdout
-    ).split()[0]
+    first_mode = str(repo._run("ls-tree", first, "--", target.name).stdout).split()[0]
     if first_mode != "100755":
         pytest.skip("filesystem does not expose executable bits to Git")
 
@@ -650,9 +639,7 @@ def test_snapshot_force_path_file_to_directory_swap_never_stages_descendants(
     assert tip == baseline or repo.file_bytes(tip, child_rel) is None
 
 
-def test_force_add_file_to_directory_swap_never_stages_descendants(
-    tracker, root
-):
+def test_force_add_file_to_directory_swap_never_stages_descendants(tracker, root):
     target = root / "race-target"
     child_rel = "race-target/ignored-child.txt"
     replacement = root.parent / "force-add-replacement"
@@ -939,10 +926,7 @@ def test_snapshot_force_path_drops_file_when_nested_marker_appears_during_final_
 
     def create_marker_before_index(self, *args, **kwargs):
         nonlocal exact_stages
-        if (
-            self.root == root.resolve()
-            and args[:2] == ("update-index", "--add")
-        ):
+        if self.root == root.resolve() and args[:2] == ("update-index", "--add"):
             exact_stages += 1
             if exact_stages == 2:
                 (child / ".git").mkdir()
@@ -1048,12 +1032,15 @@ def test_supplied_boundary_does_not_leak_force_paths_to_another_conversation(
     unrelated.await_baseline()
     target.write_bytes(expected)
 
-    assert tracker.end_turn(
-        continuation,
-        touched_paths=[str(target)],
-        end_shas=successor.baselines,
-        successor_handle=successor,
-    ) == []
+    assert (
+        tracker.end_turn(
+            continuation,
+            touched_paths=[str(target)],
+            end_shas=successor.baselines,
+            successor_handle=successor,
+        )
+        == []
+    )
 
     assert tracker.end_turn(unrelated) == []
     successor_records = tracker.end_turn(successor)
@@ -1083,12 +1070,15 @@ def test_supplied_sha_deferred_file_growing_before_successor_e_is_disclosed(
     supplied = successor.baselines[key]
     target.write_bytes(b"small")
 
-    assert tracker.end_turn(
-        continuation,
-        touched_paths=[str(target)],
-        end_shas=successor.baselines,
-        successor_handle=successor,
-    ) == []
+    assert (
+        tracker.end_turn(
+            continuation,
+            touched_paths=[str(target)],
+            end_shas=successor.baselines,
+            successor_handle=successor,
+        )
+        == []
+    )
     assert continuation.end_shas[key] == supplied
     repo = tracker.service.repo_for_root(root)
     assert str(repo._run("ls-files", "--", target.name).stdout).strip() == ""
@@ -1127,12 +1117,15 @@ def test_supplied_sha_deferred_path_becoming_nested_before_successor_e_is_disclo
     supplied = successor.baselines[key]
     target.write_text("must stay child-owned\n")
 
-    assert tracker.end_turn(
-        continuation,
-        touched_paths=[str(target)],
-        end_shas=successor.baselines,
-        successor_handle=successor,
-    ) == []
+    assert (
+        tracker.end_turn(
+            continuation,
+            touched_paths=[str(target)],
+            end_shas=successor.baselines,
+            successor_handle=successor,
+        )
+        == []
+    )
     assert continuation.end_shas[key] == supplied
     repo = tracker.service.repo_for_root(root)
     assert str(repo._run("ls-files", "--", target_rel).stdout).strip() == ""
@@ -1171,12 +1164,15 @@ def test_supplied_sha_deferred_path_treats_pathspec_magic_as_a_literal_filename(
     target.write_bytes(expected)
     sibling.write_text("must stay ignored\n")
 
-    assert tracker.end_turn(
-        continuation,
-        touched_paths=[str(target)],
-        end_shas=successor.baselines,
-        successor_handle=successor,
-    ) == []
+    assert (
+        tracker.end_turn(
+            continuation,
+            touched_paths=[str(target)],
+            end_shas=successor.baselines,
+            successor_handle=successor,
+        )
+        == []
+    )
     successor_records = tracker.end_turn(successor)
 
     assert len(successor_records) == 1
@@ -1341,10 +1337,7 @@ def test_deferred_force_path_snapshot_failure_is_disclosed_by_successor(
     assert records[0].end_sha == supplied
     assert records[0].tracking_error == ""
     assert len(successor_records) == 1
-    assert (
-        successor_records[0].tracking_error
-        == "injected deferred snapshot failure"
-    )
+    assert successor_records[0].tracking_error == "injected deferred snapshot failure"
 
 
 def test_invalid_supplied_sha_does_not_defer_or_stage_the_path(tracker, root):
@@ -1372,9 +1365,7 @@ def test_invalid_supplied_sha_does_not_defer_or_stage_the_path(tracker, root):
     assert str(repo._run("ls-files", "--", target.name).stdout).strip() == ""
 
 
-def test_supplied_sha_preserves_nonempty_continuation_range_statistics(
-    tracker, root
-):
+def test_supplied_sha_preserves_nonempty_continuation_range_statistics(tracker, root):
     parent = tracker.begin_turn([root])
     parent.await_baseline()
     assert tracker.end_turn(parent) == []
@@ -1518,9 +1509,7 @@ class _SideEffectGateway:
     bridge test failed with an empty run.
     """
 
-    def __init__(
-        self, scripts, side_effect=None, explode=False, side_effect_on_call=1
-    ):
+    def __init__(self, scripts, side_effect=None, explode=False, side_effect_on_call=1):
         self._scripts = list(scripts)
         self._side_effect = side_effect
         self._explode = explode
@@ -1621,9 +1610,7 @@ def test_bridge_run_with_no_changes_records_no_row(tmp_path, root, tracker):
     assert db.change_snapshots_for_run(run_id) == []
 
 
-def test_bridge_returns_before_coordinated_end_snapshot_finishes(
-    tmp_path, root
-):
+def test_bridge_returns_before_coordinated_end_snapshot_finishes(tmp_path, root):
     end_entered = threading.Event()
     release_end = threading.Event()
 
@@ -1635,9 +1622,7 @@ def test_bridge_returns_before_coordinated_end_snapshot_finishes(
                 handle, touched_paths=touched_paths, end_shas=end_shas
             )
 
-    tracker = _HeldEndTracker(
-        service=ShadowRepoService(data_dir=tmp_path / "appdata")
-    )
+    tracker = _HeldEndTracker(service=ShadowRepoService(data_dir=tmp_path / "appdata"))
     gateway = _SideEffectGateway(
         [[_calc_fence()], ["done."]],
         side_effect_on_call=2,
@@ -1761,9 +1746,7 @@ def test_bridge_does_not_append_capacity_marker_after_coordinator_shutdown(
     ]
 
 
-def test_third_turn_starts_while_second_review_finalization_is_held(
-    tmp_path, root
-):
+def test_third_turn_starts_while_second_review_finalization_is_held(tmp_path, root):
     second_end_entered = threading.Event()
     release_second_end = threading.Event()
 
@@ -1825,9 +1808,7 @@ def test_third_turn_starts_while_second_review_finalization_is_held(
     second_assistant = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     )
-    second_run_id, _second_outcome = _run(
-        bridge, session, second_assistant.id, root
-    )
+    second_run_id, _second_outcome = _run(bridge, session, second_assistant.id, root)
     bridge.record_run_assistant_message(second_run_id, "persisted-second")
     assert db.get_run(second_run_id)["assistant_message_id"] == "persisted-second"
     assert second_end_entered.wait(timeout=1)
@@ -1854,9 +1835,7 @@ def test_third_turn_starts_while_second_review_finalization_is_held(
     coordinator.shutdown(timeout=1)
 
 
-def test_cancelled_turn_still_schedules_coordinated_finalization(
-    tmp_path, root
-):
+def test_cancelled_turn_still_schedules_coordinated_finalization(tmp_path, root):
     tracker = ChangeTurnTracker(
         service=ShadowRepoService(data_dir=tmp_path / "appdata")
     )
@@ -1965,9 +1944,7 @@ def test_review_runs_before_baseline_gate_and_tool_dispatch_waits(tmp_path, root
         events.append("review-called")
         return {}
 
-    run_id, outcome = _run(
-        bridge, session, aid, root, review_tool_calls=probe_review
-    )
+    run_id, outcome = _run(bridge, session, aid, root, review_tool_calls=probe_review)
 
     assert "baseline-finished" in events and "review-called" in events
     assert events.index("review-called") < events.index("baseline-finished"), (
@@ -2126,9 +2103,7 @@ def test_carveout_survives_a_symlink_spelled_root(tmp_path):
     handle.await_baseline()
     (real_root / ".env").write_text("SECRET=1\n")
 
-    records = tracker.end_turn(
-        handle, touched_paths=[str(real_root / ".env")]
-    )
+    records = tracker.end_turn(handle, touched_paths=[str(real_root / ".env")])
 
     assert len(records) == 1 and not records[0].tracking_error
     changed = tracker.service.repo_for_root(real_root).changed_files(
@@ -2152,9 +2127,7 @@ def _tool_rows(store, session):
     ]
 
 
-def test_a_change_turn_emits_the_summary_row_with_real_counts(
-    tmp_path, root, tracker
-):
+def test_a_change_turn_emits_the_summary_row_with_real_counts(tmp_path, root, tracker):
     gateway = _SideEffectGateway(
         [[_calc_fence()], ["done."]],
         side_effect_on_call=2,
@@ -2177,9 +2150,7 @@ def test_a_clean_turn_emits_no_summary_row(tmp_path, root, tracker):
     gateway = _SideEffectGateway([["done."]])
     bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
     _run(bridge, session, aid, root)
-    assert not [
-        m for m in _tool_rows(store, session) if m.content.startswith("✎")
-    ]
+    assert not [m for m in _tool_rows(store, session) if m.content.startswith("✎")]
 
 
 def test_tracking_failure_emits_the_warning_row(tmp_path, root):
@@ -2192,9 +2163,7 @@ def test_tracking_failure_emits_the_warning_row(tmp_path, root):
     bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, broken)
     _run(bridge, session, aid, root)
     warns = [
-        m
-        for m in _tool_rows(store, session)
-        if "change tracking failed" in m.content
+        m for m in _tool_rows(store, session) if "change tracking failed" in m.content
     ]
     assert len(warns) == 1, "a tracking failure must be DISCLOSED in the transcript"
 
@@ -2219,9 +2188,7 @@ def test_skipped_review_root_emits_alias_only_warning_without_snapshot_state(
         aid,
         tmp_path / "unused-root",
         change_roots=[],
-        change_review_skipped_roots=(
-            SkippedReviewRoot(alias=alias, reason=reason),
-        ),
+        change_review_skipped_roots=(SkippedReviewRoot(alias=alias, reason=reason),),
     )
 
     assert outcome.status == "done"
@@ -2248,9 +2215,7 @@ def test_summary_row_survives_the_next_message(tmp_path, root, tracker):
     )
     bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
     _run(bridge, session, aid, root)
-    store.append_message(
-        session.id, role=ConsoleMessageRole.USER, content="follow-up"
-    )
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="follow-up")
     rows = [m for m in _tool_rows(store, session) if m.content.startswith("✎")]
     assert len(rows) == 1, "the summary row was destroyed by the next message"
 
@@ -2265,14 +2230,10 @@ def test_resume_re_derives_the_summary_row_byte_identical(tmp_path, root, tracke
     )
     bridge, db, store, session, aid = _bridge_with(tmp_path, gateway, tracker)
     run_id, _ = _run(bridge, session, aid, root)
-    live = [
-        m for m in _tool_rows(store, session) if m.content.startswith("✎")
-    ]
+    live = [m for m in _tool_rows(store, session) if m.content.startswith("✎")]
     assert live, "precondition"
 
-    fresh = ConsoleAgentBridge(
-        agent_runs_db=db, store=None, provider_gateway=None
-    )
+    fresh = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     resumed = [
         m
         for _anchor, block in fresh.resume_marker_messages("conv-1")
@@ -2310,17 +2271,13 @@ def test_review_changes_action_offered_only_for_summary_rows():
         role=ConsoleMessageRole.TOOL, content="⚙ calculator → 42"
     )
     svc = ConsoleMessageActionService()
-    assert "review-changes" in [
-        a.action_id for a in svc.available_actions(summary)
-    ]
+    assert "review-changes" in [a.action_id for a in svc.available_actions(summary)]
     assert "review-changes" not in [
         a.action_id for a in svc.available_actions(plain_marker)
     ]
 
 
-def test_bridge_exposes_a_provider_for_the_review_screen(
-    tmp_path, root, tracker
-):
+def test_bridge_exposes_a_provider_for_the_review_screen(tmp_path, root, tracker):
     gateway = _SideEffectGateway(
         [[_calc_fence()], ["done."]],
         side_effect_on_call=2,
@@ -2411,8 +2368,8 @@ async def test_the_opener_pushes_the_screen_and_selects_the_turn(
         # The run-store id for the harness's session is the session id
         # itself (no persisted conversation) -- point the bridge's provider
         # at the id the run actually recorded under instead.
-        chat_screen._console_chat_controller._agent_conversation_id = (
-            lambda _sid: "conv-1"
+        chat_screen._console_chat_controller._agent_conversation_id = lambda _sid: (
+            "conv-1"
         )
 
         chat_screen._open_change_review(run_id)
@@ -2456,9 +2413,7 @@ async def test_the_summary_rows_own_review_action_opens_the_screen(
 
     run_id, outcome = await _asyncio.to_thread(_run, bridge, session, aid, root)
     assert outcome.status not in ("error",), outcome.steps
-    marker = next(
-        m for m in _tool_rows(store, session) if m.content.startswith("✎")
-    )
+    marker = next(m for m in _tool_rows(store, session) if m.content.startswith("✎"))
     assert marker.change_review_run_id == run_id
 
     class _ConsoleHarness(ConsolidatedCSSApp):
@@ -2493,8 +2448,8 @@ async def test_the_summary_rows_own_review_action_opens_the_screen(
         chat_screen._ensure_console_chat_controller()
         controller = chat_screen._console_chat_controller
         assert controller is not None
-        chat_screen._console_chat_controller._agent_conversation_id = (
-            lambda _sid: "conv-1"
+        chat_screen._console_chat_controller._agent_conversation_id = lambda _sid: (
+            "conv-1"
         )
         await chat_screen._sync_native_console_transcript()
         await pilot.pause()
@@ -2574,9 +2529,7 @@ def test_resume_re_derives_the_failure_row_too(tmp_path, root):
     ]
     assert live, "precondition: the live run disclosed the failure"
 
-    fresh = ConsoleAgentBridge(
-        agent_runs_db=db, store=None, provider_gateway=None
-    )
+    fresh = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     resumed = [
         m.content
         for _anchor, block in fresh.resume_marker_messages("conv-1")
@@ -2637,9 +2590,7 @@ class _FleetSurvivorGateway:
             with self._lock:
                 self.child_calls += 1
                 first_call = self.child_calls == 1
-                chunks = (
-                    self._child.pop(0) if self._child else ["child answer"]
-                )
+                chunks = self._child.pop(0) if self._child else ["child answer"]
             loop = asyncio.get_running_loop()
             if first_call:
                 self.child_started.set()
@@ -2676,9 +2627,7 @@ class _FleetSurvivorGateway:
 def _spawn_fence(task: str) -> str:
     return (
         f"{FENCE_OPEN}\n"
-        + json.dumps(
-            {"name": "spawn_subagent", "arguments": {"task": task}}
-        )
+        + json.dumps({"name": "spawn_subagent", "arguments": {"task": task}})
         + "\n```"
     )
 
@@ -2905,8 +2854,7 @@ def test_pending_child_before_scope_entry_keeps_ignored_write_reviewable(
     )
     assert [item.path for item in changed] == [target.name], changed
     assert (
-        repo.file_bytes(survivor_rows[0]["end_sha"], target.name)
-        == sentinel.encode()
+        repo.file_bytes(survivor_rows[0]["end_sha"], target.name) == sentinel.encode()
     )
 
 
@@ -3108,9 +3056,7 @@ def test_child_write_during_blocked_parent_e_is_retried_by_immediate_close(
         )
 
         rows = db.change_snapshots_for_run(run_id)
-        survivor_rows = [
-            row for row in rows if row["kind"] == "subagent_post_turn"
-        ]
+        survivor_rows = [row for row in rows if row["kind"] == "subagent_post_turn"]
         assert len(survivor_rows) == 1, (
             "the pre-scope child's ignored WRITE path published during E was "
             f"omitted from immediate survivor close: {rows}"
@@ -3203,15 +3149,12 @@ def test_settled_child_before_parent_e_keeps_ignored_write_reviewable(
     rows = db.change_snapshots_for_run(run_id)
     turn_rows = [row for row in rows if row["kind"] == "turn"]
     assert len(turn_rows) == 1, (
-        "the settled child's local WRITE state was omitted from parent E: "
-        f"{rows}"
+        f"the settled child's local WRITE state was omitted from parent E: {rows}"
     )
     assert not [row for row in rows if row["kind"] == "subagent_post_turn"], rows
     assert bridge._post_turn_change_windows.get("conv-1") is None
     repo = tracker.service.repo_for_root(root)
-    changed = repo.changed_files(
-        turn_rows[0]["baseline_sha"], turn_rows[0]["end_sha"]
-    )
+    changed = repo.changed_files(turn_rows[0]["baseline_sha"], turn_rows[0]["end_sha"])
     assert [item.path for item in changed] == [target.name], changed
     assert repo.file_bytes(turn_rows[0]["end_sha"], target.name) == sentinel.encode()
 
@@ -3273,7 +3216,8 @@ def test_child_write_path_normalization_failure_is_best_effort(
             len(steps) == 1
             and steps[0].kind == STEP_TOOL_CALL
             and steps[0].tool_name == "write_file"
-            and steps[0].args == {
+            and steps[0].args
+            == {
                 "file_path": target.name,
                 "content": sentinel,
             }
@@ -3440,10 +3384,7 @@ def test_a_survivors_write_after_its_turn_lands_in_a_change_record(
 
     assert (root / "survivor.txt").exists(), "precondition: the child wrote"
     rows = db.change_snapshots_for_run(run_id)
-    assert len(rows) == 1, (
-        "the survivor's write landed in NO change record: "
-        f"{rows}"
-    )
+    assert len(rows) == 1, f"the survivor's write landed in NO change record: {rows}"
     row = rows[0]
     assert row["files_changed"] == 1, row
     changed = tracker.service.repo_for_root(root).changed_files(
@@ -3525,9 +3466,7 @@ def test_a_survivors_write_during_the_next_turn_is_disclosed_on_it(
     )
 
 
-def test_a_survivors_write_racing_the_next_baseline_is_still_reviewable(
-    tmp_path, root
-):
+def test_a_survivors_write_racing_the_next_baseline_is_still_reviewable(tmp_path, root):
     """The audit's second half: a survivor's tool dispatch passes turn 1's
     ALREADY-SATISFIED `await_baseline()`, so it is gated on nothing while
     turn 2's baseline is being taken -- and a write during that window is
@@ -3604,8 +3543,7 @@ def test_a_survivors_write_racing_the_next_baseline_is_still_reviewable(
     )
     rows_1 = db.change_snapshots_for_run(run_1)
     assert len(rows_1) == 1, (
-        "a write that raced the next turn's baseline is in NO record: "
-        f"{rows_1}"
+        f"a write that raced the next turn's baseline is in NO record: {rows_1}"
     )
     changed = tracker.service.repo_for_root(root).changed_files(
         rows_1[0]["baseline_sha"], rows_1[0]["end_sha"]
@@ -3613,9 +3551,7 @@ def test_a_survivors_write_racing_the_next_baseline_is_still_reviewable(
     assert [c.path for c in changed] == ["raced.txt"], changed
 
 
-def test_a_survivors_tool_dispatch_is_gated_on_nothing_across_turns(
-    tmp_path, root
-):
+def test_a_survivors_tool_dispatch_is_gated_on_nothing_across_turns(tmp_path, root):
     """CHARACTERISATION (green before and after this task's fix): the
     mechanism behind the test above.
 
@@ -3669,9 +3605,7 @@ def test_a_survivors_tool_dispatch_is_gated_on_nothing_across_turns(
         return {}
 
     try:
-        run_1, outcome_1 = _run(
-            bridge, session, aid, root, review_tool_calls=review
-        )
+        run_1, outcome_1 = _run(bridge, session, aid, root, review_tool_calls=review)
         assert outcome_1.status == "done"
         assert gateway.child_started.wait(5), "the child never started"
         child_run_ids.extend(
@@ -3697,9 +3631,7 @@ def test_a_survivors_tool_dispatch_is_gated_on_nothing_across_turns(
         for index, event in enumerate(events)
         if event == f"review:{child_run_ids[0]}"
     ]
-    assert child_reviews, (
-        f"the survivor never dispatched a tool after turn 1: {events}"
-    )
+    assert child_reviews, f"the survivor never dispatched a tool after turn 1: {events}"
     baseline_done = events.index("baseline-finished")
     assert child_reviews[0] < baseline_done, (
         "the survivor's tool batch waited for turn 2's baseline (it does "
@@ -3795,14 +3727,8 @@ def test_the_survivor_window_ends_exactly_where_the_next_turn_begins(
     # re-derive it in -- BEFORE the next turn's own row, since it belongs
     # to the earlier turn's block. (Closing the window as a side effect of
     # opening the next one produces the same record in the wrong place.)
-    live = [
-        m.content
-        for m in _tool_rows(store, session)
-        if m.content.startswith("✎")
-    ]
-    fresh = ConsoleAgentBridge(
-        agent_runs_db=db, store=None, provider_gateway=None
-    )
+    live = [m.content for m in _tool_rows(store, session) if m.content.startswith("✎")]
+    fresh = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     resumed = [
         m.content
         for _anchor, block in fresh.resume_marker_messages("conv-1")
@@ -3839,9 +3765,7 @@ def test_a_child_that_finishes_inside_its_turn_opens_no_survivor_window(
     rows = db.change_snapshots_for_run(run_id)
     assert [r["kind"] for r in rows] == ["turn"], rows
     assert not [
-        m
-        for m in _tool_rows(store, session)
-        if "after this turn" in m.content
+        m for m in _tool_rows(store, session) if "after this turn" in m.content
     ], "a survivor row was emitted for a child that never survived"
 
 
@@ -3866,14 +3790,10 @@ def test_a_turn_without_a_foreign_survivor_is_not_stamped_concurrent(
     _join_fleet_threads()
 
     assert [r["kind"] for r in db.change_snapshots_for_run(run_id)] == ["turn"]
-    assert not [
-        m for m in _tool_rows(store, session) if "earlier turn" in m.content
-    ]
+    assert not [m for m in _tool_rows(store, session) if "earlier turn" in m.content]
 
 
-def test_resume_re_derives_the_survivor_rows_byte_identical(
-    tmp_path, root, tracker
-):
+def test_resume_re_derives_the_survivor_rows_byte_identical(tmp_path, root, tracker):
     """Both new transcript rows are re-derived from the stored `kind`.
 
     Without the column a post-turn row and a turn row are indistinguishable
@@ -3918,18 +3838,14 @@ def test_resume_re_derives_the_survivor_rows_byte_identical(
     ]
     assert len(live) >= 2, live
 
-    fresh = ConsoleAgentBridge(
-        agent_runs_db=db, store=None, provider_gateway=None
-    )
+    fresh = ConsoleAgentBridge(agent_runs_db=db, store=None, provider_gateway=None)
     resumed = [
         m.content
         for _anchor, block in fresh.resume_marker_messages("conv-1")
         for m in block
         if m.content.startswith("✎") or "earlier turn" in m.content
     ]
-    assert resumed == live, (
-        "the survivor rows did not survive resume byte-identical"
-    )
+    assert resumed == live, "the survivor rows did not survive resume byte-identical"
 
 
 def test_opening_a_window_whose_last_child_already_left_closes_it_at_once(
@@ -4333,9 +4249,7 @@ def test_successor_b_rejects_a_completed_but_failed_fresh_close(
 
     def close_old_window() -> None:
         try:
-            owner_results.append(
-                bridge._close_post_turn_change_window("conv-1")
-            )
+            owner_results.append(bridge._close_post_turn_change_window("conv-1"))
         except BaseException as exc:  # noqa: BLE001 -- asserted below
             failures.append(exc)
 
@@ -4524,15 +4438,18 @@ def test_successor_b_freezes_paths_atomically_with_older_publication(
         if row["baseline_sha"] and row["end_sha"]
     )
     successor_rows = db.change_snapshots_for_run(run_id)
-    assert sum(
-        target.name
-        in [
-            item.path
-            for item in repo.changed_files(row["baseline_sha"], row["end_sha"])
-        ]
-        for row in successor_rows
-        if row["baseline_sha"] and row["end_sha"]
-    ) == 1
+    assert (
+        sum(
+            target.name
+            in [
+                item.path
+                for item in repo.changed_files(row["baseline_sha"], row["end_sha"])
+            ]
+            for row in successor_rows
+            if row["baseline_sha"] and row["end_sha"]
+        )
+        == 1
+    )
     assert window.close_done.is_set()
 
 
@@ -4726,8 +4643,7 @@ def test_inherited_child_write_waits_for_claimed_successor_baseline(
         ]
 
     assert not any(
-        target.name in changed_paths(row)
-        for row in db.change_snapshots_for_run(run_1)
+        target.name in changed_paths(row) for row in db.change_snapshots_for_run(run_1)
     )
     successor_rows = [
         row
@@ -4859,9 +4775,7 @@ def test_successor_e_waits_for_close_time_force_path_handoff(
     ]
     assert len(rows_with_target) == 1, successor_rows
     assert rows_with_target[0]["baseline_sha"] == baseline
-    assert (
-        repo.file_bytes(rows_with_target[0]["end_sha"], target.name) == expected
-    )
+    assert repo.file_bytes(rows_with_target[0]["end_sha"], target.name) == expected
     assert not db.change_snapshots_for_run(old_run_id)
 
 
@@ -5288,9 +5202,7 @@ def test_claim_and_close_failures_release_waiters_without_breaking_runs(
     def close_claimed_window() -> None:
         claim_close_started.set()
         try:
-            claim_close_results.append(
-                bridge._close_post_turn_change_window("conv-1")
-            )
+            claim_close_results.append(bridge._close_post_turn_change_window("conv-1"))
         except BaseException as exc:  # noqa: BLE001 -- asserted on test thread
             errors.append(exc)
         finally:
@@ -5457,9 +5369,7 @@ def test_inherited_child_state_crosses_successor_e_and_second_window_without_bac
         child_states=(inherited_state,),
     )
     bridge._post_turn_change_windows["conv-1"] = old_window
-    bridge._child_change_states["conv-1"] = {
-        inherited_state.owner_key: inherited_state
-    }
+    bridge._child_change_states["conv-1"] = {inherited_state.owner_key: inherited_state}
 
     try:
         successor_run_id, outcome = _run(

--- a/Tests/Chat/test_chat_api_call_endpoint_redaction.py
+++ b/Tests/Chat/test_chat_api_call_endpoint_redaction.py
@@ -152,7 +152,10 @@ def test_the_log_line_keeps_the_length_for_debugging(loguru_caplog):
     with pytest.raises(Exception):
         chat_api_call("abcdefghij", [{"role": "user", "content": "q"}])
 
-    routing = [r.getMessage() for r in loguru_caplog.records
-               if "Routing to endpoint" in r.getMessage()]
+    routing = [
+        r.getMessage()
+        for r in loguru_caplog.records
+        if "Routing to endpoint" in r.getMessage()
+    ]
     assert routing, "expected a routing log line"
     assert any("10 chars" in line for line in routing), routing[:2]

--- a/Tests/Chat/test_extract_response_content.py
+++ b/Tests/Chat/test_extract_response_content.py
@@ -40,16 +40,19 @@ def test_missing_everything():
     assert extract_response_content({}) == ""
 
 
-@pytest.mark.parametrize("resp", [
-    {"choices": ["not-a-dict"]},
-    {"choices": "abc"},
-    {"choices": {"foo": "bar"}},
-    {"choices": [42]},
-    {"choices": [["nested-list"]]},
-    {"choices": [None]},
-    42,
-    [1, 2, 3],
-])
+@pytest.mark.parametrize(
+    "resp",
+    [
+        {"choices": ["not-a-dict"]},
+        {"choices": "abc"},
+        {"choices": {"foo": "bar"}},
+        {"choices": [42]},
+        {"choices": [["nested-list"]]},
+        {"choices": [None]},
+        42,
+        [1, 2, 3],
+    ],
+)
 def test_malformed_never_raises_returns_str(resp):
     out = extract_response_content(resp)
     assert isinstance(out, str)

--- a/Tests/Chat/test_fleet_attention.py
+++ b/Tests/Chat/test_fleet_attention.py
@@ -27,6 +27,7 @@ Full-path tests drive a real ``ConsoleAgentBridge`` + gated fleet child
 (the Task 1/3 harness); matrix tests deliver synthetic ``FleetDrained``
 events to the consumer directly (the Task 3 pattern).
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -94,9 +95,7 @@ class _AppStub:
             return 1
 
     def notify(self, message, *, severity="information", **_kwargs):
-        self.notifications.append(
-            (threading.current_thread().name, message, severity)
-        )
+        self.notifications.append((threading.current_thread().name, message, severity))
 
 
 def _drain(conversation_id="conv-att", children=()):
@@ -166,9 +165,7 @@ async def test_a_survivor_settle_writes_the_durable_mark_and_toasts_once(
         register_fleet_attention(bridge, app)  # captures this test's loop
         conversation_id = "conv-att"
         try:
-            outcome = _run(
-                bridge, store, session, aid, conversation_id=conversation_id
-            )
+            outcome = _run(bridge, store, session, aid, conversation_id=conversation_id)
             assert outcome.status == "done"
             assert gateway.entered_event.wait(5), "the child never started"
             # The turn is over, the child is not: nothing may be marked or
@@ -265,9 +262,9 @@ async def test_a_child_that_finishes_inside_its_turn_marks_and_toasts_nothing(
         assert outcome.status == "done"
         _join_fleet_threads()
         assert drain_fired.is_set(), "precondition: the drain fired mid-turn"
-        assert [c.settled_after_turn for e in events for c in e.children] == [
-            False
-        ], "a child settling while its turn still runs is within-turn"
+        assert [c.settled_after_turn for e in events for c in e.children] == [False], (
+            "a child settling while its turn still runs is within-turn"
+        )
 
         await asyncio.sleep(0.2)  # give a wrong hop time to land
         assert app.notifications == [], (
@@ -409,7 +406,9 @@ def test_a_drain_with_no_after_turn_children_is_a_strict_no_op(tmp_path):
         app = _AppStub(chacha)
         consumer = ConsoleFleetAttentionConsumer(app, loop=None)
         consumer(
-            _drain(children=[_child(after_turn=False), _child("error", after_turn=False)])
+            _drain(
+                children=[_child(after_turn=False), _child("error", after_turn=False)]
+            )
         )
         assert app.notifications == []
         assert app.staged == []

--- a/Tests/Chat/test_fleet_autowake.py
+++ b/Tests/Chat/test_fleet_autowake.py
@@ -8,10 +8,10 @@ USER transcript row, the composer untouched, a SYSTEM-class notice row
 marked ``origin="agent_wake"``, and the model payload carrying the fenced
 results as an explicitly-labelled not-user-input injection.
 """
+
 from __future__ import annotations
 
 import asyncio
-import threading
 import time
 
 import pytest
@@ -44,12 +44,12 @@ class _WakeStreamingGateway:
 
     async def resolve_for_send(self, selection):
         return provider_resolution(
-                   ready=True,
-                   provider="llama_cpp",
-                   model="test-model",
-                   base_url="http://127.0.0.1:9099",
-                   visible_copy="",
-               )
+            ready=True,
+            provider="llama_cpp",
+            model="test-model",
+            base_url="http://127.0.0.1:9099",
+            visible_copy="",
+        )
 
     async def stream_chat(self, resolution, messages, **kwargs):
         self.messages_seen.append(list(messages))

--- a/Tests/Chat/test_fleet_settle_fanout.py
+++ b/Tests/Chat/test_fleet_settle_fanout.py
@@ -30,6 +30,7 @@ status fallback) feeding one bridge-lifetime fan-out. These tests pin:
 Each test is mutation-tested (Task 2 report): every listed mutation makes
 the named test fail on its own assertion.
 """
+
 from __future__ import annotations
 
 import threading
@@ -113,14 +114,12 @@ def test_drain_fires_once_with_terminal_rows_and_a_finished_coordinator(
     _join_fleet_threads()
 
     assert len(fires) == 1, (
-        "the drain must fire exactly once per drain, not per child: "
-        f"{fires}"
+        f"the drain must fire exactly once per drain, not per child: {fires}"
     )
     fire = fires[0]
     assert fire["thread"].startswith("fleet-"), fire
     assert fire["db_statuses"] == ["done", "done"], (
-        "every settled row must be terminal at fire time on the happy "
-        f"path: {fire}"
+        f"every settled row must be terminal at fire time on the happy path: {fire}"
     )
     assert all(s != "running" for s in fire["coordinator_statuses"]), (
         "the drain fires strictly after fleet.finish -- unlike the "
@@ -220,8 +219,7 @@ def test_change_window_close_completes_before_the_drain_fires(tmp_path):
     _join_fleet_threads()
 
     assert order == ["change-window-closed", "drain"], (
-        "the change window must have fully closed before the drain "
-        f"fires: {order}"
+        f"the change window must have fully closed before the drain fires: {order}"
     )
 
 
@@ -276,13 +274,12 @@ def test_a_raising_settle_hook_never_reaches_the_child_threads_excepthook(
 
     monkeypatch.setattr(threading, "excepthook", recording_excepthook)
 
-    def raising_hook(self, conversation_id, session_id, assistant_message_id,
-                     run_id, status):
+    def raising_hook(
+        self, conversation_id, session_id, assistant_message_id, run_id, status
+    ):
         raise RuntimeError("induced: the settle hook itself is broken")
 
-    monkeypatch.setattr(
-        ConsoleAgentBridge, "_on_fleet_child_settled", raising_hook
-    )
+    monkeypatch.setattr(ConsoleAgentBridge, "_on_fleet_child_settled", raising_hook)
 
     gate, gateway, db, store, session, aid, bridge = _survivor_bridge(
         tmp_path,
@@ -305,12 +302,10 @@ def test_a_raising_settle_hook_never_reaches_the_child_threads_excepthook(
         "a raising settle hook must be contained inside run_child's "
         f"finally, never killing the child's thread: {fleet_deaths}"
     )
-    assert not [
-        t for t in threading.enumerate() if t.name.startswith("fleet-")
-    ], "the child thread must have finished cleanly"
-    row = next(
-        r for r in db.list_runs("conv-hook") if r["agent_kind"] == "subagent"
+    assert not [t for t in threading.enumerate() if t.name.startswith("fleet-")], (
+        "the child thread must have finished cleanly"
     )
+    row = next(r for r in db.list_runs("conv-hook") if r["agent_kind"] == "subagent")
     assert row["status"] == "done", row
 
 
@@ -358,15 +353,11 @@ def test_a_consumer_registered_once_fires_once_per_drain_across_turns(
     aid_1 = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     ).id
-    bridge = ConsoleAgentBridge(
-        agent_runs_db=db, store=store, provider_gateway=gateway
-    )
+    bridge = ConsoleAgentBridge(agent_runs_db=db, store=store, provider_gateway=gateway)
     events: list[FleetDrained] = []
     bridge.on_fleet_drained("once", events.append)
 
-    outcome = _run(
-        bridge, store, session, aid_1, conversation_id="conv-turns"
-    )
+    outcome = _run(bridge, store, session, aid_1, conversation_id="conv-turns")
     assert outcome.status == "done"
     _join_fleet_threads()
     assert len(events) == 1, events
@@ -375,9 +366,7 @@ def test_a_consumer_registered_once_fires_once_per_drain_across_turns(
     aid_2 = store.append_message(
         session.id, role=ConsoleMessageRole.ASSISTANT, content=""
     ).id
-    outcome = _run(
-        bridge, store, session, aid_2, conversation_id="conv-turns"
-    )
+    outcome = _run(bridge, store, session, aid_2, conversation_id="conv-turns")
     assert outcome.status == "done"
     _join_fleet_threads()
 

--- a/Tests/Chat/test_local_server_discovery.py
+++ b/Tests/Chat/test_local_server_discovery.py
@@ -57,11 +57,7 @@ def _openai_models_payload(*model_ids: str) -> dict:
         ([" \t\x00"], None),
         ({"data": [{"id": "", "name": "fallback-name"}]}, ("fallback-name",)),
         (
-            {
-                "data": [
-                    {"id": "", "name": "\t", "model": "fallback-model"}
-                ]
-            },
+            {"data": [{"id": "", "name": "\t", "model": "fallback-model"}]},
             ("fallback-model",),
         ),
     ),
@@ -153,9 +149,7 @@ def test_normalize_and_localhost_helpers() -> None:
 
 def test_normalize_probe_base_url_uses_contract_persistence_shape() -> None:
     assert (
-        normalize_probe_base_url(
-            "http://127.0.0.1:8080/proxy/v1/chat/completions"
-        )
+        normalize_probe_base_url("http://127.0.0.1:8080/proxy/v1/chat/completions")
         == "http://127.0.0.1:8080/proxy"
     )
     assert (
@@ -352,9 +346,7 @@ async def test_probe_success_with_empty_model_list() -> None:
 async def test_probe_accepts_bare_list_string_model_entry() -> None:
     result = await probe_models_endpoint(
         "http://127.0.0.1:9099",
-        http_client=_client(
-            lambda request: httpx.Response(200, json=["model-a"])
-        ),
+        http_client=_client(lambda request: httpx.Response(200, json=["model-a"])),
     )
 
     assert result.ok is True
@@ -382,8 +374,7 @@ async def test_local_probe_rejects_listing_with_only_unusable_identifiers(
     assert result.ok is False
     assert result.model_ids == ()
     assert result.detail == (
-        "No models endpoint at http://127.0.0.1:9099 "
-        "(unrecognized API payload)."
+        "No models endpoint at http://127.0.0.1:9099 (unrecognized API payload)."
     )
 
 
@@ -428,16 +419,13 @@ async def test_probe_rejects_nonempty_listing_without_recognized_entries(
 ) -> None:
     result = await probe_models_endpoint(
         "http://127.0.0.1:9099",
-        http_client=_client(
-            lambda request: httpx.Response(200, json=payload)
-        ),
+        http_client=_client(lambda request: httpx.Response(200, json=payload)),
     )
 
     assert result.ok is False
     assert result.model_ids == ()
     assert result.detail == (
-        "No models endpoint at http://127.0.0.1:9099 "
-        "(unrecognized API payload)."
+        "No models endpoint at http://127.0.0.1:9099 (unrecognized API payload)."
     )
 
 
@@ -466,9 +454,7 @@ async def test_probe_handles_recursive_json_as_bounded_failure(monkeypatch) -> N
 @pytest.mark.asyncio
 async def test_local_probe_accepts_json_body_at_exact_byte_limit() -> None:
     prefix = b'{"data":[]}'
-    body = prefix + b" " * (
-        _EXPECTED_MODEL_PROBE_RESPONSE_MAX_BYTES - len(prefix)
-    )
+    body = prefix + b" " * (_EXPECTED_MODEL_PROBE_RESPONSE_MAX_BYTES - len(prefix))
 
     result = await probe_models_endpoint(
         "http://127.0.0.1:9099",
@@ -820,6 +806,5 @@ async def test_probe_rejects_non_chat_and_unrecognized_only_listing() -> None:
     assert result.ok is False
     assert result.model_ids == ()
     assert result.detail == (
-        "No models endpoint at http://127.0.0.1:9099 "
-        "(unrecognized API payload)."
+        "No models endpoint at http://127.0.0.1:9099 (unrecognized API payload)."
     )

--- a/Tests/Chat/test_local_thinking_wire_formats.py
+++ b/Tests/Chat/test_local_thinking_wire_formats.py
@@ -7,30 +7,22 @@ from tldw_chatbook.Chat.console_provider_support import (
 
 class TestLlamaCppFamily:
     def test_level_goes_into_chat_template_kwargs(self):
-        fields = build_local_thinking_payload_fields(
-            "llama_cpp", "low", None
-        )
+        fields = build_local_thinking_payload_fields("llama_cpp", "low", None)
         assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
 
     def test_budget_goes_top_level(self):
-        fields = build_local_thinking_payload_fields(
-            "local_llamacpp", None, 2048
-        )
+        fields = build_local_thinking_payload_fields("local_llamacpp", None, 2048)
         assert fields == {"reasoning_budget_tokens": 2048}
 
     def test_level_and_budget_together(self):
-        fields = build_local_thinking_payload_fields(
-            "local_llamafile", "xhigh", 4096
-        )
+        fields = build_local_thinking_payload_fields("local_llamafile", "xhigh", 4096)
         assert fields == {
             "chat_template_kwargs": {"reasoning_effort": "xhigh"},
             "reasoning_budget_tokens": 4096,
         }
 
     def test_none_effort_sends_verbatim_and_disables_thinking(self):
-        fields = build_local_thinking_payload_fields(
-            "local-llm", "none", None
-        )
+        fields = build_local_thinking_payload_fields("local-llm", "none", None)
         assert fields == {
             "chat_template_kwargs": {
                 "reasoning_effort": "none",
@@ -68,9 +60,7 @@ class TestCustomOpenAI:
 
 class TestMlx:
     def test_level_via_template_kwargs_budget_dropped(self):
-        fields = build_local_thinking_payload_fields(
-            "local_mlx_lm", "low", 2048
-        )
+        fields = build_local_thinking_payload_fields("local_mlx_lm", "low", 2048)
         assert fields == {"chat_template_kwargs": {"reasoning_effort": "low"}}
 
 
@@ -80,29 +70,21 @@ class TestTemplateSafeEfforts:
     efforts must not be forwarded via chat_template_kwargs."""
 
     def test_minimal_effort_drops_template_kwargs_but_keeps_budget(self):
-        fields = build_local_thinking_payload_fields(
-            "llama_cpp", "minimal", 2048
-        )
+        fields = build_local_thinking_payload_fields("llama_cpp", "minimal", 2048)
         assert fields == {"reasoning_budget_tokens": 2048}
 
     def test_minimal_effort_drops_template_kwargs_on_mlx(self):
-        fields = build_local_thinking_payload_fields(
-            "local_mlx_lm", "minimal", None
-        )
+        fields = build_local_thinking_payload_fields("local_mlx_lm", "minimal", None)
         assert fields == {}
 
     def test_minimal_effort_on_vllm_keeps_top_level_verbatim(self):
-        fields = build_local_thinking_payload_fields(
-            "vllm", "minimal", None
-        )
+        fields = build_local_thinking_payload_fields("vllm", "minimal", None)
         assert fields == {"reasoning_effort": "minimal"}
         assert "chat_template_kwargs" not in fields
 
     def test_high_effort_emitted_verbatim(self):
         # "high" is aliased to "xhigh" by the Qwen3.8 template and is safe.
-        fields = build_local_thinking_payload_fields(
-            "llama_cpp", "high", None
-        )
+        fields = build_local_thinking_payload_fields("llama_cpp", "high", None)
         assert fields == {"chat_template_kwargs": {"reasoning_effort": "high"}}
 
     def test_minimal_effort_on_custom_openai_stays_verbatim(self):

--- a/Tests/Chat/test_openai_reasoning_sampling_params.py
+++ b/Tests/Chat/test_openai_reasoning_sampling_params.py
@@ -132,9 +132,7 @@ def test_non_reasoning_model_keeps_default_sampling(captured_payloads):
 
 
 @pytest.mark.parametrize("model", ["gpt-5", "o3", "o4-mini", "gpt-5.1"])
-def test_no_effort_modern_model_uses_max_completion_tokens(
-    captured_payloads, model
-):
+def test_no_effort_modern_model_uses_max_completion_tokens(captured_payloads, model):
     """TASK-18803 headline: with NO reasoning effort configured these models
     fall through to chat-completions, where the classic ``max_tokens`` cap is
     HTTP 400 ``unsupported_parameter`` (probe-verified with the exact built

--- a/Tests/Chat/test_reply_sentence_sequencer.py
+++ b/Tests/Chat/test_reply_sentence_sequencer.py
@@ -56,8 +56,8 @@ def test_flush_clears_queue_and_stops_inflight():
     seq.feed("A one. A two. A three. ")
     seq.flush()
     assert stops == [1]
-    seq.utterance_finished(ok=False)   # late completion of the stopped utterance
-    assert spoken == ["A one."]        # nothing further spoken
+    seq.utterance_finished(ok=False)  # late completion of the stopped utterance
+    assert spoken == ["A one."]  # nothing further spoken
 
 
 def test_reply_completed_flushes_final_partial_and_drains():
@@ -174,7 +174,7 @@ def test_ellipsis_is_not_a_boundary_mid_thought():
 def test_fence_delimiter_split_across_deltas_still_skips_the_fence():
     spoken = []
     seq = SentenceSequencer(speak=spoken.append, stop_speech=lambda: None)
-    seq.feed("Before.\n``")       # opening fence marker split mid-backtick-run
+    seq.feed("Before.\n``")  # opening fence marker split mid-backtick-run
     assert spoken == ["Before."]
     seq.feed("`python\nx = 1. Yes.\n``")  # closing fence marker split too
     seq.feed("`\nAfter now. ")

--- a/Tests/Chat/test_turn_context_posture.py
+++ b/Tests/Chat/test_turn_context_posture.py
@@ -187,9 +187,7 @@ def test_compose_builds_run_call_caps_from_rule_verdicts():
         assert first.ok is True
         second = registry.invoke_by_name("web_search", {})
         assert second.ok is False
-        assert second.error == PERSONA_POLICY_CALL_CAP_REFUSAL.format(
-            name="web_search"
-        )
+        assert second.error == PERSONA_POLICY_CALL_CAP_REFUSAL.format(name="web_search")
         # An uncapped sibling tool is untouched by the cap refusal.
         assert registry.invoke_by_name("fs_read", {}).ok is True
 

--- a/Tests/Chat/test_visual_renderer_decoupling.py
+++ b/Tests/Chat/test_visual_renderer_decoupling.py
@@ -72,12 +72,7 @@ def test_a_full_width_line_fits_inside_the_canvas():
     draw.text((MARGIN_X, 8), "W" * MAX_LINE_CHARACTERS, fill=0, font=font)
     pixels = image.load()
     rightmost = max(
-        (
-            x
-            for x in range(LOGICAL_WIDTH)
-            for y in range(64)
-            if pixels[x, y] < 128
-        ),
+        (x for x in range(LOGICAL_WIDTH) for y in range(64) if pixels[x, y] < 128),
         default=0,
     )
     assert rightmost <= LOGICAL_WIDTH - MARGIN_X, (
@@ -140,9 +135,7 @@ def test_identity_hash_is_pixel_based_not_png_based():
 def test_pages_expose_both_digests_with_distinct_meanings():
     """Identity (pixels) and wire integrity (bytes) are different questions;
     conflating them is what put the encoder into the identity."""
-    artifact = render_visual_transcript(
-        _units(1), summarized_prefix_digest="d" * 64
-    )
+    artifact = render_visual_transcript(_units(1), summarized_prefix_digest="d" * 64)
     page = artifact.pages[0]
     assert page.pixel_sha256 != page.png_sha256
     from hashlib import sha256

--- a/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
+++ b/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
@@ -55,7 +55,6 @@ Clean the `ruff-chat-general` Ruff formatter batch at the owner boundary recorde
 ```
 
 ## Acceptance Criteria
-<!-- AC:BEGIN -->
 Owner-approved exception (2026-09-05): strict AST parity permits only splitting the first combined import in `test__zz_probe2.py` into three imports preserving order, replacing the unused `note_id = db.add_change_note(...)` assignment in `test_mark_notes_delivered_empty_list_is_noop` with the identical call expression, and removing the unused `threading` import from `test_fleet_autowake.py`. Verify these precise changes separately and compare formatting against the corrected baseline; all other AST structure and comments/directives remain protected.
 <!-- AC:BEGIN -->
 - [x] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
@@ -124,4 +123,3 @@ At integration base `c0fa6639a1fd294bf2bfbdc043c0dcb70782a689`, the compact JSON
 
 - `Tests/Chat/test_anthropic_caching_degrade.py`: `ed6c31a4687b3fc2532c71f6b70922a4de664f93`, `c2db1f7054cadbabd03fe7b92b25dda97fc12280`, and `75c69f2f34bbbbd0be853bfed6574a8085cd8b1a` added prompt-cache behavior and review corrections.
 - `Tests/Chat/test_fleet_attention.py`: `b3860842c0f74cb0c6a5a1d37e7d997cf30c9aa9` completed the Console activity switchboard.
-<!-- AC:END -->

--- a/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
+++ b/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-26951
 title: Clean Ruff formatter debt for ruff-chat-general
-status: In Progress
+status: Done
 assignee:
   - codex
 created_date: '2026-08-31 18:31'
-updated_date: '2026-09-06 03:03'
+updated_date: '2026-09-06 03:31'
 labels:
   - maintenance
   - formatting
@@ -55,27 +55,73 @@ Clean the `ruff-chat-general` Ruff formatter batch at the owner boundary recorde
 ```
 
 ## Acceptance Criteria
-
+<!-- AC:BEGIN -->
 Owner-approved exception (2026-09-05): strict AST parity permits only splitting the first combined import in `test__zz_probe2.py` into three imports preserving order, replacing the unused `note_id = db.add_change_note(...)` assignment in `test_mark_notes_delivered_empty_list_is_noop` with the identical call expression, and removing the unused `threading` import from `test_fleet_autowake.py`. Verify these precise changes separately and compare formatting against the corrected baseline; all other AST structure and comments/directives remain protected.
 <!-- AC:BEGIN -->
-- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [x] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [x] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [x] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [x] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [x] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [x] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [x] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [x] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: no. ADR path: N/A. Reason: mechanical formatting under the approved TASK-26000 contract. Reconcile all 19 assigned paths against latest dev and authority cut; capture Python 3.12.11 structural/comment/directive evidence and targeted baseline; run Ruff 0.15.22 only on assigned paths; verify parity, deterministic replay, lint/format, targeted outcomes, diagnostic inventory and backlog uniqueness; review and integrate through Qodo and CI. Preflight found three inherited lint errors that require owner approval before any non-formatting correction.
+ADR required: no. ADR path: N/A. Reason: mechanical formatting under the approved TASK-26000 contract. Reconcile all 19 assigned paths against latest dev and authority cut; capture Python 3.12.11 structural/comment/directive evidence and targeted baseline; apply the three owner-approved test-only lint corrections; run Ruff 0.15.22 only on assigned paths; verify parity, deterministic replay, lint/format, targeted outcomes, diagnostic inventory and backlog uniqueness; review and integrate through Qodo and CI.
 <!-- SECTION:PLAN:END -->
 
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Formatted all 19 assigned Python files with Ruff 0.15.22 in `707739747fc789b226601e4d7c1a9717283efb67`. Included only the three owner-approved test lint corrections; there are no hand-written production behavior changes or unassigned Python edits. ADR required: no; existing TASK-26000 contract plus the explicit owner amendment applies. The focused test surface is all 15 assigned direct Chat modules, not the full suite.
+
+### Structural and formatter evidence
+
+Python 3.12.11 is invoked as `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python` (`PY` below). `PATHS` denotes the exact ordered 19-path Assigned Paths JSON above. Original/corrected structural captures used `PY /tmp/task26947_format_guard.py capture /tmp/task26951_original.json PATHS` and the same command with `/tmp/task26951_corrected.json` after the approved corrections. `PY /tmp/task26951_approved_delta.py` proves only the three permitted AST transformations against immutable commit `1ba0aaae097ac3a08b462bbfab2dbde608d205f1`; it passes before and after formatting. The corrected files have no inline directives, standalone Ruff directives or fmt ranges; all original/corrected comment and directive fields match exactly.
+
+`PY -m ruff format PATHS` reformatted 19 files. `PY /tmp/task26947_format_guard.py compare /tmp/task26951_corrected.json PATHS` passes all 19 type-comment-aware ASTs, ordered comments, directive anchors and fmt intervals. Corrected sources archived before formatting at `/tmp/task26951_corrected_sources.tar` were extracted into `/tmp/task26951-replay.45j6zk`, formatted using `PY -m ruff format --config /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/task-26951-ruff-chat-general/pyproject.toml PATHS`, and compared byte-for-byte with the worktree: all 19 match. `PY -m ruff check PATHS` and `PY -m ruff format --check PATHS` both pass.
+
+Evidence SHA256:
+
+- Guard: `3fac070e94fe91cd152f956b19093c457c48787ea5449b54945b2305386b7471`.
+- Approved-delta verifier: `666ab01abd79ce433141b8cbffbb1bebd4ede5e774d8ad33a48e9948c7aa765b`.
+- Original structural JSON: `61f9970a2a0772b96eb8b1d7b03e4af94f18b75ee18282b936e9d18331d539eb`.
+- Corrected structural JSON: `9b56f704a4875b93a4b8cc3bf4bd3cd37d9e595522bfb6e872681300835ff43f`.
+- Corrected source archive: `5ead2350ab6db3085ee693e2256d46667927915291a5e6719ed764d0b5396dee`.
+
+### Targeted tests
+
+Exact before command (repeat with only the output filename changed to `/tmp/task26951_after.xml`):
+
+```bash
+/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Chat/test__zz_probe2.py Tests/Chat/test_anthropic_caching_degrade.py Tests/Chat/test_change_notes_db.py Tests/Chat/test_change_turn_tracking.py Tests/Chat/test_chat_api_call_endpoint_redaction.py Tests/Chat/test_extract_response_content.py Tests/Chat/test_fleet_attention.py Tests/Chat/test_fleet_autowake.py Tests/Chat/test_fleet_settle_fanout.py Tests/Chat/test_local_server_discovery.py Tests/Chat/test_local_thinking_wire_formats.py Tests/Chat/test_openai_reasoning_sampling_params.py Tests/Chat/test_reply_sentence_sequencer.py Tests/Chat/test_turn_context_posture.py Tests/Chat/test_visual_renderer_decoupling.py -q --timeout=10 --timeout-method=signal --timeout-disable-debugger-detection --show-capture=no --tb=short --junitxml=/tmp/task26951_before.xml
+```
+
+Before: 336 passed, one failed, 3 warnings in 148.15s. After: 336 passed, the same one failed, 2 warnings in 166.54s. All 337 identity/outcome triples match; sorted compact JSON with `passed`/`failed` labels hashes to `cbe80fc35e680cc8d0a5fb15674daf7ca2aac314e390dc8c0468236559dfc792`. The inherited failure is `test_fleet_settle_fanout.py::test_drain_row_is_terminal_at_fire_time_on_the_raise_path_too`: its `raising_persist(self, run_id, outcome)` mock receives an additional durable-handle argument. That behavioral repair is outside this formatter scope. This is exact regression parity, not a green test suite. The warning difference is a pre-existing invalid-escape SyntaxWarning emitted on baseline import; both runs include dependency/deprecation warnings and macOS temporary-directory cleanup noise.
+
+### Governance
+
+Independent task review found no actionable findings and verified exact scope, approved AST delta, comment/directive parity, and all 337 before/after test outcomes. No new architecture decisions or behavior changes were introduced. The temporary proof scripts and detailed implementation report remain available through PR integration.
+
+`PY -m pytest -q Tests/CI/test_backlog_task_id_uniqueness.py --junitxml=/tmp/task26951_governance.xml` passed (3 tests, 2 warnings, 2.97s). `PY scripts/check_persistent_diagnostic_inventory.py --diff` passes on both original and formatted trees with no drift: 580 owners, 1336 TASK-492 calls, 30 TASK-31551 calls, 7617 TASK-494 calls, 12 sink files. `git diff --check` passes. No full test suite was run.
+<!-- SECTION:NOTES:END -->
+
 ## Historical preflight checkpoint (before approval)
+
+The owner subsequently approved the three precise test-only exceptions listed under Acceptance Criteria. The checkpoint below records the original state, not a pending approval.
 
 Started from current `origin/dev` at `c0fa6639a1fd294bf2bfbdc043c0dcb70782a689` in an isolated worktree; the dirty main checkout is untouched. No Python files have been changed and no tests have been run yet.
 
 Ruff 0.15.22 lint on the exact 19 assigned paths reports three inherited violations: E401 at `Tests/Chat/test__zz_probe2.py:1` (combined imports), F841 at `Tests/Chat/test_change_notes_db.py:351` (unused `note_id` assignment), and F401 at `Tests/Chat/test_fleet_autowake.py:14` (unused `threading` import). Formatting alone cannot satisfy both strict AST parity and clean lint. Proposed test-only exception, pending owner approval: split the combined import into three imports preserving order; retain the `db.add_change_note(...)` call but remove its unused assignment; remove the unused `threading` import. All other AST structure and all comments/directives remain under the existing parity contract. Do not implement these exceptions without approval.
+
+## Assigned-path reconciliation
+
+At integration base `c0fa6639a1fd294bf2bfbdc043c0dcb70782a689`, the compact JSON digest for all 19 assigned paths remains `845fb91c16932e965061e116d600f846d1b6f4cbc51468a6a859fe9509dfc3c3`. Compared with authority cut `e555df102c950c29beed5e7119f433d35eee1f3c`, 17 files are unchanged and two are modified; none are renamed or deleted and ownership is unchanged:
+
+- `Tests/Chat/test_anthropic_caching_degrade.py`: `ed6c31a4687b3fc2532c71f6b70922a4de664f93`, `c2db1f7054cadbabd03fe7b92b25dda97fc12280`, and `75c69f2f34bbbbd0be853bfed6574a8085cd8b1a` added prompt-cache behavior and review corrections.
+- `Tests/Chat/test_fleet_attention.py`: `b3860842c0f74cb0c6a5a1d37e7d997cf30c9aa9` completed the Console activity switchboard.
+<!-- AC:END -->

--- a/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
+++ b/backlog/tasks/task-26951 - Clean Ruff formatter debt for ruff-chat-general.md
@@ -1,10 +1,11 @@
 ---
 id: TASK-26951
 title: Clean Ruff formatter debt for ruff-chat-general
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - codex
 created_date: '2026-08-31 18:31'
-updated_date: '2026-08-31 18:31'
+updated_date: '2026-09-06 03:03'
 labels:
   - maintenance
   - formatting
@@ -17,15 +18,15 @@ references:
 priority: medium
 ---
 
-<!-- TASK-26000-BATCH: ruff-chat-general -->
-<!-- TASK-26000-PATHS-SHA256: 845fb91c16932e965061e116d600f846d1b6f4cbc51468a6a859fe9509dfc3c3 -->
-<!-- TASK-26000-FINAL: false -->
-
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
 Clean the `ruff-chat-general` Ruff formatter batch at the owner boundary recorded as: Remaining cohesive Chat orchestration helpers and direct Chat tests.. The focused test surface recorded by TASK-26000 is `["Tests/Chat"]`.
 <!-- SECTION:DESCRIPTION:END -->
+
+<!-- TASK-26000-BATCH: ruff-chat-general -->
+<!-- TASK-26000-PATHS-SHA256: 845fb91c16932e965061e116d600f846d1b6f4cbc51468a6a859fe9509dfc3c3 -->
+<!-- TASK-26000-FINAL: false -->
 
 ## Assigned Paths
 
@@ -54,13 +55,27 @@ Clean the `ruff-chat-general` Ruff formatter batch at the owner boundary recorde
 ```
 
 ## Acceptance Criteria
+
+Owner-approved exception (2026-09-05): strict AST parity permits only splitting the first combined import in `test__zz_probe2.py` into three imports preserving order, replacing the unused `note_id = db.add_change_note(...)` assignment in `test_mark_notes_delivered_empty_list_is_noop` with the identical call expression, and removing the unused `threading` import from `test_fleet_autowake.py`. Verify these precise changes separately and compare formatting against the corrected baseline; all other AST structure and comments/directives remain protected.
 <!-- AC:BEGIN -->
-- [ ] After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
-- [ ] Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
-- [ ] Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
-- [ ] Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
-- [ ] Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
-- [ ] Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
-- [ ] `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
-- [ ] The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
+- [ ] #1 After rebasing onto current `origin/dev`, reproduce and reconcile every TASK-26000 assigned path; if upstream deleted, renamed, modified, or already formatted it, record that lineage and amend ownership mechanically without silently dropping it or absorbing an unassigned path. <!-- TASK-26000-CONTRACT: rebase-reconcile --><!-- TASK-26000-CONTRACT: drift-reconciliation -->
+- [ ] #2 Run Ruff 0.15.22 formatting on only the assigned paths, with no unassigned Python path changed. <!-- TASK-26000-CONTRACT: assigned-paths-only -->
+- [ ] #3 Before and after formatting, parse each assigned file on Python 3.12.11 with `ast.parse(..., type_comments=True)`, normalize only `TypeIgnore.lineno`, and require equal `ast.dump(..., include_attributes=False)`. <!-- TASK-26000-CONTRACT: ast-type-comments -->
+- [ ] #4 Preserve ordered comment-token text; anchor inline `# noqa`, `# type: ignore`, and single-target Ruff directives to the same deepest AST-node path and significant-token position, preserve standalone file directives between the same adjacent statement paths, and require each `# fmt: off` / `# fmt: on` range to enclose the same ordered AST-node interval. <!-- TASK-26000-CONTRACT: comment-directives -->
+- [ ] #5 Ruff lint and `ruff format --check` pass on every touched Python path. <!-- TASK-26000-CONTRACT: ruff-checks -->
+- [ ] #6 Implementation Notes record the focused-test rationale and every exact test command/result. <!-- TASK-26000-CONTRACT: focused-tests -->
+- [ ] #7 `git diff --check` and `Tests/CI/test_backlog_task_id_uniqueness.py` pass. <!-- TASK-26000-CONTRACT: governance -->
+- [ ] #8 The diff contains no hand-written production behavior change. <!-- TASK-26000-CONTRACT: no-handwritten-behavior -->
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no. ADR path: N/A. Reason: mechanical formatting under the approved TASK-26000 contract. Reconcile all 19 assigned paths against latest dev and authority cut; capture Python 3.12.11 structural/comment/directive evidence and targeted baseline; run Ruff 0.15.22 only on assigned paths; verify parity, deterministic replay, lint/format, targeted outcomes, diagnostic inventory and backlog uniqueness; review and integrate through Qodo and CI. Preflight found three inherited lint errors that require owner approval before any non-formatting correction.
+<!-- SECTION:PLAN:END -->
+
+## Historical preflight checkpoint (before approval)
+
+Started from current `origin/dev` at `c0fa6639a1fd294bf2bfbdc043c0dcb70782a689` in an isolated worktree; the dirty main checkout is untouched. No Python files have been changed and no tests have been run yet.
+
+Ruff 0.15.22 lint on the exact 19 assigned paths reports three inherited violations: E401 at `Tests/Chat/test__zz_probe2.py:1` (combined imports), F841 at `Tests/Chat/test_change_notes_db.py:351` (unused `note_id` assignment), and F401 at `Tests/Chat/test_fleet_autowake.py:14` (unused `threading` import). Formatting alone cannot satisfy both strict AST parity and clean lint. Proposed test-only exception, pending owner approval: split the combined import into three imports preserving order; retain the `db.add_change_note(...)` call but remove its unused assignment; remove the unused `threading` import. All other AST structure and all comments/directives remain under the existing parity contract. Do not implement these exceptions without approval.

--- a/tldw_chatbook/Chat/assistant_generation_state.py
+++ b/tldw_chatbook/Chat/assistant_generation_state.py
@@ -68,9 +68,7 @@ def normalize_assistant_generation_state(
     """
     if str(role or "").lower() != "assistant":
         return None
-    normalized = (
-        None if raw_state is None else AssistantGenerationState(str(raw_state))
-    )
+    normalized = None if raw_state is None else AssistantGenerationState(str(raw_state))
     if has_valid_active_continuation:
         return AssistantGenerationState.CONTINUATION_ACTIVE
     return normalized

--- a/tldw_chatbook/Chat/document_generator.py
+++ b/tldw_chatbook/Chat/document_generator.py
@@ -167,9 +167,7 @@ class DocumentGenerator:
                 "role": msg.get("role") or msg.get("sender", "unknown"),
                 "content": msg.get("content", ""),
                 "timestamp": msg.get("timestamp", ""),
-                "assistant_generation_state": msg.get(
-                    "assistant_generation_state"
-                ),
+                "assistant_generation_state": msg.get("assistant_generation_state"),
             }
             for msg in messages
         ]
@@ -250,9 +248,7 @@ class DocumentGenerator:
 
         # Build prompt
         system_prompt = get_internal_prompt("document_generation.timeline_system")
-        user_prompt = (
-            f"{get_internal_prompt('document_generation.timeline_user')}\n\nConversation Context:\n{context}"
-        )
+        user_prompt = f"{get_internal_prompt('document_generation.timeline_user')}\n\nConversation Context:\n{context}"
 
         # Call LLM
         try:
@@ -348,9 +344,7 @@ class DocumentGenerator:
 
         # Build prompt
         system_prompt = get_internal_prompt("document_generation.study_guide_system")
-        user_prompt = (
-            f"{get_internal_prompt('document_generation.study_guide_user')}\n\nConversation Context:\n{context}"
-        )
+        user_prompt = f"{get_internal_prompt('document_generation.study_guide_user')}\n\nConversation Context:\n{context}"
 
         # Call LLM
         try:
@@ -446,9 +440,7 @@ class DocumentGenerator:
 
         # Build prompt
         system_prompt = get_internal_prompt("document_generation.briefing_system")
-        user_prompt = (
-            f"{get_internal_prompt('document_generation.briefing_user')}\n\nConversation Context:\n{context}"
-        )
+        user_prompt = f"{get_internal_prompt('document_generation.briefing_user')}\n\nConversation Context:\n{context}"
 
         # Call LLM
         try:

--- a/tldw_chatbook/Chat/reply_sentence_sequencer.py
+++ b/tldw_chatbook/Chat/reply_sentence_sequencer.py
@@ -179,9 +179,28 @@ MAX_UTTERANCE_LENGTH = 200
 #: not merge into one utterance).
 _ABBREVIATIONS = frozenset(
     {
-        "dr", "mr", "mrs", "ms", "prof", "sr", "jr",
-        "vs", "etc", "inc", "ltd", "fig", "approx",
-        "capt", "col", "gov", "sgt", "ave", "blvd", "dept", "univ", "assn",
+        "dr",
+        "mr",
+        "mrs",
+        "ms",
+        "prof",
+        "sr",
+        "jr",
+        "vs",
+        "etc",
+        "inc",
+        "ltd",
+        "fig",
+        "approx",
+        "capt",
+        "col",
+        "gov",
+        "sgt",
+        "ave",
+        "blvd",
+        "dept",
+        "univ",
+        "assn",
     }
 )
 
@@ -296,7 +315,9 @@ class SentenceSequencer:
             flight (barge-in abandon signal).
     """
 
-    def __init__(self, speak: Callable[[str], None], stop_speech: Callable[[], None]) -> None:
+    def __init__(
+        self, speak: Callable[[str], None], stop_speech: Callable[[], None]
+    ) -> None:
         self._speak = speak
         self._stop_speech = stop_speech
 
@@ -442,8 +463,10 @@ class SentenceSequencer:
             nl_idx = self._pending_line.find("\n")
             if nl_idx != -1:
                 line = self._pending_line[:nl_idx]
-                self._pending_line = self._pending_line[nl_idx + 1:]
-                self._resolve_line(line, had_newline=True, at_line_start=self._at_line_start)
+                self._pending_line = self._pending_line[nl_idx + 1 :]
+                self._resolve_line(
+                    line, had_newline=True, at_line_start=self._at_line_start
+                )
                 self._at_line_start = True  # whatever follows starts a fresh line
                 continue
 
@@ -451,7 +474,9 @@ class SentenceSequencer:
             if final:
                 self._pending_line = ""
                 if tail:
-                    self._resolve_line(tail, had_newline=False, at_line_start=self._at_line_start)
+                    self._resolve_line(
+                        tail, had_newline=False, at_line_start=self._at_line_start
+                    )
                     self._at_line_start = False
                 return
 
@@ -501,7 +526,7 @@ class SentenceSequencer:
             idx = _find_confirmed_boundary(self._content)
             if idx is not None:
                 raw = self._content[: idx + 1]
-                self._content = self._content[idx + 1:]
+                self._content = self._content[idx + 1 :]
                 self._emit(_normalize(raw))
                 continue
             if len(self._content) > MAX_UTTERANCE_LENGTH:
@@ -528,7 +553,9 @@ class SentenceSequencer:
             return  # barge-in latch: nothing queues for this reply again
         if not normalized:
             return
-        if len(normalized) < MIN_SENTENCE_LENGTH and not any(c.isalnum() for c in normalized):
+        if len(normalized) < MIN_SENTENCE_LENGTH and not any(
+            c.isalnum() for c in normalized
+        ):
             return  # pure punctuation noise below the floor; see module docstring
         self._queue.append(normalized)
 
@@ -541,7 +568,12 @@ class SentenceSequencer:
         self._speak(text)
 
     def _check_drained(self) -> None:
-        if self._completed and not self._queue and not self._inflight and not self._drained_fired:
+        if (
+            self._completed
+            and not self._queue
+            and not self._inflight
+            and not self._drained_fired
+        ):
             self._drained_fired = True
             if self.on_drained:
                 self.on_drained()

--- a/tldw_chatbook/Chat/thinking_blocks.py
+++ b/tldw_chatbook/Chat/thinking_blocks.py
@@ -393,9 +393,7 @@ def thinking_envelope_to_exchange(raw_json: object) -> dict[str, object] | None:
             "Upgrade Chatbook before exporting this conversation's thinking data."
         )
     if result.envelope is None:
-        raise ThinkingEnvelopeValidationError(
-            _INVALID_MESSAGE.format(rule="envelope")
-        )
+        raise ThinkingEnvelopeValidationError(_INVALID_MESSAGE.format(rule="envelope"))
     canonical = dump_thinking_blocks_json(result.envelope)
     return cast(dict[str, object], json.loads(canonical or "null"))
 
@@ -417,14 +415,13 @@ def preflight_thinking_history_policy(
     """Validate imported raw policy and normalize bounded unknown strings."""
     if value is None:
         return "auto", None
-    if type(value) is not str or len(cast(str, value)) > MAX_THINKING_HISTORY_POLICY_CHARS:
+    if (
+        type(value) is not str
+        or len(cast(str, value)) > MAX_THINKING_HISTORY_POLICY_CHARS
+    ):
         raise ValueError("Invalid thinking history policy.")
     normalized = normalize_thinking_history_policy(value)
-    warning = (
-        None
-        if normalized == value
-        else UNKNOWN_THINKING_HISTORY_POLICY_WARNING
-    )
+    warning = None if normalized == value else UNKNOWN_THINKING_HISTORY_POLICY_WARNING
     return normalized, warning
 
 


### PR DESCRIPTION
## Summary

Clean TASK-26951's 19 assigned general Chat files with Ruff 0.15.22. Include the three owner-approved test-only lint corrections: split combined imports in order, preserve a database call while dropping its unused assignment, and remove an unused threading import. No hand-written production behavior changes.

## Scope and verification

The TASK-26000 manifest and exact path ownership are retained. Two files changed upstream since the authority cut; their lineage is recorded in the task. All other assigned files are unchanged at the integration base.

- Exact approved AST delta verified; all other AST/comment/directive structure preserved across 19 files.
- Deterministic Ruff replay, lint, format, Backlog uniqueness, diagnostic inventory and whitespace checks pass.
- All 337 focused test outcomes match baseline: 336 passed, one inherited stale persistence-mock failure. This is regression parity, not a green behavioral suite.
- No full test suite was run.

ADR required: no; existing TASK-26000 contract with the explicit owner-approved test exception.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Executes TASK-26951: applies Ruff 0.15.22 formatting to 19 Chat files while preserving AST structure and comment placement. No production behavior changes.

- Includes three owner-approved test-only corrections: splits combined imports in `Tests/Chat/test__zz_probe2.py`, drops an unused assignment while keeping the `db.add_change_note(...)` call in `Tests/Chat/test_change_notes_db.py`, and removes an unused `threading` import from `Tests/Chat/test_fleet_autowake.py`.
- Focused test run matches baseline exactly: 336 passed, one inherited failure in `Tests/Chat/test_fleet_settle_fanout.py`.
- Adds the plan document and records verification evidence in the backlog task, marking TASK-26951 done.

<sup>Written for commit 675b03560a3da1391ce64307af71500b79d34bbe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2450?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

