### PR TITLE
fix(ui): clear stale Roleplay Inspector avatar + silence spurious boot worker warnings (TASK-31804, TASK-31806)

### DIFF
--- a/Tests/App/test_worker_failure_event.py
+++ b/Tests/App/test_worker_failure_event.py
@@ -132,6 +132,91 @@ async def test_screen_navigation_worker_transition_does_not_warn_unhandled():
     ], f"navigation worker warned unhandled: {warnings}"
 
 
+# TASK-31806: a fresh boot spawns these fire-and-forget one-shot workers.
+# Their transitions used to warn "No handler found for worker" once per state
+# (PENDING/RUNNING/SUCCESS), polluting the Logs "Warnings+" filter on every
+# launch. Captured from a live fresh boot (name, group) pairs.
+_FRESH_BOOT_FIRE_AND_FORGET_WORKERS = [
+    ("restore_ingest_jobs", "ingest_restore"),
+    ("deferred_actor_pack_recovery", "actor_pack_recovery"),
+    ("deferred_actor_pack_staging_sweep", "actor_pack_staging_sweep"),
+    ("_backfill_chachanotes_messages_fts", "chachanotes-fts-backfill"),
+    ("resume_startup", "research_source_association_startup"),
+    ("_sweep_research_paste_staging", "research_paste_staging_startup"),
+    (
+        "_reconcile_research_quick_notes_startup",
+        "research-quick-notes-startup-reconciliation",
+    ),
+    # Sibling of the research startup sweeps above, spawned in the same
+    # startup method but data-gated (only when the ingest/operation stores
+    # exist), so it does not fire on every profile -- same benign category.
+    ("_reconcile_research_source_held_jobs", "research_source_held_startup"),
+]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "worker_name,worker_group",
+    _FRESH_BOOT_FIRE_AND_FORGET_WORKERS,
+    ids=[g for _, g in _FRESH_BOOT_FIRE_AND_FORGET_WORKERS],
+)
+async def test_fresh_boot_fire_and_forget_worker_does_not_warn_unhandled(
+    worker_name, worker_group
+):
+    """TASK-31806: fresh-boot one-shot workers must be acknowledged by the
+    registry, not warn 'No handler found' once per state transition."""
+    from loguru import logger as loguru_root_logger
+    from textual.worker import Worker
+
+    from Tests.UI.app_factory import _build_test_app
+
+    warnings: list[str] = []
+    sink_id = loguru_root_logger.add(
+        lambda message: warnings.append(str(message)), level="WARNING"
+    )
+    try:
+        app = _build_test_app()
+        async with app.run_test(size=(120, 40)) as pilot:
+            for state in (
+                WorkerState.PENDING,
+                WorkerState.RUNNING,
+                WorkerState.SUCCESS,
+            ):
+                worker = MagicMock(spec=Worker)
+                worker.name = worker_name
+                worker.group = worker_group
+                worker.error = None
+                worker.description = f"{worker_name}=<probe>"
+                await app.on_worker_state_changed(
+                    Worker.StateChanged(worker, state)
+                )
+            await pilot.pause()
+    finally:
+        loguru_root_logger.remove(sink_id)
+
+    assert not [
+        w for w in warnings if "No handler found" in w and worker_name in w
+    ], f"fresh-boot worker {worker_group!r} warned unhandled: {warnings}"
+
+
+def test_every_boot_policy_group_is_acknowledged():
+    """TASK-31806: the acknowledged set is DERIVED from BOOT_WORKER_POLICY, so a
+    future BootWorkerSpec can never silently reintroduce the boot warning."""
+    from tldw_chatbook.Event_Handlers.worker_handlers.misc_worker_handler import (
+        MiscWorkerHandler,
+    )
+    from tldw_chatbook.Utils.boot_worker_policy import BOOT_WORKER_POLICY
+
+    unacknowledged = sorted(
+        {spec.group for spec in BOOT_WORKER_POLICY}
+        - MiscWorkerHandler.HANDLED_GROUPS
+    )
+    assert not unacknowledged, (
+        "boot-policy worker groups missing from MiscWorkerHandler.HANDLED_GROUPS "
+        f"(each warns 'No handler found' every boot): {unacknowledged}"
+    )
+
+
 @pytest.mark.asyncio
 async def test_unknown_worker_group_still_warns_unhandled():
     """Guard for task-2726: acknowledging known fire-and-forget groups must not

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -1571,6 +1571,36 @@ async def test_clear_selection_resets_everything():
         )
 
 
+async def test_clear_selection_drops_stale_avatar():
+    """TASK-31804: deselection must not leave a previous face in the rail.
+
+    The status line reads "Selected: none" after clear_selection(), but the
+    portrait box used to keep the previously-selected character's avatar
+    mounted -- a contradictory rail state. clear_selection() must blank the
+    avatar so the "Selected: none" summary and the portrait agree.
+    """
+    from rich.text import Text
+    from textual.containers import Container
+
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        pane = pilot.app.query_one(PersonasInspectorPane)
+        pane.show_selection(name="Detective Sam", kind="character")
+        pane.set_avatar_thumbnail(Text("portrait"))
+        await pilot.pause()
+        thumb_box = pane.query_one("#personas-inspector-avatar-thumb", Container)
+        assert len(thumb_box.children) == 1, "avatar should be mounted while selected"
+        await pane.clear_selection()
+        await pilot.pause()
+        assert "Selected: none" in str(
+            pilot.app.query_one("#personas-selected-name", Static).renderable
+        )
+        assert len(thumb_box.children) == 0, (
+            "clear_selection left a stale avatar mounted while the summary "
+            "reads 'Selected: none'"
+        )
+
+
 async def test_show_conversations_twice_in_same_tick_does_not_crash():
     app = InspectorApp()
     async with app.run_test() as pilot:

--- a/backlog/tasks/task-31804 - Roleplay Inspector shows the previous character's avatar while reporting 'Selected - none'.md
+++ b/backlog/tasks/task-31804 - Roleplay Inspector shows the previous character's avatar while reporting 'Selected - none'.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31804
 title: Roleplay Inspector shows the previous character's avatar while reporting 'Selected: none'
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-05 19:15'
+updated_date: '2026-09-06 14:47'
 labels:
   - bug
   - ui
@@ -20,5 +22,21 @@ Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When selection is none, the Inspector shows no stale avatar.
+- [x] #1 When selection is none, the Inspector shows no stale avatar.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce with a mounted inspector test: show_selection(character) + set_avatar_thumbnail, then clear_selection, assert the avatar box has no children (fails on dev).
+2. Fix at the widget seam: blank the avatar in `PersonasInspectorPane.clear_selection()` (`set_avatar_thumbnail(None)`), matching the non-character `show_selection` paths in `personas_screen.py` that already blank the portrait "so the rail never shows a face that belongs to a different selection".
+3. Verify: new test passes; full inspector-pane suite green.
+
+## Implementation Notes
+
+Reproduced on dev tip 5894f4755e. `PersonasInspectorPane.clear_selection()` updated the summary line to "Selected: none" and cleared conversations/validation but never cleared the portrait box (`#personas-inspector-avatar-thumb`), so a previous character's avatar lingered — the exact contradiction reported. The character-selection path renders the avatar via a worker (`_render_inspector_avatar`), and the persona/dictionary/lore `show_selection` paths already call `set_avatar_thumbnail(None)` to drop a stale face; only the deselect path was missing it.
+
+Fix: added a single `self.set_avatar_thumbnail(None)` call inside `clear_selection()`. Centralizing the invariant at the widget means every screen-side `clear_selection()` caller gets it for free. The avatar worker's own staleness guard (keyed on `selected_entity_id`) already prevents a late repaint after deselection, so no worker-cancellation change was needed.
+
+Modified files:
+- `tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py`
+- `Tests/UI/test_personas_inspector_pane.py` (new `test_clear_selection_drops_stale_avatar`)

--- a/backlog/tasks/task-31806 - 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter.md
+++ b/backlog/tasks/task-31806 - 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31806
 title: 13 'No handler found for worker' warnings on every fresh boot pollute the Logs Warnings+ filter
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-05 19:15'
+updated_date: '2026-09-06 14:47'
 labels:
   - bug
   - logs
@@ -20,5 +22,26 @@ Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A fresh boot emits zero spurious 'No handler found for worker' warnings.
+- [x] #1 A fresh boot emits zero spurious 'No handler found for worker' warnings.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce: temporarily instrument the `on_worker_state_changed` warning site, live-boot an isolated scratch profile, and capture the unhandled (name, group) pairs.
+2. Analyse register-vs-downgrade: confirm each is a fire-and-forget boot/startup one-shot whose failures the diagnostics hook already persists (the ERROR branch runs before registry delegation). Register/acknowledge them, matching the task-2726 precedent.
+3. Fix: derive the boot-fleet groups from `BOOT_WORKER_POLICY` and add the research startup groups to `MiscWorkerHandler.HANDLED_GROUPS`.
+4. Verify: parametrized "does not warn unhandled" tests over the live-captured groups + a derivation guard; live re-boot shows zero warnings.
+
+## Implementation Notes
+
+Root cause: the app-wide `on_worker_state_changed` hook warns "No handler found for worker" for any worker whose group is not in `MiscWorkerHandler.HANDLED_GROUPS`. Seven fire-and-forget startup one-shots were unregistered, and each warns once per state transition (PENDING/RUNNING/SUCCESS), so a fresh boot emitted a burst of these (13 in the reporter's profile; a live capture on dip 5894f4755e showed 21 = 7 groups x 3 states, the count varying with which data-gated workers run). Live-captured groups: `ingest_restore`, `actor_pack_recovery`, `actor_pack_staging_sweep`, `chachanotes-fts-backfill`, `research_source_association_startup`, `research_paste_staging_startup`, `research-quick-notes-startup-reconciliation`.
+
+These are all self-contained boot/startup sweeps that consume their own results and whose failures are ALREADY persisted by the diagnostics hook before registry delegation — so acknowledging them (registering, not silencing a real result) is correct, exactly as task-2726 did for `screen-navigation`/`scheduling`/`subscriptions-fts-backfill`.
+
+Chosen fix is register-and-harden: the boot-fleet groups are now DERIVED from `BOOT_WORKER_POLICY` (`_BOOT_WORKER_GROUPS`) rather than hand-listed, so a future `BootWorkerSpec` can never silently reintroduce the warning (this closes a maintenance gap — four boot-policy groups had gone unregistered while two others were already present). The research startup sweeps spawned directly (not via the policy) are listed explicitly in `_RESEARCH_STARTUP_GROUPS`, including the data-gated `research_source_held_startup` sibling. Genuinely unknown workers still warn (guard test retained).
+
+Live verification: re-booted the isolated profile on the fixed build and confirmed ZERO "No handler found" warnings across the full boot + staggered-worker settle window.
+
+Modified files:
+- `tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py`
+- `Tests/App/test_worker_failure_event.py` (parametrized no-warn tests + boot-policy derivation guard)

--- a/tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py
+++ b/tldw_chatbook/Event_Handlers/worker_handlers/misc_worker_handler.py
@@ -11,8 +11,33 @@ from typing import Optional
 from textual.worker import Worker, WorkerState
 
 from tldw_chatbook.Constants import MODEL_CATALOG_REFRESH_WORKER_GROUP
+from tldw_chatbook.Utils.boot_worker_policy import BOOT_WORKER_POLICY
 
 from .base_handler import BaseWorkerHandler
+
+#: Every group in the declarative boot fleet (``scheduling``,
+#: ``ingest_restore``, the actor-pack prefetches, the FTS backfills). DERIVED
+#: from BOOT_WORKER_POLICY, not hand-listed, so a future BootWorkerSpec can
+#: never silently reintroduce the per-transition "No handler found for worker"
+#: warning these one-shots emit at boot (TASK-31806). Each is fire-and-forget:
+#: its failure is already persisted by the diagnostics hook in
+#: on_worker_state_changed before registry delegation runs.
+_BOOT_WORKER_GROUPS = frozenset(spec.group for spec in BOOT_WORKER_POLICY)
+
+#: Fire-and-forget research/library startup reconciliation sweeps spawned
+#: directly (TldwCli, not via the boot policy). Same rationale as the boot
+#: fleet: self-contained coroutines that catch-and-log their own outcome and
+#: need no per-transition handler (TASK-31806). Data-gated ones
+#: (``research_source_held_startup``) only fire on some profiles, but warn
+#: identically when they do.
+_RESEARCH_STARTUP_GROUPS = frozenset(
+    {
+        "research_source_association_startup",
+        "research_source_held_startup",
+        "research_paste_staging_startup",
+        "research-quick-notes-startup-reconciliation",
+    }
+)
 
 
 class MiscWorkerHandler(BaseWorkerHandler):
@@ -28,10 +53,8 @@ class MiscWorkerHandler(BaseWorkerHandler):
         # "No handler found" warning — one per tab switch for
         # screen-navigation (TASK-1230), several at startup for the others.
         "screen-navigation",
-        "scheduling",
         MODEL_CATALOG_REFRESH_WORKER_GROUP,
-        "subscriptions-fts-backfill",
-    }
+    } | _BOOT_WORKER_GROUPS | _RESEARCH_STARTUP_GROUPS
 
     def can_handle(self, worker_name: str, worker_group: Optional[str] = None) -> bool:
         """

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -418,10 +418,13 @@ class PersonasInspectorPane(VerticalScroll):
         self.set_console_actions_enabled(False, reason="select an item")
         self.query_one("#personas-selected-name", Static).update("Selected: none")
         self.query_one("#personas-selected-kind", Static).update("Type: -")
-        # TASK-31804: the rail must never show a face that belongs to a
-        # cleared selection. show_selection paths for non-character kinds
-        # already blank the portrait; deselection must too, or the "Selected:
-        # none" summary contradicts a lingering avatar.
+        # TASK-31804: blank the portrait on deselect -- load-bearing, do NOT
+        # drop as redundant with the show_selection paths. Those paths blank
+        # the avatar only when a NEW item is selected; a pure deselection
+        # (selection cleared, nothing selected next) reaches none of them, so
+        # without this line the previously selected character's face lingers
+        # in the rail while the summary reads "Selected: none" -- the exact
+        # contradictory state this fixes.
         self.set_avatar_thumbnail(None)
         await self.show_conversations(())
         self.show_validation(())

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -418,6 +418,11 @@ class PersonasInspectorPane(VerticalScroll):
         self.set_console_actions_enabled(False, reason="select an item")
         self.query_one("#personas-selected-name", Static).update("Selected: none")
         self.query_one("#personas-selected-kind", Static).update("Type: -")
+        # TASK-31804: the rail must never show a face that belongs to a
+        # cleared selection. show_selection paths for non-character kinds
+        # already blank the portrait; deselection must too, or the "Selected:
+        # none" summary contradicts a lingering avatar.
+        self.set_avatar_thumbnail(None)
         await self.show_conversations(())
         self.show_validation(())
         self._apply_action_state()


### PR DESCRIPTION
Fixes two small UI bugs filed in the 2026-09-05 pre-release live UAT sweep. Both reproduced on current dev before fixing.

## TASK-31804 (P3) — Roleplay Inspector shows a stale avatar after deselection

**Reproduced** on dev tip `5894f4755e`. `PersonasInspectorPane.clear_selection()` updated the summary line to "Selected: none" and cleared the conversations/validation sections, but never blanked the portrait box (`#personas-inspector-avatar-thumb`). The previously-selected character's avatar therefore lingered while the status line reported no selection — the exact contradiction reported.

**Fix**: blank the avatar in `clear_selection()` (`self.set_avatar_thumbnail(None)`), matching the persona/dictionary/lore `show_selection` paths that already drop a stale face ("the rail must never show a face that belongs to a different selection"). Centralizing the invariant at the widget means every screen-side `clear_selection()` caller inherits it. The avatar render worker's own staleness guard (keyed on `selected_entity_id`) already prevents a late repaint after deselection, so no worker-cancellation change was needed.

**Test**: new `test_clear_selection_drops_stale_avatar` — mounts an avatar, calls `clear_selection`, asserts the portrait box has zero children while the summary reads "Selected: none". Fails on dev, passes with the fix. Full inspector-pane suite: 79 passed.

## TASK-31806 (P3) — 13 "No handler found for worker" WARNINGs on every fresh boot

**Reproduced** by instrumenting the `on_worker_state_changed` warning site and live-booting an isolated scratch profile. The app-wide worker hook warns for any worker group absent from `MiscWorkerHandler.HANDLED_GROUPS`, once per state transition (PENDING/RUNNING/SUCCESS). Seven fire-and-forget startup one-shots were unregistered — a live capture showed 21 warning lines (7 groups × 3 states; the reporter's profile showed 13, the count varying with which data-gated workers run). Captured groups: `ingest_restore`, `actor_pack_recovery`, `actor_pack_staging_sweep`, `chachanotes-fts-backfill`, `research_source_association_startup`, `research_paste_staging_startup`, `research-quick-notes-startup-reconciliation`.

These are all self-contained boot/startup sweeps whose failures are **already** persisted by the diagnostics hook before registry delegation, so acknowledging them (registering, not silencing a real result) is correct — the same treatment task-2726 gave `screen-navigation`/`scheduling`/`subscriptions-fts-backfill`.

**Fix** (register + harden): the boot-fleet groups are now **derived** from `BOOT_WORKER_POLICY` (`_BOOT_WORKER_GROUPS`) rather than hand-listed, so a future `BootWorkerSpec` can never silently reintroduce the warning — this closes the maintenance gap that let four boot-policy groups go unregistered while two were already present. The directly-spawned research startup sweeps are listed explicitly (`_RESEARCH_STARTUP_GROUPS`), including the data-gated `research_source_held_startup` sibling. Genuinely unknown workers still warn (guard test retained).

**Test**: parametrized `test_fresh_boot_fire_and_forget_worker_does_not_warn_unhandled` over the live-captured (name, group) pairs, plus `test_every_boot_policy_group_is_acknowledged` deriving from `BOOT_WORKER_POLICY`. Worker-failure suite: 13 passed.

**Live verification**: re-booted the isolated profile on the fixed build and confirmed **zero** "No handler found" warnings across the full boot + staggered-worker settle window.

## Checks
- `./scripts/preflight.sh`: all derived-artifact checks pass (no diagnostic-inventory drift — the change only extends a set).
- Directly-relevant suites green; pre-existing dev-red `test_resize_sync_skips_work_when_compact_state_is_unchanged` is unrelated (proven to fail identically on clean origin/dev; it exercises `PersonasScreen._sync_responsive_workbench`, which neither fix touches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two UAT bugs: the Roleplay Inspector kept a stale avatar after deselection, and fresh boots emitted spurious "No handler found for worker" warnings.

**Bug Fixes**
- `PersonasInspectorPane.clear_selection()` now blanks the avatar thumbnail so the portrait matches the "Selected: none" summary.
- Fresh-boot and research-startup fire-and-forget worker groups are acknowledged in `MiscWorkerHandler.HANDLED_GROUPS`; boot groups are derived from `BOOT_WORKER_POLICY` so a future `BootWorkerSpec` can't silently reintroduce the warning.
- Genuinely unknown workers still warn, and both fixes have targeted regression tests.

<sup>Written for commit 9ddc4718f0c0a5ac0137985c8905605e43bb2d61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

