### PR TITLE
fix(library): analysis saves commit — Reader Save and bulk Analyze were lost on exit (task-31942)

### DIFF
--- a/Tests/Media/test_local_media_reading_service.py
+++ b/Tests/Media/test_local_media_reading_service.py
@@ -3,12 +3,14 @@ from importlib.util import module_from_spec, spec_from_file_location
 import io
 import json
 from pathlib import Path
+import sqlite3
 import threading
 import zipfile
 
 import pytest
 from loguru import logger
 
+from tldw_chatbook.DB.Client_Media_DB_v2 import DatabaseError as MediaDatabaseError
 from tldw_chatbook.DB.Client_Media_DB_v2 import MediaDatabase as Database
 from tldw_chatbook.Media.media_reading_scope_service import MediaReadingScopeService
 
@@ -995,6 +997,145 @@ def test_local_service_get_media_item_surfaces_latest_document_version_analysis(
     assert any(
         v["analysis_content"] == "First analysis" for v in versions_after_revision[1:]
     )
+
+
+@pytest.fixture
+def file_db_factory(tmp_path):
+    """File-backed MediaDatabase plus a raw second connection to the same file.
+
+    A commit bug is invisible to the app's own connection (it reads its own
+    uncommitted writes), so every pin here checks persistence through a
+    separate ``sqlite3.connect``.
+    """
+    created = []
+
+    def _create(name="analysis-commit.sqlite", client_id="commit_client"):
+        db_path = tmp_path / name
+        db = Database(db_path=db_path, client_id=client_id)
+        created.append(db)
+        return db, db_path
+
+    yield _create
+
+    for db in created:
+        try:
+            db.close_connection()
+        except Exception:
+            pass
+
+
+def _versions_from_second_connection(db_path):
+    connection = sqlite3.connect(str(db_path))
+    try:
+        connection.row_factory = sqlite3.Row
+        return [
+            dict(row)
+            for row in connection.execute(
+                "SELECT uuid, version_number, analysis_content, deleted "
+                "FROM DocumentVersions ORDER BY version_number"
+            )
+        ]
+    finally:
+        connection.close()
+
+
+def test_local_service_save_analysis_version_commits_for_other_connections(
+    file_db_factory,
+):
+    """TASK-31942: a saved analysis must survive the process that wrote it.
+
+    ``create_document_version`` documents that it assumes an open
+    transaction and never commits; the service called it bare, so the row
+    sat on the app's thread-local connection and was lost on exit.
+    """
+    db, db_path = file_db_factory()
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Report", content="Body text", media_type="article", keywords=[]
+    )
+    service = LocalMediaReadingService(db)
+
+    saved = service.save_analysis_version(
+        media_id, content="Body text", analysis_content="Committed analysis"
+    )
+    assert saved["media_id"] == media_id
+
+    assert db.get_connection().in_transaction is False
+    rows = _versions_from_second_connection(db_path)
+    assert [row["analysis_content"] for row in rows] == [None, "Committed analysis"]
+
+
+def test_local_service_overwrite_analysis_version_commits_for_other_connections(
+    file_db_factory,
+):
+    """TASK-31942: the overwrite path (same seam) must commit too."""
+    db, db_path = file_db_factory()
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Report", content="Body text", media_type="article", keywords=[]
+    )
+    service = LocalMediaReadingService(db)
+
+    service.overwrite_analysis_version(
+        media_id, content="Body text", analysis_content="Overwritten analysis"
+    )
+
+    assert db.get_connection().in_transaction is False
+    rows = _versions_from_second_connection(db_path)
+    assert rows[-1]["analysis_content"] == "Overwritten analysis"
+
+
+def test_local_service_delete_analysis_version_commits_for_other_connections(
+    file_db_factory,
+):
+    """TASK-31942: the soft delete must be visible to a second connection."""
+    db, db_path = file_db_factory()
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Report", content="Body text", media_type="article", keywords=[]
+    )
+    service = LocalMediaReadingService(db)
+    saved = service.save_analysis_version(
+        media_id, content="Body text", analysis_content="Doomed analysis"
+    )
+
+    assert service.delete_analysis_version(saved["uuid"]) is True
+
+    assert db.get_connection().in_transaction is False
+    rows = _versions_from_second_connection(db_path)
+    deleted_row = next(row for row in rows if row["uuid"] == saved["uuid"])
+    assert deleted_row["deleted"] == 1
+
+
+def test_local_service_failed_analysis_save_rolls_back_and_raises(
+    file_db_factory, monkeypatch
+):
+    """TASK-31942 AC#3: a mid-write failure leaves no partial version row.
+
+    The Reader's ``_save_library_media_analysis`` only warns the user when
+    the call *raises*, so the failure must propagate rather than return a
+    half-written version.
+    """
+    db, db_path = file_db_factory()
+    media_id, _, _ = db.add_media_with_keywords(
+        title="Report", content="Body text", media_type="article", keywords=[]
+    )
+    service = LocalMediaReadingService(db)
+    before = _versions_from_second_connection(db_path)
+
+    original_log_sync_event = type(db)._log_sync_event
+
+    def exploding_log_sync_event(self, conn, entity, *args, **kwargs):
+        if entity == "DocumentVersions":
+            raise RuntimeError("sync log write failed")
+        return original_log_sync_event(self, conn, entity, *args, **kwargs)
+
+    monkeypatch.setattr(type(db), "_log_sync_event", exploding_log_sync_event)
+
+    with pytest.raises(MediaDatabaseError, match="sync log write failed"):
+        service.save_analysis_version(
+            media_id, content="Body text", analysis_content="Never persisted"
+        )
+
+    assert db.get_connection().in_transaction is False
+    assert _versions_from_second_connection(db_path) == before
 
 
 def test_local_service_saves_direct_reading_item_with_content(memory_db_factory):

--- a/backlog/tasks/task-31942 - Library-media-analysis-saves-never-commit-Reader-Save-and-bulk-Analyze-lost-on-exit.md
+++ b/backlog/tasks/task-31942 - Library-media-analysis-saves-never-commit-Reader-Save-and-bulk-Analyze-lost-on-exit.md
@@ -3,9 +3,11 @@ id: TASK-31942
 title: >-
   Library media - analysis saves never commit (Reader Save and bulk Analyze lost
   on exit)
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-07 07:28'
+updated_date: '2026-09-07 07:50'
 labels:
   - library
   - media-ux
@@ -22,8 +24,20 @@ Found during wave-5 PR J Task 3 and reproduced with a two-connection probe: Loca
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A saved analysis is visible to a second SQLite connection immediately after save_analysis_version returns (pinned with a real second connection, not the app's)
-- [ ] #2 overwrite_analysis_version, delete_analysis_version and any other service-layer DocumentVersions or highlight write commit the same way, or are shown to already run inside a transaction
-- [ ] #3 A failed write leaves no partial version row and surfaces as an error the Reader shows
-- [ ] #4 The Reader's analysis section and the list row's analysed marker reflect the persisted state after an app restart (live-verified once)
+- [x] #1 A saved analysis is visible to a second SQLite connection immediately after save_analysis_version returns (pinned with a real second connection, not the app's)
+- [x] #2 overwrite_analysis_version, delete_analysis_version and any other service-layer DocumentVersions or highlight write commit the same way, or are shown to already run inside a transaction
+- [x] #3 A failed write leaves no partial version row and surfaces as an error the Reader shows
+- [x] #4 The Reader's analysis section and the list row's analysed marker reflect the persisted state after an app restart (live-verified once)
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce with a two-connection probe (a file-backed MediaDatabase, save through the service, read through a plain sqlite3 connection). 2. Wrap the service-layer analysis write in the DB's transaction() (it nests: joins an open transaction, commits only at the outermost level); leave create_document_version's in-transaction contract untouched for the DB's own callers. 3. Pin save/overwrite/delete through a real second connection plus a mid-write failure that leaves no partial row and raises. 4. Audit every other DocumentVersions/highlight writer. 5. Live: scratch profile, save in the Reader, quit, relaunch.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: LocalMediaReadingService.save_analysis_version called MediaDatabase.create_document_version bare; that method assumes an open transaction and never commits, so the INSERT sat in an open transaction on the app's thread-local connection (invisible to any other connection, rolled back on close) and poisoned the next write on that connection — delete_analysis_version's own transaction() merely joined it. Fix: save_analysis_version wraps the call in db.transaction() (overwrite delegates to save; delete already opened its own transaction and commits now that nothing leaks). Audit: scope-service async wrappers inherit (worker-thread connection); MediaWindow_v2 callers inherit and already notify on exception; meeting_speaker_rename's two calls sit inside its own transaction; the server service is HTTP; every other local-service mutator opens its own transaction. AC#3 needed no UI change: _save_library_media_analysis already catches and warns, and the failure now reaches it. Live (scratch profile, one instance): a second process saw version 2 committed while the app ran; after quit and relaunch the Reader's Analysis tab and the row's analysed marker showed the saved text. Riders: create_document_version's contract is docstring-only (a future bare caller can reintroduce this); the list row's analysed marker refreshes only on the next fetch until PR J's item 19 lands. Files: tldw_chatbook/Media/local_media_reading_service.py, Tests/Media/test_local_media_reading_service.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31942 - Library-media-analysis-saves-never-commit-Reader-Save-and-bulk-Analyze-lost-on-exit.md
+++ b/backlog/tasks/task-31942 - Library-media-analysis-saves-never-commit-Reader-Save-and-bulk-Analyze-lost-on-exit.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31942
+title: >-
+  Library media - analysis saves never commit (Reader Save and bulk Analyze lost
+  on exit)
+status: To Do
+assignee: []
+created_date: '2026-09-07 07:28'
+labels:
+  - library
+  - media-ux
+  - bug
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found during wave-5 PR J Task 3 and reproduced with a two-connection probe: LocalMediaReadingService.save_analysis_version delegates to MediaDatabase.create_document_version, whose docstring says it assumes an existing transaction context, but the service calls it bare. The INSERT lands on the app's thread-local connection, which is left in_transaction; a second connection (another process, the next app launch) sees only the ingest version. The Reader's Generate/Save analysis and the bulk Analyze run therefore persist only when some later write on the same connection happens to commit, and are silently lost on exit otherwise. overwrite_analysis_version / delete_analysis_version and the highlight writers need the same audit.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A saved analysis is visible to a second SQLite connection immediately after save_analysis_version returns (pinned with a real second connection, not the app's)
+- [ ] #2 overwrite_analysis_version, delete_analysis_version and any other service-layer DocumentVersions or highlight write commit the same way, or are shown to already run inside a transaction
+- [ ] #3 A failed write leaves no partial version row and surfaces as an error the Reader shows
+- [ ] #4 The Reader's analysis section and the list row's analysed marker reflect the persisted state after an app restart (live-verified once)
+<!-- AC:END -->

--- a/tldw_chatbook/Media/local_media_reading_service.py
+++ b/tldw_chatbook/Media/local_media_reading_service.py
@@ -4819,12 +4819,36 @@ class LocalMediaReadingService:
         analysis_content: str,
         prompt: Optional[str] = None,
     ) -> Any:
-        return self._require_db().create_document_version(
-            self._coerce_media_id(media_id),
-            content=content,
-            prompt=prompt,
-            analysis_content=analysis_content,
-        )
+        """Persist an analysis as a new ``DocumentVersions`` row, and commit it.
+
+        ``create_document_version`` documents that it assumes an already-open
+        transaction (its DB-internal callers -- ``add_media_with_keywords``,
+        ``rollback_to_version`` -- all supply one) and never commits. Called
+        bare from here the INSERT sat on the app's thread-local connection,
+        left it ``in_transaction``, and was lost on exit: the Reader's Save
+        and the bulk Analyze run both persisted nothing (TASK-31942). The
+        leak also poisoned the next write on that connection --
+        ``soft_delete_document_version``'s own ``transaction()`` merely
+        joined the open one, so deletes stopped committing too. Owning the
+        transaction here also makes a mid-write failure roll back whole.
+
+        Args:
+            media_id: Parent Media row id.
+            content: Document content stored alongside the analysis.
+            analysis_content: The analysis text to persist.
+            prompt: Prompt that produced the analysis, if any.
+
+        Returns:
+            The new version's descriptor from ``create_document_version``.
+        """
+        db = self._require_db()
+        with db.transaction():
+            return db.create_document_version(
+                self._coerce_media_id(media_id),
+                content=content,
+                prompt=prompt,
+                analysis_content=analysis_content,
+            )
 
     def overwrite_analysis_version(
         self,


### PR DESCRIPTION
## Summary

Fixes task-31942, a data-loss bug found while verifying wave-5 PR J: the Reader's analysis Save (and the bulk Analyze run, which shares the seam) never committed.

`LocalMediaReadingService.save_analysis_version` called `MediaDatabase.create_document_version` bare. That DB method documents that it assumes an open transaction and never commits, so the new version sat in an open transaction on the app's thread-local connection: invisible to any other connection, rolled back on close, and persisted only if some later write on the same connection happened to commit. The leaked transaction also poisoned the next write on that connection, which is why `delete_analysis_version`'s own transaction merely joined it.

The fix wraps the service-layer save in the database's `transaction()` (it nests: joins an open transaction and commits only at the outermost level), leaving `create_document_version`'s in-transaction contract untouched for the database's own callers. `overwrite_analysis_version` delegates to save; `delete_analysis_version` already opened its own transaction and commits now that nothing leaks. Every other DocumentVersions and highlight writer was audited: the scope service's async wrappers inherit the fix on their worker-thread connection, the Media window callers inherit and already notify on exception, the meeting speaker rename runs inside its own transaction, the server service is HTTP.

## Verification

- Four pins in `Tests/Media/test_local_media_reading_service.py` read back through a real second `sqlite3` connection and assert the app connection is no longer mid-transaction (save, overwrite, delete), plus a mid-write failure that leaves no partial row and raises to the Reader's existing warning path. RED 4 → GREEN 4; the file is 84 passed; `test_media_reading_scope_service.py` 106, `test_client_media_pagination.py` 27, `test_library_media_reader_flow.py` 75.
- Live, on a scratch profile with one app instance: an analysis saved in the Reader was visible to a second process while the app ran, and after quit and relaunch the Reader's Analysis tab and the row's `analysed` marker showed it.
- One review (Sonnet): code fix correct and minimal, no Important or Critical findings.

Riders: `create_document_version`'s contract stays docstring-only; the list row's `analysed` marker refreshes on the next fetch until PR J's item 19 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes analysis saves being silently lost on exit: `save_analysis_version` called `create_document_version` bare, which never commits, so the Reader's Save and bulk Analyze runs left the row in an open transaction that rolled back on close. The leaked transaction also joined `delete_analysis_version`'s own transaction, so deletes stopped committing too. The save now wraps the write in `db.transaction()`; overwrite delegates to save, and a mid-write failure rolls back whole and raises to the Reader's existing warning path.

**Verification**
- Tests read back through a real second `sqlite3` connection to confirm save, overwrite, and delete persist, plus a mid-write failure leaves no partial row.
- All other DocumentVersions and highlight writers were audited; the scope service's async wrappers inherit the fix on their worker-thread connection.

<sup>Written for commit 24dd1c7f8a1d42aade233c356b55e8e8b583fbf1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2476?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

