### PR TITLE
feat(console): More-menu summarize / transcript-up-to-here note actions (TASK-31759)

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2535,8 +2535,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 13,
-      "diagnostic_digest": "dbc82a289e52f7a3fbb9",
+      "call_count": 14,
+      "diagnostic_digest": "6ffafd40c155704dfbd2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/message.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11462,6 +11462,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 35,
     "task_492_calls": 1347,
-    "task_494_calls": 7668
+    "task_494_calls": 7669
   }
 }

--- a/Tests/Chat/test_console_message_actions.py
+++ b/Tests/Chat/test_console_message_actions.py
@@ -121,6 +121,8 @@ def test_assistant_message_actions_include_required_order():
         "--->",
         "Feedback",
         "🗑",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
 
 
@@ -164,6 +166,8 @@ def test_streaming_assistant_message_shows_completed_actions_disabled_with_reaso
         "--->",
         "Feedback",
         "🗑",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -192,6 +196,8 @@ def test_pending_assistant_message_shows_completed_actions_disabled_with_reasons
         "--->",
         "Feedback",
         "🗑",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
     assert all(action.enabled is False for action in actions)
     assert all(action.disabled_reason for action in actions)
@@ -279,6 +285,8 @@ def test_variant_action_labels_use_symbolic_navigation():
         "--->",
         "Feedback",
         "🗑",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
 
 
@@ -359,8 +367,11 @@ def test_failed_action_labels_offer_retry_instead_of_continue():
 
     assert "retry" in action_ids
     assert "continue" not in action_ids
-    assert " ".join(labels) == "Copy Edit Save as... Fork Retry 👍 👎 🗑"
-    assert len(" ".join(labels)) <= 52
+    assert " ".join(labels) == (
+        "Copy Edit Save as... Fork Retry 👍 👎 🗑 "
+        "Summarize up to here as note Save transcript up to here as note"
+    )
+    assert len(" ".join(labels)) <= 120
 
 
 def test_copy_action_returns_clipboard_text():
@@ -477,6 +488,8 @@ def test_regression_no_generation_kwargs_matches_text_sibling_gating():
         "--->",
         "Feedback",
         "🗑",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
     by_id = {action.action_id: action for action in actions}
     assert by_id["variant-previous"].enabled is True
@@ -985,6 +998,8 @@ def test_speak_action_swaps_to_stop_when_message_is_speaking():
         "continue",
         "feedback",
         "delete",
+        "summarize-note",
+        "save-transcript-note",
     ]
 
 
@@ -1102,6 +1117,8 @@ def test_original_attempt_is_an_exceptional_diagnostic_in_more() -> None:
         "feedback-up",
         "feedback-down",
         "delete",
+        "summarize-note",
+        "save-transcript-note",
     )
     assert groups.media == ()
 
@@ -1484,6 +1501,8 @@ def test_action_groups_separate_primary_overflow_and_media_actions() -> None:
         "Helpful",
         "Not helpful",
         "Delete",
+        "Summarize up to here as note",
+        "Save transcript up to here as note",
     ]
     assert [action.action_id for action in groups.media] == [
         "variant-previous",
@@ -1570,6 +1589,8 @@ def test_user_and_stopped_assistant_action_groups_are_exact(
         "feedback-up",
         "feedback-down",
         "delete",
+        "summarize-note",
+        "save-transcript-note",
     )
     assert groups.media == ()
 
@@ -1606,6 +1627,8 @@ def test_video_actions_are_an_exact_separate_media_group() -> None:
         "feedback-up",
         "feedback-down",
         "delete",
+        "summarize-note",
+        "save-transcript-note",
     )
     assert tuple(action.action_id for action in groups.media) == (
         "video-play",

--- a/Tests/Chat/test_console_note_span_actions.py
+++ b/Tests/Chat/test_console_note_span_actions.py
@@ -1,0 +1,327 @@
+"""Controller-level tests for the TASK-31759 More-menu note actions.
+
+Covers ``ConsoleChatController.build_transcript_note`` and
+``summarize_span_as_note``: span slicing (inclusive, active-path only,
+USER/ASSISTANT rows), note formatting, gates, and the core contract that
+the summarize path is STATELESS with respect to compaction -- no attempt
+ledger rows, no context-summary boundary move. Reuses the fake-gateway
+harness shape from ``test_console_rewind_summarize.py``.
+"""
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_controller import (
+    ConsoleChatController,
+    ConsoleNoteDraft,
+    ConsoleSubmitResult,
+)
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_provider_gateway import (
+    AuxiliaryCompletionResult,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.Chat.provider_usage import ProviderUsage
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from Tests.console_provider_doubles import provider_resolution
+
+
+class NoteSummaryGateway:
+    """Fake gateway capturing the auxiliary summary call."""
+
+    def __init__(self, summary: str = "NOTE SUMMARY", ready: bool = True) -> None:
+        self.summary = summary
+        self.ready = ready
+        self.captured_auxiliary = None
+        self.calls = 0
+
+    async def resolve_for_send(self, selection):
+        destination = provider_resolution(
+            ready=True,
+            provider="llama_cpp",
+            model="test-model",
+            base_url="http://127.0.0.1:9099",
+        ).resolved_destination
+        return ConsoleProviderResolution(
+            ready=self.ready,
+            provider="llama_cpp",
+            model="test-model",
+            base_url="http://127.0.0.1:9099",
+            max_tokens=512,
+            visible_copy="" if self.ready else "Provider blocked: no key.",
+            resolved_destination=destination if self.ready else None,
+        )
+
+    async def complete_auxiliary(self, request):
+        self.calls += 1
+        self.captured_auxiliary = request
+        return AuxiliaryCompletionResult(
+            provider=request.resolution.provider,
+            model=request.resolution.model or "test-model",
+            text=self.summary,
+            usage=ProviderUsage(
+                uncached_input=20,
+                output=5,
+                provider=request.resolution.provider,
+                model=request.resolution.model or "test-model",
+            ),
+        )
+
+    async def stream_chat(self, resolution, messages, **kwargs):  # pragma: no cover
+        yield ""
+
+
+def _note_controller(tmp_path, *, gateway=None):
+    db = CharactersRAGDB(tmp_path / "note-span.sqlite", "note-span")
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    session = store.create_session()
+    store.persist_session_if_needed(session.id)
+    resolved_gateway = gateway or NoteSummaryGateway()
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=resolved_gateway,
+    )
+    return controller, store, session, resolved_gateway, db
+
+
+def _seed_rows(store, session_id):
+    """U1/A1/U2/A2 then a TOOL row then U3/A3; returns the appended rows."""
+    rows = []
+    for role, content in (
+        (ConsoleMessageRole.USER, "first question"),
+        (ConsoleMessageRole.ASSISTANT, "first answer"),
+        (ConsoleMessageRole.USER, "second question"),
+        (ConsoleMessageRole.ASSISTANT, "second answer"),
+        (ConsoleMessageRole.TOOL, "tool noise"),
+        (ConsoleMessageRole.USER, "third question"),
+        (ConsoleMessageRole.ASSISTANT, "third answer"),
+    ):
+        rows.append(store.append_message(session_id, role=role, content=content))
+    return tuple(rows)
+
+
+@pytest.mark.asyncio
+async def test_build_transcript_note_is_inclusive_and_user_assistant_only(
+    tmp_path,
+):
+    controller, store, session, _gateway, _db = _note_controller(tmp_path)
+    rows = _seed_rows(store, session.id)
+
+    draft = controller.build_transcript_note(rows[3].id)
+
+    assert isinstance(draft, ConsoleNoteDraft)
+    assert draft.title == "Transcript: first question"
+    assert draft.content.startswith("> Generated: ")
+    assert "**User:** first question" in draft.content
+    assert "**Assistant:** first answer" in draft.content
+    assert "**Assistant:** second answer" in draft.content
+    # Inclusive boundary: nothing AFTER the selected row, and the TOOL row
+    # never appears.
+    assert "third" not in draft.content
+    assert "tool noise" not in draft.content
+
+
+@pytest.mark.asyncio
+async def test_build_transcript_note_accepts_assistant_target(tmp_path):
+    controller, store, session, _gateway, _db = _note_controller(tmp_path)
+    rows = _seed_rows(store, session.id)
+
+    draft = controller.build_transcript_note(rows[6].id)
+
+    assert isinstance(draft, ConsoleNoteDraft)
+    assert "**Assistant:** third answer" in draft.content
+
+
+@pytest.mark.asyncio
+async def test_note_actions_block_off_path_and_unknown_targets(tmp_path):
+    controller, store, session, _gateway, _db = _note_controller(tmp_path)
+    _rows = _seed_rows(store, session.id)
+
+    blocked_transcript = controller.build_transcript_note("no-such-message")
+    assert isinstance(blocked_transcript, ConsoleSubmitResult)
+    assert blocked_transcript.accepted is False
+    assert blocked_transcript.visible_copy
+
+    blocked_summary = await controller.summarize_span_as_note("no-such-message")
+    assert isinstance(blocked_summary, ConsoleSubmitResult)
+    assert blocked_summary.accepted is False
+    assert blocked_summary.visible_copy
+
+
+@pytest.mark.asyncio
+async def test_summarize_span_as_note_returns_draft_without_compaction_writes(
+    tmp_path,
+):
+    controller, store, session, gateway, db = _note_controller(tmp_path)
+    rows = _seed_rows(store, session.id)
+
+    draft = await controller.summarize_span_as_note(rows[3].id)
+
+    assert isinstance(draft, ConsoleNoteDraft)
+    assert draft.title == "Summary: first question"
+    assert "NOTE SUMMARY" in draft.content
+    assert draft.content.startswith("> Generated: ")
+    # The auxiliary call carried the note-summarize system prompt and the
+    # span text (inclusive, tool-free) as the user message.
+    assert gateway.calls == 1
+    sent = list(gateway.captured_auxiliary.messages)
+    assert sent[0]["role"] == "system"
+    assert "saved as a note" in sent[0]["content"]
+    user_text = sent[1]["content"]
+    assert "User: first question" in user_text
+    assert "Assistant: second answer" in user_text
+    assert "third" not in user_text
+    assert "tool noise" not in user_text
+    # Stateless contract: the rewind context summary and boundary are
+    # untouched, and no auxiliary attempt ledger rows were written.
+    assert store.session_context_summary(session.id) == (None, None)
+    with db.get_connection() as connection:
+        count = connection.execute(
+            "SELECT COUNT(*) FROM console_auxiliary_attempts"
+        ).fetchone()[0]
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_summarize_span_as_note_blocks_when_provider_not_ready(tmp_path):
+    controller, store, session, _gateway, _db = _note_controller(
+        tmp_path, gateway=NoteSummaryGateway(ready=False)
+    )
+    rows = _seed_rows(store, session.id)
+
+    blocked = await controller.summarize_span_as_note(rows[3].id)
+
+    assert isinstance(blocked, ConsoleSubmitResult)
+    assert blocked.accepted is False
+    assert "Provider blocked" in blocked.visible_copy
+
+
+@pytest.mark.asyncio
+async def test_summarize_span_as_note_blocks_oversized_span(tmp_path, monkeypatch):
+    controller, store, session, gateway, _db = _note_controller(tmp_path)
+    rows = _seed_rows(store, session.id)
+    # Shrink the span budget so the seeded span blows past it; the action
+    # must BLOCK (user-visible copy), never silently trim oldest turns --
+    # a note that quietly omits turns is worse than no note.
+    monkeypatch.setattr(controller, "_SUMMARY_SPAN_TOKEN_BUDGET", 3)
+
+    blocked = await controller.summarize_span_as_note(rows[3].id)
+
+    assert isinstance(blocked, ConsoleSubmitResult)
+    assert blocked.accepted is False
+    assert "too large" in blocked.visible_copy
+    assert gateway.calls == 0
+
+# --- UI dispatch wiring (TASK-31759) ---------------------------------------
+
+
+def _build_screen():
+    from Tests.UI.app_factory import _build_test_app
+    from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
+
+    app = _build_test_app()
+    app.app_config["chat_defaults"] = {"provider": "llama_cpp", "model": "test-model"}
+    app.app_config["api_settings"] = {
+        "llama_cpp": {"api_url": "http://127.0.0.1:9099", "model": "test-model"}
+    }
+    app.chat_api_provider_value = "llama_cpp"
+    app.chat_api_model_value = "test-model"
+    return app, ChatScreen(app)
+
+
+def _dispatch_event(action_id: str, message_id: str):
+    from types import SimpleNamespace
+
+    return SimpleNamespace(
+        button=SimpleNamespace(
+            id=f"console-message-action-{action_id}-{message_id}"
+        ),
+        stop=lambda: None,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action_id", ["summarize-note", "save-transcript-note"])
+async def test_note_actions_dispatch_one_exclusive_note_worker(action_id):
+    """Each More-menu note action routes to the shared console-note-actions
+    worker group (never console-run, so it can never cancel a live stream)."""
+    import asyncio
+    from types import SimpleNamespace
+
+    app, screen = _build_screen()
+    store = screen._ensure_console_chat_store()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="q")
+    completed = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="done."
+    )
+
+    spawned = []
+
+    def fake_run_worker(work, **kwargs):
+        spawned.append(kwargs)
+        if asyncio.iscoroutine(work):
+            work.close()
+        return SimpleNamespace(cancel=lambda: None)
+
+    screen.run_worker = fake_run_worker
+
+    handled = await screen.handle_console_message_action(
+        _dispatch_event(action_id, completed.id)
+    )
+
+    assert handled is True
+    assert len(spawned) == 1
+    assert spawned[0].get("group") == "console-note-actions"
+    assert spawned[0].get("exclusive") is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action_id", ["summarize-note", "save-transcript-note"])
+async def test_note_actions_mid_run_notify_instead_of_summarizing(action_id):
+    """With a run streaming, the note actions must not reach a provider
+    call: the worker resolves to the controller's active-run rejection and
+    surfaces it as a notice."""
+    import asyncio
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Chat.console_chat_models import (
+        ConsoleRunState,
+        ConsoleRunStatus,
+    )
+
+    app, screen = _build_screen()
+    store = screen._ensure_console_chat_store()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="q")
+    completed = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="done."
+    )
+    notices: list[str] = []
+
+    tasks: list[asyncio.Future] = []
+
+    def capture_worker(work, **kwargs):
+        notices.append("spawned")
+        tasks.append(asyncio.ensure_future(work))
+        return SimpleNamespace(cancel=lambda: None)
+
+    screen.run_worker = capture_worker
+    app.notify = lambda message, **kwargs: notices.append(str(message))
+    screen._ensure_console_chat_controller()._set_run_state(
+        ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response.")
+    )
+
+    handled = await screen.handle_console_message_action(
+        _dispatch_event(action_id, completed.id)
+    )
+
+    assert handled is True
+    for task in tasks:
+        await task
+    # The worker ran to completion and the controller's run gate produced
+    # the user-visible rejection.
+    assert any("run" in note.lower() for note in notices), notices

--- a/Tests/Chat/test_console_note_span_actions.py
+++ b/Tests/Chat/test_console_note_span_actions.py
@@ -9,6 +9,7 @@ harness shape from ``test_console_rewind_summarize.py``.
 """
 
 import asyncio
+from types import SimpleNamespace
 
 import pytest
 
@@ -325,3 +326,105 @@ async def test_note_actions_mid_run_notify_instead_of_summarizing(action_id):
     # The worker ran to completion and the controller's run gate produced
     # the user-visible rejection.
     assert any("run" in note.lower() for note in notices), notices
+
+
+# --- Review follow-ups (Qodo on PR #2467) -----------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("action_id", ["summarize-note", "save-transcript-note"])
+async def test_note_actions_persist_through_notes_service(action_id):
+    """End-to-end (review follow-up): driving each action's worker against
+    a stubbed notes service persists the draft with the expected title,
+    content, scope, keywords, and the app's configured notes identity."""
+    app, screen = _build_screen()
+    app.notes_user_id = "notes-owner-1"
+    saved: list[dict] = []
+
+    class StubNotesService:
+        async def save_note(self, **kwargs):
+            saved.append(kwargs)
+            return {"note_id": "n1"}
+
+    app.notes_scope_service = StubNotesService()
+    screen._ensure_console_chat_controller()
+    store = screen._ensure_console_chat_store()
+    session = store.ensure_session()
+    store.append_message(session.id, role=ConsoleMessageRole.USER, content="the question")
+    completed = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="the answer"
+    )
+    # The save tail runs through run_worker (it needs a live Textual app
+    # context); capture the coroutine instead so the save can be awaited
+    # and asserted here.
+    work: list = []
+    scheduled: list = []
+
+    def capture_worker(coroutine, **kwargs):
+        scheduled.append(kwargs)
+        work.append(coroutine)
+        return SimpleNamespace(cancel=lambda: None)
+
+    screen.run_worker = capture_worker
+    if action_id == "summarize-note":
+        # No live provider under the pytest app fixture (the stateless
+        # summary seam's contract is covered by the controller-level tests
+        # above); stub the controller boundary so this test exercises the
+        # save path end-to-end.
+        async def fake_summarize(message_id):
+            return ConsoleNoteDraft(
+                title="Summary: the question",
+                content="> Generated: test\n\nSTUB SUMMARY",
+            )
+
+        screen._ensure_console_chat_controller().summarize_span_as_note = (
+            fake_summarize
+        )
+
+    worker = (
+        screen._message._summarize_console_span_as_note(completed.id)
+        if action_id == "summarize-note"
+        else screen._message._save_console_transcript_as_note(completed.id)
+    )
+    await worker
+    assert len(scheduled) == 1
+    assert scheduled[0].get("group") == "console-note-actions"
+    for coroutine in work:
+        await coroutine
+
+    assert len(saved) == 1
+    call = saved[0]
+    assert call["scope"] == "local_note"
+    assert call["keywords"] == ["console"]
+    assert call["user_id"] == "notes-owner-1"
+    assert call["title"].startswith(
+        "Summary: " if action_id == "summarize-note" else "Transcript: "
+    )
+    if action_id == "summarize-note":
+        assert call["content"].startswith("> Generated: ")
+        assert "STUB SUMMARY" in call["content"]
+    else:
+        assert "**User:** the question" in call["content"]
+        assert "**Assistant:** the answer" in call["content"]
+
+
+@pytest.mark.asyncio
+async def test_oversized_span_blocks_at_the_real_budget(tmp_path):
+    """Review follow-up (bug fix): the budget check must see the UNTRIMMED
+    span. _build_summary_span_text silently drops oldest turns, so checking
+    after it could never fire; a >12k-token span must now block outright."""
+    controller, store, session, gateway, _db = _note_controller(tmp_path)
+    big = "word " * 13_000
+    store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content=big, persist=True
+    )
+    target = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="short", persist=True
+    )
+
+    blocked = await controller.summarize_span_as_note(target.id)
+
+    assert isinstance(blocked, ConsoleSubmitResult)
+    assert blocked.accepted is False
+    assert "too large" in blocked.visible_copy
+    assert gateway.calls == 0

--- a/backlog/tasks/task-31759 - Console-More-menu-summarize-up-to-here-as-note-save-transcript-up-to-here-as-note.md
+++ b/backlog/tasks/task-31759 - Console-More-menu-summarize-up-to-here-as-note-save-transcript-up-to-here-as-note.md
@@ -3,11 +3,11 @@ id: TASK-31759
 title: >-
   Console More-menu: summarize up to here as note + save transcript up to here
   as note
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-09-06 02:45'
-updated_date: '2026-09-06 02:45'
+updated_date: '2026-09-06 15:33'
 labels: []
 dependencies: []
 ---
@@ -20,13 +20,13 @@ Add two per-message actions to the Console message More-menu: (1) summarize the 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [x] More-menu on a completed USER/ASSISTANT message offers 'Summarize up to here as note' and 'Save transcript up to here as note'
-- [x] Summarize action uses a dedicated internal prompt (console.summarize_note) and a stateless provider call that does NOT write context_summary or move the rewind boundary
-- [x] Save action writes a role-prefixed Markdown transcript with provenance header, inclusive of the selected message, active-path only
-- [x] Both notes are created via notes_scope_service.save_note with keywords=['console']
-- [x] Oversized summarize spans are blocked with a user-visible notice (no silent truncation)
-- [x] Actions are blocked with a notice while a run is active; summarize requires a configured provider
-- [x] Unit tests cover action availability, dispatch, gates, note content, and no-compaction-side-effects
+- [x] #1 More-menu on a completed USER/ASSISTANT message offers 'Summarize up to here as note' and 'Save transcript up to here as note'
+- [x] #2 Summarize action uses a dedicated internal prompt (console.summarize_note) and a stateless provider call that does NOT write context_summary or move the rewind boundary
+- [x] #3 Save action writes a role-prefixed Markdown transcript with provenance header, inclusive of the selected message, active-path only
+- [x] #4 Both notes are created via notes_scope_service.save_note with keywords=['console']
+- [x] #5 Oversized summarize spans are blocked with a user-visible notice (no silent truncation)
+- [x] #6 Actions are blocked with a notice while a run is active; summarize requires a configured provider
+- [x] #7 Unit tests cover action availability, dispatch, gates, note content, and no-compaction-side-effects
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -42,11 +42,6 @@ Add two per-message actions to the Console message More-menu: (1) summarize the 
 
 ## Implementation Notes
 
-- **Approach**: Reused the existing origin/dev More-menu overflow (`_overflow_actions`) — the two actions are overflow-only entries behind the existing `More…` popup, dispatched via the pre-`dispatch()` interception pattern used by `save-as`. No new modal or menu widget.
-- **Stateless summarize seam**: `ConsoleCompactionService.summarize_span_to_text` wraps the existing `_summary_completion` (bounded, aux-model routed) without the attempt ledger, branch-memory admission, or boundary commit that `summarize_manual` always performs. Controller method `summarize_span_as_note` uses it with the new `console.summarize_note` prompt; the `/rewind` context summary and boundary are provably untouched (asserted in tests, including zero `console_auxiliary_attempts` rows).
-- **Span semantics**: active-path messages up to AND INCLUDING the selected message (USER or ASSISTANT target), skipping TOOL rows, failed rows, and empty rows. Oversized spans (> `_SUMMARY_SPAN_TOKEN_BUDGET`) block with a notice rather than silently trimming — a note must not quietly omit turns.
-- **Notes write**: both drafts flow through one shared `_save_console_note_draft` tail that mirrors `_save_console_message_as_note` (`notes_scope_service.save_note`, `scope=LOCAL_NOTE`, `keywords=["console"]`), running in the `console-note-actions` exclusive worker group (never `console-run`, so it cannot cancel a live stream).
-- **Gotcha found**: `_parse_console_message_action_button_id` has an explicit prefix table; the new action ids had to be registered there or presses fall through unhandled.
-- **Files modified**: `Internal_Prompts/console_prompts.py` (new prompt), `Chat/console_context_compaction.py` (stateless method), `Chat/console_chat_controller.py` (`ConsoleNoteDraft`, `_note_span_messages`, `_note_provenance_header`, `build_transcript_note`, `summarize_span_as_note`, `_NOTE_SUMMARY_OUTPUT_CAP`), `Chat/console_message_actions.py` (two `_COMPLETED_ACTIONS` + overflow entries), `UI/Console_Modules/message.py` (router interception, worker methods, parser prefixes), tests: `Tests/Chat/test_console_note_span_actions.py` (new, 10 tests) + expectation updates in `Tests/Chat/test_console_message_actions.py`.
-- **ADR check**: ADR required: no — no schema/sync/boundary changes; direct use of existing store/notes/compaction seams within existing surfaces.
-- **Verification**: targeted runs — `Tests/Chat/test_console_note_span_actions.py` (10 passed), `test_console_message_actions.py` (106), `test_console_rewind_summarize.py` + `test_internal_prompts_panel.py` (76), `test_console_context_compaction.py` (143), `test_console_run_gate.py` (in 334-run), chat-flow action subset (21). `Tests/UI/test_console_native_transcript.py` shows 31 pre-existing failures identical on clean origin/dev (verified via stash baseline) — not regressions. Full suite not run (per repo policy).
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on branch feat/console-more-note-actions (worktree ../tldw-chatbook-note-actions, based on origin/dev). See Implementation Notes in the task file; targeted tests green.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31759 - Console-More-menu-summarize-up-to-here-as-note-save-transcript-up-to-here-as-note.md
+++ b/backlog/tasks/task-31759 - Console-More-menu-summarize-up-to-here-as-note-save-transcript-up-to-here-as-note.md
@@ -1,0 +1,52 @@
+---
+id: TASK-31759
+title: >-
+  Console More-menu: summarize up to here as note + save transcript up to here
+  as note
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-09-06 02:45'
+updated_date: '2026-09-06 02:45'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add two per-message actions to the Console message More-menu: (1) summarize the active-path conversation span up to and including the selected message into a note, and (2) save the formatted transcript of that span as a note. Both write to the notes library via notes_scope_service and are independent of the /rewind compaction state.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] More-menu on a completed USER/ASSISTANT message offers 'Summarize up to here as note' and 'Save transcript up to here as note'
+- [x] Summarize action uses a dedicated internal prompt (console.summarize_note) and a stateless provider call that does NOT write context_summary or move the rewind boundary
+- [x] Save action writes a role-prefixed Markdown transcript with provenance header, inclusive of the selected message, active-path only
+- [x] Both notes are created via notes_scope_service.save_note with keywords=['console']
+- [x] Oversized summarize spans are blocked with a user-visible notice (no silent truncation)
+- [x] Actions are blocked with a notice while a run is active; summarize requires a configured provider
+- [x] Unit tests cover action availability, dispatch, gates, note content, and no-compaction-side-effects
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Register console.summarize_note internal prompt
+2. Add public stateless summarize_span_to_text on the console_context_compaction service
+3. Controller: span slicing helpers + transcript-note builder + summarize_span_as_note
+4. Action service: two overflow entries + dispatch branches in the message controller
+5. UI wiring: button-id parser entries, exclusive workers, transient notices
+6. Tests mirroring existing console action/summarize suites
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+- **Approach**: Reused the existing origin/dev More-menu overflow (`_overflow_actions`) — the two actions are overflow-only entries behind the existing `More…` popup, dispatched via the pre-`dispatch()` interception pattern used by `save-as`. No new modal or menu widget.
+- **Stateless summarize seam**: `ConsoleCompactionService.summarize_span_to_text` wraps the existing `_summary_completion` (bounded, aux-model routed) without the attempt ledger, branch-memory admission, or boundary commit that `summarize_manual` always performs. Controller method `summarize_span_as_note` uses it with the new `console.summarize_note` prompt; the `/rewind` context summary and boundary are provably untouched (asserted in tests, including zero `console_auxiliary_attempts` rows).
+- **Span semantics**: active-path messages up to AND INCLUDING the selected message (USER or ASSISTANT target), skipping TOOL rows, failed rows, and empty rows. Oversized spans (> `_SUMMARY_SPAN_TOKEN_BUDGET`) block with a notice rather than silently trimming — a note must not quietly omit turns.
+- **Notes write**: both drafts flow through one shared `_save_console_note_draft` tail that mirrors `_save_console_message_as_note` (`notes_scope_service.save_note`, `scope=LOCAL_NOTE`, `keywords=["console"]`), running in the `console-note-actions` exclusive worker group (never `console-run`, so it cannot cancel a live stream).
+- **Gotcha found**: `_parse_console_message_action_button_id` has an explicit prefix table; the new action ids had to be registered there or presses fall through unhandled.
+- **Files modified**: `Internal_Prompts/console_prompts.py` (new prompt), `Chat/console_context_compaction.py` (stateless method), `Chat/console_chat_controller.py` (`ConsoleNoteDraft`, `_note_span_messages`, `_note_provenance_header`, `build_transcript_note`, `summarize_span_as_note`, `_NOTE_SUMMARY_OUTPUT_CAP`), `Chat/console_message_actions.py` (two `_COMPLETED_ACTIONS` + overflow entries), `UI/Console_Modules/message.py` (router interception, worker methods, parser prefixes), tests: `Tests/Chat/test_console_note_span_actions.py` (new, 10 tests) + expectation updates in `Tests/Chat/test_console_message_actions.py`.
+- **ADR check**: ADR required: no — no schema/sync/boundary changes; direct use of existing store/notes/compaction seams within existing surfaces.
+- **Verification**: targeted runs — `Tests/Chat/test_console_note_span_actions.py` (10 passed), `test_console_message_actions.py` (106), `test_console_rewind_summarize.py` + `test_internal_prompts_panel.py` (76), `test_console_context_compaction.py` (143), `test_console_run_gate.py` (in 334-run), chat-flow action subset (21). `Tests/UI/test_console_native_transcript.py` shows 31 pre-existing failures identical on clean origin/dev (verified via stash baseline) — not regressions. Full suite not run (per repo policy).

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -2695,6 +2695,20 @@ class ConsoleSubmitResult:
 
 
 @dataclass(frozen=True)
+class ConsoleNoteDraft:
+    """A ready-to-save note built from the active-path transcript span.
+
+    TASK-31759: produced by the More-menu "up to here" note actions. The
+    controller builds title/content; the screen-side caller owns the
+    ``notes_scope_service.save_note`` write (the controller has no note
+    library seam).
+    """
+
+    title: str
+    content: str
+
+
+@dataclass(frozen=True)
 class ImpersonateResult:
     """Outcome of an Impersonate draft request (task-1683 / Qodo #1160).
 
@@ -2932,6 +2946,12 @@ class ConsoleChatController:
 
     #: Shared guidance cap for summary and impersonation transcript inputs.
     _SUMMARY_SPAN_TOKEN_BUDGET = 12000
+
+    #: Output cap for the More-menu "summarize as note" side call
+    #: (TASK-31759). Modest on purpose: notes are reference material, and
+    #: the stateless call bypasses the policy-merged ``summary_max_tokens``
+    #: used by compaction.
+    _NOTE_SUMMARY_OUTPUT_CAP = 2048
 
     #: TASK-21145 (UAT H-3): "Validating provider." must always reach a
     #: terminal state — the UAT run sat on it 30s+ with no error, no retry,
@@ -15461,6 +15481,168 @@ class ConsoleChatController:
             rows = rows[1:]
             body = assemble(rows)
         return body
+
+    def _note_span_messages(
+        self, session_id: str, message_id: str
+    ) -> list[ConsoleChatMessage] | ConsoleSubmitResult:
+        """Active-path USER/ASSISTANT rows up to AND INCLUDING message_id.
+
+        Unlike the manual summarize planning path, the target may be a USER
+        or an ASSISTANT message (the More-menu action reads "up to here"),
+        and no persistence requirement applies -- an unsaved conversation is
+        still a valid transcript to save or summarize into a note.
+        """
+        if message_id not in self.store.active_path_message_ids(session_id):
+            return self._summarize_block(
+                session_id, "Switch to that branch before saving a note."
+            )
+        try:
+            self.store.get_message(message_id)
+        except KeyError:
+            return self._summarize_block(
+                session_id, "Switch to that branch before saving a note."
+            )
+        span: list[ConsoleChatMessage] = []
+        for message in self.store.messages_for_session(session_id):
+            if message.role not in (ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT):
+                continue
+            if getattr(message, "status", None) == "failed":
+                continue
+            if not (message.content or "").strip():
+                continue
+            span.append(message)
+            if message.id == message_id:
+                return span
+        return self._summarize_block(
+            session_id, "The selected conversation range is not ready."
+        )
+
+    def _note_provenance_header(self, session_id: str, message_id: str) -> str:
+        """Provenance block prefixed to note content (TASK-31759)."""
+        conversation_id = ""
+        owner = next(
+            (item for item in self.store.sessions() if item.id == session_id), None
+        )
+        if owner is not None and owner.persisted_conversation_id is not None:
+            conversation_id = str(owner.persisted_conversation_id)
+        generated = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
+        parts = [f"Generated: {generated}"]
+        if conversation_id:
+            parts.append(f"Conversation: {conversation_id}")
+        parts.append(f"Up to message: {message_id}")
+        return "\n".join(f"> {part}" for part in parts)
+
+    def build_transcript_note(self, message_id: str) -> ConsoleNoteDraft | ConsoleSubmitResult:
+        """Format the transcript up to and including message_id as a note."""
+        active_rejection = self._active_run_rejection()
+        if active_rejection is not None:
+            return active_rejection
+        session_id = self.store.active_session_id
+        if session_id is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
+        span = self._note_span_messages(session_id, message_id)
+        if isinstance(span, ConsoleSubmitResult):
+            return span
+        title = "Transcript: " + (span[0].content.strip().splitlines() or [""])[0][:48]
+        body_lines = [
+            f"**{'User' if m.role is ConsoleMessageRole.USER else 'Assistant'}:** {m.content}"
+            for m in span
+        ]
+        content = (
+            self._note_provenance_header(session_id, message_id)
+            + "\n\n"
+            + "\n\n".join(body_lines)
+        )
+        return ConsoleNoteDraft(title=title, content=content)
+
+    async def summarize_span_as_note(
+        self, message_id: str
+    ) -> ConsoleNoteDraft | ConsoleSubmitResult:
+        """Summarize the span up to message_id into note-ready text.
+
+        TASK-31759. State-by-state separate from the manual compaction
+        path: no attempt ledger, no branch-memory admission, and the
+        session context summary / rewind boundary are never touched. An
+        oversized span is BLOCKED (matching the manual path's contract)
+        rather than silently trimmed, because a user-facing note must not
+        quietly omit turns.
+        """
+        active_rejection = self._active_run_rejection()
+        if active_rejection is not None:
+            return active_rejection
+        session_id = self.store.active_session_id
+        if session_id is None:
+            return ConsoleSubmitResult(False, False, "No active Console session.")
+        service = self._compaction_service
+        if service is None:
+            return self._summarize_block(
+                session_id, "Summarization is unavailable in this session."
+            )
+        span = self._note_span_messages(session_id, message_id)
+        if isinstance(span, ConsoleSubmitResult):
+            return span
+        configuration = self.resolve_turn_configuration_snapshot(session_id)
+        try:
+            resolution = await self._resolve_for_send_bounded(
+                configuration.provider_selection
+            )
+        except Exception:
+            return self._summarize_block(
+                session_id,
+                "The active provider could not be prepared for summarization.",
+            )
+        if not getattr(resolution, "ready", False):
+            return self._summarize_block(
+                session_id,
+                self._blocked_visible_copy(getattr(resolution, "visible_copy", "")),
+            )
+        resolution = await self._auxiliary_compaction_resolution(
+            configuration.provider_selection, resolution
+        )
+        span_text = self._build_summary_span_text(span, None, model=resolution.model or "")
+        model = resolution.model or ""
+        if (
+            count_console_messages_tokens(
+                [{"role": "user", "content": span_text}], model
+            )
+            > self._SUMMARY_SPAN_TOKEN_BUDGET
+        ):
+            return self._summarize_block(
+                session_id,
+                "That span is too large to summarize in one call. "
+                "Choose an earlier message.",
+            )
+        prompt_text = get_internal_prompt("console.summarize_note")
+        try:
+            summary = await service.summarize_span_to_text(
+                resolution=resolution,
+                messages=(
+                    {"role": "system", "content": prompt_text},
+                    {"role": "user", "content": span_text},
+                ),
+                max_output_tokens=self._NOTE_SUMMARY_OUTPUT_CAP,
+            )
+        except asyncio.CancelledError:
+            raise
+        except TimeoutError:
+            return self._summarize_block(
+                session_id, "Summarization timed out before a note could be saved."
+            )
+        except Exception:
+            return self._summarize_block(
+                session_id, "Summarization failed before a note could be saved."
+            )
+        if not summary:
+            return self._summarize_block(
+                session_id, "Summarization returned nothing to save."
+            )
+        title = "Summary: " + (span[0].content.strip().splitlines() or [""])[0][:48]
+        content = (
+            self._note_provenance_header(session_id, message_id)
+            + "\n\n"
+            + summary
+        )
+        return ConsoleNoteDraft(title=title, content=content)
 
     async def impersonate_user_reply(self, session_id: str) -> "ImpersonateResult":
         """Draft the USER's next message with the session's current model.

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -15491,6 +15491,15 @@ class ConsoleChatController:
         or an ASSISTANT message (the More-menu action reads "up to here"),
         and no persistence requirement applies -- an unsaved conversation is
         still a valid transcript to save or summarize into a note.
+
+        Args:
+            session_id: The session whose transcript to slice.
+            message_id: The selected message bounding the span (inclusive).
+
+        Returns:
+            The span messages in transcript order, or a blocked
+            ``ConsoleSubmitResult`` when the message is off the active path
+            or no longer exists.
         """
         if message_id not in self.store.active_path_message_ids(session_id):
             return self._summarize_block(
@@ -15533,7 +15542,17 @@ class ConsoleChatController:
         return "\n".join(f"> {part}" for part in parts)
 
     def build_transcript_note(self, message_id: str) -> ConsoleNoteDraft | ConsoleSubmitResult:
-        """Format the transcript up to and including message_id as a note."""
+        """Format the transcript up to and including message_id as a note.
+
+        Args:
+            message_id: The selected message bounding the span (inclusive).
+
+        Returns:
+            A ``ConsoleNoteDraft`` carrying the note title and
+            role-prefixed Markdown content with a provenance header, or a
+            blocked ``ConsoleSubmitResult`` (no active session, active run,
+            or off-path/missing target).
+        """
         active_rejection = self._active_run_rejection()
         if active_rejection is not None:
             return active_rejection
@@ -15565,7 +15584,22 @@ class ConsoleChatController:
         session context summary / rewind boundary are never touched. An
         oversized span is BLOCKED (matching the manual path's contract)
         rather than silently trimmed, because a user-facing note must not
-        quietly omit turns.
+        quietly omit turns -- the span is counted UNTRIMMED before the
+        provider call (``_build_summary_span_text``'s oldest-turn trimming
+        is deliberately not used here).
+
+        Args:
+            message_id: The selected message bounding the span (inclusive).
+
+        Returns:
+            A ``ConsoleNoteDraft`` carrying the summary note title/content,
+            or a blocked ``ConsoleSubmitResult`` (active run, no session,
+            off-path/missing target, provider not ready, oversized span,
+            timeout, or provider failure).
+
+        Raises:
+            asyncio.CancelledError: Propagated unchanged when the caller's
+                task is cancelled, so cancellation is never swallowed.
         """
         active_rejection = self._active_run_rejection()
         if active_rejection is not None:
@@ -15599,7 +15633,14 @@ class ConsoleChatController:
         resolution = await self._auxiliary_compaction_resolution(
             configuration.provider_selection, resolution
         )
-        span_text = self._build_summary_span_text(span, None, model=resolution.model or "")
+        # Deliberately NOT _build_summary_span_text: that helper silently
+        # drops oldest turns to fit the budget, which would defeat the
+        # block-below check below (it would always see an already-fitting
+        # span) and quietly omit turns from a user-facing note.
+        span_text = "\n".join(
+            f"{'User' if m.role is ConsoleMessageRole.USER else 'Assistant'}: {m.content}"
+            for m in span
+        )
         model = resolution.model or ""
         if (
             count_console_messages_tokens(

--- a/tldw_chatbook/Chat/console_context_compaction.py
+++ b/tldw_chatbook/Chat/console_context_compaction.py
@@ -2398,6 +2398,28 @@ class ConsoleCompactionService:
                 memory=record,
             )
 
+    async def summarize_span_to_text(
+        self,
+        *,
+        resolution: ConsoleProviderResolution,
+        messages: tuple[Mapping[str, Any], ...],
+        max_output_tokens: int,
+    ) -> str:
+        """One stateless summary completion; no attempt ledger, no commit.
+
+        Serves user-facing "summarize into a note" actions that must not
+        touch compaction state: no auxiliary-attempt rows, no branch-memory
+        admission, no context-summary boundary move. Raises whatever the
+        bounded auxiliary call raises (e.g. TimeoutError) so the caller can
+        surface a notice.
+        """
+        completion, _engine = await self._summary_completion(
+            resolution=resolution,
+            messages=messages,
+            max_output_tokens=max_output_tokens,
+        )
+        return completion.text.strip()
+
     async def _summary_completion(
         self,
         *,

--- a/tldw_chatbook/Chat/console_context_compaction.py
+++ b/tldw_chatbook/Chat/console_context_compaction.py
@@ -2409,9 +2409,24 @@ class ConsoleCompactionService:
 
         Serves user-facing "summarize into a note" actions that must not
         touch compaction state: no auxiliary-attempt rows, no branch-memory
-        admission, no context-summary boundary move. Raises whatever the
-        bounded auxiliary call raises (e.g. TimeoutError) so the caller can
-        surface a notice.
+        admission, no context-summary boundary move.
+
+        Args:
+            resolution: The provider resolution to summarize with (an
+                auxiliary-model routing decision already applied by the
+                caller).
+            messages: The full provider message array (system prompt plus
+                transcript span) as immutable mappings.
+            max_output_tokens: Output cap for the completion.
+
+        Returns:
+            The stripped completion text.
+
+        Raises:
+            TimeoutError: The bounded auxiliary call exceeded
+                ``auxiliary_timeout_seconds``.
+            Exception: Whatever the provider gateway raises, so the caller
+                can surface a user-visible failure.
         """
         completion, _engine = await self._summary_completion(
             resolution=resolution,

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -782,6 +782,7 @@ class ConsoleMessageActionService:
                     )
                 )
             elif action.action_id.startswith("canvas-open"):
+                overflow.append(action)
             elif action.action_id in {"summarize-note", "save-transcript-note"}:
                 overflow.append(action)
         return tuple(overflow)

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -328,6 +328,12 @@ class ConsoleMessageActionService:
         ("continue", "--->"),
         ("feedback", "Feedback"),
         ("delete", "🗑"),
+        # TASK-31759: More-menu note actions over the active-path span up
+        # to and including the selected message. Overflow-only (never in
+        # ``_PRIMARY_ACTION_IDS``) and dispatched by the UI router before
+        # ``dispatch()`` -- same pattern as ``save-as``.
+        ("summarize-note", "Summarize up to here as note"),
+        ("save-transcript-note", "Save transcript up to here as note"),
     )
     #: TASK-1860: reveals the FULL tool result behind a truncated marker.
     #: Offered only for a TOOL marker that actually carries more than its
@@ -776,6 +782,7 @@ class ConsoleMessageActionService:
                     )
                 )
             elif action.action_id.startswith("canvas-open"):
+            elif action.action_id in {"summarize-note", "save-transcript-note"}:
                 overflow.append(action)
         return tuple(overflow)
 

--- a/tldw_chatbook/Internal_Prompts/console_prompts.py
+++ b/tldw_chatbook/Internal_Prompts/console_prompts.py
@@ -2,10 +2,11 @@
 """Native Console prompt specs.
 
 Registers the shared Console conversation-summary instruction used by both
-automatic conversation-memory compaction and `/rewind` "Summarize up to here".
-The transcript span is passed as untrusted user data at call time, so this
-prompt takes no placeholders. Editable in Settings like any other internal
-prompt.
+automatic conversation-memory compaction and `/rewind` "Summarize up to here",
+plus the user-facing note variant used by the Console message More-menu
+"Summarize up to here as note" action. The transcript span is passed as
+untrusted user data at call time, so these prompts take no placeholders.
+Editable in Settings like any other internal prompt.
 """
 
 from .catalog import PromptSpec, register
@@ -37,6 +38,37 @@ register(
             "The conversation transcript to summarize is supplied as the user "
             "message at call time; this prompt is the system instruction and "
             "takes no placeholders."
+        ),
+    )
+)
+
+register(
+    PromptSpec(
+        id="console.summarize_note",
+        subsystem="console",
+        title="Console summarize-to-note summary",
+        description=(
+            "Summarizes the conversation up to a selected message into a "
+            "readable note saved to the notes library via the Console "
+            "message More-menu action."
+        ),
+        used_in=(
+            "Chat/console_chat_controller.py (summarize_span_as_note)"
+        ),
+        default=(
+            "You are summarizing a conversation transcript for the user's "
+            "own reference; the summary will be saved as a note. Write a "
+            "clear, factual account of what was discussed and decided: the "
+            "user's goal, the key questions and answers, decisions made, "
+            "important facts, names, and values, and where things stand at "
+            "the end of the transcript. Use plain prose or short bullets as "
+            "content demands. Omit greetings and pleasantries. Do not "
+            "invent details that are not in the transcript."
+        ),
+        contract_note=(
+            "The conversation transcript to summarize is supplied as the "
+            "user message at call time; this prompt is the system "
+            "instruction and takes no placeholders."
         ),
     )
 )

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -116,7 +116,11 @@ from loguru import logger
 from rich.markup import escape as escape_markup
 from textual.widgets import Button
 
-from ...Chat.console_chat_controller import ConsoleChatController
+from ...Chat.console_chat_controller import (
+    ConsoleChatController,
+    ConsoleNoteDraft,
+    ConsoleSubmitResult,
+)
 from ...Chat.console_chat_models import (
     ConsoleChatMessage,
     ConsoleMessageRole,
@@ -1489,6 +1493,22 @@ class ConsoleMessageController:
             )
             return True
 
+        if action_id == "summarize-note":
+            self.run_worker(
+                self._summarize_console_span_as_note(message_id),
+                exclusive=True,
+                group="console-note-actions",
+            )
+            return True
+
+        if action_id == "save-transcript-note":
+            self.run_worker(
+                self._save_console_transcript_as_note(message_id),
+                exclusive=True,
+                group="console-note-actions",
+            )
+            return True
+
         if action_id == "fork":
             eligibility = self.console_fork_eligibility(message_id)
             if not eligibility.eligible:
@@ -2114,6 +2134,107 @@ class ConsoleMessageController:
         # FB-07 (TASK-2154.17): success confirmations read as success.
         self.app_instance.notify("Saved message as Note.", severity="success")
 
+    def _save_console_note_draft(
+        self, draft: "ConsoleNoteDraft", *, action_id: str, saved_copy: str
+    ) -> None:
+        """Persist a controller-built note draft; notify either way.
+
+        Shared tail of the TASK-31759 More-menu note actions: the draft
+        already carries title/content (and its provenance header); this
+        writes it through the same notes seam as save-as Note.
+        """
+
+        async def _run() -> None:
+            notes_scope_service = getattr(
+                self.app_instance, "notes_scope_service", None
+            )
+            save_note = getattr(notes_scope_service, "save_note", None)
+            if not callable(save_note):
+                self.app_instance.notify(
+                    "Saving as a Note is unavailable: Notes service is not ready.",
+                    severity="warning",
+                )
+                return
+            try:
+                result = save_note(
+                    scope=ScopeType.LOCAL_NOTE.value,
+                    title=draft.title,
+                    content=draft.content,
+                    note_id=None,
+                    version=None,
+                    user_id=getattr(self.app_instance, "current_user", None)
+                    or "default_user",
+                    workspace_id=None,
+                    keywords=["console"],
+                )
+                if inspect.isawaitable(result):
+                    result = await result
+            except Exception as exc:
+                logger.opt(exception=True).warning("Console note action failed.")
+                self.app_instance.notify(
+                    f"Saving as a Note failed: {exc}", severity="error"
+                )
+                return
+            if not result:
+                self.app_instance.notify("Saving as a Note failed.", severity="error")
+                return
+            self._last_console_action = ConsoleActionResult(
+                action_id=action_id,
+                status="completed",
+                visible_copy=saved_copy,
+            )
+            self.app_instance.notify(saved_copy, severity="success")
+
+        self.run_worker(_run(), exclusive=True, group="console-note-actions")
+
+    async def _summarize_console_span_as_note(self, message_id: str) -> None:
+        """Summarize the active-path span up to message_id into a Note.
+
+        The controller call is stateless with respect to compaction: no
+        attempt ledger, no branch memory, and the /rewind context summary
+        boundary is never moved (TASK-31759).
+        """
+        controller = self._console_chat_controller
+        if controller is None:
+            self.app_instance.notify(
+                "Summarization is unavailable: Console is not ready.",
+                severity="warning",
+            )
+            return
+        draft = await controller.summarize_span_as_note(message_id)
+        if isinstance(draft, ConsoleSubmitResult):
+            self.app_instance.notify(
+                draft.visible_copy or "Summarization was blocked.", severity="warning"
+            )
+            return
+        self._save_console_note_draft(
+            draft,
+            action_id="summarize-note",
+            saved_copy="Saved summary as Note.",
+        )
+
+    async def _save_console_transcript_as_note(self, message_id: str) -> None:
+        """Save the formatted active-path span up to message_id as a Note."""
+        controller = self._console_chat_controller
+        if controller is None:
+            self.app_instance.notify(
+                "Saving as a Note is unavailable: Console is not ready.",
+                severity="warning",
+            )
+            return
+        draft = controller.build_transcript_note(message_id)
+        if isinstance(draft, ConsoleSubmitResult):
+            self.app_instance.notify(
+                draft.visible_copy or "Saving the transcript was blocked.",
+                severity="warning",
+            )
+            return
+        self._save_console_note_draft(
+            draft,
+            action_id="save-transcript-note",
+            saved_copy="Saved transcript as Note.",
+        )
+
     async def _save_console_message_as_media(self, message_id: str) -> None:
         """Persist one selected Console message as a Library media item."""
         media_db = getattr(self.app_instance, "media_db", None)
@@ -2434,6 +2555,8 @@ class ConsoleMessageController:
             ("console-message-action-keep-", "keep"),
             ("console-message-action-review-changes-", "review-changes"),
             ("console-message-action-save-as-", "save-as"),
+            ("console-message-action-save-transcript-note-", "save-transcript-note"),
+            ("console-message-action-summarize-note-", "summarize-note"),
             ("console-message-action-save-image-", "save-image"),
             ("console-message-action-video-play-", "video-play"),
             ("console-message-action-video-save-copy-", "video-save-copy"),

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -2162,7 +2162,12 @@ class ConsoleMessageController:
                     content=draft.content,
                     note_id=None,
                     version=None,
-                    user_id=getattr(self.app_instance, "current_user", None)
+                    # TASK-31759 review: notes are owned by the configured
+                    # notes identity (app.notes_user_id drives every local
+                    # note view/ingest), NOT current_user -- saving under a
+                    # different id would make the note invisible in the
+                    # library.
+                    user_id=getattr(self.app_instance, "notes_user_id", None)
                     or "default_user",
                     workspace_id=None,
                     keywords=["console"],


### PR DESCRIPTION
## Summary

Adds two per-message actions to the Console message **More…** menu (TASK-31759):

- **Summarize up to here as note** — summarizes the active-path span up to and including the selected message (USER or ASSISTANT target) into a note, via a new `console.summarize_note` internal prompt.
- **Save transcript up to here as note** — saves that span as a formatted Markdown transcript note (role-prefixed turns + provenance header).

## Key design points

- **Stateless summarize seam**: new `ConsoleCompactionService.summarize_span_to_text` wraps the existing bounded `_summary_completion` without the attempt ledger, branch-memory admission, or boundary commit that `summarize_manual` always performs. The `/rewind` context summary and boundary are provably untouched (tests assert zero `console_auxiliary_attempts` rows and unchanged `session_context_summary`).
- **Oversized spans block** with a user-visible notice (matching the manual summarize contract) instead of silently trimming oldest turns.
- Notes are written via `notes_scope_service.save_note` (`scope=LOCAL_NOTE`, `keywords=["console"]`), same seam as save-as Note, in a dedicated `console-note-actions` exclusive worker group — never `console-run`, so it cannot cancel a live stream. Mid-run attempts surface the active-run rejection as a notice.
- Overflow-only entries in `ConsoleMessageActionService`; dispatched via the pre-`dispatch()` interception pattern used by `save-as`, plus the two new prefixes in `_parse_console_message_action_button_id`.

## Tests

- New `Tests/Chat/test_console_note_span_actions.py` (10 tests): span inclusivity/tool-skip, note formatting + provenance, provider-not-ready / oversized-span / off-path gates, statelessness, UI dispatch wiring, mid-run notice.
- Updated exact-list expectations in `Tests/Chat/test_console_message_actions.py`.
- Targeted regression runs green: rewind-summarize, context compaction, run gate, prompts panel, chat-flow action subset (~365 passed total). `test_console_native_transcript.py` has 31 failures identical on clean `origin/dev` (verified via stash baseline) — pre-existing, unrelated.

Task: TASK-31759 (marked Done, ADR not required — no schema/boundary changes).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds "Summarize up to here as note" and "Save transcript up to here as note" to the Console More-menu, turning the active-path conversation up to the selected message into a note without touching compaction state.

- Summarize uses the `console.summarize_note` prompt via a stateless provider call that never writes attempt-ledger rows or moves the rewind boundary.
- Save transcript writes a role-prefixed Markdown transcript with a provenance header, inclusive of the selected message, skipping tool, failed, and empty rows.
- Both actions run in an exclusive `console-note-actions` worker group, so they never cancel a live stream; mid-run attempts show a notice.
- Oversized summarize spans are blocked with a visible notice; the budget check sees the untrimmed span so notes never silently omit turns.
- Notes are saved through `notes_scope_service.save_note` (`keywords=["console"]`, under the configured notes owner) so they appear in the library.
- New tests in `Tests/Chat/test_console_note_span_actions.py` cover span inclusivity, formatting, gates, the stateless contract, and end-to-end note persistence.
- Pins the production diagnostic inventory for the new fixed-string warning on note-action failure.

<sup>Written for commit 46328592b2607a72ed5dee7747bc8f38000ebe9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2467?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

