### PR TITLE
fix(scheduling): resolve stuck Schedules sync header + guard queue/example regressions (31798/31799/31800)

### DIFF
--- a/Tests/Scheduling/test_example_run_at_text.py
+++ b/Tests/Scheduling/test_example_run_at_text.py
@@ -1,0 +1,41 @@
+"""task-31800: the run-at example shown in the reminder/automation forms and
+detail panes must always be a FUTURE datetime, never a hardcoded literal that
+drifts into the past.
+
+The three sites the UAT flagged (reminder_form placeholder + hint, and
+definition_detail example + error copy) all render `example_run_at_text()`, so
+pinning the helper pins every caller.
+"""
+from datetime import datetime, timedelta
+
+from tldw_chatbook.Scheduling.schedule_input_parsing import (
+    example_run_at_text,
+    parse_forgiving_datetime,
+)
+
+
+def test_example_run_at_text_is_always_in_the_future():
+    text = example_run_at_text()
+    parsed, assumed_local = parse_forgiving_datetime(text)
+    assert parsed is not None, f"the example {text!r} must be a parseable date-time"
+    # Strictly future: a user who copies the example verbatim gets a run time
+    # that has not already passed.
+    assert parsed > datetime.now(parsed.tzinfo), (
+        f"example {text!r} parsed to {parsed}, which is not in the future"
+    )
+
+
+def test_example_run_at_text_shape_and_days_ahead():
+    # Shared default keeps every caller's shown example identical, and the
+    # forgiving 'YYYY-MM-DD 09:00' shape parse_forgiving_datetime accepts.
+    text = example_run_at_text(days_ahead=7)
+    expected_date = (datetime.now() + timedelta(days=7)).date().isoformat()
+    assert text == f"{expected_date} 09:00"
+
+
+def test_no_literal_past_date_hardcoded_in_the_helper():
+    # Guard against a regression back to a fixed literal (the 2026-08-28 09:00
+    # the UAT found): the value must change as 'now' advances.
+    far = example_run_at_text(days_ahead=3650)
+    near = example_run_at_text(days_ahead=1)
+    assert far != near

--- a/Tests/Scheduling/test_example_run_at_text.py
+++ b/Tests/Scheduling/test_example_run_at_text.py
@@ -25,11 +25,27 @@ def test_example_run_at_text_is_always_in_the_future():
     )
 
 
-def test_example_run_at_text_shape_and_days_ahead():
+def test_example_run_at_text_shape_and_days_ahead(monkeypatch):
     # Shared default keeps every caller's shown example identical, and the
     # forgiving 'YYYY-MM-DD 09:00' shape parse_forgiving_datetime accepts.
+    #
+    # Pin a single reference "now" (deliberately near local midnight) so the
+    # value produced and the expected date are derived from the SAME instant:
+    # two independent `datetime.now()` calls straddling midnight would compute
+    # different calendar dates and fail spuriously.
+    import tldw_chatbook.Scheduling.schedule_input_parsing as sip
+
+    fixed_now = datetime(2026, 9, 6, 23, 59, 30)
+
+    class _FrozenDateTime(datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return fixed_now if tz is None else fixed_now.replace(tzinfo=tz)
+
+    monkeypatch.setattr(sip, "datetime", _FrozenDateTime)
+
     text = example_run_at_text(days_ahead=7)
-    expected_date = (datetime.now() + timedelta(days=7)).date().isoformat()
+    expected_date = (fixed_now + timedelta(days=7)).date().isoformat()
     assert text == f"{expected_date} 09:00"
 
 

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -5124,6 +5124,145 @@ async def test_header_paints_checking_not_a_false_unreachable_during_mount_probe
         db.close()
 
 
+class _PolicyRefusedService(_MockSchedulingServiceMixin):
+    """task-31798: a fresh LOCAL profile whose placeholder `[tldw_api]` URL
+    makes `active_server_id` truthy, but the local runtime policy refuses the
+    capabilities probe (`ServerClientPolicyError`) before any round trip --
+    so `server_reachable` stays `None` and `server_permission_denied` is set,
+    permanently. The header must NOT sit on the transient "Checking sync
+    status…" copy in this settled state."""
+
+    server_client = _MockServerClient(notifications_service=object())
+
+    def __init__(self) -> None:
+        self.db = _MockSchedulingDB()
+        self._server_reachable = None
+        self._server_permission_denied = False
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return [
+            ReminderTask(
+                id="task-1",
+                title="Test",
+                schedule_kind=ScheduleKind.ONE_TIME,
+                run_at=datetime(2099, 1, 1, tzinfo=timezone.utc),
+            )
+        ]
+
+    async def refresh_server_reachability(self) -> bool:
+        # ServerClientPolicyError branch of the real probe: refused locally
+        # before the wire, so reachability is left None and permission-denied
+        # is recorded.
+        self._server_permission_denied = True
+        return bool(self._server_reachable)
+
+    @property
+    def server_reachable(self):
+        return self._server_reachable
+
+    @property
+    def server_permission_denied(self) -> bool:
+        return self._server_permission_denied
+
+
+@pytest.mark.asyncio
+async def test_header_resolves_local_only_when_probe_is_policy_refused():
+    """task-31798 AC#1/#2: once the mount-time reachability probe has
+    COMPLETED and could not establish a usable connection (policy-refused in
+    local mode), the destination header must resolve to the same local-only
+    status the footer already shows, not sit on "Checking sync status…"
+    forever."""
+    from tldw_chatbook.UI.Workbench.workbench_widgets import DestinationHeader
+
+    app = WorkbenchTestApp()
+    app.scheduling_service = _PolicyRefusedService()
+    # Fresh profile: placeholder base_url -> truthy active_server_id, source
+    # still local.
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id="127.0.0.1:8000")
+    )
+    async with app.run_test(size=(160, 48)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await settle_schedules_workbench(pilot)
+        header = pilot.app.screen.query_one(
+            "#schedules-destination-header", DestinationHeader
+        )
+        assert header.state.status_label == "Local only — no server connection", (
+            f"got {header.state.status_label!r} -- a settled, policy-refused "
+            "probe must read local-only (matching the footer), never the "
+            "transient 'Checking sync status…' copy"
+        )
+
+
+class _EmptyThenOneReminderService(_MockSchedulingServiceMixin):
+    """task-31799: an empty queue until the first reminder is created, so the
+    empty -> first-row transition (the one the UAT found truncated to header
+    width) is exercised through the real create path."""
+
+    server_client = _MockServerClient()
+
+    def __init__(self) -> None:
+        self.db = _MockSchedulingDB()
+        self._tasks: list[ReminderTask] = []
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return list(self._tasks)
+
+    async def create_reminder(self, payload: dict, *, owner_id: str | None = None):
+        task = ReminderTask(
+            id="task-1",
+            title=payload.get("title", ""),
+            schedule_kind=ScheduleKind.ONE_TIME,
+            run_at=datetime(2099, 1, 1, 9, 0, tzinfo=timezone.utc),
+        )
+        self._tasks = [task]
+        return task
+
+
+@pytest.mark.asyncio
+async def test_first_row_added_to_empty_queue_is_not_truncated():
+    """task-31799: the first row inserted into a previously-empty Schedule
+    Queue must render with correctly measured column widths -- the UAT saw
+    Title clipped to the header label width ('UAT f') and Details to 'One-tim'
+    until any filter keystroke forced a re-measure. Drive the real create flow
+    (empty queue -> create the first reminder via the form) and assert the
+    painted row shows the full title, not a header-width truncation."""
+    app = WorkbenchTestApp()
+    app.scheduling_service = _EmptyThenOneReminderService()
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id=None)
+    )
+    title = "UAT first reminder title here"
+    async with app.run_test(size=(160, 48)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await settle_schedules_workbench(pilot)
+        workbench = pilot.app.screen
+
+        await workbench.action_create_reminder()
+        await pilot.pause()
+        assert isinstance(pilot.app.screen, ReminderForm)
+        pilot.app.screen.query_one("#reminder-title", Input).value = title
+        pilot.app.screen.query_one("#reminder-run-at", Input).value = (
+            "2099-01-01T09:00:00+00:00"
+        )
+        await pilot.click("#reminder-save")
+        await pilot.pause()
+        await pilot.app.workers.wait_for_complete()
+        await settle_schedules_workbench(pilot, workbench)
+
+        table = workbench.query_one("#scheduling-task-table", DataTable)
+        assert table.row_count == 1
+        title_col = next(c for c in table.ordered_columns if c.label.plain == "Title")
+        assert title_col.content_width >= len(title), (
+            f"Title column stuck at {title_col.content_width} (header width) -- "
+            "the first row was not re-measured on insert"
+        )
+        painted = painted_glyphs_at(pilot.app, table)
+        assert title in painted, (
+            f"first row title truncated in painted output; got:\n{painted}"
+        )
+
+
 # -- Fix round 1, finding 1: _on_owner_server / action_sync_now must
 # re-probe like _run_owner_transfer already did, not trust a stale
 # mount-time `server_reachable` while the background probe is still

--- a/Tests/UI/test_schedules_workbench.py
+++ b/Tests/UI/test_schedules_workbench.py
@@ -5194,6 +5194,64 @@ async def test_header_resolves_local_only_when_probe_is_policy_refused():
         )
 
 
+class _PendingProbeService(_MockSchedulingServiceMixin):
+    """task-31798: the OTHER arm of the same branch -- `server_reachable` is
+    None but the probe was NOT policy-refused (`server_permission_denied` stays
+    False), i.e. a probe still genuinely in flight. The header must keep the
+    transient "Checking sync status…" copy in this case, never prematurely
+    settle to local-only."""
+
+    server_client = _MockServerClient(notifications_service=object())
+
+    def __init__(self) -> None:
+        self.db = _MockSchedulingDB()
+        self._server_reachable = None
+        self._server_permission_denied = False
+
+    async def list_tasks(self, owner_id=None, include_projections=True):
+        return []
+
+    async def refresh_server_reachability(self) -> bool:
+        # Models an unresolved probe: neither reachability nor a permission
+        # verdict has been established.
+        return bool(self._server_reachable)
+
+    @property
+    def server_reachable(self):
+        return self._server_reachable
+
+    @property
+    def server_permission_denied(self) -> bool:
+        return self._server_permission_denied
+
+
+@pytest.mark.asyncio
+async def test_header_stays_checking_while_probe_unresolved_without_permission_denial():
+    """task-31798: the `server_reachable is None` header branch must ONLY
+    settle to local-only when `server_permission_denied` is set (the completed,
+    policy-refused case). With permission-denial False (probe not yet
+    resolved), it must keep painting "Checking sync status…" -- the guard that
+    keeps the 31798 fix from swallowing the honest in-flight state."""
+    from tldw_chatbook.UI.Workbench.workbench_widgets import DestinationHeader
+
+    app = WorkbenchTestApp()
+    app.scheduling_service = _PendingProbeService()
+    app.runtime_policy = SimpleNamespace(
+        state=SimpleNamespace(active_server_id="127.0.0.1:8000")
+    )
+    async with app.run_test(size=(160, 48)) as pilot:
+        await pilot.app.push_screen(SchedulesWorkbench(app_instance=pilot.app))
+        await settle_schedules_workbench(pilot)
+        header = pilot.app.screen.query_one(
+            "#schedules-destination-header", DestinationHeader
+        )
+        assert header.state.status_label == "Checking sync status…", (
+            f"got {header.state.status_label!r} -- with no permission denial "
+            "recorded the probe is treated as still in flight, so the header "
+            "must stay on the transient checking copy"
+        )
+
+
 class _EmptyThenOneReminderService(_MockSchedulingServiceMixin):
     """task-31799: an empty queue until the first reminder is created, so the
     empty -> first-row transition (the one the UAT found truncated to header

--- a/backlog/tasks/task-31798 - Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured.md
+++ b/backlog/tasks/task-31798 - Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31798
 title: Schedules header permanently shows 'Checking sync status...' when no scheduling server is configured
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-05 19:15'
 labels:
@@ -20,6 +20,24 @@ Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The header resolves to the local-only status (matching the footer) shortly after mount when no server is configured.
-- [ ] #2 Test covering the no-server header path.
+- [x] #1 The header resolves to the local-only status (matching the footer) shortly after mount when no server is configured.
+- [x] #2 Test covering the no-server header path.
 <!-- AC:END -->
+
+## Implementation Plan
+
+1. Reproduce on current dev; identify why the header stays on the compose-time "Checking sync status…" seed.
+2. Trace `_refresh_owner_select`: `server_reachable is None` is the "still checking" signal, but the mount-time reachability probe can leave it `None` forever.
+3. Add a RED test that pins the settled stuck state, then fix, then confirm GREEN + live.
+
+## Implementation Notes
+
+**Root cause.** A fresh LOCAL profile ships the placeholder `[tldw_api] base_url = http://127.0.0.1:8000`, so `derive_configured_server_binding` makes `runtime_state.active_server_id` truthy even though the app is in local mode. `SchedulesWorkbench.on_mount` runs `_refresh_owner_select()`, then kicks `_refresh_server_reachability()`. The probe (`SchedulingService.refresh_server_reachability` → `get_capabilities`) is `_enforce`-gated on a server permission; in local mode it raises `ServerClientPolicyError`, whose handler deliberately leaves `_server_reachable` **unchanged** (`None`) and only records `_server_permission_denied = True`. `_refresh_owner_select` treated `server_reachable is None` as "a probe is still in flight" → the header sat on the transient "Checking sync status…" copy permanently, while the footer correctly read local-only (it only gates on `not server_available`).
+
+**Fix.** In `_refresh_owner_select`, inside the `not server_available` / `server_reachable is None` branch, distinguish "probe still pending" from "probe completed and could not establish a usable connection" using the existing honest signal `service.server_permission_denied`. `server_reachable` can only stay `None` after a completed probe via the `ServerClientPolicyError` path, which always sets `server_permission_denied` — so it is the exact settled-state signal. When set, resolve the header to `"Local only — no server connection"` (the same copy the `not active_server_id` branch and the footer already use). The genuinely-pending window (permission-denied still False) keeps painting "Checking sync status…", so the existing `test_header_paints_checking_not_a_false_unreachable_during_mount_probe` is unaffected.
+
+**Tests.** Added `test_header_resolves_local_only_when_probe_is_policy_refused` (RED→GREEN) modelling the exact settled state (truthy `active_server_id`, `server_reachable=None`, `server_permission_denied=True`, no sync errors).
+
+**Live verification** (isolated scratch profile, tmux, current dev): with the placeholder `[tldw_api]` URL configured (truthy `active_server_id`), the header reads "Local only — no server connection" and the footer reads "Local schedules — no scheduling server connected; sync is off." — they match, and no "Checking sync status…" persists.
+
+**Files:** `tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py` (fix), `Tests/UI/test_schedules_workbench.py` (regression test).

--- a/backlog/tasks/task-31799 - Schedule Queue table truncates the first-inserted row to header-width columns.md
+++ b/backlog/tasks/task-31799 - Schedule Queue table truncates the first-inserted row to header-width columns.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31799
 title: Schedule Queue table truncates the first-inserted row to header-width columns
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-05 19:15'
 labels:
@@ -20,5 +20,18 @@ Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The first row added to an empty Schedule Queue renders with correctly measured column widths.
+- [x] #1 The first row added to an empty Schedule Queue renders with correctly measured column widths.
 <!-- AC:END -->
+
+## Implementation Notes
+
+**No longer reproduces on current dev (Done-already-fixed) — regression guard added.**
+
+Attempted to reproduce on current dev (tip 5894f4755e) both ways:
+
+- Harness, faithful end-to-end: empty queue → create the first reminder through the real pushed `ReminderForm` flow → the `#scheduling-task-table` `DataTable` renders the first row with the Title column's `content_width` measured to the full title length (29, not the 5-char header width) and the compositor paints the full "UAT first reminder title here" text. No truncation.
+- Live (isolated scratch profile, tmux): navigated to Schedules with an empty queue, created the first scheduled task via `n` → the queue row shows the full "UAT first reminder title here" title and full "One-time at 2026-09-13 16:00 UTC · …" details — not the "UAT f"/"One-tim" header-width clip the UAT reported.
+
+The bug was found on an earlier dev (8e9d1128d4). PR #2454 (bbca9eaa85) subsequently reworked the same `_render_table` clear/add-row path (task-31713's `scroll_x` preservation), and the first-insert measurement is now correct. Rather than ship a speculative no-op fix, added a regression test that drives the real empty→first-row create flow and asserts both the measured column width and the painted output, so a future change cannot silently reintroduce the truncation.
+
+**Files:** `Tests/UI/test_schedules_workbench.py` (`test_first_row_added_to_empty_queue_is_not_truncated`).

--- a/backlog/tasks/task-31800 - Reminder form 'Run at' placeholder and examples hardcode a past datetime.md
+++ b/backlog/tasks/task-31800 - Reminder form 'Run at' placeholder and examples hardcode a past datetime.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31800
 title: Reminder form 'Run at' placeholder and examples hardcode a past datetime
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-05 19:15'
 labels:
@@ -21,6 +21,23 @@ Found in the 2026-09-05 pre-release live UAT sweep (fresh scratch profile, dev t
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The run-at example shown to users is always a future datetime (or clearly synthetic).
-- [ ] #2 All three literal sites updated consistently.
+- [x] #1 The run-at example shown to users is always a future datetime (or clearly synthetic).
+- [x] #2 All three literal sites updated consistently.
 <!-- AC:END -->
+
+## Implementation Notes
+
+**Already fixed on current dev (Done-already-fixed) — regression guard added.**
+
+The hardcoded literal is gone. PR #2454 (bbca9eaa85, task-31711 AC#4) replaced all 12 hardcoded example-date sites with a single `example_run_at_text(days_ahead=7)` helper (`tldw_chatbook/Scheduling/schedule_input_parsing.py`) that computes a never-in-the-past `"YYYY-MM-DD 09:00"` fresh relative to `datetime.now()`. The three sites the UAT flagged now all render it:
+
+- `forms/reminder_form.py` — the `Run at` `Input` placeholder + the "A local time like {…}" hint (and the parse-error/preview copy).
+- `definition_detail.py:1286` (example) and `:1627` (error copy).
+
+A `grep` for any `YYYY-MM-DD` literal across the reminder/automation forms and detail panes now returns nothing.
+
+**Live verification** (tmux, current dev, 2026-09-06): the `Run at` placeholder rendered "2026-09-13 09:00" (7 days ahead — future), and the hint read "A local time like 2026-09-13 09:00, or full ISO-8601 with offset."
+
+**Test.** The helper had no direct coverage; added `Tests/Scheduling/test_example_run_at_text.py` pinning that the example is always in the future, has the shared `days_ahead` shape, and is not a fixed literal.
+
+**Files:** `Tests/Scheduling/test_example_run_at_text.py` (regression test).

--- a/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
+++ b/tldw_chatbook/UI/Screens/scheduling/schedules_workbench.py
@@ -4379,7 +4379,24 @@ class SchedulesWorkbench(BaseAppScreen):
                     "empty", "Local only — no server connection"
                 )
             elif getattr(service, "server_reachable", True) is None:
-                self._sync_header_status("loading", "Checking sync status…")
+                # task-31798: `server_reachable` stays `None` ONLY after the
+                # mount-time probe hit `ServerClientPolicyError` -- the local
+                # runtime policy refused the capabilities round trip before it
+                # ever reached the wire (a fresh LOCAL profile whose
+                # placeholder `[tldw_api]` URL makes `active_server_id` truthy).
+                # That path always sets `server_permission_denied`, so it is
+                # the exact signal for "the probe COMPLETED and could not
+                # establish a usable server connection" as opposed to "a probe
+                # is still genuinely in flight". Left un-distinguished, the
+                # header sat on the transient "Checking sync status…" copy
+                # forever while the footer correctly read local-only; resolve
+                # it to the same local-only status the footer shows.
+                if getattr(service, "server_permission_denied", False):
+                    self._sync_header_status(
+                        "empty", "Local only — no server connection"
+                    )
+                else:
+                    self._sync_header_status("loading", "Checking sync status…")
             else:
                 self._sync_header_status(
                     "empty", "Server configured but not reachable"


### PR DESCRIPTION
## Summary

Close-out for three P3 findings from the 2026-09-05 Schedules pre-release live UAT.

### TASK-31798 — header stuck on "Checking sync status…" (FIX)
On a fresh **local** profile the destination header sat on its compose-time "Checking sync status…" seed indefinitely, while the footer correctly read "Local schedules — no scheduling server connected; sync is off."

**Root cause:** the shipped placeholder `[tldw_api] base_url = http://127.0.0.1:8000` makes `runtime_state.active_server_id` truthy even in local mode. `on_mount` kicks the reachability probe, which in local mode raises `ServerClientPolicyError` — a path that deliberately leaves `server_reachable = None` (only recording `server_permission_denied = True`). `_refresh_owner_select` read `server_reachable is None` as "a probe is still in flight" → permanent "Checking sync status…".

**Fix:** inside the `not server_available` / `server_reachable is None` branch, use the existing honest `service.server_permission_denied` signal to tell "probe still pending" from "probe completed, no usable connection" (the policy-refused path is the *only* one that leaves reachable `None`, and it always sets permission-denied). When set, resolve to `"Local only — no server connection"` — matching the footer. The genuinely-pending window still paints "Checking sync status…", so `test_header_paints_checking_not_a_false_unreachable_during_mount_probe` is unaffected.

### TASK-31799 — first queue row truncated to header width (ALREADY FIXED on dev + regression guard)
No longer reproduces on current dev — verified both in-harness (real empty→first-reminder create flow) and live in tmux (first row shows the full title/details, not the "UAT f"/"One-tim" clip). Added a regression test asserting the measured column width **and** painted output so it can't silently regress.

### TASK-31800 — hardcoded past example datetime (ALREADY FIXED on dev + regression guard)
The literal was replaced by `example_run_at_text(days_ahead=7)` in #2454 (never-in-the-past, all three flagged sites). Live-confirmed the placeholder renders a future date (`2026-09-13 09:00`). Added a unit test pinning the example is always future.

## Testing
- `Tests/UI/test_schedules_workbench.py` — full file green (168), incl. two new tests.
- `Tests/Scheduling/test_example_run_at_text.py` — new, green.
- `./scripts/preflight.sh` — all derived-artifact checks pass.
- Live tmux verification on an isolated scratch profile (current dev).

## Note (pre-existing, not from this PR)
`Tests/UI/test_schedules_terminology.py::test_no_bare_reminder_noun_in_schedules_screen_copy` fails on current dev because of copy in `task_detail.py:457` (`_REMINDER_NOTIFICATIONS_TOOLTIP`, introduced by #2454) — untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Schedules destination header so it no longer gets stuck on "Checking sync status…" for local profiles without a scheduling server, and adds regression guards for two UAT findings already fixed on dev.

**Bug Fixes**
- The header now resolves to "Local only — no server connection" when the reachability probe completes without a usable connection.
- A companion test pins that an unresolved probe (no permission denial) keeps the transient "Checking sync status…" state.

**Regression Guards**
- An end-to-end test drives the empty→first-row queue create flow and asserts column width and painted output.
- A unit test pins that the run-at example is always in the future; a frozen clock prevents midnight-boundary flakiness.

<sup>Written for commit 5cdde05f77372a77e954b31ee5139cbeb9d72822. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2463?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

