### PR TITLE
fix(scheduling): deferred burndown (31415, 31419)

### DIFF
--- a/Docs/User_Guide/schedules.md
+++ b/Docs/User_Guide/schedules.md
@@ -570,6 +570,18 @@ transfer** / **Cancel transfer** pair.
 **A disabled server reminder stays disabled** when it is released to this
 device — the release moves the task, not its on/off state.
 
+**A recurring question's run/result history does not follow a
+server → local release.** A local → server move keeps the same task
+identity (this device's row just gains a server link), so its run and
+result history stays visible under either id, before and after the
+move. A server → local release is different: it creates a brand-new,
+independent local row rather than converting the existing one, so the
+findings and run history the automation built up while server-owned
+stay attached to the now-archived server-owned row and do not carry
+over to the new one. The new row starts a clean history from the
+moment it arms. There is currently no way to view or reattach the prior
+history from the new row.
+
 ## Creating a recurring question
 
 A recurring question runs a scoped search on a schedule and reports what

--- a/Tests/Scheduling/test_scheduled_tasks_db.py
+++ b/Tests/Scheduling/test_scheduled_tasks_db.py
@@ -2906,3 +2906,181 @@ def test_get_pending_mutation_for_local_id_returns_newest_across_owners(tmp_path
     row = db.get_pending_mutation_for_local_id(rid, "automation_definition")
     assert row is not None
     assert row["owner_id"] == "server:b"
+
+
+# ----------------------------------------------------------------------
+# Cross-id-space run/result history bridge (task-31415)
+# ----------------------------------------------------------------------
+
+
+def test_list_automation_runs_and_results_bridge_across_transfer_identity(tmp_path):
+    """A transferred definition's pre-transfer local-id run/result history
+    and its post-transfer server-id-mirrored results both surface under
+    EITHER id, from `list_automation_runs`, `list_automation_results`, AND
+    `count_automation_results`/`count_unread_results` (which route through
+    the same `_definition_id_aliases` seam) -- not just the id that
+    happened to be queried."""
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition("local", "recurring_question", "D1")
+
+    # Pre-transfer: a locally-executed run + result, carrying the local id
+    # (automation_runs is local-only -- see count_automation_runs's own
+    # docstring -- so every run always carries the local id regardless of
+    # transfer).
+    run_id = db.create_automation_run("local", local_id, 1, "manual", status="completed")
+    assert run_id is not None
+    local_result_id = db.create_automation_result(
+        "local", local_id, run_id, "finding", "Local finding", "summary", "key-local",
+    )
+    assert local_result_id is not None
+
+    # Transfer to server: local id kept, server_id linked (id answers to
+    # BOTH spaces from here on).
+    assert db.adopt_server_definition_identity(
+        local_id, {"id": "srv-1", "name": "D1"}
+    ) is True
+
+    # Post-transfer: a result mirrored from the server carries the
+    # server id verbatim (`upsert_automation_results_from_server` has no
+    # local id to translate it to).
+    db.upsert_automation_results_from_server(
+        "local",
+        [{
+            "id": "srv-res-1",
+            "definition_id": "srv-1",
+            "run_id": "srv-run-1",
+            "kind": "finding",
+            "title": "Server finding",
+            "summary": "summary",
+            "dedupe_key": "key-server",
+            "created_at": "2026-09-05T00:00:00+00:00",
+        }],
+    )
+    server_result_id = next(
+        row["id"] for row in db.list_automation_results("local")
+        if row["dedupe_key"] == "key-server"
+    )
+
+    for query_id in (local_id, "srv-1"):
+        runs = db.list_automation_runs("local", definition_id=query_id)
+        assert [r["id"] for r in runs] == [run_id]
+
+        results = db.list_automation_results("local", definition_id=query_id)
+        assert {r["id"] for r in results} == {local_result_id, server_result_id}
+
+        assert db.count_automation_results("local", definition_id=query_id) == 2
+        assert db.count_unread_results("local", definition_id=query_id) == 2
+
+
+def test_list_automation_runs_and_results_never_transferred_unchanged(tmp_path):
+    """AC#4 regression gate: a definition that has never transferred
+    (server_id NULL, alias set == {id}) returns EXACTLY what a plain
+    equality filter would -- no extra rows, no changed ordering. Pinned
+    against >=3 rows at distinct timestamps for both runs and results."""
+    db = _mk_db(tmp_path)
+    local_id = db.create_automation_definition(
+        "local", "recurring_question", "Untransferred"
+    )
+
+    run_ids = [
+        db.create_automation_run("local", local_id, 1, "manual", status="completed")
+        for _ in range(3)
+    ]
+    result_ids = [
+        db.create_automation_result(
+            "local", local_id, run_ids[0], "finding", f"T{i}", "S", f"key-{i}",
+        )
+        for i in range(3)
+    ]
+    with closing(db._get_connection()) as conn:
+        for i, run_id in enumerate(run_ids):
+            conn.execute(
+                "UPDATE automation_runs SET created_at = ? WHERE id = ?",
+                (f"2026-09-0{i + 1}T00:00:00+00:00", run_id),
+            )
+        for i, result_id in enumerate(result_ids):
+            conn.execute(
+                "UPDATE automation_results SET created_at = ? WHERE id = ?",
+                (f"2026-09-0{i + 1}T00:00:00.000000+00:00", result_id),
+            )
+        conn.commit()
+
+    with closing(db._get_connection()) as conn:
+        expected_run_ids = [
+            row["id"] for row in conn.execute(
+                "SELECT id FROM automation_runs WHERE owner_id = ? "
+                "AND definition_id = ? ORDER BY created_at DESC, id DESC",
+                ("local", local_id),
+            ).fetchall()
+        ]
+        expected_result_ids = [
+            row["id"] for row in conn.execute(
+                "SELECT id FROM automation_results WHERE definition_id = ? "
+                "ORDER BY strftime('%Y-%m-%dT%H:%M:%f', created_at) DESC, "
+                "created_at DESC, id DESC",
+                (local_id,),
+            ).fetchall()
+        ]
+
+    assert [
+        r["id"] for r in db.list_automation_runs("local", definition_id=local_id)
+    ] == expected_run_ids
+    assert [
+        r["id"] for r in db.list_automation_results("local", definition_id=local_id)
+    ] == expected_result_ids
+    assert db.count_automation_results("local", definition_id=local_id) == 3
+    assert db.count_unread_results("local", definition_id=local_id) == 3
+
+
+def test_list_automation_runs_and_results_unknown_id_and_no_cross_bleed(tmp_path):
+    """Revert-check test 3: an id with no matching definition row returns
+    exactly its own carried rows (no error, no cross-bleed) -- and, for
+    two REAL definitions with unrelated id spaces, aliasing a query for
+    one never leaks the other's rows."""
+    db = _mk_db(tmp_path)
+    def_a = db.create_automation_definition("local", "recurring_question", "A")
+    def_b = db.create_automation_definition("local", "recurring_question", "B")
+    assert db.adopt_server_definition_identity(def_a, {"id": "srv-a", "name": "A"})
+    assert db.adopt_server_definition_identity(def_b, {"id": "srv-b", "name": "B"})
+
+    run_a = db.create_automation_run("local", def_a, 1, "manual", status="completed")
+    run_b = db.create_automation_run("local", def_b, 1, "manual", status="completed")
+    result_a = db.create_automation_result(
+        "local", def_a, run_a, "finding", "A", "S", "key-a"
+    )
+    result_b = db.create_automation_result(
+        "local", def_b, run_b, "finding", "B", "S", "key-b"
+    )
+
+    for query_id in (def_a, "srv-a"):
+        assert [
+            r["id"] for r in db.list_automation_runs("local", definition_id=query_id)
+        ] == [run_a]
+        assert {
+            r["id"] for r in db.list_automation_results("local", definition_id=query_id)
+        } == {result_a}
+
+    for query_id in (def_b, "srv-b"):
+        assert [
+            r["id"] for r in db.list_automation_runs("local", definition_id=query_id)
+        ] == [run_b]
+        assert {
+            r["id"] for r in db.list_automation_results("local", definition_id=query_id)
+        } == {result_b}
+
+    # An id with no matching automation_definitions row at all: no error,
+    # exactly the rows carrying that literal id, no cross-bleed from A/B.
+    orphan_run = db.create_automation_run(
+        "local", "orphan-def", 1, "manual", status="completed"
+    )
+    orphan_result = db.create_automation_result(
+        "local", "orphan-def", orphan_run, "finding", "Orphan", "S", "key-orphan",
+    )
+    assert [
+        r["id"] for r in db.list_automation_runs("local", definition_id="orphan-def")
+    ] == [orphan_run]
+    assert {
+        r["id"] for r in db.list_automation_results("local", definition_id="orphan-def")
+    } == {orphan_result}
+    assert db.list_automation_runs("local", definition_id="unknown-def-xyz") == []
+    assert db.list_automation_results("local", definition_id="unknown-def-xyz") == []

--- a/backlog/docs/plan-2026-09-06-schedules-deferred-burndown.md
+++ b/backlog/docs/plan-2026-09-06-schedules-deferred-burndown.md
@@ -1,0 +1,22 @@
+# Schedules deferred-tasks burndown (round 2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development.
+
+**Goal:** Close the two tasks deferred from the 2026-09-05 close-out burndown (PR #2454): 31415 (post-transfer history-identity bridge) and 31419 (shell-chrome floor measurement).
+
+**Spec:** the two backlog task files ARE the spec (`task-31415`, `task-31419`); ledger trail for 31415 in `backlog/docs/spec-2026-08-31-schedules-handoff-parity.md` §9/§12.
+
+## Global Constraints
+- NEVER `git stash`; baselines via `git show <rev>:<path>` or throwaway detached worktrees, removed after.
+- FOREGROUND pytest only; tmp_path DBs; exact pasted tail lines from the final run.
+- Diagnostics pin is a SCRIPT (`scripts/check_persistent_diagnostic_inventory.py --write` + commit JSON), not a pytest.
+- Live app measurement uses a scratch profile (`TLDW_CONFIG_PATH`) on the real shell; never the real user profile.
+
+### Task 1 (=31415): Bridge automation run/result history across a post-transfer identity change
+One shared identity-resolution seam INSIDE `Scheduling/db/scheduled_tasks_db.py` (per AC#3): `list_automation_runs` (:2265) and `list_automation_results` (:2424) currently filter on a single `definition_id`; after `adopt_server_definition_identity` (:2913) a definition answers to two ids (local `id` + `server_id`), and `upsert_automation_results_from_server` (:2989) stores server ids verbatim. Resolve the alias set once (both directions: given either id, find the row and collect {id, server_id}) and filter `IN (aliases)` — the 6 workbench call sites then need no changes. Model: `index_definitions_by_id` (`unified_rows.py`) indexes under both id spaces. AC#4 is the regression gate: a never-transferred definition returns byte-identical rows and ordering. AC#5 (to-local direction): bridge if the data is local, else record why it is server-side work and name the gap in `Docs/User_Guide/schedules.md`. Commit `fix(scheduling): bridge run/result history across post-transfer identity change (31415)`.
+
+### Task 2 (=31419): Reclaim narrow-terminal rows from the app shell — measure, classify, decide
+A measurement exercise with a decide-and-close mandate. Re-measure the 13-row app-shell chrome figure IN THE REAL SHELL at 80x24 (tmux, scratch profile), record per element (AC#1); classify each element reducible / conditionally-reducible-at-floor / deliberate with reasons (AC#2). If a clean shell-level reduction exists, apply it at the shell so every destination benefits (AC#3) and prove Schedules' floor test passes unchanged (AC#4). If not, AC#5: record no-reclaim as the answer and close. Findings go in the task file; any measurement artifacts in the SDD workspace. Commit `docs(shell): narrow-terminal chrome measurement + ruling (31419)` (or `fix(shell): ...` if a reduction ships).
+
+## After
+Final review → PR `fix(scheduling): deferred burndown (31415, 31419)` → in-loop merge → mark both Done.

--- a/backlog/tasks/task-31415 - Bridge-automation-run-and-result-history-across-a-post-transfer-identity-change.md
+++ b/backlog/tasks/task-31415 - Bridge-automation-run-and-result-history-across-a-post-transfer-identity-change.md
@@ -62,3 +62,9 @@ AC#5 ruling: NOT bridged, recorded as server-side/data-does-not-exist-locally. T
 
 Files: tldw_chatbook/Scheduling/db/scheduled_tasks_db.py (_definition_id_aliases + 3 call sites), tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py (_definition_results_query, _definition_unread_result_ids simplified to single calls), Tests/Scheduling/test_scheduled_tasks_db.py (3 new tests), Docs/User_Guide/schedules.md (AC#5 gap note).
 <!-- SECTION:NOTES:END -->
+
+**Known limitation (from review, LOW, pre-existing):** `_definition_id_aliases`
+resolves without an owner scope from its current callers; two different owners
+sharing a `server_id` would make the `LIMIT 1` pick arbitrary. The exposure
+predates this change (the workbench's hand-rolled both-id loops had it too)
+and the collision surface is narrow; noted here rather than fixed.

--- a/backlog/tasks/task-31415 - Bridge-automation-run-and-result-history-across-a-post-transfer-identity-change.md
+++ b/backlog/tasks/task-31415 - Bridge-automation-run-and-result-history-across-a-post-transfer-identity-change.md
@@ -3,9 +3,11 @@ id: TASK-31415
 title: >-
   Bridge automation run and result history across a post-transfer identity
   change
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-04 22:40'
+updated_date: '2026-09-06 14:07'
 labels:
   - scheduling
   - sync
@@ -30,9 +32,33 @@ Ledger trail: `backlog/docs/spec-2026-08-31-schedules-handoff-parity.md` section
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A transferred definition's run history shows runs recorded under both its local id and its server id
-- [ ] #2 The same holds for its results, in the inbox and in the pane's results rows
-- [ ] #3 Identity resolution is one shared seam, not a bridge duplicated at each call site
-- [ ] #4 A definition that has never transferred returns exactly the rows it returns today, with no extra rows and no changed ordering
-- [ ] #5 A to-local transfer leaves the definition's prior server-side history reachable, or the task records why that is server-side work and names the gap in the user guide
+- [x] #1 A transferred definition's run history shows runs recorded under both its local id and its server id
+- [x] #2 The same holds for its results, in the inbox and in the pane's results rows
+- [x] #3 Identity resolution is one shared seam, not a bridge duplicated at each call site
+- [x] #4 A definition that has never transferred returns exactly the rows it returns today, with no extra rows and no changed ordering
+- [x] #5 A to-local transfer leaves the definition's prior server-side history reachable, or the task records why that is server-side work and names the gap in the user guide
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a private `_definition_id_aliases(owner_id, definition_id)` helper to ScheduledTasksDB: given either a definition's local id or server_id, look up the row and return the distinct {id, server_id} set; fall back to (definition_id,) when no row matches.
+2. Route list_automation_runs and list_automation_results' definition_id filters through the helper (IN clause instead of equality), preserving ORDER BY exactly.
+3. Investigate whether the same id-space ambiguity reaches the results count/unread-count path used by the inbox and pane badge (count_automation_results / count_unread_results); bridge it through the same helper if warranted, and check the workbench call sites that already hand-roll a dual-id-space loop (_definition_results_query, _definition_unread_result_ids) for regressions.
+4. AC#5: grep the to-local (from_server_pending) transfer path for any persisted link from the new local row back to the origin server/mirror id; bridge it if the data exists locally, otherwise record the gap in the task file and the user guide's transfer section.
+5. Add DB-layer tests: cross-identity bridge (revert-checked), never-transferred regression gate (pinned ordering), unknown-id/no-cross-bleed. Run the scheduling DB test module + Tests/Scheduling/ + Tests/UI/test_schedules_workbench.py.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added ScheduledTasksDB._definition_id_aliases(owner_id, definition_id): given either a definition's local id or server_id, resolves the definition row and returns the distinct {id, server_id} set (falls back to (definition_id,) when no row matches, so history for a deleted/unknown definition is unaffected). list_automation_runs and list_automation_results now filter `definition_id IN (aliases)` through this helper instead of `= ?`, with ORDER BY unchanged.
+
+Scope grew beyond the two named functions: count_automation_results (and count_unread_results, which delegates to it) carries the identical id-space ambiguity for the results side and feeds the pane's unread badge and the definition-scoped "mark all read" fan-out (_fetch_definition_detail_counts, _definition_unread_result_ids in schedules_workbench.py) -- so it is bridged through the same helper too, one shared seam for both runs and results (AC#3). count_automation_runs is untouched: automation_runs is local-only (never synced from the server, per its own docstring), so a run's definition_id is always the local id and there is no ambiguity to bridge.
+
+Bridging count_automation_results forced touching two workbench call sites the task said to leave alone: `_definition_results_query` and `_definition_unread_result_ids` were hand-rolling their OWN dual-id-space bridge (loop over local_id/server_id, merge/sum) -- exactly the "duplicated bridge" AC#3 asks to eliminate. Left as-is once the DB layer also bridges, they break in two different, verified ways: test_definition_results_query_merges_local_and_server_id_spaces failed (total double-counted, 4 instead of 2) when only list_automation_results was bridged and count stayed exact-match; test_definition_unread_result_ids_merges_both_id_spaces would fail the opposite way (silently drops results -- a definition-scoped "Mark all read" that never actually clears some post-transfer unread rows) if count stayed exact-match while list was bridged, because the caller's dynamic `limit=unread_total` becomes inconsistent with the now-broader list query. Bridging both DB functions and collapsing those two workbench methods from a loop-and-merge to one call each (the seam already returns the union) is the only combination that keeps both pre-existing pinned tests true; verified by running the base (pre-fix) file against the tests and back. No other of the "6 workbench call sites" were touched.
+
+AC#5 ruling: NOT bridged, recorded as server-side/data-does-not-exist-locally. Traced create_local_copy_from_mirror (the from_server_pending leg): the new local row is a fresh INSERT with a fresh uuid4 id and no server_id (never set), and the field dict built there has no column carrying the origin mirror's id or server_id -- the only place that link ever existed was payload["server_definition_id"] inside the release's pending_mutations row, which sync_engine._push_definition_release deletes via delete_pending_mutation() the moment the release lands. sync_mapping (the table that WOULD carry such a link) is wired for reminder_task only, never automation_definition. The old mirror row is never deleted -- it survives as an archived row still answering to its own (id, server_id) -- so the prior history is not lost, just permanently detached from the new local row with nothing in the schema to reattach it. Documented in Docs/User_Guide/schedules.md's "Moving a task between this device and the server" section.
+
+Files: tldw_chatbook/Scheduling/db/scheduled_tasks_db.py (_definition_id_aliases + 3 call sites), tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py (_definition_results_query, _definition_unread_result_ids simplified to single calls), Tests/Scheduling/test_scheduled_tasks_db.py (3 new tests), Docs/User_Guide/schedules.md (AC#5 gap note).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31419 - Reclaim-narrow-terminal-rows-from-the-app-shell-rather-than-from-individual-screens.md
+++ b/backlog/tasks/task-31419 - Reclaim-narrow-terminal-rows-from-the-app-shell-rather-than-from-individual-screens.md
@@ -3,9 +3,10 @@ id: TASK-31419
 title: >-
   Reclaim narrow-terminal rows from the app shell rather than from individual
   screens
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-04 22:42'
+updated_date: '2026-09-06 14:15'
 labels:
   - ui
   - responsive
@@ -28,9 +29,47 @@ This is a placeholder for the shell-side conversation, not a commitment to shrin
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The 13-row app-shell chrome figure is re-measured in the real app shell at 80x24 and recorded per element
-- [ ] #2 Each chrome element is classified as reducible, conditionally reducible at the floor, or deliberate, with the reason stated
-- [ ] #3 Any reduction applies at the shell so every destination benefits, not as a per-screen override
-- [ ] #4 The Schedules floor test still passes unchanged, proving the screen was not asked to absorb the change
-- [ ] #5 If the conclusion is that no row can be reclaimed, that is recorded as the answer and the task closes rather than staying open indefinitely
+- [x] #1 The 13-row app-shell chrome figure is re-measured in the real app shell at 80x24 and recorded per element
+- [x] #2 Each chrome element is classified as reducible, conditionally reducible at the floor, or deliberate, with the reason stated
+- [x] #3 Any reduction applies at the shell so every destination benefits, not as a per-screen override
+- [x] #4 The Schedules floor test still passes unchanged, proving the screen was not asked to absorb the change
+- [x] #5 If the conclusion is that no row can be reclaimed, that is recorded as the answer and the task closes rather than staying open indefinitely
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+**Outcome: AC#5 branch — no row is reclaimable from the app shell; recorded as the answer and closed.** The one real narrow-terminal lever found is a shared-widget-layer change, filed as TASK-31825.
+
+**Measurement (AC#1):** real app shell, dev tip, 80×24, tmux with a scratch
+`TLDW_CONFIG_PATH` profile (real user profile untouched), verified on
+Schedules plus Home and Console. Per-element record:
+
+| Rows | Element | Owner | Source | Classification (AC#2) |
+|------|---------|-------|--------|------------------------|
+| 1–3 (3) | Top navigation (`MainNavigationBar`) | **shell** (`BaseAppScreen.compose()`, `base_app_screen.py:225`, `height: 3`) | identical on every destination | deliberate — primary navigation |
+| 24 (1) | Footer (`AppFooterStatus`) | **shell** (`base_app_screen.py:243`, `height: 1`) | identical on every destination | deliberate — already minimal |
+| 4–8 (5) | Destination header | **screen** (`schedules_workbench.py:596` via shared `DestinationHeader`, `UI/Workbench/workbench_widgets.py:164`) | absent on Home/Console | conditionally reducible — a dormant `density="compact"` CSS rule exists that no caller triggers (→ TASK-31825) |
+| 9 (1) | Scheduler-liveness line | **screen** (`schedules_workbench.py:628`) | schedules-only | deliberate, but a screen concern, not shell |
+| 20–23 (4) | Status strip (`#scheduling-status-strip`) | **screen** (`schedules_workbench.py:759`) | carries the conflicts badge; schedules-only; distinct from `AppFooterStatus` | deliberate, but a screen concern, not shell |
+
+**Key correction to the premise:** PR-4 Task 6's per-element arithmetic (3+5+1+4=13)
+reproduces exactly, but its *attribution* was wrong — only **4 rows**
+(navigation 3 + footer 1) are true, unconditional app-shell chrome. The
+destination header, liveness line, and status strip are composed inside
+`SchedulesWorkbench.compose_content()` and do not exist on other destinations,
+so "13 rows the schedules screen neither owns nor can reclaim" overstated the
+shell's share by ~10 rows. Any future floor work on those 10 rows is
+screen/shared-widget work, not shell work.
+
+**AC#3:** consequently no shell-level reduction ships — both true shell elements
+are already minimal and deliberate. **AC#4:** `Tests/UI/test_schedules_responsive_floor.py`
+untouched and green (27/28; the 1 failure,
+`test_the_docked_task_detail_pane_scrolls_to_reveal_history_past_the_fold`,
+fails identically at the branch base — pre-existing dev debt, attributed in a
+throwaway worktree). **AC#5:** this note is the recorded answer; the task closes.
+
+Full raw measurement (per-row table, captures) in the SDD workspace
+(`.superpowers/sdd/plan-2026-09-06-schedules-deferred-burndown/t31419-measurement.md`,
+session-local).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31825 - Wire-DestinationHeaders-dormant-compact-density-to-a-height-based-trigger.md
+++ b/backlog/tasks/task-31825 - Wire-DestinationHeaders-dormant-compact-density-to-a-height-based-trigger.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31825
+title: Wire DestinationHeader's dormant compact density to a height-based trigger
+status: To Do
+assignee: []
+created_date: '2026-09-06 14:15'
+labels:
+  - ui
+  - responsive
+  - workbench
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up from task-31419's real-shell measurement (2026-09-06, 80x24, scratch profile). The measurement corrected PR-4 Task 6's attribution: of the claimed 13 chrome rows, only 4 are true app shell (MainNavigationBar 3, AppFooterStatus 1 -- both deliberate/minimal); the destination header (5 rows), scheduler liveness (1) and status strip (4) are composed inside SchedulesWorkbench itself. The one real narrow-terminal lever found: the shared DestinationHeader widget (UI/Workbench/workbench_widgets.py:~164) already ships a density="compact" CSS rule that NO caller ever triggers, and no height-based responsive logic exists anywhere in the workbench layer. Wiring a height-based trigger there would reclaim rows for every (~12) workbench screen that uses the widget -- a shared-widget-layer change, not UI/Navigation/ and not a per-screen override. Full measurement in task-31419's Implementation Notes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 DestinationHeader renders its compact density automatically below a height threshold, via the shared workbench-widget layer (no per-screen overrides)
+- [ ] #2 Every workbench screen using DestinationHeader benefits without per-screen changes, verified on at least Schedules plus one other
+- [ ] #3 Geometry is asserted with the bundled stylesheet (compact rows measurably fewer at 80x24; normal density unchanged at standard sizes)
+- [ ] #4 Tests/UI/test_schedules_responsive_floor.py stays green (minus the known pre-existing dev red)
+<!-- AC:END -->

--- a/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
+++ b/tldw_chatbook/Scheduling/db/scheduled_tasks_db.py
@@ -2262,6 +2262,62 @@ class ScheduledTasksDB(BaseDB):
             )
             return cursor.rowcount > 0
 
+    def _definition_id_aliases(
+        self, owner_id: str | None, definition_id: str
+    ) -> tuple[str, ...]:
+        """Resolve ``definition_id`` to every id space its definition answers to.
+
+        A definition keeps its local ``id`` for life, but may also carry a
+        ``server_id`` once ``adopt_server_definition_identity`` links it to
+        a server-transferred row (or ``upsert_automation_definitions_from_
+        server`` pulls a server-owned mirror) -- from that point on, runs
+        and results recorded before the link carry the local id while ones
+        mirrored afterward carry the server's (``upsert_automation_
+        results_from_server`` copies ``definition_id`` verbatim -- there is
+        no local row to translate it to). A history query filtered on a
+        single id therefore misses whichever half was recorded under the
+        OTHER id (task-31415).
+
+        Given EITHER id, this finds the definition row (scoped to
+        ``owner_id`` when given; ``None`` matches any owner, mirroring
+        ``list_automation_results``'s all-owners mode) and returns the
+        distinct non-``None`` ``{id, server_id}`` set. When no definition
+        row matches -- a deleted or unknown definition -- returns a
+        single-element tuple with just ``definition_id``: history for such
+        a definition must not vanish or error, it behaves exactly as a
+        plain equality filter would.
+
+        This is the query-side counterpart to ``index_definitions_by_id``
+        (``UI/Screens/scheduling/unified_rows.py``), which indexes each
+        definition row under both id spaces on the LOOKUP side.
+
+        Args:
+            owner_id: Owner to scope the definition lookup to, or ``None``
+                to match any owner.
+            definition_id: Either the definition's local ``id`` or its
+                ``server_id``.
+
+        Returns:
+            A tuple of the distinct id(s) to filter history rows on.
+        """
+        conditions = ["(id = ? OR server_id = ?)"]
+        params: list[Any] = [definition_id, definition_id]
+        if owner_id is not None:
+            conditions.insert(0, "owner_id = ?")
+            params.insert(0, owner_id)
+        with closing(self._get_connection()) as conn:
+            row = conn.execute(
+                "SELECT id, server_id FROM automation_definitions "
+                f"WHERE {' AND '.join(conditions)} LIMIT 1",
+                params,
+            ).fetchone()
+        if row is None:
+            return (definition_id,)
+        aliases = {row["id"]}
+        if row["server_id"]:
+            aliases.add(row["server_id"])
+        return tuple(aliases)
+
     def list_automation_runs(
         self,
         owner_id: str,
@@ -2271,15 +2327,20 @@ class ScheduledTasksDB(BaseDB):
     ) -> list[dict[str, Any]]:
         """List automation runs for an owner, newest first.
 
-        Optionally filtered to a single definition; paginated via
-        ``limit``/``offset``.
+        Optionally filtered to a single definition -- resolved across
+        BOTH id spaces via ``_definition_id_aliases`` (task-31415), so a
+        transferred definition's runs show up whether ``definition_id``
+        is its local id or its server id. Paginated via ``limit``/
+        ``offset``.
         """
         conditions = ["owner_id = ?"]
         params: list[Any] = [owner_id]
 
         if definition_id is not None:
-            conditions.append("definition_id = ?")
-            params.append(definition_id)
+            aliases = self._definition_id_aliases(owner_id, definition_id)
+            placeholders = ", ".join("?" for _ in aliases)
+            conditions.append(f"definition_id IN ({placeholders})")
+            params.extend(aliases)
 
         where_clause = f"WHERE {' AND '.join(conditions)}"
         params.extend([limit, offset])
@@ -2436,6 +2497,13 @@ class ScheduledTasksDB(BaseDB):
         filtered by ``review_state`` and/or ``definition_id``; paginated
         via ``limit``/``offset``.
 
+        ``definition_id`` is resolved across BOTH id spaces via
+        ``_definition_id_aliases`` (task-31415): a locally-created result
+        carries the definition's local id while one mirrored from the
+        server carries its server id, so a transferred definition's
+        results now show up under either id, not just the one the row
+        itself carries.
+
         Ordered by ``strftime('%Y-%m-%dT%H:%M:%f', created_at)`` rather
         than a raw string comparison: server-mirrored rows copy
         ``created_at`` verbatim from the server payload (see
@@ -2471,7 +2539,9 @@ class ScheduledTasksDB(BaseDB):
         Args:
             owner_id: Owner to scope to, or ``None`` for every owner.
             review_state: Optional ``review_state`` equality filter.
-            definition_id: Optional ``definition_id`` equality filter.
+            definition_id: Optional definition filter -- matched across
+                BOTH the definition's local id and its server id (see
+                ``_definition_id_aliases``), whichever one is given.
             limit: Maximum number of rows to return.
             offset: Rows to skip before collecting ``limit`` rows.
 
@@ -2491,8 +2561,10 @@ class ScheduledTasksDB(BaseDB):
             params.append(review_state)
 
         if definition_id is not None:
-            conditions.append("definition_id = ?")
-            params.append(definition_id)
+            aliases = self._definition_id_aliases(owner_id, definition_id)
+            placeholders = ", ".join("?" for _ in aliases)
+            conditions.append(f"definition_id IN ({placeholders})")
+            params.extend(aliases)
 
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         params.extend([limit, offset])
@@ -2524,17 +2596,13 @@ class ScheduledTasksDB(BaseDB):
             owner_id: Owner to scope to, or ``None`` for every owner.
             review_state: Optional ``review_state`` equality filter --
                 ``None`` counts every state.
-            definition_id: Optional ``definition_id`` equality filter,
-                matched exactly as given -- NOT translated across id
-                spaces. A result's ``definition_id`` is whatever id the
-                side that produced it used: a locally-created result
-                carries the LOCAL definition id, while a result mirrored
-                from the server carries the SERVER's id (see
-                ``UI/Screens/scheduling/results_tab.py``'s
-                ``index_definitions_by_id`` for how a caller resolves
-                which space a given definition row lives in). Pass the
-                id in whichever space applies to the rows you expect to
-                count; ``None`` counts every space.
+            definition_id: Optional definition filter -- matched across
+                BOTH id spaces via ``_definition_id_aliases`` (task-31415):
+                a locally-created result carries the definition's LOCAL
+                id while one mirrored from the server carries its SERVER
+                id, so this counts a transferred definition's results
+                regardless of which id is given. ``None`` counts every
+                definition.
 
         Returns:
             The number of matching ``automation_results`` rows.
@@ -2548,8 +2616,10 @@ class ScheduledTasksDB(BaseDB):
             conditions.append("owner_id = ?")
             params.append(owner_id)
         if definition_id is not None:
-            conditions.append("definition_id = ?")
-            params.append(definition_id)
+            aliases = self._definition_id_aliases(owner_id, definition_id)
+            placeholders = ", ".join("?" for _ in aliases)
+            conditions.append(f"definition_id IN ({placeholders})")
+            params.extend(aliases)
         where_clause = f"WHERE {' AND '.join(conditions)}" if conditions else ""
         with closing(self._get_connection()) as conn:
             cursor = conn.execute(

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -4191,59 +4191,60 @@ class SchedulesWorkbench(BaseAppScreen):
     def _definition_results_query(
         self, service: "SchedulingService", definition: dict[str, Any]
     ) -> tuple[list[dict[str, Any]], int]:
-        """`(results, total)` for `definition` alone, across BOTH its id
-        spaces -- the definition-filtered pushed Results view's listing
-        (redesign PR-4 task 2). Capped at `RESULTS_INBOX_LIMIT`, same as
-        the global inbox (the brief: "preserve the cap-line honesty").
+        """`(results, total)` for `definition` alone -- the definition-
+        filtered pushed Results view's listing (redesign PR-4 task 2).
+        Capped at `RESULTS_INBOX_LIMIT`, same as the global inbox (the
+        brief: "preserve the cap-line honesty").
 
         `ScheduledTasksDB.list_automation_results`/`count_automation_
-        results` only equality-filter ONE `definition_id` at a time (own
-        docstring's caveat), so a definition with results in both spaces
-        needs two queries, merged here and re-sorted by REAL instant
-        (`_result_sort_key`) rather than trusting either query's own
-        newest-first order to interleave correctly across the merge.
+        results` resolve `definition_id` across BOTH a definition's id
+        spaces INTERNALLY now (task-31415's `_definition_id_aliases`
+        seam) -- a single query under either id already returns results
+        recorded under both, so this no longer loops over
+        `_definition_id_space` and merges two queries by hand (that used
+        to be required, and double-counts `total` if repeated now that
+        the seam does the union itself).
         """
         local_id, server_id = self._definition_id_space(definition)
-        merged: dict[str, dict[str, Any]] = {}
-        total = 0
-        for definition_id in (local_id, server_id):
-            if not definition_id:
-                continue
-            total += service.db.count_automation_results(
-                owner_id=None, definition_id=definition_id
-            )
-            for row in service.db.list_automation_results(
-                owner_id=None, definition_id=definition_id, limit=RESULTS_INBOX_LIMIT
-            ):
-                merged[row["id"]] = row
-        results = sorted(merged.values(), key=_result_sort_key, reverse=True)
+        definition_id = local_id or server_id
+        if not definition_id:
+            return [], 0
+        total = service.db.count_automation_results(
+            owner_id=None, definition_id=definition_id
+        )
+        results = service.db.list_automation_results(
+            owner_id=None, definition_id=definition_id, limit=RESULTS_INBOX_LIMIT
+        )
+        results = sorted(results, key=_result_sort_key, reverse=True)
         return results[:RESULTS_INBOX_LIMIT], total
 
     def _definition_unread_result_ids(
         self, service: "SchedulingService", definition: dict[str, Any]
     ) -> list[str]:
         """Definition-scoped counterpart of `_unread_result_ids` -- every
-        unread result id for THIS definition alone (both id spaces),
-        uncapped by `RESULTS_INBOX_LIMIT` for the same Qodo-HIGH reason
-        that method's own docstring documents."""
+        unread result id for THIS definition alone, uncapped by
+        `RESULTS_INBOX_LIMIT` for the same Qodo-HIGH reason that method's
+        own docstring documents.
+
+        Single query, same reasoning as `_definition_results_query`
+        (task-31415): the DB layer already resolves both id spaces.
+        """
         local_id, server_id = self._definition_id_space(definition)
-        ids: list[str] = []
-        for definition_id in (local_id, server_id):
-            if not definition_id:
-                continue
-            unread_total = service.db.count_unread_results(
-                owner_id=None, definition_id=definition_id
-            )
-            if not unread_total:
-                continue
-            results = service.db.list_automation_results(
-                owner_id=None,
-                definition_id=definition_id,
-                review_state="unread",
-                limit=unread_total,
-            )
-            ids.extend(result["id"] for result in results)
-        return ids
+        definition_id = local_id or server_id
+        if not definition_id:
+            return []
+        unread_total = service.db.count_unread_results(
+            owner_id=None, definition_id=definition_id
+        )
+        if not unread_total:
+            return []
+        results = service.db.list_automation_results(
+            owner_id=None,
+            definition_id=definition_id,
+            review_state="unread",
+            limit=unread_total,
+        )
+        return [result["id"] for result in results]
 
     async def _dispatch_mark_all_results_read(
         self, service: "SchedulingService", unread_ids: list[str]


### PR DESCRIPTION
## Schedules deferred burndown (round 2)

Closes the two tasks deferred from the #2454 close-out — the schedules backlog is now fully drained.

### 31415 — bridge run/result history across a post-transfer identity change
One shared alias-resolution seam in `ScheduledTasksDB`: `list_automation_runs`, `list_automation_results`, and `count_automation_results` now resolve a definition's {local id, server id} alias set once and filter across both, so a transferred definition's pre-transfer history stays visible under either id. Two workbench call sites that hand-rolled a both-id loop were collapsed onto the seam (the review independently reproduced the double-count that made this mandatory — `total` 4 instead of 2). Never-transferred definitions return byte-identical rows and ordering (pinned). **To-local direction (AC#5):** the history link is genuinely lost server-side today (the release ack deletes the only `server_definition_id` payload; `sync_mapping` is wired for reminders only) — recorded honestly in `Docs/User_Guide/schedules.md` rather than papered over.

### 31419 — narrow-terminal rows from the app shell: measured, classified, answered
Re-measured in the **real** shell at 80×24 (scratch profile): of the claimed 13 chrome rows, only **4** (navigation 3 + footer 1) are true app-shell chrome — both deliberate and already minimal. The destination header, liveness line, and status strip are screen-owned (`SchedulesWorkbench.compose_content`), correcting PR-4 Task 6's attribution. **No shell row is reclaimable → AC#5 recorded-answer close.** The one real lever — `DestinationHeader`'s dormant `density="compact"` in the shared workbench-widget layer — filed as **TASK-31825**.

### Testing
- 31415 task review: APPROVE/MEETS, deviation independently reproduced as load-bearing; `335 passed` across `test_scheduled_tasks_db.py` + `test_schedules_results_tab.py` + `test_schedules_workbench.py`; full `Tests/Scheduling/` 1076 passed.
- Schedules floor test 27/28 — the 1 red fails identically at the branch base (pre-existing dev debt, attributed in a throwaway worktree).
- Diagnostics pin verified; CSS bundle reproduces; backlog dup-ID check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes transferred recurring questions losing their pre-transfer run/result history: the history is now visible under either the local or server id instead of only the id the row carries. Also re-measures the app shell's narrow-terminal chrome at 80×24 and closes that task with a no-reclaim ruling.

**31415 — run/result history bridge**
- A shared alias-resolution seam in `ScheduledTasksDB` now filters run/result queries across both a definition's local and server ids.
- Two workbench call sites that hand-rolled a both-id loop were collapsed onto the seam; the old loop double-counted totals.
- Never-transferred definitions return identical rows and ordering.
- A server → local release still loses the prior history server-side; the gap is now documented in the user guide.

**31419 — narrow-terminal shell ruling**
- Re-measured the claimed 13 chrome rows: only 4 (navigation 3 + footer 1) are true app-shell chrome, both deliberate and already minimal.
- The destination header, liveness line, and status strip are screen-owned, correcting the earlier attribution.
- No shell row is reclaimable, so the task closes with that as the recorded answer.
- The one real lever, `DestinationHeader`'s dormant `density="compact"`, is filed as TASK-31825.

<sup>Written for commit 7d1ba86f5f264ffd4dc6c61b00a526c8661685d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

