### PR TITLE
fix(library): one-cell pane grips on the Conversations, Skills and Collections readers; grip leftovers removed (tasks 31951, 31952, 31953)

### DIFF
--- a/Docs/User_Guide/library/collections.md
+++ b/Docs/User_Guide/library/collections.md
@@ -179,3 +179,7 @@ membership, while member items always remain in the Library.)*
 (TASK-18916 / ADR-067: exact 20-item pages, deterministic mutation
 placement, one-clamp shrink recovery, applied-page restoration, and stale
 Retry posture.)*
+*Verified against fix/media-riders-n — 2026-09-07 (task-31951: the Collections
+reader's two pane grips are one column each, painting `‹`/`›` instead of the
+five-column `<---`/`--->` run; opened live at 235x52, and collapsing the
+Library pane repainted its grip as a one-cell `›`.)*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -35,8 +35,8 @@ Narrow (Media)
 ```
 
 Media's two grips are one column each — the `‹` (open pane) and `›`
-(collapsed pane) above. Conversations and
-the other Library destinations keep the wider `+--->+` grip.
+(collapsed pane) above. Conversations, Skills and Collections use the same
+one-column grips; Notes, File Notes and Prompts keep the wider `+--->+` grip.
 
 Media has three stable roles:
 
@@ -48,10 +48,13 @@ Media has three stable roles:
 - **Reader** — a permanent reading surface. Selecting another row updates
   Reader in place; the Items list is not replaced.
 
-Library and Items each have a full-height grip. On Media the grip is **one
-column** and paints **`‹`** to collapse the pane to its left and **`›`** to
-expand it; every other Library destination keeps the five-column **`<---`** /
-**`--->`** grip. The grips are clickable and keyboard-operable. Reader has no
+Library and Items each have a full-height grip. On Media, Conversations,
+Skills and Collections the grip is **one column** and paints **`‹`** to
+collapse the pane to its left and **`›`** to expand it; Notes, File Notes and
+Prompts keep the five-column **`<---`** / **`--->`** grip. Because the screen
+holds back exactly the columns a grip paints, the narrow grip also moves the
+width at which the navigation rail joins: on Conversations it now appears at
+110 columns (was 118) and on Skills and Collections at 114 (was 122). The grips are clickable and keyboard-operable. Reader has no
 grip and never collapses. Your manual pane choices are remembered. If the
 terminal is too narrow, the screen temporarily collapses Library first and
 then Items; widening the terminal restores the remembered layout instead of
@@ -103,6 +106,16 @@ extra. Long tags are cut to ten characters (`keyword: quokkasand…`) to keep
 the line short. It can still be too long for a narrow Items pane: at the
 pane's narrowest the row clips mid-term at the pane edge, and a row that is
 both analysed and a keyword hit can clip at the default width too.
+
+*Verified against fix/media-riders-n — 2026-09-07 (task-31951: Conversations,
+Skills and Collections opened live at 235x52. Each painted one-cell `‹` grips
+— the Library grip at columns 37 on two rows, the Items grip at column 78 on
+one — and no `<---`/`--->` run appeared anywhere on the three surfaces.
+Collapsing the Collections Library pane repainted its grip as a one-cell `›`
+at column 3, and expanding it restored the `‹`. The rail-open thresholds these
+grips move (110 on Conversations, 114 on Skills and Collections, from 118 and
+122) are the resolver's own answers, pinned at both edges of each moved band
+in `Tests/Library/test_library_adaptive_reader_state.py`.)*
 
 *Verified against fix/media-wave5-i @ c9838b5e4 — 2026-09-06 (tasks 28008/28009: four
 seeded `document` items, two of them analysed, live at 235x52 and 100x30.

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -54,11 +54,12 @@ collapse the pane to its left and **`›`** to expand it; Notes, File Notes and
 Prompts keep the five-column **`<---`** / **`--->`** grip. Because the screen
 holds back exactly the columns a grip paints, the narrow grip also moves the
 width at which the navigation rail joins: on Conversations it now appears at
-110 columns (was 118) and on Skills and Collections at 114 (was 122). The grips are clickable and keyboard-operable. Reader has no
-grip and never collapses. Your manual pane choices are remembered. If the
-terminal is too narrow, the screen temporarily collapses Library first and
-then Items; widening the terminal restores the remembered layout instead of
-saving the temporary responsive state.
+110 columns (was 118) and on Skills and Collections at 114 (was 122). The
+grips are clickable and keyboard-operable. Reader has no grip and never
+collapses. Your manual pane choices are remembered. If the terminal is too
+narrow, the screen temporarily collapses Library first and then Items;
+widening the terminal restores the remembered layout instead of saving the
+temporary responsive state.
 
 On Media nothing sits between the panes but those two one-cell grips, and the
 list uses the width that frees up:

--- a/Docs/User_Guide/library/skills.md
+++ b/Docs/User_Guide/library/skills.md
@@ -407,3 +407,7 @@ one-press toggles with their full option set now on the label —
 per-project discovery at startup and workspace creation, the fingerprint
 gated prompt ledger, the quarantine/trust-review expectation, and the
 `[skills] project_skills_prompt_enabled` kill-switch.)*
+
+*Verified against fix/media-riders-n — 2026-09-07 (task-31951: the Skills
+reader's two pane grips are one column each, painting `‹`/`›` instead of the
+five-column `<---`/`--->` run; opened live at 235x52.)*

--- a/Docs/superpowers/plans/2026-09-07-media-riders-pr-n.md
+++ b/Docs/superpowers/plans/2026-09-07-media-riders-pr-n.md
@@ -1,0 +1,25 @@
+# Media riders PR N — grips and the reader resolver (tasks 31951, 31952, 31953)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. The three backlog task files are the briefs; this plan carries the batching, constraints and verification.
+
+**Goal:** finish what PR H started on the adaptive reader shell: the three sibling readers (Conversations, Skills, Collections) opt into the one-cell grip with the same glyphs as Media (31951); the dead five-column grip CSS and the unused `PANE_GRIP_WIDTH` readers go, so the reserved and painted grip widths come from one value (31952); the custom-items-width pin stops overclaiming the library-closed comfort branch, or that branch obeys a typed width (31953 — decide and record).
+
+**Spec:** the task files under `backlog/tasks/` (31951, 31952, 31953).
+
+## Global Constraints
+- Worktree `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.claude/worktrees/media-riders-n`, branch `fix/media-riders-n` off dev. Every command `cd <worktree> && git branch --show-current`; python `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python` with `PYTHONPATH=$PWD`; `-p no:cacheprovider`; UI test files one per process, SERIAL.
+- `tldw_chatbook/Utils/adaptive_reader_state.py` is shared by all four readers; `AdaptiveReaderLayoutProfile.grip_width` (default 5) is the per-profile knob PR H added (Media = 1); the grip widget paints `‹`/`›` under four cells. Opting the siblings in CHANGES their widths: re-pin their resolver tables honestly (old value in the comment, no ranges) and their painted shell pins; the Items floors and PR D's row positions on the Media surface do not move.
+- CSS: `css/screen_agentic_library.tcss` and the bundle are GENERATED from `css/components/_agentic_terminal.tcss` — edit the source, `python -m tldw_chatbook.css.build_css`, `python tldw_chatbook/css/check_bundle_sync.py` exit 0, commit the regenerated files.
+- No new `logger.*`; do NOT edit `backlog/`; painted pins for anything a user sees.
+- Evidence: compare failing NAME sets against a detached copy of the merge-base; known dev reds per task-31249's census.
+- Live: ONE app instance, tmux socket `wrn` via `t() { tmux -L wrn "$@"; }`; three orphaned instances on `/private/tmp/tldw-uat-wizard` are another session's. Capture each sibling reader's grips at 235×52.
+- Commit per batch with the trailer `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>`.
+
+## Batches
+### Batch 1: 31951 + 31952 (one commit each is fine)
+Opt the three sibling profiles into `grip_width=1`; re-pin; remove the dead `.library-adaptive-reader-pane-grip { width/min-width/max-width: 5 }` rule; remove the unused `PANE_GRIP_WIDTH` import in `library_screen.py` and make `library_skills_controller.py`'s `2 * PANE_GRIP_WIDTH` read the profile; consider carrying `grip_width` on the effective layout so the resolver's reservation and the shell's paint are one number (say whether you did, and why).
+### Batch 2: 31953
+Decide: obey a typed custom width in the library-closed comfort branch (`adaptive_reader_state.py` ~295-303), or rename/re-document the pin to state the branch it does not cover. Record the decision and reason beside the pin.
+
+## Land
+Final whole-branch review → fix round → PR N. Update `Docs/User_Guide/library/*.md` where the grip is described for the sibling surfaces.

--- a/Tests/Library/test_library_adaptive_reader_state.py
+++ b/Tests/Library/test_library_adaptive_reader_state.py
@@ -629,13 +629,20 @@ def test_media_items_column_grows_once_the_reader_is_comfortable(
 
 @pytest.mark.parametrize("custom_items_width", [32, 34, 48])
 @pytest.mark.parametrize("width", [160, 235])
-def test_a_typed_custom_items_width_is_obeyed_rather_than_grown(
+def test_a_typed_custom_items_width_is_obeyed_by_the_growth_gate(
     width: int, custom_items_width: int
 ) -> None:
     """Settings > Appearance > Custom widths is a hand-typed number.
 
-    "Automatic" adapts; "Custom" obeys. Without the gate the typed value was
-    silently overridden above ~130 columns (review Important 1).
+    "Automatic" adapts; "Custom" obeys. Without the `list_grows` gate the
+    typed value was silently overridden above ~130 columns (review
+    Important 1).
+
+    Scope: the `list_grows` gate only, with BOTH panes open. It does NOT
+    cover the two comfort clamps, which still widen a typed width once the
+    Library pane is gone -- see
+    `test_a_typed_custom_items_width_is_still_widened_once_the_library_closes`
+    for what those actually do, and why.
     """
     custom = MediaReaderLayoutPreferences(
         custom_widths_enabled=True,
@@ -648,6 +655,36 @@ def test_a_typed_custom_items_width_is_obeyed_rather_than_grown(
 
     assert grown.items_width == custom_items_width
     assert grown == ungrown
+
+
+@pytest.mark.parametrize("priority", [None, "items"])
+def test_a_typed_custom_items_width_is_still_widened_once_the_library_closes(
+    priority: str | None,
+) -> None:
+    """task-31953: the comfort clamps are NOT gated on custom widths.
+
+    Decision: documented, not changed. TWO clamps widen a typed width once
+    the Library pane is gone -- the library-closed clamp in
+    `adaptive_reader_state.py` (`if items_open and not library_open`) and the
+    priority-pane clamp above it -- so "obey the typed width" is not the
+    one-line change this test-debt rider is scoped to, and
+    `test_resolution_never_mutates_saved_preferences` already pins one of the
+    widened values (a typed 40 resolves to 56). Changing it is a
+    user-visible width change on all four reader surfaces; it needs its own
+    task. This pin records what the resolver does today so the next reader
+    change is not blamed for it.
+    """
+    custom = MediaReaderLayoutPreferences(
+        custom_widths_enabled=True,
+        library_width=31,
+        items_width=32,
+    )
+
+    layout = resolve_media_reader_layout(100, custom, priority=priority)
+
+    # A typed 32 paints 52: 100 cells less the two one-cell grips and the
+    # 46-cell Reader minimum.
+    assert (layout.library_open, layout.items_width) == (False, 52)
 
 
 def test_media_items_column_is_wider_at_235_than_at_100() -> None:

--- a/Tests/Library/test_library_adaptive_reader_state.py
+++ b/Tests/Library/test_library_adaptive_reader_state.py
@@ -455,6 +455,14 @@ SIBLING_PROFILES = {
     "skills": LIBRARY_SKILLS_READER_PROFILE,
     "collections": LIBRARY_COLLECTIONS_READER_PROFILE,
 }
+# task-31951: the three sibling readers joined Media on the one-cell grip.
+# Notes, File Notes and Prompts keep the five-cell default, so this is the
+# opt-in list, not "everything but Media".
+ONE_CELL_GRIP_PROFILE_NAMES = {
+    "LIBRARY_CONVERSATION_READER_PROFILE",
+    "LIBRARY_SKILLS_READER_PROFILE",
+    "LIBRARY_COLLECTIONS_READER_PROFILE",
+}
 DECLARED_PROFILES = {
     name: value
     for name, value in vars(screen_constants).items()
@@ -476,10 +484,14 @@ def _pane_widths(
 
 def test_only_the_media_profile_opts_into_list_growth() -> None:
     assert MEDIA_READER_LAYOUT_PROFILE.list_grows is True
-    # task-31633 AC#2: the one-cell grip is opt-in the same way.
+    # task-31633 AC#2: the one-cell grip is opt-in the same way. task-31951
+    # opted the three sibling readers in as well (each was PANE_GRIP_WIDTH);
+    # the default and the destinations that did not opt in stay at five.
     assert MEDIA_READER_LAYOUT_PROFILE.grip_width == 1
     for name, profile in DECLARED_PROFILES.items():
-        assert profile.grip_width == PANE_GRIP_WIDTH, name
+        expected = 1 if name in ONE_CELL_GRIP_PROFILE_NAMES else PANE_GRIP_WIDTH
+        assert profile.grip_width == expected, name
+    assert ONE_CELL_GRIP_PROFILE_NAMES <= set(DECLARED_PROFILES)
     assert AdaptiveReaderLayoutProfile().grip_width == PANE_GRIP_WIDTH
     assert set(SIBLING_PROFILES.values()) <= set(DECLARED_PROFILES.values())
     assert len(DECLARED_PROFILES) >= 6, sorted(DECLARED_PROFILES)
@@ -488,22 +500,65 @@ def test_only_the_media_profile_opts_into_list_growth() -> None:
     assert AdaptiveReaderLayoutProfile().list_grows is False
 
 
+@pytest.mark.parametrize("width", [100, 235])
+def test_every_profile_reserves_exactly_the_grip_columns_it_paints(width: int) -> None:
+    """task-31951 AC#3 / task-31952 AC#3: one number, not two.
+
+    The resolver holds back ``2 * profile.grip_width`` AND reports that same
+    per-grip width on the layout it returns, and the shell paints its grips
+    from the layout it is mounted with (pinned on the rendered widgets in
+    ``Tests/UI/test_library_adaptive_reader_shell.py``). A destination can no
+    longer reserve five columns and paint one.
+    """
+    profiles = dict(DECLARED_PROFILES)
+    profiles["MEDIA_READER_LAYOUT_PROFILE"] = MEDIA_READER_LAYOUT_PROFILE
+
+    for name, profile in profiles.items():
+        layout = resolve_adaptive_reader_layout(
+            width, AdaptiveReaderLayoutPreferences(), profile
+        )
+
+        assert layout.grip_width == profile.grip_width, name
+        assert (
+            layout.library_width
+            + layout.items_width
+            + layout.reader_width
+            + 2 * layout.grip_width
+        ) == width, name
+
+
 @pytest.mark.parametrize(
     ("surface", "width", "expected"),
     [
-        # Recorded from the resolver at badff73f1, before list growth existed.
-        ("conversations", 100, (False, True, 0, 46, 44)),
-        ("conversations", 117, (False, True, 0, 56, 51)),
-        ("conversations", 118, (True, True, 24, 40, 44)),
-        ("conversations", 235, (True, True, 34, 40, 151)),
-        ("skills", 100, (False, True, 0, 42, 48)),
-        ("skills", 121, (False, True, 0, 56, 55)),
-        ("skills", 122, (True, True, 24, 40, 48)),
-        ("skills", 235, (True, True, 34, 40, 151)),
-        ("collections", 100, (False, True, 0, 42, 48)),
-        ("collections", 121, (False, True, 0, 56, 55)),
-        ("collections", 122, (True, True, 24, 40, 48)),
-        ("collections", 235, (True, True, 34, 40, 151)),
+        # Recorded from the resolver at badff73f1, before list growth existed,
+        # and RE-ANCHORED by task-31951: the three siblings joined Media on
+        # the one-cell grip, so each row gained the eight cells their two
+        # five-cell grips used to hold back. Growth is still off for all
+        # three -- every cell below lands on the pane the resolver already
+        # gave the surplus to. Old value beside each row.
+        #
+        # `required_width()` counts the grips, so the rail-open threshold
+        # moved down by eight on every sibling as well: 118 -> 110 on
+        # Conversations, 122 -> 114 on Skills and Collections. Both edges of
+        # each moved band are pinned underneath.
+        ("conversations", 100, (False, True, 0, 54, 44)),  # was (…, 0, 46, 44)
+        ("conversations", 109, (False, True, 0, 56, 51)),  # was (…, 0, 55, 44)
+        ("conversations", 110, (True, True, 24, 40, 44)),  # was (False, …, 56, 44)
+        ("conversations", 117, (True, True, 24, 40, 51)),  # was (False, …, 56, 51)
+        ("conversations", 118, (True, True, 24, 40, 52)),  # was (…, 24, 40, 44)
+        ("conversations", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
+        ("skills", 100, (False, True, 0, 50, 48)),  # was (…, 0, 42, 48)
+        ("skills", 113, (False, True, 0, 56, 55)),  # was (…, 0, 55, 48)
+        ("skills", 114, (True, True, 24, 40, 48)),  # was (False, …, 56, 48)
+        ("skills", 121, (True, True, 24, 40, 55)),  # was (False, …, 56, 55)
+        ("skills", 122, (True, True, 24, 40, 56)),  # was (…, 24, 40, 48)
+        ("skills", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
+        ("collections", 100, (False, True, 0, 50, 48)),  # was (…, 0, 42, 48)
+        ("collections", 113, (False, True, 0, 56, 55)),  # was (…, 0, 55, 48)
+        ("collections", 114, (True, True, 24, 40, 48)),  # was (False, …, 56, 48)
+        ("collections", 121, (True, True, 24, 40, 55)),  # was (False, …, 56, 55)
+        ("collections", 122, (True, True, 24, 40, 56)),  # was (…, 24, 40, 48)
+        ("collections", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
     ],
 )
 def test_sibling_reader_layouts_are_untouched_by_media_list_growth(

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -37,7 +37,6 @@ from tldw_chatbook.Library.library_media_state import (
 )
 from tldw_chatbook.Media import LocalMediaReadingService, MediaReadingScopeService
 from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
-from tldw_chatbook.Utils.adaptive_reader_state import PANE_GRIP_WIDTH
 from tldw_chatbook.app import TldwCli
 from tldw_chatbook.config import get_cli_config_path, get_cli_log_file_path, get_user_data_dir
 
@@ -263,7 +262,7 @@ def _assert_reader_width_contract(
         layout.library_width
         + layout.items_width
         + layout.reader_width
-        + (2 * PANE_GRIP_WIDTH)
+        + (2 * layout.grip_width)
         == shell_content_width
     )
     assert library_region_width == layout.library_width

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -342,7 +342,7 @@ def test_reader_width_contract_rejects_one_column_mutation() -> None:
         library_width=0,
         items_width=56,
         reader_width=50,
-        grip_width=layout.grip_width,
+        grip_width=1,  # the Media profile's one-cell grip (PR H)
     )
     with pytest.raises(AssertionError):
         _assert_reader_width_contract(

--- a/Tests/Live/test_library_media_trash_paging_closeout.py
+++ b/Tests/Live/test_library_media_trash_paging_closeout.py
@@ -342,6 +342,7 @@ def test_reader_width_contract_rejects_one_column_mutation() -> None:
         library_width=0,
         items_width=56,
         reader_width=50,
+        grip_width=layout.grip_width,
     )
     with pytest.raises(AssertionError):
         _assert_reader_width_contract(

--- a/Tests/UI/test_library_adaptive_reader_shell.py
+++ b/Tests/UI/test_library_adaptive_reader_shell.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import replace
 from pathlib import Path
 
 import pytest
@@ -66,7 +67,10 @@ class _ProbeApp(ConsolidatedCSSApp):
         grip_width: int = PANE_GRIP_WIDTH,
     ) -> None:
         super().__init__()
-        self.layout = layout or _layout()
+        # task-31952 AC#3: the grip width reaches the shell ONLY on the
+        # layout the resolver produced, so a probe cannot paint a width the
+        # resolver never reserved.
+        self.layout = replace(layout or _layout(), grip_width=grip_width)
         self.focusable_content = focusable_content
         self.hidden_items_subtree = hidden_items_subtree
         self.work_disabled = work_disabled
@@ -99,7 +103,6 @@ class _ProbeApp(ConsolidatedCSSApp):
             id_prefix="probe",
             library_label="Library",
             items_label="Items",
-            grip_width=self.grip_width,
             id="probe-shell",
         )
         yield shell
@@ -129,8 +132,9 @@ def _painted_rows_containing(app: _ProbeApp, widget: Widget, token: str) -> list
 @pytest.mark.parametrize(
     ("grip_width", "arrow"),
     # task-31633 AC#2: the grip width is the destination profile's, and the
-    # arrow is as wide as the grip. Five columns is the shared default every
-    # destination but Media still uses; one column is Media's.
+    # arrow is as wide as the grip. Five columns is the shared default Notes,
+    # File Notes and Prompts still use; one column is Media's, and since
+    # task-31951 also Conversations', Skills' and Collections'.
     [(PANE_GRIP_WIDTH, "<---"), (MEDIA_READER_LAYOUT_PROFILE.grip_width, "‹")],
 )
 async def test_shell_mounts_three_concrete_widgets_and_two_profile_width_grips(
@@ -159,6 +163,8 @@ async def test_shell_mounts_three_concrete_widgets_and_two_profile_width_grips(
             grip_width,
             grip_width,
         ]
+        # task-31952 AC#3: painted width IS the resolver's reservation.
+        assert shell.effective_layout.grip_width == grip_width
         assert _painted_rows_containing(app, shell.items_grip, arrow), arrow
 
 

--- a/Tests/UI/test_library_adaptive_reader_shell.py
+++ b/Tests/UI/test_library_adaptive_reader_shell.py
@@ -74,7 +74,6 @@ class _ProbeApp(ConsolidatedCSSApp):
         self.focusable_content = focusable_content
         self.hidden_items_subtree = hidden_items_subtree
         self.work_disabled = work_disabled
-        self.grip_width = grip_width
         self.toggles: list[str] = []
         self.resize_messages = 0
 
@@ -574,6 +573,34 @@ def test_shared_shell_structure_is_owned_by_shared_tcss_selectors():
         ".library-adaptive-reader-shell > .library-adaptive-reader-pane-grip {"
         in source
     )
+
+
+@pytest.mark.parametrize(
+    "sheet",
+    [
+        CSS_SOURCE,
+        # The rebuilt sheet: `build_css` routes this screen-scoped rule here
+        # rather than into `tldw_cli_modular.tcss`, which carries only the
+        # grip's :hover/.-active pair.
+        CSS_SOURCE.parents[1] / "screen_agentic_library.tcss",
+    ],
+    ids=["component-source", "generated-screen-sheet"],
+)
+def test_no_sheet_declares_a_grip_width_beside_the_inline_one(sheet: Path) -> None:
+    """task-31952 AC#1: the five-column fallback is gone everywhere.
+
+    Every mounted grip sets its width inline from the layout the resolver
+    produced, and an inline style outranks a rule -- so ``width: 5`` here was
+    dead for Media, dead for the three siblings task-31951 narrowed, and a
+    second (stale) answer to a question the resolver already settles.
+    """
+    grip_block = sheet.read_text(encoding="utf-8").split(
+        ".library-adaptive-reader-shell > .library-adaptive-reader-pane-grip {",
+        1,
+    )[1].split("}", 1)[0]
+
+    for declaration in ("width:", "min-width:", "max-width:"):
+        assert declaration not in grip_block, (sheet.name, declaration)
 
 
 def test_shared_tcss_owns_the_calm_visual_contract_for_every_reader():

--- a/Tests/UI/test_library_collections_reader_geometry.py
+++ b/Tests/UI/test_library_collections_reader_geometry.py
@@ -7,10 +7,11 @@ from textual import on
 from textual.widgets import Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.UI.Library_Modules.screen_constants import (
+    LIBRARY_COLLECTIONS_READER_PROFILE,
+)
 from tldw_chatbook.Utils.adaptive_reader_state import (
-    PANE_GRIP_WIDTH,
     AdaptiveReaderLayoutPreferences,
-    AdaptiveReaderLayoutProfile,
     resolve_adaptive_reader_layout,
 )
 from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
@@ -19,17 +20,24 @@ from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
 )
 
 
-PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48, work_comfort_width=56)
+# task-31951: the profile the Collections route actually mounts, not a local
+# copy of its widths -- a copy kept passing while the shipped profile moved to
+# the one-cell grip.
+PROFILE = LIBRARY_COLLECTIONS_READER_PROFILE
 PREFERENCES = AdaptiveReaderLayoutPreferences()
 
 
 @pytest.mark.parametrize(
     ("width", "expected"),
     (
-        (160, (30, 40, 80)),
-        (120, (0, 56, 54)),
-        (100, (0, 42, 48)),
-        (80, (0, 0, 70)),
+        # task-31951 re-anchored these to the one-cell grip: each row gained
+        # the eight cells the two five-cell grips used to hold back, and the
+        # rail now opens at 114 instead of 122 -- which is why 120 flipped
+        # from a library-closed 56-cell list to the rail beside a 40-cell one.
+        (160, (30, 40, 88)),  # was (30, 40, 80)
+        (120, (24, 40, 54)),  # was (0, 56, 54)
+        (100, (0, 50, 48)),  # was (0, 42, 48)
+        (80, (0, 0, 78)),  # was (0, 0, 70)
     ),
 )
 def test_collections_profile_has_pinned_pure_geometry(width, expected) -> None:
@@ -82,7 +90,9 @@ async def test_mounted_collections_geometry_matches_one_settled_resolution(size)
         assert shell.library.region.width == expected.library_width
         assert shell.items.region.width == expected.items_width
         assert shell.work.region.width == expected.reader_width
-        assert shell.library_grip.region.width == PANE_GRIP_WIDTH
-        assert shell.items_grip.region.width == PANE_GRIP_WIDTH
+        # task-31951/31952: painted width IS the resolver's reservation.
+        assert shell.library_grip.region.width == 1
+        assert shell.items_grip.region.width == 1
+        assert expected.grip_width == 1
         assert shell.work.is_mounted and shell.work.display
         assert sum(child.region.width for child in shell.children) == measured_width

--- a/Tests/UI/test_library_conversation_reader.py
+++ b/Tests/UI/test_library_conversation_reader.py
@@ -1981,7 +1981,8 @@ async def test_conversations_geometry_contains_protected_work_and_restore_grips(
         for grip in (shell.library_grip, shell.items_grip):
             assert grip in visible
             # task-31951: one cell, was 5 -- Conversations joined Media on
-            # the one-cell grip, so the ten dead columns are back in the panes.
+            # the one-cell grip, so eight of the ten columns the two grips
+            # used to hold back are back in the panes.
             assert grip.region.width == 1
             assert shell.region.contains_region(grip.region)
             assert grip.can_focus

--- a/Tests/UI/test_library_conversation_reader.py
+++ b/Tests/UI/test_library_conversation_reader.py
@@ -1980,7 +1980,9 @@ async def test_conversations_geometry_contains_protected_work_and_restore_grips(
         assert shell.work in visible and shell.region.contains_region(shell.work.region)
         for grip in (shell.library_grip, shell.items_grip):
             assert grip in visible
-            assert grip.region.width == 5
+            # task-31951: one cell, was 5 -- Conversations joined Media on
+            # the one-cell grip, so the ten dead columns are back in the panes.
+            assert grip.region.width == 1
             assert shell.region.contains_region(grip.region)
             assert grip.can_focus
         for pane, open_ in (

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -77,6 +77,7 @@ from Tests.UI.test_library_shell import (
     LibraryHarness,
     _FakeSkillsScopeService,
     _active_library_screen,
+    _wait_for_condition,
     _wait_for_library_shell,
 )
 from Tests.UI.app_factory import _build_test_app as _build_shared_test_app
@@ -1664,15 +1665,29 @@ async def test_library_skills_items_priority_floor_moves_with_the_grip_width(
             AsyncMock(),
         )
         screen.query_one("#library-row-browse-skills").press()
-        shell = None
-        for _ in range(200):
-            await pilot.pause(0.01)
-            found = screen.query("#library-skills-reader-shell")
-            if found and found.first().effective_layout.reader_width:
-                shell = found.first()
-                break
 
-        assert shell is not None and shell.region.width == width
+        def _painted() -> bool:
+            # task-31953: anchor on the PAINTED Items width, not on
+            # `effective_layout.reader_width` alone -- the layout field lands
+            # a frame before the shell re-lays out its panes, so breaking on
+            # it read `items.region.width == 0` about one run in nine.
+            found = screen.query("#library-skills-reader-shell")
+            if not found:
+                return False
+            candidate = found.first()
+            return bool(
+                candidate.effective_layout.reader_width
+                and candidate.items.region.width == items_width
+            )
+
+        await _wait_for_condition(
+            pilot,
+            _painted,
+            message="Skills reader shell never painted the expected Items width.",
+        )
+        shell = screen.query_one("#library-skills-reader-shell")
+
+        assert shell.region.width == width
         assert shell.effective_layout.items_open is items_open
         assert shell.effective_layout.items_width == items_width
         assert shell.items.region.width == items_width

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -1627,6 +1627,59 @@ async def test_library_skills_retry_recovers_transient_list_failure():
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("width", "items_open", "items_width"),
+    # task-31951/31952: `_sync_library_skills_reader_layout_from_shell` gives
+    # the Items pane priority once the shell can hold both grips, the list's
+    # 32-cell floor and the 48-cell work minimum. That floor reads the
+    # profile's `grip_width`, so it moved with the one-cell grip: 2*5+32+48 =
+    # 90 before, 2*1+32+48 = 82 now. The band 82-89 is the difference -- the
+    # list paints there instead of collapsing -- so both edges are pinned.
+    [(81, False, 0), (82, True, 32)],
+)
+async def test_library_skills_items_priority_floor_moves_with_the_grip_width(
+    width: int,
+    items_open: bool,
+    items_width: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    app = _build_test_app()
+    app.notes_scope_service = StaticLibraryNotesListScopeService([])
+    app.media_reading_scope_service = StaticLibraryMediaScopeService([])
+    app.chat_conversation_scope_service = StaticLibraryConversationScopeService([])
+    app.skills_scope_service = _FakeSkillsScopeService(
+        available=[
+            {"name": f"skill-{index:03d}", "description": f"Skill {index}"}
+            for index in range(45)
+        ]
+    )
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=(width, 24)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        monkeypatch.setattr(
+            screen,
+            "_persist_library_reader_preference",
+            AsyncMock(),
+        )
+        screen.query_one("#library-row-browse-skills").press()
+        shell = None
+        for _ in range(200):
+            await pilot.pause(0.01)
+            found = screen.query("#library-skills-reader-shell")
+            if found and found.first().effective_layout.reader_width:
+                shell = found.first()
+                break
+
+        assert shell is not None and shell.region.width == width
+        assert shell.effective_layout.items_open is items_open
+        assert shell.effective_layout.items_width == items_width
+        assert shell.items.region.width == items_width
+        assert shell.effective_layout.reader_width >= 48
+
+
+@pytest.mark.asyncio
 async def test_library_skills_manual_items_priority_survives_compact_layout_sync(
     monkeypatch: pytest.MonkeyPatch,
 ):

--- a/Tests/UI/test_library_skills_reader.py
+++ b/Tests/UI/test_library_skills_reader.py
@@ -415,7 +415,8 @@ async def test_skills_reader_live_matrix_preserves_modes_work_floor_and_grips(
 
         assert shell.work.region.width >= 48
         # task-31951: one cell each, was 5 -- Skills joined Media on the
-        # one-cell grip, so the ten dead columns are back in the panes.
+        # one-cell grip, so eight of the ten columns the two grips used to
+        # hold back are back in the panes.
         assert shell.library_grip.region.width == 1
         assert shell.items_grip.region.width == 1
         assert shell.library_grip.display and shell.items_grip.display

--- a/Tests/UI/test_library_skills_reader.py
+++ b/Tests/UI/test_library_skills_reader.py
@@ -414,8 +414,10 @@ async def test_skills_reader_live_matrix_preserves_modes_work_floor_and_grips(
             await pilot.pause()
 
         assert shell.work.region.width >= 48
-        assert shell.library_grip.region.width == 5
-        assert shell.items_grip.region.width == 5
+        # task-31951: one cell each, was 5 -- Skills joined Media on the
+        # one-cell grip, so the ten dead columns are back in the panes.
+        assert shell.library_grip.region.width == 1
+        assert shell.items_grip.region.width == 1
         assert shell.library_grip.display and shell.items_grip.display
         assert screen.query_one("#library-skill-overview-region").display is True
 

--- a/backlog/tasks/task-31951 - Library-opt-the-Conversations-Skills-and-Collections-readers-into-the-1-cell-pane-grip.md
+++ b/backlog/tasks/task-31951 - Library-opt-the-Conversations-Skills-and-Collections-readers-into-the-1-cell-pane-grip.md
@@ -3,9 +3,11 @@ id: TASK-31951
 title: >-
   Library - opt the Conversations, Skills and Collections readers into the
   1-cell pane grip
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-07 08:26'
+updated_date: '2026-09-07 17:41'
 labels:
   - library
   - media-ux
@@ -21,7 +23,19 @@ H Task 2 ruling: PR H made LibraryAdaptiveReaderPaneGrip's width per reader prof
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The three sibling readers render a 1-cell grip with the same glyphs as Media
-- [ ] #2 Their resolver width pins are updated to the new reservation
-- [ ] #3 No reader surface reserves grip columns it does not paint
+- [x] #1 The three sibling readers render a 1-cell grip with the same glyphs as Media
+- [x] #2 Their resolver width pins are updated to the new reservation
+- [x] #3 No reader surface reserves grip columns it does not paint
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-pin the three sibling profiles' resolver tuples and painted grips to the one-cell grip first (old values in the comments), then set grip_width=1 on the profiles. 2. Carry grip_width on the effective layout so the shell paints from the resolved value (delete the shell parameter). 3. Pin that every profile reserves exactly the grip columns it paints; pin the moved rail-open thresholds and the Skills items-priority floor at both band edges. 4. Live capture per sibling; guide update.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Profiles: Conversations/Skills/Collections grip_width=1 (screen_constants.py). The width rides AdaptiveReaderEffectiveLayout.grip_width; LibraryAdaptiveReaderShell reads it (its own grip_width parameter deleted, zero call-site edits); LibraryAdaptiveReaderPaneGrip.sync_width() is applied at construction and in sync_layout. Consequences (pinned both edges, "was" in comments): rail-open 118→110 (Conversations), 122→114 (Skills, Collections); Skills items-priority floor 90→82. Live: one-cell ‹/› on all three at 235x52. Riders: sync_layout re-apply now closes the stale-grip window; File Notes' placeholder layout hard-codes the default until its first resolve (circular import).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31952 - Library-remove-the-grip-width-leftovers-after-the-per-profile-grip.md
+++ b/backlog/tasks/task-31952 - Library-remove-the-grip-width-leftovers-after-the-per-profile-grip.md
@@ -1,9 +1,11 @@
 ---
 id: TASK-31952
 title: Library - remove the grip-width leftovers after the per-profile grip
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-07 08:26'
+updated_date: '2026-09-07 17:41'
 labels:
   - library
   - media-ux
@@ -19,7 +21,19 @@ H final review: every LibraryAdaptiveReaderPaneGrip now sets its width inline fr
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The dead grip width rule is gone from the component source and from the rebuilt bundle
-- [ ] #2 No module reads PANE_GRIP_WIDTH where a profile's grip_width is the real number
-- [ ] #3 The width the resolver reserves and the width the shell paints come from one value
+- [x] #1 The dead grip width rule is gone from the component source and from the rebuilt bundle
+- [x] #2 No module reads PANE_GRIP_WIDTH where a profile's grip_width is the real number
+- [x] #3 The width the resolver reserves and the width the shell paints come from one value
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Remove the dead .library-adaptive-reader-pane-grip width rule from the component source; rebuild; pin its absence in source and sheet. 2. Remove the unused PANE_GRIP_WIDTH import; make the Skills controller read the profile's grip_width. 3. Pin reserved == painted per profile.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Dead rule removed from _agentic_terminal.tcss and the regenerated screen_agentic_library.tcss (bundle reproduces); library_screen.py import gone; library_skills_controller.py reads LIBRARY_SKILLS_READER_PROFILE.grip_width (this is what moved the Skills floor 90→82 — pinned). Remaining PANE_GRIP_WIDTH reads are the dataclass defaults and Watchlists' own unrelated constant.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31953 - Library-reader-a-typed-custom-items-width-is-still-widened-by-the-library-closed-comfort-branch.md
+++ b/backlog/tasks/task-31953 - Library-reader-a-typed-custom-items-width-is-still-widened-by-the-library-closed-comfort-branch.md
@@ -3,9 +3,11 @@ id: TASK-31953
 title: >-
   Library reader - a typed custom items width is still widened by the
   library-closed comfort branch
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-07 08:26'
+updated_date: '2026-09-07 17:41'
 labels:
   - library
   - media-ux
@@ -22,6 +24,18 @@ H final review: test_a_typed_custom_items_width_is_obeyed_rather_than_grown's do
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Either the comfort branch obeys a typed custom width, or the test's name and docstring state the branch it does not cover
-- [ ] #2 The decision and its reason are recorded in the task or beside the pin
+- [x] #1 Either the comfort branch obeys a typed custom width, or the test's name and docstring state the branch it does not cover
+- [x] #2 The decision and its reason are recorded in the task or beside the pin
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Test the one-line option (obey a typed width in the library-closed comfort branch) against Media 100x30 and the siblings. 2. If it is not one line with no impact, rename the pin to the branch it covers, add a characterization pin for the widening, record the decision beside the clamp.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+DOCUMENTED, not changed: two clamps widen a typed Items width (the library-closed clamp and the priority-pane clamp in adaptive_reader_state.py; typed 32 → 52 at width 100), and test_resolution_never_mutates_saved_preferences already pins typed 40 → 56, so obeying is a user-visible width change on all four readers plus pin churn — a product decision (rider filed: are custom widths floors, exact, or advisory?). The pin is now test_a_typed_custom_items_width_is_obeyed_by_the_growth_gate with a scoped docstring; test_a_typed_custom_items_width_is_still_widened_once_the_library_closes characterizes the widening; the clamp carries the reason. Also fixed here: the batch-1 floor pin's wait is anchored on the painted region (30/30). Also fixed at the final review: Tests/Live's Media geometry contract summed 2 * PANE_GRIP_WIDTH (off by eight since PR H); it now reads layout.grip_width.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Library_Modules/library_skills_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_skills_controller.py
@@ -368,7 +368,7 @@ from ...Library.library_skills_state import (
     skill_invocation_copy,
     skill_review_identity_line,
 )
-from ...Utils.adaptive_reader_state import PANE_GRIP_WIDTH, resolve_adaptive_reader_layout
+from ...Utils.adaptive_reader_state import resolve_adaptive_reader_layout
 from ...config import coerce_bool_setting
 from ...Widgets.Library import (
     LIBRARY_SKILLS_FILTER_ID,
@@ -803,7 +803,7 @@ class LibrarySkillsController:
             and self._library_skills_reader_preferences.items_open
         ):
             items_priority_floor = (
-                2 * PANE_GRIP_WIDTH
+                2 * LIBRARY_SKILLS_READER_PROFILE.grip_width
                 + LIBRARY_SKILLS_READER_PROFILE.list_min_width
                 + LIBRARY_SKILLS_READER_PROFILE.work_min_width
             )

--- a/tldw_chatbook/UI/Library_Modules/screen_constants.py
+++ b/tldw_chatbook/UI/Library_Modules/screen_constants.py
@@ -45,15 +45,26 @@ from ...Widgets.Library import PROMPT_DISCARD_TOOLTIP_BUSY
 LIBRARY_SKILLS_IMPORT_WORKER_GROUP = "library_skills_import"
 
 
-LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile()
+# task-31951: Conversations, Skills and Collections join Media on the
+# one-cell grip (task-31633 AC#2 shipped it for Media alone). Each surface was
+# spending ten columns on two five-column grips that paint a single arrow;
+# the resolver reserves what the grip paints, so those ten cells now go to the
+# panes -- and the rail-open threshold drops by eight (118 -> 110 here,
+# 122 -> 114 on Skills and Collections), the ordinary consequence of a
+# cheaper `required_width()`. Notes, File Notes and Prompts keep the default.
+LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile(grip_width=1)
 LIBRARY_COLLECTIONS_READER_PROFILE = AdaptiveReaderLayoutProfile(
     work_min_width=48,
     work_comfort_width=56,
+    grip_width=1,
 )
 LIBRARY_NOTES_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
 LIBRARY_FILE_NOTES_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=30)
 LIBRARY_PROMPTS_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
-LIBRARY_SKILLS_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
+LIBRARY_SKILLS_READER_PROFILE = AdaptiveReaderLayoutProfile(
+    work_min_width=48,
+    grip_width=1,
+)
 LIBRARY_CONVERSATION_READER_MAX_CHARS = 8000
 LIBRARY_SOURCE_PAGE_SIZES = {
     "notes": 100,

--- a/tldw_chatbook/UI/Library_Modules/screen_constants.py
+++ b/tldw_chatbook/UI/Library_Modules/screen_constants.py
@@ -48,8 +48,9 @@ LIBRARY_SKILLS_IMPORT_WORKER_GROUP = "library_skills_import"
 # task-31951: Conversations, Skills and Collections join Media on the
 # one-cell grip (task-31633 AC#2 shipped it for Media alone). Each surface was
 # spending ten columns on two five-column grips that paint a single arrow;
-# the resolver reserves what the grip paints, so those ten cells now go to the
-# panes -- and the rail-open threshold drops by eight (118 -> 110 here,
+# the resolver reserves what the grip paints, so eight of those ten cells now
+# go to the panes (the two the one-cell grips paint stay reserved) -- and the
+# rail-open threshold drops by the same eight (118 -> 110 here,
 # 122 -> 114 on Skills and Collections), the ordinary consequence of a
 # cheaper `required_width()`. Notes, File Notes and Prompts keep the default.
 LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile(grip_width=1)

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -101,7 +101,6 @@ from ...Library.library_content_evidence import (
 from ...Utils.adaptive_reader_state import (
     AdaptiveReaderEffectiveLayout,
     AdaptiveReaderLayoutPreferences,
-    PANE_GRIP_WIDTH,
     PaneName,
     normalize_adaptive_reader_preferences,
     resolve_adaptive_reader_layout,

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -70,10 +70,12 @@ class AdaptiveReaderLayoutProfile:
             opts in today.
         grip_width: Width of EACH of the two pane grips -- both what a grip
             paints and what the resolver holds back for it, so the two can
-            never disagree. Defaults to ``PANE_GRIP_WIDTH`` (5). Media passes
-            1: its two five-column grips left ten dead columns around the
-            Items pane (task-31633 AC#2). A grip narrower than four cells
-            paints the one-cell guillemet instead of the ``<---`` run.
+            never disagree (the resolved layout carries this width to the
+            shell). Defaults to ``PANE_GRIP_WIDTH`` (5). Media passes 1: its
+            two five-column grips left ten dead columns around the Items pane
+            (task-31633 AC#2), and task-31951 opted Conversations, Skills and
+            Collections in for the same reason. A grip narrower than four
+            cells paints the one-cell guillemet instead of the ``<---`` run.
     """
 
     list_min_width: int = 32
@@ -99,7 +101,13 @@ class AdaptiveReaderLayoutPreferences:
 
 @dataclass(frozen=True)
 class AdaptiveReaderEffectiveLayout:
-    """One rendered layout derived from preferences and available width."""
+    """One rendered layout derived from preferences and available width.
+
+    ``grip_width`` carries the resolving profile's per-grip width through to
+    the shell, which sizes both grips from it (task-31952 AC#3): the columns
+    the resolver held back and the columns a grip paints are then literally
+    the same number, and a destination cannot reserve five and paint one.
+    """
 
     library_open: bool
     items_open: bool
@@ -107,6 +115,7 @@ class AdaptiveReaderEffectiveLayout:
     items_width: int
     reader_width: int
     priority_pane: PaneName | None
+    grip_width: int = PANE_GRIP_WIDTH
 
 
 def _coerce_bool(value: Any, default: bool) -> bool:
@@ -213,6 +222,7 @@ def resolve_adaptive_reader_layout(
             items_width=0,
             reader_width=0,
             priority_pane=None,
+            grip_width=profile.grip_width,
         )
 
     requested_library_width = (
@@ -280,6 +290,7 @@ def resolve_adaptive_reader_layout(
                 items_width=items_width,
                 reader_width=max(width - grip_width - library_width - items_width, 0),
                 priority_pane=priority,
+                grip_width=profile.grip_width,
             )
         priority = None
 
@@ -355,4 +366,5 @@ def resolve_adaptive_reader_layout(
         items_width=items_width,
         reader_width=max(width - grip_width - library_width - items_width, 0),
         priority_pane=priority,
+        grip_width=profile.grip_width,
     )

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -326,6 +326,11 @@ def resolve_adaptive_reader_layout(
     library_width = requested_library_width if library_open else 0
     items_width = preferences.items_width if items_open else 0
     if items_open and not library_open:
+        # task-31953: this clamp is deliberately NOT gated on
+        # `custom_widths_enabled` -- with the Library pane gone a typed 32
+        # still widens to the comfort ceiling (52 at width 100 on Media), as
+        # does the priority-pane clamp above. Documented, not changed; see
+        # `test_a_typed_custom_items_width_is_still_widened_once_the_library_closes`.
         comfort_width = max(
             items_width,
             min(profile.list_comfort_width, profile.list_max_width),

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -169,7 +169,6 @@ class LibraryAdaptiveReaderShell(Horizontal):
         library_label: str,
         items_label: str,
         grip_classes: str = "",
-        grip_width: int = PANE_GRIP_WIDTH,
         **kwargs: Any,
     ) -> None:
         """Assemble the three-pane shell around caller-owned pane widgets.
@@ -187,10 +186,11 @@ class LibraryAdaptiveReaderShell(Horizontal):
             items_label: Human name of the items pane, for grip copy.
             grip_classes: Extra CSS classes for both grips, for
                 per-destination styling.
-            grip_width: The destination profile's ``grip_width`` in cells,
-                passed to both grips so they paint exactly the columns the
-                resolver held back (task-31633 AC#2).
             **kwargs: Forwarded to ``Horizontal`` (``id``, ``classes``, ...).
+
+        Both grips are sized from ``layout.grip_width`` -- the width the
+        resolver held back for them (task-31952 AC#3), so a caller cannot
+        paint a grip the resolver never reserved.
         """
         super().__init__(**kwargs)
         self.add_class("library-adaptive-reader-shell")
@@ -205,7 +205,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
             open=layout.library_open,
             pane_label=library_label,
             extra_classes=grip_classes,
-            width=grip_width,
+            width=layout.grip_width,
             id=f"{id_prefix}-library-grip",
         )
         self.items_grip = LibraryAdaptiveReaderPaneGrip(
@@ -213,7 +213,7 @@ class LibraryAdaptiveReaderShell(Horizontal):
             open=layout.items_open,
             pane_label=items_label,
             extra_classes=grip_classes,
-            width=grip_width,
+            width=layout.grip_width,
             id=f"{id_prefix}-items-grip",
         )
         self._last_focused_descendant: dict[PaneName, Widget | None] = {

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -88,15 +88,27 @@ class LibraryAdaptiveReaderPaneGrip(Button):
         if extra_classes:
             classes = f"{classes} {extra_classes}"
         super().__init__(compact=True, flat=True, classes=classes, **kwargs)
-        self.styles.width = width
-        self.styles.min_width = width
-        self.styles.max_width = width
+        self.sync_width(width)
         self.styles.height = "100%"
         self.styles.padding = 0
         self.styles.line_pad = 0
         self.styles.border = ("none", "transparent")
         self.styles.content_align = ("center", "middle")
         self.sync_open(open)
+
+    def sync_width(self, width: int) -> None:
+        """Size the grip to the layout's reservation, in place.
+
+        Args:
+            width: The resolved layout's ``grip_width`` in cells.
+
+        Returns:
+            None.
+        """
+        self.grip_width = width
+        self.styles.width = width
+        self.styles.min_width = width
+        self.styles.max_width = width
 
     def sync_open(self, open: bool) -> None:
         """Patch arrow and action copy without changing geometry.
@@ -336,6 +348,10 @@ class LibraryAdaptiveReaderShell(Horizontal):
                     ),
                     grip,
                 )
+            if grip.grip_width != layout.grip_width:
+                # Reserve-and-paint holds for every layout the shell is given,
+                # not only the one it was built with (task-31952 AC#3).
+                grip.sync_width(layout.grip_width)
             grip.sync_open(open)
             if open and not was_open and manual_reopen == pane_name:
                 manual_reopen_pane = pane

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1227,6 +1227,12 @@ class LibraryFileNotesWorkspace(Vertical):
         self._reader_work_widget = self._build_reader_work_pane()
         self._reader_shell: LibraryAdaptiveReaderShell | None = None
         self._reader_shell_external = False
+        # Placeholder until the first resolve; its default `grip_width` is
+        # `PANE_GRIP_WIDTH`, which is what LIBRARY_FILE_NOTES_READER_PROFILE
+        # reserves. If File Notes ever opts into a narrower grip (as Media did
+        # in task-31633 and its three siblings in task-31951), this literal
+        # has to move with it -- the shell sizes its grips from the layout it
+        # is constructed with (task-31952 AC#3).
         self._reader_layout = AdaptiveReaderEffectiveLayout(
             library_open=False,
             items_open=True,

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -1229,10 +1229,9 @@ class LibraryFileNotesWorkspace(Vertical):
         self._reader_shell_external = False
         # Placeholder until the first resolve; its default `grip_width` is
         # `PANE_GRIP_WIDTH`, which is what LIBRARY_FILE_NOTES_READER_PROFILE
-        # reserves. If File Notes ever opts into a narrower grip (as Media did
-        # in task-31633 and its three siblings in task-31951), this literal
-        # has to move with it -- the shell sizes its grips from the layout it
-        # is constructed with (task-31952 AC#3).
+        # reserves today. It does not have to be kept in step by hand: the
+        # shell re-applies `layout.grip_width` on every `sync_layout`, so the
+        # first resolved layout corrects a stale grip (task-31952 AC#3).
         self._reader_layout = AdaptiveReaderEffectiveLayout(
             library_open=False,
             items_open=True,

--- a/tldw_chatbook/Widgets/Library/library_media_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_media_reader_shell.py
@@ -69,8 +69,8 @@ class LibraryMediaReaderShell(LibraryAdaptiveReaderShell):
             layout: The resolved Media layout to mount with.
             **kwargs: Forwarded to ``LibraryAdaptiveReaderShell`` (``id``,
                 ``classes``, ...); the Media identity arguments (id prefix,
-                pane labels, grip classes and the profile's one-cell
-                ``grip_width``) are fixed here.
+                pane labels and grip classes) are fixed here. The one-cell
+                grip width rides in on ``layout`` (task-31952 AC#3).
         """
         super().__init__(
             library=library,
@@ -81,7 +81,6 @@ class LibraryMediaReaderShell(LibraryAdaptiveReaderShell):
             library_label="Library",
             items_label="Items",
             grip_classes="library-media-pane-grip",
-            grip_width=MEDIA_READER_LAYOUT_PROFILE.grip_width,
             **kwargs,
         )
         self.reader = reader

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1252,15 +1252,12 @@ ConsoleRunLogModal {
     min-width: 0;
 }
 
-/* The three width declarations are a fallback only: every mounted grip sets
-   its width as an INLINE style from its destination profile's `grip_width`
-   (task-31633 AC#2), and an inline style outranks this rule -- so for Media,
-   whose grips are one cell, these three lines are dead. Keep them in step
-   with `PANE_GRIP_WIDTH` (the shared default every other reader uses). */
+/* No width here (task-31952 AC#1). Every mounted grip sets its width as an
+   INLINE style from the resolved layout's `grip_width` -- the same number the
+   resolver held back for it -- and an inline style outranks this rule, so the
+   `width/min-width/max-width: 5` fallback that used to sit here was dead for
+   every destination and a second, stale answer for the four on one cell. */
 .library-adaptive-reader-shell > .library-adaptive-reader-pane-grip {
-    width: 5;
-    min-width: 5;
-    max-width: 5;
     height: 100%;
     min-height: 0;
     margin: 0;
@@ -1285,7 +1282,8 @@ ConsoleRunLogModal {
 }
 
 /* task-31276: no focus outline here. The grip is as TALL AS THE SHELL (5
-   columns wide then, one for Media since task-31633 AC#2), so an outline can
+   columns wide then, one on the four readers that opted in since task-31633
+   AC#2 and task-31951), so an outline can
    only ever paint its top and bottom rows -- and the top row sits on the
    Reader's identity line, where such a rule reads as a rendering artifact at
    the pane join, not as focus (live: `┐─────Local Media item`, 14 captures -- and it persists,

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -173,15 +173,12 @@ $ds-library-source-browser-width: 31;
     min-width: 0;
 }
 
-/* The three width declarations are a fallback only: every mounted grip sets
-   its width as an INLINE style from its destination profile's `grip_width`
-   (task-31633 AC#2), and an inline style outranks this rule -- so for Media,
-   whose grips are one cell, these three lines are dead. Keep them in step
-   with `PANE_GRIP_WIDTH` (the shared default every other reader uses). */
+/* No width here (task-31952 AC#1). Every mounted grip sets its width as an
+   INLINE style from the resolved layout's `grip_width` -- the same number the
+   resolver held back for it -- and an inline style outranks this rule, so the
+   `width/min-width/max-width: 5` fallback that used to sit here was dead for
+   every destination and a second, stale answer for the four on one cell. */
 .library-adaptive-reader-shell > .library-adaptive-reader-pane-grip {
-    width: 5;
-    min-width: 5;
-    max-width: 5;
     height: 100%;
     min-height: 0;
     margin: 0;
@@ -200,7 +197,8 @@ $ds-library-source-browser-width: 31;
 }
 
 /* task-31276: no focus outline here. The grip is as TALL AS THE SHELL (5
-   columns wide then, one for Media since task-31633 AC#2), so an outline can
+   columns wide then, one on the four readers that opted in since task-31633
+   AC#2 and task-31951), so an outline can
    only ever paint its top and bottom rows -- and the top row sits on the
    Reader's identity line, where such a rule reads as a rendering artifact at
    the pane join, not as focus (live: `┐─────Local Media item`, 14 captures -- and it persists,


### PR DESCRIPTION
## Summary

Media riders PR N (tasks 31951, 31952, 31953): the adaptive reader's pane grips finished after PR H.

- **The three sibling readers use the one-cell grip** (31951). Conversations, Skills and Collections carried the five-column `LibraryAdaptiveReaderPaneGrip` PR H shrank for Media only, ten dead columns per surface. Their profiles now set `grip_width=1` and paint `‹`/`›`. The grip width rides the resolved layout (`AdaptiveReaderEffectiveLayout.grip_width`) and the shell reads it from there, so what the resolver reserves and what the shell paints are one number by construction; the shell's own `grip_width` parameter is gone. Consequences pinned at both edges with the old values in the comments: the rail-open thresholds move (Conversations 118→110, Skills and Collections 122→114) and the Skills items-priority floor moves 90→82 (at 82–89 columns the list paints 32–39 cells beside the 48-cell work pane where it used to collapse). `sync_layout` re-applies the grip width, so a re-resolved layout cannot leave a stale grip.
- **The grip-width leftovers are gone** (31952): the dead `width/min-width/max-width: 5` rule in the component source and the regenerated sheet, the unused `PANE_GRIP_WIDTH` import in the Library screen, and the Skills controller's `2 * PANE_GRIP_WIDTH` (now the profile's width). A pin asserts every declared profile reserves exactly the grip columns it paints.
- **The custom-width pin says what it covers** (31953, documented rather than changed): two resolver clamps widen a typed Items width (a typed 32 becomes 52 at width 100 once the library pane closes), and an existing pin already encodes that policy, so obeying the typed width is a user-visible change on all four readers and a product decision, filed as a follow-up. The pin is renamed to the growth gate it tests, a characterization pin records the widening, and the clamp carries the reason.

## Verification

Reviews: two batch reviews (Opus) with one fix round (the Skills items-priority floor had moved unpinned; pinned at 81/82), one scoped re-review (Sonnet), and a final whole-branch review (Opus) that independently reproduced every re-anchored tuple and every "was" comment with a control resolver, confirmed Media untouched (100 → list 52; 235 → Items 56), and blocked only on a live geometry contract in `Tests/Live` still summing ten grip columns — fixed here.

Whole-file, serial, failing-name sets compared against a detached copy of the merge-base: `Tests/Library/test_library_adaptive_reader_state.py` 338, `Tests/UI/test_library_adaptive_reader_shell.py` 35, `test_library_media_reader_shell.py` 38, `test_library_collections_reader_geometry.py` 8, `test_library_conversation_reader.py` 52, `test_library_skills_reader.py` 17 passed; `test_library_skills_canvas.py` 153 passed with the same 7 pre-existing reds as dev; the `notes_reader`, `skills_canvas` and `file_notes_workspace` files' pre-existing reds identical to (or a strict subset of) dev's. `check_bundle_sync` exit 0; diagnostic inventory unchanged; preflight green.

Live at 235×52, one instance: Conversations, Skills and Collections each paint one-cell `‹` grips (library column 37, items column 78); collapsing Collections' library pane repaints a one-cell `›`; no `<---`/`--->` run remains on the three surfaces.

User Guide: the Media page's "other destinations keep the wider grip" sentence is gone; the Skills and Collections pages carry a stamp for the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Conversations, Skills, and Collections from five-column pane grips to one-cell grips like Media, returning eight columns of width to each surface's panes. Grip width now rides on the resolved layout, so the resolver reserves exactly what the shell paints; the shell's separate `grip_width` parameter is gone.

**Behavior changes**
- Rail-open thresholds move: Conversations 118→110, Skills and Collections 122→114.
- The Skills items-priority floor moves 90→82; at 82–89 columns the list paints 32–39 cells instead of collapsing.
- Notes, File Notes, and Prompts keep the five-column grip.

**Cleanup and pin scope**
- Dead five-column grip CSS removed from the component source and generated sheet; unused `PANE_GRIP_WIDTH` imports dropped.
- The live Media geometry contract and its mutation fake now read the profile's one-cell width, not the old five-column constant.
- The custom-width pin is scoped to the gate it tests: with the library pane closed, two clamps still widen a typed width; obeying the typed width is a product decision, documented and filed as a follow-up.

<sup>Written for commit 92bb3568a05e5f8170ed0f816238625496854f64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2481?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

