### PR TITLE
fix(library): re-key speaker-legend CSS to classes (Perf Guard bare-type ratchet)

### DIFF
--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -485,11 +485,13 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         width: 100%;
         height: auto;
     }
-    .library-media-speaker-row Static {
+    /* Class-keyed (not `.row Static`): ancestor-scoped bare-type subjects
+     * are ratcheted by test_textual_css_fastpath (ADR-097). */
+    Static.library-media-speaker-label {
         width: auto;
         min-width: 0;
     }
-    .library-media-speaker-row Input {
+    Input.library-media-speaker-input {
         width: 1fr;
     }
     """
@@ -1742,10 +1744,12 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                                         label,
                                         id=f"library-media-speaker-label-{cluster_id}",
                                         markup=False,
+                                        classes="library-media-speaker-label",
                                     ),
                                     Input(
                                         placeholder="Rename…",
                                         id=f"library-media-speaker-input-{cluster_id}",
+                                        classes="library-media-speaker-input",
                                     ),
                                     classes="library-media-speaker-row",
                                 )

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2905,11 +2905,13 @@
         width: 100%;
         height: auto;
     }
-    LibraryMediaCanvas .library-media-speaker-row Static {
+    /* Class-keyed (not `.row Static`): ancestor-scoped bare-type subjects
+     * are ratcheted by test_textual_css_fastpath (ADR-097). */
+    LibraryMediaCanvas Static.library-media-speaker-label {
         width: auto;
         min-width: 0;
     }
-    LibraryMediaCanvas .library-media-speaker-row Input {
+    LibraryMediaCanvas Input.library-media-speaker-input {
         width: 1fr;
     }
 

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2575,6 +2575,8 @@
      * width 100%, which inside a row Horizontal would blow the label off
      * to the side. */
 
+    /* Class-keyed (not `.row Static`): ancestor-scoped bare-type subjects
+     * are ratcheted by test_textual_css_fastpath (ADR-097). */
 
 
 


### PR DESCRIPTION
Follow-up to #2456. The speaker-legend rows used `.library-media-speaker-row Static` and `... Input`, two ancestor-scoped bare-type-subject rules, which pushed the Perf Guard CSS ratchet (`test_ancestor_scoped_bare_type_rule_count_is_a_ratchet`) to 276 against its 274 limit on dev. Re-keyed to `Static.library-media-speaker-label` / `Input.library-media-speaker-input` with the classes set in `compose()`, exactly as the ratchet's guidance prescribes; the widget-defaults bundle is regenerated. Ratchet test, speaker-rename tests, and `./scripts/preflight.sh` all pass. No behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-keys the speaker-legend CSS selectors from ancestor-scoped bare-type rules to class-based rules, keeping the Perf Guard CSS ratchet within its limit. No behavior change; all tests pass.

<sup>Written for commit 6543dc814b033da4b2210b79d3e6f7eb9903f835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

