### PR TITLE
fix(library): route every media-viewer sync follow-up through one viewer-scoped seam; Args docstrings (task-31633 follow-up)

### DIFF
--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1329,6 +1329,39 @@ def test_more_toggle_without_a_viewer_falls_back_to_the_screen_seam():
     assert calls[-1] == ("focus", "#library-media-reader-more")
 
 
+def test_viewer_sync_seam_skips_the_hook_when_no_recompose_was_armed():
+    """PR H2: the hook is used only when the VIEWER is the thing rebuilding.
+
+    ``_sync_library_media_viewer_state`` returns True for the no-change
+    short-circuit too (nothing is rebuilt, so nothing would ever fire the
+    hook), and it returns False -- whole-screen recompose -- while the OLD
+    viewer is still mounted and about to be torn down. Queuing on either
+    swallows the follow-up outright, so the seam reads the viewer's own armed
+    recompose flag rather than assuming a mounted viewer means a rebuild.
+    """
+    calls: list = []
+    viewer = _RecomposeHookViewer(pending=lambda: calls.append("pr-f-restore"))
+    viewer._recompose_required = False
+    fake = SimpleNamespace(
+        _sync_library_media_viewer_or_recompose=lambda: calls.append("sync"),
+        _mounted_library_media_viewer=lambda: viewer,
+        _focus_library_control=lambda selector: calls.append(("focus", selector)),
+        call_after_refresh=lambda callback, *args: calls.append(("after", callback)),
+    )
+
+    LibraryScreen._after_library_media_viewer_sync(
+        fake, "#library-media-reader-more"
+    )
+
+    assert calls[0] == "sync"
+    # The follow-up went to the screen seam, and the viewer's own slot is
+    # untouched -- whatever was queued there still belongs to its owner.
+    assert calls[1][0] == "after"
+    assert viewer._post_recompose_callback is not None
+    calls[1][1]()
+    assert calls[-1] == ("focus", "#library-media-reader-more")
+
+
 def test_escape_closes_more_find_confirmation_before_leaving_reader():
     """Every Reader transient consumes Escape before outward graduation."""
     fake, calls, _shell, _find = _escape_fake(region="reader", more_open=True)

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1210,6 +1210,14 @@ def _escape_fake(
     fake._close_library_media_find = MethodType(
         LibraryScreen._close_library_media_find, fake
     )
+    # PR H2: and every "sync, then focus this control" follow-up routes
+    # through ONE seam, so the fake exercises the real ordering logic. No
+    # viewer is mounted in these fakes, so it takes the screen fallback --
+    # the same ``sync`` then ``focus`` pair the branches recorded before.
+    fake._mounted_library_media_viewer = lambda: None
+    fake._after_library_media_viewer_sync = MethodType(
+        LibraryScreen._after_library_media_viewer_sync, fake
+    )
     # task-31271 seam (a): Escape and its footer label read one seam now.
     fake._library_media_find_state = MethodType(
         LibraryScreen._library_media_find_state, fake
@@ -1249,6 +1257,11 @@ def test_escape_and_its_label_read_the_same_find_state():
 class _RecomposeHookViewer:
     """The one-slot post-recompose hook, with no Textual machinery."""
 
+    #: ``refresh(recompose=True)`` arms this on a real widget and the
+    #: rebuild clears it. The seam reads it to tell a sync that handed the
+    #: rebuild to this viewer's pump from one that changed nothing.
+    _recompose_required = True
+
     def __init__(self, pending=None):
         self._post_recompose_callback = pending
 
@@ -1270,6 +1283,9 @@ def test_more_toggle_chains_the_restore_already_queued_on_the_viewer():
         _mounted_library_media_viewer=lambda: viewer,
         _focus_library_control=lambda selector: calls.append(("focus", selector)),
         call_after_refresh=lambda *args: calls.append("call_after_refresh"),
+    )
+    fake._after_library_media_viewer_sync = MethodType(
+        LibraryScreen._after_library_media_viewer_sync, fake
     )
 
     LibraryScreen.handle_library_media_reader_more(
@@ -1296,6 +1312,9 @@ def test_more_toggle_without_a_viewer_falls_back_to_the_screen_seam():
         _mounted_library_media_viewer=lambda: None,
         _focus_library_control=lambda selector: calls.append(("focus", selector)),
         call_after_refresh=lambda callback, *args: calls.append(("after", callback)),
+    )
+    fake._after_library_media_viewer_sync = MethodType(
+        LibraryScreen._after_library_media_viewer_sync, fake
     )
 
     LibraryScreen.handle_library_media_reader_more(
@@ -1646,6 +1665,12 @@ def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
     )
     fake._close_library_media_find = MethodType(
         LibraryScreen._close_library_media_find, fake
+    )
+    # PR H2: the focus follow-up rides the shared post-sync seam; no viewer
+    # is mounted in this fake, so it takes the screen fallback.
+    fake._mounted_library_media_viewer = lambda: None
+    fake._after_library_media_viewer_sync = MethodType(
+        LibraryScreen._after_library_media_viewer_sync, fake
     )
     # Qodo on #2378: the handler refuses when the tab has nothing to search.
     fake._library_media_find_unavailable_reason = MethodType(
@@ -2274,7 +2299,18 @@ async def test_opening_find_costs_no_extra_focus_move(size):
         original_set_focus = screen.set_focus
 
         def counting_set_focus(_self, widget, scroll_visible=True):
-            moves.append(str(getattr(widget, "id", widget)))
+            # PR H2: EFFECTIVE focus changes only. ``Widget.focus()`` always
+            # defers a ``set_focus`` call, and ``Screen.set_focus`` returns at
+            # ``widget is self.focused`` BEFORE any Blur/Focus pair -- a call
+            # naming the widget that already holds focus moves nothing and
+            # posts no ``DescendantFocus``, which is what this pin counts.
+            # Both channels that land this input now run inside the counted
+            # window (the seam's follow-up rides the viewer's post-recompose
+            # hook, the token channel rides the content widget's), so one of
+            # the two is always such an inert duplicate -- measured: the same
+            # Input object, ``widget is screen.focused`` already True.
+            if widget is not screen.focused:
+                moves.append(str(getattr(widget, "id", widget)))
             return original_set_focus(widget, scroll_visible=scroll_visible)
 
         screen.set_focus = MethodType(counting_set_focus, screen)

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -26,10 +26,13 @@ from types import SimpleNamespace
 from textual.widgets import Button, Input, OptionList, Static
 from textual.worker import WorkerState
 
-from tldw_chatbook.Library.library_media_reader_state import set_mode
+from tldw_chatbook.Library.library_media_reader_state import set_mode, set_more_open
 from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
+    LIBRARY_ADAPTIVE_READER_GRIP_CLASS,
+)
 from tldw_chatbook.Widgets.Library.library_media_reader_shell import (
     LibraryMediaReaderShell,
 )
@@ -2536,3 +2539,186 @@ async def test_media_items_paint_two_rows_each_with_no_blank_row_between():
                 meta,
                 lines,
             )
+
+
+# --- PR H2 (Qodo on #2470): every viewer-sync follow-up rides the VIEWER ---
+#
+# ``_sync_library_media_viewer_or_recompose`` rebuilds the Reader on the
+# VIEWER's message pump. A ``screen.call_after_refresh`` follow-up has no
+# ordering against that pump: it can focus the control the recompose is
+# about to detach, and Textual then re-picks focus for the pruned widget --
+# landing on a pane grip (or, when the follow-up wins the race the other
+# way, on a detached orphan). PR H fixed the More BUTTON that way; these pin
+# the Escape paths, which took the same shape.
+
+
+async def _open_reader_find(screen, pilot):
+    """Open the Reader's Find bar and wait for its input to take focus."""
+    screen.query_one("#library-media-reader-find", Button).press()
+    search_input = await _wait_for_selector(
+        screen, pilot, "#library-media-content-search"
+    )
+    await _wait_for_condition(
+        pilot,
+        lambda: search_input.has_focus,
+        message=lambda: f"Find never focused its input: {screen.focused!r}.",
+    )
+    return search_input
+
+
+def _focus_report(screen) -> str:
+    focused = screen.focused
+    return (
+        f"{focused!r} (id={getattr(focused, 'id', None)!r}, "
+        f"attached={getattr(focused, 'is_attached', None)!r})"
+    )
+
+
+async def _settle_focus_on(screen, pilot, control_id: str, what: str) -> None:
+    """Wait until ``control_id`` holds focus as a MOUNTED widget."""
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            screen.focused is not None
+            and screen.focused.id == control_id
+            and screen.focused.is_attached
+        ),
+        message=lambda: f"{what} left focus on {_focus_report(screen)}.",
+    )
+    # The identity check the orphan cannot pass: the focused widget IS the
+    # one a fresh query returns, not a detached same-id predecessor.
+    assert screen.focused is screen.query_one(f"#{control_id}", Button)
+    assert screen.focused.is_attached
+
+
+@pytest.mark.asyncio
+async def test_escape_closing_more_lands_on_the_live_more_button():
+    """Escape closes the disclosure and leaves focus on the NEW More button.
+
+    Qodo High on #2470 ("Readers lose keys after escape"): the follow-up ran
+    on the screen's pump while the viewer rebuilt on its own, so focus ended
+    up on a widget with no parent chain -- which swallows every subsequent
+    key, Escape included. The second half presses Enter on whatever holds
+    focus: only a live, mounted More button re-opens the row.
+    """
+    host = _four_action_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+        await _open_reader_more(screen, pilot)
+        await _settle_focus_on(
+            screen, pilot, "library-media-reader-more", "Opening More"
+        )
+
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query("#library-media-reader-more-actions"),
+            message="Escape never closed More.",
+        )
+        await _settle_focus_on(
+            screen, pilot, "library-media-reader-more", "Escape closing More"
+        )
+
+        # Again from INSIDE the disclosure, where the restore cannot mask the
+        # bug: the focused action is recomposed away, so PR F's captured
+        # identity is gone and its fallback leaves the Reader entirely (on
+        # 43b0a7440 this landed on the media list row). The disclosure's own
+        # target has to survive the rebuild.
+        await _open_reader_more(screen, pilot)
+        screen.query_one("#library-media-edit", Button).focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query("#library-media-reader-more-actions"),
+            message="Escape never closed More from inside it.",
+        )
+        await _settle_focus_on(
+            screen,
+            pilot,
+            "library-media-reader-more",
+            "Escape closing More from inside it",
+        )
+
+        await pilot.press("enter")
+        await _wait_for_selector(screen, pilot, "#library-media-reader-more-actions")
+
+
+@pytest.mark.asyncio
+async def test_escape_closing_find_lands_on_the_live_find_button():
+    """Both Escape-closes-Find branches land on the mounted Find button.
+
+    First from INSIDE the bar (the branch that reads the focused widget's
+    ancestry), then with focus moved out to the content body (the branch
+    that consumes an open bar regardless of where focus sits).
+    """
+    host = _four_action_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+
+        await _open_reader_find(screen, pilot)
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query("#library-media-content-search-controls"),
+            message="Escape never closed the Find bar.",
+        )
+        await _settle_focus_on(
+            screen, pilot, "library-media-reader-find", "Escape closing Find"
+        )
+
+        await _open_reader_find(screen, pilot)
+        screen.query_one("#library-media-viewer-content").focus()
+        await pilot.pause()
+        await pilot.press("escape")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query("#library-media-content-search-controls"),
+            message="Escape never closed the Find bar from the content body.",
+        )
+        await _settle_focus_on(
+            screen,
+            pilot,
+            "library-media-reader-find",
+            "Escape closing Find from the content body",
+        )
+
+        # Keys still work afterwards: Enter on the restored button re-opens.
+        await pilot.press("enter")
+        await _wait_for_selector(
+            screen, pilot, "#library-media-content-search-controls"
+        )
+
+
+@pytest.mark.asyncio
+async def test_viewer_sync_follow_up_chains_the_restore_when_its_target_is_gone():
+    """PR F's restore is CHAINED behind the follow-up, never evicted.
+
+    ``queue_after_recompose`` REPLACES, and the sync queues task-31567's
+    focus restore on that same one slot. The helper captures it and calls it
+    after its own target, so a follow-up whose target is not composed leaves
+    focus where the restore puts it (the captured identity) -- never on the
+    pane grip Textual re-picks when the focused child is recomposed away.
+    """
+    host = _four_action_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+        screen.query_one("#library-media-reader-find", Button).focus()
+        await pilot.pause()
+
+        screen._library_media_reader_session = set_more_open(
+            screen._library_media_reader_session, True
+        )
+        screen._after_library_media_viewer_sync("#library-media-reader-absent")
+        await _wait_for_selector(screen, pilot, "#library-media-reader-more-actions")
+
+        await _settle_focus_on(
+            screen,
+            pilot,
+            "library-media-reader-find",
+            "An absent follow-up target",
+        )
+        assert not screen.focused.has_class(LIBRARY_ADAPTIVE_READER_GRIP_CLASS)

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -2545,11 +2545,13 @@ async def test_media_items_paint_two_rows_each_with_no_blank_row_between():
 #
 # ``_sync_library_media_viewer_or_recompose`` rebuilds the Reader on the
 # VIEWER's message pump. A ``screen.call_after_refresh`` follow-up has no
-# ordering against that pump: it can focus the control the recompose is
-# about to detach, and Textual then re-picks focus for the pruned widget --
-# landing on a pane grip (or, when the follow-up wins the race the other
-# way, on a detached orphan). PR H fixed the More BUTTON that way; these pin
-# the Escape paths, which took the same shape.
+# ordering against that pump: it focuses the control the recompose is about
+# to detach, Textual re-picks focus for the pruned widget, and task-31567's
+# restore -- whose captured identity went with the same children -- takes
+# its list-entry fallback. Measured on 43b0a7440: Escape from inside the
+# open More disclosure left focus on ``#library-media-row-0``, outside the
+# Reader, so the next Escape acted on the LIST. PR H fixed the More BUTTON;
+# these pin the Escape paths, which took the same shape.
 
 
 async def _open_reader_find(screen, pilot):
@@ -2596,10 +2598,13 @@ async def test_escape_closing_more_lands_on_the_live_more_button():
     """Escape closes the disclosure and leaves focus on the NEW More button.
 
     Qodo High on #2470 ("Readers lose keys after escape"): the follow-up ran
-    on the screen's pump while the viewer rebuilt on its own, so focus ended
-    up on a widget with no parent chain -- which swallows every subsequent
-    key, Escape included. The second half presses Enter on whatever holds
-    focus: only a live, mounted More button re-opens the row.
+    on the screen's pump while the viewer rebuilt on its own, so it never
+    held the control it named. The first half passes on 43b0a7440 by
+    coincidence -- the identity task-31567 captured IS the More button, so
+    its restore lands where the follow-up wanted; the second half, from
+    inside the disclosure, is where the two differ and the base fails.
+    Both then press Enter on whatever holds focus: only a live, mounted More
+    button re-opens the row.
     """
     host = _four_action_host()
     async with host.run_test(size=(235, 52)) as pilot:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -34624,7 +34624,15 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-media-reader-more")
     def handle_library_media_reader_more(self, event: Button.Pressed) -> None:
-        """Toggle the transient inline secondary-action region."""
+        """Toggle the transient inline secondary-action region.
+
+        Args:
+            event: The More button press. Stopped here so the Reader's own
+                toolbar handling never sees it.
+
+        Returns:
+            None.
+        """
         event.stop()
         session = self._library_media_reader_session
         self._library_media_reader_session = set_more_open(

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -35125,9 +35125,15 @@ class LibraryScreen(BaseAppScreen):
         CHAINED behind whatever is already queued there rather than replacing
         it: ``queue_after_recompose`` replaces, and the sync above just
         queued task-31567's restore on that same one slot (that is how
-        task-31567 lost a receipt's "land on Undo"). Ours runs first and wins
-        outright; the restore behind it only acts when nothing claimed focus,
-        which is exactly the case where the target is not composed at all.
+        task-31567 lost a receipt's "land on Undo"). Order inside the chain:
+        our ``_focus_library_control`` DEFERS (``Widget.focus`` goes through
+        ``app.call_later``), so when the chained restore runs, focus is still
+        wherever the recompose left it and the restore does its own landing
+        (the captured identity, else the list entry); the deferred focus then
+        lands on the target and wins. The transient is benign -- the list
+        entry is focused with ``scroll_visible=False`` and the programmatic
+        marker armed -- and when the target is not composed at all the focus
+        call no-ops and the restore's landing stands.
 
         Args:
             follow_up: A Library control selector to focus once the sync has
@@ -35144,8 +35150,10 @@ class LibraryScreen(BaseAppScreen):
             else follow_up
         )
         viewer = self._mounted_library_media_viewer()
-        # ``refresh(recompose=True)`` arms this flag and ``_check_recompose``
-        # clears it only when the rebuild actually runs, so it is the honest
+        # ``refresh(recompose=True)`` arms this flag synchronously and only
+        # ``_check_recompose`` (on the viewer's pump) clears it, before
+        # awaiting ``recompose()``; read here with no await in between it is
+        # the honest
         # answer to "did THIS sync hand the rebuild to the viewer's pump?".
         # False covers both cases where the hook would swallow the follow-up
         # instead of ordering it: the no-change short-circuit (nothing is

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -32134,19 +32134,13 @@ class LibraryScreen(BaseAppScreen):
             and (focused is find_controls or find_controls in focused.ancestors)
         ):
             self._close_library_media_find()
-            self._sync_library_media_viewer_or_recompose()
-            self.call_after_refresh(
-                self._focus_library_control, "#library-media-reader-find"
-            )
+            self._after_library_media_viewer_sync("#library-media-reader-find")
             return
         if self._library_media_reader_session.more_open:
             self._library_media_reader_session = set_more_open(
                 self._library_media_reader_session, False
             )
-            self._sync_library_media_viewer_or_recompose()
-            self.call_after_refresh(
-                self._focus_library_control, "#library-media-reader-more"
-            )
+            self._after_library_media_viewer_sync("#library-media-reader-more")
             return
         # task-31272: the Items pane's own type/sort strips open over the
         # three-pane Reader too, and this action owns Escape there (the
@@ -32203,10 +32197,7 @@ class LibraryScreen(BaseAppScreen):
         # never consumes the reader's find state.
         if find_open:
             self._close_library_media_find()
-            self._sync_library_media_viewer_or_recompose()
-            self.call_after_refresh(
-                self._focus_library_control, "#library-media-reader-find"
-            )
+            self._after_library_media_viewer_sync("#library-media-reader-find")
             return
         if layout.items_open:
             self._focus_library_media_items_pane()
@@ -34639,43 +34630,12 @@ class LibraryScreen(BaseAppScreen):
         self._library_media_reader_session = set_more_open(
             session, not session.more_open
         )
-        self._sync_library_media_viewer_or_recompose()
         # task-31633 AC#3: the disclosure owns its own focus target -- PR F's
         # restore seam otherwise leaves focus wherever it already was (the
         # Items row that opened the Reader), so More could not be closed
-        # again without hunting for it.
-        #
-        # Queued on the VIEWER's post-recompose hook, never
-        # ``screen.call_after_refresh``: this rebuild runs on the viewer's
-        # message pump and the two have no ordering. Measured with the
-        # screen-level callback -- it ran BEFORE the new children mounted,
-        # focused the More button that was about to be detached, and left
-        # focus on an orphan with no parent chain, which swallowed every
-        # subsequent key (Escape stopped closing anything at all).
-        #
-        # Read AFTER the sync and CHAINED, never replacing: the sync queues
-        # PR F's focus restore on this same one-slot hook and
-        # ``queue_after_recompose`` replaces (that is how task-31567 lost a
-        # receipt's "land on Undo"). Ours runs first and wins outright; the
-        # restore behind it only acts when nothing claimed focus -- which is
-        # exactly the case where More is not composed at all.
-        viewer = self._mounted_library_media_viewer()
-        if viewer is None:
-            # The whole-screen fallback took the sync: there is no viewer to
-            # hang the hook on, so the screen's own post-refresh seam carries
-            # the target instead.
-            self.call_after_refresh(
-                partial(self._focus_library_control, "#library-media-reader-more")
-            )
-            return
-        pending = viewer._post_recompose_callback
-
-        def focus_more_then_restore() -> None:
-            self._focus_library_control("#library-media-reader-more")
-            if pending is not None:
-                pending()
-
-        viewer.queue_after_recompose(focus_more_then_restore)
+        # again without hunting for it. The shared seam is what orders that
+        # target against the viewer's own rebuild.
+        self._after_library_media_viewer_sync("#library-media-reader-more")
 
     @on(Button.Pressed, "#library-media-image-preview-toggle")
     def handle_library_media_image_preview_toggle(self, event: Button.Pressed) -> None:
@@ -34733,13 +34693,16 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_reader_session,
             mode,  # type: ignore[arg-type]
         )
-        self._sync_library_media_viewer_or_recompose()
-        if mode == "read":
-            loaded_id = self._library_media_reader_session.loaded_id
-            if loaded_id is not None:
-                self.call_after_refresh(
-                    self._restore_library_media_loaded_progress, loaded_id
-                )
+        # The one follow-up here is not a focus move -- the stored reading
+        # position is restored against the rebuilt body, and reading it from
+        # the OLD children (or after they are detached) is the same race.
+        loaded_id = self._library_media_reader_session.loaded_id
+        if mode == "read" and loaded_id is not None:
+            self._after_library_media_viewer_sync(
+                partial(self._restore_library_media_loaded_progress, loaded_id)
+            )
+        else:
+            self._sync_library_media_viewer_or_recompose()
 
     def _reset_library_media_search_on_mode_change(self, new_mode: str) -> None:
         """Drop the in-item search when the Reader actually changes tab.
@@ -34982,8 +34945,9 @@ class LibraryScreen(BaseAppScreen):
         # token below is what lets its mount take focus -- once.
         self._library_media_find_open = True
         self._library_media_find_focus_pending = True
-        self._sync_library_media_viewer_or_recompose()
-        self.call_after_refresh(self._focus_library_media_content_search_input)
+        self._after_library_media_viewer_sync(
+            self._focus_library_media_content_search_input
+        )
 
     @on(Button.Pressed, "#library-media-open-original")
     def handle_library_media_open_original(self, event: Button.Pressed) -> None:
@@ -35133,6 +35097,64 @@ class LibraryScreen(BaseAppScreen):
         viewer = self._mounted_library_media_viewer()
         if viewer is None or not self._sync_library_media_viewer_state(viewer):
             self.refresh(recompose=True)
+
+    def _after_library_media_viewer_sync(
+        self, follow_up: str | Callable[[], object]
+    ) -> None:
+        """Sync the media viewer, then run ``follow_up`` against its NEW children.
+
+        task-31633 / Qodo High on #2470 ("Readers lose keys after escape").
+        A viewer-scoped sync rebuilds the Reader on the VIEWER's message pump,
+        and ``screen.call_after_refresh`` queues onto the SCREEN's -- two
+        pumps with no ordering. Measured on 43b0a7440 with the screen seam:
+        Escape from inside the More disclosure focused the control the
+        recompose was about to detach, Textual re-picked focus for the pruned
+        widget, and task-31567's restore (its captured identity gone with the
+        rest of the children) fell back to the media list row -- focus out of
+        the Reader entirely, so the next Escape acted on the list.
+
+        So the follow-up rides the viewer's own post-recompose hook, and is
+        CHAINED behind whatever is already queued there rather than replacing
+        it: ``queue_after_recompose`` replaces, and the sync above just
+        queued task-31567's restore on that same one slot (that is how
+        task-31567 lost a receipt's "land on Undo"). Ours runs first and wins
+        outright; the restore behind it only acts when nothing claimed focus,
+        which is exactly the case where the target is not composed at all.
+
+        Args:
+            follow_up: A Library control selector to focus once the sync has
+                landed (``"#library-media-reader-more"``), or a zero-argument
+                callable to run there instead.
+
+        Returns:
+            None.
+        """
+        self._sync_library_media_viewer_or_recompose()
+        callback = (
+            partial(self._focus_library_control, follow_up)
+            if isinstance(follow_up, str)
+            else follow_up
+        )
+        viewer = self._mounted_library_media_viewer()
+        # ``refresh(recompose=True)`` arms this flag and ``_check_recompose``
+        # clears it only when the rebuild actually runs, so it is the honest
+        # answer to "did THIS sync hand the rebuild to the viewer's pump?".
+        # False covers both cases where the hook would swallow the follow-up
+        # instead of ordering it: the no-change short-circuit (nothing is
+        # rebuilt, so nothing ever fires the hook and the target is still
+        # mounted anyway) and the whole-screen fallback (the screen's pump
+        # owns the ordering, and this viewer is the one being torn down).
+        if viewer is None or not getattr(viewer, "_recompose_required", False):
+            self.call_after_refresh(callback)
+            return
+        pending = viewer._post_recompose_callback
+
+        def follow_up_then_pending() -> None:
+            callback()
+            if pending is not None:
+                pending()
+
+        viewer.queue_after_recompose(follow_up_then_pending)
 
     def _sync_library_media_viewer_mutation_gate(self) -> None:
         """Disable a still-mounted edit Save while its write is unsettled."""

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -40,18 +40,36 @@ PaneName = Literal["library", "items"]
 class AdaptiveReaderLayoutProfile:
     """Destination-specific list and work-pane width policy.
 
-    ``list_grows`` is opt-in per destination (task-31633): when set, a
-    comfortable Reader shares its surplus width with the list -- up to
-    ``list_comfort_width`` -- instead of absorbing every extra cell. It
-    applies to automatic widths only; a custom width is obeyed as typed.
-    Only Media opts in today.
+    One frozen profile per reader destination. Every field is a width in
+    terminal cells, and the two task-31633 fields are opt-in: their defaults
+    reproduce the pre-task behaviour exactly, so a destination that does not
+    name them is unaffected.
 
-    ``grip_width`` is the width of EACH of the two pane grips, in cells --
-    both what they paint and what the resolver holds back for them, so the
-    two can never disagree. It is opt-in per destination for the same reason
-    (task-31633 AC#2): Media's two five-column grips left ten dead columns
-    around the Items pane, so Media narrows them to one cell each while every
-    other destination keeps ``PANE_GRIP_WIDTH``.
+    Attributes:
+        list_min_width: Floor for the list (Items) pane. The resolver
+            collapses the pane rather than paint it narrower.
+        list_target_width: The list pane's width once the shell has room for
+            both panes but no surplus to share.
+        list_comfort_width: Ceiling for ``list_grows``. Surplus width stops
+            flowing into the list here and goes to the work pane instead.
+        list_max_width: Hard ceiling for the list pane, including a width the
+            user typed.
+        work_min_width: Floor for the work (Reader) pane; below it the shell
+            drops the list pane rather than squeeze the document.
+        work_comfort_width: The work-pane width at which the Reader counts as
+            comfortable -- the gate ``list_grows`` waits on.
+        list_grows: When ``True``, a work pane already at
+            ``work_comfort_width`` shares further surplus with the list, up to
+            ``list_comfort_width``, instead of absorbing every extra cell.
+            Automatic widths only: a custom width is obeyed as typed. Default
+            ``False`` (every extra cell goes to the work pane); only Media
+            opts in today.
+        grip_width: Width of EACH of the two pane grips -- both what a grip
+            paints and what the resolver holds back for it, so the two can
+            never disagree. Defaults to ``PANE_GRIP_WIDTH`` (5). Media passes
+            1: its two five-column grips left ten dead columns around the
+            Items pane (task-31633 AC#2). A grip narrower than four cells
+            paints the one-cell guillemet instead of the ``<---`` run.
     """
 
     list_min_width: int = 32

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -48,19 +48,23 @@ class AdaptiveReaderLayoutProfile:
     Attributes:
         list_min_width: Floor for the list (Items) pane. The resolver
             collapses the pane rather than paint it narrower.
-        list_target_width: The list pane's width once the shell has room for
-            both panes but no surplus to share.
+        list_target_width: Not read by the resolver. The list's automatic
+            width comes from ``preferences.items_width`` (defaulted from
+            ``ITEMS_TARGET_WIDTH``); the field is retained only so profiles
+            can be constructed with it in tests.
         list_comfort_width: Ceiling for ``list_grows``. Surplus width stops
             flowing into the list here and goes to the work pane instead.
         list_max_width: Hard ceiling for the list pane, including a width the
             user typed.
         work_min_width: Floor for the work (Reader) pane; below it the shell
             drops the list pane rather than squeeze the document.
-        work_comfort_width: The work-pane width at which the Reader counts as
-            comfortable -- the gate ``list_grows`` waits on.
+        work_comfort_width: Not read by the resolver. The ``list_grows``
+            gate is ``max(work_min_width, READER_COMFORT_WIDTH)``; only
+            Collections sets this field (56), to no effect.
         list_grows: When ``True``, a work pane already at
-            ``work_comfort_width`` shares further surplus with the list, up to
-            ``list_comfort_width``, instead of absorbing every extra cell.
+            ``max(work_min_width, READER_COMFORT_WIDTH)`` shares half of any
+            further surplus with the list, up to ``list_comfort_width``,
+            instead of absorbing every extra cell.
             Automatic widths only: a custom width is obeyed as typed. Default
             ``False`` (every extra cell goes to the work pane); only Media
             opts in today.

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -61,6 +61,26 @@ class LibraryAdaptiveReaderPaneGrip(Button):
         width: int = PANE_GRIP_WIDTH,
         **kwargs: Any,
     ) -> None:
+        """Build one pane grip sized to its destination's profile.
+
+        Args:
+            pane: Which optional pane this grip toggles -- ``"library"`` or
+                ``"items"``. Carried on the ``PaneToggleRequested`` message
+                the press posts.
+            open: Whether that pane is open right now. Decides the arrow and
+                the action copy only; geometry never changes with it.
+            pane_label: Human name of the pane, used verbatim in the tooltip
+                and accessible name ("Collapse Items pane").
+            extra_classes: Space-separated CSS classes appended to
+                ``LIBRARY_ADAPTIVE_READER_GRIP_CLASS`` for per-destination
+                styling. The shared class is always present -- the focus
+                restore seam reads it to know it must never land here.
+            width: The destination profile's ``grip_width``, in cells. The
+                grip paints exactly the columns the resolver held back for it
+                (task-31633 AC#2); below four cells the arrow becomes a
+                one-cell guillemet.
+            **kwargs: Forwarded to ``Button`` (``id``, ``disabled``, ...).
+        """
         self.pane = pane
         self.pane_label = pane_label
         self.grip_width = width
@@ -79,7 +99,19 @@ class LibraryAdaptiveReaderPaneGrip(Button):
         self.sync_open(open)
 
     def sync_open(self, open: bool) -> None:
-        """Patch arrow and action copy without changing geometry."""
+        """Patch arrow and action copy without changing geometry.
+
+        The in-place alternative to recomposing the grip: label, accessible
+        name and tooltip are assigned only when they actually differ, so a
+        shell re-sync that changes nothing costs no refresh -- and the grip
+        cannot be the widget a recompose detaches while it holds focus.
+
+        Args:
+            open: Whether the pane this grip toggles is now open.
+
+        Returns:
+            None.
+        """
         action = "Collapse" if open else "Expand"
         copy = f"{action} {self.pane_label} pane"
         # task-31633 AC#2: the arrow is as wide as the grip. The
@@ -140,6 +172,26 @@ class LibraryAdaptiveReaderShell(Horizontal):
         grip_width: int = PANE_GRIP_WIDTH,
         **kwargs: Any,
     ) -> None:
+        """Assemble the three-pane shell around caller-owned pane widgets.
+
+        Args:
+            library: Widget for the leftmost (Library rail) pane.
+            items: Widget for the middle (list) pane.
+            work: Widget for the work pane -- the Reader or its equivalent.
+            layout: The resolved layout to mount with: which optional panes
+                are open and how wide each is.
+            id_prefix: Per-destination id stem (``"library-media"``) for the
+                composed grips, giving each destination its own stable
+                selectors.
+            library_label: Human name of the Library pane, for grip copy.
+            items_label: Human name of the items pane, for grip copy.
+            grip_classes: Extra CSS classes for both grips, for
+                per-destination styling.
+            grip_width: The destination profile's ``grip_width`` in cells,
+                passed to both grips so they paint exactly the columns the
+                resolver held back (task-31633 AC#2).
+            **kwargs: Forwarded to ``Horizontal`` (``id``, ``classes``, ...).
+        """
         super().__init__(**kwargs)
         self.add_class("library-adaptive-reader-shell")
         self.library = library

--- a/tldw_chatbook/Widgets/Library/library_media_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_media_reader_shell.py
@@ -27,6 +27,14 @@ class LibraryMediaPaneGrip(LibraryAdaptiveReaderPaneGrip):
     """Preserve the public Media grip constructor and visual class."""
 
     def __init__(self, pane: PaneName, *, open: bool, **kwargs: Any) -> None:
+        """Build a Media grip at the profile's width.
+
+        Args:
+            pane: Which optional pane this grip toggles.
+            open: Whether that pane is open right now.
+            **kwargs: Forwarded to ``LibraryAdaptiveReaderPaneGrip``; the
+                Media label, class and ``grip_width`` are fixed here.
+        """
         super().__init__(
             pane,
             open=open,
@@ -48,6 +56,22 @@ class LibraryMediaReaderShell(LibraryAdaptiveReaderShell):
         layout: MediaReaderEffectiveLayout,
         **kwargs: Any,
     ) -> None:
+        """Adapt Media's pane vocabulary onto the shared shell.
+
+        Media calls its work pane the ``reader``, and the attribute is part
+        of this class's public surface (callers reach for ``shell.reader``),
+        so the shared ``work`` name is bridged here rather than renamed.
+
+        Args:
+            library: Widget for the Library rail pane.
+            items: Widget for the media list pane.
+            reader: Widget for the Reader pane -- the shared shell's ``work``.
+            layout: The resolved Media layout to mount with.
+            **kwargs: Forwarded to ``LibraryAdaptiveReaderShell`` (``id``,
+                ``classes``, ...); the Media identity arguments (id prefix,
+                pane labels, grip classes and the profile's one-cell
+                ``grip_width``) are fixed here.
+        """
         super().__init__(
             library=library,
             items=items,


### PR DESCRIPTION
## Summary

Follow-up to PR H #2470 (task-31633) for its two Qodo review threads.

- **Bug (Qodo High, "Readers lose keys after escape").** After `_sync_library_media_viewer_or_recompose()` the Media Reader viewer rebuilds on its own message pump, so a `screen.call_after_refresh(<focus>)` queued behind it has no ordering guarantee and can focus the outgoing button before the recompose detaches it, leaving keyboard focus on an orphan. PR H fixed this inline for the `More` handler only; five sibling sites (Escape closing Find, Escape closing More, and three more follow-ups after a viewer sync) still used the screen queue. All six now go through one seam, `_after_library_media_viewer_sync`, which queues the follow-up on the viewer's post-recompose hook chained with PR F's pending focus restore (never replacing it), and falls back to the screen seam only when that viewer was not asked to recompose. The gate closes a latent hole in PR H's inline copy as well: with the viewer mounted but the whole-screen fallback taking the sync, the follow-up was silently swallowed by the hook's attached-widget guard.
- **Maintainability (Qodo Medium).** Google-style `Args:` docstrings on `AdaptiveReaderLayoutProfile` (the `list_grows` / `grip_width` knobs), the adaptive and Media shell constructors, `sync_open`, the pane grip, `handle_library_media_reader_more` and the new seam. No behaviour change in that commit.

Pins observe real focus on a mounted widget after a bounded wait (identity plus `is_attached`, then a keypress that a dead target could not satisfy): Escape closing More from inside the disclosure and from the button, Escape closing Find, the chained restore when the target is absent, and the screen fallback. The reviewer reverted the seam to the base shape in-process and reran them: the More pin fails with the More button `attached=False` (the literal orphan), the Find pin fails with focus outside the Reader on the first list row, and against an evicting seam the chain pin fails with focus on a pane grip.

## Verification

One whole-branch review (Opus): With fixes — the fix judged correct, minimal and well-gated, with the orphan and the eviction both reproduced independently; the three Important findings were docstring accuracy (two profile fields with zero production reads were described as driving behaviour; the seam comment misstated its own ordering) and are fixed in the last commit.

Whole-file, one process per file, failing-name sets compared against a detached `43b0a7440`: `test_library_media_render_fixes.py` 71, `test_library_media_reader_flow.py` 75, `test_library_media_reader_shell.py` 38, `test_library_adaptive_reader_shell.py` 33 passed, plus four related files identical to the base; `test_library_shell.py` whole-file is 230 failed / 600 passed on both trees (one order-dependent flake per side, each verified against the base). Diagnostic inventory passes; no new `logger.*`; no CSS.

Resolves the two Qodo threads on #2470.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes keyboard focus escaping the media viewer after any recompose-driven sync, and adds Args docstrings to the adaptive reader shell surface.

**Bug Fixes**
- All six viewer-sync follow-ups now go through `_after_library_media_viewer_sync`, which queues on the viewer's post-recompose hook (chained with the restore) or falls back to the screen seam when the viewer isn't rebuilding.
- The fallback also covers the case where a viewer is mounted but not recomposing, which previously swallowed the follow-up.

**Refactors**
- Adds Google-style `Args:` docstrings to `AdaptiveReaderLayoutProfile`, the adaptive and Media shell constructors, `sync_open`, the pane grip, and the More handler.

<sup>Written for commit 4274ffd6aada3a54d53cf824207a79ca18637e2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

