### PR TITLE
chore(backlog): close out the meeting-diarization follow-ups merged in #2471

### DIFF
--- a/backlog/tasks/task-31743 - Meetings-diarize-the-mic-channel-for-hybrid-rooms.md
+++ b/backlog/tasks/task-31743 - Meetings-diarize-the-mic-channel-for-hybrid-rooms.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31743
 title: 'Meetings: diarize the mic channel for hybrid rooms'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-05 22:49'
 labels:
@@ -17,6 +17,10 @@ In call mode the whole mic channel is labelled You, so a second person sitting n
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Mic-channel diarization is available behind a config option
-- [ ] #2 Default behaviour (mic = You in call mode) is unchanged
+- [x] #1 Mic-channel diarization is available behind a config option
+- [x] #2 Default behaviour (mic = You in call mode) is unchanged
 <!-- AC:END -->
+
+## Implementation Notes
+
+`[meetings] diarize_mic_channel` (default false): when on in call mode, mic-channel and overlap segments are also sent to the diarizer and the Stop pass diarizes `mixed.wav`; `render_label(..., diarize_mic=True)` lets a diarized mic segment render its speaker instead of the reserved "You". Stamped into `meeting.json`; documented in `Docs/User_Guide/meetings.md`. Landed in PR #2471 (commits aa72e1f9f, e060f8d27).

--- a/backlog/tasks/task-31744 - Meetings-forward-pin-through-SpeechBrainDiarizer-to-the-worker-clusterer.md
+++ b/backlog/tasks/task-31744 - Meetings-forward-pin-through-SpeechBrainDiarizer-to-the-worker-clusterer.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31744
 title: 'Meetings: forward pin() through SpeechBrainDiarizer to the worker clusterer'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-06 07:40'
 labels:
@@ -17,5 +17,9 @@ The sticky-pin guarantee (a user-named speaker cluster is never auto-merged) liv
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A live rename pins the cluster in the real subprocess backend so it is never auto-merged
+- [x] #1 A live rename pins the cluster in the real subprocess backend so it is never auto-merged
 <!-- AC:END -->
+
+## Implementation Notes
+
+`Diarizer.pin(cluster_id)` added to the protocol; `SpeechBrainDiarizer.pin` sends `{"cmd": "pin"}` to the worker (best-effort, non-blocking lock acquire, no reply awaited, only the cluster id crosses the pipe); the worker calls the live `OnlineClusterer.pin`. Covered by fake-subprocess tests and a torch-free test that drives the worker's real command loop (`serve()`). Landed in PR #2471 (commits 691f968a9, 3598e070c, 39f046f84).

--- a/backlog/tasks/task-31745 - Meetings-surface-the-speaker-rename-legend-in-LibraryMediaViewer.md
+++ b/backlog/tasks/task-31745 - Meetings-surface-the-speaker-rename-legend-in-LibraryMediaViewer.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31745
 title: 'Meetings: surface the speaker-rename legend in LibraryMediaViewer'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-06 07:40'
 labels:
@@ -17,5 +17,9 @@ After-the-fact speaker rename on a finished meeting is DOM-correct and tested, b
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A user can rename meeting speakers from the live Library media reader (LibraryMediaViewer), not only the hidden canvas preview
+- [x] #1 A user can rename meeting speakers from the live Library media reader (LibraryMediaViewer), not only the hidden canvas preview
 <!-- AC:END -->
+
+## Implementation Notes
+
+The rename functions moved to `Library/meeting_speaker_rename.py` (re-exported from the canvas) and the tested speaker legend is mounted in `LibraryMediaViewer` (height-auto, bounded to 12 rows), with an item-scoped `SpeakerRenamed` refresh that clears the viewer-state memo. The content guard accepts both app-produced transcript shapes (plain and Markdown, including the pre-escape legacy Markdown) and rewrites in the matching shape; ingest-produced content is refused with a one-line explanation, as decided. A failed rename restores the prior `meeting.json` so retries succeed. Landed in PR #2471 (commits 823d961cf, d25190898, 0ec964a4f, 8f01a6bd3, 2491787bc, d43e7ccc1, ddbcd1b3d).

--- a/backlog/tasks/task-31746 - Meetings-pre-fill-the-You-channel-from-user_display_name.md
+++ b/backlog/tasks/task-31746 - Meetings-pre-fill-the-You-channel-from-user_display_name.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31746
 title: 'Meetings: pre-fill the You channel from user_display_name'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-06 07:40'
 labels:
@@ -17,5 +17,9 @@ The mic channel label uses a Meetings-local 'You' default instead of chat_defaul
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A configured user_display_name appears on the mic channel; an unset value falls back to You
+- [x] #1 A configured user_display_name appears on the mic channel; an unset value falls back to You
 <!-- AC:END -->
+
+## Implementation Notes
+
+One shared helper (`meeting_user_display_name`, reusing `config.get_chat_defaults_user_display_name`) renders the mic channel everywhere: the configured name when set and different from the factory default, else "You"; `MeetingMeta.user_display_name` is stamped at Start (and the live screen uses the stamped value) so live rows, the partial preview, the Markdown transcript and the Library render agree. Overlap segments now render "<name> + Others" everywhere. Landed in PR #2471 (commits 05f2d353d, 48e8541df, 7fd57fe5c, b7c8fc29b).

--- a/backlog/tasks/task-31748 - Meetings-redact-raw-exception-paths-in-phase-1-meeting-logs.md
+++ b/backlog/tasks/task-31748 - Meetings-redact-raw-exception-paths-in-phase-1-meeting-logs.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31748
 title: 'Meetings: redact raw exception paths in phase-1 meeting logs'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-06 07:41'
 labels:
@@ -17,5 +17,9 @@ The phase-2 diarization review found the same privacy-leak pattern in PHASE-1 co
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 No meeting logger call interpolates a raw exception/path into a persistent sink; redaction is regression-tested
+- [x] #1 No meeting logger call interpolates a raw exception/path into a persistent sink; redaction is regression-tested
 <!-- AC:END -->
+
+## Implementation Notes
+
+Five phase-1 meeting logger calls that interpolated a raw exception (which can embed a filesystem path via OSError) now log the exception type or a path-redacted message; regression tests use a real loguru sink and force a path-bearing OSError (`Tests/Audio/test_meeting_log_privacy.py`), plus the two phase-2 rename-failure sites. Diagnostic inventory re-pinned. Landed in PR #2471 (commit b7466ce24c).

--- a/backlog/tasks/task-31749 - Meetings-post-crash-Stop-pass-mints-ids-that-inherit-pre-crash-speaker-names.md
+++ b/backlog/tasks/task-31749 - Meetings-post-crash-Stop-pass-mints-ids-that-inherit-pre-crash-speaker-names.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-31749
 title: 'Meetings: post-crash Stop pass mints ids that inherit pre-crash speaker names'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-06 14:53'
 labels:
@@ -17,5 +17,9 @@ After the diarizer worker crashes and is restarted once (the backend then serves
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 After a worker crash and restart, no pre-crash speaker name is applied to a post-crash minted cluster id
+- [x] #1 After a worker crash and restart, no pre-crash speaker name is applied to a post-crash minted cluster id
 <!-- AC:END -->
+
+## Implementation Notes
+
+After a worker crash the restarted worker is spawned with `--start-id <max id seen>` so post-crash ids are minted past the pre-crash range (the Stop-pass batch mint honours the same floor), the backend records `crashed_at_seq`, and `MeetingSession.stop()` runs the batch pass only over the post-crash span and overlays only those segments, so pre-crash segments keep their ids and names. When no post-crash segment exists the pass is skipped rather than run full-span. Landed in PR #2471 (commit 656ec4236).


### PR DESCRIPTION
Backlog hygiene only: marks TASK-31743, 31744, 31745, 31746, 31748 and 31749 Done (acceptance criteria ticked, Implementation Notes with landing commits) now that #2471 is merged. No code changes; preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks the six meeting-diarization follow-up tasks (TASK-31743–31746, 31748, 31749) as Done now that the underlying changes landed in #2471. No code changes; each task gets its acceptance criteria ticked and implementation notes recording the landing commits.

<sup>Written for commit 7d67473bcbfd930cadcd0d6b68afd540a5f3bdca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2474?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

