### PR TITLE
docs: add Persona Buddy setup and voice guide

### DIFF
--- a/Docs/User_Guide/buddy.md
+++ b/Docs/User_Guide/buddy.md
@@ -1,0 +1,178 @@
+# Persona Buddy — set up Migu, move it, and use it with Console
+
+## What Buddy is for
+
+Buddy is an optional floating companion that reflects activity in Chatbook, such
+as listening, thinking, replying, tool work, and approval requests. Start with the
+included **pixel-migu** art, or use an active visual pack on another local Persona.
+
+The companion selection and your conversation selection are separate. **Use for
+Buddy** chooses the floating Persona; it does not change the current Console
+assistant, send a message, grant tool permission, or start a microphone. Use
+Console to chat, speak, and review tool requests.
+
+This page covers the terminal application. For the server's browser-based
+companion, see the [server Persona documentation](https://github.com/rmusser01/tldw_server/blob/dev/Docs/User_Guides/Server/Personas_User_Guide.md).
+
+## Set up pixel-migu
+
+1. Open **Roleplay** from the navigation bar and choose **Personas**.
+2. Select **pixel-migu** in the Library. Fresh local profiles include this Persona
+   and its visual pack; no image-generation account or art import is needed.
+3. In the **Inspector**, choose **Use for Buddy**. The floating companion appears
+   on supported application screens.
+4. Open **Console** and send a short text message using a configured provider and
+   model. Use the Console transcript and status to confirm the result.
+
+If you want Migu to be the character you chat with as well, select **pixel-migu**
+in **Characters** and choose **Start Chat**. Its character expressions and the
+floating Persona's animations are separate features.
+
+Buddy accepts a saved, active **local Persona**. A highlighted library row alone
+never changes it. For a server-backed Persona, the Inspector says **Save a local
+copy first**; work from an eligible local copy before choosing **Use for Buddy**.
+An unsaved or inactive Persona must be saved or activated first.
+
+![Included pixel-migu expressions](images/roleplay/pixel-migu-expressions.png)
+
+*The image shows the bundled character expression palette. Available Buddy
+animations are determined by the Persona Visual pack.*
+
+## Show, fold, close, or disable
+
+Select the Persona currently used by Buddy to manage these Inspector actions:
+
+| Control | Result |
+|---|---|
+| **Use for Buddy** | Selects this eligible local Persona and enables Buddy. Use it again after disabling. |
+| **Show Buddy** | Reopens the selected, enabled Buddy after closing it. |
+| **Close Buddy** or the floating **×** | Closes the companion view without deleting the Persona or its pack. |
+| **Disable Buddy** | Turns Buddy off. **Use for Buddy** enables it again. |
+| Floating fold control | Folds or unfolds the companion. Its tooltip identifies the current action. |
+
+Selection, visibility, folded state, size, and position are saved in the current
+Chatbook profile. They are not exported with the character or visual pack.
+Switching the Console assistant or browsing another Persona does not silently
+replace Buddy. Modal, authentication, and recovery screens may temporarily hide
+or cover it.
+
+## Move and resize
+
+- **Move:** press and drag the pet surface, away from its fold and close buttons.
+- **Resize:** drag its lower-right edge.
+- **Recover placement:** focus Buddy and press **0** to reset its geometry.
+
+Click the pet surface without dragging to focus Buddy, then use the keys below.
+Click the Console composer again before typing a message. These keys apply only
+while Buddy has focus:
+
+| Key | Action |
+|---|---|
+| `h` / `j` / `k` / `l` | Move left / down / up / right |
+| `H` / `L` | Make narrower / wider |
+| `J` / `K` | Make taller / shorter |
+| `0` | Reset size and position |
+| `c` | Fold or unfold |
+| `x` | Close |
+
+The saved position is clamped to the available terminal area. If a drag selects
+terminal text, try the keyboard controls and check your terminal's mouse handling.
+Earlier native-terminal UAT verified movement, resizing, and saved geometry;
+that does not certify every terminal or browser-hosted terminal transport.
+
+## Use voice with Buddy
+
+Configure your conversation provider under **Settings → Providers & Models**.
+Configure speech under **Settings → Speech & TTS** and follow the
+[Console voice guide](console/attachments-images-voice.md). A visible animation
+alone is not proof that a microphone is recording or audio is playing.
+
+Use a TTS provider configured for Chatbook; the historical Kokoro tests below do
+not make Kokoro a requirement. Server Persona voice settings and browser speech
+choices are separate from Chatbook's speech settings.
+
+Dictation needs the optional microphone and transcription dependencies described
+in the Console voice guide. First use may download a speech model and take several
+minutes; **Mic…** means preparation, not recording. Dictation stops and transcribes
+automatically at 60 seconds.
+
+For a deliberate first test:
+
+1. In Console, enable **Speak replies** if you want spoken output, with an
+   available TTS provider and playback device. It speaks new assistant replies;
+   enabling it after a reply has finished does not replay that reply.
+2. Click **Mic** and wait for **Rec ●** before speaking.
+3. Say one short phrase. Click **Rec ●** to stop and transcribe it.
+4. Inspect and edit the resulting **draft**, then send it normally. Dictation
+   does not send automatically.
+5. Read the reply and confirm that you actually hear it if **Speak replies** is on.
+
+For continuous conversation, **Hands-free** starts the configured voice loop;
+**Esc** or turning the switch off exits it. Check the Console's capture and
+playback indicators when stopping. The optional **Realtime engine** is configured
+separately under Speech & TTS; enabling Buddy does not configure its dependencies
+or credentials. See the [speech service guide](../Features/Speech-Services-Guide.md)
+for engine setup and fallback behavior, and
+[OpenAI-compatible TTS](openai-compatible-tts.md) for a compatible speech server.
+
+Chatbook's **Mic → Rec ● → editable draft** workflow differs from the server's
+**Start listening → Send now** workflow. The server's 30-second Persona voice
+turn limit is not a Chatbook dictation setting.
+
+## Interpret animation and handle approvals
+
+| Appearance | What to check |
+|---|---|
+| Idle | No higher-priority activity is being displayed. |
+| Listening | Check the voice controls for the current capture state. |
+| Thinking / speaking | Check Console for generation or speech activity; streamed text can also drive a speaking state. |
+| Typing / tool work | Read the current tool activity and its result in Console. |
+| Approval / error / offline | Read the actual approval card or diagnostic before taking action. |
+
+The active pack determines which artwork is available. Missing state art may
+fall back to another frame. These operational animations do not infer emotion
+from every message, and the bundled art does not enable automatic sentiment
+selection.
+
+When an approval appears, inspect the tool, inputs, target, and permission in
+**Console**, then approve or deny using the actual approval card. Buddy is an
+indicator, not an approval control. See
+[Agent runs and tools](console/agent-runs-and-tools.md).
+
+## Use your own Persona Visual pack
+
+Open a saved local Persona's editor and find **Persona Visual**. Select a state
+to preview it; use **Replace…**, **Clear**, **Add Custom State**, or
+**Import Pack…** to prepare a draft. **Save Pack** publishes the changes;
+**Cancel Draft** discards the draft. A preview alone does not replace the active
+runtime pack. See [Characters and Personas](roleplay-chat-dictionaries/characters-and-personas.md)
+for the surrounding editor and import/export workflow.
+
+## Troubleshooting
+
+| Symptom | Next step |
+|---|---|
+| Buddy never appears | Select a saved active local Persona, use **Use for Buddy**, and leave any modal screen. Check the Inspector's disabled-control explanation. |
+| **Show Buddy** is disabled | It is disabled when Buddy is already open. Otherwise, select the Persona currently used by Buddy; if Buddy is disabled, choose **Use for Buddy**. |
+| Migu is missing after an upgrade | Check the local source and search filters. Upgrades preserve renamed, customized, and deleted entries; they do not replace your chosen assistant. |
+| Buddy changes after selecting another conversation | Selection should remain explicit. Record the source Persona and steps if it changes unexpectedly. |
+| Position or size is awkward | Focus Buddy, press **0**, then resize or move it. Try a larger terminal. |
+| Text succeeds but no voice is heard | Check TTS setup, assigned/global voice, playback device, and **Speak replies**. Read Console errors; a speaking sprite is not an audio test. |
+| Speech recognition is wrong | Stop dictation, edit the draft before sending, and retry with background audio paused. An animation cannot validate transcript accuracy. |
+| Buddy remains busy after completion | Check whether another run, tool, approval, or voice session is active. If none is active, record the status and reproduction steps; closing Buddy does not cancel Console work. |
+
+## Verification scope and related guides
+
+This guide was checked against Chatbook `dev` **307df6c79** on **2026-09-07**
+using current controls, existing mounted UI coverage, and recorded September 5
+Migu UAT. It is not a claim that every instruction was re-executed in a fresh
+physical session for this documentation update. Native dragging and local Kokoro
+readback were previously exercised; provider-specific realtime behavior requires
+its own configured voice test.
+
+- [First-run setup](First_Run_Setup.md)
+- [Characters and Personas](roleplay-chat-dictionaries/characters-and-personas.md)
+- [Console voice](console/attachments-images-voice.md)
+- [Agent runs and tools](console/agent-runs-and-tools.md)
+- [Recorded live-verification lessons](../../backlog/docs/lessons-live-verification.md)
+- [Buddy implementation and verification record](<../../backlog/tasks/task-19055 - Add-opt-in-app-wide-floating-Persona-Buddy.md>)

--- a/Docs/User_Guide/console/attachments-images-voice.md
+++ b/Docs/User_Guide/console/attachments-images-voice.md
@@ -138,6 +138,9 @@ is never sent automatically, so you can edit before pressing Enter.
 
 ### Hands-free — the voice conversation loop
 
+Using the floating companion alongside voice? See the [Persona Buddy guide](../buddy.md)
+for selection, animation meaning, and troubleshooting.
+
 Dictation's big sibling: instead of one capture at a time, **Hands-free**
 (`Ctrl+Shift+H`, or the control bar's **Hands-free** switch next to
 **Speak replies**) runs a continuous speak → transcribe → reply →

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -67,6 +67,7 @@ separate screens.
 
 | Guide | What it covers |
 |-------|----------------|
+| [Set up and use Persona Buddy](buddy.md) | Select Migu, move and resize the companion, use Console voice, handle approvals, and troubleshoot. |
 | [Set up and manage your Personal Context Profile](settings/personal-context-profile.md) | Optional interviews, global/workspace context, agent proposals, synchronization boundaries, export, and removal. |
 | [Turn feeds into a scheduled Watchlist briefing](watchlists-quickstart.md) | A start-to-finish Console walkthrough: create feeds and a Watchlist, follow receipts, generate a briefing, schedule it every 24 hours, and verify the saved result. |
 | [Using OpenAI-compatible TTS servers](openai-compatible-tts.md) | Pointing text-to-speech at your own server (e.g. a local, keyless engine like pocket-tts) via Settings ▸ Speech & TTS; also covers the app-wide default voice profile and per-character voices. |

--- a/Docs/User_Guide/roleplay-chat-dictionaries/characters-and-personas.md
+++ b/Docs/User_Guide/roleplay-chat-dictionaries/characters-and-personas.md
@@ -37,6 +37,9 @@ and **"World Books (copied into this character)"**. The rail's **New**,
 
 ## Included pixel-migu character and Buddy
 
+For the complete setup, movement, voice, and troubleshooting workflow, see the
+[Persona Buddy guide](../buddy.md).
+
 ![pixel-migu expression palette](../images/roleplay/pixel-migu-expressions.png)
 
 A fresh local profile includes **pixel-migu** in both **Characters** and

--- a/backlog/tasks/task-31943 - Document-Chatbook-Buddy-setup-controls-voice-and-troubleshooting.md
+++ b/backlog/tasks/task-31943 - Document-Chatbook-Buddy-setup-controls-voice-and-troubleshooting.md
@@ -1,0 +1,49 @@
+---
+id: TASK-31943
+title: Document Chatbook Buddy setup controls voice and troubleshooting
+status: Done
+created_date: 2026-09-07 08:35
+labels:
+- documentation
+- buddy
+updated_date: 2026-09-07 16:45
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give users a single practical Buddy guide with setup, Migu selection, movement, voice, approvals and honest troubleshooting guidance.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A discoverable user guide covers the current Buddy workflow and links related setup and voice documentation.
+- [x] #2 Instructions distinguish verified behavior from outstanding UAT limitations and use current control labels.
+- [x] #3 Relative documentation links and navigation resolve; published mirrors match where applicable.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no. ADR path: N/A. Reason: user documentation of existing behavior, no runtime or contract change.
+1. Read current controls, existing guides and UAT records.
+2. Write a dedicated guide and link it from the documentation index and relevant feature pages.
+3. Validate links/navigation, inspect the rendered Markdown, and record source revision and evidence limitations.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
+Added Docs/User_Guide/buddy.md and discoverability links from the user-guide index, character/Persona guide, and Console voice guide. Covers local Migu selection, movement/resize, explicit visibility controls, Console voice, approvals, visual editing, and troubleshooting. Source checked at dev 307df6c79 and reviewed against recorded UAT; no fresh physical voice claim. Independent source review completed. Validation: 12 case-sensitive relative links resolve, rendered Markdown inspected, git diff --check passes, 3 mounted movement/control tests and 7 Inspector tests passed. Documentation-only change; no runtime, dependency, security boundary, or schema changes, so runtime lint/performance/security suites were not required. ADR required: no; documentation of existing behavior. No new generalizable lesson arose.
+User-requested second review: clarify Speak replies timing, how to focus Buddy, first-run speech preparation, and already-open Show Buddy state. Recheck rendered anchors and source references before completing.
+Second review resolved: Speak replies must be enabled before sending (console_speech_controls.py tooltip specifies new replies only); click the pet surface to focus keyboard controls, then return focus to composer; document optional speech dependencies, first-run preparation and 60-second dictation cap; explain Show Buddy is disabled when already open. Checked against widget, Inspector, speech controls, dispatch coordinator and existing voice guide. Reparsed final Markdown and checked all 12 rendered relative href/src targets case-sensitively; git diff --check passed. No runtime changes or new physical UAT claimed; previous 10 targeted control tests remain the evidence for unchanged behavior.
+Follow-up provider audit clarified that Kokoro is optional in Chatbook and that server Persona/browser voice settings do not configure Chatbook speech. The guide retains historical Kokoro UAT as evidence only. Relative links and whitespace rechecked; runtime behavior unchanged.
+<!-- SECTION:IMPLEMENTATION_NOTES:END -->
+## Final Summary
+
+<!-- SECTION:FINAL_SUMMARY:BEGIN -->
+Created and linked the consolidated Chatbook Buddy user guide. Verified links, rendering, current control labels, and focused mounted controls.
+<!-- SECTION:FINAL_SUMMARY:END -->
+## Definition of Done
+<!-- DOD:BEGIN -->
+<!-- DOD:END -->

--- a/backlog/tasks/task-31967 - Document-Chatbook-Buddy-setup-controls-voice-and-troubleshooting.md
+++ b/backlog/tasks/task-31967 - Document-Chatbook-Buddy-setup-controls-voice-and-troubleshooting.md
@@ -1,12 +1,16 @@
 ---
-id: TASK-31943
+id: TASK-31967
 title: Document Chatbook Buddy setup controls voice and troubleshooting
 status: Done
-created_date: 2026-09-07 08:35
+assignee: []
+created_date: '2026-09-07 08:35'
+updated_date: '2026-09-07 19:23'
 labels:
-- documentation
-- buddy
-updated_date: 2026-09-07 16:45
+  - documentation
+  - buddy
+dependencies: []
+references:
+  - 'https://github.com/rmusser01/tldw_chatbook/pull/2482'
 ---
 
 ## Description
@@ -33,17 +37,27 @@ ADR required: no. ADR path: N/A. Reason: user documentation of existing behavior
 
 ## Implementation Notes
 
+<!-- SECTION:NOTES:BEGIN -->
 <!-- SECTION:IMPLEMENTATION_NOTES:BEGIN -->
 Added Docs/User_Guide/buddy.md and discoverability links from the user-guide index, character/Persona guide, and Console voice guide. Covers local Migu selection, movement/resize, explicit visibility controls, Console voice, approvals, visual editing, and troubleshooting. Source checked at dev 307df6c79 and reviewed against recorded UAT; no fresh physical voice claim. Independent source review completed. Validation: 12 case-sensitive relative links resolve, rendered Markdown inspected, git diff --check passes, 3 mounted movement/control tests and 7 Inspector tests passed. Documentation-only change; no runtime, dependency, security boundary, or schema changes, so runtime lint/performance/security suites were not required. ADR required: no; documentation of existing behavior. No new generalizable lesson arose.
 User-requested second review: clarify Speak replies timing, how to focus Buddy, first-run speech preparation, and already-open Show Buddy state. Recheck rendered anchors and source references before completing.
 Second review resolved: Speak replies must be enabled before sending (console_speech_controls.py tooltip specifies new replies only); click the pet surface to focus keyboard controls, then return focus to composer; document optional speech dependencies, first-run preparation and 60-second dictation cap; explain Show Buddy is disabled when already open. Checked against widget, Inspector, speech controls, dispatch coordinator and existing voice guide. Reparsed final Markdown and checked all 12 rendered relative href/src targets case-sensitively; git diff --check passed. No runtime changes or new physical UAT claimed; previous 10 targeted control tests remain the evidence for unchanged behavior.
 Follow-up provider audit clarified that Kokoro is optional in Chatbook and that server Persona/browser voice settings do not configure Chatbook speech. The guide retains historical Kokoro UAT as evidence only. Relative links and whitespace rechecked; runtime behavior unchanged.
 <!-- SECTION:IMPLEMENTATION_NOTES:END -->
+
+PR #2482 rebased onto dev 2f378c48d. Fresh independent source review found no issues; Qodo reports zero bugs, rule violations, and requirement gaps. Rendered Markdown and all 12 relative link/image targets verified, all three guide entry points resolve, and git diff --check passes. Rebase exposed task ID collision with older Library rail task; moved this record to TASK-31967 with provenance and retained the older task unchanged.
+<!-- SECTION:NOTES:END -->
+
 ## Final Summary
 
 <!-- SECTION:FINAL_SUMMARY:BEGIN -->
 Created and linked the consolidated Chatbook Buddy user guide. Verified links, rendering, current control labels, and focused mounted controls.
 <!-- SECTION:FINAL_SUMMARY:END -->
+
 ## Definition of Done
 <!-- DOD:BEGIN -->
 <!-- DOD:END -->
+
+## Renumbering provenance
+
+Renumbered from TASK-31943 after PR #2482 rebased onto current dev. The Library rail Media-count task was created at 2026-09-07 08:25; this Buddy guide task was created at 08:35. The older task retains the ID under the repository collision rule. A fresh sweep of 420 refs and 72 worktrees found 31967 available. No runtime or guide-content changes were needed.


### PR DESCRIPTION
## Summary

Adds a consolidated Persona Buddy user guide so users can select pixel-migu, show and move Buddy, configure Console voice, interpret activity, and handle approvals. Links the guide from the user-guide index, character/Persona guide, and Console voice guide.

The guide distinguishes Buddy selection from the conversation assistant and Chatbook speech settings from server/browser voice settings. Kokoro is optional. Troubleshooting and verification notes separate recorded UAT evidence from behavior that still needs a physical provider-specific test.

Tracks TASK-31967. Documentation only; no runtime, dependency, or schema changes.

## Validation

- Rebased onto current `dev` (`53813b3b9`); repeated backlog and whitespace checks pass.
- Markdown rendered successfully; all 12 relative link/image targets resolve.
- All three documentation entry points link to the guide.
- `git diff --check` passed.
- Earlier verification covered 10 mounted movement/control and Inspector tests; no new physical voice UAT is claimed for this documentation change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a consolidated Persona Buddy user guide so users can set up pixel-migu, move and resize Buddy, configure speech providers and Console voice, interpret animations, and handle approvals. Links the guide from the user-guide index, character/Persona guide, and Console voice guide.

The guide marks verified behavior separately from provider-specific voice UAT that still needs physical testing. Documentation only; no runtime, dependency, or schema changes. The task record is now TASK-31967 after a rebase exposed an ID collision with an older Library rail task.

<sup>Written for commit a544a79e9b290a70c5ea9d4e4716428607496451. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

