### PR TITLE
feat(console): add Character conversations to Context (TASK-31244)

### DIFF
--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -16,8 +16,8 @@ layout tour). Everything on this page lives in two places:
 
 - The **tab strip** — the row of tabs directly under the
   "Conversation" title above the transcript.
-- The **"Console context"** rail on the left — its separate **Sessions**,
-  **Workspaces**, **Conversations**, and **Details** sections. If the rail is
+- The **"Console context"** rail on the left — its separate **Workspaces**,
+  **Conversations**, **Character**, and **Details** sections. If the rail is
   collapsed, click the **Context->** handle at the left edge to open it when
   the viewport can retain a usable transcript.
 
@@ -39,9 +39,6 @@ strip: "Each tab runs its own agent — up to 3 in parallel (change in
 Settings > Console Behavior)." Dismiss it with its "✕". The "3" is the
 default limit — the banner shows whatever your configured limit is.
 
-**Sessions section** (left rail). Names the active conversation ("None" when
-no conversation is active yet); hover the value to see its durable id.
-
 **Workspaces section** (left rail). Shows the active workspace on one compact
 line, keeps **Switch**, **New**, and **RAG** together, and renders every
 named workspace in a native Tree with its conversations as children. The
@@ -55,6 +52,20 @@ only Default-workspace and unassigned conversations. A conversation assigned
 to a named workspace appears under that workspace in the Tree instead, never
 in both places. Starred entries sort first inside their one owner; starring is
 a property and action, not a duplicate Starred group.
+
+**Character section** (left rail). Shows up to four local character cards or
+unavailable-character groups, with up to five recent saved conversations in
+the one expanded group. Search returns at most eight saved local character
+conversations and never sends titles or transcript text to a network service.
+Each search result keeps its title, character name, and Local/age metadata
+on separate lines so the metadata remains readable in the narrow rail.
+Enter or double-click opens an exact saved conversation in its Console tab;
+single-click selects it. **View all N in Roleplay** opens that character's
+complete saved history. A current card with no saved chats offers **Start in
+Console**, while the overall empty state offers **Open Roleplay**. Chats whose
+card was deleted or cannot be identified are never guessed open: use **Repair
+in Library**, or **View all N in Library**, to resolve them. Turning off
+`show_character_avatar` hides only the image; these navigation controls remain.
 
 **Details section** (left rail, collapsed by default). Status lines for
 "Storage", "Sync", "Local file tools", "Server", and "ACP", plus a "Handoff" list.
@@ -166,8 +177,8 @@ Workspaces search can reveal matching conversation results whose parent branch
 was closed. Those temporary disclosure changes are discarded when the search
 is cleared, restoring the exact disclosure state from before the search.
 
-Context preserves complete reading bodies up to 15 rows for Sessions, Model,
-Agent, and Details; 20 for Workspaces and Conversations; and 35 for Character.
+Context preserves complete reading bodies up to 15 rows for Model, Agent, and
+Details; 20 for Workspaces and Conversations; and 35 for Character.
 Longer sections scroll locally, while **▼ more sections — scroll** means to
 scroll the outer rail to reach complete later sections. Inspector sections keep
 their separate 20-row ceiling. Character art remains centered and complete with

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2718,6 +2718,13 @@
     },
     {
       "call_count": 2,
+      "diagnostic_digest": "bba2cd1277c985d6d990",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 2,
       "diagnostic_digest": "d3e10425769d4c50be03",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/note_session_port.py",
@@ -11422,11 +11429,11 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 584,
+    "owner_files": 585,
     "path_privacy_candidate_calls": 710,
     "persistent_sink_files": 12,
     "task_31551_calls": 30,
     "task_492_calls": 1347,
-    "task_494_calls": 7651
+    "task_494_calls": 7653
   }
 }

--- a/Tests/Architecture/test_library_modules_size_ratchet.py
+++ b/Tests/Architecture/test_library_modules_size_ratchet.py
@@ -383,7 +383,7 @@ _SLACK_TOLERANCE_LINES = 50
 
 # TASK-31244: initial exact pin for the focused navigation helper. Existing
 # controller ceilings remain unchanged; route hooks stay outside LibraryScreen.
-_BUDGETS["tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py"] = 713
+_BUDGETS["tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py"] = 803
 
 
 @lru_cache(maxsize=None)

--- a/Tests/Architecture/test_library_modules_size_ratchet.py
+++ b/Tests/Architecture/test_library_modules_size_ratchet.py
@@ -381,6 +381,10 @@ _BUDGETS: dict[str, int] = {
 #: pin every file to its exact byte count at all times.
 _SLACK_TOLERANCE_LINES = 50
 
+# TASK-31244: initial exact pin for the focused navigation helper. Existing
+# controller ceilings remain unchanged; route hooks stay outside LibraryScreen.
+_BUDGETS["tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py"] = 713
+
 
 @lru_cache(maxsize=None)
 def _measure(rel_path: str) -> int:

--- a/Tests/Architecture/test_library_modules_size_ratchet.py
+++ b/Tests/Architecture/test_library_modules_size_ratchet.py
@@ -383,7 +383,7 @@ _SLACK_TOLERANCE_LINES = 50
 
 # TASK-31244: initial exact pin for the focused navigation helper. Existing
 # controller ceilings remain unchanged; route hooks stay outside LibraryScreen.
-_BUDGETS["tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py"] = 803
+_BUDGETS["tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py"] = 811
 
 
 @lru_cache(maxsize=None)

--- a/Tests/UI/test_character_context_async_ownership.py
+++ b/Tests/UI/test_character_context_async_ownership.py
@@ -1,0 +1,229 @@
+"""Character navigation preserves async generation, profile and focus ownership."""
+
+import asyncio
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_console_character_context import (
+    _CharacterApp,
+    _controller,
+    _groups,
+)
+from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+    CharacterConversationGroup,
+    CharacterConversationRow,
+    ResolvedLocalCharacterKey,
+    UnavailableCharacterReason,
+    UnresolvedConversationKey,
+)
+from tldw_chatbook.UI.Console_Modules.character_context import (
+    ConsoleCharacterContextState,
+)
+from tldw_chatbook.Widgets.Console.console_character_context import (
+    ConsoleCharacterContext,
+)
+
+
+@pytest.mark.asyncio
+async def test_removed_browser_rejects_late_presentation():
+    controller = _controller()
+    state = ConsoleCharacterContextState(groups=_groups())
+    app = _CharacterApp(controller, state)
+    async with app.run_test() as pilot:
+        widget = app.screen.query_one(ConsoleCharacterContext)
+        await widget.remove()
+        widget.sync_state(replace(state, data_revision=999))
+        await pilot.pause()
+        assert widget.state is state
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("churn", ["before", "during", "none"])
+async def test_start_keeps_exact_profile_through_picker_fetch(tmp_path, churn):
+    from Tests.UI.test_console_character_controller import (
+        _controller as picker_controller,
+    )
+    from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+    from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.UI.Console_Modules.wiring import _start_character_context_chat
+
+    first = CharactersRAGDB(tmp_path / "first.sqlite", client_id="first")
+    second = CharactersRAGDB(tmp_path / "second.sqlite", client_id="second")
+    release = threading.Event()
+    try:
+        first_id = first.add_character_card({"name": "Original"})
+        second_id = second.add_character_card({"name": "Different"})
+        assert first_id == second_id
+        key = ResolvedLocalCharacterKey(first.get_local_authority_id(), first_id)
+        group = CharacterConversationGroup(key, "Original", (), 0, True)
+        active = [first]
+        store = ConsoleChatStore()
+        picker = picker_controller(
+            character_db_accessor=lambda: active[0],
+            ensure_chat_store=lambda: store,
+            default_session_settings=lambda: ConsoleSessionSettings(
+                provider="synthetic"
+            ),
+        )
+        screen = SimpleNamespace(_character=picker)
+        controller = _controller(
+            database_accessor=lambda: active[0],
+            current_character_accessor=lambda: (first_id, "Original"),
+            start_console=lambda *args: _start_character_context_chat(screen, *args),
+        )
+        controller.state = replace(
+            controller.state, scope_fingerprint=await controller._fingerprint()
+        )
+        entered = threading.Event()
+        fetch = first.get_character_card_by_id
+
+        def delayed(character_id):
+            entered.set()
+            assert release.wait(2)
+            return fetch(character_id)
+
+        if churn == "before":
+            active[0] = second
+        if churn == "during":
+            first.get_character_card_by_id = delayed
+        pending = asyncio.create_task(controller.start_current(group))
+        if churn == "during":
+            assert await asyncio.to_thread(entered.wait, 2)
+            active[0] = second
+            release.set()
+        await pending
+        if churn != "none":
+            assert store.active_session_id is None
+        else:
+            session = store.switch_session(store.active_session_id)
+            assert session.character_name == "Original"
+            assert session.assistant_authority_id == key.data_authority_id
+    finally:
+        release.set()
+        first.close()
+        second.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "refresh",
+        "refresh_error",
+        "search",
+        "search_error",
+        "refresh_missing",
+        "search_missing",
+        "details",
+        "repair",
+        "inspection",
+        "browse",
+    ],
+)
+async def test_superseded_operation_cannot_publish_after_final_scope_await(operation):
+    dispatched = []
+    controller = _controller(
+        navigate_inspection=dispatched.append,
+        navigate_repair=dispatched.append,
+        navigate_unavailable_browse=dispatched.append,
+    )
+    key = UnresolvedConversationKey("authority", "lost")
+    row = CharacterConversationRow.unavailable(
+        key,
+        reason=UnavailableCharacterReason.DELETED_CARD,
+        character_label="Lost",
+        title="Lost",
+        last_modified="2026-09-01",
+        created_at="2026-09-01",
+    )
+    group = CharacterConversationGroup(key, "Unavailable", (row,), 1, False)
+    original_search = controller._search_sync
+    if operation.endswith("missing"):
+        controller._database_accessor = lambda: None
+    if operation.endswith("error"):
+
+        def fail(*args):
+            raise RuntimeError("synthetic read failure")
+
+        if operation.startswith("search"):
+            controller._search_sync = fail
+        else:
+            controller._load_recent_sync = fail
+    entered, release = asyncio.Event(), asyncio.Event()
+    validate = controller._scope_is_current
+    old = None
+
+    async def delayed(snapshot):
+        if asyncio.current_task() is old and not entered.is_set():
+            entered.set()
+            await release.wait()
+        return await validate(snapshot)
+
+    controller._scope_is_current = delayed
+    if operation.startswith("refresh"):
+        work = controller.refresh()
+    elif operation.startswith("search"):
+        work = controller.search("old")
+    elif operation == "details":
+        work = controller.refresh_unavailable_details((group,))
+    elif operation == "repair":
+        work = controller.repair_unavailable(key, row_key=row.row_key)
+    elif operation == "inspection":
+        work = controller.open_unavailable(key, row_key=row.row_key)
+    else:
+        work = controller.view_group(group)
+    old = asyncio.create_task(work)
+    await asyncio.wait_for(entered.wait(), 2)
+    controller._search_sync = original_search
+    await controller.search("new")
+    newer = controller.state
+    release.set()
+    await old
+    assert controller.state is newer
+    assert not dispatched
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("leave_character", [True, False])
+async def test_recompose_preserves_only_owned_focus_intent(leave_character):
+    controller = _controller()
+    state = ConsoleCharacterContextState(
+        groups=_groups(), expanded_key=_groups()[0].key
+    )
+    app = _CharacterApp(controller, state)
+    async with app.run_test(size=(80, 35)) as pilot:
+        widget = app.screen.query_one(ConsoleCharacterContext)
+        external = Button("Composer", id="outside-character")
+        await app.screen.mount(external)
+        await pilot.pause()
+        row = widget.query_one(".console-character-row", Button)
+        row.focus()
+        await pilot.pause()
+        entered, release = asyncio.Event(), asyncio.Event()
+        original = widget.recompose
+
+        async def delayed():
+            entered.set()
+            await release.wait()
+            await original()
+
+        widget.recompose = delayed
+        widget.sync_state(replace(widget.state, data_revision=99))
+        await asyncio.wait_for(entered.wait(), 2)
+        if leave_character:
+            external.focus()
+        else:
+            widget.sync_state(replace(widget.state, data_revision=100))
+        await pilot.pause()
+        release.set()
+        await pilot.pause()
+        if leave_character:
+            assert app.focused is external
+        else:
+            assert app.focused.id == row.id
+            assert app.focused is not row

--- a/Tests/UI/test_character_conversation_navigation_payloads.py
+++ b/Tests/UI/test_character_conversation_navigation_payloads.py
@@ -1,11 +1,61 @@
 from __future__ import annotations
 
+
+def test_library_unavailable_inspection_and_browse_payloads_are_distinct() -> None:
+    """Catch exact inspection or complete browse being serialized as repair."""
+
+    assert hasattr(navigation, "LibraryUnavailableConversationInspection")
+    assert hasattr(navigation, "LibraryUnavailableConversationsBrowse")
+    unresolved = UnresolvedConversationKey("Authority-A", "Conversation-X")
+    return_target = RoleplayReturnTarget.console_context_character()
+    inspection = navigation.LibraryUnavailableConversationInspection(
+        unresolved=unresolved,
+        return_target=return_target,
+    )
+    browse = navigation.LibraryUnavailableConversationsBrowse(
+        selected=unresolved,
+        return_target=return_target,
+    )
+
+    inspection_payload = navigation.serialize_library_unavailable_inspection(inspection)
+    browse_payload = navigation.serialize_library_unavailable_browse(browse)
+
+    assert (
+        navigation.deserialize_library_unavailable_inspection(inspection_payload)
+        == inspection
+    )
+    assert navigation.deserialize_library_unavailable_browse(browse_payload) == browse
+    assert inspection_payload == {
+        "version": 1,
+        "source": "local",
+        "data_authority_id": "Authority-A",
+        "unresolved": {
+            "version": 1,
+            "tag": "unresolved_conversation",
+            "data_authority_id": "Authority-A",
+            "conversation_id": "Conversation-X",
+        },
+        "return_target": {
+            "screen_id": "chat",
+            "focus_id": "console-context-character",
+        },
+    }
+    assert browse_payload == {
+        "version": 1,
+        "source": "local",
+        "data_authority_id": "Authority-A",
+        "selected": inspection_payload["unresolved"],
+        "return_target": inspection_payload["return_target"],
+    }
+
+
 import pytest
 
 from tldw_chatbook.Character_Chat.character_conversation_navigation import (
     ResolvedLocalCharacterKey,
     UnresolvedConversationKey,
 )
+from tldw_chatbook.UI.Navigation import character_conversation_navigation as navigation
 from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
     LibraryCharacterRepairContext,
     RoleplayCharacterConversationLink,
@@ -15,6 +65,49 @@ from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
     serialize_library_character_repair_context,
     serialize_roleplay_character_conversation_link,
 )
+
+
+@pytest.mark.parametrize("kind", ["inspection", "browse"])
+@pytest.mark.parametrize(
+    "invalid",
+    [
+        "boolean_version",
+        "nested_boolean_version",
+        "extra",
+        "authority",
+        "resolved",
+        "return_extra",
+    ],
+)
+def test_unavailable_routes_preserve_strict_lazy_wire_boundary(kind, invalid):
+    key = UnresolvedConversationKey("Authority-A", "Conversation-X")
+    anchor = RoleplayReturnTarget.console_context_character()
+    if kind == "inspection":
+        payload = navigation.serialize_library_unavailable_inspection(
+            navigation.LibraryUnavailableConversationInspection(key, anchor)
+        )
+        deserialize = navigation.deserialize_library_unavailable_inspection
+        field = "unresolved"
+    else:
+        payload = navigation.serialize_library_unavailable_browse(
+            navigation.LibraryUnavailableConversationsBrowse(key, anchor)
+        )
+        deserialize = navigation.deserialize_library_unavailable_browse
+        field = "selected"
+    if invalid == "boolean_version":
+        payload["version"] = True
+    elif invalid == "nested_boolean_version":
+        payload[field]["version"] = True
+    elif invalid == "extra":
+        payload["unexpected"] = "value"
+    elif invalid == "authority":
+        payload["data_authority_id"] = "Authority-B"
+    elif invalid == "resolved":
+        payload[field]["tag"] = "resolved_local_character"
+    else:
+        payload["return_target"]["unexpected"] = "value"
+    with pytest.raises(ValueError):
+        deserialize(payload)
 
 
 def test_roleplay_payload_round_trip_preserves_exact_typed_key_and_safe_fields() -> (

--- a/Tests/UI/test_character_conversation_navigation_payloads.py
+++ b/Tests/UI/test_character_conversation_navigation_payloads.py
@@ -355,3 +355,64 @@ def test_strict_wire_rejects_identity_coercion_and_noncanonical_bounds(field, va
     payload["character"][field] = value
     with pytest.raises(ValueError):
         deserialize_roleplay_character_conversation_link(payload)
+
+
+@pytest.mark.parametrize("kind", ("inspection", "browse"))
+@pytest.mark.parametrize(
+    "anchor",
+    (
+        RoleplayReturnTarget.personas_filter(),
+        RoleplayReturnTarget.personas_conversations(),
+    ),
+)
+def test_unavailable_routes_reject_non_console_origins_without_narrowing_repair(
+    kind, anchor
+):
+    from tldw_chatbook.UI.Navigation import (
+        character_conversation_navigation as navigation,
+    )
+
+    key = UnresolvedConversationKey("authority", "conversation")
+    make, serialize, parse = (
+        (
+            navigation.LibraryUnavailableConversationInspection,
+            navigation.serialize_library_unavailable_inspection,
+            navigation.deserialize_library_unavailable_inspection,
+        )
+        if kind == "inspection"
+        else (
+            navigation.LibraryUnavailableConversationsBrowse,
+            navigation.serialize_library_unavailable_browse,
+            navigation.deserialize_library_unavailable_browse,
+        )
+    )
+    valid = make(key, RoleplayReturnTarget.console_context_character())
+    assert parse(serialize(valid)) == valid
+    with pytest.raises(ValueError):
+        make(key, anchor)
+    payload = serialize(valid)
+    payload["return_target"] = {
+        "screen_id": anchor.screen_id,
+        "focus_id": anchor.focus_id,
+    }
+    with pytest.raises(ValueError):
+        parse(payload)
+    from tldw_chatbook.UI.Navigation._character_conversation_wire import (
+        _LibraryUnavailableBrowseWire,
+        _LibraryUnavailableInspectionWire,
+    )
+
+    wire = (
+        _LibraryUnavailableInspectionWire
+        if kind == "inspection"
+        else _LibraryUnavailableBrowseWire
+    )
+    with pytest.raises(ValueError):
+        wire.model_validate(payload)
+    repair = LibraryCharacterRepairContext(key, 1, "Historical", anchor)
+    assert (
+        deserialize_library_character_repair_context(
+            serialize_library_character_repair_context(repair)
+        )
+        == repair
+    )

--- a/Tests/UI/test_character_navigation_diagnostics.py
+++ b/Tests/UI/test_character_navigation_diagnostics.py
@@ -56,7 +56,9 @@ async def test_unavailable_authority_failure_keeps_exception_canary_out_of_diagn
     )
 
     screen._library_navigation_context_generation = 1
-    screen._navigation_controller = SimpleNamespace(character_route=None)
+    screen._navigation_controller = SimpleNamespace(
+        character_route=None, character_candidate=None
+    )
     screen._pending_library_character_navigation = None
     screen._conversations_state = SimpleNamespace(loading=False)
     screen.is_mounted = False

--- a/Tests/UI/test_character_navigation_diagnostics.py
+++ b/Tests/UI/test_character_navigation_diagnostics.py
@@ -30,6 +30,37 @@ def rollback_records():
         logger.remove(sink)
 
 
+def test_unavailable_authority_failure_keeps_exception_canary_out_of_diagnostics():
+    from tldw_chatbook.UI.Library_Modules.library_unavailable_navigation import (
+        _library_character_authority_is_current,
+    )
+
+    secret = "/synthetic/private-profile/CANARY-unavailable-authority.sqlite"
+
+    def fail():
+        raise RuntimeError(secret)
+
+    screen = SimpleNamespace(
+        app_instance=SimpleNamespace(
+            chachanotes_db=SimpleNamespace(get_local_authority_id=fail)
+        )
+    )
+    records = []
+    sink = logger.add(
+        lambda message: records.append((str(message), message.record)),
+        level="WARNING",
+    )
+    try:
+        assert not _library_character_authority_is_current(screen, "authority")
+    finally:
+        logger.remove(sink)
+    assert len(records) == 1
+    rendered, record = records[0]
+    assert secret not in rendered
+    assert record["exception"] is None
+    assert "exception_type=RuntimeError" in record["message"]
+
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize("owner", ("coordinator", "workspace"))
 async def test_activation_rollback_logs_have_safe_attempt_context(

--- a/Tests/UI/test_character_navigation_diagnostics.py
+++ b/Tests/UI/test_character_navigation_diagnostics.py
@@ -30,9 +30,11 @@ def rollback_records():
         logger.remove(sink)
 
 
-def test_unavailable_authority_failure_keeps_exception_canary_out_of_diagnostics():
+@pytest.mark.asyncio
+async def test_unavailable_authority_failure_keeps_exception_canary_out_of_diagnostics():
     from tldw_chatbook.UI.Library_Modules.library_unavailable_navigation import (
-        _library_character_authority_is_current,
+        _LibraryCharacterNavigationAdmission,
+        _validate_library_character_admission,
     )
 
     secret = "/synthetic/private-profile/CANARY-unavailable-authority.sqlite"
@@ -45,13 +47,34 @@ def test_unavailable_authority_failure_keeps_exception_canary_out_of_diagnostics
             chachanotes_db=SimpleNamespace(get_local_authority_id=fail)
         )
     )
+    from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+        UnresolvedConversationKey,
+    )
+    from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+        RoleplayReturnTarget,
+    )
+
+    screen._library_navigation_context_generation = 1
+    screen._navigation_controller = SimpleNamespace(character_route=None)
+    screen._pending_library_character_navigation = None
+    screen._conversations_state = SimpleNamespace(loading=False)
+    screen.is_mounted = False
+    admission = _LibraryCharacterNavigationAdmission(
+        LibraryUnavailableConversationInspection(
+            UnresolvedConversationKey("authority", "canary-chat"),
+            RoleplayReturnTarget.console_context_character(),
+        ),
+        screen.app_instance.chachanotes_db,
+        1,
+    )
     records = []
     sink = logger.add(
         lambda message: records.append((str(message), message.record)),
         level="WARNING",
     )
     try:
-        assert not _library_character_authority_is_current(screen, "authority")
+        assert not await _validate_library_character_admission(screen, admission)
     finally:
         logger.remove(sink)
     assert len(records) == 1

--- a/Tests/UI/test_character_navigation_screen_reuse.py
+++ b/Tests/UI/test_character_navigation_screen_reuse.py
@@ -43,6 +43,7 @@ async def test_unavailable_route_returns_to_originating_console_character(
     from tldw_chatbook.Constants import (
         LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE,
         LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION,
+        LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR,
         TAB_LIBRARY,
     )
     from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
@@ -107,6 +108,26 @@ async def test_unavailable_route_returns_to_originating_console_character(
                 break
         library = app.screen
         back = library.query_one("#library-character-back-console", Button)
+        committed = library._navigation_controller.character_route
+        library.apply_navigation_context({LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR: {}})
+        library.apply_navigation_context({LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: {}})
+        assert library._navigation_controller.character_route is committed
+        original_incoming_flush = library._flush_active_file_notes
+        rejected = asyncio.Event()
+
+        async def reject_incoming():
+            rejected.set()
+            return False
+
+        library._flush_active_file_notes = reject_incoming
+        for replacement in ({"mode": "search"}, context):
+            rejected.clear()
+            library.apply_navigation_context(replacement)
+            await asyncio.wait_for(rejected.wait(), 2)
+            await pilot.pause()
+            assert library._navigation_controller.character_route is committed
+            assert library.query_one("#library-character-back-console") is back
+        library._flush_active_file_notes = original_incoming_flush
         back.focus()
         await pilot.pause()
         painted = "\n".join(strip.text for strip in library._compositor.render_strips())

--- a/Tests/UI/test_character_navigation_screen_reuse.py
+++ b/Tests/UI/test_character_navigation_screen_reuse.py
@@ -25,6 +25,213 @@ from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    "route_kind,size",
+    [("inspection", (52, 20)), ("inspection", (80, 24)), ("browse", (140, 42))],
+)
+async def test_unavailable_route_returns_to_originating_console_character(
+    monkeypatch, tmp_path, route_kind, size
+):
+    from copy import deepcopy
+
+    from textual.widgets import Button
+
+    from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+        UnresolvedConversationKey,
+    )
+    from tldw_chatbook.Constants import (
+        LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE,
+        LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION,
+        TAB_LIBRARY,
+    )
+    from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+        LibraryUnavailableConversationsBrowse,
+        RoleplayReturnTarget,
+        serialize_library_unavailable_browse,
+        serialize_library_unavailable_inspection,
+    )
+
+    _scratch_env(monkeypatch, tmp_path)
+    app = TldwCli()
+    _configure_native_ready_console(app)
+    async with app.run_test(size=size) as pilot:
+        await asyncio.wait_for(_boot_settled(app, pilot), 30)
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        console = app.screen
+        database = app.chachanotes_db
+        actor = database.add_character_card({"name": "Synthetic lost actor"})
+        authority = database.get_local_authority_id()
+        database.add_conversation(
+            {
+                "id": "synthetic-return-chat",
+                "title": "Synthetic unavailable chat",
+                "character_id": actor,
+                "assistant_kind": "character",
+                "assistant_id": str(actor),
+                "assistant_authority_id": authority,
+            }
+        )
+        with database.transaction(immediate=True) as connection:
+            connection.execute(
+                "UPDATE conversations SET assistant_id = 'Historical actor', assistant_authority_id = NULL WHERE id = ?",
+                ("synthetic-return-chat",),
+            )
+        key = UnresolvedConversationKey(authority, "synthetic-return-chat")
+        anchor = RoleplayReturnTarget.console_context_character()
+        if route_kind == "inspection":
+            context = {
+                LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: serialize_library_unavailable_inspection(
+                    LibraryUnavailableConversationInspection(key, anchor)
+                )
+            }
+        else:
+            context = {
+                LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: serialize_library_unavailable_browse(
+                    LibraryUnavailableConversationsBrowse(key, anchor)
+                )
+            }
+        console._set_console_rail_preference(
+            left_open=False, section_updates={"character": False}
+        )
+        prior_preferences = deepcopy(
+            app.app_config.get("console", {}).get("rail_state", {})
+        )
+        app.post_message(NavigateToScreen(TAB_LIBRARY, context))
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if type(app.screen).__name__ == "LibraryScreen" and app.screen.query(
+                "#library-character-back-console"
+            ):
+                break
+        library = app.screen
+        back = library.query_one("#library-character-back-console", Button)
+        back.focus()
+        await pilot.pause()
+        painted = "\n".join(strip.text for strip in library._compositor.render_strips())
+        assert "Back to Console" in painted
+        app.save_screenshot(
+            filename=f"library-return-{route_kind}-{size[0]}x{size[1]}.svg",
+            path=str(tmp_path),
+        )
+        (tmp_path / "return-paint.txt").write_text(painted)
+        if size == (80, 24):
+            original_flush = library.flush_pending_work
+            vetoed = asyncio.Event()
+
+            async def veto_departure():
+                vetoed.set()
+                return False
+
+            library.flush_pending_work = veto_departure
+            back.press()
+            await asyncio.wait_for(vetoed.wait(), 2)
+            await pilot.pause()
+            assert app.screen is library
+            assert library.query_one("#library-character-back-console") is back
+            library.flush_pending_work = original_flush
+        back.press()
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if app.screen is console and (
+                size[0] == 52
+                or getattr(app.focused, "id", None) == "console-character-search"
+            ):
+                break
+        assert app.screen is console
+        await pilot.pause(0.3)
+        if size[0] == 52:
+            assert not console.query_one("#console-left-rail").display
+            assert getattr(app.focused, "id", None) != "console-character-search"
+            assert app.focused is not None and app.focused.visible
+            assert console.query_one("#console-native-composer") in (
+                app.focused,
+                *app.focused.ancestors,
+            )
+            assert (
+                console._pending_character_return_focus_id
+                == "console-context-character"
+            )
+            app.save_screenshot(
+                filename="console-return-fallback-52x20.svg", path=str(tmp_path)
+            )
+            fallback = app.focused
+            await pilot.resize_terminal(80, 24)
+            await pilot.pause(0.3)
+            assert app.focused is fallback
+            assert (
+                console._pending_character_return_focus_id
+                == "console-context-character"
+            )
+        else:
+            # Refresh-on-resume may replace the first focused Input. Wait for
+            # the final owned node to paint, without scrolling it from the test.
+            from textual.errors import NoWidget
+
+            for _ in range(60):
+                await pilot.pause(0.05)
+                search = console.query_one("#console-character-search")
+                try:
+                    geometry = console.find_widget(search)
+                except NoWidget:
+                    continue
+                if app.focused is search and geometry.clip.contains_region(
+                    search.region
+                ):
+                    break
+            search = console.query_one("#console-character-search")
+            assert app.focused is search
+            geometry = console.find_widget(search)
+            assert geometry.clip.contains_region(search.region)
+            painted_focus = "\n".join(
+                strip.text[search.region.x : search.region.right]
+                for strip in console._compositor.render_strips()[
+                    search.region.y : search.region.bottom
+                ]
+            )
+            assert "Search chats" in painted_focus
+            app.save_screenshot(
+                filename=f"console-return-{route_kind}-{size[0]}x{size[1]}.svg",
+                path=str(tmp_path),
+            )
+        assert (
+            app.app_config.get("console", {}).get("rail_state", {}) == prior_preferences
+        )
+        if size[0] == 52:
+            console._toggle_console_rail_section("character", next_open=True)
+            await pilot.pause(0.3)
+            assert console._pending_character_return_focus_id is None
+            assert app.focused is console.query_one("#console-character-search")
+        console._toggle_console_rail_section("character", next_open=False)
+        assert not console._character_context.return_reveal
+        assert not console.query_one("#console-rail-section-body-character").display
+        await pilot.pause()
+        app.post_message(NavigateToScreen(TAB_LIBRARY, {"mode": "conversations"}))
+        for _ in range(100):
+            await pilot.pause(0.05)
+            if app.screen is library:
+                break
+        assert not library.query("#library-character-back-console")
+        settled_frames = 0
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if (
+                not library._recompose_required
+                and not library._conversations_state.loading
+            ):
+                settled_frames += 1
+                if settled_frames == 3:
+                    break
+            else:
+                settled_frames = 0
+        assert settled_frames == 3
+        assert not library._recompose_required
+        assert not library._conversations_state.loading
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     "fail_visibility,prior_resume_gate", [(False, False), (True, False), (True, True)]
 )
 async def test_character_activation_uses_cached_console_and_preserves_rollback(

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -351,10 +351,14 @@ async def test_character_section_composes_when_config_on(
 
 
 @pytest.mark.asyncio
-async def test_character_section_absent_when_config_off(console_screen_avatar_off):
-    # console_screen_avatar_off: app_config has chat.images.show_character_avatar = False
+async def test_character_section_remains_when_avatar_config_off(
+    console_screen_avatar_off,
+):
+    # The image preference cannot remove the Character navigation surface.
     screen = console_screen_avatar_off
-    assert not screen.query("#console-rail-section-body-character")
+    assert screen.query("#console-rail-section-body-character")
+    assert screen.query("#console-character-identity")
+    assert screen.query_one("#console-character-avatar-frame").styles.display == "none"
 
 
 @pytest.mark.asyncio
@@ -1836,6 +1840,30 @@ async def test_character_shapes_and_controls_settle_inside_35_rows(
         <= 1
     )
 
+    from Tests.UI.test_console_character_context import _resolved
+    from tldw_chatbook.UI.Console_Modules.character_context import (
+        ConsoleCharacterContextState,
+    )
+
+    screen._character_context._publish(
+        ConsoleCharacterContextState(
+            query="needle",
+            search_rows=tuple(_resolved(1, f"search-{index}") for index in range(8)),
+        )
+    )
+    for _ in range(20):
+        left_rail.request_allocation_reconcile()
+        await pilot.pause(0.05)
+        if (
+            body.virtual_region_with_margin.height <= 35
+            and bounded.desired_content_lines <= 35
+        ):
+            break
+    assert len(screen.query(".console-character-search-row")) == 8
+    assert body.virtual_region_with_margin.height <= 35
+    assert bounded.desired_content_lines <= 35
+    assert screen.query_one("#console-character-reaction-open") is reaction_button
+
 
 @pytest.mark.asyncio
 async def test_oversized_character_controls_use_local_scroll_and_keep_offset(
@@ -1861,7 +1889,8 @@ async def test_oversized_character_controls_use_local_scroll_and_keep_offset(
     bounded = screen.query_one(
         "#console-bounded-section-character", ConsoleBoundedSection
     )
-    name = screen.query_one("#console-character-name", Static)
+    # Navigation owns the visible identity; the legacy painter caption is hidden.
+    name = screen.query_one("#console-character-identity", Static)
     reaction_button = screen.query_one("#console-character-reaction-open")
     name.styles.height = 36
     left_rail.apply_section_open("character", True)
@@ -2005,6 +2034,27 @@ async def test_character_geometry_replacement_is_equality_guarded_and_keeps_focu
     assert len(settled_calls) == 1
     assert tuple(calls) == settled_calls
     assert screen.app.focused is reaction_button
+
+
+@pytest.mark.asyncio
+async def test_character_browse_refresh_preserves_reaction_focus_and_mount(
+    console_screen_with_db_and_pilot,
+):
+    """Refreshing saved chats must not remove the independent reaction control."""
+
+    from dataclasses import replace
+
+    _app, screen, _db, pilot = console_screen_with_db_and_pilot
+    reaction = screen.query_one("#console-character-reaction-open")
+    reaction.focus()
+    await pilot.pause()
+    controller = screen._character_context
+    controller._publish(replace(controller.state, error="Could not load chats"))
+    await pilot.pause()
+
+    assert reaction.is_mounted
+    assert screen.query_one("#console-character-reaction-open") is reaction
+    assert screen.app.focused is reaction
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_character_context.py
+++ b/Tests/UI/test_console_character_context.py
@@ -175,6 +175,150 @@ async def test_controller_enforces_four_by_five_and_eight_search_bounds() -> Non
     assert controller.state.restore_scroll_offset == 6
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize("query", [None, 42, b"needle", "x" * 513, " " * 513])
+async def test_character_query_validation_rejects_before_state_or_database(query):
+    from tldw_chatbook.Utils.input_validation import validate_console_switcher_query
+
+    with pytest.raises(ValueError):
+        validate_console_switcher_query(query)
+    controller = _controller()
+    await controller.refresh()
+    await controller.search("needle")
+    before = controller.state
+    generation = controller._generation
+    _Service.search_calls.clear()
+    with pytest.raises(ValueError):
+        await controller.search(query)
+    assert controller.state is before
+    assert controller._generation == generation
+    assert _Service.search_calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "query, expected", [(" " + "é" * 510 + " ", "é" * 510), ("  needle  ", "needle")]
+)
+async def test_character_query_validation_preserves_bounded_trimmed_keyword(
+    query, expected
+):
+    from tldw_chatbook.Utils.input_validation import validate_console_switcher_query
+
+    assert validate_console_switcher_query(query) == query
+    controller = _controller()
+    _Service.search_calls.clear()
+    await controller.search(query)
+    assert controller.state.query == expected
+    assert _Service.search_calls == [(expected, 8)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalid", ["x" * 513, " " * 513, None, 42])
+@pytest.mark.parametrize("previous_query", ["", "needle"])
+async def test_widget_query_validation_preserves_search_and_clear(
+    invalid, previous_query, monkeypatch
+):
+    from textual.widgets import Input
+
+    activated = []
+
+    async def activate(request, _cancel):
+        activated.append(request)
+
+    controller = _controller(activate_target=activate)
+    app = _CharacterIdentityApp(controller)
+    async with app.run_test(size=(80, 35)) as pilot:
+        await pilot.pause()
+        await controller.search(previous_query)
+        await pilot.pause()
+        widget = app.query_one(ConsoleCharacterContext)
+        field = widget.query_one("#console-character-search", Input)
+        field.focus()
+        before = controller.state
+        _Service.search_calls.clear()
+        feedback = []
+        monkeypatch.setattr(
+            widget, "notify", lambda message, **kwargs: feedback.append(message)
+        )
+        if isinstance(invalid, str):
+            field.value = invalid
+        else:
+            widget._search_changed(Input.Changed(field, invalid))
+        await pilot.pause()
+        assert controller.state is before
+        assert _Service.search_calls == []
+        assert len(feedback) == 1 and "512" in feedback[0] and len(feedback[0]) < 100
+        assert invalid is None or str(invalid) not in feedback[0]
+        assert field.value == previous_query == controller.state.query
+        await pilot.press("enter")
+        await pilot.pause()
+        assert activated == []
+        field.value = "  next  "
+        await pilot.pause()
+        assert controller.state.query == "next"
+        assert _Service.search_calls == [("next", 8)]
+        field = widget.query_one("#console-character-search", Input)
+        field.focus()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert controller.state.query == ""
+        assert len(widget.query(".console-character-group")) == 4
+
+
+@pytest.mark.asyncio
+async def test_character_mount_loads_groups_without_duplicate_cold_resume_worker(
+    monkeypatch,
+):
+    from Tests.UI.test_console_left_rail import make_console_pilot
+    from tldw_chatbook.UI.Console_Modules.wiring import (
+        _sync_character_context_presentation,
+    )
+
+    revision = [7]
+    database = SimpleNamespace(
+        get_local_authority_id=lambda: "authority",
+        get_character_conversation_search_revision=lambda: revision[0],
+    )
+    original_build = chat_screen_module.build_console_controllers
+    original_worker = chat_screen_module.ChatScreen.run_worker
+    refresh_workers = []
+
+    def build(screen, *args, **kwargs):
+        original_build(screen, *args, **kwargs)
+        screen._character_context = _controller(
+            database_accessor=lambda: database,
+            state_changed=lambda state: _sync_character_context_presentation(
+                screen, state
+            ),
+        )
+
+    def run_worker(screen, work, *args, **kwargs):
+        if kwargs.get("group") == "console-character-context-refresh":
+            refresh_workers.append(work)
+        return original_worker(screen, work, *args, **kwargs)
+
+    monkeypatch.setattr(chat_screen_module, "build_console_controllers", build)
+    monkeypatch.setattr(chat_screen_module.ChatScreen, "run_worker", run_worker)
+    async with make_console_pilot(size=(120, 50)) as pilot:
+        screen = pilot.app.screen
+        for _ in range(40):
+            if screen._character_context.state.groups:
+                break
+            await pilot.pause(0.05)
+        assert len(screen.query(".console-character-group")) == 4
+        assert screen._character_context.state.scope_fingerprint.data_revision == 7
+        assert refresh_workers == []
+        revision[0] = 8
+        screen.on_screen_resume()
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if screen._character_context.state.scope_fingerprint.data_revision == 8:
+                break
+        assert len(refresh_workers) == 1
+        assert screen._character_context.state.scope_fingerprint.data_revision == 8
+        assert len(screen.query(".console-character-group")) == 4
+
+
 def test_accordion_keeps_at_most_one_stable_typed_key_expanded() -> None:
     controller = _controller()
     controller._publish(ConsoleCharacterContextState(groups=_groups()))

--- a/Tests/UI/test_console_character_context.py
+++ b/Tests/UI/test_console_character_context.py
@@ -142,7 +142,7 @@ def _controller(**overrides):
         "navigate_unavailable_browse": lambda _link: None,
         "navigate_roleplay_home": lambda: None,
         "navigate_library_home": lambda: None,
-        "start_console": lambda _id, _name: None,
+        "start_console": lambda _key, _database, _name, _guard: None,
         "service_factory": _Service,
     }
     params.update(overrides)
@@ -432,7 +432,7 @@ async def test_start_current_invalidates_context_before_current_mutation() -> No
     calls: list[tuple[str, bool]] = []
     controller = None
 
-    async def start(_character_id: int, _name: str) -> None:
+    async def start(_key, _database, _name: str, _guard) -> None:
         assert controller is not None
         calls.append(("mutated", controller.state.scope_fingerprint is None))
 

--- a/Tests/UI/test_console_character_context.py
+++ b/Tests/UI/test_console_character_context.py
@@ -1,0 +1,1329 @@
+"""Task 4 contract tests for Console Character navigation."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import ClassVar
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+    CharacterConversationGroup,
+    CharacterConversationPage,
+    CharacterConversationRow,
+    CharacterKeywordIndexStatus,
+    CharacterRepairCandidate,
+    CharacterRepairPage,
+    LocalCharacterConversationTarget,
+    ResolvedLocalCharacterKey,
+    UnavailableCharacterReason,
+    UnresolvedConversationKey,
+)
+from tldw_chatbook.Chat.console_conversation_activation import (
+    CharacterConversationActivationRequest,
+    ConsoleActivationResultKind,
+    ConsoleConversationActivationResult,
+)
+from tldw_chatbook.Chat.console_rail_state import (
+    CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY,
+    ConsoleRailPreferenceKey,
+    build_console_rail_state,
+    serialize_console_rail_stored_preferences,
+)
+from tldw_chatbook.UI.Console_Modules.character_context import (
+    CONSOLE_CHARACTER_GROUP_LIMIT,
+    CONSOLE_CHARACTER_ROW_LIMIT,
+    CONSOLE_CHARACTER_SEARCH_LIMIT,
+    ConsoleCharacterContextController,
+    ConsoleCharacterContextState,
+    ConsoleCharacterFocusIdentity,
+    ConsoleCharacterOperationPhase,
+    ConsoleCharacterQueryHandoff,
+    ConsoleCharacterQueryHandoffCapability,
+    ConsoleCharacterScopeFingerprint,
+    ConsoleCharacterUnavailableDetail,
+)
+from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
+    LibraryCharacterRepairContext,
+    LibraryUnavailableConversationInspection,
+    LibraryUnavailableConversationsBrowse,
+    RoleplayCharacterConversationLink,
+    RoleplayReturnTarget,
+)
+from tldw_chatbook.UI.Screens import chat_screen as chat_screen_module
+from tldw_chatbook.Widgets.Console.console_character_context import (
+    ConsoleCharacterContext,
+)
+
+
+def _resolved(character_id: int, conversation_id: str) -> CharacterConversationRow:
+    key = ResolvedLocalCharacterKey("authority", character_id)
+    return CharacterConversationRow.resolved(
+        LocalCharacterConversationTarget(key, conversation_id),
+        character_label=f"Character {character_id}",
+        title=f"Chat {conversation_id}",
+        last_modified=f"2026-09-0{character_id}T12:00:00Z",
+        created_at="2026-09-01T00:00:00Z",
+    )
+
+
+def _groups() -> tuple[CharacterConversationGroup, ...]:
+    groups = []
+    for character_id in range(1, 5):
+        key = ResolvedLocalCharacterKey("authority", character_id)
+        rows = tuple(_resolved(character_id, f"{character_id}-{n}") for n in range(5))
+        groups.append(
+            CharacterConversationGroup(
+                key,
+                f"Character {character_id}",
+                rows,
+                9,
+                character_id == 1,
+            )
+        )
+    return tuple(groups)
+
+
+class _Service:
+    recent_calls: ClassVar[list[tuple[int, int]]] = []
+    search_calls: ClassVar[list[tuple[str, int]]] = []
+
+    def __init__(self, _db, *, current_character=None):
+        self.current_character = current_character
+
+    def recent_groups(self, *, group_limit: int, row_limit: int):
+        self.recent_calls.append((group_limit, row_limit))
+        return _groups()[:group_limit]
+
+    def ensure_keyword_index(self):
+        return CharacterKeywordIndexStatus.READY
+
+    def keyword_search(self, query: str, *, limit: int):
+        self.search_calls.append((query, limit))
+        rows = tuple(_resolved(1, f"search-{n}") for n in range(12))
+        return CharacterConversationPage(
+            rows=rows[:limit],
+            total=12,
+            next_cursor=None,
+            data_revision=7,
+            keyword_status=CharacterKeywordIndexStatus.READY,
+        )
+
+    def refresh_unresolved_evidence(self, _key):
+        return 3, "Historical Ada"
+
+    def repair_candidates(self, _key, *, limit=20):
+        return CharacterRepairPage((), 0, None)
+
+
+def _controller(**overrides):
+    async def activate(request, _cancel):
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.OPENED, request.target, True
+        )
+
+    database = SimpleNamespace(
+        get_local_authority_id=lambda: "authority",
+        get_character_conversation_search_revision=lambda: 7,
+    )
+    params = {
+        "database_accessor": lambda: database,
+        "current_character_accessor": lambda: (1, "Character 1"),
+        "open_conversation_accessor": lambda: None,
+        "activate_target": activate,
+        "navigate_roleplay": lambda _link: None,
+        "navigate_repair": lambda _context: None,
+        "navigate_inspection": lambda _link: None,
+        "navigate_unavailable_browse": lambda _link: None,
+        "navigate_roleplay_home": lambda: None,
+        "navigate_library_home": lambda: None,
+        "start_console": lambda _id, _name: None,
+        "service_factory": _Service,
+    }
+    params.update(overrides)
+    return ConsoleCharacterContextController(**params)
+
+
+@pytest.mark.asyncio
+async def test_controller_enforces_four_by_five_and_eight_search_bounds() -> None:
+    _Service.recent_calls.clear()
+    _Service.search_calls.clear()
+    controller = _controller()
+
+    await controller.refresh()
+    focus = ConsoleCharacterFocusIdentity("group", group_key=_groups()[0].key)
+    controller.capture_browse(focus=focus, scroll_offset=6)
+    await controller.search("needle")
+
+    assert _Service.recent_calls == [
+        (CONSOLE_CHARACTER_GROUP_LIMIT, CONSOLE_CHARACTER_ROW_LIMIT)
+    ]
+    assert _Service.search_calls == [("needle", CONSOLE_CHARACTER_SEARCH_LIMIT)]
+    assert len(controller.state.groups) == 4
+    assert all(len(group.rows) <= 5 for group in controller.state.groups)
+    assert len(controller.state.search_rows) == 8
+    assert all(row.selected_excerpt == "" for row in controller.state.search_rows)
+
+    await controller.search("")
+    assert controller.state.expanded_key == _groups()[0].key
+    assert controller.state.restore_focus == focus
+    assert controller.state.restore_scroll_offset == 6
+
+
+def test_accordion_keeps_at_most_one_stable_typed_key_expanded() -> None:
+    controller = _controller()
+    controller._publish(ConsoleCharacterContextState(groups=_groups()))
+
+    controller.toggle_group(_groups()[1].key)
+    assert controller.state.expanded_key == ResolvedLocalCharacterKey("authority", 2)
+    controller.toggle_group(_groups()[2].key)
+    assert controller.state.expanded_key == ResolvedLocalCharacterKey("authority", 3)
+    controller.toggle_group(_groups()[2].key)
+    assert controller.state.expanded_key is None
+
+
+def test_character_disclosure_new_explicit_and_legacy_rules() -> None:
+    key = ConsoleRailPreferenceKey("global", "layout", "key")
+
+    assert (
+        build_console_rail_state(
+            preference_key=key,
+            stored_preferences={},
+            character_context_exists=True,
+        ).character_open
+        is True
+    )
+
+
+@pytest.mark.asyncio
+async def test_canonical_writer_persists_first_use_close_reopen_and_legacy(
+    monkeypatch,
+) -> None:
+    from copy import deepcopy
+
+    from Tests.UI.test_console_inspector_compact_access import (
+        _stored_rail_preferences,
+    )
+    from Tests.UI.test_console_left_rail import make_console_pilot
+
+    key = ConsoleRailPreferenceKey("global", "layout", "key")
+
+    async with make_console_pilot(size=(120, 40)) as pilot:
+        screen = pilot.app.screen
+        app = screen.app_instance
+        screen._character_context._publish(
+            ConsoleCharacterContextState(groups=_groups(), data_revision=7)
+        )
+        await pilot.pause()
+        assert screen._current_console_rail_state().character_open is True
+
+        screen._toggle_console_rail_section("character", next_open=False)
+        stored = _stored_rail_preferences(app)
+        assert stored["character_open"] is False
+        assert stored[CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY] is True
+        assert screen._current_console_rail_state().character_open is False
+
+        screen._toggle_console_rail_section("character", next_open=True)
+        stored = _stored_rail_preferences(app)
+        assert stored["character_open"] is True
+        assert stored[CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY] is True
+
+        rail_key = next(iter(app.app_config["console"]["rail_state"]))
+        legacy = deepcopy(stored)
+        legacy["character_open"] = False
+        legacy.pop(CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY)
+        app.app_config["console"]["rail_state"][rail_key] = legacy
+        screen._toggle_console_rail_section("details", next_open=True)
+        stored = _stored_rail_preferences(app)
+        assert stored["character_open"] is False
+        assert CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY not in stored
+
+        writes: list[dict[str, bool]] = []
+        monkeypatch.setattr(
+            type(screen),
+            "_save_console_rail_preferences",
+            lambda _screen, _key, payload, **_kwargs: writes.append(dict(payload)),
+        )
+        await pilot.resize_terminal(52, 20)
+        await pilot.pause(0.2)
+        assert writes == []
+    assert (
+        build_console_rail_state(
+            preference_key=key,
+            stored_preferences={
+                "character_open": False,
+                CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY: True,
+            },
+            character_context_exists=True,
+        ).character_open
+        is False
+    )
+    assert (
+        build_console_rail_state(
+            preference_key=key,
+            stored_preferences={"character_open": True},
+            character_context_exists=False,
+            available_columns=52,
+        ).character_open
+        is True
+    )
+    assert "character_open" not in serialize_console_rail_stored_preferences(None)
+    assert (
+        serialize_console_rail_stored_preferences(
+            {CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY: True}
+        )["character_open"]
+        is False
+    )
+
+
+class _CharacterApp(App):
+    def __init__(self, controller, state):
+        super().__init__()
+        self.controller = controller
+        self.state = state
+        controller._publish(state)
+
+    def compose(self) -> ComposeResult:
+        widget = ConsoleCharacterContext(self.controller)
+        widget._state = self.state
+        yield widget
+
+
+class _CharacterIdentityApp(App):
+    def __init__(self, controller):
+        super().__init__()
+        self.controller = controller
+        self.identity = Static()
+
+    def compose(self) -> ComposeResult:
+        yield self.identity
+        widget = ConsoleCharacterContext(
+            self.controller,
+            identity_state=self.identity,
+        )
+        self.controller._state_changed = widget.sync_state
+        yield widget
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("current", "open_conversation_id", "groups", "expected"),
+    [
+        (
+            None,
+            "ordinary-open",
+            _groups(),
+            "No current character · Local · No open chat",
+        ),
+        (
+            (9, "Zero"),
+            None,
+            (
+                CharacterConversationGroup(
+                    ResolvedLocalCharacterKey("authority", 9),
+                    "Zero",
+                    (),
+                    0,
+                    True,
+                ),
+            ),
+            "Zero · Local · No open chat",
+        ),
+        ((1, "Saved"), None, _groups(), "Saved · Local · No open chat"),
+        ((1, "Open"), "1-1", _groups(), "Open · Local · Open"),
+    ],
+)
+async def test_identity_line_uses_only_owner_current_and_exact_open_state(
+    current,
+    open_conversation_id,
+    groups,
+    expected,
+) -> None:
+    class IdentityService(_Service):
+        def recent_groups(self, *, group_limit: int, row_limit: int):
+            return groups[:group_limit]
+
+    controller = _controller(
+        current_character_accessor=lambda: current,
+        open_conversation_accessor=lambda: open_conversation_id,
+        service_factory=IdentityService,
+    )
+    app = _CharacterIdentityApp(controller)
+    async with app.run_test(size=(80, 35)) as pilot:
+        await controller.refresh()
+        await pilot.pause()
+        assert str(app.identity.render()) == expected
+
+
+@pytest.mark.asyncio
+async def test_production_avatar_repaint_never_overwrites_identity_variants() -> None:
+    from Tests.UI.test_console_left_rail import make_console_pilot
+
+    variants = (
+        (None, "", "No current character · Local · No open chat"),
+        ((9, "Zero"), "", "Zero · Local · No open chat"),
+        ((1, "Saved"), "", "Saved · Local · No open chat"),
+        ((1, "Open"), "1-1", "Open · Local · Open"),
+    )
+    async with make_console_pilot(size=(120, 40)) as pilot:
+        screen = pilot.app.screen
+        for current, open_id, expected in variants:
+            character_id = None if current is None else current[0]
+            character_label = "" if current is None else current[1]
+            state = replace(
+                screen._character_context.state,
+                scope_fingerprint=ConsoleCharacterScopeFingerprint(
+                    database_identity=1,
+                    data_authority_id="authority",
+                    data_revision=7,
+                    current_character_id=character_id,
+                    current_character_label=character_label,
+                    open_conversation_id=open_id,
+                ),
+            )
+            screen._character_context._publish(state)
+            await pilot.pause()
+
+            await screen._render_character_avatar_into_section(
+                spec=None,
+                name="Avatar painter must not own identity",
+                manual_label="Happy",
+                is_current=lambda: True,
+            )
+            await pilot.pause()
+
+            identity = screen.query_one("#console-character-identity", Static)
+            assert str(identity.renderable) == expected
+
+
+def test_character_picker_invalidates_context_before_current_mutation() -> None:
+    calls: list[str] = []
+
+    async def apply(_choice) -> None:
+        calls.append("mutated")
+
+    def run_worker(coroutine, **_kwargs) -> None:
+        calls.append("scheduled")
+        coroutine.close()
+
+    screen = SimpleNamespace(
+        _character_context=SimpleNamespace(
+            invalidate_scope=lambda: calls.append("invalidated")
+        ),
+        _character=SimpleNamespace(_apply_console_character_choice_async=apply),
+        run_worker=run_worker,
+    )
+
+    chat_screen_module.ChatScreen._apply_console_character_choice(
+        screen,
+        SimpleNamespace(),
+    )
+
+    assert calls == ["invalidated", "scheduled"]
+
+
+@pytest.mark.asyncio
+async def test_start_current_invalidates_context_before_current_mutation() -> None:
+    calls: list[tuple[str, bool]] = []
+    controller = None
+
+    async def start(_character_id: int, _name: str) -> None:
+        assert controller is not None
+        calls.append(("mutated", controller.state.scope_fingerprint is None))
+
+    controller = _controller(start_console=start)
+    await controller.refresh()
+    group = _groups()[0]
+
+    await controller.start_current(group)
+
+    assert calls == [("mutated", True)]
+
+
+@pytest.mark.asyncio
+async def test_mounted_widget_has_four_headers_five_rows_and_no_future_handoff_copy() -> (
+    None
+):
+    state = ConsoleCharacterContextState(
+        groups=_groups(), expanded_key=_groups()[0].key, data_revision=7
+    )
+    app = _CharacterApp(_controller(), state)
+    async with app.run_test(size=(72, 35)) as pilot:
+        await pilot.pause()
+        assert len(app.screen.query(".console-character-group")) == 4
+        assert len(app.screen.query(".console-character-row")) == 5
+        assert "Continue search in Character chats" not in str(app.screen.render())
+        assert "View all 9 in Roleplay" in str(
+            app.screen.query_one(
+                f"#{ConsoleCharacterContext.action_dom_id('view-all', _groups()[0].key)}"
+            ).label
+        )
+
+
+@pytest.mark.asyncio
+async def test_unavailable_row_is_repair_only_and_zero_chat_current_can_start() -> None:
+    unresolved = UnresolvedConversationKey("authority", "lost")
+    unavailable = CharacterConversationGroup(
+        unresolved,
+        "Chats with unavailable characters",
+        (
+            CharacterConversationRow.unavailable(
+                unresolved,
+                reason=UnavailableCharacterReason.MISSING_CARD,
+                character_label="Historical Ada",
+                title="Lost chat",
+                last_modified="2026-09-03T12:00:00Z",
+                created_at="2026-09-01T00:00:00Z",
+            ),
+        ),
+        1,
+        False,
+    )
+    current = CharacterConversationGroup(
+        ResolvedLocalCharacterKey("authority", 1), "Ada", (), 0, True
+    )
+    state = ConsoleCharacterContextState(
+        groups=(current, unavailable), expanded_key=current.key
+    )
+    app = _CharacterApp(_controller(), state)
+    async with app.run_test(size=(80, 24)) as pilot:
+        await pilot.pause()
+        app.controller._publish(state)
+        app.screen.query_one(ConsoleCharacterContext).sync_state(state)
+        await pilot.pause()
+        assert app.screen.query_one(
+            f"#{ConsoleCharacterContext.action_dom_id('start', current.key)}"
+        )
+        assert "No chats with Ada yet" == str(
+            app.screen.query_one(".console-character-empty").renderable
+        )
+        assert not app.screen.query(
+            f"#{ConsoleCharacterContext.action_dom_id('view-all', current.key)}"
+        )
+        await pilot.click(f"#{ConsoleCharacterContext.group_dom_id(unavailable.key)}")
+        await pilot.pause()
+        assert "Card missing" in str(
+            app.screen.query_one(
+                f"#{ConsoleCharacterContext.row_dom_id(unavailable.rows[0].row_key)}"
+            ).label
+        )
+        assert "View all 1 in Library" in str(
+            app.screen.query_one(
+                f"#{ConsoleCharacterContext.action_dom_id('view-all', unavailable.key)}"
+            ).label
+        )
+
+
+@pytest.mark.asyncio
+async def test_controller_routes_only_typed_activation_roleplay_and_repair() -> None:
+    activations: list[CharacterConversationActivationRequest] = []
+    roleplay: list[RoleplayCharacterConversationLink] = []
+    repairs: list[LibraryCharacterRepairContext] = []
+    inspections: list[LibraryUnavailableConversationInspection] = []
+    unavailable_browses: list[LibraryUnavailableConversationsBrowse] = []
+
+    async def activate(request, _cancel):
+        activations.append(request)
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.OPENED,
+            request.target,
+            True,
+        )
+
+    controller = _controller(
+        activate_target=activate,
+        navigate_roleplay=roleplay.append,
+        navigate_repair=repairs.append,
+        navigate_inspection=inspections.append,
+        navigate_unavailable_browse=unavailable_browses.append,
+        service_factory=type(
+            "CandidateService",
+            (_Service,),
+            {
+                "repair_candidates": lambda self, _key, *, limit=20: (
+                    CharacterRepairPage(
+                        (
+                            CharacterRepairCandidate(
+                                ResolvedLocalCharacterKey("authority", 7),
+                                "Replacement",
+                                1,
+                            ),
+                        ),
+                        1,
+                        None,
+                    )
+                )
+            },
+        ),
+    )
+    controller._publish(
+        ConsoleCharacterContextState(
+            groups=_groups(),
+            expanded_key=_groups()[0].key,
+            data_revision=7,
+        )
+    )
+    target = _groups()[0].rows[0].target
+    assert target is not None
+
+    await controller.activate(target)
+    await controller.view_group(_groups()[0])
+    unresolved = UnresolvedConversationKey("authority", "lost")
+    await controller.open_unavailable(unresolved, row_key="lost-row")
+    await controller.repair_unavailable(unresolved, row_key="lost-row")
+    unavailable_group = CharacterConversationGroup(
+        unresolved,
+        "Chats with unavailable characters",
+        (
+            CharacterConversationRow.unavailable(
+                unresolved,
+                reason=UnavailableCharacterReason.MISSING_CARD,
+                character_label="Historical Ada",
+                title="Lost chat",
+                last_modified="2026-09-03T12:00:00Z",
+                created_at="2026-09-01T00:00:00Z",
+            ),
+        ),
+        9,
+        False,
+    )
+    controller.select_unavailable(unavailable_group.rows[0].row_key)
+    await controller.view_group(unavailable_group)
+
+    assert activations == [
+        CharacterConversationActivationRequest(target, "authority", 7)
+    ]
+    assert roleplay == [
+        RoleplayCharacterConversationLink(
+            character=_groups()[0].key,
+            return_target=RoleplayReturnTarget.console_context_character(),
+        )
+    ]
+    assert inspections == [
+        LibraryUnavailableConversationInspection(
+            unresolved=unresolved,
+            return_target=RoleplayReturnTarget.console_context_character(),
+        )
+    ]
+    assert repairs == [
+        LibraryCharacterRepairContext(
+            unresolved=unresolved,
+            expected_conversation_version=3,
+            historical_display_snapshot="Historical Ada",
+            return_target=RoleplayReturnTarget.console_context_character(),
+        )
+    ]
+    assert unavailable_browses == [
+        LibraryUnavailableConversationsBrowse(
+            selected=unresolved,
+            return_target=RoleplayReturnTarget.console_context_character(),
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_scope_fingerprint_refreshes_current_profile_revision_and_activation() -> (
+    None
+):
+    calls: list[ResolvedLocalCharacterKey | None] = []
+    current = {"value": (1, "Ada")}
+    database = SimpleNamespace(
+        authority="authority",
+        revision=7,
+        get_local_authority_id=lambda: database.authority,
+        get_character_conversation_search_revision=lambda: database.revision,
+    )
+
+    class ScopeService(_Service):
+        def recent_groups(self, *, group_limit: int, row_limit: int):
+            calls.append(self.current_character)
+            return _groups()[:group_limit]
+
+    controller = _controller(
+        database_accessor=lambda: database,
+        current_character_accessor=lambda: current["value"],
+        service_factory=ScopeService,
+    )
+    await controller.refresh_if_scope_changed()
+    await controller.refresh_if_scope_changed()
+    assert len(calls) == 1
+
+    current["value"] = (2, "Bea")
+    await controller.refresh_if_scope_changed()
+    database.revision = 8
+    await controller.refresh_if_scope_changed()
+    database.authority = "authority-2"
+    await controller.refresh_if_scope_changed()
+    assert [key.character_id if key else None for key in calls] == [1, 2, 2, 2]
+    assert controller.state.scope_fingerprint is not None
+    assert controller.state.scope_fingerprint.data_authority_id == "authority-2"
+
+    target = LocalCharacterConversationTarget(
+        ResolvedLocalCharacterKey("authority-2", 2), "after-open"
+    )
+    controller._publish(
+        replace(controller.state, data_revision=8, scope_fingerprint=None)
+    )
+    await controller.activate(target, row_key="activation-row")
+    assert len(calls) == 5
+
+
+@pytest.mark.asyncio
+async def test_scope_capture_retries_when_database_switches_during_revision_read() -> (
+    None
+):
+    """Catch a pre-await database identity being committed after profile switch."""
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class Database:
+        def __init__(self, authority: str, *, block: bool = False) -> None:
+            self.authority = authority
+            self.block = block
+
+        def get_local_authority_id(self) -> str:
+            if self.block:
+                entered.set()
+                assert release.wait(2)
+            return self.authority
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    old = Database("old-authority")
+    new = Database("new-authority")
+    active = {"database": old}
+    calls: list[str] = []
+
+    class ScopeService(_Service):
+        def __init__(self, database, *, current_character=None):
+            super().__init__(database, current_character=current_character)
+            calls.append(database.authority)
+
+    controller = _controller(
+        database_accessor=lambda: active["database"],
+        service_factory=ScopeService,
+    )
+    await controller.refresh()
+    old.block = True
+    pending = asyncio.create_task(controller.refresh_if_scope_changed())
+    assert await asyncio.to_thread(entered.wait, 2)
+    active["database"] = new
+    release.set()
+
+    assert await pending is True
+    assert controller.state.scope_fingerprint is not None
+    assert controller.state.scope_fingerprint.data_authority_id == "new-authority"
+    assert calls[-1] == "new-authority"
+
+
+@pytest.mark.asyncio
+async def test_scope_capture_retries_when_current_character_switches_during_read() -> (
+    None
+):
+    """Catch a pre-await character identity being retained after session switch."""
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class Database:
+        block = False
+
+        def get_local_authority_id(self) -> str:
+            if self.block:
+                entered.set()
+                assert release.wait(2)
+            return "authority"
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    database = Database()
+    current = {"value": (1, "Ada")}
+    calls: list[int | None] = []
+
+    class ScopeService(_Service):
+        def recent_groups(self, *, group_limit: int, row_limit: int):
+            calls.append(
+                None
+                if self.current_character is None
+                else self.current_character.character_id
+            )
+            return _groups()[:group_limit]
+
+    controller = _controller(
+        database_accessor=lambda: database,
+        current_character_accessor=lambda: current["value"],
+        service_factory=ScopeService,
+    )
+    await controller.refresh()
+    database.block = True
+    pending = asyncio.create_task(controller.refresh_if_scope_changed())
+    assert await asyncio.to_thread(entered.wait, 2)
+    current["value"] = (2, "Bea")
+    release.set()
+
+    assert await pending is True
+    assert controller.state.scope_fingerprint is not None
+    assert controller.state.scope_fingerprint.current_character_id == 2
+    assert calls[-1] == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mutated_member", ["authority", "revision"])
+async def test_scope_capture_retries_same_handle_metadata_mutation_across_await(
+    mutated_member: str,
+) -> None:
+    """Every database-owned fingerprint member is recaptured after the await."""
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class Database:
+        authority = "old-authority"
+        revision = 7
+        block_member = ""
+        blocked_once = False
+
+        def _read(self, member: str):
+            value = getattr(self, member)
+            if self.block_member == member and not self.blocked_once:
+                self.blocked_once = True
+                entered.set()
+                assert release.wait(2)
+            return value
+
+        def get_local_authority_id(self) -> str:
+            return str(self._read("authority"))
+
+        def get_character_conversation_search_revision(self) -> int:
+            return int(self._read("revision"))
+
+    database = Database()
+    controller = _controller(database_accessor=lambda: database)
+    await controller.refresh()
+    database.block_member = mutated_member
+    database.blocked_once = False
+    pending = asyncio.create_task(controller.refresh_if_scope_changed())
+    assert await asyncio.to_thread(entered.wait, 2)
+    if mutated_member == "authority":
+        database.authority = "new-authority"
+    else:
+        database.revision = 8
+    release.set()
+
+    assert await pending is True
+    assert controller.state.scope_fingerprint is not None
+    assert controller.state.scope_fingerprint.data_authority_id == database.authority
+    assert controller.state.scope_fingerprint.data_revision == database.revision
+
+
+@pytest.mark.asyncio
+async def test_stable_scope_metadata_exception_settles_idle_retryable_error() -> None:
+    class Database:
+        fail = False
+
+        def get_local_authority_id(self) -> str:
+            if self.fail:
+                raise RuntimeError("metadata unavailable")
+            return "authority"
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    database = Database()
+    controller = _controller(database_accessor=lambda: database)
+    await controller.refresh()
+    database.fail = True
+
+    await controller.refresh()
+
+    assert controller.state.phase is ConsoleCharacterOperationPhase.IDLE
+    assert controller.state.loading is False
+    assert controller.state.error == "Could not load local character chats · Retry"
+
+
+@pytest.mark.asyncio
+async def test_search_scope_metadata_exception_settles_idle_retryable_error() -> None:
+    """A stable metadata failure cannot leave Keyword search latched busy."""
+
+    class Database:
+        fail = False
+
+        def get_local_authority_id(self) -> str:
+            if self.fail:
+                raise RuntimeError("metadata unavailable")
+            return "authority"
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    database = Database()
+    controller = _controller(database_accessor=lambda: database)
+    await controller.refresh()
+    groups = controller.state.groups
+    database.fail = True
+
+    await controller.search("needle")
+
+    assert controller.state.phase is ConsoleCharacterOperationPhase.IDLE
+    assert controller.state.loading is False
+    assert controller.state.operation_row_key == ""
+    assert controller.state.error == "Could not search local character chats · Retry"
+    assert controller.state.query == "needle"
+    assert controller.state.search_rows == ()
+    assert controller.state.groups == groups
+
+
+@pytest.mark.asyncio
+async def test_repair_scope_metadata_exception_settles_idle_retryable_error() -> None:
+    """A stable metadata failure cannot leave Library repair latched busy."""
+
+    class Database:
+        fail = False
+
+        def get_local_authority_id(self) -> str:
+            if self.fail:
+                raise RuntimeError("metadata unavailable")
+            return "authority"
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    database = Database()
+    controller = _controller(database_accessor=lambda: database)
+    await controller.refresh()
+    previous_details = controller.state.unavailable_details
+    database.fail = True
+
+    repaired = await controller.repair_unavailable(
+        UnresolvedConversationKey("authority", "lost"),
+        row_key="lost-row",
+    )
+
+    assert repaired is False
+    assert controller.state.phase is ConsoleCharacterOperationPhase.IDLE
+    assert controller.state.loading is False
+    assert controller.state.operation_row_key == ""
+    assert controller.state.error == "Could not refresh Library details · Retry"
+    assert controller.state.unavailable_details == previous_details
+
+
+@pytest.mark.asyncio
+async def test_replaced_closed_database_error_never_paints_new_profile() -> None:
+    """Catch an exception from a replaced handle becoming the new profile's error."""
+
+    entered = threading.Event()
+    release = threading.Event()
+
+    class OldDatabase:
+        closed = False
+
+        def get_local_authority_id(self) -> str:
+            entered.set()
+            assert release.wait(2)
+            if self.closed:
+                raise RuntimeError("closed old database")
+            return "old-authority"
+
+        def get_character_conversation_search_revision(self) -> int:
+            return 7
+
+    new = SimpleNamespace(
+        authority="new-authority",
+        get_local_authority_id=lambda: "new-authority",
+        get_character_conversation_search_revision=lambda: 8,
+    )
+    old = OldDatabase()
+    active = {"database": old}
+    controller = _controller(database_accessor=lambda: active["database"])
+    pending = asyncio.create_task(controller.refresh())
+    assert await asyncio.to_thread(entered.wait, 2)
+    active["database"] = new
+    old.closed = True
+    release.set()
+
+    await pending
+    assert controller.state.error == ""
+    assert controller.state.scope_fingerprint is not None
+    assert controller.state.scope_fingerprint.data_authority_id == "new-authority"
+
+
+@pytest.mark.asyncio
+async def test_semantic_focus_survives_reorder_and_falls_back_to_group() -> None:
+    groups = _groups()[:2]
+    state = ConsoleCharacterContextState(
+        groups=groups,
+        expanded_key=groups[0].key,
+        data_revision=7,
+    )
+    app = _CharacterApp(_controller(), state)
+    async with app.run_test(size=(80, 35)) as pilot:
+        await pilot.pause()
+        row_key = groups[0].rows[1].row_key
+        row = app.screen.query_one(f"#{ConsoleCharacterContext.row_dom_id(row_key)}")
+        row.focus()
+        await pilot.pause()
+        reordered_group = replace(
+            groups[0], rows=(groups[0].rows[1], groups[0].rows[0], *groups[0].rows[2:])
+        )
+        reordered = ConsoleCharacterContextState(
+            groups=(groups[1], reordered_group),
+            expanded_key=reordered_group.key,
+            data_revision=8,
+        )
+        app.screen.query_one(ConsoleCharacterContext).sync_state(reordered)
+        await pilot.pause()
+        assert getattr(
+            app.screen.focused, "id", None
+        ) == ConsoleCharacterContext.row_dom_id(row_key)
+
+        disappeared = replace(
+            reordered, groups=(groups[1], replace(reordered_group, rows=()))
+        )
+        app.screen.query_one(ConsoleCharacterContext).sync_state(disappeared)
+        await pilot.pause()
+        assert getattr(
+            app.screen.focused, "id", None
+        ) == ConsoleCharacterContext.group_dom_id(reordered_group.key)
+
+
+@pytest.mark.asyncio
+async def test_unavailable_detail_reason_exact_open_and_candidate_gated_repair() -> (
+    None
+):
+    unresolved = UnresolvedConversationKey("authority", "lost")
+    row = CharacterConversationRow.unavailable(
+        unresolved,
+        reason=UnavailableCharacterReason.DELETED_CARD,
+        character_label="Historical Ada",
+        title="Lost chat",
+        last_modified="2026-09-03T12:00:00Z",
+        created_at="2026-09-01T00:00:00Z",
+    )
+    group = CharacterConversationGroup(
+        unresolved, "Chats with unavailable characters", (row,), 1, False
+    )
+    context = LibraryCharacterRepairContext(
+        unresolved=unresolved,
+        expected_conversation_version=3,
+        historical_display_snapshot="Historical Ada",
+        return_target=RoleplayReturnTarget.console_context_character(),
+    )
+    inspections: list[LibraryUnavailableConversationInspection] = []
+    state = ConsoleCharacterContextState(
+        groups=(group,),
+        expanded_key=unresolved,
+        unavailable_details=(
+            ConsoleCharacterUnavailableDetail(
+                row_key=row.row_key,
+                reason_copy="Card deleted",
+                context=context,
+                candidate_count=0,
+            ),
+        ),
+        selected_unavailable_row_key=row.row_key,
+    )
+    controller = _controller(navigate_inspection=inspections.append)
+    app = _CharacterApp(controller, state)
+    async with app.run_test(size=(80, 35)) as pilot:
+        await pilot.pause()
+        controller._publish(state)
+        app.screen.query_one(ConsoleCharacterContext).sync_state(state)
+        await pilot.pause()
+        assert (
+            str(
+                app.screen.query_one("#console-character-unavailable-reason").renderable
+            )
+            == "Card deleted"
+        )
+        assert app.screen.query_one("#console-character-open-library")
+        assert not app.screen.query("#console-character-repair-library")
+        app.screen.query_one("#console-character-open-library", Button).press()
+        await pilot.pause()
+        assert inspections == [
+            LibraryUnavailableConversationInspection(
+                unresolved=unresolved,
+                return_target=RoleplayReturnTarget.console_context_character(),
+            )
+        ]
+
+    candidate = CharacterRepairCandidate(
+        ResolvedLocalCharacterKey("authority", 7), "Replacement", 1
+    )
+
+    class CandidateService(_Service):
+        def repair_candidates(self, _key, *, limit=20):
+            assert limit == 20
+            return CharacterRepairPage((candidate,), 27, 1)
+
+    controller = _controller(service_factory=CandidateService)
+    controller._publish(replace(state, unavailable_details=()))
+    await controller.refresh_unavailable_details((group,))
+    assert controller.state.unavailable_details[0].candidate_count == 27
+    repairs = []
+    controller._navigate_repair = repairs.append
+    assert await controller.repair_unavailable(unresolved, row_key=row.row_key)
+    assert controller.state.unavailable_details[0].candidate_count == 27
+    assert repairs[0].unresolved == unresolved
+
+
+@pytest.mark.asyncio
+async def test_opening_phase_preserves_row_blocks_duplicates_and_escape_cancels() -> (
+    None
+):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    cancellations: list[asyncio.Event] = []
+
+    async def activate(request, cancellation):
+        cancellations.append(cancellation)
+        entered.set()
+        await release.wait()
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.CANCELLED_PRECOMMIT
+            if cancellation.is_set()
+            else ConsoleActivationResultKind.OPENED,
+            request.target,
+            False,
+        )
+
+    state = ConsoleCharacterContextState(
+        groups=_groups(), expanded_key=_groups()[0].key, data_revision=7
+    )
+    controller = _controller(activate_target=activate)
+    app = _CharacterApp(controller, state)
+    async with app.run_test(size=(80, 35)) as pilot:
+        await pilot.pause()
+        controller._publish(state)
+        app.screen.query_one(ConsoleCharacterContext).sync_state(state)
+        await pilot.pause()
+        row = app.screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(_groups()[0].rows[0].row_key)}"
+        )
+        row.focus()
+        await pilot.pause()
+        target = _groups()[0].rows[0].target
+        assert target is not None
+        pending = asyncio.create_task(
+            controller.activate(target, row_key=_groups()[0].rows[0].row_key)
+        )
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        app.screen.query_one(ConsoleCharacterContext).sync_state(controller.state)
+        await pilot.pause()
+        opening = app.screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(_groups()[0].rows[0].row_key)}"
+        )
+        assert controller.state.phase is ConsoleCharacterOperationPhase.OPENING
+        assert "Opening…" in str(opening.label)
+        assert opening.has_class("-opening")
+        assert app.screen.focused is opening
+        duplicate = await controller.activate(
+            target, row_key=_groups()[0].rows[0].row_key
+        )
+        assert duplicate.kind is ConsoleActivationResultKind.FAILED
+        assert len(cancellations) == 1
+        await pilot.press("escape")
+        assert cancellations[0].is_set()
+        release.set()
+        await pending
+        await pilot.pause()
+        assert controller.state.phase is ConsoleCharacterOperationPhase.IDLE
+
+
+@pytest.mark.asyncio
+async def test_opening_search_result_escape_preserves_query_rows_and_focus() -> None:
+    """Catch cancellation falling through into idle search clearing."""
+
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    cancellations: list[asyncio.Event] = []
+
+    async def activate(request, cancellation):
+        cancellations.append(cancellation)
+        entered.set()
+        await release.wait()
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.CANCELLED_PRECOMMIT,
+            request.target,
+            False,
+        )
+
+    rows = tuple(_resolved(1, f"search-{index}") for index in range(2))
+    state = ConsoleCharacterContextState(
+        groups=_groups(),
+        query="needle",
+        search_rows=rows,
+        data_revision=7,
+    )
+    controller = _controller(activate_target=activate)
+    state = replace(state, scope_fingerprint=await controller._fingerprint())
+    app = _CharacterApp(controller, state)
+    async with app.run_test(size=(80, 35)) as pilot:
+        widget = app.screen.query_one(ConsoleCharacterContext)
+        controller._state_changed = widget.sync_state
+        controller._publish(state)
+        await pilot.pause()
+        row_id = ConsoleCharacterContext.row_dom_id(rows[0].row_key)
+        row = app.screen.query_one(f"#{row_id}", Button)
+        row.focus()
+        row.press()
+        await asyncio.wait_for(entered.wait(), timeout=1)
+        await pilot.pause()
+
+        await pilot.press("escape")
+        await pilot.pause()
+
+        assert cancellations[0].is_set()
+        assert controller.state.phase is ConsoleCharacterOperationPhase.OPENING
+        assert controller.state.query == "needle"
+        assert controller.state.search_rows == rows
+        assert getattr(app.screen.focused, "id", None) == row_id
+
+        release.set()
+        for _ in range(40):
+            if controller.state.phase is ConsoleCharacterOperationPhase.IDLE:
+                break
+            await pilot.pause(0.05)
+        assert controller.state.query == "needle"
+        assert controller.state.search_rows == rows
+        assert getattr(app.screen.focused, "id", None) == row_id
+
+
+def test_dormant_typed_query_handoff_is_default_false() -> None:
+    handed_off: list[ConsoleCharacterQueryHandoff] = []
+    controller = _controller(query_handoff=handed_off.append)
+    assert controller.handoff_query("needle") is False
+    assert handed_off == []
+
+    controller = _controller(
+        query_handoff_capability=ConsoleCharacterQueryHandoffCapability(True),
+        query_handoff=handed_off.append,
+    )
+    assert controller.handoff_query("needle") is True
+    assert handed_off == [ConsoleCharacterQueryHandoff("needle")]
+
+
+@pytest.mark.asyncio
+async def test_newer_search_generation_fences_late_activation_presentation() -> None:
+    release = asyncio.Event()
+
+    async def activate(request, _cancel):
+        await release.wait()
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.OPENED,
+            request.target,
+            True,
+        )
+
+    controller = _controller(activate_target=activate)
+    controller._publish(ConsoleCharacterContextState(groups=_groups(), data_revision=7))
+    target = _groups()[0].rows[0].target
+    assert target is not None
+    pending = asyncio.create_task(controller.activate(target))
+    await asyncio.sleep(0)
+    await controller.search("newer")
+    release.set()
+    await pending
+
+    assert controller.state.query == "newer"
+    assert controller.state.error == ""
+    assert len(controller.state.search_rows) == 8
+
+
+@pytest.mark.asyncio
+async def test_search_reports_index_build_instead_of_false_empty_success() -> None:
+    class _BuildingService(_Service):
+        def ensure_keyword_index(self):
+            return CharacterKeywordIndexStatus.BUILDING
+
+        def keyword_search(self, query: str, *, limit: int):
+            return CharacterConversationPage(
+                rows=(),
+                total=0,
+                next_cursor=None,
+                data_revision=7,
+                keyword_status=CharacterKeywordIndexStatus.BUILDING,
+            )
+
+    controller = _controller(service_factory=_BuildingService)
+    await controller.search("needle")
+
+    assert controller.state.search_rows == ()
+    assert controller.state.error == "Character chat search is rebuilding · Retry"
+    assert controller.state.keyword_status is CharacterKeywordIndexStatus.BUILDING
+
+
+@pytest.mark.asyncio
+async def test_browse_reports_missing_local_database_instead_of_false_empty() -> None:
+    controller = _controller(database_accessor=lambda: None)
+
+    await controller.refresh()
+
+    assert controller.state.groups == ()
+    assert controller.state.error == "Local character data is unavailable · Retry"
+
+
+@pytest.mark.asyncio
+async def test_pointer_selects_then_double_click_and_enter_activate_exact_row() -> None:
+    opened: list[LocalCharacterConversationTarget] = []
+
+    async def activate(request, _cancel):
+        opened.append(request.target)
+        return ConsoleConversationActivationResult(
+            ConsoleActivationResultKind.OPENED,
+            request.target,
+            True,
+        )
+
+    state = ConsoleCharacterContextState(
+        groups=_groups(), expanded_key=_groups()[0].key, data_revision=7
+    )
+    app = _CharacterApp(_controller(activate_target=activate), state)
+    async with app.run_test(size=(72, 35)) as pilot:
+        await pilot.pause()
+        app.controller._publish(state)
+        app.screen.query_one(ConsoleCharacterContext).sync_state(state)
+        await pilot.pause()
+        row = app.screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(_groups()[0].rows[0].row_key)}"
+        )
+        assert await pilot.click(row)
+        await pilot.pause()
+        assert opened == []
+        assert await pilot.click(row, times=2)
+        await pilot.pause()
+        assert opened == [row.character_row.target]
+
+        second = app.screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(_groups()[0].rows[1].row_key)}"
+        )
+        second.focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert opened[-1] == second.character_row.target
+
+        header = app.screen.query_one(
+            f"#{ConsoleCharacterContext.group_dom_id(_groups()[0].key)}"
+        )
+        header.focus()
+        await pilot.press("left")
+        await pilot.pause()
+        assert app.controller.state.expanded_key is None
+        await pilot.press("right")
+        await pilot.pause()
+        assert app.controller.state.expanded_key == _groups()[0].key
+
+        second = app.screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(_groups()[0].rows[1].row_key)}"
+        )
+        second.focus()
+        await pilot.press("space")
+        await pilot.pause()
+        assert opened[-1] == second.character_row.target

--- a/Tests/UI/test_console_character_context_geometry.py
+++ b/Tests/UI/test_console_character_context_geometry.py
@@ -92,6 +92,19 @@ async def test_character_context_stays_inside_rail_and_never_claims_task5(
                         break
                 assert geometry.clip.contains_region(action.region)
 
+                if isinstance(action, Input):
+                    painted_search = "\n".join(
+                        strip.text[action.region.x : action.region.right]
+                        for strip in screen._compositor.render_strips()[
+                            action.region.y : action.region.bottom
+                        ]
+                    )
+                    assert "Search chats" in painted_search
+                    assert (
+                        action.name
+                        == "Global Keyword search over local character chats"
+                    )
+
             view_all.focus()
             for _ in range(20):
                 view_all.scroll_visible(animate=False, immediate=True, force=True)

--- a/Tests/UI/test_console_character_context_geometry.py
+++ b/Tests/UI/test_console_character_context_geometry.py
@@ -1,0 +1,454 @@
+"""Mounted geometry contracts for the Console Character browser."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button, Input
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.console_rail_section_helpers import open_rail_section
+from Tests.UI.consolidated_css import BUNDLED_STYLESHEET
+from Tests.UI.test_console_character_avatar import _set_chat_images_setting
+from Tests.UI.test_console_character_context import _groups, _resolved
+from Tests.UI.test_console_inspector_compact_access import _stored_rail_preferences
+from Tests.UI.test_console_left_rail import make_console_pilot
+from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+    ResolvedLocalCharacterKey,
+    UnresolvedConversationKey,
+)
+from tldw_chatbook.Chat.console_conversation_activation import (
+    CharacterConversationActivationRequest,
+    ConsoleActivationResultKind,
+    ConsoleConversationActivationResult,
+)
+from tldw_chatbook.Chat.console_rail_state import (
+    CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Console_Modules.character_context import (
+    ConsoleCharacterContextState,
+)
+from tldw_chatbook.UI.Navigation.character_conversation_navigation import (
+    LibraryCharacterRepairContext,
+    LibraryUnavailableConversationInspection,
+    LibraryUnavailableConversationsBrowse,
+    RoleplayCharacterConversationLink,
+)
+from tldw_chatbook.Widgets.Console.console_character_context import (
+    ConsoleCharacterContext,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", ((52, 20), (72, 35), (80, 24), (120, 50)))
+async def test_character_context_stays_inside_rail_and_never_claims_task5(
+    size, tmp_path
+) -> None:
+    async with make_console_pilot(size=size, production_styles=True) as pilot:
+        screen = pilot.app.screen
+        if size[0] >= 72:
+            screen._set_console_rail_preference(
+                left_open=True,
+                notify_on_failure=False,
+            )
+            await pilot.pause(0.4)
+            rail = screen.query_one("#console-left-rail")
+            assert rail.display
+            await open_rail_section(screen, pilot, "character")
+            await pilot.pause(0.4)
+            browse_state = ConsoleCharacterContextState(
+                groups=_groups(),
+                expanded_key=_groups()[0].key,
+                data_revision=7,
+            )
+            screen._character_context._publish(browse_state)
+            await pilot.pause()
+            character = screen.query_one("#console-character-context")
+            character_geometry = screen.find_widget(character)
+            assert character_geometry.clip
+            assert rail.region.contains_region(character_geometry.clip)
+            assert len(screen.query(".console-character-group")) == 4
+            assert len(screen.query(".console-character-row")) == 5
+            view_all = screen.query_one(
+                f"#{ConsoleCharacterContext.action_dom_id('view-all', _groups()[0].key)}"
+            )
+            assert str(view_all.label) == "View all 9 in Roleplay"
+            for action in character.query("Button, Input"):
+                action.focus()
+                for _ in range(20):
+                    action.scroll_visible(animate=False, immediate=True, force=True)
+                    await pilot.pause(0.05)
+                    geometry = screen.find_widget(action)
+                    if geometry.clip.contains_region(action.region):
+                        break
+                assert geometry.clip.contains_region(action.region)
+
+            view_all.focus()
+            for _ in range(20):
+                view_all.scroll_visible(animate=False, immediate=True, force=True)
+                await pilot.pause(0.05)
+                painted = "\n".join(
+                    strip.text for strip in screen._compositor.render_strips()
+                )
+                if "View all 9 in Roleplay" in painted:
+                    break
+            assert "View all 9 in Roleplay" in painted
+            pilot.app.save_screenshot(
+                filename=f"character-browse-{size[0]}x{size[1]}.svg",
+                path=str(tmp_path),
+            )
+            (tmp_path / "browse-paint.txt").write_text(painted, encoding="utf-8")
+
+            search_state = ConsoleCharacterContextState(
+                groups=_groups(),
+                query="needle",
+                search_rows=tuple(
+                    replace(
+                        _resolved(1, f"search-{index}"),
+                        last_modified=datetime.now(UTC).isoformat(),
+                    )
+                    for index in range(8)
+                ),
+                data_revision=7,
+            )
+            screen._character_context._publish(search_state)
+            await pilot.pause()
+            assert len(character.query(".console-character-row")) == 8
+            for action in character.query("Button, Input"):
+                action.focus()
+                for _ in range(20):
+                    action.scroll_visible(animate=False, immediate=True, force=True)
+                    await pilot.pause(0.05)
+                    geometry = screen.find_widget(action)
+                    if geometry.clip.contains_region(action.region):
+                        break
+                assert geometry.clip.contains_region(action.region), [
+                    (
+                        str(parent),
+                        parent.region,
+                        parent.virtual_size,
+                        parent.scroll_y,
+                        parent.max_scroll_y,
+                    )
+                    for parent in action.ancestors
+                    if hasattr(parent, "scroll_y")
+                ]
+                if action.has_class("console-character-row"):
+                    strips = screen._compositor.render_strips()
+                    row_paint = "\n".join(
+                        strip.text[action.region.x : action.region.right]
+                        for strip in strips[action.region.y : action.region.bottom]
+                    )
+                    assert "Character 1" in row_paint
+                    assert "Local" in row_paint
+                    assert "now" in row_paint
+        else:
+            character = screen.query_one("#console-character-context")
+            character_controls = set(character.query(Button)) | set(
+                character.query(Input)
+            )
+            assert character_controls.isdisjoint(screen.focus_chain)
+        rendered = str(screen.render())
+        assert "Continue search in Character chats" not in rendered
+        painted = "\n".join(strip.text for strip in screen._compositor.render_strips())
+        assert "Continue search in Character chats" not in painted
+        pilot.app.save_screenshot(
+            filename=f"character-final-{size[0]}x{size[1]}.svg",
+            path=str(tmp_path),
+        )
+        (tmp_path / "final-paint.txt").write_text(painted, encoding="utf-8")
+
+
+@pytest.fixture
+def character_walkthrough_database(tmp_path: Path, record_property):
+    """Close the test-owned handle after the Pilot host and workers settle."""
+    database = CharactersRAGDB(
+        tmp_path / "task4-walkthrough.sqlite",
+        client_id="task4-walkthrough",
+    )
+    try:
+        yield database
+    finally:
+        record_property(
+            "context_db_connections_before_close",
+            database.registered_connection_count(),
+        )
+        database.close()
+        record_property(
+            "context_db_connections_after_close",
+            database.registered_connection_count(),
+        )
+
+
+@pytest.mark.asyncio
+async def test_real_console_walkthrough_uses_synthetic_local_database(
+    character_walkthrough_database,
+) -> None:
+    """Walk every Step 10 state in one production-composed Textual host."""
+
+    app = _build_test_app()
+    database = character_walkthrough_database
+    app.chachanotes_db = database
+    character_id = database.add_character_card({"name": "Synthetic Ada"})
+    assert character_id is not None
+    authority = database.get_local_authority_id()
+    assert (
+        database.add_conversation(
+            {
+                "id": "task4-synthetic-chat",
+                "character_id": character_id,
+                "assistant_kind": "character",
+                "assistant_id": str(character_id),
+                "assistant_authority_id": authority,
+                "title": "Lantern archive",
+            }
+        )
+        == "task4-synthetic-chat"
+    )
+    assert (
+        database.add_message(
+            {
+                "id": "task4-synthetic-message",
+                "conversation_id": "task4-synthetic-chat",
+                "sender": "user",
+                "role": "user",
+                "content": "SYNTHETIC_LANTERN_CANARY",
+                "timestamp": "2026-09-03T12:00:00Z",
+            }
+        )
+        == "task4-synthetic-message"
+    )
+    database.set_conversation_active_leaf(
+        "task4-synthetic-chat", "task4-synthetic-message"
+    )
+    assert (
+        database.add_conversation(
+            {
+                "id": "task4-unavailable-chat",
+                "character_id": character_id,
+                "assistant_kind": "character",
+                "assistant_id": str(character_id),
+                "assistant_authority_id": authority,
+                "title": "Historical unavailable chat",
+            }
+        )
+        == "task4-unavailable-chat"
+    )
+    assert (
+        database.add_message(
+            {
+                "id": "task4-unavailable-message",
+                "conversation_id": "task4-unavailable-chat",
+                "sender": "user",
+                "role": "user",
+                "content": "historical unavailable",
+                "timestamp": "2026-09-03T11:00:00Z",
+            }
+        )
+        == "task4-unavailable-message"
+    )
+    database.set_conversation_active_leaf(
+        "task4-unavailable-chat", "task4-unavailable-message"
+    )
+    with database.transaction() as connection:
+        connection.execute(
+            "UPDATE conversations SET assistant_authority_id = NULL, "
+            "assistant_id = 'historical-unknown' WHERE id = ?",
+            ("task4-unavailable-chat",),
+        )
+    _configure_native_ready_console(app)
+    _set_chat_images_setting(app, "show_character_avatar", False)
+
+    class ProductionStyledConsoleHarness(ConsoleHarness):
+        CSS_PATH = str(BUNDLED_STYLESHEET)
+
+    host = ProductionStyledConsoleHarness(app)
+    async with host.run_test(size=(120, 50)) as pilot:
+        screen = host.screen_stack[-1]
+        await _wait_for_selector(screen, pilot, "#console-native-composer")
+        for _ in range(80):
+            if screen._character_context.state.groups:
+                break
+            await pilot.pause(0.05)
+        labels = {
+            group.character_label for group in screen._character_context.state.groups
+        }
+        assert labels == {"Synthetic Ada", "Chats with unavailable characters"}
+        await open_rail_section(screen, pilot, "character")
+        await pilot.pause()
+
+        # First-use and returning-user disclosure are exercised through the
+        # canonical screen writer in this production composition.
+        assert screen._current_console_rail_state().character_open
+        screen._toggle_console_rail_section("character", next_open=False)
+        await pilot.pause()
+        stored = _stored_rail_preferences(app)
+        assert stored["character_open"] is False
+        assert stored[CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY] is True
+        screen._toggle_console_rail_section("character", next_open=True)
+        await pilot.pause()
+        assert _stored_rail_preferences(app)["character_open"] is True
+        assert not screen.query_one("#console-character-avatar-frame").display
+
+        controller = screen._character_context
+        activations: list[CharacterConversationActivationRequest] = []
+        roleplay_links: list[RoleplayCharacterConversationLink] = []
+        repair_contexts: list[LibraryCharacterRepairContext] = []
+        inspection_links: list[LibraryUnavailableConversationInspection] = []
+        unavailable_browses: list[LibraryUnavailableConversationsBrowse] = []
+        roleplay_home: list[bool] = []
+
+        async def activate(request, _cancellation):
+            activations.append(request)
+            return ConsoleConversationActivationResult(
+                ConsoleActivationResultKind.OPENED,
+                request.target,
+                True,
+            )
+
+        controller._activate_target = activate
+        controller._navigate_roleplay = roleplay_links.append
+        controller._navigate_repair = repair_contexts.append
+        controller._navigate_inspection = inspection_links.append
+        controller._navigate_unavailable_browse = unavailable_browses.append
+        controller._navigate_roleplay_home = lambda: roleplay_home.append(True)
+
+        resolved_group = next(
+            group
+            for group in controller.state.groups
+            if isinstance(group.key, ResolvedLocalCharacterKey)
+        )
+        if controller.state.expanded_key != resolved_group.key:
+            screen.query_one(
+                f"#{ConsoleCharacterContext.group_dom_id(resolved_group.key)}",
+                Button,
+            ).press()
+            await pilot.pause()
+
+        row_key = resolved_group.rows[0].row_key
+        row_id = ConsoleCharacterContext.row_dom_id(row_key)
+        row = screen.query_one(f"#{row_id}")
+        row.press()
+        for _ in range(40):
+            if activations:
+                break
+            await pilot.pause(0.05)
+        assert activations and activations[0].target == resolved_group.rows[0].target
+
+        await pilot.pause()
+        screen.query_one(
+            f"#{ConsoleCharacterContext.action_dom_id('view-all', resolved_group.key)}",
+            Button,
+        ).press()
+        await pilot.pause()
+        assert roleplay_links and roleplay_links[0].character == resolved_group.key
+
+        row = screen.query_one(f"#{row_id}")
+        row.focus()
+        await pilot.pause()
+        search = screen.query_one("#console-character-search", Input)
+        search.focus()
+        await pilot.pause()
+        search.value = "SYNTHETIC_LANTERN_CANARY"
+        for _ in range(80):
+            state = screen._character_context.state
+            if state.query and not state.loading:
+                break
+            await pilot.pause(0.05)
+        state = screen._character_context.state
+        assert len(state.search_rows) == 1
+        assert state.search_rows[0].selected_excerpt == ""
+        await _wait_for_selector(
+            screen,
+            pilot,
+            f"#{row_id}",
+        )
+        search_row = screen.query_one(f"#{row_id}")
+        assert "Local" in str(search_row.label)
+
+        await pilot.press("escape")
+        for _ in range(80):
+            if (
+                not screen._character_context.state.query
+                and getattr(screen.focused, "id", None) == row_id
+            ):
+                break
+            await pilot.pause(0.05)
+        assert screen._character_context.state.query == ""
+        assert getattr(screen.focused, "id", None) == row_id
+
+        unavailable_group = next(
+            group
+            for group in controller.state.groups
+            if isinstance(group.key, UnresolvedConversationKey)
+        )
+        screen.query_one(
+            f"#{ConsoleCharacterContext.group_dom_id(unavailable_group.key)}",
+            Button,
+        ).press()
+        await pilot.pause()
+        unavailable_row = unavailable_group.rows[0]
+        screen.query_one(
+            f"#{ConsoleCharacterContext.row_dom_id(unavailable_row.row_key)}",
+            Button,
+        ).focus()
+        await pilot.pause()
+        reason = screen.query_one("#console-character-unavailable-reason")
+        assert str(reason.renderable) == "Historical identity incomplete"
+        await controller.refresh_unavailable_details((unavailable_group,))
+        await pilot.pause()
+        assert screen.query_one("#console-character-repair-library", Button)
+        screen.query_one("#console-character-open-library", Button).press()
+        for _ in range(40):
+            if inspection_links:
+                break
+            await pilot.pause(0.05)
+        assert inspection_links[0].unresolved == unavailable_row.unresolved
+        assert repair_contexts == []
+        await _wait_for_selector(
+            screen,
+            pilot,
+            "#console-character-repair-library",
+        )
+        screen.query_one("#console-character-repair-library", Button).press()
+        for _ in range(40):
+            if repair_contexts:
+                break
+            await pilot.pause(0.05)
+        assert repair_contexts[0].unresolved == unavailable_row.unresolved
+        unavailable_view_all_id = ConsoleCharacterContext.action_dom_id(
+            "view-all", unavailable_group.key
+        )
+        await _wait_for_selector(screen, pilot, f"#{unavailable_view_all_id}")
+        screen.query_one(
+            f"#{unavailable_view_all_id}",
+            Button,
+        ).press()
+        for _ in range(40):
+            if unavailable_browses:
+                break
+            await pilot.pause(0.05)
+        assert unavailable_browses[0].selected == unavailable_row.unresolved
+
+        # Overall empty recovery and the narrow fallback remain truthful and
+        # do not advertise the dormant Task 5 capability.
+        controller._publish(ConsoleCharacterContextState())
+        await pilot.pause()
+        screen.query_one("#console-character-open-roleplay", Button).press()
+        await pilot.pause()
+        assert roleplay_home == [True]
+        await pilot.resize_terminal(52, 20)
+        await pilot.pause()
+        character = screen.query_one("#console-character-context")
+        controls = set(character.query(Button)) | set(character.query(Input))
+        assert controls.isdisjoint(screen.focus_chain)
+        assert "Continue search in Character chats" not in str(screen.render())

--- a/Tests/UI/test_console_context_rail_content.py
+++ b/Tests/UI/test_console_context_rail_content.py
@@ -77,6 +77,25 @@ async def test_character_avatar_placeholder_does_not_echo_the_name_row() -> None
 
 
 @pytest.mark.asyncio
+async def test_character_is_between_conversations_and_model() -> None:
+    """Character navigation has a stable peer position in the Context rail."""
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        ids = [
+            widget.id
+            for widget in screen.query(".console-rail-section-header")
+            if widget.id
+        ]
+        assert ids.index("console-rail-section-header-conversations") + 1 == ids.index(
+            "console-rail-section-header-character"
+        )
+        assert ids.index("console-rail-section-header-character") + 1 == ids.index(
+            "console-rail-section-header-model"
+        )
+        assert screen.query_one("#console-character-context")
+
+
+@pytest.mark.asyncio
 async def test_no_keyboard_reachable_context_control_paints_nothing() -> None:
     """Every control Tab can reach in the rail must actually be on screen.
 

--- a/Tests/UI/test_console_inspector_compact_access.py
+++ b/Tests/UI/test_console_inspector_compact_access.py
@@ -427,7 +427,9 @@ async def test_console_rail_scope_seeding_is_lossless_one_time_and_responsive_sa
         )
         defaults = serialize_console_rail_preferences(ConsoleRailPreferences())
         seeded_defaults = {
-            key: value for key, value in defaults.items() if key != "right_open"
+            key: value
+            for key, value in defaults.items()
+            if key not in {"right_open", "character_open"}
         }
         workspace_payload = {**defaults, "left_open": False, "workspace_open": False}
         legacy_payload = {**defaults, "right_open": True, "details_open": True}

--- a/Tests/UI/test_console_left_rail.py
+++ b/Tests/UI/test_console_left_rail.py
@@ -110,10 +110,10 @@ async def test_context_section_headers_match_inspector_title_band() -> None:
         assert [section.max_content_lines for section in sections] == [
             20,
             20,
-            15,
-            15,
-            15,
             35,
+            15,
+            15,
+            15,
         ]
 
 
@@ -297,28 +297,28 @@ async def test_context_direct_bodies_use_six_bounded_wrappers_in_dom_order():
         assert [section.section_id for section in sections] == [
             "workspace",
             "conversations",
+            "character",
             "model",
             "agent",
             "details",
-            "character",
         ]
         assert [section.max_content_lines for section in sections] == [
             20,
             20,
-            15,
-            15,
-            15,
             35,
+            15,
+            15,
+            15,
         ]
         assert [
             section.query_one(".console-rail-section-body").id for section in sections
         ] == [
             "console-rail-section-body-workspace",
             "console-rail-section-body-conversations",
+            "console-rail-section-body-character",
             "console-rail-section-body-model",
             "console-rail-section-body-agent",
             "console-rail-section-body-details",
-            "console-rail-section-body-character",
         ]
         assert [
             (
@@ -329,12 +329,12 @@ async def test_context_direct_bodies_use_six_bounded_wrappers_in_dom_order():
         ] == [
             (section_id, section_id)
             for section_id in [
-                                "workspace",
+                "workspace",
                 "conversations",
+                "character",
                 "model",
                 "agent",
                 "details",
-                "character",
             ]
         ]
         assert all(
@@ -377,12 +377,12 @@ async def test_pinned_terminal_action_posts_typed_request_outside_six_sections(
 
 
 @pytest.mark.asyncio
-async def test_character_absence_omits_its_bounded_descriptor_without_phantom_body():
-    """The config-gated Character section vanishes from the mounted allocation set."""
+async def test_avatar_preference_never_omits_character_navigation_descriptor():
+    """The old image gate hides pixels, not Character navigation."""
 
     async with make_console_pilot() as pilot:
         rail = pilot.app.screen.query_one("#console-left-rail")
-        rail._show_character_section = False
+        rail._show_character_avatar = False
         await rail.recompose()
         await pilot.pause()
 
@@ -390,8 +390,9 @@ async def test_character_absence_omits_its_bounded_descriptor_without_phantom_bo
             section.section_id
             for section in rail.query("#console-left-rail-body ConsoleBoundedSection")
         ] == [
-                        "workspace",
+            "workspace",
             "conversations",
+            "character",
             "model",
             "agent",
             "details",
@@ -406,8 +407,9 @@ async def test_character_absence_omits_its_bounded_descriptor_without_phantom_bo
         ] == [
             (section_id, section_id)
             for section_id in [
-                                "workspace",
+                "workspace",
                 "conversations",
+                "character",
                 "model",
                 "agent",
                 "details",
@@ -418,7 +420,7 @@ async def test_character_absence_omits_its_bounded_descriptor_without_phantom_bo
             and isinstance(direct_children[index + 1], ConsoleBoundedSection)
             for index in range(0, len(direct_children), 2)
         )
-        assert not rail.query("#console-bounded-section-character")
+        assert rail.query_one("#console-character-avatar-frame").display is False
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_content_hub.py
+++ b/Tests/UI/test_library_content_hub.py
@@ -3,17 +3,15 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 import time
 from collections.abc import Iterable, Sequence
-from typing import Any
+from types import SimpleNamespace
+from typing import Any, ClassVar
 
 import pytest
 from textual.widgets import Button, Input, Static
 
-from tldw_chatbook.Constants import (
-    LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
-    LIBRARY_NAV_CONTEXT_MODE,
-)
 from Tests.UI.test_destination_shells import (
     DestinationHarness,
     StaticLibraryConversationScopeService,
@@ -24,6 +22,24 @@ from Tests.UI.test_destination_shells import (
     _visible_text,
     _wait_for_selector,
 )
+from tldw_chatbook import Constants as constants
+from tldw_chatbook.Character_Chat import (
+    character_conversation_navigation as character_service_module,
+)
+from tldw_chatbook.Character_Chat.character_conversation_navigation import (
+    CharacterConversationPage,
+    CharacterConversationRow,
+    UnavailableCharacterReason,
+    UnresolvedConversationKey,
+)
+from tldw_chatbook.Constants import (
+    LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
+    LIBRARY_NAV_CONTEXT_MODE,
+)
+from tldw_chatbook.UI.Navigation import (
+    character_conversation_navigation as character_navigation,
+)
+from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 
 
 async def _wait_for_library_shell_ready(screen, pilot, *, timeout: float = 2.0) -> None:
@@ -371,6 +387,458 @@ async def test_library_navigation_context_opens_requested_conversation() -> None
         assert screen.query_one("#library-row-browse-conversations", Button).has_class(
             "library-rail-row-selected"
         )
+
+
+@pytest.mark.asyncio
+async def test_library_unavailable_inspection_opens_exact_detail_once_without_repair() -> (
+    None
+):
+    """Inspection keeps its typed intent through exact detail settlement."""
+
+    assert hasattr(constants, "LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION")
+    assert hasattr(constants, "LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE")
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [
+            {"title": "Other chat", "conversation_id": "chat-1"},
+            {"title": "Unavailable chat", "conversation_id": "chat-2"},
+        ]
+    )
+    authority = "task4-library-authority"
+    app.chachanotes_db = SimpleNamespace(
+        get_local_authority_id=lambda: authority,
+    )
+    unresolved = UnresolvedConversationKey(authority, "chat-2")
+    return_target = (
+        character_navigation.RoleplayReturnTarget.console_context_character()
+    )
+    key = constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION
+    value = character_navigation.serialize_library_unavailable_inspection(
+        character_navigation.LibraryUnavailableConversationInspection(
+            unresolved, return_target
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen.apply_navigation_context({key: value})
+        await _wait_for_library_conversation_selection(
+            screen, pilot, "chat-2", "Unavailable chat"
+        )
+
+        assert not screen.query("#library-character-repair-dialog")
+        assert screen._library_selected_row_id == "browse-conversations"
+        assert screen._pending_library_source_open is None
+        locator_calls = [
+            call
+            for call in app.chat_conversation_scope_service.calls
+            if call.get("locator")
+        ]
+        assert len(locator_calls) == 1
+        await screen._unavailable_navigation._open_pending_library_character_navigation(
+            screen,
+        )
+        assert (
+            len(
+                [
+                    call
+                    for call in app.chat_conversation_scope_service.calls
+                    if call.get("locator")
+                ]
+            )
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_library_unavailable_browse_is_complete_explicit_projection(
+    monkeypatch,
+) -> None:
+    """Browse excludes ordinary resolved rows and preserves the selected anchor."""
+
+    authority = "task4-library-authority"
+    unresolved_rows = tuple(
+        CharacterConversationRow.unavailable(
+            UnresolvedConversationKey(authority, conversation_id),
+            reason=UnavailableCharacterReason.MISSING_CARD,
+            character_label="Missing",
+            title=title,
+            last_modified=f"2026-09-0{index}T10:00:00Z",
+            created_at="2026-09-01T00:00:00Z",
+        )
+        for index, (conversation_id, title) in enumerate(
+            (("chat-2", "Unavailable chat"), ("chat-3", "Also unavailable")),
+            start=1,
+        )
+    )
+
+    class NavigationService:
+        def __init__(self, _database):
+            pass
+
+        def unavailable_page(self, *, offset: int, limit: int):
+            rows = unresolved_rows[offset : offset + limit]
+            return CharacterConversationPage(rows, 2, None, 7)
+
+    monkeypatch.setattr(
+        character_service_module,
+        "CharacterConversationNavigationService",
+        NavigationService,
+    )
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService(
+        [{"title": "Ordinary resolved chat", "conversation_id": "chat-1"}]
+    )
+    app.chachanotes_db = SimpleNamespace(get_local_authority_id=lambda: authority)
+    selected = UnresolvedConversationKey(authority, "chat-3")
+    payload = character_navigation.serialize_library_unavailable_browse(
+        character_navigation.LibraryUnavailableConversationsBrowse(
+            selected,
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen.apply_navigation_context(
+            {constants.LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: payload}
+        )
+        for _ in range(80):
+            if screen._conversations_state.total == 2:
+                break
+            await pilot.pause(0.05)
+
+        assert screen._conversations_state.total == 2
+        assert screen._selected_conversation_id == "chat-3"
+        assert {
+            str(record.get("conversation_id"))
+            for record in screen._conversations_state.page_records
+        } == {"chat-2", "chat-3"}
+        await _wait_for_selector(screen, pilot, "#library-conversations-title")
+        title = screen.query_one("#library-conversations-title", Static)
+        assert str(title.renderable) == "Unavailable character conversations (2)"
+        assert "Ordinary resolved chat" not in _visible_text(screen)
+        assert screen._pending_library_character_navigation is None
+
+
+@pytest.mark.asyncio
+async def test_library_unavailable_browse_owns_page_filter_and_retry(
+    monkeypatch,
+) -> None:
+    """Pager/filter/retry must stay on the retained unavailable-only source."""
+
+    authority = "task4-library-authority"
+    page_size = library_screen_module.LIBRARY_CONVERSATION_PAGE_SIZE
+    rows = tuple(
+        CharacterConversationRow.unavailable(
+            UnresolvedConversationKey(authority, f"chat-{index:02d}"),
+            reason=UnavailableCharacterReason.MISSING_CARD,
+            character_label="Missing",
+            title=("Special unavailable" if index == page_size else f"Lost {index}"),
+            last_modified=f"2026-09-03T10:{index:02d}:00Z",
+            created_at="2026-09-01T00:00:00Z",
+        )
+        for index in range(page_size + 1)
+    )
+
+    class NavigationService:
+        calls: ClassVar[list[tuple[int, int, str]]] = []
+        fail_retry_once = True
+
+        def __init__(self, _database):
+            pass
+
+        def unavailable_page(self, *, offset: int, limit: int, query: str = ""):
+            type(self).calls.append((offset, limit, query))
+            if query == "retry" and type(self).fail_retry_once:
+                type(self).fail_retry_once = False
+                raise RuntimeError("temporary failure")
+            matching = tuple(
+                row
+                for row in rows
+                if not query or query.casefold() in row.title.casefold()
+            )
+            return CharacterConversationPage(
+                matching[offset : offset + limit],
+                len(matching),
+                None,
+                7,
+            )
+
+    monkeypatch.setattr(
+        character_service_module,
+        "CharacterConversationNavigationService",
+        NavigationService,
+    )
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    ordinary = StaticLibraryConversationScopeService(
+        [{"title": "Ordinary resolved chat", "conversation_id": "ordinary"}]
+    )
+    app.chat_conversation_scope_service = ordinary
+    database = SimpleNamespace(get_local_authority_id=lambda: authority)
+    app.chachanotes_db = database
+    selected = UnresolvedConversationKey(authority, f"chat-{page_size:02d}")
+    payload = character_navigation.serialize_library_unavailable_browse(
+        character_navigation.LibraryUnavailableConversationsBrowse(
+            selected,
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen.apply_navigation_context(
+            {constants.LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: payload}
+        )
+        for _ in range(80):
+            if screen._conversations_state.total == page_size + 1:
+                break
+            await pilot.pause(0.05)
+        ordinary_calls = len(ordinary.calls)
+        assert screen._pending_library_character_navigation is None
+        assert screen._library_unavailable_browse_scope is not None
+
+        screen.query_one("#library-conversations-next", Button).press()
+        for _ in range(80):
+            if screen._conversations_state.page == 2:
+                break
+            await pilot.pause(0.05)
+        assert NavigationService.calls[-1] == (page_size, page_size, "")
+        assert screen._conversations_state.total == page_size + 1
+        assert [
+            record["conversation_id"]
+            for record in screen._conversations_state.page_records
+        ] == [f"chat-{page_size:02d}"]
+        assert screen._selected_conversation_id == selected.conversation_id
+        assert len(ordinary.calls) == ordinary_calls
+
+        filter_input = screen.query_one("#library-conversations-filter", Input)
+        filter_input.value = "Special"
+        filter_input.focus()
+        await pilot.press("enter")
+        expected_filter_call = (0, page_size, "Special")
+        for _ in range(80):
+            if (
+                screen._conversations_state.requested_query == "Special"
+                and not screen._conversations_state.loading
+                and NavigationService.calls[-1:] == [expected_filter_call]
+            ):
+                break
+            await pilot.pause(0.05)
+        assert NavigationService.calls[-1] == expected_filter_call
+        assert screen._conversations_state.total == 1
+        assert len(ordinary.calls) == ordinary_calls
+
+        filter_input = screen.query_one("#library-conversations-filter", Input)
+        filter_input.value = "retry"
+        filter_input.focus()
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-conversations-retry")
+        screen.query_one("#library-conversations-retry", Button).press()
+        expected_retry_calls = [
+            (0, page_size, "retry"),
+            (0, page_size, "retry"),
+        ]
+        for _ in range(80):
+            if (
+                screen._conversations_state.requested_query == "retry"
+                and not screen._conversations_state.loading
+                and not screen._conversations_state.error
+                and NavigationService.calls[-2:] == expected_retry_calls
+            ):
+                break
+            await pilot.pause(0.05)
+        assert NavigationService.calls[-2:] == expected_retry_calls
+        assert len(ordinary.calls) == ordinary_calls
+        assert screen._library_unavailable_browse_scope is not None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_stage", ("service", "final_recompose"))
+async def test_library_unavailable_browse_rejects_profile_churn_before_commit(
+    monkeypatch,
+    blocked_stage: str,
+) -> None:
+    """Old-profile unavailable rows never commit across either final await."""
+
+    authority = "task4-library-authority"
+    entered = threading.Event()
+    release = threading.Event()
+
+    class NavigationService:
+        returned = False
+
+        def __init__(self, _database):
+            pass
+
+        def unavailable_page(self, *, offset: int, limit: int, query: str = ""):
+            if blocked_stage == "service":
+                entered.set()
+                assert release.wait(2)
+            type(self).returned = True
+            row = CharacterConversationRow.unavailable(
+                UnresolvedConversationKey(authority, "old-unavailable"),
+                reason=UnavailableCharacterReason.MISSING_CARD,
+                character_label="Missing",
+                title="Old unavailable",
+                last_modified="2026-09-03T10:00:00Z",
+                created_at="2026-09-01T00:00:00Z",
+            )
+            return CharacterConversationPage((row,), 1, None, 7)
+
+    monkeypatch.setattr(
+        character_service_module,
+        "CharacterConversationNavigationService",
+        NavigationService,
+    )
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    database = SimpleNamespace(get_local_authority_id=lambda: authority)
+    app.chachanotes_db = database
+    selected = UnresolvedConversationKey(authority, "old-unavailable")
+    payload = character_navigation.serialize_library_unavailable_browse(
+        character_navigation.LibraryUnavailableConversationsBrowse(
+            selected,
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        original_recompose = screen.recompose
+
+        async def blocked_recompose():
+            if (
+                blocked_stage == "final_recompose"
+                and NavigationService.returned
+                and not entered.is_set()
+            ):
+                entered.set()
+                assert await asyncio.to_thread(release.wait, 2)
+            return await original_recompose()
+
+        monkeypatch.setattr(screen, "recompose", blocked_recompose)
+        screen.apply_navigation_context(
+            {constants.LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: payload}
+        )
+        assert await asyncio.to_thread(entered.wait, 2)
+        app.chachanotes_db = SimpleNamespace(get_local_authority_id=lambda: authority)
+        release.set()
+        await pilot.pause(0.3)
+
+        assert screen._pending_library_character_navigation is None
+        assert screen._library_unavailable_browse_scope is None
+        assert screen._conversations_state.loading is False
+        assert all(
+            record.get("conversation_id") != "old-unavailable"
+            for record in screen._conversations_state.page_records
+        )
+        assert screen._selected_conversation_id != "old-unavailable"
+        assert "Old unavailable" not in _visible_text(screen)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("blocked_stage", ("flush", "lookup"))
+async def test_library_character_route_rejects_profile_churn_across_await(
+    blocked_stage: str,
+) -> None:
+    """A new DB handle cannot consume an admitted typed route, even with same authority."""
+
+    authority = "task4-library-authority"
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    class BlockingConversationService(StaticLibraryConversationScopeService):
+        async def locate_conversation_page(self, conversation_id, **kwargs):
+            if blocked_stage == "lookup":
+                entered.set()
+                await release.wait()
+            return await super().locate_conversation_page(conversation_id, **kwargs)
+
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    service = BlockingConversationService(
+        [{"title": "Unavailable chat", "conversation_id": "chat-2"}]
+    )
+    app.chat_conversation_scope_service = service
+    old_database = SimpleNamespace(get_local_authority_id=lambda: authority)
+    app.chachanotes_db = old_database
+    unresolved = UnresolvedConversationKey(authority, "chat-2")
+    payload = character_navigation.serialize_library_unavailable_inspection(
+        character_navigation.LibraryUnavailableConversationInspection(
+            unresolved,
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        if blocked_stage == "flush":
+
+            async def blocked_flush():
+                entered.set()
+                await release.wait()
+                return True
+
+            screen._flush_active_file_notes = blocked_flush
+        screen.apply_navigation_context(
+            {constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: payload}
+        )
+        await asyncio.wait_for(entered.wait(), 2)
+        app.chachanotes_db = SimpleNamespace(get_local_authority_id=lambda: authority)
+        release.set()
+        await pilot.pause(0.3)
+
+        assert screen._selected_conversation_id != "chat-2"
+        assert screen._pending_library_character_navigation is None
+        if blocked_stage == "flush":
+            assert not any(call.get("locator") for call in service.calls)
+
+
+@pytest.mark.asyncio
+async def test_library_character_route_rejects_authority_mismatch() -> None:
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    service = StaticLibraryConversationScopeService(
+        [{"title": "Wrong profile", "conversation_id": "chat-2"}]
+    )
+    app.chat_conversation_scope_service = service
+    app.chachanotes_db = SimpleNamespace(
+        get_local_authority_id=lambda: "active-authority"
+    )
+    payload = character_navigation.serialize_library_unavailable_inspection(
+        character_navigation.LibraryUnavailableConversationInspection(
+            UnresolvedConversationKey("other-authority", "chat-2"),
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+
+    async with host.run_test(size=(180, 50)) as pilot:
+        screen = _active_destination_screen(host)
+        screen.apply_navigation_context(
+            {constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: payload}
+        )
+        await pilot.pause(0.2)
+
+        assert screen._selected_conversation_id != "chat-2"
+        assert screen._pending_library_character_navigation is None
+        assert not any(call.get("locator") for call in service.calls)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_content_hub.py
+++ b/Tests/UI/test_library_content_hub.py
@@ -842,6 +842,52 @@ async def test_library_character_route_rejects_authority_mismatch() -> None:
 
 
 @pytest.mark.asyncio
+async def test_character_authority_read_yields_ui_and_cannot_admit_superseded_route():
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    entered, release = threading.Event(), threading.Event()
+    read_threads = []
+
+    def delayed_authority():
+        read_threads.append(threading.get_ident())
+        entered.set()
+        release.wait(0.4)
+        return "slow-authority"
+
+    app.chachanotes_db = SimpleNamespace(get_local_authority_id=delayed_authority)
+    payload = character_navigation.serialize_library_unavailable_inspection(
+        character_navigation.LibraryUnavailableConversationInspection(
+            UnresolvedConversationKey("slow-authority", "stale-chat"),
+            character_navigation.RoleplayReturnTarget.console_context_character(),
+        )
+    )
+    host = DestinationHarness(app, "library")
+    try:
+        async with host.run_test(size=(120, 40)) as pilot:
+            screen = _active_destination_screen(host)
+            await _wait_for_library_shell_ready(screen, pilot)
+            started = time.monotonic()
+            screen.apply_navigation_context(
+                {constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: payload}
+            )
+            assert time.monotonic() - started < 0.1
+            assert await asyncio.to_thread(entered.wait, 1)
+            heartbeat = asyncio.Event()
+            asyncio.get_running_loop().call_soon(heartbeat.set)
+            await asyncio.wait_for(heartbeat.wait(), 0.1)
+            assert screen._conversations_state.loading
+            screen.apply_navigation_context({LIBRARY_NAV_CONTEXT_MODE: "search"})
+            release.set()
+            await pilot.pause(0.2)
+            assert screen._selected_conversation_id != "stale-chat"
+            assert read_threads and threading.get_ident() not in read_threads
+    finally:
+        release.set()
+
+
+@pytest.mark.asyncio
 async def test_library_navigation_context_opens_requested_valid_mode() -> None:
     app = _build_test_app()
     _seed_library_content(app)

--- a/Tests/UI/test_library_content_hub.py
+++ b/Tests/UI/test_library_content_hub.py
@@ -842,6 +842,182 @@ async def test_library_character_route_rejects_authority_mismatch() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "incoming",
+    (
+        "invalid_repair",
+        "invalid_character",
+        "ordinary_veto",
+        "typed_veto",
+        "superseded_typed",
+    ),
+)
+async def test_rejected_navigation_preserves_committed_unavailable_browse(
+    monkeypatch, incoming
+):
+    from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+
+    authority = "retained-authority"
+    key = UnresolvedConversationKey(authority, "retained-chat")
+    row = CharacterConversationRow.unavailable(
+        key,
+        reason=UnavailableCharacterReason.MISSING_CARD,
+        character_label="Unavailable",
+        title="Retained chat",
+        last_modified="2026-09-03T10:00:00Z",
+        created_at="2026-09-01T00:00:00Z",
+    )
+
+    class NavigationService:
+        def __init__(self, database):
+            pass
+
+        def unavailable_page(self, *, offset, limit, query=""):
+            return CharacterConversationPage((row,), 1, None, 7)
+
+    monkeypatch.setattr(
+        character_service_module,
+        "CharacterConversationNavigationService",
+        NavigationService,
+    )
+    app = _build_test_app()
+    _seed_library_content(app)
+    app.chachanotes_db = SimpleNamespace(get_local_authority_id=lambda: authority)
+    route = character_navigation.LibraryUnavailableConversationsBrowse(
+        key, character_navigation.RoleplayReturnTarget.console_context_character()
+    )
+    context = {
+        constants.LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: character_navigation.serialize_library_unavailable_browse(
+            route
+        )
+    }
+    returned = []
+    host = DestinationHarness(app, "library")
+    async with host.run_test(
+        size=(120, 40),
+        message_hook=lambda message: (
+            returned.append(message) if isinstance(message, NavigateToScreen) else None
+        ),
+    ) as pilot:
+        screen = _active_destination_screen(host)
+        await _wait_for_library_shell_ready(screen, pilot)
+        screen.apply_navigation_context(context)
+        for _ in range(60):
+            await pilot.pause(0.05)
+            if screen._conversations_state.page_loaded and screen.query(
+                "#library-character-back-console"
+            ):
+                break
+        back = screen.query_one("#library-character-back-console", Button)
+        committed = screen._navigation_controller.character_route
+        scope = screen._library_unavailable_browse_scope
+        records = screen._conversations_state.page_records
+        generation = screen._library_navigation_context_generation
+        entered = asyncio.Event()
+
+        async def veto():
+            entered.set()
+            return False
+
+        screen._flush_active_file_notes = veto
+        if incoming == "invalid_repair":
+            rejected = {constants.LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR: {}}
+        elif incoming == "invalid_character":
+            rejected = {constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: {}}
+        elif incoming == "ordinary_veto":
+            rejected = {LIBRARY_NAV_CONTEXT_MODE: "search"}
+        else:
+            rejected = {
+                constants.LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: character_navigation.serialize_library_unavailable_inspection(
+                    character_navigation.LibraryUnavailableConversationInspection(
+                        UnresolvedConversationKey(authority, "replacement-chat"),
+                        route.return_target,
+                    )
+                )
+            }
+        if incoming == "superseded_typed":
+            release = asyncio.Event()
+
+            async def delayed_save():
+                entered.set()
+                try:
+                    await release.wait()
+                except asyncio.CancelledError:
+                    await asyncio.wait_for(release.wait(), 2)
+                return True
+
+            async def permit():
+                return True
+
+            screen._flush_active_file_notes = delayed_save
+            screen.apply_navigation_context(rejected)
+            await asyncio.wait_for(entered.wait(), 2)
+            attempted_generation = screen._library_navigation_context_generation
+            assert screen._navigation_controller.character_route is committed
+            assert not screen._conversations_state.loading
+            screen._flush_active_file_notes = permit
+            screen.apply_navigation_context(context)
+            for _ in range(40):
+                await pilot.pause(0.05)
+                if (
+                    screen._navigation_controller.character_route is not committed
+                    and screen._pending_library_character_navigation is None
+                ):
+                    break
+            replacement = screen._navigation_controller.character_route
+            assert replacement is not None and replacement is not committed
+            successful_generation = screen._library_navigation_context_generation
+            assert successful_generation > attempted_generation > generation
+            release.set()
+            await pilot.pause(0.2)
+            assert screen._navigation_controller.character_route is replacement
+            assert (
+                screen._library_navigation_context_generation == successful_generation
+            )
+            screen._unavailable_navigation.return_from_character(screen, committed)
+            await pilot.pause()
+            assert not returned
+            committed = replacement
+            scope = screen._library_unavailable_browse_scope
+            records = screen._conversations_state.page_records
+        else:
+            screen.apply_navigation_context(rejected)
+        if incoming.endswith("veto"):
+            await asyncio.wait_for(entered.wait(), 2)
+        await pilot.pause()
+        assert screen._navigation_controller.character_route is committed
+        assert screen._library_navigation_context_generation >= generation
+        assert screen._library_unavailable_browse_scope is scope
+        assert screen._conversations_state.page_records == records
+        assert (
+            screen._unavailable_navigation._library_unavailable_browse_scope_is_current(
+                screen, scope
+            )
+        )
+        filter_input = screen.query_one("#library-conversations-filter", Input)
+        filter_input.value = "Retained"
+        filter_input.focus()
+        await pilot.press("enter")
+        for _ in range(40):
+            await pilot.pause(0.05)
+            if not screen._conversations_state.loading:
+                break
+        assert screen._conversations_state.projection == "unavailable_character"
+        assert (
+            screen._conversations_state.page_records[0]["conversation_id"]
+            == "retained-chat"
+        )
+        back = screen.query_one("#library-character-back-console", Button)
+        back.press()
+        await pilot.pause()
+        assert returned and all(message is returned[0] for message in returned)
+        assert (returned[0].screen_name, returned[0].screen_context) == (
+            "chat",
+            {"return_focus": "console-context-character"},
+        )
+
+
+@pytest.mark.asyncio
 async def test_character_authority_read_yields_ui_and_cannot_admit_superseded_route():
     app = _build_test_app()
     app.notes_scope_service = StaticLibraryNotesScopeService([])

--- a/Tests/UI/test_library_content_hub.py
+++ b/Tests/UI/test_library_content_hub.py
@@ -345,6 +345,26 @@ async def test_library_source_rail_marks_active_mode_without_mutating_action_lab
         assert collections_row.tooltip == "Collections"
 
 
+def test_navigation_uses_extracted_prompt_state_before_and_after_admission():
+    app = _build_test_app()
+    screen = library_screen_module.LibraryScreen(app)
+    state = screen._prompts_state
+    state.mutation_in_flight = True
+    state.selected_prompt_id = 99
+    state.view = "editor"
+    context = {"open_source_type": "prompt", "open_source_id": "7"}
+    before_generation = screen._library_navigation_context_generation
+    screen.apply_navigation_context(context)
+    screen._apply_navigation_context_state(context, recompose=False)
+    assert screen._library_navigation_context_generation == before_generation
+    assert (state.selected_prompt_id, state.view) == (99, "editor")
+    state.mutation_in_flight = False
+    screen._apply_navigation_context_state(context, recompose=False)
+    assert (state.selected_prompt_id, state.view) == (7, "list")
+    assert not hasattr(screen, "_selected_prompt_id")
+    assert not hasattr(screen, "_library_prompts_view")
+
+
 @pytest.mark.asyncio
 async def test_library_navigation_context_opens_requested_conversation() -> None:
     app = _build_test_app()

--- a/backlog/decisions/120-character-conversation-navigation-and-local-semantic-search.md
+++ b/backlog/decisions/120-character-conversation-navigation-and-local-semantic-search.md
@@ -114,6 +114,15 @@ explicit user selection and confirmation; and commits through compare-and-set.
 Context, `Ctrl+K`, and Roleplay may navigate to that flow but cannot repair.
 Names never select or preselect a repair target.
 
+Task4 release clarification (2026-09-05): unavailable inspection and unavailable
+browse deep links originate only from Console Context and retain its Character
+return anchor. Both their typed objects and wire payloads reject other origins;
+their native return action is **Back to Console**. Incumbent repair continues to
+accept its existing Console and Roleplay return targets. This scopes the two
+new Task4 routes, not future navigation origins; later delivery must explicitly
+define any extension. Returning reveals Character transiently and does not write
+manual disclosure preferences.
+
 Surface roles remain distinct:
 
 - Console Context owns a bounded ambient Character section directly after

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -11854,3 +11854,16 @@ guard on a modal must measure from first paint, not from mount: under load
 those diverge by seconds. Note also that the wizard's bottom hint line stays
 visible while the dialog is up, so grepping the footer proves nothing about
 whether a dialog opened.
+
+### TASK-31244: navigation completion is not completion of every app worker
+
+During the Character Context fix-round return tests, all Back, focus-paint and
+preference assertions passed, but a blanket `app.workers.wait_for_complete()`
+made all three cases fail with `WorkerCancelled`: normal navigation had
+cancelled unrelated visit-scoped workers. The covering run recorded 231 passes
+and those three fixture failures. Waiting instead for the destination's bounded
+loading/layout completion produced 19 passing ownership/return regressions.
+Do not make successful completion of every app worker a navigation assertion;
+observe the destination's completion state. Preserve genuine late-publish
+stacks separately: this incident also found and fixed an owned Character
+presentation callback running after its screen stack had been removed.

--- a/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
+++ b/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:08'
-updated_date: '2026-09-06 04:44'
+updated_date: '2026-09-06 05:41'
 labels:
   - console
   - context
@@ -56,4 +56,6 @@ ADR required: no new ADR. ADR path: backlog/decisions/120-character-conversation
 
 <!-- SECTION:NOTES:BEGIN -->
 Implemented the bounded, avatar-independent Character Context browser, exact typed activation and complete Roleplay/Library handoffs. Reused reviewed Task4 and owning focus/avatar lifetime fixes, adapted paginated repair totals and strict lazy Pydantic payloads, and kept unavailable navigation in the existing Library module boundary (ADR120/ADR083; no new ADR). Search rows retain visible title, character and Local/age metadata; existing outer scrolling follows the exact focused Character control. Targeted aggregate:355 passed/3 inherited-evidence failures; final scoped paint/avatar/rail/preference confirmation:137 passed; final scoped static/CSS/diagnostics:12 passed. No cap raises. Native/platform and aggregate FD attribution remain unverified; retain In Progress and unchecked AC pending controller qualification. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-report.md.
+
+Fix round1 closes post-await generation admission, retained-profile Start, off-loop Library authority reads, recompose focus ownership and route-owned Back to Console. ADR120 now clarifies the two new routes originate only in Console Context; incumbent repair origins remain unchanged. Return reveal is transient, preserves manual disclosure policy, and keeps the semantic anchor with visible composer fallback at52x20 without resize focus theft. Search copy is Search chats. Covering gate231 passed/3 fixture-wait failures; corrected final ownership/return confirmation19 passed; final static/startup/CSS/canary17 passed. The new unmerged helper initial pin is803 (+90), explicitly approved; all incumbent caps fixed. Native/platform/resource attribution remains unqualified; no Done or AC change. Full fix evidence and capture/source manifests: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-1-report.md.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
+++ b/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:08'
-updated_date: '2026-09-06 05:41'
+updated_date: '2026-09-06 06:06'
 labels:
   - console
   - context
@@ -58,4 +58,6 @@ ADR required: no new ADR. ADR path: backlog/decisions/120-character-conversation
 Implemented the bounded, avatar-independent Character Context browser, exact typed activation and complete Roleplay/Library handoffs. Reused reviewed Task4 and owning focus/avatar lifetime fixes, adapted paginated repair totals and strict lazy Pydantic payloads, and kept unavailable navigation in the existing Library module boundary (ADR120/ADR083; no new ADR). Search rows retain visible title, character and Local/age metadata; existing outer scrolling follows the exact focused Character control. Targeted aggregate:355 passed/3 inherited-evidence failures; final scoped paint/avatar/rail/preference confirmation:137 passed; final scoped static/CSS/diagnostics:12 passed. No cap raises. Native/platform and aggregate FD attribution remain unverified; retain In Progress and unchecked AC pending controller qualification. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-report.md.
 
 Fix round1 closes post-await generation admission, retained-profile Start, off-loop Library authority reads, recompose focus ownership and route-owned Back to Console. ADR120 now clarifies the two new routes originate only in Console Context; incumbent repair origins remain unchanged. Return reveal is transient, preserves manual disclosure policy, and keeps the semantic anchor with visible composer fallback at52x20 without resize focus theft. Search copy is Search chats. Covering gate231 passed/3 fixture-wait failures; corrected final ownership/return confirmation19 passed; final static/startup/CSS/canary17 passed. The new unmerged helper initial pin is803 (+90), explicitly approved; all incumbent caps fixed. Native/platform/resource attribution remains unqualified; no Done or AC change. Full fix evidence and capture/source manifests: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-1-report.md.
+
+Fix round 2 preserves the committed unavailable Library route, browse projection, and Back action through invalid or save-vetoed incoming navigation. Validated candidates are staged separately, with monotonic attempt generations and promotion only after guarded admission; a late superseded save cannot resurrect ownership. Direct ADR120 implementation, no new ADR. Genuine RED: 4 failures; final affected Library/payload/diagnostic/complete-return gate: 85 passed, 1 known incumbent empty-preview deselected; scoped size/slack gate: 4 passed. The still-unmerged helper initial pin is 811 (+8), explicitly approved; incumbent caps and both screens are unchanged. No new Ruff diagnostics; four incumbent diagnostics remain. Native/platform/resource qualifications remain open; status and AC unchanged. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-2-report.md.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
+++ b/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:08'
-updated_date: '2026-09-06 06:47'
+updated_date: '2026-09-06 13:53'
 labels:
   - console
   - context
@@ -62,4 +62,6 @@ Fix round1 closes post-await generation admission, retained-profile Start, off-l
 Fix round 2 preserves the committed unavailable Library route, browse projection, and Back action through invalid or save-vetoed incoming navigation. Validated candidates are staged separately, with monotonic attempt generations and promotion only after guarded admission; a late superseded save cannot resurrect ownership. Direct ADR120 implementation, no new ADR. Genuine RED: 4 failures; final affected Library/payload/diagnostic/complete-return gate: 85 passed, 1 known incumbent empty-preview deselected; scoped size/slack gate: 4 passed. The still-unmerged helper initial pin is 811 (+8), explicitly approved; incumbent caps and both screens are unchanged. No new Ruff diagnostics; four incumbent diagnostics remain. Native/platform/resource qualifications remain open; status and AC unchanged. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-2-report.md.
 
 PR2452 fix round 3 reuses strict shared 512-character Console query validation in the widget and controller before trimming or DB work. Invalid edits restore the last valid visible query with bounded native feedback; clear, Enter safety, and later valid search are covered. Added Google-style documentation to all four new unavailable route APIs. Removed the redundant cold-resume Character worker through the existing mount-visit guard, preserving mounted initial groups and warm refresh; no allowlist or cap change. Direct ADR120/shared-validation implementation, no new ADR. Focused RED/GREEN 10 failures to 12 passes; final covering 136 passed/1 unchanged pre-Console splash/stagger observation failure, also isolated. Worker census, exact warm handoff, and UI-ready 971/972 pass; no new lint/format diagnostics. Status/AC and qualification gaps unchanged. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-3-report.md.
+
+Latest-dev integration onto f356ddc4a9b37d5c272d8398376764b9d83e04a1: preserved reviewed cb2 safety ref and rebased all four Task4 commits. Retargeted four deleted Prompt flat fields to the upstream state owner; simplified only the affected navigation admission method to retain the new 198-line incumbent cap (helper 811, no cap or allowlist changes). Genuine integration RED retained; final focused 8 passed, covering 170 passed / 1 known empty-preview deselected, 11 warnings; inventory no drift and zero new correction Ruff diagnostics. Exact range-diff, corrections, logs and source equivalence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-approved-merge-rebase-report.md. User-approved manual/resource/scale/baseline qualifications remain deferred, not passed; controller owns review, publication, CI and merge. No Done change.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
+++ b/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31244
 title: Add Character conversations to Console Context
-status: To Do
-assignee: []
+status: In Progress
+assignee:
+  - '@codex'
 created_date: '2026-09-04 02:08'
+updated_date: '2026-09-06 04:44'
 labels:
   - console
   - context
@@ -19,18 +21,18 @@ references:
 priority: high
 ---
 
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make recent character conversations discoverable in the Console Context rail through a bounded, date-sorted, local-only Character section that preserves first-use comprehension and expert state.
+<!-- SECTION:DESCRIPTION:END -->
+
 ## Renumbering provenance
 
 Renumbered from TASK-31236 on 2026-09-04. The final pre-commit worktree sweep
 found the older `Review set Dismiss gets an Undo receipt` task created at 01:50;
 it keeps TASK-31236 under the older-arrival rule. This unshipped task moves with
 all plan and dependency references.
-
-## Description
-
-<!-- SECTION:DESCRIPTION:BEGIN -->
-Make recent character conversations discoverable in the Console Context rail through a bounded, date-sorted, local-only Character section that preserves first-use comprehension and expert state.
-<!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
@@ -43,3 +45,15 @@ Make recent character conversations discoverable in the Console Context rail thr
 - [ ] #7 This PR renders no Continue search in Character chats control and makes no narrow-terminal claim before the Ctrl+K fallback exists.
 - [ ] #8 Production CSS and tests cover 52x20, standard widths, keyboard, pointer, truncation, empty, failure, preference migration, and exact activation.
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no new ADR. ADR path: backlog/decisions/120-character-conversation-navigation-and-local-semantic-search.md and ADR-083. Reason: direct implementation of accepted Context ownership and bounds. Prepare a separate PR on latest dev after PR2446. Adapt preserved Task4 implementation and owning fixes to merged projection, paginated repair, and strict typed navigation contracts. This PR must not render Continue search in Character chats. Verify focused baseline, new adaptation RED/GREEN, full targeted Context and reachable Library/avatar tests, production geometry, startup/static/CSS checks, then independent review. Record native/platform gaps honestly; no full repository sweep or semantic feature work.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the bounded, avatar-independent Character Context browser, exact typed activation and complete Roleplay/Library handoffs. Reused reviewed Task4 and owning focus/avatar lifetime fixes, adapted paginated repair totals and strict lazy Pydantic payloads, and kept unavailable navigation in the existing Library module boundary (ADR120/ADR083; no new ADR). Search rows retain visible title, character and Local/age metadata; existing outer scrolling follows the exact focused Character control. Targeted aggregate:355 passed/3 inherited-evidence failures; final scoped paint/avatar/rail/preference confirmation:137 passed; final scoped static/CSS/diagnostics:12 passed. No cap raises. Native/platform and aggregate FD attribution remain unverified; retain In Progress and unchecked AC pending controller qualification. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-report.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
+++ b/backlog/tasks/task-31244 - Add-Character-conversations-to-Console-Context.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:08'
-updated_date: '2026-09-06 06:06'
+updated_date: '2026-09-06 06:47'
 labels:
   - console
   - context
@@ -60,4 +60,6 @@ Implemented the bounded, avatar-independent Character Context browser, exact typ
 Fix round1 closes post-await generation admission, retained-profile Start, off-loop Library authority reads, recompose focus ownership and route-owned Back to Console. ADR120 now clarifies the two new routes originate only in Console Context; incumbent repair origins remain unchanged. Return reveal is transient, preserves manual disclosure policy, and keeps the semantic anchor with visible composer fallback at52x20 without resize focus theft. Search copy is Search chats. Covering gate231 passed/3 fixture-wait failures; corrected final ownership/return confirmation19 passed; final static/startup/CSS/canary17 passed. The new unmerged helper initial pin is803 (+90), explicitly approved; all incumbent caps fixed. Native/platform/resource attribution remains unqualified; no Done or AC change. Full fix evidence and capture/source manifests: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-1-report.md.
 
 Fix round 2 preserves the committed unavailable Library route, browse projection, and Back action through invalid or save-vetoed incoming navigation. Validated candidates are staged separately, with monotonic attempt generations and promotion only after guarded admission; a late superseded save cannot resurrect ownership. Direct ADR120 implementation, no new ADR. Genuine RED: 4 failures; final affected Library/payload/diagnostic/complete-return gate: 85 passed, 1 known incumbent empty-preview deselected; scoped size/slack gate: 4 passed. The still-unmerged helper initial pin is 811 (+8), explicitly approved; incumbent caps and both screens are unchanged. No new Ruff diagnostics; four incumbent diagnostics remain. Native/platform/resource qualifications remain open; status and AC unchanged. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-2-report.md.
+
+PR2452 fix round 3 reuses strict shared 512-character Console query validation in the widget and controller before trimming or DB work. Invalid edits restore the last valid visible query with bounded native feedback; clear, Enter safety, and later valid search are covered. Added Google-style documentation to all four new unavailable route APIs. Removed the redundant cold-resume Character worker through the existing mount-visit guard, preserving mounted initial groups and warm refresh; no allowlist or cap change. Direct ADR120/shared-validation implementation, no new ADR. Focused RED/GREEN 10 failures to 12 passes; final covering 136 passed/1 unchanged pre-Console splash/stagger observation failure, also isolated. Worker census, exact warm handoff, and UI-ready 971/972 pass; no new lint/format diagnostics. Status/AC and qualification gaps unchanged. Full evidence: .superpowers/sdd/2026-09-05-character-keyword-release-isolation/task-4-fix-3-report.md.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -822,6 +822,7 @@ def build_console_rail_state(
     can_save_chatbook: bool = False,
     available_columns: int | None = None,
     character_context_exists: bool = False,
+    character_return_reveal: bool = False,
 ) -> ConsoleRailState:
     """Build effective Console rail state without importing Textual.
 
@@ -870,6 +871,10 @@ def build_console_rail_state(
             preferences,
             character_open=bool(character_context_exists),
         )
+    if character_return_reveal:
+        preferences = replace(
+            preferences, left_open=True, right_open=False, character_open=True
+        )
     # TASK-2154.2 (LY-11, ADR-043): the compact-collapse rules below are the
     # responsive default. Explicit opens are honored while the 70/74-column
     # usable-transcript budgets permit, and receive the layout-minimum waiver;
@@ -891,7 +896,9 @@ def build_console_rail_state(
     #   (``CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY``, set by
     #   ``ChatScreen._set_console_rail_preference``) records it. Legacy
     #   payloads lack the marker and keep the force-collapse default.
-    explicit_left_open = console_rail_left_open_explicit(stored_preferences)
+    explicit_left_open = character_return_reveal or console_rail_left_open_explicit(
+        stored_preferences
+    )
     # task-18911: an explicit toggle is honored only while the viewport can
     # afford rail + a usable transcript (rail min + main floor). Below that
     # budget the collapse is a rendering override the explicit marker

--- a/tldw_chatbook/Chat/console_rail_state.py
+++ b/tldw_chatbook/Chat/console_rail_state.py
@@ -86,6 +86,10 @@ CONSOLE_RAIL_INSPECTOR_LABEL = f"{GLYPH_COLLAPSE_LEFT} Inspector"
 #: right rail needs no marker because its closed default is distinguishable
 #: from an explicit ``right_open=True`` by value alone.
 CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY = "left_open_explicit"
+#: TASK-31244: distinguishes a user's Character disclosure gesture from a
+#: first-use default.  Presence of the old Boolean without this marker is a
+#: legacy preference and must remain authoritative until the first toggle.
+CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY = "character_disclosure_explicit"
 
 _PERSISTENCE_PREFIX = "console_rail_state"
 _INVALID_KEY_RUN_RE = re.compile(r"[^A-Za-z0-9_.-]+")
@@ -361,6 +365,14 @@ def console_rail_left_open_explicit(stored_preferences: Any) -> bool:
     )
 
 
+def console_character_disclosure_explicit(stored_preferences: Any) -> bool:
+    """Return whether Character openness came from an explicit user toggle."""
+
+    return isinstance(stored_preferences, Mapping) and _coerce_bool(
+        stored_preferences.get(CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY), False
+    )
+
+
 def coerce_console_rail_preferences(raw: Any) -> ConsoleRailPreferences:
     """Normalize stored Console rail preferences.
 
@@ -454,8 +466,41 @@ def serialize_console_rail_stored_preferences(raw: Any) -> dict[str, bool]:
     )
     if not isinstance(raw, Mapping) or "right_open" not in raw:
         serialized.pop("right_open")
+    # A genuinely absent record must stay distinguishable from an old record
+    # that explicitly stored the legacy Character Boolean.
+    if not console_character_disclosure_explicit(raw) and (
+        not isinstance(raw, Mapping) or "character_open" not in raw
+    ):
+        serialized.pop("character_open")
     if console_rail_left_open_explicit(raw):
         serialized[CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY] = True
+    if console_character_disclosure_explicit(raw):
+        serialized[CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY] = True
+    return serialized
+
+
+def serialize_console_rail_updated_preferences(
+    preferences: ConsoleRailPreferences,
+    prior_stored: Any,
+    *,
+    left_open: bool | None,
+    right_open: bool | None,
+    character_toggled: bool,
+) -> dict[str, bool]:
+    """Serialize a manual change while preserving untouched disclosure intent."""
+    serialized = serialize_console_rail_preferences(preferences)
+    if left_open is not None or console_rail_left_open_explicit(prior_stored):
+        serialized[CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY] = True
+    if character_toggled or console_character_disclosure_explicit(prior_stored):
+        serialized[CONSOLE_CHARACTER_DISCLOSURE_EXPLICIT_KEY] = True
+    elif not isinstance(prior_stored, Mapping) or "character_open" not in prior_stored:
+        serialized.pop("character_open", None)
+    if (
+        right_open is None
+        and isinstance(prior_stored, Mapping)
+        and "right_open" not in prior_stored
+    ):
+        serialized.pop("right_open")
     return serialized
 
 
@@ -776,6 +821,7 @@ def build_console_rail_state(
     approval_count: Any = 0,
     can_save_chatbook: bool = False,
     available_columns: int | None = None,
+    character_context_exists: bool = False,
 ) -> ConsoleRailState:
     """Build effective Console rail state without importing Textual.
 
@@ -810,6 +856,20 @@ def build_console_rail_state(
         mark persisted preference or explicit intent.
     """
     preferences = coerce_console_rail_preferences(stored_preferences)
+    # New scopes reveal useful Character context once. Explicit payloads and
+    # legacy Booleans both win; only total absence receives the first-use
+    # default. This decision is render-only and never writes on read/resize.
+    if not (
+        isinstance(stored_preferences, Mapping)
+        and (
+            console_character_disclosure_explicit(stored_preferences)
+            or "character_open" in stored_preferences
+        )
+    ):
+        preferences = replace(
+            preferences,
+            character_open=bool(character_context_exists),
+        )
     # TASK-2154.2 (LY-11, ADR-043): the compact-collapse rules below are the
     # responsive default. Explicit opens are honored while the 70/74-column
     # usable-transcript budgets permit, and receive the layout-minimum waiver;

--- a/tldw_chatbook/Constants.py
+++ b/tldw_chatbook/Constants.py
@@ -64,6 +64,8 @@ CONSOLE_NAV_CONTEXT_CHARACTER_CONVERSATION_TARGET = "character_conversation_targ
 # Trusted character-conversation navigation context keys.
 ROLEPLAY_NAV_CONTEXT_CHARACTER_CONVERSATION = "character_conversation"
 LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR = "character_repair"
+LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION = "character_unavailable_inspection"
+LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE = "character_unavailable_browse"
 CHARACTER_NAV_CONTEXT_RETURN_FOCUS = "return_focus"
 
 # Saved-conversation pagination shared by the Roleplay controller and inspector.

--- a/tldw_chatbook/Library/library_conversations_state.py
+++ b/tldw_chatbook/Library/library_conversations_state.py
@@ -63,6 +63,7 @@ class LibraryConversationsCanvasState:
     pager: LibraryPagerDisplay | None = None
     selection_notice: str = ""
     actions_disabled: bool = False
+    title: str = "Conversations"
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Console_Modules/character.py
+++ b/tldw_chatbook/UI/Console_Modules/character.py
@@ -193,12 +193,56 @@ class ConsoleCharacterController:
     async def _apply_console_character_choice_async(
         self,
         choice: ConsoleCharacterChoice,
+        *,
+        expected_key: Any = None,
+        required_database: Any = None,
+        commit_is_current: Callable[[], bool] | None = None,
     ) -> None:
         """Apply a picked character to this session or a fresh one."""
-        card = await asyncio.to_thread(
-            self._fetch_character_card_for_avatar,
-            choice.character_id,
-        )
+        if expected_key is None:
+            card = await asyncio.to_thread(
+                self._fetch_character_card_for_avatar, choice.character_id
+            )
+        else:
+            from ...Character_Chat.character_conversation_navigation import (
+                ResolvedLocalCharacterKey,
+            )
+
+            def admission_is_current() -> bool:
+                return (
+                    isinstance(expected_key, ResolvedLocalCharacterKey)
+                    and expected_key.character_id == choice.character_id
+                    and required_database is not None
+                    and self._character_db_accessor() is required_database
+                    and commit_is_current is not None
+                    and commit_is_current()
+                )
+
+            if not admission_is_current():
+                return
+
+            def fetch_exact() -> dict | None:
+                try:
+                    if (
+                        required_database.get_local_authority_id()
+                        != expected_key.data_authority_id
+                    ):
+                        return None
+                    result = required_database.get_character_card_by_id(
+                        expected_key.character_id
+                    )
+                    return (
+                        result
+                        if required_database.get_local_authority_id()
+                        == expected_key.data_authority_id
+                        else None
+                    )
+                except Exception:  # noqa: BLE001 - reject unavailable retained storage
+                    return None
+
+            card = await asyncio.to_thread(fetch_exact)
+            if not admission_is_current():
+                return
         if card is None:
             display_name = (
                 sanitize_character_display_label(
@@ -246,7 +290,7 @@ class ConsoleCharacterController:
                 runtime_backend="local",
                 assistant_kind="character",
                 assistant_id=str(choice.character_id),
-                assistant_authority_id=None,
+                assistant_authority_id=(expected_key.data_authority_id if expected_key is not None else None),
                 character_id=choice.character_id,
                 character_name=seed.name,
             )

--- a/tldw_chatbook/UI/Console_Modules/character_context.py
+++ b/tldw_chatbook/UI/Console_Modules/character_context.py
@@ -225,7 +225,9 @@ class ConsoleCharacterContextController:
         ],
         navigate_roleplay_home: Callable[[], None],
         navigate_library_home: Callable[[], None],
-        start_console: Callable[[int, str], Any],
+        start_console: Callable[
+            [ResolvedLocalCharacterKey, Any, str, Callable[[], bool]], Any
+        ],
         state_changed: Callable[[ConsoleCharacterContextState], None] | None = None,
         service_factory: Callable[..., CharacterConversationNavigationService] = (
             CharacterConversationNavigationService
@@ -251,6 +253,7 @@ class ConsoleCharacterContextController:
         )
         self._query_handoff = query_handoff
         self._generation = 0
+        self.return_reveal = False
         self._browse_snapshot: ConsoleCharacterBrowseSnapshot | None = None
         self._activation_cancellation: asyncio.Event | None = None
         self.state = ConsoleCharacterContextState()
@@ -397,6 +400,11 @@ class ConsoleCharacterContextController:
             and current.fingerprint == snapshot.fingerprint
         )
 
+    async def _operation_scope_is_current(self, snapshot, generation: int) -> bool:
+        """Fence both sides of the final asynchronous authority validation."""
+        current = await self._scope_is_current(snapshot)
+        return current and generation == self._generation
+
     def invalidate_scope(self) -> None:
         """Fence work and force the next lifecycle check to reload."""
 
@@ -519,8 +527,9 @@ class ConsoleCharacterContextController:
             database = snapshot.database
             fingerprint = snapshot.fingerprint
             if database is None:
-                if generation == self._generation and await self._scope_is_current(
-                    snapshot
+                if (
+                    generation == self._generation
+                    and await self._operation_scope_is_current(snapshot, generation)
                 ):
                     self._publish(
                         replace(
@@ -539,7 +548,7 @@ class ConsoleCharacterContextController:
             except Exception:  # noqa: BLE001 - DB boundary becomes visible recovery
                 if generation != self._generation:
                     return
-                if not await self._scope_is_current(snapshot):
+                if not await self._operation_scope_is_current(snapshot, generation):
                     continue
                 self._publish(
                     replace(
@@ -552,7 +561,7 @@ class ConsoleCharacterContextController:
                 return
             if generation != self._generation:
                 return
-            if not await self._scope_is_current(snapshot):
+            if not await self._operation_scope_is_current(snapshot, generation):
                 continue
             expanded = self.state.expanded_key
             keys = {group.key for group in groups}
@@ -607,12 +616,12 @@ class ConsoleCharacterContextController:
             except Exception:  # noqa: BLE001 - stale DB failures fail closed
                 if generation != self._generation:
                     return
-                if not await self._scope_is_current(snapshot):
+                if not await self._operation_scope_is_current(snapshot, generation):
                     continue
                 return
             if generation != self._generation:
                 return
-            if not await self._scope_is_current(snapshot):
+            if not await self._operation_scope_is_current(snapshot, generation):
                 continue
             self._publish(
                 replace(
@@ -729,8 +738,9 @@ class ConsoleCharacterContextController:
                 )
                 return
             if snapshot.database is None:
-                if generation == self._generation and await self._scope_is_current(
-                    snapshot
+                if (
+                    generation == self._generation
+                    and await self._operation_scope_is_current(snapshot, generation)
                 ):
                     self._publish(
                         replace(
@@ -752,7 +762,7 @@ class ConsoleCharacterContextController:
             except Exception:  # noqa: BLE001 - DB boundary becomes visible recovery
                 if generation != self._generation:
                     return
-                if not await self._scope_is_current(snapshot):
+                if not await self._operation_scope_is_current(snapshot, generation):
                     continue
                 self._publish(
                     replace(
@@ -765,7 +775,7 @@ class ConsoleCharacterContextController:
                 return
             if generation != self._generation:
                 return
-            if not await self._scope_is_current(snapshot):
+            if not await self._operation_scope_is_current(snapshot, generation):
                 continue
             fingerprint = snapshot.fingerprint
             keyword_error = {
@@ -917,8 +927,9 @@ class ConsoleCharacterContextController:
                 )
                 return False
             if snapshot.database is None:
-                if generation == self._generation and await self._scope_is_current(
-                    snapshot
+                if (
+                    generation == self._generation
+                    and await self._operation_scope_is_current(snapshot, generation)
                 ):
                     self._publish(
                         replace(
@@ -945,7 +956,7 @@ class ConsoleCharacterContextController:
             except Exception:  # noqa: BLE001 - repair evidence is a DB boundary
                 if generation != self._generation:
                     return False
-                if not await self._scope_is_current(snapshot):
+                if not await self._operation_scope_is_current(snapshot, generation):
                     continue
                 self._publish(
                     replace(
@@ -957,7 +968,7 @@ class ConsoleCharacterContextController:
                 return False
             if generation != self._generation:
                 return False
-            if not await self._scope_is_current(snapshot):
+            if not await self._operation_scope_is_current(snapshot, generation):
                 continue
             break
         else:
@@ -1075,7 +1086,7 @@ class ConsoleCharacterContextController:
         if (
             generation != self._generation
             or snapshot.fingerprint.data_authority_id != key.data_authority_id
-            or not await self._scope_is_current(snapshot)
+            or not await self._operation_scope_is_current(snapshot, generation)
         ):
             if generation == self._generation:
                 self._publish(
@@ -1118,6 +1129,7 @@ class ConsoleCharacterContextController:
         return await self._prepare_unavailable_repair(key, row_key=row_key)
 
     async def view_group(self, group: CharacterConversationGroup) -> None:
+        generation = self._generation
         from ..Navigation.character_conversation_navigation import (
             LibraryUnavailableConversationsBrowse,
             RoleplayCharacterConversationLink,
@@ -1149,7 +1161,7 @@ class ConsoleCharacterContextController:
             if (
                 snapshot.fingerprint.data_authority_id
                 != row.unresolved.data_authority_id
-                or not await self._scope_is_current(snapshot)
+                or not await self._operation_scope_is_current(snapshot, generation)
             ):
                 return
             self._navigate_unavailable_browse(
@@ -1166,11 +1178,33 @@ class ConsoleCharacterContextController:
 
     async def start_current(self, group: CharacterConversationGroup) -> None:
         if isinstance(group.key, ResolvedLocalCharacterKey):
+            generation = self._generation
+            try:
+                snapshot = await self._capture_scope()
+            except (_ConsoleCharacterScopeChanged, _ConsoleCharacterScopeReadError):
+                return
+            if (
+                snapshot.database is None
+                or snapshot.fingerprint.data_authority_id != group.key.data_authority_id
+                or not await self._operation_scope_is_current(snapshot, generation)
+            ):
+                return
             self.invalidate_scope()
+            generation = self._generation
+
+            def is_current() -> bool:
+                return (
+                    generation == self._generation
+                    and self._database_accessor() is snapshot.database
+                )
+
             await _maybe_await(
-                self._start_console(group.key.character_id, group.character_label)
+                self._start_console(
+                    group.key, snapshot.database, group.character_label, is_current
+                )
             )
-            await self.refresh_if_scope_changed(force=True)
+            if is_current():
+                await self.refresh_if_scope_changed(force=True)
 
     def handoff_query(self, query: str) -> bool:
         """Invoke Task 5's typed handoff only after capability installation."""

--- a/tldw_chatbook/UI/Console_Modules/character_context.py
+++ b/tldw_chatbook/UI/Console_Modules/character_context.py
@@ -679,9 +679,18 @@ class ConsoleCharacterContextController:
         return rows, page.keyword_status or status
 
     async def search(self, query: str) -> None:
-        """Search at most eight local rows and restore semantic browse state."""
+        """Search at most eight local rows and restore semantic browse state.
 
-        normalized = str(query or "").strip()
+        Args:
+            query: Raw text validated before trimming or changing state.
+
+        Raises:
+            ValueError: If query is not text or exceeds the shared Console limit.
+        """
+
+        from ...Utils.input_validation import validate_console_switcher_query
+
+        normalized = validate_console_switcher_query(query).strip()
         if not normalized:
             self._generation += 1
             snapshot = self._browse_snapshot

--- a/tldw_chatbook/UI/Console_Modules/character_context.py
+++ b/tldw_chatbook/UI/Console_Modules/character_context.py
@@ -1,0 +1,1189 @@
+"""Read-only controller for the Console Character context browser."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+from ...Character_Chat.character_conversation_navigation import (
+    CharacterConversationGroup,
+    CharacterConversationKey,
+    CharacterConversationNavigationService,
+    CharacterConversationRow,
+    CharacterKeywordIndexStatus,
+    LocalCharacterConversationTarget,
+    ResolvedLocalCharacterKey,
+    UnavailableCharacterReason,
+    UnresolvedConversationKey,
+)
+
+if TYPE_CHECKING:
+    from ...Chat.console_conversation_activation import (
+        CharacterConversationActivationRequest,
+        ConsoleConversationActivationResult,
+    )
+    from ..Navigation.character_conversation_navigation import (
+        LibraryCharacterRepairContext,
+        LibraryUnavailableConversationInspection,
+        LibraryUnavailableConversationsBrowse,
+        RoleplayCharacterConversationLink,
+    )
+
+CONSOLE_CHARACTER_GROUP_LIMIT = 4
+CONSOLE_CHARACTER_ROW_LIMIT = 5
+CONSOLE_CHARACTER_SEARCH_LIMIT = 8
+CONSOLE_CHARACTER_REPAIR_CANDIDATE_LIMIT = 20
+_SCOPE_CAPTURE_ATTEMPTS = 3
+
+
+class ConsoleCharacterOperationPhase(StrEnum):
+    """One explicit asynchronous presentation phase."""
+
+    IDLE = "idle"
+    REFRESHING = "refreshing"
+    SEARCHING = "searching"
+    OPENING = "opening"
+    REPAIRING = "repairing"
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterScopeFingerprint:
+    """Stable authority and ambient Console identity for one projection."""
+
+    database_identity: int | None
+    data_authority_id: str
+    data_revision: int
+    current_character_id: int | None
+    current_character_label: str = ""
+    open_conversation_id: str = ""
+
+
+@dataclass(frozen=True)
+class _ConsoleCharacterScopeSnapshot:
+    """One self-validated ambient scope plus its exact database handle."""
+
+    database: Any
+    fingerprint: ConsoleCharacterScopeFingerprint
+
+
+class _ConsoleCharacterScopeChanged(RuntimeError):
+    """Raised when ambient scope cannot settle within the bounded capture."""
+
+
+class _ConsoleCharacterScopeReadError(RuntimeError):
+    """Stable database metadata failure, paired with its ambient identities."""
+
+    def __init__(
+        self,
+        database: Any,
+        current: tuple[int, str] | None,
+        open_conversation_id: str,
+    ) -> None:
+        super().__init__("Character context scope metadata is unavailable")
+        self.database = database
+        self.current = current
+        self.open_conversation_id = open_conversation_id
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterFocusIdentity:
+    """Semantic focus target, independent of projection ordering."""
+
+    role: str
+    group_key: CharacterConversationKey | None = None
+    row_key: str = ""
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterBrowseSnapshot:
+    """Stable browse presentation restored after leaving search."""
+
+    expanded_key: CharacterConversationKey | None = None
+    focus: ConsoleCharacterFocusIdentity | None = None
+    scroll_offset: int = 0
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterUnavailableDetail:
+    """Bounded, same-authority recovery evidence for one unavailable row."""
+
+    row_key: str
+    reason_copy: str
+    context: LibraryCharacterRepairContext | None
+    candidate_count: int
+
+    @property
+    def can_repair(self) -> bool:
+        return self.context is not None and self.candidate_count > 0
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterQueryHandoffCapability:
+    """Dormant Task 5 installation capability."""
+
+    available: bool = False
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterQueryHandoff:
+    """Validated query transferred to the future Task 5 mode."""
+
+    query: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.query, str) or not self.query.strip():
+            raise ValueError("query handoff requires nonblank text")
+
+
+@dataclass(frozen=True)
+class ConsoleCharacterContextState:
+    """Complete render snapshot for the bounded Character section."""
+
+    groups: tuple[CharacterConversationGroup, ...] = ()
+    query: str = ""
+    search_rows: tuple[CharacterConversationRow, ...] = ()
+    expanded_key: CharacterConversationKey | None = None
+    loading: bool = False
+    error: str = ""
+    data_revision: int = 0
+    keyword_status: CharacterKeywordIndexStatus | None = None
+    restore_focus: ConsoleCharacterFocusIdentity | None = None
+    restore_scroll_offset: int | None = None
+    scope_fingerprint: ConsoleCharacterScopeFingerprint | None = None
+    phase: ConsoleCharacterOperationPhase = ConsoleCharacterOperationPhase.IDLE
+    operation_row_key: str = ""
+    unavailable_details: tuple[ConsoleCharacterUnavailableDetail, ...] = ()
+    selected_unavailable_row_key: str = ""
+
+    @property
+    def has_context(self) -> bool:
+        return bool(self.groups)
+
+    @property
+    def chat_count(self) -> int:
+        return sum(group.total for group in self.groups)
+
+    def unavailable_detail(
+        self, row_key: str
+    ) -> ConsoleCharacterUnavailableDetail | None:
+        return next(
+            (
+                detail
+                for detail in self.unavailable_details
+                if detail.row_key == row_key
+            ),
+            None,
+        )
+
+
+async def _maybe_await(value: Any) -> Any:
+    return await value if inspect.isawaitable(value) else value
+
+
+_UNAVAILABLE_REASON_COPY = {
+    UnavailableCharacterReason.MISSING_CARD: "Card missing",
+    UnavailableCharacterReason.DELETED_CARD: "Card deleted",
+    UnavailableCharacterReason.MISSING_CHARACTER_AUTHORITY_LINK: (
+        "Character source changed"
+    ),
+    UnavailableCharacterReason.AMBIGUOUS_LEGACY_LINK: (
+        "Historical identity incomplete"
+    ),
+}
+
+
+def console_character_unavailable_reason_copy(
+    reason: UnavailableCharacterReason | None,
+) -> str:
+    """Map repository reason identity to concise visible recovery copy."""
+
+    return _UNAVAILABLE_REASON_COPY.get(reason, "Character unavailable")
+
+
+class ConsoleCharacterContextController:
+    """Own bounded Character reads, search state, and typed action routing."""
+
+    def __init__(
+        self,
+        *,
+        database_accessor: Callable[[], Any | None],
+        current_character_accessor: Callable[[], tuple[int, str] | None],
+        open_conversation_accessor: Callable[[], str | None],
+        activate_target: Callable[
+            [CharacterConversationActivationRequest, asyncio.Event],
+            Awaitable[ConsoleConversationActivationResult],
+        ],
+        navigate_roleplay: Callable[[RoleplayCharacterConversationLink], None],
+        navigate_repair: Callable[[LibraryCharacterRepairContext], None],
+        navigate_inspection: Callable[[LibraryUnavailableConversationInspection], None],
+        navigate_unavailable_browse: Callable[
+            [LibraryUnavailableConversationsBrowse], None
+        ],
+        navigate_roleplay_home: Callable[[], None],
+        navigate_library_home: Callable[[], None],
+        start_console: Callable[[int, str], Any],
+        state_changed: Callable[[ConsoleCharacterContextState], None] | None = None,
+        service_factory: Callable[..., CharacterConversationNavigationService] = (
+            CharacterConversationNavigationService
+        ),
+        query_handoff_capability: ConsoleCharacterQueryHandoffCapability | None = None,
+        query_handoff: Callable[[ConsoleCharacterQueryHandoff], None] | None = None,
+    ) -> None:
+        self._database_accessor = database_accessor
+        self._current_character_accessor = current_character_accessor
+        self._open_conversation_accessor = open_conversation_accessor
+        self._activate_target = activate_target
+        self._navigate_roleplay = navigate_roleplay
+        self._navigate_repair = navigate_repair
+        self._navigate_inspection = navigate_inspection
+        self._navigate_unavailable_browse = navigate_unavailable_browse
+        self._navigate_roleplay_home = navigate_roleplay_home
+        self._navigate_library_home = navigate_library_home
+        self._start_console = start_console
+        self._state_changed = state_changed or (lambda _state: None)
+        self._service_factory = service_factory
+        self._query_handoff_capability = (
+            query_handoff_capability or ConsoleCharacterQueryHandoffCapability()
+        )
+        self._query_handoff = query_handoff
+        self._generation = 0
+        self._browse_snapshot: ConsoleCharacterBrowseSnapshot | None = None
+        self._activation_cancellation: asyncio.Event | None = None
+        self.state = ConsoleCharacterContextState()
+
+    def _publish(self, state: ConsoleCharacterContextState) -> None:
+        self.state = state
+        self._state_changed(state)
+
+    def _begin(
+        self,
+        phase: ConsoleCharacterOperationPhase,
+        *,
+        row_key: str = "",
+        **changes: Any,
+    ) -> int:
+        self._generation += 1
+        self._publish(
+            replace(
+                self.state,
+                phase=phase,
+                loading=phase
+                in {
+                    ConsoleCharacterOperationPhase.REFRESHING,
+                    ConsoleCharacterOperationPhase.SEARCHING,
+                },
+                operation_row_key=row_key,
+                error="",
+                **changes,
+            )
+        )
+        return self._generation
+
+    def _current_character_identity(self) -> tuple[int, str] | None:
+        current = self._current_character_accessor()
+        if current is None:
+            return None
+        return int(current[0]), str(current[1])
+
+    def _open_conversation_identity(self) -> str:
+        conversation_id = self._open_conversation_accessor()
+        return str(conversation_id) if conversation_id else ""
+
+    def _ambient_scope_matches(
+        self,
+        database: Any,
+        current: tuple[int, str] | None,
+        open_conversation_id: str,
+    ) -> bool:
+        return (
+            self._database_accessor() is database
+            and self._current_character_identity() == current
+            and self._open_conversation_identity() == open_conversation_id
+        )
+
+    @staticmethod
+    def _read_database_scope_metadata(database: Any) -> tuple[str, int]:
+        return (
+            str(database.get_local_authority_id()),
+            int(database.get_character_conversation_search_revision()),
+        )
+
+    async def _capture_scope(self) -> _ConsoleCharacterScopeSnapshot:
+        """Capture DB/current identity atomically across off-thread metadata reads."""
+
+        for _attempt in range(_SCOPE_CAPTURE_ATTEMPTS):
+            database = self._database_accessor()
+            current = self._current_character_identity()
+            open_conversation_id = self._open_conversation_identity()
+            if database is None:
+                if (
+                    self._database_accessor() is database
+                    and self._current_character_identity() == current
+                    and self._open_conversation_identity() == open_conversation_id
+                ):
+                    return _ConsoleCharacterScopeSnapshot(
+                        database,
+                        ConsoleCharacterScopeFingerprint(
+                            database_identity=None,
+                            data_authority_id="",
+                            data_revision=0,
+                            current_character_id=(
+                                None if current is None else current[0]
+                            ),
+                            current_character_label=(
+                                "" if current is None else current[1]
+                            ),
+                            open_conversation_id=open_conversation_id,
+                        ),
+                    )
+                continue
+            try:
+                metadata_before = await asyncio.to_thread(
+                    self._read_database_scope_metadata, database
+                )
+            except Exception:  # noqa: BLE001 - DB adapters have no shared error base.
+                if not self._ambient_scope_matches(
+                    database, current, open_conversation_id
+                ):
+                    continue
+                raise _ConsoleCharacterScopeReadError(
+                    database, current, open_conversation_id
+                ) from None
+            if not self._ambient_scope_matches(database, current, open_conversation_id):
+                continue
+            try:
+                metadata_after = await asyncio.to_thread(
+                    self._read_database_scope_metadata, database
+                )
+            except Exception:  # noqa: BLE001 - DB adapters have no shared error base.
+                if not self._ambient_scope_matches(
+                    database, current, open_conversation_id
+                ):
+                    continue
+                raise _ConsoleCharacterScopeReadError(
+                    database, current, open_conversation_id
+                ) from None
+            if metadata_before != metadata_after:
+                continue
+            if self._ambient_scope_matches(database, current, open_conversation_id):
+                authority, revision = metadata_after
+                return _ConsoleCharacterScopeSnapshot(
+                    database,
+                    ConsoleCharacterScopeFingerprint(
+                        database_identity=id(database),
+                        data_authority_id=authority,
+                        data_revision=revision,
+                        current_character_id=(None if current is None else current[0]),
+                        current_character_label=("" if current is None else current[1]),
+                        open_conversation_id=open_conversation_id,
+                    ),
+                )
+        raise _ConsoleCharacterScopeChanged("Character context scope did not settle")
+
+    async def _fingerprint(self) -> ConsoleCharacterScopeFingerprint:
+        return (await self._capture_scope()).fingerprint
+
+    async def _scope_is_current(self, snapshot: _ConsoleCharacterScopeSnapshot) -> bool:
+        try:
+            current = await self._capture_scope()
+        except (_ConsoleCharacterScopeChanged, _ConsoleCharacterScopeReadError):
+            return False
+        return (
+            current.database is snapshot.database
+            and current.fingerprint == snapshot.fingerprint
+        )
+
+    def invalidate_scope(self) -> None:
+        """Fence work and force the next lifecycle check to reload."""
+
+        self._generation += 1
+        self._publish(replace(self.state, scope_fingerprint=None))
+
+    async def refresh_if_scope_changed(self, *, force: bool = False) -> bool:
+        try:
+            snapshot = await self._capture_scope()
+        except _ConsoleCharacterScopeChanged:
+            self.invalidate_scope()
+        except _ConsoleCharacterScopeReadError:
+            await self.refresh()
+            return True
+        else:
+            if not force and snapshot.fingerprint == self.state.scope_fingerprint:
+                return False
+        await self.refresh()
+        return True
+
+    @staticmethod
+    def _unavailable_rows(
+        groups: Iterable[CharacterConversationGroup],
+    ) -> tuple[CharacterConversationRow, ...]:
+        return tuple(
+            row for group in groups for row in group.rows if row.unresolved is not None
+        )
+
+    def _load_unavailable_details_sync(
+        self,
+        service: CharacterConversationNavigationService,
+        groups: Iterable[CharacterConversationGroup],
+    ) -> tuple[ConsoleCharacterUnavailableDetail, ...]:
+        details: list[ConsoleCharacterUnavailableDetail] = []
+        for row in self._unavailable_rows(groups):
+            key = row.unresolved
+            if key is None:
+                continue
+            evidence = service.refresh_unresolved_evidence(key)
+            context = None
+            candidate_count = 0
+            if evidence is not None:
+                from ..Navigation.character_conversation_navigation import (
+                    LibraryCharacterRepairContext,
+                    RoleplayReturnTarget,
+                )
+
+                version, snapshot = evidence
+                context = LibraryCharacterRepairContext(
+                    unresolved=key,
+                    expected_conversation_version=version,
+                    historical_display_snapshot=snapshot,
+                    return_target=RoleplayReturnTarget.console_context_character(),
+                )
+                page = service.repair_candidates(
+                    key, limit=CONSOLE_CHARACTER_REPAIR_CANDIDATE_LIMIT
+                )
+                candidate_count = page.total
+            details.append(
+                ConsoleCharacterUnavailableDetail(
+                    row_key=row.row_key,
+                    reason_copy=console_character_unavailable_reason_copy(
+                        row.unavailable_reason
+                    ),
+                    context=context,
+                    candidate_count=candidate_count,
+                )
+            )
+        return tuple(details)
+
+    def _load_recent_sync(
+        self,
+        database: Any,
+        fingerprint: ConsoleCharacterScopeFingerprint,
+    ) -> tuple[
+        tuple[CharacterConversationGroup, ...],
+        tuple[ConsoleCharacterUnavailableDetail, ...],
+    ]:
+        current = (
+            ResolvedLocalCharacterKey(
+                fingerprint.data_authority_id,
+                fingerprint.current_character_id,
+            )
+            if fingerprint.current_character_id is not None
+            else None
+        )
+        service = self._service_factory(database, current_character=current)
+        groups = service.recent_groups(
+            group_limit=CONSOLE_CHARACTER_GROUP_LIMIT,
+            row_limit=CONSOLE_CHARACTER_ROW_LIMIT,
+        )
+        return groups, self._load_unavailable_details_sync(service, groups)
+
+    async def refresh(self) -> None:
+        """Refresh the bounded projection under one complete scope fence."""
+
+        generation = self._begin(ConsoleCharacterOperationPhase.REFRESHING)
+        for _attempt in range(_SCOPE_CAPTURE_ATTEMPTS):
+            try:
+                snapshot = await self._capture_scope()
+            except _ConsoleCharacterScopeChanged:
+                continue
+            except _ConsoleCharacterScopeReadError as error:
+                if generation != self._generation:
+                    return
+                if not self._ambient_scope_matches(
+                    error.database, error.current, error.open_conversation_id
+                ):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        loading=False,
+                        error="Could not load local character chats · Retry",
+                        scope_fingerprint=None,
+                    )
+                )
+                return
+            database = snapshot.database
+            fingerprint = snapshot.fingerprint
+            if database is None:
+                if generation == self._generation and await self._scope_is_current(
+                    snapshot
+                ):
+                    self._publish(
+                        replace(
+                            self.state,
+                            phase=ConsoleCharacterOperationPhase.IDLE,
+                            loading=False,
+                            error="Local character data is unavailable · Retry",
+                            scope_fingerprint=fingerprint,
+                        )
+                    )
+                return
+            try:
+                groups, details = await asyncio.to_thread(
+                    self._load_recent_sync, database, fingerprint
+                )
+            except Exception:  # noqa: BLE001 - DB boundary becomes visible recovery
+                if generation != self._generation:
+                    return
+                if not await self._scope_is_current(snapshot):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        loading=False,
+                        error="Could not load local character chats · Retry",
+                    )
+                )
+                return
+            if generation != self._generation:
+                return
+            if not await self._scope_is_current(snapshot):
+                continue
+            expanded = self.state.expanded_key
+            keys = {group.key for group in groups}
+            if expanded not in keys:
+                expanded = next((g.key for g in groups if g.is_current), None)
+                expanded = expanded or (groups[0].key if groups else None)
+            selected = self.state.selected_unavailable_row_key
+            row_keys = {detail.row_key for detail in details}
+            if selected not in row_keys:
+                selected = ""
+            self._publish(
+                ConsoleCharacterContextState(
+                    groups=groups,
+                    expanded_key=expanded,
+                    data_revision=fingerprint.data_revision,
+                    scope_fingerprint=fingerprint,
+                    unavailable_details=details,
+                    selected_unavailable_row_key=selected,
+                )
+            )
+            return
+        if generation == self._generation:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    loading=False,
+                    error="Local character chats changed · Retry",
+                    scope_fingerprint=None,
+                )
+            )
+
+    async def refresh_unavailable_details(
+        self, groups: Iterable[CharacterConversationGroup]
+    ) -> None:
+        generation = self._generation
+        bounded_groups = tuple(groups)
+        for _attempt in range(_SCOPE_CAPTURE_ATTEMPTS):
+            try:
+                snapshot = await self._capture_scope()
+            except _ConsoleCharacterScopeChanged:
+                continue
+            if snapshot.database is None:
+                return
+            try:
+                service = self._service_factory(
+                    snapshot.database, current_character=None
+                )
+                details = await asyncio.to_thread(
+                    self._load_unavailable_details_sync, service, bounded_groups
+                )
+            except Exception:  # noqa: BLE001 - stale DB failures fail closed
+                if generation != self._generation:
+                    return
+                if not await self._scope_is_current(snapshot):
+                    continue
+                return
+            if generation != self._generation:
+                return
+            if not await self._scope_is_current(snapshot):
+                continue
+            self._publish(
+                replace(
+                    self.state,
+                    unavailable_details=details,
+                    scope_fingerprint=snapshot.fingerprint,
+                )
+            )
+            return
+
+    def toggle_group(self, key: CharacterConversationKey) -> None:
+        self._publish(
+            replace(
+                self.state,
+                expanded_key=None if self.state.expanded_key == key else key,
+                restore_focus=None,
+                restore_scroll_offset=None,
+            )
+        )
+
+    def select_unavailable(self, row_key: str) -> None:
+        self._publish(replace(self.state, selected_unavailable_row_key=row_key))
+
+    def capture_browse(
+        self,
+        *,
+        focus: ConsoleCharacterFocusIdentity | None,
+        scroll_offset: int,
+    ) -> None:
+        if self._browse_snapshot is None:
+            self._browse_snapshot = ConsoleCharacterBrowseSnapshot(
+                expanded_key=self.state.expanded_key,
+                focus=focus,
+                scroll_offset=max(0, int(scroll_offset)),
+            )
+
+    def _search_sync(
+        self,
+        database: Any,
+        fingerprint: ConsoleCharacterScopeFingerprint,
+        query: str,
+    ) -> tuple[tuple[CharacterConversationRow, ...], CharacterKeywordIndexStatus]:
+        current = (
+            ResolvedLocalCharacterKey(
+                fingerprint.data_authority_id,
+                fingerprint.current_character_id,
+            )
+            if fingerprint.current_character_id is not None
+            else None
+        )
+        service = self._service_factory(database, current_character=current)
+        status = service.ensure_keyword_index()
+        page = service.keyword_search(query, limit=CONSOLE_CHARACTER_SEARCH_LIMIT)
+        rows = tuple(replace(row, selected_excerpt="") for row in page.rows)
+        return rows, page.keyword_status or status
+
+    async def search(self, query: str) -> None:
+        """Search at most eight local rows and restore semantic browse state."""
+
+        normalized = str(query or "").strip()
+        if not normalized:
+            self._generation += 1
+            snapshot = self._browse_snapshot
+            self._browse_snapshot = None
+            self._publish(
+                replace(
+                    self.state,
+                    query="",
+                    search_rows=(),
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    loading=False,
+                    error="",
+                    operation_row_key="",
+                    expanded_key=(
+                        snapshot.expanded_key
+                        if snapshot is not None
+                        else self.state.expanded_key
+                    ),
+                    restore_focus=(snapshot.focus if snapshot else None),
+                    restore_scroll_offset=(
+                        snapshot.scroll_offset if snapshot else None
+                    ),
+                )
+            )
+            return
+        generation = self._begin(
+            ConsoleCharacterOperationPhase.SEARCHING,
+            query=normalized,
+            search_rows=(),
+            restore_focus=None,
+            restore_scroll_offset=None,
+        )
+        for _attempt in range(_SCOPE_CAPTURE_ATTEMPTS):
+            try:
+                snapshot = await self._capture_scope()
+            except _ConsoleCharacterScopeChanged:
+                continue
+            except _ConsoleCharacterScopeReadError as error:
+                if generation != self._generation:
+                    return
+                if not self._ambient_scope_matches(
+                    error.database, error.current, error.open_conversation_id
+                ):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        loading=False,
+                        operation_row_key="",
+                        error="Could not search local character chats · Retry",
+                        scope_fingerprint=None,
+                    )
+                )
+                return
+            if snapshot.database is None:
+                if generation == self._generation and await self._scope_is_current(
+                    snapshot
+                ):
+                    self._publish(
+                        replace(
+                            self.state,
+                            phase=ConsoleCharacterOperationPhase.IDLE,
+                            loading=False,
+                            error="Local character search is unavailable · Retry",
+                            scope_fingerprint=snapshot.fingerprint,
+                        )
+                    )
+                return
+            try:
+                rows, status = await asyncio.to_thread(
+                    self._search_sync,
+                    snapshot.database,
+                    snapshot.fingerprint,
+                    normalized,
+                )
+            except Exception:  # noqa: BLE001 - DB boundary becomes visible recovery
+                if generation != self._generation:
+                    return
+                if not await self._scope_is_current(snapshot):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        loading=False,
+                        error="Could not search local character chats · Retry",
+                    )
+                )
+                return
+            if generation != self._generation:
+                return
+            if not await self._scope_is_current(snapshot):
+                continue
+            fingerprint = snapshot.fingerprint
+            keyword_error = {
+                CharacterKeywordIndexStatus.ABSENT: "Character source changed · Retry",
+                CharacterKeywordIndexStatus.BUILDING: (
+                    "Character chat search is rebuilding · Retry"
+                ),
+                CharacterKeywordIndexStatus.FAILED: (
+                    "Character chat index needs repair · Retry"
+                ),
+            }.get(status, "")
+            self._publish(
+                replace(
+                    self.state,
+                    search_rows=(
+                        rows[:CONSOLE_CHARACTER_SEARCH_LIMIT]
+                        if not keyword_error
+                        else ()
+                    ),
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    loading=False,
+                    error=keyword_error,
+                    data_revision=fingerprint.data_revision,
+                    scope_fingerprint=fingerprint,
+                    keyword_status=status,
+                )
+            )
+            return
+        if generation == self._generation:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    loading=False,
+                    error="Local character chats changed · Retry",
+                    scope_fingerprint=None,
+                )
+            )
+
+    async def activate(
+        self,
+        target: LocalCharacterConversationTarget,
+        *,
+        row_key: str = "",
+    ) -> ConsoleConversationActivationResult:
+        """Activate one exact target while preserving its visible row."""
+        from ...Chat.console_conversation_activation import (
+            CharacterConversationActivationRequest,
+            ConsoleActivationResultKind,
+            ConsoleConversationActivationResult,
+        )
+
+        if self._activation_cancellation is not None:
+            return ConsoleConversationActivationResult(
+                ConsoleActivationResultKind.FAILED, target, False
+            )
+        generation = self._begin(
+            ConsoleCharacterOperationPhase.OPENING, row_key=row_key
+        )
+        cancellation = asyncio.Event()
+        self._activation_cancellation = cancellation
+        request = CharacterConversationActivationRequest(
+            target=target,
+            data_authority_id=target.character.data_authority_id,
+            data_revision=self.state.data_revision,
+        )
+        try:
+            result = await self._activate_target(request, cancellation)
+        except Exception:  # noqa: BLE001 - typed UI failure at navigation boundary
+            result = ConsoleConversationActivationResult(
+                ConsoleActivationResultKind.FAILED, target, False
+            )
+        finally:
+            if self._activation_cancellation is cancellation:
+                self._activation_cancellation = None
+        failure = {
+            ConsoleActivationResultKind.NOT_FOUND: "Chat no longer exists · Refresh",
+            ConsoleActivationResultKind.DATA_PROFILE_CHANGED: (
+                "Data Profile changed · Refresh"
+            ),
+            ConsoleActivationResultKind.CHARACTER_UNAVAILABLE: (
+                "Character unavailable · Open in Library"
+            ),
+            ConsoleActivationResultKind.FAILED: (
+                "Could not open character chat · Retry"
+            ),
+        }.get(result.kind, "")
+        if generation == self._generation:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    loading=False,
+                    operation_row_key="",
+                    error=failure,
+                )
+            )
+        if (
+            result.kind is ConsoleActivationResultKind.OPENED
+            and generation == self._generation
+        ):
+            await self.refresh_if_scope_changed(force=True)
+        return result
+
+    def cancel_activation(self) -> None:
+        if self._activation_cancellation is not None:
+            self._activation_cancellation.set()
+
+    def open_roleplay(self, link: RoleplayCharacterConversationLink) -> None:
+        self._navigate_roleplay(link)
+
+    def open_repair(self, context: LibraryCharacterRepairContext) -> None:
+        self._navigate_repair(context)
+
+    async def _prepare_unavailable_repair(
+        self,
+        key: UnresolvedConversationKey,
+        *,
+        row_key: str,
+    ) -> bool:
+        generation = self._begin(
+            ConsoleCharacterOperationPhase.REPAIRING, row_key=row_key
+        )
+        snapshot: _ConsoleCharacterScopeSnapshot | None = None
+        evidence = None
+        candidates: tuple[Any, ...] = ()
+        candidate_total = 0
+        for _attempt in range(_SCOPE_CAPTURE_ATTEMPTS):
+            try:
+                snapshot = await self._capture_scope()
+            except _ConsoleCharacterScopeChanged:
+                continue
+            except _ConsoleCharacterScopeReadError as error:
+                if generation != self._generation:
+                    return False
+                if not self._ambient_scope_matches(
+                    error.database, error.current, error.open_conversation_id
+                ):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        loading=False,
+                        operation_row_key="",
+                        error="Could not refresh Library details · Retry",
+                        scope_fingerprint=None,
+                    )
+                )
+                return False
+            if snapshot.database is None:
+                if generation == self._generation and await self._scope_is_current(
+                    snapshot
+                ):
+                    self._publish(
+                        replace(
+                            self.state,
+                            phase=ConsoleCharacterOperationPhase.IDLE,
+                            error="Local character data is unavailable",
+                        )
+                    )
+                return False
+            try:
+                service = self._service_factory(
+                    snapshot.database, current_character=None
+                )
+                evidence, page = await asyncio.to_thread(
+                    lambda service=service: (
+                        service.refresh_unresolved_evidence(key),
+                        service.repair_candidates(
+                            key, limit=CONSOLE_CHARACTER_REPAIR_CANDIDATE_LIMIT
+                        ),
+                    )
+                )
+                candidates = page.candidates
+                candidate_total = page.total
+            except Exception:  # noqa: BLE001 - repair evidence is a DB boundary
+                if generation != self._generation:
+                    return False
+                if not await self._scope_is_current(snapshot):
+                    continue
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        error="Could not refresh Library details · Retry",
+                    )
+                )
+                return False
+            if generation != self._generation:
+                return False
+            if not await self._scope_is_current(snapshot):
+                continue
+            break
+        else:
+            if generation == self._generation:
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        error="Data Profile changed · Refresh",
+                        scope_fingerprint=None,
+                    )
+                )
+            return False
+        fingerprint = snapshot.fingerprint
+        if fingerprint.data_authority_id != key.data_authority_id:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    error="Data Profile changed · Refresh",
+                    scope_fingerprint=None,
+                )
+            )
+            return False
+        if evidence is None:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    error="Chat changed · Refresh",
+                )
+            )
+            return False
+        same_authority = tuple(
+            candidate
+            for candidate in candidates
+            if candidate.key.data_authority_id == key.data_authority_id
+        )
+        if not same_authority:
+            self._publish(
+                replace(
+                    self.state,
+                    phase=ConsoleCharacterOperationPhase.IDLE,
+                    operation_row_key="",
+                    error="No compatible local character cards",
+                )
+            )
+            return False
+        version, snapshot = evidence
+        from ..Navigation.character_conversation_navigation import (
+            LibraryCharacterRepairContext,
+            RoleplayReturnTarget,
+        )
+
+        context = LibraryCharacterRepairContext(
+            unresolved=key,
+            expected_conversation_version=version,
+            historical_display_snapshot=snapshot,
+            return_target=RoleplayReturnTarget.console_context_character(),
+        )
+        updated = tuple(
+            replace(
+                item,
+                context=context,
+                candidate_count=candidate_total,
+            )
+            if item.row_key == row_key
+            else item
+            for item in self.state.unavailable_details
+        )
+        if not any(item.row_key == row_key for item in updated):
+            updated = (
+                *updated,
+                ConsoleCharacterUnavailableDetail(
+                    row_key=row_key,
+                    reason_copy="Character unavailable",
+                    context=context,
+                    candidate_count=candidate_total,
+                ),
+            )
+        self._publish(
+            replace(
+                self.state,
+                phase=ConsoleCharacterOperationPhase.IDLE,
+                operation_row_key="",
+                error="",
+                unavailable_details=updated,
+                scope_fingerprint=fingerprint,
+            )
+        )
+        self.open_repair(context)
+        return True
+
+    async def open_unavailable(
+        self, key: UnresolvedConversationKey, *, row_key: str
+    ) -> bool:
+        """Open exact Library detail whether or not repair candidates exist."""
+
+        generation = self._begin(
+            ConsoleCharacterOperationPhase.REPAIRING, row_key=row_key
+        )
+        try:
+            snapshot = await self._capture_scope()
+        except Exception:  # noqa: BLE001 - scope boundary becomes visible recovery
+            if generation == self._generation:
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        operation_row_key="",
+                        error="Could not open Library details · Retry",
+                    )
+                )
+            return False
+        if (
+            generation != self._generation
+            or snapshot.fingerprint.data_authority_id != key.data_authority_id
+            or not await self._scope_is_current(snapshot)
+        ):
+            if generation == self._generation:
+                self._publish(
+                    replace(
+                        self.state,
+                        phase=ConsoleCharacterOperationPhase.IDLE,
+                        operation_row_key="",
+                        error="Data Profile changed · Refresh",
+                        scope_fingerprint=None,
+                    )
+                )
+            return False
+        self._publish(
+            replace(
+                self.state,
+                phase=ConsoleCharacterOperationPhase.IDLE,
+                operation_row_key="",
+                error="",
+                scope_fingerprint=snapshot.fingerprint,
+            )
+        )
+        from ..Navigation.character_conversation_navigation import (
+            LibraryUnavailableConversationInspection,
+            RoleplayReturnTarget,
+        )
+
+        self._navigate_inspection(
+            LibraryUnavailableConversationInspection(
+                unresolved=key,
+                return_target=RoleplayReturnTarget.console_context_character(),
+            )
+        )
+        return True
+
+    async def repair_unavailable(
+        self, key: UnresolvedConversationKey, *, row_key: str = ""
+    ) -> bool:
+        """Navigate to repair only with fresh same-authority candidates."""
+
+        return await self._prepare_unavailable_repair(key, row_key=row_key)
+
+    async def view_group(self, group: CharacterConversationGroup) -> None:
+        from ..Navigation.character_conversation_navigation import (
+            LibraryUnavailableConversationsBrowse,
+            RoleplayCharacterConversationLink,
+            RoleplayReturnTarget,
+        )
+
+        if isinstance(group.key, ResolvedLocalCharacterKey):
+            self.open_roleplay(
+                RoleplayCharacterConversationLink(
+                    character=group.key,
+                    return_target=RoleplayReturnTarget.console_context_character(),
+                )
+            )
+            return
+        selected = self.state.selected_unavailable_row_key
+        row = next(
+            (
+                item
+                for item in group.rows
+                if item.row_key == selected and item.unresolved is not None
+            ),
+            next((item for item in group.rows if item.unresolved is not None), None),
+        )
+        if row is not None and row.unresolved is not None:
+            try:
+                snapshot = await self._capture_scope()
+            except Exception:  # noqa: BLE001 - route fails closed on scope churn
+                return
+            if (
+                snapshot.fingerprint.data_authority_id
+                != row.unresolved.data_authority_id
+                or not await self._scope_is_current(snapshot)
+            ):
+                return
+            self._navigate_unavailable_browse(
+                LibraryUnavailableConversationsBrowse(
+                    selected=row.unresolved,
+                    return_target=RoleplayReturnTarget.console_context_character(),
+                )
+            )
+        else:
+            self._navigate_library_home()
+
+    def open_roleplay_home(self) -> None:
+        self._navigate_roleplay_home()
+
+    async def start_current(self, group: CharacterConversationGroup) -> None:
+        if isinstance(group.key, ResolvedLocalCharacterKey):
+            self.invalidate_scope()
+            await _maybe_await(
+                self._start_console(group.key.character_id, group.character_label)
+            )
+            await self.refresh_if_scope_changed(force=True)
+
+    def handoff_query(self, query: str) -> bool:
+        """Invoke Task 5's typed handoff only after capability installation."""
+
+        if not self._query_handoff_capability.available or self._query_handoff is None:
+            return False
+        self._query_handoff(ConsoleCharacterQueryHandoff(query.strip()))
+        return True
+
+    @property
+    def query_handoff_available(self) -> bool:
+        """Return whether Task 5 installed both halves of the dormant seam."""
+
+        return (
+            self._query_handoff_capability.available and self._query_handoff is not None
+        )

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -5,7 +5,7 @@ decomposition, task 3): the subtree that used to live inside
 ``with self._frame_console_region(left_rail):`` — the rail header, the
 pinned fleet-summary line, and the scrollable context sections. The former
 mixed Session section is now three peer sections (Sessions, Workspaces, and
-Conversations), followed by Model, Agent, Details, and Character.
+Conversations), followed by Character, Model, Agent, and Details.
 
 Deliberately NOT included: ``left_handle`` (``ConsoleRailHandle``, id
 ``console-context-rail-handle``), the collapsed 13-column form shown when
@@ -86,6 +86,7 @@ from ...Widgets.Console.console_agent_steering_bar import (
     ConsoleAgentSteeringState,
 )
 from ...Widgets.Console.console_image_viewer_modal import ClickableAvatarBox
+from ...Widgets.Console.console_character_context import ConsoleCharacterContext
 from ...Widgets.Console.console_workspace_details import ConsoleWorkspaceDetailsTray
 from ...Widgets.destination_rail import (
     RAIL_SECTION_TOGGLE_PREFIX,
@@ -100,6 +101,10 @@ from .agent import (
     apply_console_agent_status_state,
 )
 from .frame import frame_console_region
+from .character_context import (
+    ConsoleCharacterContextController,
+    ConsoleCharacterContextState,
+)
 from .rail_section_layout import (
     ContextSectionDemand,
     fallback_active_section,
@@ -153,10 +158,10 @@ CONTEXT_SECTION_DESCRIPTORS = (
     # marked "active session".
     ContextSectionDescriptor("workspace", "Workspaces", 20),
     ContextSectionDescriptor("conversations", "Conversations", 20),
+    ContextSectionDescriptor("character", "Character", 35),
     ContextSectionDescriptor("model", "Model", 15),
     ContextSectionDescriptor("agent", "Agent", 15),
     ContextSectionDescriptor("details", "Details", 15),
-    ContextSectionDescriptor("character", "Character", 35),
 )
 
 
@@ -286,10 +291,8 @@ class ConsoleLeftRail(Vertical):
             if bool(header.open) is opened:
                 continue
             self.post_message(
-                self.SectionToggled(
-                    section_id=descriptor.section_id, opened=opened
+                self.SectionToggled(section_id=descriptor.section_id, opened=opened)
                 )
-            )
 
 
     class SectionToggled(Message):
@@ -342,6 +345,7 @@ class ConsoleLeftRail(Vertical):
         character_avatar_name: str,
         character_avatar_fit_box: CharacterAvatarFitBox | None = None,
         character_avatar_prerender_job: CharacterAvatarPrerenderJob | None = None,
+        character_context_controller: ConsoleCharacterContextController | None = None,
         workspace_tree_expanded_ids: frozenset[str] | None = None,
         workspace_tree_expansion_preferences_changed: (
             Callable[[frozenset[str]], None] | None
@@ -393,12 +397,11 @@ class ConsoleLeftRail(Vertical):
                 visible``. Passed at construction for the same
                 recompose-mid-state reason as ``agent_steering_state``;
                 the default keeps bare test constructions valid (hidden).
-            show_character_section: Whether the Character section is
-                composed at all (config-gated; matches
-                ``resolve_show_character_avatar``).
+            show_character_section: Historical keyword for the avatar image
+                preference. Character navigation itself is always composed.
             character_avatar_widget_builder: Callable that builds the avatar
-                widget for an optional fitted cell box, when
-                ``show_character_section`` is True (``None`` otherwise). The
+                widget for an optional fitted cell box, when the avatar image
+                preference is true (``None`` otherwise). The
                 screen still owns
                 ``_build_character_avatar_widget`` and the spec it reads
                 (``self._active_character_avatar``); only the CALL is
@@ -415,8 +418,7 @@ class ConsoleLeftRail(Vertical):
                 late-binding constructor rule -- see ``dictation.py``'s
                 module docstring) always mounts a brand-new instance built
                 from the CURRENT ``self._active_character_avatar`` instead.
-            character_avatar_name: Character name label text, when
-                ``show_character_section`` is True.
+            character_avatar_name: Character identity label text.
             character_avatar_fit_box: Late-binding source-aware contain fitter.
                 It receives the mounted body's measured image budget and returns
                 the scale-down-only cell box, ``(0, 0)`` when no image rows
@@ -449,7 +451,10 @@ class ConsoleLeftRail(Vertical):
         self._agent_full_log_available = agent_full_log_available
         self._agent_steering_state = agent_steering_state
         self._agent_cancel_all_visible = agent_cancel_all_visible
-        self._show_character_section = show_character_section
+        # Kept under the historical keyword for compatibility: this setting
+        # now controls only the image, never whether Character exists.
+        self._show_character_avatar = show_character_section
+        self._character_context_controller = character_context_controller
         self._character_avatar_widget_builder = character_avatar_widget_builder
         self._character_avatar_name = character_avatar_name
         self._character_avatar_fit_box = character_avatar_fit_box
@@ -499,6 +504,35 @@ class ConsoleLeftRail(Vertical):
 
         return self._character_avatar_box
 
+    def sync_character_context(self, state: ConsoleCharacterContextState) -> None:
+        """Synchronize body content and the collapsed Character summary."""
+
+        try:
+            widget = self.query_one("#console-character-context", ConsoleCharacterContext)
+            header = self.query_one(
+                "#console-rail-section-header-character",
+                DestinationRailSectionHeader,
+            )
+            title = header.query_one("#console-rail-section-title-character", Static)
+        except (NoMatches, QueryError):
+            return
+        widget.sync_state(state)
+        header.title = self._character_context_title(state)
+        title.update(header.title)
+        title.tooltip = header.title
+        self.request_allocation_reconcile()
+
+    @staticmethod
+    def _character_context_title(state: ConsoleCharacterContextState) -> str:
+        """Build the collapsed summary from an already-loaded snapshot."""
+
+        current = next((group for group in state.groups if group.is_current), None)
+        if current is None and state.groups:
+            current = state.groups[0]
+        if current is None:
+            return "Character · No chats"
+        return f"Character · {current.character_label} · {current.total} chats"
+
     def invalidate_character_avatar_geometry(self) -> None:
         """Start a new source/viewport epoch for the Character contain fit."""
 
@@ -520,6 +554,8 @@ class ConsoleLeftRail(Vertical):
     def _section_header(
         section_id: str,
         is_open: bool,
+        *,
+        title: str | None = None,
     ) -> DestinationRailSectionHeader:
         """Build a direct header from the stable descriptor title source."""
 
@@ -529,7 +565,7 @@ class ConsoleLeftRail(Vertical):
             if item.section_id == section_id
         )
         header = DestinationRailSectionHeader(
-            descriptor.title,
+            title or descriptor.title,
             section_id=section_id,
             open=is_open,
             id=f"console-rail-section-header-{section_id}",
@@ -1793,6 +1829,16 @@ class ConsoleLeftRail(Vertical):
             return
         if not (outer.is_mounted and header.is_mounted and bounded.display):
             return
+        if target_required and target_id and target_id.startswith("console-character-"):
+            # A search result can be below the header-sized visible slice. The
+            # validated keyboard target, not the header, owns this reveal.
+            outer.scroll_to_widget(
+                self.query_one(f"#{target_id}", Widget),
+                animate=False,
+                immediate=True,
+                force=True,
+            )
+            return
         outer.scroll_to(
             y=max(0, outer.scroll_y + header.region.y - outer.content_region.y),
             animate=False,
@@ -2041,6 +2087,106 @@ class ConsoleLeftRail(Vertical):
             yield _ContextBoundedSection(
                 conversations_body,
                 section_id="conversations",
+                owner=self,
+            )
+
+            # Character is a peer navigation surface, always immediately
+            # after Conversations. The preference gates only avatar pixels.
+            character_state = (
+                self._character_context_controller.state
+                if self._character_context_controller is not None
+                else ConsoleCharacterContextState()
+            )
+            yield self._section_header(
+                "character",
+                rail_state.character_open,
+                title=self._character_context_title(character_state),
+            )
+            avatar_children = ()
+            if (
+                self._show_character_avatar
+                and self._character_avatar_widget_builder is not None
+            ):
+                avatar_children = (
+                    self._character_avatar_widget_builder(self._character_avatar_box),
+                )
+            avatar_holder = ClickableAvatarBox(
+                *avatar_children,
+                id="console-character-avatar",
+            )
+            avatar_holder.styles.width = "auto"
+            avatar_holder.styles.height = "auto"
+            avatar_frame = Horizontal(avatar_holder, id="console-character-avatar-frame")
+            avatar_frame.styles.width = "100%"
+            avatar_frame.styles.height = "auto"
+            avatar_frame.styles.align_horizontal = "center"
+            if not self._show_character_avatar:
+                avatar_frame.styles.display = "none"
+            character_name = Static(
+                self._character_avatar_name or "Roleplay character",
+                id="console-character-name",
+                markup=False,
+            )
+            # Kept as a hidden avatar-caption seam for the existing painter;
+            # the visible Local/open identity below has one controller owner.
+            character_name.styles.display = "none"
+            character_identity = Static(
+                "No current character · Local · No open chat",
+                id="console-character-identity",
+                markup=False,
+            )
+            reaction_state = Static(
+                (
+                    f"Reaction: {self._manual_reaction_label} (manual)"
+                    if self._manual_reaction_label
+                    else "Reaction: Automatic"
+                ),
+                id="console-character-reaction-state",
+                markup=False,
+            )
+            reaction_state.styles.text_wrap = "nowrap"
+            reaction_state.styles.text_overflow = "ellipsis"
+            reaction_button = Button(
+                "Reaction…",
+                id="console-character-reaction-open",
+                classes="console-workspace-action",
+                compact=True,
+            )
+            reaction_button.tooltip = "Choose or clear a reaction"
+            if self._character_context_controller is not None:
+                character_content: Widget = Vertical(
+                    # Avatar painting is independent of the browser's data
+                    # refresh/recompose lifecycle.  Keep its holder and
+                    # private caption outside that replaceable subtree.
+                    avatar_frame,
+                    character_name,
+                    character_identity,
+                    reaction_state,
+                    reaction_button,
+                    ConsoleCharacterContext(
+                        self._character_context_controller,
+                        identity_state=character_identity,
+                    ),
+                )
+            else:
+                character_content = Vertical(
+                    avatar_frame,
+                    character_name,
+                    reaction_state,
+                    reaction_button,
+                    Static("No character chats yet", markup=False),
+                    id="console-character-context",
+                )
+            character_content.styles.height = "auto"
+            character_content.styles.min_height = 0
+            character_body = self._section_body(
+                "character",
+                rail_state.character_open,
+                character_content,
+            )
+            yield _ContextBoundedSection(
+                character_body,
+                section_id="character",
                 owner=self,
             )
 
@@ -2310,70 +2456,6 @@ class ConsoleLeftRail(Vertical):
                 section_id="details",
                 owner=self,
             )
-
-            # Character (avatar of the active character).
-            if self._show_character_section:
-                yield self._section_header(
-                    "character",
-                    rail_state.character_open,
-                )
-                avatar_children = ()
-                if self._character_avatar_widget_builder is not None:
-                    avatar_children = (
-                        self._character_avatar_widget_builder(
-                            self._character_avatar_box
-                        ),
-                    )
-                avatar_holder = ClickableAvatarBox(
-                    *avatar_children,
-                    id="console-character-avatar",
-                )
-                # task-1661: hug the image instead of claiming the rail.
-                avatar_holder.styles.width = "auto"
-                avatar_holder.styles.height = "auto"
-                avatar_frame = Horizontal(
-                    avatar_holder,
-                    id="console-character-avatar-frame",
-                )
-                avatar_frame.styles.width = "100%"
-                avatar_frame.styles.height = "auto"
-                avatar_frame.styles.align_horizontal = "center"
-                character_name = Static(
-                    self._character_avatar_name,
-                    id="console-character-name",
-                    markup=False,
-                )
-                reaction_state = Static(
-                    (
-                        f"Reaction: {self._manual_reaction_label} (manual)"
-                        if self._manual_reaction_label
-                        else "Reaction: Automatic"
-                    ),
-                    id="console-character-reaction-state",
-                    markup=False,
-                )
-                reaction_state.styles.text_wrap = "nowrap"
-                reaction_state.styles.text_overflow = "ellipsis"
-                reaction_button = Button(
-                    "Reaction…",
-                    id="console-character-reaction-open",
-                    classes="console-workspace-action",
-                    compact=True,
-                )
-                reaction_button.tooltip = "Choose or clear a reaction"
-                character_body = self._section_body(
-                    "character",
-                    rail_state.character_open,
-                    avatar_frame,
-                    character_name,
-                    reaction_state,
-                    reaction_button,
-                )
-                yield _ContextBoundedSection(
-                    character_body,
-                    section_id="character",
-                    owner=self,
-                )
 
         outer_hint = Static(
             "",

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -1125,7 +1125,10 @@ class ConsoleLeftRail(Vertical):
         if (
             self.app.focused is target
             and target.is_mounted
-            and not self._section_is_outer_visible(section_id)
+            and (
+                section_id == "character"
+                or not self._section_is_outer_visible(section_id)
+            )
         ):
             self.activate_section(section_id, reveal_target=target)
             return

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -159,14 +159,17 @@ def _navigate_character_context(screen: Any, context_key: str, target: Any) -> N
 
 
 async def _start_character_context_chat(
-    screen: Any, character_id: int, name: str
+    screen: Any, key: Any, database: Any, name: str, is_current: Callable[[], bool]
 ) -> None:
     from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
         ConsoleCharacterChoice,
     )
 
     await screen._character._apply_console_character_choice_async(
-        ConsoleCharacterChoice(character_id, name, "new")
+        ConsoleCharacterChoice(key.character_id, name, "new"),
+        expected_key=key,
+        required_database=database,
+        commit_is_current=is_current,
     )
 
 
@@ -181,6 +184,8 @@ def _sync_character_context_presentation(
 ) -> None:
     """Push a complete Character snapshot into the current mounted rail."""
 
+    if not screen.is_attached or not screen.app.screen_stack:
+        return
     try:
         widget = screen.query_one("#console-character-context", ConsoleCharacterContext)
     except QueryError:
@@ -1071,8 +1076,8 @@ def build_console_controllers(
             lambda: screen.post_message(NavigateToScreen(TAB_LIBRARY))
         ),
         start_console=(
-            lambda character_id, name: _start_character_context_chat(
-                screen, character_id, name
+            lambda key, database, name, is_current: _start_character_context_chat(
+                screen, key, database, name, is_current
             )
         ),
         state_changed=lambda state: _sync_character_context_presentation(

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -59,9 +59,20 @@ from tldw_chatbook.Chat.console_fleet_attention import (
     fleet_unseen_conversation_ids,
 )
 from tldw_chatbook.Chat.console_runtime import leave_console_runtime
+from tldw_chatbook.Constants import (
+    LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE,
+    LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION,
+    LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR,
+    ROLEPLAY_NAV_CONTEXT_CHARACTER_CONVERSATION,
+    TAB_LIBRARY,
+    TAB_PERSONAS,
+)
 from tldw_chatbook.Widgets.confirmation_dialog import ConfirmationDialog
 from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
     ConsoleAutoSpeakCoordinator,
+)
+from tldw_chatbook.Widgets.Console.console_character_context import (
+    ConsoleCharacterContext,
 )
 from tldw_chatbook.Widgets.Console.console_control_bar import ConsoleControlBar
 from tldw_chatbook.Widgets.Console.console_feedback_comment_modal import (
@@ -72,10 +83,15 @@ from tldw_chatbook.Widgets.Console.console_speech_controls import (
 )
 from tldw_chatbook.Workspaces.models import RuntimeBindingStatus
 
+from ..Navigation.main_navigation import NavigateToScreen
 from ..Screens.settings_library_rag_defaults import load_direct_library_tools
 from .agent import ConsoleAgentController
 from .capture_policy_bindings import build_capture_policy_bindings
 from .character import ConsoleCharacterController
+from .character_context import (
+    ConsoleCharacterContextController,
+    ConsoleCharacterContextState,
+)
 from .console_spend_projection import ConsoleDraftSpendRefresh
 from .dictation import ConsoleDictationController
 from .fleet import ConsoleFleetLifecycleController
@@ -90,7 +106,6 @@ from .prompt_queue import (
 )
 from .prompts import ConsolePromptsController
 from .raw_cli import ConsoleRawCliController, restore_refused_raw_cli_stash
-from .reaction_preview import get_console_reaction_preview_coordinator
 from .realtime import ConsoleRealtimeController
 from .retrieval import ConsoleRetrievalController
 from .review_selection import (
@@ -111,6 +126,78 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
     from ..Screens.chat_screen import ChatScreen
 
 __all__ = ["build_console_controllers"]
+
+
+def _navigate_character_context(screen: Any, context_key: str, target: Any) -> None:
+    """Serialize exact navigation only when the user leaves the Character browser."""
+    from ..Navigation.character_conversation_navigation import (
+        serialize_library_character_repair_context,
+        serialize_library_unavailable_browse,
+        serialize_library_unavailable_inspection,
+        serialize_roleplay_character_conversation_link,
+    )
+
+    route, serialize = {
+        ROLEPLAY_NAV_CONTEXT_CHARACTER_CONVERSATION: (
+            TAB_PERSONAS,
+            serialize_roleplay_character_conversation_link,
+        ),
+        LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR: (
+            TAB_LIBRARY,
+            serialize_library_character_repair_context,
+        ),
+        LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION: (
+            TAB_LIBRARY,
+            serialize_library_unavailable_inspection,
+        ),
+        LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE: (
+            TAB_LIBRARY,
+            serialize_library_unavailable_browse,
+        ),
+    }[context_key]
+    screen.post_message(NavigateToScreen(route, {context_key: serialize(target)}))
+
+
+async def _start_character_context_chat(
+    screen: Any, character_id: int, name: str
+) -> None:
+    from tldw_chatbook.Widgets.Console.console_character_picker_modal import (
+        ConsoleCharacterChoice,
+    )
+
+    await screen._character._apply_console_character_choice_async(
+        ConsoleCharacterChoice(character_id, name, "new")
+    )
+
+
+def _reaction_preview_coordinator(screen: Any) -> Any:
+    from .reaction_preview import get_console_reaction_preview_coordinator
+
+    return get_console_reaction_preview_coordinator(screen.app_instance)
+
+
+def _sync_character_context_presentation(
+    screen: Any, state: ConsoleCharacterContextState
+) -> None:
+    """Push a complete Character snapshot into the current mounted rail."""
+
+    try:
+        widget = screen.query_one("#console-character-context", ConsoleCharacterContext)
+    except QueryError:
+        return
+    widget.sync_state(state)
+    try:
+        rail = screen.query_one("#console-left-rail")
+    except QueryError:
+        return
+    sync = getattr(rail, "sync_character_context", None)
+    if callable(sync):
+        sync(state)
+    # A scope may have no active character but still gain its first useful
+    # context when the off-loop recent-chat read settles. Re-resolve the
+    # render-only first-use default; this does not persist on read.
+    current_rail_state = screen._current_console_rail_state()
+    screen._sync_console_rail_visibility_if_changed(current_rail_state)
 
 
 def _displayed_console_composer_draft(screen: Any) -> str | None:
@@ -519,7 +606,8 @@ def build_console_controllers(
 
     Assigns, in this order, `screen._image`, `screen._video`,
     `screen._retrieval`, `screen._library_policy`, `screen._library_activity`,
-    `screen._skill`, `screen._workspace`, `screen._character`, `screen._fleet`,
+    `screen._skill`, `screen._workspace`, `screen._character`,
+    `screen._character_context`, `screen._fleet`,
     `screen._session`, `screen._dictation`, `screen._hands_free`,
     `screen._realtime`, `screen._message`, `screen._console_auto_speak`,
     `screen._prompts`, `screen._agent`, `screen._terminal`, `screen._raw_cli`,
@@ -929,6 +1017,68 @@ def build_console_controllers(
             lambda **kwargs: screen._render_character_avatar_into_section(**kwargs)
         ),
     )
+    screen._character_context = ConsoleCharacterContextController(
+        database_accessor=(
+            lambda: getattr(screen.app_instance, "chachanotes_db", None)
+        ),
+        current_character_accessor=(
+            lambda: (
+                (
+                    character_id,
+                    screen._character._current_console_rail_character_name()
+                    or "Current character",
+                )
+                if (
+                    character_id
+                    := screen._character._current_console_rail_character_id()
+                )
+                is not None
+                else None
+            )
+        ),
+        open_conversation_accessor=(
+            lambda: screen._session._current_console_conversation_id()
+        ),
+        activate_target=(
+            lambda request, cancellation: (
+                screen._workspace.activate_character_conversation(request, cancellation)
+            )
+        ),
+        navigate_roleplay=(
+            lambda link: _navigate_character_context(
+                screen, ROLEPLAY_NAV_CONTEXT_CHARACTER_CONVERSATION, link
+            )
+        ),
+        navigate_repair=(
+            lambda context: _navigate_character_context(
+                screen, LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR, context
+            )
+        ),
+        navigate_inspection=(
+            lambda link: _navigate_character_context(
+                screen, LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION, link
+            )
+        ),
+        navigate_unavailable_browse=(
+            lambda link: _navigate_character_context(
+                screen, LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE, link
+            )
+        ),
+        navigate_roleplay_home=(
+            lambda: screen.post_message(NavigateToScreen(TAB_PERSONAS))
+        ),
+        navigate_library_home=(
+            lambda: screen.post_message(NavigateToScreen(TAB_LIBRARY))
+        ),
+        start_console=(
+            lambda character_id, name: _start_character_context_chat(
+                screen, character_id, name
+            )
+        ),
+        state_changed=lambda state: _sync_character_context_presentation(
+            screen, state
+        ),
+    )
 
     screen._fleet = ConsoleFleetLifecycleController(
         pending_handoffs_accessor=lambda: screen.app_instance.pending_handoffs,
@@ -1234,7 +1384,7 @@ def build_console_controllers(
             lambda: getattr(screen.app_instance, "chachanotes_db", None)
         ),
         reaction_preview_coordinator_accessor=(
-            lambda: get_console_reaction_preview_coordinator(screen.app_instance)
+            lambda: _reaction_preview_coordinator(screen)
         ),
         refresh_character_avatar=(
             lambda **kwargs: (

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -4837,8 +4837,21 @@ class ConsoleWorkspaceController:
         focus_id = screen._pending_character_return_focus_id
         if focus_id is None or screen.app.screen is not screen:
             return
+        if focus_id == "console-context-character":
+            screen._character_context.return_reveal = True
+            rail_state = screen._current_console_rail_state()
+            screen._sync_console_rail_visibility_if_changed(rail_state)
+            if not rail_state.left_open:
+                self._focus_composer_if_needed_fn(force=True)
+                return
+            # Rail reveal restores saved child display flags. Apply the
+            # transient disclosure afterwards, without persisting a gesture.
+            screen.query_one("#console-left-rail").sync_sections(rail_state)
+            focus_id = "console-character-search"
         try:
-            screen.set_focus(screen.query_one(f"#{focus_id}"))
+            target = screen.query_one(f"#{focus_id}")
+            screen.set_focus(target)
+            target.scroll_visible(animate=False)
         except NoMatches:
             return
         screen._pending_character_return_focus_id = None

--- a/tldw_chatbook/UI/Library_Modules/library_conversations_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_conversations_controller.py
@@ -244,7 +244,6 @@ from ...Library.library_conversation_reader_state import (
     project_conversation_multiselect,
 )
 from ...Library.library_conversations_state import (
-    build_library_conversations_state,
     validate_library_conversation_page,
 )
 from ...Library.library_export_scope import ExportScope
@@ -935,60 +934,9 @@ class LibraryConversationsController:
         return "Updated: unknown"
 
     def _build_library_conversations_state(self):
-        """Build the conversations canvas display state from local records."""
-        state = build_library_conversations_state(
-            self._conversation_records(),
-            query=self._library_conversation_query,
-            selected_id=self._selected_conversation_id,
-            select_mode=self._library_conversations_select_mode,
-            selected_ids=self._library_conversations_row_selection.ids,
-            page=self._library_conversation_page,
-            requested_page=self._library_conversation_requested_page,
-            page_size=self._library_conversation_page_size,
-            total_count=self._library_conversation_total,
-            total_known=self._library_conversation_total_known,
-            has_more=self._library_conversation_has_more,
-            freshness=self._library_conversation_freshness,
-            stale_copy=self._library_conversation_stale_copy,
-            loading=self._library_conversation_loading,
-            error_copy=self._library_conversation_error,
-            selection_notice=self._library_conversation_selection_notice,
-        )
-        state = dataclasses.replace(
-            state,
-            query=self._library_conversation_requested_query,
-            status_copy=(
-                state.status_copy or self._library_conversation_selection_notice
-            ),
-        )
-        retained_reader_id = self._library_conversation_reader_state.selected_id
-        if (
-            retained_reader_id
-            and not self._library_conversation_reader_state.unavailable
-            and all(row.conversation_id != retained_reader_id for row in state.rows)
-        ):
-            state = dataclasses.replace(
-                state,
-                selected_id="",
-                preview_lines=(),
-                rows=tuple(
-                    dataclasses.replace(row, selected=False) for row in state.rows
-                ),
-            )
-        if self._library_conversation_deleted_selection_id:
-            state = dataclasses.replace(
-                state,
-                selected_id="",
-                preview_lines=(),
-                rows=tuple(
-                    dataclasses.replace(row, selected=False) for row in state.rows
-                ),
-            )
-        if self._library_conversations_select_mode:
-            self._library_conversations_row_selection.reconcile(
-                r.conversation_id for r in state.rows
-            )
-        return state
+        from .library_unavailable_navigation import build_canvas_state
+
+        return build_canvas_state(self)
 
     def _sync_library_conversation_canvas(
         self, *, then: Callable[[], None] | None = None

--- a/tldw_chatbook/UI/Library_Modules/library_conversations_state.py
+++ b/tldw_chatbook/UI/Library_Modules/library_conversations_state.py
@@ -123,6 +123,7 @@ class LibraryConversationsState:
     find_focus_intent: tuple[int, int, str] | None = None
     reader_mounted_authority: bool = False
     deleted_selection_id: str = ""
+    projection: str = ""
 
     # Placeholder defaults only -- see module docstring: the original
     # `__init__` line for each of these three still runs (assigning

--- a/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
@@ -16,10 +16,13 @@ from loguru import logger
 
 from ...Constants import (
     CHARACTER_NAV_CONTEXT_RETURN_FOCUS,
+    LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE,
+    LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION,
     LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR,
 )
 from ...Library.library_shell_state import (
     LIBRARY_ROW_BROWSE_COLLECTIONS,
+    LIBRARY_ROW_BROWSE_CONVERSATIONS,
     LIBRARY_ROW_BROWSE_MEDIA,
     LIBRARY_ROW_BROWSE_PROMPTS,
 )
@@ -79,6 +82,10 @@ class LibraryNavigationController:
             return
         if not isinstance(context, Mapping):
             return
+        is_character_navigation = set(context) in (
+            {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION},
+            {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE},
+        )
         if set(context) == {LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR}:
             from ..Navigation.character_conversation_navigation import (
                 deserialize_library_character_repair_context,
@@ -97,10 +104,25 @@ class LibraryNavigationController:
             if self.screen.is_mounted:
                 self.screen.call_after_refresh(self.present_pending_repair)
             return
-        target_row_id = self.screen._library_navigation_context_target_row(context)
+        target_row_id = (
+            LIBRARY_ROW_BROWSE_CONVERSATIONS
+            if is_character_navigation
+            else self.screen._library_navigation_context_target_row(context)
+        )
         if target_row_id is None:
             return
         self.screen._library_navigation_context_generation += 1
+        character_admission = (
+            self.screen._unavailable_navigation._library_character_navigation_admission(
+                self.screen,
+                context,
+                generation=self.screen._library_navigation_context_generation,
+            )
+            if is_character_navigation
+            else None
+        )
+        if is_character_navigation and character_admission is None:
+            return
         if target_row_id != LIBRARY_ROW_BROWSE_MEDIA:
             self._invalidate_media_browse()
         if target_row_id != LIBRARY_ROW_BROWSE_COLLECTIONS:
@@ -122,12 +144,15 @@ class LibraryNavigationController:
                     dict(context),
                     target_row_id,
                     generation,
+                    character_admission,
                 ),
                 exclusive=True,
                 group="library_nav_context",
             )
             return
-        self.screen._apply_navigation_context_state(context)
+        self.screen._apply_navigation_context_state(
+            context, character_admission=character_admission
+        )
 
     def present_pending_repair(self) -> None:
         """Present a typed context once the retained Library owns the screen."""

--- a/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
@@ -55,6 +55,7 @@ class LibraryNavigationController:
         self.keyword_generation = 0
         self.semantic_generation = 0
         self.character_route = None
+        self.character_candidate = None
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply route context supplied by shell navigation.
@@ -83,7 +84,8 @@ class LibraryNavigationController:
             return
         if not isinstance(context, Mapping):
             return
-        self.character_route = None
+        self.character_candidate = None
+        self.screen._library_navigation_context_generation += 1
         is_character_navigation = set(context) in (
             {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION},
             {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE},
@@ -113,7 +115,6 @@ class LibraryNavigationController:
         )
         if target_row_id is None:
             return
-        self.screen._library_navigation_context_generation += 1
         character_admission = (
             self.screen._unavailable_navigation._library_character_navigation_admission(
                 self.screen,

--- a/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
@@ -58,38 +58,17 @@ class LibraryNavigationController:
         self.character_candidate = None
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
-        """Apply route context supplied by shell navigation.
+        """Admit shell routes without replacing a view before its save guards.
 
         Args:
-            context: Navigation payload from ``NavigateToScreen``. A valid
-                Library mode switches the active mode. A ``conversation_id``
-                selects that conversation when the local source snapshot
-                arrives, defaulting the mode to Conversations when no valid
-                mode is supplied. A ``notes_create`` flag lands on the
-                in-canvas Create > New note view (the retired Notes tab's
-                "new note" deep link). A ``note_id`` opens that note's
-                in-canvas editor directly (the retired Notes tab's
-                chat-sidebar deep link); ``mode="notes"`` alone (no
-                ``note_id``) lands on the Notes list instead. An
-                ``ingest_media`` flag lands on the in-canvas Ingest >
-                Import media view (Home's ingest-jobs "Open details"
-                control, L3b Task 6). A supported ``open_source_type`` and
-                exact ``open_source_id`` pair delegates to Library's existing
-                item opener.
+            context: Ordinary mode/ID/create/ingest/source navigation or typed
+                Character inspection, browse, or independently presented repair.
         """
-        # wave-6 (prompts) retarget: the flat `_library_prompts_mutation_in_
-        # flight` attribute this line read on dev was deleted by the prompts
-        # cleanup PR; the field now lives on the Prompts state object.
-        if self.screen._prompts_state.mutation_in_flight:
-            return
-        if not isinstance(context, Mapping):
+        screen = self.screen
+        if screen._prompts_state.mutation_in_flight or not isinstance(context, Mapping):
             return
         self.character_candidate = None
-        self.screen._library_navigation_context_generation += 1
-        is_character_navigation = set(context) in (
-            {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION},
-            {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE},
-        )
+        screen._library_navigation_context_generation += 1
         if set(context) == {LIBRARY_NAV_CONTEXT_CHARACTER_REPAIR}:
             from ..Navigation.character_conversation_navigation import (
                 deserialize_library_character_repair_context,
@@ -105,55 +84,48 @@ class LibraryNavigationController:
                 return
             self.pending_repair_context = repair_context
             self.repair_present_on_resume = True
-            if self.screen.is_mounted:
-                self.screen.call_after_refresh(self.present_pending_repair)
+            if screen.is_mounted:
+                screen.call_after_refresh(self.present_pending_repair)
             return
-        target_row_id = (
-            LIBRARY_ROW_BROWSE_CONVERSATIONS
-            if is_character_navigation
-            else self.screen._library_navigation_context_target_row(context)
-        )
-        if target_row_id is None:
-            return
-        character_admission = (
-            self.screen._unavailable_navigation._library_character_navigation_admission(
-                self.screen,
+        character_admission = None
+        if set(context) in (
+            {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION},
+            {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE},
+        ):
+            navigation = screen._unavailable_navigation
+            character_admission = navigation._library_character_navigation_admission(
+                screen,
                 context,
-                generation=self.screen._library_navigation_context_generation,
+                generation=screen._library_navigation_context_generation,
             )
-            if is_character_navigation
-            else None
-        )
-        if is_character_navigation and character_admission is None:
-            return
+            if character_admission is None:
+                return
+            target_row_id = LIBRARY_ROW_BROWSE_CONVERSATIONS
+        else:
+            target_row_id = screen._library_navigation_context_target_row(context)
+            if target_row_id is None:
+                return
         if target_row_id != LIBRARY_ROW_BROWSE_MEDIA:
             self._invalidate_media_browse()
         if target_row_id != LIBRARY_ROW_BROWSE_COLLECTIONS:
             self._unmount_collections_capture()
-        generation = self.screen._library_navigation_context_generation
+        generation = screen._library_navigation_context_generation
         if (
-            self.screen.is_mounted
+            screen.is_mounted
             and target_row_id == LIBRARY_ROW_BROWSE_PROMPTS
-            and self.screen._library_selected_row_id == LIBRARY_ROW_BROWSE_PROMPTS
+            and screen._library_selected_row_id == LIBRARY_ROW_BROWSE_PROMPTS
         ):
             return
-        if self.screen.is_mounted:
-            # A cached mounted screen must admit the route through the same
-            # awaited save/leave guards as a rail switch. Applying it
-            # synchronously could discard a dirty editor or an active Prompt
-            # selection before the transition is actually admitted.
-            self.screen.run_worker(
-                self.screen._apply_navigation_context_after_flush(
-                    dict(context),
-                    target_row_id,
-                    generation,
-                    character_admission,
+        if screen.is_mounted:
+            screen.run_worker(
+                screen._apply_navigation_context_after_flush(
+                    dict(context), target_row_id, generation, character_admission
                 ),
                 exclusive=True,
                 group="library_nav_context",
             )
             return
-        self.screen._apply_navigation_context_state(
+        screen._apply_navigation_context_state(
             context, character_admission=character_admission
         )
 

--- a/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_navigation_controller.py
@@ -54,6 +54,7 @@ class LibraryNavigationController:
         self.repair_present_on_resume = False
         self.keyword_generation = 0
         self.semantic_generation = 0
+        self.character_route = None
 
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Apply route context supplied by shell navigation.
@@ -82,6 +83,7 @@ class LibraryNavigationController:
             return
         if not isinstance(context, Mapping):
             return
+        self.character_route = None
         is_character_navigation = set(context) in (
             {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION},
             {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE},

--- a/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
+++ b/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
@@ -1,0 +1,713 @@
+"""Library-owned unavailable inspection and complete archive projection."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Any
+
+from loguru import logger
+
+from ...Constants import (
+    LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE,
+    LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION,
+)
+from ...Library.library_conversation_reader_state import LIBRARY_CONVERSATION_PAGE_SIZE
+
+if TYPE_CHECKING:
+    from ...Character_Chat.character_conversation_navigation import (
+        UnresolvedConversationKey,
+    )
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+        LibraryUnavailableConversationsBrowse,
+    )
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryCharacterNavigationAdmission:
+    """Typed Character route plus the exact Data Profile that admitted it."""
+
+    route: (
+        LibraryUnavailableConversationInspection | LibraryUnavailableConversationsBrowse
+    )
+    database: Any
+    generation: int
+
+
+@dataclasses.dataclass(frozen=True)
+class _LibraryUnavailableBrowseScope:
+    """Authority retained for the complete unavailable-only browse session."""
+
+    database: Any
+    authority: str
+    selected: UnresolvedConversationKey
+    navigation_generation: int
+
+
+def build_canvas_state(self):
+    """Build the conversations canvas display state from local records."""
+    from ...Library.library_conversations_state import build_library_conversations_state
+
+    state = build_library_conversations_state(
+        self._conversation_records(),
+        query=self._library_conversation_query,
+        selected_id=self._selected_conversation_id,
+        select_mode=self._library_conversations_select_mode,
+        selected_ids=self._library_conversations_row_selection.ids,
+        page=self._library_conversation_page,
+        requested_page=self._library_conversation_requested_page,
+        page_size=self._library_conversation_page_size,
+        total_count=self._library_conversation_total,
+        total_known=self._library_conversation_total_known,
+        has_more=self._library_conversation_has_more,
+        freshness=self._library_conversation_freshness,
+        stale_copy=self._library_conversation_stale_copy,
+        loading=self._library_conversation_loading,
+        error_copy=self._library_conversation_error,
+        selection_notice=self._library_conversation_selection_notice,
+    )
+    state = dataclasses.replace(
+        state,
+        query=self._library_conversation_requested_query,
+        title=(
+            f"Unavailable character conversations ({self._library_conversation_total})"
+            if self._library_conversation_projection == "unavailable_character"
+            else "Conversations"
+        ),
+        status_copy=(state.status_copy or self._library_conversation_selection_notice),
+    )
+    retained_reader_id = self._library_conversation_reader_state.selected_id
+    if (
+        retained_reader_id
+        and not self._library_conversation_reader_state.unavailable
+        and all(row.conversation_id != retained_reader_id for row in state.rows)
+    ):
+        state = dataclasses.replace(
+            state,
+            selected_id="",
+            preview_lines=(),
+            rows=tuple(dataclasses.replace(row, selected=False) for row in state.rows),
+        )
+    if self._library_conversation_deleted_selection_id:
+        state = dataclasses.replace(
+            state,
+            selected_id="",
+            preview_lines=(),
+            rows=tuple(dataclasses.replace(row, selected=False) for row in state.rows),
+        )
+    if self._library_conversations_select_mode:
+        self._library_conversations_row_selection.reconcile(
+            r.conversation_id for r in state.rows
+        )
+    return state
+
+
+def _library_character_navigation_admission(
+    self,
+    context: Mapping[str, Any],
+    *,
+    generation: int,
+) -> _LibraryCharacterNavigationAdmission | None:
+    """Parse one strict typed route and bind it to the active DB handle."""
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+        deserialize_library_unavailable_browse,
+        deserialize_library_unavailable_inspection,
+    )
+
+    route: (
+        LibraryUnavailableConversationInspection
+        | LibraryUnavailableConversationsBrowse
+        | None
+    ) = None
+    try:
+        if set(context) == {LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION}:
+            payload = context.get(LIBRARY_NAV_CONTEXT_CHARACTER_INSPECTION)
+            if isinstance(payload, Mapping):
+                route = deserialize_library_unavailable_inspection(payload)
+        elif set(context) == {LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE}:
+            payload = context.get(LIBRARY_NAV_CONTEXT_CHARACTER_BROWSE)
+            if isinstance(payload, Mapping):
+                route = deserialize_library_unavailable_browse(payload)
+    except (TypeError, ValueError):
+        logger.warning("Rejected invalid Library unavailable navigation")
+        return None
+    if route is None:
+        return None
+    database = getattr(self.app_instance, "chachanotes_db", None)
+    if not _library_character_authority_is_current(
+        self,
+        route.unresolved.data_authority_id
+        if isinstance(route, LibraryUnavailableConversationInspection)
+        else route.selected.data_authority_id,
+    ):
+        return None
+    return _LibraryCharacterNavigationAdmission(route, database, generation)
+
+
+def _library_character_admission_is_current(
+    self,
+    admission: _LibraryCharacterNavigationAdmission | None,
+) -> bool:
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+    )
+
+    if admission is None:
+        return True
+    database = getattr(self.app_instance, "chachanotes_db", None)
+    if database is not admission.database:
+        return False
+    authority = (
+        admission.route.unresolved.data_authority_id
+        if isinstance(admission.route, LibraryUnavailableConversationInspection)
+        else admission.route.selected.data_authority_id
+    )
+    return (
+        admission.generation == self._library_navigation_context_generation
+        and _library_character_authority_is_current(self, authority)
+    )
+
+
+def _discard_library_character_admission(
+    self,
+    admission: _LibraryCharacterNavigationAdmission | None,
+) -> None:
+    if (
+        admission is not None
+        and self._pending_library_character_navigation is admission
+    ):
+        self._pending_library_character_navigation = None
+
+
+def _library_unavailable_browse_scope_is_current(
+    self,
+    scope: _LibraryUnavailableBrowseScope | None,
+) -> bool:
+    """Return whether an unavailable browse still owns its exact profile."""
+
+    return bool(
+        scope is not None
+        and self._library_unavailable_browse_scope is scope
+        and getattr(self.app_instance, "chachanotes_db", None) is scope.database
+        and scope.navigation_generation == self._library_navigation_context_generation
+        and _library_character_authority_is_current(self, scope.authority)
+    )
+
+
+def _discard_library_unavailable_browse_scope(
+    self,
+    scope: _LibraryUnavailableBrowseScope | None,
+    *,
+    profile_changed: bool = False,
+) -> None:
+    """Discard one owned browse and fail closed on Data Profile churn."""
+
+    if scope is None or self._library_unavailable_browse_scope is not scope:
+        return
+    self._library_unavailable_browse_scope = None
+    if not profile_changed:
+        return
+    self._conversations_state.page_records = ()
+    self._conversations_state.total = 0
+    self._conversations_state.total_known = False
+    self._conversations_state.has_more = False
+    self._conversations_state.page_loaded = False
+    self._conversations_state.loading = False
+    self._conversations_state.error = "Data Profile changed · Retry"
+    self._conversations_state.projection = ""
+    self._selected_conversation_id = ""
+    if self.is_mounted:
+        self._sync_library_conversation_canvas()
+
+
+def _library_character_authority_is_current(self, authority: str) -> bool:
+    """Fail closed unless a typed Character route owns the active database."""
+
+    database = getattr(self.app_instance, "chachanotes_db", None)
+    try:
+        return bool(
+            database is not None and database.get_local_authority_id() == authority
+        )
+    except Exception as error:  # noqa: BLE001 - navigation rejects unavailable storage
+        logger.warning(
+            "Could not validate Library character navigation authority "
+            "exception_type={}",
+            type(error).__name__,
+        )
+        return False
+
+
+async def _open_pending_library_character_navigation(self) -> None:
+    """Consume one typed Character route without dropping intent or authority."""
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+    )
+
+    admission = self._pending_library_character_navigation
+    if admission is None:
+        return
+    if not _library_character_admission_is_current(self, admission):
+        _discard_library_character_admission(self, admission)
+        return
+    route = admission.route
+    if isinstance(route, LibraryUnavailableConversationInspection):
+        await self._open_library_item_by_id(
+            "conversations",
+            route.unresolved.conversation_id,
+            entry_origin=True,
+            required_database=admission.database,
+            required_authority=route.unresolved.data_authority_id,
+        )
+        if not _library_character_admission_is_current(self, admission):
+            _discard_library_character_admission(self, admission)
+            self._pending_library_source_open = None
+            return
+        self._pending_library_source_open = None
+        _discard_library_character_admission(self, admission)
+        return
+
+    scope = self._library_unavailable_browse_scope
+    try:
+        if not _library_unavailable_browse_scope_is_current(self, scope):
+            _discard_library_unavailable_browse_scope(
+                self,
+                scope,
+                profile_changed=True,
+            )
+            return
+        normalized_query, generation = self._prepare_library_conversation_page_request(
+            "", page=1
+        )
+        await _load_library_unavailable_conversation_page(
+            self,
+            scope,
+            1,
+            normalized_query,
+            generation,
+        )
+    finally:
+        _discard_library_character_admission(self, admission)
+
+
+def _start_library_unavailable_conversation_page_request(
+    self,
+    page: int,
+    query: str,
+    *,
+    refocus_filter: bool = False,
+    focus_after_apply: str = "",
+) -> None:
+    """Start a page request owned by the retained unavailable projection."""
+
+    scope = self._library_unavailable_browse_scope
+    if not _library_unavailable_browse_scope_is_current(self, scope):
+        _discard_library_unavailable_browse_scope(
+            self,
+            scope,
+            profile_changed=True,
+        )
+        return
+    requested_page = self._normalize_library_conversation_page(page)
+    normalized_query, generation = self._prepare_library_conversation_page_request(
+        query,
+        page=requested_page,
+        refocus_filter=refocus_filter,
+        focus_after_apply=focus_after_apply,
+    )
+    self.run_worker(
+        _load_library_unavailable_conversation_page(
+            self,
+            scope,
+            requested_page,
+            normalized_query,
+            generation,
+        ),
+        exclusive=True,
+        group="library_conversation_page",
+    )
+
+
+async def _load_library_unavailable_conversation_page(
+    self,
+    scope: _LibraryUnavailableBrowseScope,
+    page: int,
+    query: str,
+    generation: int,
+) -> None:
+    """Stage and fence an unavailable-only page through final composition."""
+
+    from ...Character_Chat.character_conversation_navigation import (
+        CharacterConversationNavigationService,
+    )
+
+    requested_page = self._normalize_library_conversation_page(page)
+    normalized_query = self._safe_text(query, max_length=200)
+    requested_offset = (requested_page - 1) * LIBRARY_CONVERSATION_PAGE_SIZE
+
+    def request_is_current() -> bool:
+        return bool(
+            generation == self._conversations_state.request_generation
+            and _library_unavailable_browse_scope_is_current(self, scope)
+        )
+
+    if not request_is_current():
+        _discard_library_unavailable_browse_scope(
+            self,
+            scope,
+            profile_changed=True,
+        )
+        return
+    unavailable_page = CharacterConversationNavigationService(
+        scope.database
+    ).unavailable_page
+    call_kwargs: dict[str, Any] = {
+        "offset": requested_offset,
+        "limit": LIBRARY_CONVERSATION_PAGE_SIZE,
+    }
+    if normalized_query:
+        call_kwargs["query"] = normalized_query
+    try:
+        result = await self._run_library_service_call(
+            unavailable_page,
+            **call_kwargs,
+        )
+    except Exception:  # noqa: BLE001 - this projection remains retryable
+        if request_is_current():
+            self._fail_library_conversation_request(
+                requested_page,
+                normalized_query,
+                generation,
+                copy="Could not load unavailable character conversations.",
+            )
+        else:
+            _discard_library_unavailable_browse_scope(
+                self,
+                scope,
+                profile_changed=True,
+            )
+        return
+    if not request_is_current():
+        _discard_library_unavailable_browse_scope(
+            self,
+            scope,
+            profile_changed=True,
+        )
+        return
+
+    try:
+        total = result.total
+        rows = tuple(result.rows)
+        if isinstance(total, bool) or not isinstance(total, int) or total < 0:
+            raise ValueError("invalid unavailable total")
+        if len(rows) > LIBRARY_CONVERSATION_PAGE_SIZE:
+            raise ValueError("unavailable page exceeded its bound")
+        records = tuple(
+            {
+                "conversation_id": row.unresolved.conversation_id,
+                "title": row.title,
+                "last_modified": row.last_modified,
+                "unavailable_reason": row.unavailable_reason.value,
+            }
+            for row in rows
+            if row.unresolved is not None
+            and row.target is None
+            and row.unresolved.data_authority_id == scope.authority
+        )
+        if len(records) != len(rows):
+            raise ValueError("unavailable page mixed authorities or resolved rows")
+    except (AttributeError, TypeError, ValueError):
+        if request_is_current():
+            self._fail_library_conversation_request(
+                requested_page,
+                normalized_query,
+                generation,
+                copy="Could not load unavailable character conversations.",
+            )
+        return
+
+    # Keep staged old-profile data out of retained state and the DOM.  The
+    # awaited composition is the last UI scheduling boundary; only a scope
+    # still exact on both sides may publish the page synchronously.
+    if self.is_mounted:
+        await self.recompose()
+    if not request_is_current():
+        _discard_library_unavailable_browse_scope(
+            self,
+            scope,
+            profile_changed=True,
+        )
+        return
+
+    self._conversations_state.page_records = records
+    self._conversations_state.page = requested_page
+    self._conversations_state.total = total
+    self._conversations_state.total_known = True
+    self._conversations_state.has_more = requested_offset + len(records) < total
+    self._conversations_state.page_loaded = True
+    self._conversations_state.query = normalized_query
+    self._conversations_state.requested_page = requested_page
+    self._conversations_state.requested_query = normalized_query
+    self._conversations_state.freshness = "fresh"
+    self._conversations_state.loading = False
+    self._conversations_state.error = ""
+    self._conversations_state.projection = "unavailable_character"
+    self._selected_conversation_id = scope.selected.conversation_id
+    self._sync_library_conversation_canvas(
+        then=self._conversations_controller._finish_library_conversation_page_apply
+    )
+
+
+def _apply_navigation_context_state(
+    self,
+    context: Mapping[str, Any],
+    *,
+    recompose: bool = True,
+    character_admission: _LibraryCharacterNavigationAdmission | None = None,
+) -> None:
+    """Apply validated navigation context to canvas state and recompose.
+
+    Split from ``apply_navigation_context`` so its mounted path can admit
+    every pending save first (see
+    ``_apply_navigation_context_after_flush``) while the pre-mount and
+    clean-editor paths apply directly.
+    """
+    from ...Constants import (
+        LIBRARY_MODE_CONVERSATIONS,
+        LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
+        LIBRARY_NAV_CONTEXT_INGEST,
+        LIBRARY_NAV_CONTEXT_MODE,
+        LIBRARY_NAV_CONTEXT_NOTE_ID,
+        LIBRARY_NAV_CONTEXT_NOTES_CREATE,
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID,
+        LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE,
+    )
+    from ...Library.library_shell_state import (
+        LIBRARY_ROW_BROWSE_COLLECTIONS,
+        LIBRARY_ROW_BROWSE_CONVERSATIONS,
+        LIBRARY_ROW_BROWSE_MEDIA,
+        LIBRARY_ROW_BROWSE_NOTES,
+        LIBRARY_ROW_BROWSE_PROMPTS,
+        LIBRARY_ROW_CREATE_NOTE,
+        LIBRARY_ROW_INGEST_MEDIA,
+    )
+    from .screen_constants import (
+        LIBRARY_NAV_MODE_TO_ROW_ID,
+        LIBRARY_NOTES_SOURCE_DATABASE,
+    )
+
+    if self._library_prompts_mutation_in_flight:
+        return
+    if character_admission is not None:
+        if not _library_character_admission_is_current(self, character_admission):
+            return
+        from ..Library_Modules.library_unavailable_navigation import (
+            _LibraryUnavailableBrowseScope,
+        )
+        from ..Navigation.character_conversation_navigation import (
+            LibraryUnavailableConversationsBrowse,
+        )
+
+        self._pending_library_character_navigation = character_admission
+        route = character_admission.route
+        if isinstance(route, LibraryUnavailableConversationsBrowse):
+            self._library_unavailable_browse_scope = _LibraryUnavailableBrowseScope(
+                database=character_admission.database,
+                authority=route.selected.data_authority_id,
+                selected=route.selected,
+                navigation_generation=character_admission.generation,
+            )
+        else:
+            self._library_unavailable_browse_scope = None
+        self._pending_library_source_open = None
+        self._conversations_state.projection = (
+            "unavailable_character"
+            if isinstance(
+                route,
+                LibraryUnavailableConversationsBrowse,
+            )
+            else ""
+        )
+        self._set_library_destination_with_conversation_fence(
+            LIBRARY_ROW_BROWSE_CONVERSATIONS
+        )
+        self._invalidate_library_workspace_depth_state()
+        if self.is_mounted and recompose:
+            self.refresh(recompose=True)
+        return
+    self._library_unavailable_browse_scope = None
+    self._supersede_library_notes_navigation()
+    raw_open_source_type = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE)
+    raw_open_source_id = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID)
+    open_source_type = ""
+    open_source_id = ""
+    should_open_pending_source = False
+    if type(raw_open_source_type) is str and type(raw_open_source_id) is str:
+        validated_source_type = self._safe_text(
+            raw_open_source_type,
+            max_length=64,
+        )
+        validated_source_id = self._safe_text(
+            raw_open_source_id,
+            max_length=500,
+        )
+        if (
+            validated_source_type == raw_open_source_type
+            and validated_source_id == raw_open_source_id
+            and validated_source_type in ("media", "notes", "conversations", "prompt")
+            and validated_source_id
+        ):
+            open_source_type = validated_source_type
+            open_source_id = validated_source_id
+            self._pending_library_source_open = (
+                open_source_type,
+                open_source_id,
+            )
+            should_open_pending_source = True
+    requested_mode = self._safe_text(
+        context.get(LIBRARY_NAV_CONTEXT_MODE),
+        max_length=64,
+    )
+    conversation_id = self._safe_text(
+        context.get(LIBRARY_NAV_CONTEXT_CONVERSATION_ID),
+        max_length=200,
+    )
+    note_id = self._safe_text(
+        context.get(LIBRARY_NAV_CONTEXT_NOTE_ID),
+        max_length=200,
+    )
+    notes_create = bool(context.get(LIBRARY_NAV_CONTEXT_NOTES_CREATE))
+    ingest_media = bool(context.get(LIBRARY_NAV_CONTEXT_INGEST))
+    target_mode = requested_mode if requested_mode in LIBRARY_NAV_MODE_TO_ROW_ID else ""
+    if conversation_id and not target_mode:
+        target_mode = LIBRARY_MODE_CONVERSATIONS
+    if target_mode:
+        selected_row_id = LIBRARY_NAV_MODE_TO_ROW_ID.get(target_mode)
+        if selected_row_id:
+            self._set_library_destination_with_conversation_fence(selected_row_id)
+        self._invalidate_library_workspace_depth_state()
+    if conversation_id:
+        self._selected_conversation_id = conversation_id
+        self._set_library_destination_with_conversation_fence(
+            LIBRARY_ROW_BROWSE_CONVERSATIONS
+        )
+        if not should_open_pending_source:
+            # Persona still emits the legacy conversation_id context.
+            # A paged snapshot may not contain that id, so resolve it
+            # through the same point-lookup opener used by Search/RAG.
+            self._pending_library_source_open = (
+                "conversations",
+                conversation_id,
+            )
+            should_open_pending_source = True
+    if requested_mode == "notes" and not note_id:
+        # "notes" is a canvas row, not a nav-context table entry (see
+        # target_mode above), so it needs its own selection here --
+        # mirrors handle_library_notes_row's list-view entry state.
+        self._set_library_destination_with_conversation_fence(LIBRARY_ROW_BROWSE_NOTES)
+    if notes_create:
+        # Mirrors _select_library_rail_row(LIBRARY_ROW_CREATE_NOTE) --
+        # the create-note rail row's own target_id. The rail row's
+        # flush of a dirty editor is handled upstream by
+        # apply_navigation_context's mounted dirty-editor branch; here we
+        # only apply the selection the recompose reads. Reset the note
+        # editor state FIRST (a mounted screen re-entered via this
+        # deep link can still hold a previously opened note's
+        # id/detail/version) then re-assert the create-note target state
+        # AFTER, since the reset flips _library_notes_view back to
+        # "list" -- same reset-then-set ordering as
+        # _open_library_item_by_id's notes branch.
+        self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
+        self._dispatch_database_note_identity_cleared()
+        self._reset_library_note_editor_state()
+        self._set_library_destination_with_conversation_fence(LIBRARY_ROW_CREATE_NOTE)
+    if ingest_media:
+        # Home's ingest-jobs "Open details" control re-points here
+        # (L3b Task 6): running/queued/failed Library ingest jobs
+        # mirror into Home's Running and Needs Attention sections, and
+        # this deep link is their one-hop route back to the in-canvas
+        # ingest queue. Mirrors
+        # _select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA) -- unlike
+        # collections/note_id above, the ingest canvas reads the job
+        # registry directly on recompose, so no async data fetch (and
+        # therefore no on_mount deferral) is needed even pre-mount.
+        self._set_library_destination_with_conversation_fence(LIBRARY_ROW_INGEST_MEDIA)
+        # Mirrors _select_library_rail_row's reset: a cached LibraryScreen
+        # re-entered via this deep link (e.g. from Home's ingest-jobs
+        # "Open details" control) must never show a stale half-filled
+        # form left over from a previous Ingest visit.
+        self._reset_library_ingest_transient_state()
+    if note_id:
+        # Forward-compat entry point: the retired Notes tab's chat-sidebar
+        # deep link carried a note id, and this rebuilds the editor for it.
+        # No caller in the tree emits a note_id context today (the surviving
+        # open_notes_workspace route carries none, landing on the list), so
+        # this is exercised only by tests until such a producer is wired --
+        # not orphaned wiring.
+        self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
+        self._set_library_destination_with_conversation_fence(LIBRARY_ROW_BROWSE_NOTES)
+        if self.is_mounted:
+            self._begin_library_note_load(note_id)
+        else:
+            self._library_note_session.close_session()
+            self._selected_note_id = note_id
+            self._library_notes_view = "editor"
+            self._library_note_load_state = "loading"
+            self._library_note_load_message = ""
+            self._library_note_autosave_state = "idle"
+            self._library_note_confirming_delete = False
+            self._library_note_preview = False
+            self._library_note_editor_armed = False
+        # A deep link never owns the current blank-note GC identity.
+        self._library_note_pending_blank_gc_id = None
+        self._library_note_session_blank_id = None
+        self._library_note_title_user_edited = False
+    if open_source_type:
+        self._set_library_destination_with_conversation_fence(
+            {
+                "media": LIBRARY_ROW_BROWSE_MEDIA,
+                "notes": LIBRARY_ROW_BROWSE_NOTES,
+                "conversations": LIBRARY_ROW_BROWSE_CONVERSATIONS,
+                "prompt": LIBRARY_ROW_BROWSE_PROMPTS,
+            }[open_source_type]
+        )
+        if open_source_type == "media":
+            self._selected_media_id = open_source_id
+            self._library_media_view = "list"
+        elif open_source_type == "notes":
+            self._selected_note_id = open_source_id
+            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
+            self._library_notes_view = "list"
+        elif open_source_type == "conversations":
+            self._selected_conversation_id = open_source_id
+        elif open_source_type == "prompt":
+            try:
+                self._selected_prompt_id = int(open_source_id)
+            except ValueError:
+                self._selected_prompt_id = None
+            self._library_prompts_view = "list"
+    if should_open_pending_source and self.is_mounted:
+        self.run_worker(
+            self._open_pending_library_source(),
+            exclusive=True,
+            group="library_nav_open_source",
+        )
+    # F-012: a deep link can change the active canvas (e.g. mode="search")
+    # without a rail-row press -- the footer's `u` hint must follow the
+    # canvas, not just the rail switch, or the key works unadvertised.
+    self._register_footer_shortcuts()
+    if self._library_notes_workflow_active():
+        self._library_notes_stage = "notes"
+        self._library_notes_explicit_stage_intent = not self.is_mounted
+    else:
+        self._library_notes_explicit_stage_intent = False
+    if self.is_mounted:
+        if self._library_selected_row_id == LIBRARY_ROW_BROWSE_COLLECTIONS:
+            self.run_worker(
+                self._load_library_collections_capture_entry(),
+                exclusive=True,
+                group="library_collections_capture_entry",
+            )
+        elif recompose and not open_source_type:
+            self.refresh(recompose=True)

--- a/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
+++ b/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
@@ -111,7 +111,6 @@ def _library_character_navigation_admission(
 ) -> _LibraryCharacterNavigationAdmission | None:
     """Parse one strict typed route and bind it to the active DB handle."""
     from ..Navigation.character_conversation_navigation import (
-        LibraryUnavailableConversationInspection,
         deserialize_library_unavailable_browse,
         deserialize_library_unavailable_inspection,
     )
@@ -136,37 +135,62 @@ def _library_character_navigation_admission(
     if route is None:
         return None
     database = getattr(self.app_instance, "chachanotes_db", None)
-    if not _library_character_authority_is_current(
-        self,
-        route.unresolved.data_authority_id
-        if isinstance(route, LibraryUnavailableConversationInspection)
-        else route.selected.data_authority_id,
-    ):
+    if database is None:
         return None
     return _LibraryCharacterNavigationAdmission(route, database, generation)
+
+
+def compose_character_return(self):
+    """Expose the return only while the validated Character route owns this view."""
+    from ...Library.library_shell_state import LIBRARY_ROW_BROWSE_CONVERSATIONS
+
+    admission = self._navigation_controller.character_route
+    if (
+        admission is not None
+        and _library_character_admission_is_current(self, admission)
+        and self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+    ):
+        from ...Widgets.Library.library_character_return import LibraryCharacterReturn
+
+        yield LibraryCharacterReturn(lambda: return_from_character(self, admission))
+
+
+def return_from_character(self, admission) -> None:
+    from ...Constants import CHARACTER_NAV_CONTEXT_RETURN_FOCUS
+    from ..Navigation.main_navigation import NavigateToScreen
+
+    if not _library_character_admission_is_current(self, admission):
+        return
+    target = admission.route.return_target
+    self.post_message(
+        NavigateToScreen(
+            target.screen_id, {CHARACTER_NAV_CONTEXT_RETURN_FOCUS: target.focus_id}
+        )
+    )
+
+
+def clear_character_return(self) -> None:
+    from textual.screen import ModalScreen
+
+    if isinstance(self.app.screen, ModalScreen):
+        return
+    self._navigation_controller.character_route = None
+    for control in self.query("#library-character-return"):
+        control.display = False
 
 
 def _library_character_admission_is_current(
     self,
     admission: _LibraryCharacterNavigationAdmission | None,
 ) -> bool:
-    from ..Navigation.character_conversation_navigation import (
-        LibraryUnavailableConversationInspection,
-    )
-
     if admission is None:
         return True
     database = getattr(self.app_instance, "chachanotes_db", None)
     if database is not admission.database:
         return False
-    authority = (
-        admission.route.unresolved.data_authority_id
-        if isinstance(admission.route, LibraryUnavailableConversationInspection)
-        else admission.route.selected.data_authority_id
-    )
     return (
         admission.generation == self._library_navigation_context_generation
-        and _library_character_authority_is_current(self, authority)
+        and self._navigation_controller.character_route is admission
     )
 
 
@@ -223,20 +247,73 @@ def _discard_library_unavailable_browse_scope(
 
 
 def _library_character_authority_is_current(self, authority: str) -> bool:
-    """Fail closed unless a typed Character route owns the active database."""
+    """UI-side fence over an off-loop validated snapshot; never performs SQL."""
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+    )
 
-    database = getattr(self.app_instance, "chachanotes_db", None)
-    try:
-        return bool(
-            database is not None and database.get_local_authority_id() == authority
+    admission = self._navigation_controller.character_route
+    if admission is None or not _library_character_admission_is_current(
+        self, admission
+    ):
+        return False
+    route = admission.route
+    key = (
+        route.unresolved
+        if isinstance(route, LibraryUnavailableConversationInspection)
+        else route.selected
+    )
+    return key.data_authority_id == authority
+
+
+async def _validate_library_character_admission(self, admission) -> bool:
+    """Read transactional authority off-loop, then retain only a current snapshot."""
+    import asyncio
+
+    from ..Navigation.character_conversation_navigation import (
+        LibraryUnavailableConversationInspection,
+    )
+
+    if admission is None:
+        return True
+    if _library_character_admission_is_current(self, admission):
+        return True
+
+    def scope_is_current():
+        return (
+            getattr(self.app_instance, "chachanotes_db", None) is admission.database
+            and admission.generation == self._library_navigation_context_generation
         )
+
+    if not scope_is_current():
+        return False
+    self._conversations_state.loading = True
+    if self.is_mounted:
+        self.notify("Loading character conversations…", severity="information")
+    route = admission.route
+    key = (
+        route.unresolved
+        if isinstance(route, LibraryUnavailableConversationInspection)
+        else route.selected
+    )
+
+    try:
+        authority = await asyncio.to_thread(admission.database.get_local_authority_id)
     except Exception as error:  # noqa: BLE001 - navigation rejects unavailable storage
         logger.warning(
             "Could not validate Library character navigation authority "
             "exception_type={}",
             type(error).__name__,
         )
+        authority = None
+    if not scope_is_current():
         return False
+    self._conversations_state.loading = False
+    if authority != key.data_authority_id:
+        _discard_library_character_admission(self, admission)
+        return False
+    self._navigation_controller.character_route = admission
+    return True
 
 
 async def _open_pending_library_character_navigation(self) -> None:
@@ -248,11 +325,22 @@ async def _open_pending_library_character_navigation(self) -> None:
     admission = self._pending_library_character_navigation
     if admission is None:
         return
+    if not await _validate_library_character_admission(self, admission):
+        _discard_library_character_admission(self, admission)
+        return
     if not _library_character_admission_is_current(self, admission):
         _discard_library_character_admission(self, admission)
         return
     route = admission.route
+    self._apply_navigation_context_state(
+        {}, recompose=False, character_admission=admission
+    )
     if isinstance(route, LibraryUnavailableConversationInspection):
+        if self.is_mounted:
+            await self.recompose()
+        if not _library_character_admission_is_current(self, admission):
+            _discard_library_character_admission(self, admission)
+            return
         await self._open_library_item_by_id(
             "conversations",
             route.unresolved.conversation_id,
@@ -501,6 +589,8 @@ def _apply_navigation_context_state(
         return
     if character_admission is not None:
         if not _library_character_admission_is_current(self, character_admission):
+            if not self.is_mounted:
+                self._pending_library_character_navigation = character_admission
             return
         from ..Library_Modules.library_unavailable_navigation import (
             _LibraryUnavailableBrowseScope,

--- a/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
+++ b/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
@@ -175,6 +175,8 @@ def clear_character_return(self) -> None:
     if isinstance(self.app.screen, ModalScreen):
         return
     self._navigation_controller.character_route = None
+    self._navigation_controller.character_candidate = None
+    self._library_navigation_context_generation += 1
     for control in self.query("#library-character-return"):
         control.display = False
 
@@ -188,9 +190,10 @@ def _library_character_admission_is_current(
     database = getattr(self.app_instance, "chachanotes_db", None)
     if database is not admission.database:
         return False
-    return (
-        admission.generation == self._library_navigation_context_generation
-        and self._navigation_controller.character_route is admission
+    navigation = self._navigation_controller
+    return navigation.character_route is admission or (
+        navigation.character_candidate is admission
+        and admission.generation == self._library_navigation_context_generation
     )
 
 
@@ -215,7 +218,8 @@ def _library_unavailable_browse_scope_is_current(
         scope is not None
         and self._library_unavailable_browse_scope is scope
         and getattr(self.app_instance, "chachanotes_db", None) is scope.database
-        and scope.navigation_generation == self._library_navigation_context_generation
+        and scope.navigation_generation
+        == getattr(self._navigation_controller.character_route, "generation", None)
         and _library_character_authority_is_current(self, scope.authority)
     )
 
@@ -287,7 +291,9 @@ async def _validate_library_character_admission(self, admission) -> bool:
 
     if not scope_is_current():
         return False
-    self._conversations_state.loading = True
+    initial_loading = self._navigation_controller.character_route is None
+    if initial_loading:
+        self._conversations_state.loading = True
     if self.is_mounted:
         self.notify("Loading character conversations…", severity="information")
     route = admission.route
@@ -308,11 +314,12 @@ async def _validate_library_character_admission(self, admission) -> bool:
         authority = None
     if not scope_is_current():
         return False
-    self._conversations_state.loading = False
+    if initial_loading:
+        self._conversations_state.loading = False
     if authority != key.data_authority_id:
         _discard_library_character_admission(self, admission)
         return False
-    self._navigation_controller.character_route = admission
+    self._navigation_controller.character_candidate = admission
     return True
 
 
@@ -592,13 +599,12 @@ def _apply_navigation_context_state(
             if not self.is_mounted:
                 self._pending_library_character_navigation = character_admission
             return
-        from ..Library_Modules.library_unavailable_navigation import (
-            _LibraryUnavailableBrowseScope,
-        )
         from ..Navigation.character_conversation_navigation import (
             LibraryUnavailableConversationsBrowse,
         )
 
+        self._navigation_controller.character_route = character_admission
+        self._navigation_controller.character_candidate = None
         self._pending_library_character_navigation = character_admission
         route = character_admission.route
         if isinstance(route, LibraryUnavailableConversationsBrowse):
@@ -626,6 +632,8 @@ def _apply_navigation_context_state(
         if self.is_mounted and recompose:
             self.refresh(recompose=True)
         return
+    self._navigation_controller.character_route = None
+    self._navigation_controller.character_candidate = None
     self._library_unavailable_browse_scope = None
     self._supersede_library_notes_navigation()
     raw_open_source_type = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE)

--- a/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
+++ b/tldw_chatbook/UI/Library_Modules/library_unavailable_navigation.py
@@ -592,7 +592,7 @@ def _apply_navigation_context_state(
         LIBRARY_NOTES_SOURCE_DATABASE,
     )
 
-    if self._library_prompts_mutation_in_flight:
+    if self._prompts_state.mutation_in_flight:
         return
     if character_admission is not None:
         if not _library_character_admission_is_current(self, character_admission):
@@ -781,10 +781,10 @@ def _apply_navigation_context_state(
             self._selected_conversation_id = open_source_id
         elif open_source_type == "prompt":
             try:
-                self._selected_prompt_id = int(open_source_id)
+                self._prompts_state.selected_prompt_id = int(open_source_id)
             except ValueError:
-                self._selected_prompt_id = None
-            self._library_prompts_view = "list"
+                self._prompts_state.selected_prompt_id = None
+            self._prompts_state.view = "list"
     if should_open_pending_source and self.is_mounted:
         self.run_worker(
             self._open_pending_library_source(),

--- a/tldw_chatbook/UI/Navigation/_character_conversation_wire.py
+++ b/tldw_chatbook/UI/Navigation/_character_conversation_wire.py
@@ -86,12 +86,17 @@ class _LibraryRepairWire(_StrictWire):
         return self
 
 
+class _ConsoleContextReturnWire(_ReturnTargetWire):
+    screen_id: Literal["chat"]
+    focus_id: Literal["console-context-character"]
+
+
 class _LibraryUnavailableInspectionWire(_StrictWire):
     version: _Version
     source: Literal["local"]
     data_authority_id: _IdentityText
     unresolved: _UnresolvedConversationWire
-    return_target: _ReturnTargetWire
+    return_target: _ConsoleContextReturnWire
 
     @model_validator(mode="after")
     def same_authority(self) -> Self:
@@ -105,7 +110,7 @@ class _LibraryUnavailableBrowseWire(_StrictWire):
     source: Literal["local"]
     data_authority_id: _IdentityText
     selected: _UnresolvedConversationWire
-    return_target: _ReturnTargetWire
+    return_target: _ConsoleContextReturnWire
 
     @model_validator(mode="after")
     def same_authority(self) -> Self:

--- a/tldw_chatbook/UI/Navigation/_character_conversation_wire.py
+++ b/tldw_chatbook/UI/Navigation/_character_conversation_wire.py
@@ -84,3 +84,31 @@ class _LibraryRepairWire(_StrictWire):
             max_bytes=4096,
         )
         return self
+
+
+class _LibraryUnavailableInspectionWire(_StrictWire):
+    version: _Version
+    source: Literal["local"]
+    data_authority_id: _IdentityText
+    unresolved: _UnresolvedConversationWire
+    return_target: _ReturnTargetWire
+
+    @model_validator(mode="after")
+    def same_authority(self) -> Self:
+        if self.data_authority_id != self.unresolved.data_authority_id:
+            raise ValueError("inspection authority components do not match")
+        return self
+
+
+class _LibraryUnavailableBrowseWire(_StrictWire):
+    version: _Version
+    source: Literal["local"]
+    data_authority_id: _IdentityText
+    selected: _UnresolvedConversationWire
+    return_target: _ReturnTargetWire
+
+    @model_validator(mode="after")
+    def same_authority(self) -> Self:
+        if self.data_authority_id != self.selected.data_authority_id:
+            raise ValueError("browse authority components do not match")
+        return self

--- a/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
+++ b/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
@@ -166,6 +166,8 @@ class LibraryUnavailableConversationInspection:
             raise TypeError("unresolved must be an UnresolvedConversationKey")
         if not isinstance(self.return_target, RoleplayReturnTarget):
             raise TypeError("return_target must be a RoleplayReturnTarget")
+        if self.return_target != RoleplayReturnTarget.console_context_character():
+            raise ValueError("unavailable inspection must return to Console Character")
 
 
 @dataclass(frozen=True)
@@ -180,6 +182,8 @@ class LibraryUnavailableConversationsBrowse:
             raise TypeError("selected must be an UnresolvedConversationKey")
         if not isinstance(self.return_target, RoleplayReturnTarget):
             raise TypeError("return_target must be a RoleplayReturnTarget")
+        if self.return_target != RoleplayReturnTarget.console_context_character():
+            raise ValueError("unavailable browse must return to Console Character")
 
 
 @dataclass(frozen=True)

--- a/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
+++ b/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
@@ -437,7 +437,17 @@ def _deserialize_unresolved_library_link(
 def serialize_library_unavailable_inspection(
     link: LibraryUnavailableConversationInspection,
 ) -> dict[str, object]:
-    """Serialize an exact non-mutating Library conversation inspection."""
+    """Serialize an exact non-mutating Library conversation inspection.
+
+    Args:
+        link: Validated inspection with an unresolved identity and Console return.
+
+    Returns:
+        A versioned local payload preserving the identity and return anchor.
+
+    Raises:
+        TypeError: If link is not a LibraryUnavailableConversationInspection.
+    """
 
     if not isinstance(link, LibraryUnavailableConversationInspection):
         raise TypeError("link must be a LibraryUnavailableConversationInspection")
@@ -449,7 +459,18 @@ def serialize_library_unavailable_inspection(
 def deserialize_library_unavailable_inspection(
     payload: Mapping[str, Any],
 ) -> LibraryUnavailableConversationInspection:
-    """Validate one exact non-mutating Library conversation inspection."""
+    """Validate one exact non-mutating Library conversation inspection.
+
+    Args:
+        payload: Untrusted versioned local inspection payload.
+
+    Returns:
+        A typed inspection with a same-authority identity and Console return.
+
+    Raises:
+        ValueError: Including Pydantic ValidationError, if payload fields,
+            identity, authority, version, or return anchor are invalid.
+    """
 
     unresolved, return_target = _deserialize_unresolved_library_link(
         payload,
@@ -462,7 +483,17 @@ def deserialize_library_unavailable_inspection(
 def serialize_library_unavailable_browse(
     link: LibraryUnavailableConversationsBrowse,
 ) -> dict[str, object]:
-    """Serialize a complete Library unavailable-list browse link."""
+    """Serialize a complete Library unavailable-list browse link.
+
+    Args:
+        link: Validated unavailable browse with a selected identity and Console return.
+
+    Returns:
+        A versioned local payload preserving the selection and return anchor.
+
+    Raises:
+        TypeError: If link is not a LibraryUnavailableConversationsBrowse.
+    """
 
     if not isinstance(link, LibraryUnavailableConversationsBrowse):
         raise TypeError("link must be a LibraryUnavailableConversationsBrowse")
@@ -474,7 +505,18 @@ def serialize_library_unavailable_browse(
 def deserialize_library_unavailable_browse(
     payload: Mapping[str, Any],
 ) -> LibraryUnavailableConversationsBrowse:
-    """Validate one complete Library unavailable-list browse link."""
+    """Validate one complete Library unavailable-list browse link.
+
+    Args:
+        payload: Untrusted versioned local unavailable-browse payload.
+
+    Returns:
+        A typed browse with a same-authority selected identity and Console return.
+
+    Raises:
+        ValueError: Including Pydantic ValidationError, if payload fields,
+            identity, authority, version, or return anchor are invalid.
+    """
 
     selected, return_target = _deserialize_unresolved_library_link(
         payload,

--- a/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
+++ b/tldw_chatbook/UI/Navigation/character_conversation_navigation.py
@@ -155,6 +155,34 @@ class LibraryCharacterRepairContext:
 
 
 @dataclass(frozen=True)
+class LibraryUnavailableConversationInspection:
+    """Library detail link for one exact unresolved local conversation."""
+
+    unresolved: UnresolvedConversationKey
+    return_target: RoleplayReturnTarget
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.unresolved, UnresolvedConversationKey):
+            raise TypeError("unresolved must be an UnresolvedConversationKey")
+        if not isinstance(self.return_target, RoleplayReturnTarget):
+            raise TypeError("return_target must be a RoleplayReturnTarget")
+
+
+@dataclass(frozen=True)
+class LibraryUnavailableConversationsBrowse:
+    """Library archive link for all unavailable chats with a selected anchor."""
+
+    selected: UnresolvedConversationKey
+    return_target: RoleplayReturnTarget
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.selected, UnresolvedConversationKey):
+            raise TypeError("selected must be an UnresolvedConversationKey")
+        if not isinstance(self.return_target, RoleplayReturnTarget):
+            raise TypeError("return_target must be a RoleplayReturnTarget")
+
+
+@dataclass(frozen=True)
 class RoleplayDraftSnapshot:
     """Aggregate dirty and in-flight state owned by the Roleplay surface."""
 
@@ -361,3 +389,92 @@ def deserialize_library_character_repair_context(
             wire.return_target.screen_id, wire.return_target.focus_id
         ),
     )
+
+
+def _serialize_unresolved_library_link(
+    unresolved: UnresolvedConversationKey,
+    return_target: RoleplayReturnTarget,
+    *,
+    identity_field: str,
+) -> dict[str, object]:
+    return {
+        "version": _PAYLOAD_VERSION,
+        "source": "local",
+        "data_authority_id": unresolved.data_authority_id,
+        identity_field: serialize_character_conversation_key(unresolved),
+        "return_target": _serialize_return_target(return_target),
+    }
+
+
+def _deserialize_unresolved_library_link(
+    payload: Mapping[str, Any],
+    *,
+    identity_field: str,
+    name: str,
+) -> tuple[UnresolvedConversationKey, RoleplayReturnTarget]:
+    from ._character_conversation_wire import (
+        _LibraryUnavailableBrowseWire,
+        _LibraryUnavailableInspectionWire,
+    )
+
+    model = (
+        _LibraryUnavailableInspectionWire
+        if identity_field == "unresolved"
+        else _LibraryUnavailableBrowseWire
+    )
+    wire = model.model_validate(payload)
+    identity = getattr(wire, identity_field)
+    return (
+        UnresolvedConversationKey(identity.data_authority_id, identity.conversation_id),
+        RoleplayReturnTarget(wire.return_target.screen_id, wire.return_target.focus_id),
+    )
+
+
+def serialize_library_unavailable_inspection(
+    link: LibraryUnavailableConversationInspection,
+) -> dict[str, object]:
+    """Serialize an exact non-mutating Library conversation inspection."""
+
+    if not isinstance(link, LibraryUnavailableConversationInspection):
+        raise TypeError("link must be a LibraryUnavailableConversationInspection")
+    return _serialize_unresolved_library_link(
+        link.unresolved, link.return_target, identity_field="unresolved"
+    )
+
+
+def deserialize_library_unavailable_inspection(
+    payload: Mapping[str, Any],
+) -> LibraryUnavailableConversationInspection:
+    """Validate one exact non-mutating Library conversation inspection."""
+
+    unresolved, return_target = _deserialize_unresolved_library_link(
+        payload,
+        identity_field="unresolved",
+        name="Library unavailable inspection",
+    )
+    return LibraryUnavailableConversationInspection(unresolved, return_target)
+
+
+def serialize_library_unavailable_browse(
+    link: LibraryUnavailableConversationsBrowse,
+) -> dict[str, object]:
+    """Serialize a complete Library unavailable-list browse link."""
+
+    if not isinstance(link, LibraryUnavailableConversationsBrowse):
+        raise TypeError("link must be a LibraryUnavailableConversationsBrowse")
+    return _serialize_unresolved_library_link(
+        link.selected, link.return_target, identity_field="selected"
+    )
+
+
+def deserialize_library_unavailable_browse(
+    payload: Mapping[str, Any],
+) -> LibraryUnavailableConversationsBrowse:
+    """Validate one complete Library unavailable-list browse link."""
+
+    selected, return_target = _deserialize_unresolved_library_link(
+        payload,
+        identity_field="selected",
+        name="Library unavailable browse",
+    )
+    return LibraryUnavailableConversationsBrowse(selected, return_target)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -12212,6 +12212,7 @@ class ChatScreen(BaseAppScreen):
                 self._character._current_console_rail_character_id() is not None
                 or self._character_context.state.has_context
             ),
+            character_return_reveal=self._character_context.return_reveal,
         )
         if self._should_open_standard_width_inspector(
             rail_state=rail_state,
@@ -12608,6 +12609,8 @@ class ChatScreen(BaseAppScreen):
         notify_on_failure: bool = True,
     ) -> ConsoleRailState:
         """Persist requested Console rail preference changes and return new state."""
+        if left_open is not None or right_open is not None or "character" in (section_updates or {}):
+            self._character_context.return_reveal = False
         workspace_context = self._workspace._current_console_workspace_context()
         workspace_key = build_console_rail_preference_key(
             workspace_id=workspace_context.active_workspace_id,
@@ -12729,6 +12732,8 @@ class ChatScreen(BaseAppScreen):
             # guard makes the next sync tick re-measure the now-visible body
             # and repaint at the rail's real width.
             self._character.invalidate_refresh_scope()
+            if self._pending_character_return_focus_id is not None:
+                self._workspace.restore_character_navigation_focus()
 
     def _sync_console_workspace_context(self) -> None:
         try:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -21991,11 +21991,11 @@ class ChatScreen(BaseAppScreen):
             self.run_worker(
                 self._skill._refresh_console_skill_candidates(), exclusive=False
             )
-        self.run_worker(
-            self._character_context.refresh_if_scope_changed(),
-            exclusive=True,
-            group="console-character-context-refresh",
-        )
+            self.run_worker(  # The Character widget owns initial load.
+                self._character_context.refresh_if_scope_changed(),
+                exclusive=True,
+                group="console-character-context-refresh",
+            )
         # Textual's MRO dispatch also invokes BaseAppScreen's shared reconciliation;
         # this handler extends that resume event with Console-owned replay work.
 

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -443,7 +443,6 @@ from ...Chat.console_rail_state import (
     CONSOLE_INSPECTOR_AUTO_OPEN_MIN_COLUMNS,
     console_auto_open_would_evict_context,
     CONSOLE_INSPECTOR_MORE_DISCLOSURE_ID,
-    CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY,
     CONSOLE_RAIL_PREFERENCE_DISCLOSURE_IDS,
     CONSOLE_RAIL_SECTION_IDS,
     CONSOLE_RAIL_SHARED_LAYOUT_SCOPE,
@@ -455,12 +454,11 @@ from ...Chat.console_rail_state import (
     coerce_console_rail_preferences,
     collect_prunable_console_rail_keys,
     console_context_reveal_preferences,
-    console_rail_left_open_explicit,
     console_rail_width_band,
     normalize_console_rail_layout_scope,
     resolve_console_rail_priority,
-    serialize_console_rail_preferences,
     serialize_console_rail_stored_preferences,
+    serialize_console_rail_updated_preferences,
 )
 from ...config import (
     DEFAULT_CONSOLE_PASTE_COLLAPSE_THRESHOLD,
@@ -11304,6 +11302,7 @@ class ChatScreen(BaseAppScreen):
         """Route the picker result to a swap or a new character session."""
         if choice is None:
             return
+        self._character_context.invalidate_scope()
         self.run_worker(
             self._character._apply_console_character_choice_async(choice),
             exclusive=True,
@@ -12209,6 +12208,10 @@ class ChatScreen(BaseAppScreen):
             approval_count=self._console_pending_approval_count(),
             can_save_chatbook=inspector_state.can_save_chatbook,
             available_columns=resolved_available_columns,
+            character_context_exists=bool(
+                self._character._current_console_rail_character_id() is not None
+                or self._character_context.state.has_context
+            ),
         )
         if self._should_open_standard_width_inspector(
             rail_state=rail_state,
@@ -12636,6 +12639,7 @@ class ChatScreen(BaseAppScreen):
             if section_id in CONSOLE_RAIL_PREFERENCE_DISCLOSURE_IDS:
                 changes[f"{section_id}_open"] = bool(section_open)
         next_preferences = replace(current, **changes)
+        character_toggled = "character" in (section_updates or {})
         # TASK-2154.2 (LY-11, ADR-043): an explicit rail toggle writes
         # through even when the coerced value is unchanged. Otherwise "open
         # the left rail" below 100 cols persisted nothing -- the default is
@@ -12650,16 +12654,19 @@ class ChatScreen(BaseAppScreen):
         # distinguishable. The augmented dict goes to both the in-memory
         # config and the persisted file so the two never disagree.
         explicit_rail_toggle = left_open is not None or right_open is not None
-        if next_preferences != current or explicit_rail_toggle or target_missing:
-            serialized = serialize_console_rail_preferences(next_preferences)
-            if left_open is not None or console_rail_left_open_explicit(prior_stored):
-                serialized[CONSOLE_RAIL_LEFT_OPEN_EXPLICIT_KEY] = True
-            if (
-                right_open is None
-                and isinstance(prior_stored, Mapping)
-                and "right_open" not in prior_stored
-            ):
-                serialized.pop("right_open")
+        if (
+            next_preferences != current
+            or explicit_rail_toggle
+            or character_toggled
+            or target_missing
+        ):
+            serialized = serialize_console_rail_updated_preferences(
+                next_preferences,
+                prior_stored,
+                left_open=left_open,
+                right_open=right_open,
+                character_toggled=character_toggled,
+            )
             rail_state_config[preference_key.value] = serialized
             self._save_console_rail_preferences(
                 preference_key.value,
@@ -14825,7 +14832,7 @@ class ChatScreen(BaseAppScreen):
                 agent_fleet_section_state = (
                     self._agent._console_agent_fleet_section_state()
                 )
-                show_character_section = resolve_show_character_avatar(
+                show_character_avatar = resolve_show_character_avatar(
                     getattr(getattr(self, "app_instance", None), "app_config", {}) or {}
                 )
                 # `character_avatar_widget_builder` hands `ConsoleLeftRail` a
@@ -14845,7 +14852,7 @@ class ChatScreen(BaseAppScreen):
                 character_avatar_fit_box = None
                 character_avatar_prerender_job = None
                 character_avatar_name = ""
-                if show_character_section:
+                if show_character_avatar:
 
                     def character_avatar_widget_builder(box=None, prerendered=None):
                         return self._build_character_avatar_widget(
@@ -14878,13 +14885,13 @@ class ChatScreen(BaseAppScreen):
                             available_lines,
                         )
 
-                    character_avatar_name = (
-                        sanitize_character_display_label(
-                            self._active_character_avatar_name,
-                            max_characters=180,
-                        )
-                        or "No character in this chat"
+                character_avatar_name = (
+                    sanitize_character_display_label(
+                        self._active_character_avatar_name,
+                        max_characters=180,
                     )
+                    or "Roleplay character"
+                )
 
                 left_rail = ConsoleLeftRail(
                     rail_state=rail_state,
@@ -14903,7 +14910,8 @@ class ChatScreen(BaseAppScreen):
                     agent_cancel_all_visible=(
                         self._agent._console_agent_cancel_all_visible()
                     ),
-                    show_character_section=show_character_section,
+                    show_character_section=show_character_avatar,
+                    character_context_controller=self._character_context,
                     character_avatar_widget_builder=character_avatar_widget_builder,
                     character_avatar_name=character_avatar_name,
                     character_avatar_fit_box=character_avatar_fit_box,
@@ -16932,6 +16940,12 @@ class ChatScreen(BaseAppScreen):
             # raises (see `_refresh_active_character_avatar_if_scope_changed`
             # docstring, T3).
             await self._character._refresh_active_character_avatar_if_scope_changed()
+            # TASK-31244 review: the Character browser is screen-owned and
+            # survives rail recomposition. Revalidate its complete local scope
+            # on every existing native sync seam; the stable fingerprint makes
+            # settled ticks a no-op while profile, current-character, and local
+            # conversation mutations reload and fence stale commits.
+            await self._character_context.refresh_if_scope_changed()
             # task-280: hand the control bar a pre-await snapshot (its own
             # pre-existing timing). The rail-VISIBILITY call below must NOT
             # reuse this snapshot: `_sync_console_native_session_tabs` can
@@ -21972,6 +21986,11 @@ class ChatScreen(BaseAppScreen):
             self.run_worker(
                 self._skill._refresh_console_skill_candidates(), exclusive=False
             )
+        self.run_worker(
+            self._character_context.refresh_if_scope_changed(),
+            exclusive=True,
+            group="console-character-context-refresh",
+        )
         # Textual's MRO dispatch also invokes BaseAppScreen's shared reconciliation;
         # this handler extends that resume event with Console-owned replay work.
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9511,6 +9511,7 @@ class LibraryScreen(BaseAppScreen):
         along the MRO separately for this event (the on_mount contract).
         """
         self._library_screen_suspended = True
+        self._unavailable_navigation.clear_character_return(self)
         self._disarm_library_list_entry_focus()
         self._stop_library_media_selection_debounce()
         self._stop_library_media_filter_timer()
@@ -11220,6 +11221,8 @@ class LibraryScreen(BaseAppScreen):
         if generation is None:
             generation = self._library_navigation_context_generation
         if generation != self._library_navigation_context_generation:
+            return
+        if not await self._unavailable_navigation._validate_library_character_admission(self, character_admission):
             return
         file_notes_flush_allowed = await self._flush_active_file_notes()
         if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
@@ -14346,6 +14349,7 @@ class LibraryScreen(BaseAppScreen):
             self.call_after_refresh(self._focus_library_ordinary_canvas_entry)
         preferences = self._library_rail_preferences()
 
+        yield from self._unavailable_navigation.compose_character_return(self)
         yield Static(
             self._library_header_line(shell.header_line),
             id="library-header-line",

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -80,7 +80,6 @@ from ...config import (
     save_settings_to_cli_config,
 )
 from ...Constants import (
-    LIBRARY_MODE_CONVERSATIONS,
     LIBRARY_NAV_CONTEXT_CONVERSATION_ID,
     LIBRARY_NAV_CONTEXT_INGEST,
     LIBRARY_NAV_CONTEXT_MODE,
@@ -537,6 +536,9 @@ if TYPE_CHECKING:
         LibraryFileNotesWorkspace,
     )
     from ...Widgets.workspace_create_modal import WorkspaceCreateResult
+    from ..Library_Modules.library_unavailable_navigation import (
+        _LibraryCharacterNavigationAdmission,
+    )
 else:
 
     def LibraryFileNotesWorkspace(*args: Any, **kwargs: Any) -> Any:
@@ -2167,6 +2169,11 @@ class LibraryScreen(BaseAppScreen):
             LibraryLandingAttentionAction | None
         ) = None
         self._library_navigation_context_generation: int = 0
+        from ..Library_Modules import library_unavailable_navigation
+
+        self._unavailable_navigation = library_unavailable_navigation
+        self._pending_library_character_navigation = None
+        self._library_unavailable_browse_scope = None
         from ..Library_Modules.library_navigation_controller import (
             LibraryNavigationController,
         )
@@ -9564,8 +9571,21 @@ class LibraryScreen(BaseAppScreen):
         if (
             self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
             and self._pending_library_source_open is None
+            and self._pending_library_character_navigation is None
+            and self._library_unavailable_browse_scope is None
         ):
             self._start_library_conversation_page_request(
+                self._conversations_state.requested_page,
+                self._conversations_state.requested_query,
+            )
+        elif (
+            self._library_selected_row_id == LIBRARY_ROW_BROWSE_CONVERSATIONS
+            and self._pending_library_source_open is None
+            and self._pending_library_character_navigation is None
+            and self._library_unavailable_browse_scope is not None
+        ):
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
                 self._conversations_state.requested_page,
                 self._conversations_state.requested_query,
             )
@@ -9802,6 +9822,12 @@ class LibraryScreen(BaseAppScreen):
                 self._open_pending_library_source(),
                 exclusive=True,
                 group="library_nav_open_source",
+            )
+        if self._pending_library_character_navigation is not None:
+            self.run_worker(
+                self._unavailable_navigation._open_pending_library_character_navigation(self, ),
+                exclusive=True,
+                group="library_nav_character",
             )
 
     async def on_unmount(self) -> None:
@@ -11118,6 +11144,7 @@ class LibraryScreen(BaseAppScreen):
             and skill_flush_allowed
         )
 
+
     def apply_navigation_context(self, context: Mapping[str, Any]) -> None:
         """Admit route context through the Library-owned navigation controller."""
         self._navigation_controller.apply_navigation_context(context)
@@ -11176,6 +11203,7 @@ class LibraryScreen(BaseAppScreen):
         context: Mapping[str, Any],
         target_row_id: str | None = None,
         generation: int | None = None,
+        character_admission: _LibraryCharacterNavigationAdmission | None = None,
     ) -> None:
         """Admit every mounted editor/source, then apply navigation context.
 
@@ -11194,6 +11222,9 @@ class LibraryScreen(BaseAppScreen):
         if generation != self._library_navigation_context_generation:
             return
         file_notes_flush_allowed = await self._flush_active_file_notes()
+        if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+            self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+            return
         if generation != self._library_navigation_context_generation:
             return
         if not file_notes_flush_allowed:
@@ -11206,6 +11237,7 @@ class LibraryScreen(BaseAppScreen):
                 context,
                 target_row_id,
                 generation,
+                character_admission,
             )
         finally:
             if callable(release_source):
@@ -11216,6 +11248,7 @@ class LibraryScreen(BaseAppScreen):
         context: Mapping[str, Any],
         target_row_id: str,
         generation: int,
+        character_admission: _LibraryCharacterNavigationAdmission | None = None,
     ) -> None:
         """Apply mounted navigation context while source admission is held."""
         if self._prompts_state.mutation_in_flight:
@@ -11223,16 +11256,25 @@ class LibraryScreen(BaseAppScreen):
         if generation != self._library_navigation_context_generation:
             return
         note_flush = await self._flush_library_note_save()
+        if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+            self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+            return
         if generation != self._library_navigation_context_generation:
             return
         if note_flush.kind is not NoteFlushOutcomeKind.PERMITTED:
             return
         prompt_flush_allowed = await self._flush_library_prompt_save()
+        if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+            self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+            return
         if generation != self._library_navigation_context_generation:
             return
         if not prompt_flush_allowed:
             return
         skill_flush_allowed = await self._flush_library_skill_save()
+        if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+            self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+            return
         if generation != self._library_navigation_context_generation:
             return
         if not skill_flush_allowed:
@@ -11240,210 +11282,35 @@ class LibraryScreen(BaseAppScreen):
             return
         if target_row_id != LIBRARY_ROW_BROWSE_PROMPTS:
             self._clear_library_prompt_selection(announce=True)
-        self._apply_navigation_context_state(context, recompose=False)
+        self._apply_navigation_context_state(
+            context,
+            recompose=False,
+            character_admission=character_admission,
+        )
+        if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+            self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+            return
         if self.is_mounted and self._pending_library_source_open is None:
             await self.recompose()
+            if not self._unavailable_navigation._library_character_admission_is_current(self, character_admission):
+                self._unavailable_navigation._discard_library_character_admission(self, character_admission)
+                return
+        if character_admission is not None:
+            await self._unavailable_navigation._open_pending_library_character_navigation(self, )
 
     def _apply_navigation_context_state(
         self,
         context: Mapping[str, Any],
         *,
         recompose: bool = True,
+        character_admission: _LibraryCharacterNavigationAdmission | None = None,
     ) -> None:
-        """Apply validated navigation context to canvas state and recompose.
+        """Commit admitted routes through the Library navigation owner."""
+        from ..Library_Modules import library_unavailable_navigation
 
-        Split from ``apply_navigation_context`` so its mounted path can admit
-        every pending save first (see
-        ``_apply_navigation_context_after_flush``) while the pre-mount and
-        clean-editor paths apply directly.
-        """
-        if self._prompts_state.mutation_in_flight:
-            return
-        self._supersede_library_notes_navigation()
-        raw_open_source_type = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_TYPE)
-        raw_open_source_id = context.get(LIBRARY_NAV_CONTEXT_OPEN_SOURCE_ID)
-        open_source_type = ""
-        open_source_id = ""
-        should_open_pending_source = False
-        if type(raw_open_source_type) is str and type(raw_open_source_id) is str:
-            validated_source_type = self._safe_text(
-                raw_open_source_type,
-                max_length=64,
-            )
-            validated_source_id = self._safe_text(
-                raw_open_source_id,
-                max_length=500,
-            )
-            if (
-                validated_source_type == raw_open_source_type
-                and validated_source_id == raw_open_source_id
-                and validated_source_type
-                in ("media", "notes", "conversations", "prompt")
-                and validated_source_id
-            ):
-                open_source_type = validated_source_type
-                open_source_id = validated_source_id
-                self._pending_library_source_open = (
-                    open_source_type,
-                    open_source_id,
-                )
-                should_open_pending_source = True
-        requested_mode = self._safe_text(
-            context.get(LIBRARY_NAV_CONTEXT_MODE),
-            max_length=64,
+        library_unavailable_navigation._apply_navigation_context_state(
+            self, context, recompose=recompose, character_admission=character_admission
         )
-        conversation_id = self._safe_text(
-            context.get(LIBRARY_NAV_CONTEXT_CONVERSATION_ID),
-            max_length=200,
-        )
-        note_id = self._safe_text(
-            context.get(LIBRARY_NAV_CONTEXT_NOTE_ID),
-            max_length=200,
-        )
-        notes_create = bool(context.get(LIBRARY_NAV_CONTEXT_NOTES_CREATE))
-        ingest_media = bool(context.get(LIBRARY_NAV_CONTEXT_INGEST))
-        target_mode = (
-            requested_mode if requested_mode in LIBRARY_NAV_MODE_TO_ROW_ID else ""
-        )
-        if conversation_id and not target_mode:
-            target_mode = LIBRARY_MODE_CONVERSATIONS
-        if target_mode:
-            selected_row_id = LIBRARY_NAV_MODE_TO_ROW_ID.get(target_mode)
-            if selected_row_id:
-                self._set_library_destination_with_conversation_fence(selected_row_id)
-            self._invalidate_library_workspace_depth_state()
-        if conversation_id:
-            self._selected_conversation_id = conversation_id
-            self._set_library_destination_with_conversation_fence(
-                LIBRARY_ROW_BROWSE_CONVERSATIONS
-            )
-            if not should_open_pending_source:
-                # Persona still emits the legacy conversation_id context.
-                # A paged snapshot may not contain that id, so resolve it
-                # through the same point-lookup opener used by Search/RAG.
-                self._pending_library_source_open = (
-                    "conversations",
-                    conversation_id,
-                )
-                should_open_pending_source = True
-        if requested_mode == "notes" and not note_id:
-            # "notes" is a canvas row, not a nav-context table entry (see
-            # target_mode above), so it needs its own selection here --
-            # mirrors handle_library_notes_row's list-view entry state.
-            self._set_library_destination_with_conversation_fence(
-                LIBRARY_ROW_BROWSE_NOTES
-            )
-        if notes_create:
-            # Mirrors _select_library_rail_row(LIBRARY_ROW_CREATE_NOTE) --
-            # the create-note rail row's own target_id. The rail row's
-            # flush of a dirty editor is handled upstream by
-            # apply_navigation_context's mounted dirty-editor branch; here we
-            # only apply the selection the recompose reads. Reset the note
-            # editor state FIRST (a mounted screen re-entered via this
-            # deep link can still hold a previously opened note's
-            # id/detail/version) then re-assert the create-note target state
-            # AFTER, since the reset flips _library_notes_view back to
-            # "list" -- same reset-then-set ordering as
-            # _open_library_item_by_id's notes branch.
-            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
-            self._dispatch_database_note_identity_cleared()
-            self._reset_library_note_editor_state()
-            self._set_library_destination_with_conversation_fence(
-                LIBRARY_ROW_CREATE_NOTE
-            )
-        if ingest_media:
-            # Home's ingest-jobs "Open details" control re-points here
-            # (L3b Task 6): running/queued/failed Library ingest jobs
-            # mirror into Home's Running and Needs Attention sections, and
-            # this deep link is their one-hop route back to the in-canvas
-            # ingest queue. Mirrors
-            # _select_library_rail_row(LIBRARY_ROW_INGEST_MEDIA) -- unlike
-            # collections/note_id above, the ingest canvas reads the job
-            # registry directly on recompose, so no async data fetch (and
-            # therefore no on_mount deferral) is needed even pre-mount.
-            self._set_library_destination_with_conversation_fence(
-                LIBRARY_ROW_INGEST_MEDIA
-            )
-            # Mirrors _select_library_rail_row's reset: a cached LibraryScreen
-            # re-entered via this deep link (e.g. from Home's ingest-jobs
-            # "Open details" control) must never show a stale half-filled
-            # form left over from a previous Ingest visit.
-            self._reset_library_ingest_transient_state()
-        if note_id:
-            # Forward-compat entry point: the retired Notes tab's chat-sidebar
-            # deep link carried a note id, and this rebuilds the editor for it.
-            # No caller in the tree emits a note_id context today (the surviving
-            # open_notes_workspace route carries none, landing on the list), so
-            # this is exercised only by tests until such a producer is wired --
-            # not orphaned wiring.
-            self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
-            self._set_library_destination_with_conversation_fence(
-                LIBRARY_ROW_BROWSE_NOTES
-            )
-            if self.is_mounted:
-                self._begin_library_note_load(note_id)
-            else:
-                self._library_note_session.close_session()
-                self._selected_note_id = note_id
-                self._library_notes_view = "editor"
-                self._library_note_load_state = "loading"
-                self._library_note_load_message = ""
-                self._library_note_autosave_state = "idle"
-                self._library_note_confirming_delete = False
-                self._library_note_preview = False
-                self._library_note_editor_armed = False
-            # A deep link never owns the current blank-note GC identity.
-            self._library_note_pending_blank_gc_id = None
-            self._library_note_session_blank_id = None
-            self._library_note_title_user_edited = False
-        if open_source_type:
-            self._set_library_destination_with_conversation_fence(
-                {
-                    "media": LIBRARY_ROW_BROWSE_MEDIA,
-                    "notes": LIBRARY_ROW_BROWSE_NOTES,
-                    "conversations": LIBRARY_ROW_BROWSE_CONVERSATIONS,
-                    "prompt": LIBRARY_ROW_BROWSE_PROMPTS,
-                }[open_source_type]
-            )
-            if open_source_type == "media":
-                self._selected_media_id = open_source_id
-                self._library_media_view = "list"
-            elif open_source_type == "notes":
-                self._selected_note_id = open_source_id
-                self._set_library_notes_source(LIBRARY_NOTES_SOURCE_DATABASE)
-                self._library_notes_view = "list"
-            elif open_source_type == "conversations":
-                self._selected_conversation_id = open_source_id
-            elif open_source_type == "prompt":
-                try:
-                    self._prompts_state.selected_prompt_id = int(open_source_id)
-                except ValueError:
-                    self._prompts_state.selected_prompt_id = None
-                self._prompts_state.view = "list"
-        if should_open_pending_source and self.is_mounted:
-            self.run_worker(
-                self._open_pending_library_source(),
-                exclusive=True,
-                group="library_nav_open_source",
-            )
-        # F-012: a deep link can change the active canvas (e.g. mode="search")
-        # without a rail-row press -- the footer's `u` hint must follow the
-        # canvas, not just the rail switch, or the key works unadvertised.
-        self._register_footer_shortcuts()
-        if self._library_notes_workflow_active():
-            self._library_notes_stage = "notes"
-            self._library_notes_explicit_stage_intent = not self.is_mounted
-        else:
-            self._library_notes_explicit_stage_intent = False
-        if self.is_mounted:
-            if self._library_selected_row_id == LIBRARY_ROW_BROWSE_COLLECTIONS:
-                self.run_worker(
-                    self._load_library_collections_capture_entry(),
-                    exclusive=True,
-                    group="library_collections_capture_entry",
-                )
-            elif recompose and not open_source_type:
-                self.refresh(recompose=True)
 
     async def _open_pending_library_source(
         self,
@@ -15470,6 +15337,7 @@ class LibraryScreen(BaseAppScreen):
             and row_id != LIBRARY_ROW_BROWSE_CONVERSATIONS
         ):
             self._invalidate_library_conversation_reader_authority()
+            self._library_unavailable_browse_scope = None
         self._library_selected_row_id = row_id
 
     def _ensure_library_conversation_reader_selection(self) -> None:
@@ -15496,6 +15364,8 @@ class LibraryScreen(BaseAppScreen):
 
 
     def _start_library_conversation_page_request(self, page: int, query: str, *, refocus_filter: bool=False, focus_after_apply: str='') -> None:
+        self._library_unavailable_browse_scope = None
+        self._conversations_state.projection = ""
         return self._conversations_controller._start_library_conversation_page_request(page, query, refocus_filter=refocus_filter, focus_after_apply=focus_after_apply)
 
 
@@ -15513,6 +15383,8 @@ class LibraryScreen(BaseAppScreen):
 
     async def _load_library_conversation_page(self, page: int, query: str, generation: int, *, _clamp_attempted: bool=False) -> None:
         return await self._conversations_controller._load_library_conversation_page(page, query, generation, _clamp_attempted=_clamp_attempted)
+
+
 
 
     def _build_library_media_state(self) -> LibraryMediaCanvasState:
@@ -22647,6 +22519,7 @@ class LibraryScreen(BaseAppScreen):
             self._skills_state.filter_cursor_context = None
             self._library_skills_browse_controller.invalidate()
         self._library_navigation_context_generation += 1
+        self._library_unavailable_browse_scope = None
         if (
             self._pending_library_source_open is not None
             and self._pending_library_source_open[0] == "conversations"
@@ -36010,6 +35883,15 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Input.Submitted, "#library-conversations-filter")
     def handle_library_conversations_filter_submitted(self, event: Input.Submitted) -> None:
+        if self._library_unavailable_browse_scope is not None:
+            event.stop()
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
+                1,
+                self._safe_text(event.value, max_length=200),
+                refocus_filter=True,
+            )
+            return
         return self._conversations_controller.handle_library_conversations_filter_submitted(event)
 
 
@@ -36035,26 +35917,75 @@ class LibraryScreen(BaseAppScreen):
         event.stop()
         if self._conversations_state.loading:
             return
-        self._start_library_conversation_page_request(
-            1,
-            "",
-            refocus_filter=True,
-        )
+        if self._library_unavailable_browse_scope is not None:
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
+                1,
+                "",
+                refocus_filter=True,
+            )
+        else:
+            self._start_library_conversation_page_request(
+                1,
+                "",
+                refocus_filter=True,
+            )
 
 
 
     @on(Button.Pressed, "#library-conversations-retry")
     def handle_library_conversations_retry(self, event: Button.Pressed) -> None:
+        if self._library_unavailable_browse_scope is not None:
+            event.stop()
+            if self._conversations_state.loading:
+                return
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
+                self._conversations_state.requested_page,
+                self._conversations_state.requested_query,
+                focus_after_apply="#library-conversations-retry",
+            )
+            return
         return self._conversations_controller.handle_library_conversations_retry(event)
 
 
     @on(Button.Pressed, "#library-conversations-previous")
     def handle_library_conversations_previous(self, event: Button.Pressed) -> None:
+        if self._library_unavailable_browse_scope is not None:
+            event.stop()
+            if (
+                self._conversations_state.loading
+                or self._conversations_state.freshness != "fresh"
+                or self._conversations_state.page <= 1
+            ):
+                return
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
+                self._conversations_state.page - 1,
+                self._conversations_state.query,
+                focus_after_apply="#library-conversations-previous",
+            )
+            return
         return self._conversations_controller.handle_library_conversations_previous(event)
 
 
     @on(Button.Pressed, "#library-conversations-next")
     def handle_library_conversations_next(self, event: Button.Pressed) -> None:
+        if self._library_unavailable_browse_scope is not None:
+            event.stop()
+            if (
+                self._conversations_state.loading
+                or self._conversations_state.freshness != "fresh"
+                or not self._conversations_state.has_more
+            ):
+                return
+            self._unavailable_navigation._start_library_unavailable_conversation_page_request(
+                self,
+                self._conversations_state.page + 1,
+                self._conversations_state.query,
+                focus_after_apply="#library-conversations-next",
+            )
+            return
         return self._conversations_controller.handle_library_conversations_next(event)
 
 
@@ -36406,6 +36337,8 @@ class LibraryScreen(BaseAppScreen):
         record_id: str,
         *,
         entry_origin: bool = False,
+        required_database: Any | None = None,
+        required_authority: str = "",
     ) -> LibraryEntryReconcileResult | None:
         """Open a Library item straight to its detail surface by id.
 
@@ -36449,15 +36382,30 @@ class LibraryScreen(BaseAppScreen):
             else None
         )
 
+        def required_character_scope_is_current() -> bool:
+            if required_database is None:
+                return True
+            return getattr(
+                self.app_instance, "chachanotes_db", None
+            ) is required_database and self._unavailable_navigation._library_character_authority_is_current(
+                self,
+                required_authority
+            )
+
         def entry_is_current() -> bool:
-            return open_generation == self._library_navigation_context_generation and (
-                not entry_origin
-                or (
-                    entry_generation == self._library_snapshot_state_generation
-                    and entry_route_key == self._library_entry_route_key()
-                    and (
-                        entry_conversation_id is None
-                        or entry_conversation_id == self._selected_conversation_id
+            return (
+                required_character_scope_is_current()
+                and open_generation == self._library_navigation_context_generation
+                and (
+                    not entry_origin
+                    or (
+                        entry_generation == self._library_snapshot_state_generation
+                        and entry_route_key == self._library_entry_route_key()
+                        and (
+                            entry_conversation_id is None
+                            or entry_conversation_id
+                            == self._selected_conversation_id
+                        )
                     )
                 )
             )

--- a/tldw_chatbook/Widgets/Console/__init__.py
+++ b/tldw_chatbook/Widgets/Console/__init__.py
@@ -7,6 +7,7 @@ from .console_assistant_turn import (
     ConsoleAssistantTurnWidget,
 )
 from .console_control_bar import ConsoleControlBar
+from .console_character_context import ConsoleCharacterContext
 from .console_speech_controls import ConsoleSpeechControls
 from .console_context_controls import (
     ConsoleContextControlState,
@@ -129,6 +130,7 @@ __all__ = [
     "ConsoleCitationSourceRow",
     "ConsoleCitationSourcesModal",
     "ConsoleControlBar",
+    "ConsoleCharacterContext",
     "ConsoleSpeechControls",
     "ConsoleContextControlState",
     "ConsoleEditMessageModal",

--- a/tldw_chatbook/Widgets/Console/console_character_context.py
+++ b/tldw_chatbook/Widgets/Console/console_character_context.py
@@ -93,6 +93,8 @@ class ConsoleCharacterContext(Vertical):
         self._task: asyncio.Task[Any] | None = None
         self._browse_focus: ConsoleCharacterFocusIdentity | None = None
         self._recompose_generation = 0
+        self._focus_intent_generation = 0
+        self._pending_focus_restore: ConsoleCharacterFocusIdentity | None = None
 
     @property
     def state(self) -> ConsoleCharacterContextState:
@@ -119,7 +121,14 @@ class ConsoleCharacterContext(Vertical):
         return f"console-character-{role}-{digest}"
 
     def on_mount(self) -> None:
+        self.watch(self.screen, "focused", self._observe_focus_intent)
         self._start(self._controller.refresh_if_scope_changed())
+
+    def _observe_focus_intent(self, old: Any, new: Any) -> None:
+        """External focus wins; pruning the owning node is not a new intent."""
+        if new is not None and new is not self and self not in new.ancestors:
+            self._focus_intent_generation += 1
+            self._pending_focus_restore = None
 
     def _start(self, coroutine: Any) -> None:
         self._task = asyncio.create_task(coroutine)
@@ -152,7 +161,7 @@ class ConsoleCharacterContext(Vertical):
     def sync_state(self, state: ConsoleCharacterContextState) -> None:
         """Apply one complete snapshot and semantically restore focus/scroll."""
 
-        if state == self._state:
+        if not self.is_attached or not self.app.screen_stack or state == self._state:
             return
         current_focus = (
             self._focus_identity(self.app.focused) if self.is_mounted else None
@@ -160,11 +169,17 @@ class ConsoleCharacterContext(Vertical):
         self._state = state
         self._sync_identity_line()
         restore = state.restore_focus or current_focus
+        if restore is None and self.app.focused is None:
+            restore = self._pending_focus_restore
+        self._pending_focus_restore = restore
         self._recompose_generation += 1
         generation = self._recompose_generation
         asyncio.create_task(
             self._recompose_and_restore(
-                generation, restore, state.restore_scroll_offset
+                generation,
+                restore,
+                state.restore_scroll_offset,
+                self._focus_intent_generation,
             )
         )
 
@@ -173,12 +188,26 @@ class ConsoleCharacterContext(Vertical):
         generation: int,
         focus: ConsoleCharacterFocusIdentity | None,
         scroll_offset: int | None,
+        focus_intent_generation: int,
     ) -> None:
         """Restore only after Textual has mounted the new semantic projection."""
 
+        if not self.is_attached or not self.app.screen_stack:
+            return
+        focused = self.app.focused
+        if focused is not None and self in focused.ancestors:
+            # Avoid Textual's automatic external fallback while pruning the
+            # old node. A real subsequent external focus still advances intent.
+            self.screen.set_focus(None)
         await self.recompose()
-        if generation == self._recompose_generation:
+        if (
+            self.is_attached
+            and bool(self.app.screen_stack)
+            and generation == self._recompose_generation
+            and focus_intent_generation == self._focus_intent_generation
+        ):
             self._restore_browse_position(focus, scroll_offset)
+            self._pending_focus_restore = None
 
     def _outer_scroll(self) -> Any | None:
         try:
@@ -412,11 +441,12 @@ class ConsoleCharacterContext(Vertical):
 
         search = Input(
             value=self._state.query,
-            placeholder="Search character chats…",
+            placeholder="Search chats",
+            name="Global Keyword search over local character chats",
             id=CONSOLE_CHARACTER_SEARCH_ID,
         )
         search.character_focus_identity = ConsoleCharacterFocusIdentity("search")
-        search.tooltip = "Search saved local character conversations"
+        search.tooltip = "Global Keyword search over local character chats"
         yield search
 
         if self._state.phase is ConsoleCharacterOperationPhase.REFRESHING:

--- a/tldw_chatbook/Widgets/Console/console_character_context.py
+++ b/tldw_chatbook/Widgets/Console/console_character_context.py
@@ -491,7 +491,21 @@ class ConsoleCharacterContext(Vertical):
 
     @on(Input.Changed, f"#{CONSOLE_CHARACTER_SEARCH_ID}")
     def _search_changed(self, event: Input.Changed) -> None:
-        query = event.value.strip()
+        from ...Utils.input_validation import (
+            CONSOLE_SWITCHER_QUERY_MAX_LENGTH,
+            validate_console_switcher_query,
+        )
+
+        try:
+            query = validate_console_switcher_query(event.value).strip()
+        except ValueError:
+            event.input.value = self._state.query
+            self.notify(
+                f"Search must be text, at most {CONSOLE_SWITCHER_QUERY_MAX_LENGTH} "
+                "characters. Previous search kept.",
+                severity="warning",
+            )
+            return
         if query == self._state.query:
             return
         if query and not self._state.query:

--- a/tldw_chatbook/Widgets/Console/console_character_context.py
+++ b/tldw_chatbook/Widgets/Console/console_character_context.py
@@ -1,0 +1,574 @@
+"""Bounded Character conversation browser for the Console Context rail."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from datetime import UTC, datetime
+from typing import Any, ClassVar
+
+from textual import on
+from textual.app import ComposeResult
+from textual.binding import Binding
+from textual.containers import Vertical
+from textual.css.query import NoMatches, QueryError
+from textual.events import Click, DescendantBlur, DescendantFocus, Key
+from textual.widgets import Button, Input, Static
+
+from ...Character_Chat.character_conversation_navigation import (
+    CharacterConversationGroup,
+    CharacterConversationKey,
+    CharacterConversationRow,
+    ResolvedLocalCharacterKey,
+    serialize_character_conversation_key,
+)
+from ...UI.Console_Modules.character_context import (
+    ConsoleCharacterContextController,
+    ConsoleCharacterContextState,
+    ConsoleCharacterFocusIdentity,
+    ConsoleCharacterOperationPhase,
+    console_character_unavailable_reason_copy,
+)
+from ...Workspaces.conversation_browser_state import format_console_relative_age
+
+CONSOLE_CHARACTER_CONTEXT_ID = "console-character-context"
+CONSOLE_CHARACTER_SEARCH_ID = "console-character-search"
+
+
+def _identity_digest(payload: object) -> str:
+    encoded = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()[:16]
+
+
+class CharacterConversationButton(Button):
+    """Native row button whose single click selects and double click opens."""
+
+    BINDINGS: ClassVar[list[Binding]] = [
+        Binding("enter,space", "press", "Open chat", show=False)
+    ]
+
+    def __init__(
+        self, *args: Any, row: CharacterConversationRow, **kwargs: Any
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.character_row = row
+
+    async def _on_click(self, event: Click) -> None:
+        event.prevent_default()
+        event.stop()
+        self.focus()
+        if event.chain >= 2 and not self.disabled:
+            self.press()
+
+
+class CharacterGroupButton(Button):
+    """Native accordion heading with conventional Enter and Space toggles."""
+
+    BINDINGS: ClassVar[list[Binding]] = [
+        Binding("enter,space", "press", "Toggle group", show=False)
+    ]
+
+
+class ConsoleCharacterContext(Vertical):
+    """Always-mounted, local-only Character browser without a nested scroller."""
+
+    BINDINGS: ClassVar[list[Binding]] = [
+        Binding("escape", "clear_search", "Clear search", show=False)
+    ]
+
+    def __init__(
+        self,
+        controller: ConsoleCharacterContextController,
+        *,
+        identity_state: Static | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(id=CONSOLE_CHARACTER_CONTEXT_ID, **kwargs)
+        self._controller = controller
+        self._state = controller.state
+        self._identity_state = identity_state
+        self._task: asyncio.Task[Any] | None = None
+        self._browse_focus: ConsoleCharacterFocusIdentity | None = None
+        self._recompose_generation = 0
+
+    @property
+    def state(self) -> ConsoleCharacterContextState:
+        return self._state
+
+    @staticmethod
+    def group_dom_id(key: CharacterConversationKey) -> str:
+        """Return a stable DOM id derived from the complete typed key."""
+
+        digest = _identity_digest(serialize_character_conversation_key(key))
+        return f"console-character-group-{digest}"
+
+    @staticmethod
+    def row_dom_id(row_key: str) -> str:
+        """Return a stable DOM id derived from the repository row identity."""
+
+        return f"console-character-row-{_identity_digest({'row_key': row_key})}"
+
+    @staticmethod
+    def action_dom_id(role: str, key: CharacterConversationKey) -> str:
+        """Return a stable DOM id for a group-scoped action."""
+
+        digest = _identity_digest(serialize_character_conversation_key(key))
+        return f"console-character-{role}-{digest}"
+
+    def on_mount(self) -> None:
+        self._start(self._controller.refresh_if_scope_changed())
+
+    def _start(self, coroutine: Any) -> None:
+        self._task = asyncio.create_task(coroutine)
+
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:
+        if action == "clear_search":
+            return bool(
+                self._state.query
+                or self._state.phase is ConsoleCharacterOperationPhase.OPENING
+            )
+        return True
+
+    def action_clear_search(self) -> None:
+        """Clear search or cancel an activation before its commit point."""
+
+        if self._state.phase is ConsoleCharacterOperationPhase.OPENING:
+            self._controller.cancel_activation()
+            return
+        if self._state.query:
+            try:
+                self.query_one(f"#{CONSOLE_CHARACTER_SEARCH_ID}", Input).value = ""
+            except (NoMatches, QueryError):
+                self._start(self._controller.search(""))
+
+    @staticmethod
+    def _focus_identity(widget: object) -> ConsoleCharacterFocusIdentity | None:
+        identity = getattr(widget, "character_focus_identity", None)
+        return identity if isinstance(identity, ConsoleCharacterFocusIdentity) else None
+
+    def sync_state(self, state: ConsoleCharacterContextState) -> None:
+        """Apply one complete snapshot and semantically restore focus/scroll."""
+
+        if state == self._state:
+            return
+        current_focus = (
+            self._focus_identity(self.app.focused) if self.is_mounted else None
+        )
+        self._state = state
+        self._sync_identity_line()
+        restore = state.restore_focus or current_focus
+        self._recompose_generation += 1
+        generation = self._recompose_generation
+        asyncio.create_task(
+            self._recompose_and_restore(
+                generation, restore, state.restore_scroll_offset
+            )
+        )
+
+    async def _recompose_and_restore(
+        self,
+        generation: int,
+        focus: ConsoleCharacterFocusIdentity | None,
+        scroll_offset: int | None,
+    ) -> None:
+        """Restore only after Textual has mounted the new semantic projection."""
+
+        await self.recompose()
+        if generation == self._recompose_generation:
+            self._restore_browse_position(focus, scroll_offset)
+
+    def _outer_scroll(self) -> Any | None:
+        try:
+            return self.screen.query_one("#console-left-rail-body")
+        except (NoMatches, QueryError):
+            return None
+
+    def _resolve_focus_id(self, identity: ConsoleCharacterFocusIdentity | None) -> str:
+        groups = self._state.groups
+        keys = {group.key for group in groups}
+        if identity is not None:
+            if identity.role == "search":
+                return CONSOLE_CHARACTER_SEARCH_ID
+            if identity.role == "row" and identity.row_key:
+                rows = (
+                    *self._state.search_rows,
+                    *(row for group in groups for row in group.rows),
+                )
+                if any(row.row_key == identity.row_key for row in rows):
+                    return self.row_dom_id(identity.row_key)
+            if identity.group_key in keys:
+                return self.group_dom_id(identity.group_key)
+        fallback = self._state.expanded_key
+        if fallback not in keys:
+            fallback = next((group.key for group in groups if group.is_current), None)
+        if fallback is None and groups:
+            fallback = groups[0].key
+        if fallback is not None:
+            return self.group_dom_id(fallback)
+        return CONSOLE_CHARACTER_SEARCH_ID
+
+    def _restore_browse_position(
+        self,
+        focus: ConsoleCharacterFocusIdentity | None,
+        scroll_offset: int | None,
+    ) -> None:
+        if focus is not None:
+            try:
+                self.query_one(f"#{self._resolve_focus_id(focus)}").focus()
+            except (NoMatches, QueryError):
+                pass
+        outer = self._outer_scroll()
+        if outer is not None and scroll_offset is not None:
+            outer.scroll_to(y=scroll_offset, animate=False, immediate=True, force=True)
+
+    def _restore_focus(self, identity: ConsoleCharacterFocusIdentity) -> None:
+        self._restore_browse_position(identity, None)
+
+    @staticmethod
+    def _row_label(row: CharacterConversationRow) -> str:
+        suffix = " · current" if row.is_current else ""
+        return f"{row.title or 'Untitled chat'}{suffix}"
+
+    @staticmethod
+    def _search_row_label(row: CharacterConversationRow) -> str:
+        age = format_console_relative_age(row.last_modified, now=datetime.now(UTC))
+        suffix = f" · {age}" if age else ""
+        return f"{row.title or 'Untitled chat'}\n{row.character_label}\nLocal{suffix}"
+
+    @staticmethod
+    def _group_label(group: CharacterConversationGroup, expanded: bool) -> str:
+        glyph = "▾" if expanded else "▸"
+        current = " · current" if group.is_current else ""
+        return f"{glyph} {group.character_label} · {group.total} chats{current}"
+
+    def _reason_for(self, row: CharacterConversationRow) -> str:
+        detail = self._state.unavailable_detail(row.row_key)
+        return (
+            detail.reason_copy
+            if detail is not None
+            else console_character_unavailable_reason_copy(row.unavailable_reason)
+        )
+
+    def _sync_identity_line(self) -> None:
+        if self._identity_state is None:
+            return
+        scope = self._state.scope_fingerprint
+        has_current = scope is not None and scope.current_character_id is not None
+        if not has_current:
+            copy = "No current character · Local · No open chat"
+        else:
+            character = scope.current_character_label or "Current character"
+            open_copy = "Open" if scope.open_conversation_id else "No open chat"
+            copy = f"{character} · Local · {open_copy}"
+        self._identity_state.update(copy)
+        self._identity_state.tooltip = copy
+
+    def _compose_unavailable_detail(
+        self, row: CharacterConversationRow
+    ) -> ComposeResult:
+        detail = self._state.unavailable_detail(row.row_key)
+        reason = detail.reason_copy if detail is not None else self._reason_for(row)
+        yield Static(reason, id="console-character-unavailable-reason", markup=False)
+        opening = (
+            self._state.phase is ConsoleCharacterOperationPhase.REPAIRING
+            and self._state.operation_row_key == row.row_key
+        )
+        open_button = Button(
+            "Opening Library…" if opening else "Open in Library",
+            id="console-character-open-library",
+            classes="console-character-action",
+            compact=True,
+            disabled=opening,
+        )
+        open_button.character_row = row
+        open_button.character_unavailable_action = "open"
+        yield open_button
+        if detail is not None and detail.can_repair:
+            repair = Button(
+                "Opening repair…" if opening else "Repair in Library",
+                id="console-character-repair-library",
+                classes="console-character-action",
+                compact=True,
+                disabled=opening,
+            )
+            repair.character_row = row
+            repair.character_unavailable_action = "repair"
+            yield repair
+
+    def _compose_group(self, group: CharacterConversationGroup) -> ComposeResult:
+        expanded = self._state.expanded_key == group.key
+        identity = ConsoleCharacterFocusIdentity("group", group_key=group.key)
+        header = CharacterGroupButton(
+            self._group_label(group, expanded),
+            id=self.group_dom_id(group.key),
+            classes="console-character-group",
+            compact=True,
+        )
+        header.character_group = group
+        header.character_focus_identity = identity
+        header.tooltip = self._group_label(group, expanded).lstrip("▾▸ ")
+        yield header
+        if not expanded:
+            return
+        if not group.rows:
+            yield Static(
+                f"No chats with {group.character_label} yet",
+                classes="console-character-empty",
+                markup=False,
+            )
+            if group.is_current and isinstance(group.key, ResolvedLocalCharacterKey):
+                start = Button(
+                    "Start in Console",
+                    id=self.action_dom_id("start", group.key),
+                    classes="console-character-action",
+                    compact=True,
+                )
+                start.character_group = group
+                yield start
+        for row in group.rows[:5]:
+            selected = self._state.selected_unavailable_row_key == row.row_key
+            label = self._row_label(row)
+            if row.unresolved is not None:
+                label = f"{label} · {self._reason_for(row)}"
+            opening = (
+                self._state.phase is ConsoleCharacterOperationPhase.OPENING
+                and self._state.operation_row_key == row.row_key
+            )
+            if opening:
+                label = f"{label} · Opening…"
+            button = CharacterConversationButton(
+                label,
+                row=row,
+                id=self.row_dom_id(row.row_key),
+                classes=(
+                    "console-character-row -opening"
+                    if opening
+                    else "console-character-row"
+                ),
+                compact=True,
+            )
+            button.character_focus_identity = ConsoleCharacterFocusIdentity(
+                "row", group_key=group.key, row_key=row.row_key
+            )
+            button.tooltip = label
+            yield button
+            if row.unresolved is not None and selected:
+                yield from self._compose_unavailable_detail(row)
+        if group.total:
+            action_label = (
+                f"View all {group.total} in Roleplay"
+                if isinstance(group.key, ResolvedLocalCharacterKey)
+                else f"View all {group.total} in Library"
+            )
+            action = Button(
+                action_label,
+                id=self.action_dom_id("view-all", group.key),
+                classes="console-character-action",
+                compact=True,
+            )
+            action.character_group = group
+            action.tooltip = action_label
+            yield action
+
+    def _compose_search_rows(self) -> ComposeResult:
+        if not self._state.search_rows:
+            yield Static(
+                "No local character chats match",
+                classes="console-character-empty",
+                markup=False,
+            )
+        for row in self._state.search_rows[:8]:
+            label = self._search_row_label(row)
+            if row.unresolved is not None:
+                label = f"{label} · {self._reason_for(row)}"
+            opening = (
+                self._state.phase is ConsoleCharacterOperationPhase.OPENING
+                and self._state.operation_row_key == row.row_key
+            )
+            if opening:
+                label = f"{label} · Opening…"
+            button = CharacterConversationButton(
+                label,
+                row=row,
+                id=self.row_dom_id(row.row_key),
+                classes=(
+                    "console-character-row console-character-search-row -opening"
+                    if opening
+                    else "console-character-row console-character-search-row"
+                ),
+                compact=True,
+            )
+            button.character_focus_identity = ConsoleCharacterFocusIdentity(
+                "row", row_key=row.row_key
+            )
+            button.tooltip = label
+            yield button
+
+    def compose(self) -> ComposeResult:
+        self._sync_identity_line()
+
+        search = Input(
+            value=self._state.query,
+            placeholder="Search character chats…",
+            id=CONSOLE_CHARACTER_SEARCH_ID,
+        )
+        search.character_focus_identity = ConsoleCharacterFocusIdentity("search")
+        search.tooltip = "Search saved local character conversations"
+        yield search
+
+        if self._state.phase is ConsoleCharacterOperationPhase.REFRESHING:
+            yield Static(
+                "Refreshing local character chats…",
+                id="console-character-loading",
+                markup=False,
+            )
+            return
+        if self._state.phase is ConsoleCharacterOperationPhase.SEARCHING:
+            yield Static(
+                "Searching local character chats…",
+                id="console-character-loading",
+                markup=False,
+            )
+            return
+        if self._state.error:
+            yield Static(self._state.error, id="console-character-error", markup=False)
+            yield Button("Retry", id="console-character-retry", compact=True)
+            return
+        if self._state.query:
+            yield from self._compose_search_rows()
+            if self._controller.query_handoff_available:
+                yield Button(
+                    "Continue search in Character chats",
+                    id="console-character-query-handoff",
+                    compact=True,
+                )
+            return
+        if not self._state.groups:
+            yield Static(
+                "No character chats yet",
+                classes="console-character-empty",
+                markup=False,
+            )
+            yield Button(
+                "Open Roleplay", id="console-character-open-roleplay", compact=True
+            )
+            return
+        for group in self._state.groups[:4]:
+            yield from self._compose_group(group)
+
+    @on(Input.Changed, f"#{CONSOLE_CHARACTER_SEARCH_ID}")
+    def _search_changed(self, event: Input.Changed) -> None:
+        query = event.value.strip()
+        if query == self._state.query:
+            return
+        if query and not self._state.query:
+            outer = self._outer_scroll()
+            focused = self.app.focused
+            self._controller.capture_browse(
+                focus=self._browse_focus or self._focus_identity(focused),
+                scroll_offset=int(getattr(outer, "scroll_y", 0) or 0),
+            )
+        self._start(self._controller.search(query))
+
+    def on_descendant_blur(self, event: DescendantBlur) -> None:
+        """Remember the last stable browse target before focus enters search."""
+
+        identity = self._focus_identity(event.widget)
+        if not self._state.query and identity is not None and identity.role != "search":
+            self._browse_focus = identity
+
+    def on_descendant_focus(self, event: DescendantFocus) -> None:
+        """Select unavailable detail without treating focus as activation."""
+
+        row = getattr(event.widget, "character_row", None)
+        if (
+            isinstance(row, CharacterConversationRow)
+            and row.unresolved is not None
+            and self._state.selected_unavailable_row_key != row.row_key
+        ):
+            self._controller.select_unavailable(row.row_key)
+            self.sync_state(self._controller.state)
+
+    @on(Button.Pressed)
+    def _button_pressed(self, event: Button.Pressed) -> None:
+        button = event.button
+        group = getattr(button, "character_group", None)
+        if button.id == "console-character-retry":
+            self._start(
+                self._controller.search(self._state.query)
+                if self._state.query
+                else self._controller.refresh()
+            )
+            return
+        if button.id == "console-character-open-roleplay":
+            self._controller.open_roleplay_home()
+            return
+        if button.id == "console-character-query-handoff":
+            self._controller.handoff_query(self._state.query)
+            return
+        if isinstance(button, CharacterGroupButton) and group is not None:
+            identity = ConsoleCharacterFocusIdentity("group", group_key=group.key)
+            self._controller.toggle_group(group.key)
+            self.sync_state(self._controller.state)
+            self.call_after_refresh(self._restore_focus, identity)
+            return
+        if button.id and button.id.startswith("console-character-start-") and group:
+            self._start(self._controller.start_current(group))
+            return
+        if button.id and button.id.startswith("console-character-view-all-") and group:
+            self._start(self._controller.view_group(group))
+            return
+        unavailable_action = getattr(button, "character_unavailable_action", "")
+        row = getattr(button, "character_row", None)
+        if unavailable_action and isinstance(row, CharacterConversationRow):
+            if row.unresolved is None:
+                return
+            route = (
+                self._controller.repair_unavailable
+                if unavailable_action == "repair"
+                else self._controller.open_unavailable
+            )
+            self._start(route(row.unresolved, row_key=row.row_key))
+            return
+        if isinstance(button, CharacterConversationButton):
+            if self._state.phase is ConsoleCharacterOperationPhase.OPENING:
+                return
+            row = button.character_row
+            if row.target is not None:
+                self._start(self._controller.activate(row.target, row_key=row.row_key))
+            elif row.unresolved is not None:
+                self._start(
+                    self._controller.open_unavailable(
+                        row.unresolved, row_key=row.row_key
+                    )
+                )
+
+    def on_key(self, event: Key) -> None:
+        focused = self.app.focused
+        group = getattr(focused, "character_group", None)
+        if group is not None and event.key in {"left", "right"}:
+            expanded = self._state.expanded_key == group.key
+            if (event.key == "left" and expanded) or (
+                event.key == "right" and not expanded
+            ):
+                event.stop()
+                identity = self._focus_identity(focused)
+                self._controller.toggle_group(group.key)
+                self.sync_state(self._controller.state)
+                if identity is not None:
+                    self.call_after_refresh(self._restore_focus, identity)
+            return
+        if event.key == "escape":
+            if self._state.phase is ConsoleCharacterOperationPhase.OPENING:
+                event.stop()
+                self._controller.cancel_activation()
+                return
+            if self._state.query:
+                event.stop()
+                try:
+                    self.query_one(f"#{CONSOLE_CHARACTER_SEARCH_ID}", Input).value = ""
+                except (NoMatches, QueryError):
+                    self._start(self._controller.search(""))

--- a/tldw_chatbook/Widgets/Library/library_character_return.py
+++ b/tldw_chatbook/Widgets/Library/library_character_return.py
@@ -1,0 +1,30 @@
+"""Native, route-owned return action for unavailable Character deep links."""
+
+from collections.abc import Callable
+
+from textual import on
+from textual.containers import Horizontal
+from textual.widgets import Button
+
+
+class LibraryCharacterReturn(Horizontal):
+    """One compact action; route admission and navigation stay with its owner."""
+
+    def __init__(self, return_to_origin: Callable[[], None]) -> None:
+        self._return_to_origin = return_to_origin
+        super().__init__(id="library-character-return")
+        self.styles.height = 1
+
+    def compose(self):
+        button = Button(
+            "Back to Console", id="library-character-back-console", compact=True
+        )
+        button.styles.height = 1
+        button.styles.min_height = 1
+        button.styles.width = "auto"
+        yield button
+
+    @on(Button.Pressed, "#library-character-back-console")
+    def return_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._return_to_origin()

--- a/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
@@ -66,7 +66,11 @@ class LibraryConversationsCanvas(
         pager = self.canvas.pager
         title_count = pager.title_count if pager is not None else None
         title = (
-            "Conversations" if title_count is None else f"Conversations ({title_count})"
+            self.canvas.title
+            if self.canvas.title != "Conversations"
+            else "Conversations"
+            if title_count is None
+            else f"Conversations ({title_count})"
         )
         yield Static(
             title,

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -4520,7 +4520,7 @@ assistant_markdown = true
 [chat.images]
 enabled = true
 show_attach_button = true  # Show/hide the attach file button in chat
-# show_character_avatar = true  # show the active character's avatar in the Console left rail
+# show_character_avatar = true  # show the active character image; Character navigation remains available
 # react_character_expressions = true  # swap the Console character avatar among idle/thinking/speaking/error as it generates a reply (requires per-state images on the character); set false to keep a static avatar
 default_render_mode = "auto"  # auto, pixels, regular
 max_size_mb = 10.0

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4771,6 +4771,71 @@ ConsoleTerminalWorkspace Button:focus {
     align: center middle;
 }
 
+/* TASK-31244: Character rows are compact, cell-clipped peers inside the
+   section's existing bounded viewport. The widget itself introduces no
+   additional scroll owner. */
+#console-character-context {
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 0;
+}
+
+#console-character-search {
+    width: 100%;
+    min-width: 0;
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+}
+
+.console-character-group,
+.console-character-row,
+.console-character-action,
+#console-character-retry,
+#console-character-open-roleplay {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    padding: 0;
+    text-align: left;
+    content-align: left middle;
+    text-overflow: ellipsis;
+}
+
+.console-character-group:focus,
+.console-character-row:focus,
+.console-character-action:focus,
+#console-character-retry:focus,
+#console-character-open-roleplay:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+}
+
+#console-character-context .console-character-search-row {
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+}
+
+.console-character-empty,
+#console-character-loading,
+#console-character-error,
+#console-character-unavailable-reason {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    text-overflow: ellipsis;
+}
+
+#console-character-context .console-character-row.-opening {
+    text-style: italic;
+}
+
 /* Shared direct-section body. The owner applies the measured content-row
    allocation inline; no CSS ceiling may override a smaller Context grant. */
 ConsoleBoundedSection {

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1269,6 +1269,67 @@ ConsoleTerminalWorkspace#console-main-column {
     align: center middle;
 }
 
+/* TASK-31244: Character rows are compact, cell-clipped peers inside the
+   section's existing bounded viewport. The widget itself introduces no
+   additional scroll owner. */
+#console-character-context {
+    width: 100%;
+    min-width: 0;
+    height: auto;
+    min-height: 0;
+}
+
+#console-character-search {
+    width: 100%;
+    min-width: 0;
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+}
+
+.console-character-group,
+.console-character-row,
+.console-character-action,
+#console-character-retry,
+#console-character-open-roleplay {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    max-height: 1;
+    padding: 0;
+    text-align: left;
+    content-align: left middle;
+    text-overflow: ellipsis;
+}
+
+.console-character-group:focus,
+.console-character-row:focus,
+.console-character-action:focus,
+#console-character-retry:focus,
+#console-character-open-roleplay:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+}
+
+#console-character-context .console-character-search-row {
+    height: 3;
+    min-height: 3;
+    max-height: 3;
+}
+
+.console-character-empty,
+#console-character-loading,
+#console-character-error,
+#console-character-unavailable-reason {
+    width: 100%;
+    min-width: 0;
+    height: 1;
+    min-height: 1;
+    text-overflow: ellipsis;
+}
+
 .console-bounded-section-viewport {
     height: auto;
     min-height: 0;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -3244,6 +3244,10 @@ ConsoleTerminalWorkspace Button:focus {
     text-style: underline bold;
 }
 
+#console-character-context .console-character-row.-opening {
+    text-style: italic;
+}
+
 /* Shared direct-section body. The owner applies the measured content-row
    allocation inline; no CSS ceiling may override a smaller Context grant. */
 ConsoleBoundedSection {


### PR DESCRIPTION
## Summary

Adds the approved local Character-conversation section to Console Context (TASK-31244), following the merged projection/FTS and typed navigation work.

- Character remains after Conversations and before Model even with avatar images disabled: at most four recent/current groups, one expanded, up to five chats each.
- Global local Keyword search returns at most eight results with title, character, local source and age. Enter resumes the exact conversation in Console.
- Resolved groups end with “View all N in Roleplay.” Unavailable characters use explicit Library inspection/recovery and a route-owned “Back to Console” action.
- Preserves draft vetoes, Data Profile authority, latest-operation ownership, focus intent, and manual disclosure preferences. Rejected incoming navigation leaves the current Library route usable.

No Meaning/semantic runtime, schema or dependencies; no Task5 Character-switcher mode or continuation control. At 52 columns Context remains policy-hidden, and Library Back uses the existing visible Console fallback. ADR120/083 apply. No incumbent budget is raised; the new Library helper is pinned at its exact 811 lines.

## Review and rebase

Independent code review and two scoped fix reviews closed all Critical/Important findings. Impeccable scored the Search chats correction resolved and found no material issue in the pictured Back/return layout. Documentation handoff found no durable design-system change or material documentation gap.

Current HEAD is 837c3bbccdf7d9111ef75d385cf41d3a453c06ff on dev f356ddc4a9b37d5c272d8398376764b9d83e04a1. The complete four-commit Task4 range was rebased, followed by one isolated Library prompt-state integration correction. Upstream migrations, Canvas callbacks, warm-resume consumers, Library extraction and lifecycle changes are preserved. Reviewed pre-rebase heads remain preserved locally.

Independent scoped integration review is spec-compliant and quality-approved: both prompt-state ownership and the unchanged 198-line navigation cap are addressed, with zero new findings. It also checked actual rebase overlap for route ownership, extraction and lifecycle preservation.

## Verification

Latest integration is rebased onto dev f356ddc4a9b37d5c272d8398376764b9d83e04a1, preserving the Library prompts extraction and scheduling/lifecycle corrections. Task4's moved navigation helper now uses `_prompts_state`; its admission controller is simplified in place to retain the new upstream 198-line cap and existing guard ordering. Focused integration: **8 passed**. Complete affected navigation/return/startup/MRO/static gate: **170 passed, 1 known empty-preview test excluded, 11 warnings**. No cap or allowlist was raised. Fresh counts are 635/660 imports, 971/972 UI-ready, 499/500 preimports and 795,056/804,000 boot-CSS bytes. ChatScreen is 23,123 lines/710 methods versus upstream 23,099/710; Library is 37,490/1,282 versus upstream 37,538/1,282.

Targeted tests only; no full repository sweep. The following historical gates and captures predate the latest integration; the 170-pass gate above is current-head evidence.

- Rebased feature gate: **242 passed, 1 explicitly excluded known Library empty-preview test, 7 warnings**. Includes Character grouping/search/activation, authority and async focus races, rejected incoming navigation, complete Library return reuse, and the new upstream warm-resume tests.
- Earlier static/startup/CSS/diagnostic gate: **18 passed, 1 failed**. The failure is the pre-existing ChatScreen cap: then-fetched dev had 23,098 lines/710 methods against 16,966/563; the branch had 23,122/710 (reviewed Task4 delta +24 lines, no methods). The cap is unchanged; this is not a clean static-suite claim.
- No new changed-owner Ruff diagnostics or newly failing formatter files. Generated inventory has no drift; Task4 adds one owner/two metadata-only calls, without new sinks or privacy candidates. Complete committed-range whitespace is clean.
- Earlier startup: 635/660 own imports, 971/972 UI-ready modules, 498/500 preimports, 791,910/804,000 boot-CSS bytes. Current counts are above. Only one UI-ready slot remains; this is local evidence, not platform clearance.
- Thirteen synthetic production-styled Textual exports were visually reviewed before the code-equivalent rebase. They establish pictured layout/copy/containment/focus paint, not native-terminal or pointer usability. Loading Library frames qualify the Back affordance only.

## PR-review corrections

Scoped independent review approved both Qodo findings and the CI correction, with zero new blocking findings. Previous published-head gate on cb2d4e6bb: **121 passed, 1 Requests warning**, covering query/ownership/payload contracts, initial and warm refresh, exact warm handoff, the previously failing boot-worker census and its policy-membership cross-check.

The follow-up correction applies the shared strict 512-character Console query validator before trimming at both widget and controller entry. Invalid UI edits restore the last valid visible query with a bounded warning; direct invalid controller input is rejected before state or database work. The four public unavailable-navigation APIs now document their arguments, returns and validation exceptions. The redundant cold-resume Character refresh is removed using the existing mount-visit guard; initial widget loading and warm-resume refresh remain. No startup allowlist, stagger policy or numeric budget changed.

Local fix verification before the final rebase: focused regression gate **12 passed**; covering query/ownership/payload/cold-warm/startup gate **136 passed, 1 failed**. The extra failure is an unchanged app-level stagger observation test: its six-second polling window ends while the configured seven-second splash is still mounted, before Console mounts. It reproduces in isolation; unchanged-owner hashes are recorded, not a full baseline runtime run. The previously failing worker census and 971/972 UI-ready census pass. No new changed-owner lint/format failures; Console remains 23,122 lines/710 methods.

## Remaining qualifications

The user explicitly approved merging after green CI while deferring incomplete native/user/scale verification and accepting the documented resource and baseline-test limitations. This is acceptance of those limits, not evidence that the missing checks passed.

Native/equal-terminal, moderated-user and large-corpus timing evidence remains incomplete. Earlier aggregate file-descriptor growth is unattributed; no FD warning in the latest smaller run is not proof of leak-free operation. Requests/datetime warnings, the known excluded test and inherited Console ratchet failure remain explicit. These are distinct from the corrected feature defects.

TASK-31244 remains In Progress; no all-AC/Done or full release-clearance claim. Task5 and Meaning remain separate work.
