### PR TITLE
chore(backlog): schedules close-out hygiene (mark 31418 Done, file 31824)

### DIFF
--- a/backlog/tasks/task-31418 - Remove-the-double-base-on_unmount-caused-by-super-calls-under-Textual-MRO-dispatch.md
+++ b/backlog/tasks/task-31418 - Remove-the-double-base-on_unmount-caused-by-super-calls-under-Textual-MRO-dispatch.md
@@ -3,9 +3,10 @@ id: TASK-31418
 title: >-
   Remove the double base on_unmount caused by super calls under Textual MRO
   dispatch
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 22:41'
+updated_date: '2026-09-06 08:08'
 labels:
   - textual
   - cleanup
@@ -39,6 +40,7 @@ This is a convention fix, not a bug fix: pick one discipline and make it uniform
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 **Approach:** Applied the repo's existing lifecycle convention (already in force
 for `on_mount` from prior work) to `on_unmount`: a subclass handler for an
 MRO-dispatched lifecycle event does NOT call `super().on_*()`, because Textual's
@@ -92,3 +94,4 @@ throwaway worktree).
 `UI/Screens/scheduling/schedules_workbench.py`,
 `Widgets/Console/{console_workspace_files_modal,console_session_switcher_modal}.py`,
 `backlog/docs/lessons-textual.md`, `Tests/UI/test_on_unmount_mro_convention.py` (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31824 - Scope-clear_server-to-a-single-server-under-TLDW_CONFIG_PATH-profile-isolation.md
+++ b/backlog/tasks/task-31824 - Scope-clear_server-to-a-single-server-under-TLDW_CONFIG_PATH-profile-isolation.md
@@ -1,0 +1,25 @@
+---
+id: TASK-31824
+title: Scope clear_server to a single server under TLDW_CONFIG_PATH profile isolation
+status: To Do
+assignee: []
+created_date: '2026-09-06 08:08'
+labels:
+  - config
+  - reliability
+  - runtime-policy
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from schedules close-out burndown (PR #2454) -- Qodo review + final whole-branch review both flagged it. In TLDW_CONFIG_PATH scoped mode, RuntimeServerContextProvider.clear_server (runtime_policy/server_context.py:~455) filters on server_profile_id, so signing out of ONE server clears credentials for ALL servers in that profile. Fail-safe (over-clears, never under-clears) and only reachable in the rare multi-server-per-scratch-profile case; default single-server installs are unaffected -- which is why it did not block the burndown merge (final review rated INFO, Qodo rated High). Also in-area (optional): 3 Qodo Medium docstring-completeness nits from the same PR -- resolve_tldw_api_auth_token (config.py:~1406), the per-profile helper's returns: (server_context.py:~46), and the scoped credential methods (server_credentials.py:~45).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 clear_server in scoped mode clears only the target server's credentials, not sibling servers in the same profile
+- [ ] #2 A test pins the scoped-clear behavior: in a multi-server profile, clearing server A leaves server B's credentials intact
+- [ ] #3 Default single-profile / single-server users are unaffected (no behavior change)
+<!-- AC:END -->


### PR DESCRIPTION
Post-merge hygiene for the schedules close-out burndown (#2454, merged).

- **Mark TASK-31418 Done** — its work (base `on_unmount` fires once under Textual MRO dispatch) merged in #2454; 8 of the 9 tasks auto-tagged Done on merge, only 31418's status field slipped.
- **File TASK-31824** — scope `clear_server` to a single server under `TLDW_CONFIG_PATH` profile isolation. Both Qodo (High) and the final whole-branch review (INFO) flagged that in scoped mode a single-server signout clears all servers' credentials in that profile (fail-safe over-clear; default single-server installs unaffected). The 3 Qodo Medium docstring-completeness nits from #2454 are noted in-area on that task.

No code changes — backlog-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates backlog tasks as close-out hygiene for the schedules burndown: marks TASK-31418 Done and files TASK-31824 for a follow-up bug. No code changes.

- TASK-31418's work merged; only its status field slipped, now Done.
- TASK-31824 tracks scoping `clear_server` to a single server under `TLDW_CONFIG_PATH` profile isolation.
- In scoped mode, signing out of one server clears all servers' credentials in that profile.
- The over-clear is fail-safe; default single-server installs are unaffected.

<sup>Written for commit 6355efa75c03aea100954780b6dbacd3e3bcc312. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2457?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

