### PR TITLE
fix(console): prevent duplicate switcher tabs and identify selected mode

### DIFF
--- a/Docs/QA/task-31245/README.md
+++ b/Docs/QA/task-31245/README.md
@@ -2,6 +2,9 @@
 
 This directory records measured evidence, not blanket release acceptance.
 
+The [2026-09-07 switcher follow-up](switcher-reuse-and-mode-follow-up.md) records
+the duplicate-tab and selected-mode corrections reported during manual QA.
+
 ## Standalone Keyword retrieval
 
 [Raw manifest and 300 timings](keyword-scale-4fcbf7721.json) were captured on

--- a/Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md
+++ b/Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md
@@ -1,0 +1,73 @@
+# Session switcher native-report follow-up — 2026-09-07
+
+Separate follow-up to merged PR #2469, based on dev
+`29442a160bb69cf2183a3aa0d1e68c7f8990e3bf`. This does not reopen the
+broader release qualification or the deferred TASK-31966 GC investigation.
+
+## Report and corrections
+
+The user reported duplicate Console tabs after reopening a conversation and
+could not identify the selected switcher mode. The screenshot establishes the
+duplicate tabs, not which mode caused them. Controlled tests reproduced
+History-to-History and Character-to-History duplicates; the other two mode
+combinations already reused the exact runtime.
+
+History now opts into exact persisted-ID reuse after saved-record validation.
+It preserves authority checks and missing-record refusal; IDs beginning with
+`native:` are not mistaken for runtime IDs. Other cold-resume callers retain
+their intentional fresh-session behavior. Warm activation uses the existing
+guarded presentation path, including refreshing the current retrieval scope.
+Existing duplicate tabs are not automatically closed or consolidated.
+
+The existing border title now names `[Active]`, `[History]`, or
+`[Character chats]`, including explicit History widening. The selected mode
+uses the app's selected styling, independently of focus. The title uses primary
+text color: visual inspection caught that inheriting the border's dark color
+made the first implementation unreadable. No rows, shortcuts, or CSS budget
+were added. Impeccable's label-before-color guidance informed this correction.
+
+## Verification
+
+- Initial duplicate/mode regression: 6 failed, 4 passed; review regressions for
+  deleted records and prefixed IDs failed before their corrections.
+- Real registry scope regression: cached one source remained stale after the
+  inactive target's workspace changed to two; then passed after refresh repair.
+- Covering run after activation repairs: **48 passed**, one expected CSS
+  headroom warning, 81.47 seconds. Covers the new reuse tests, installed
+  activation, trust, geometry, History widening/loading, and CSS budget.
+- After the final title-color correction: the two mode tests pass at **52×20
+  and 120×50**, checking actual compositor text and at least 4.5:1 title contrast
+  with search or an inactive mode button focused. Geometry and CSS rerun:
+  **12 passed**, one expected headroom warning. Boot CSS is **803,784/804,000
+  bytes**, 216 bytes remaining; no cap raise.
+- No added Ruff diagnostics against the base; changed focused files formatted,
+  whitespace clean, and all six preflight derived-artifact guards pass.
+- Covering resource observer: regular descriptors plateau at seven with no
+  remaining SQLite file handles; only first-use FIFO/socket additions. Tests
+  used the existing isolated compatible qualification dependency overlay, not
+  a shared-environment dependency change.
+- Independent static review: identity, deletion, and scope findings addressed;
+  no remaining scoped findings. Only targeted tests were run, not a full sweep.
+
+Reproduce the main functional and visual regressions with:
+
+```sh
+python -m pytest Tests/UI/test_console_switcher_reuse_and_modes.py -q
+python -m pytest Tests/UI/test_console_character_activation_presentation.py Tests/UI/test_console_session_switcher_trust.py Tests/UI/test_console_character_switcher_geometry.py Tests/Performance/test_boot_css_byte_budget.py -q
+```
+
+## Remaining manual handoff
+
+The user's existing synthetic native app and its checkout were left unchanged;
+the fixes were built in a separate worktree. Headless Textual evidence is not
+new native-terminal acceptance. On a restarted fixed build, verify:
+
+1. Ctrl+K and F3 visibly identify all three modes, even after focus moves.
+2. Resume a saved conversation from History, switch away, then resume it again:
+   the same tab is selected and the tab count does not grow.
+3. Repeat across History and Character chats; exact transcript and composer
+   focus must match. Existing duplicates from the older build may remain.
+
+Task-31245 stays In Progress. Existing native, Windows, participant, and deferred
+performance qualifications in the main QA report are not waived. Existing
+ADR-120, ADR-031, and ADR-097 apply; no new architectural decision is required.

--- a/Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md
+++ b/Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md
@@ -58,6 +58,39 @@ python -m pytest Tests/UI/test_console_character_activation_presentation.py Test
 
 ## Remaining manual handoff
 
+### PR #2487 Qodo remediation
+
+Rebased without conflicts onto dev `0bb00beaf4e324385a10878bb1ceb380ec55e3e9`;
+range-diff confirms the original patch was unchanged. Qodo's two findings were
+addressed before merge: scope-display refresh is best effort, matching native
+tab activation, and isolated unit tests supplement the installed UI coverage.
+Cancellation still restores and propagates; genuine presentation failure still
+restores the prior session. The failure was reproduced by one unit test and one
+installed History test before the exception boundary was added.
+
+The post-rebase covering run passed **60 tests in 82.87 seconds**, with only the
+expected CSS headroom warning. Eleven isolated cases cover exact saved identity,
+active-runtime preference, missing-record refusal, mode widening/selection, and
+scope-error versus cancellation/presentation outcomes. The installed regression
+also verifies reused runtime and composer focus during a scope-display outage.
+Independent static review reported no remaining findings.
+
+The diagnostic inventory was reviewed using its statement comparison before
+regeneration: one new warning in `workspace.py`, containing a fixed message and
+opaque runtime session ID, with existing exception logging semantics and no new
+sink. No conversation content, credentials, paths, or URLs were added to its
+format arguments. Native/external qualifications below remain unchanged.
+
+A smaller verification run exposed an unawaited reconciliation coroutine.
+Tracemalloc identified its allocation at the reconciliation worker handoff;
+the worker could be cancelled before starting that eagerly created coroutine.
+The handoff now uses an async `functools.partial`, so creation occurs only at
+execution. A plain lambda was rejected by Textual's actual async-worker tests;
+the final unit boundary also asserts an async-callable input. The final gate
+covering twelve isolated cases, fourteen installed switcher cases, and all
+forty-one activity-switcher cases passed **67 tests in 47.28 seconds, without
+warnings**, with the same stable descriptor plateau. No GC policy changed.
+
 The user's existing synthetic native app and its checkout were left unchanged;
 the fixes were built in a separate worktree. Headless Textual evidence is not
 new native-terminal acceptance. On a restarted fixed build, verify:

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2598,8 +2598,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 46,
-      "diagnostic_digest": "ce0a227c28a4f0e25e13",
+      "call_count": 47,
+      "diagnostic_digest": "26900a6309ea1dc996a0",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/workspace.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11462,6 +11462,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 53,
     "task_492_calls": 1347,
-    "task_494_calls": 7673
+    "task_494_calls": 7674
   }
 }

--- a/Tests/Chat/test_switcher_reuse_decisions.py
+++ b/Tests/Chat/test_switcher_reuse_decisions.py
@@ -1,0 +1,192 @@
+"""Switcher decisions without a Textual app or persistence services."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from textual.containers import Vertical
+from textual.widgets import Button, Input
+
+from tldw_chatbook.Chat.console_switcher_state import SwitcherMode
+from tldw_chatbook.UI.Console_Modules import conversation_token_preparation, workspace
+from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+    ConsoleSessionSwitcherModal,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("active, expected", [("other", "first"), ("second", "second")])
+@pytest.mark.parametrize("missing", [False, True])
+async def test_reuse_validates_saved_identity_before_selecting_runtime(
+    monkeypatch, active, expected, missing
+):
+    # A runtime whose ID equals the saved ID is deliberately unrelated.
+    sessions = [
+        SimpleNamespace(id="native:other", persisted_conversation_id="unrelated"),
+        SimpleNamespace(id="first", persisted_conversation_id="native:other"),
+        SimpleNamespace(id="second", persisted_conversation_id="native:other"),
+    ]
+    store = SimpleNamespace(active_session_id=active, sessions=lambda: sessions)
+
+    async def load(_app, target):
+        assert target == "native:other"
+        return None if missing else {"conversation": {"id": target}, "messages": []}
+
+    async def open_runtime(target):
+        store.active_session_id = target.removeprefix("native:")
+        return True
+
+    owner = SimpleNamespace(
+        app_instance=SimpleNamespace(notify=Mock()),
+        _ensure_console_chat_store=lambda: store,
+        _capture_console_draft_switch_snapshot=lambda: None,
+        _restore_console_session_after_failed_open=AsyncMock(),
+        open_console_workspace_conversation=open_runtime,
+    )
+    monkeypatch.setattr(workspace, "load_console_conversation_tree", load)
+    result = await workspace.ConsoleWorkspaceController._resume_console_workspace_conversation(
+        owner, "native:other", reuse_existing=True
+    )
+    assert result is (not missing)
+    assert store.active_session_id == (active if missing else expected)
+
+
+@pytest.mark.parametrize(
+    "mode, widened, expected",
+    [
+        (SwitcherMode.ACTIVE, False, "Active"),
+        (SwitcherMode.ACTIVE, True, "History"),
+        (SwitcherMode.HISTORY, False, "History"),
+        (SwitcherMode.CHARACTER_CHATS, False, "Character chats"),
+    ],
+)
+def test_mode_title_and_selected_class_agree_without_app(mode, widened, expected):
+    widgets = {
+        "#console-switcher-active-mode": Button(),
+        "#console-switcher-history-mode": Button(),
+        "#console-switcher-character-mode": Button(),
+        "#console-switcher-query": Input(),
+        "#console-switcher-modal": Vertical(),
+    }
+    owner = SimpleNamespace(
+        query_one=lambda selector, _kind: widgets[selector],
+        _active_results=(),
+        _mode=mode,
+        _widened_to_history=widened,
+        _activation_in_flight=False,
+    )
+    ConsoleSessionSwitcherModal._update_mode_controls(owner)
+    assert f"[{expected}]" in widgets["#console-switcher-modal"].border_title
+    selected = [
+        str(widget.label)
+        for widget in widgets.values()
+        if isinstance(widget, Button)
+        and widget.has_class("console-switcher-mode-current")
+    ]
+    assert selected == ["Active (0)" if expected == "Active" else expected]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["scope", "cancel", "presentation"])
+async def test_warm_open_scope_error_is_nonfatal_but_activation_failures_restore(
+    monkeypatch, failure
+):
+    target = SimpleNamespace(id="target")
+    store = SimpleNamespace(active_session_id="prior", sessions=lambda: [target])
+    shown = []
+    notices = []
+
+    def switch(session_id):
+        store.active_session_id = session_id
+
+    async def refresh(_session):
+        if failure == "scope":
+            raise RuntimeError("synthetic scope failure")
+        if failure == "cancel":
+            raise asyncio.CancelledError()
+
+    async def present():
+        if failure == "presentation":
+            raise RuntimeError("synthetic presentation failure")
+        shown.append(store.active_session_id)
+
+    async def restore(_store, prior):
+        store.active_session_id = prior
+
+    owner = SimpleNamespace(
+        _screen=None,
+        app_instance=SimpleNamespace(
+            notify=lambda *args, **kwargs: notices.append(args)
+        ),
+        _console_session_id_for_workspace_conversation=lambda _id: "target",
+        _ensure_chat_controller_fn=lambda: SimpleNamespace(
+            store=store, switch_session=switch
+        ),
+        _capture_console_draft_switch_snapshot=lambda: None,
+        _set_active_workspace_for_console_session=lambda _id: None,
+        _refresh_console_effective_scope_and_sync=refresh,
+        _sync_console_chat_core_state=lambda: None,
+        _sync_native_console_chat_ui_fn=present,
+        _sync_temporary_chip_fn=lambda: None,
+        _focus_composer_if_needed_fn=lambda **kwargs: None,
+        _refresh_console_conversation_browser_after_selection=AsyncMock(),
+        _restore_console_session_after_failed_open=restore,
+    )
+    monkeypatch.setattr(
+        conversation_token_preparation, "prepare_conversation_tokens", AsyncMock()
+    )
+    open_conversation = (
+        workspace.ConsoleWorkspaceController.open_console_workspace_conversation
+    )
+    if failure == "cancel":
+        with pytest.raises(asyncio.CancelledError):
+            await open_conversation(owner, "native:target")
+    else:
+        result = await open_conversation(owner, "native:target")
+        assert result is (True if failure == "scope" else None)
+    assert store.active_session_id == ("target" if failure == "scope" else "prior")
+    assert shown == (["target"] if failure == "scope" else [])
+    assert bool(notices) is (failure == "presentation")
+
+
+@pytest.mark.asyncio
+async def test_queued_reconciliation_does_not_allocate_coroutine_before_start():
+    queued = []
+    refreshed = []
+
+    async def refresh(query):
+        refreshed.append(query)
+
+    owner = SimpleNamespace(
+        _closed=False,
+        _profile_authority="profile",
+        _authority_token="token",
+        _active_projection_generation=1,
+        _activation_in_flight=False,
+        _mode=SwitcherMode.HISTORY,
+        query_one=lambda *_args: SimpleNamespace(value="Exact"),
+        run_worker=lambda work, **_kwargs: queued.append(work),
+        _refresh_results=refresh,
+    )
+    ConsoleSessionSwitcherModal.reconcile_active_results(
+        owner,
+        (),
+        profile_authority="profile",
+        authority_token="token",
+        projection_generation=2,
+    )
+    assert len(queued) == 1
+    work = queued.pop()
+    # A cancelled queued worker never starts its work. Close the old eager
+    # implementation only on RED so this regression itself does not leak it.
+    if inspect.iscoroutine(work):
+        work.close()
+        pytest.fail("queued reconciliation allocated an unawaited coroutine")
+    assert inspect.iscoroutinefunction(work), "Textual requires async-callable work"
+    assert refreshed == []
+    await work()
+    assert refreshed == ["Exact"]

--- a/Tests/UI/test_console_activity_switcher.py
+++ b/Tests/UI/test_console_activity_switcher.py
@@ -792,6 +792,7 @@ async def test_zero_active_matches_widens_to_history_and_f3_retains_query():
         )
         status = app.screen.query_one("#console-switcher-status", Static)
         assert "History matches" in str(status.renderable)
+        assert "[History]" in app.screen.query_one("#console-switcher-modal").border_title
         assert app.screen.query_one("#console-switcher-history-mode", Button).has_class(
             "console-switcher-mode-current"
         )

--- a/Tests/UI/test_console_switcher_reuse_and_modes.py
+++ b/Tests/UI/test_console_switcher_reuse_and_modes.py
@@ -248,3 +248,48 @@ async def test_history_reuse_refreshes_changed_workspace_scope(activation_librar
         assert store.active_session_id == target.id
         assert chat._console_effective_scope_cache["exact"].item_count == 2
         assert _static_plain_text(chat.query_one("#console-scope-chip")) == "Scope: 2"
+
+
+@pytest.mark.asyncio
+async def test_history_reuse_still_presents_chat_when_scope_refresh_fails(
+    activation_library,  # noqa: F811
+    monkeypatch,
+):
+    owner, _, db = activation_library
+    _seed(owner, db)
+    owner.local_chat_conversation_service = ChatConversationService(db)
+    host = ConsoleHarness(owner)
+    async with host.run_test(size=(120, 50)) as pilot:
+        chat = host.screen
+        store = chat._ensure_console_chat_store()
+        prior = store.active_session_id
+        assert await chat._workspace._resume_console_workspace_conversation("exact")
+        warm_id = store.active_session_id
+        await chat._session._activate_native_console_session(prior)
+
+        async def fail_scope(_session):
+            raise RuntimeError("synthetic scope-display outage")
+
+        monkeypatch.setattr(
+            chat._retrieval, "_refresh_console_effective_scope_and_sync", fail_scope
+        )
+        await chat.action_open_console_session_switcher(
+            initial_mode=SwitcherMode.HISTORY
+        )
+        await _until(lambda: isinstance(host.screen, ConsoleSessionSwitcherModal))
+        modal = host.screen
+        await _until(lambda: bool(modal.query("#console-switcher-query")))
+        await pilot.pause()
+        modal.query_one("#console-switcher-query", Input).value = "Exact"
+        await pilot.pause()
+        await _until(lambda: not modal._query_pending and bool(modal._entries))
+        assert modal._entries[0].target.conversation_id == "exact"
+        await pilot.press("enter")
+        await pilot.pause()
+        assert host.screen is chat
+        assert store.active_session_id == warm_id
+        assert (
+            len([s for s in store.sessions() if s.persisted_conversation_id == "exact"])
+            == 1
+        )
+        assert chat.focused is chat.query_one("#console-native-composer")

--- a/Tests/UI/test_console_switcher_reuse_and_modes.py
+++ b/Tests/UI/test_console_switcher_reuse_and_modes.py
@@ -1,0 +1,250 @@
+"""Native-report regressions: exact History reuse and visible mode ownership."""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Input
+
+from Tests.UI.test_console_character_activation_presentation import (
+    _seed,
+    _until,
+    activation_library,  # noqa: F401
+)
+from Tests.UI.test_console_character_switcher_geometry import _GeometryApp
+from Tests.UI.test_console_native_chat_flow import _static_plain_text
+from Tests.UI.test_console_scope_row import (
+    _AlwaysExistsMediaDB,
+    _open_inspector_and_get_row,
+)
+from Tests.UI.test_console_workbench_contract import ConsoleHarness
+from Tests.UI.test_library_inspection_admission import library  # noqa: F401
+from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+from tldw_chatbook.Chat.console_switcher_state import SwitcherMode
+from tldw_chatbook.Chat.rag_scope import RagScope, ScopeItem
+from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+    ConsoleSessionSwitcherModal,
+    ConsoleSwitcherChoice,
+)
+
+
+def _luminance(rgb):
+    channels = [value / 255 for value in rgb]
+    linear = [
+        value / 12.92 if value <= 0.04045 else ((value + 0.055) / 1.055) ** 2.4
+        for value in channels
+    ]
+    return sum(
+        value * weight for value, weight in zip(linear, (0.2126, 0.7152, 0.0722))
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inactive", [False, True], ids=["current", "other-tab"])
+@pytest.mark.parametrize(
+    "modes",
+    [
+        (SwitcherMode.CHARACTER_CHATS, SwitcherMode.CHARACTER_CHATS),
+        (SwitcherMode.HISTORY, SwitcherMode.HISTORY),
+        (SwitcherMode.CHARACTER_CHATS, SwitcherMode.HISTORY),
+        (SwitcherMode.HISTORY, SwitcherMode.CHARACTER_CHATS),
+    ],
+    ids=[
+        "character-character",
+        "history-history",
+        "character-history",
+        "history-character",
+    ],
+)
+async def test_reopening_exact_conversation_reuses_runtime(
+    activation_library,  # noqa: F811
+    modes,
+    inactive,
+):
+    owner, _, db = activation_library
+    _seed(owner, db)
+    owner.local_chat_conversation_service = ChatConversationService(db)
+    host = ConsoleHarness(owner)
+    async with host.run_test(size=(120, 50)) as pilot:
+        chat = host.screen
+        await _until(lambda: chat.query("#console-native-composer"))
+        store = chat._ensure_console_chat_store()
+        prior = store.active_session_id
+        first_id = None
+        for mode in modes:
+            if first_id is not None and inactive:
+                await chat._session._activate_native_console_session(prior)
+                assert store.active_session_id == prior
+            await chat.action_open_console_session_switcher(
+                initial_mode=mode,
+                initial_character_query="Exact",
+            )
+            await _until(lambda: isinstance(host.screen, ConsoleSessionSwitcherModal))
+            modal = host.screen
+            await _until(
+                lambda modal=modal: bool(modal.query("#console-switcher-query"))
+            )
+            if mode is SwitcherMode.HISTORY:
+                modal.query_one("#console-switcher-query", Input).value = "Exact"
+            await _until(
+                lambda modal=modal: (
+                    not modal._query_pending
+                    and bool(modal._entries)
+                    and modal.query_one("#console-switcher-query", Input).value
+                    == "Exact"
+                )
+            )
+            assert modal._entries[0].target.conversation_id == "exact"
+            assert modal._mode is mode
+            await pilot.press("enter")
+            await _until(
+                lambda: (
+                    host.screen is chat
+                    and any(
+                        s.id == store.active_session_id
+                        and s.persisted_conversation_id == "exact"
+                        for s in store.sessions()
+                    )
+                )
+            )
+            await pilot.pause()
+            matches = [
+                s.id for s in store.sessions() if s.persisted_conversation_id == "exact"
+            ]
+            assert len(matches) == 1, f"{mode}: duplicate runtimes {matches}"
+            assert store.active_session_id == matches[0]
+            if first_id is not None:
+                assert matches[0] == first_id
+            first_id = matches[0]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(52, 20), (120, 50)])
+async def test_current_mode_is_painted_independently_of_focus(size, tmp_path):
+    app = _GeometryApp()
+    async with app.run_test(size=size) as pilot:
+        await pilot.pause()
+        screen = app.screen
+        for label in ("Character chats", "Active", "History"):
+            await pilot.pause()
+            buttons = list(screen.query(".console-switcher-mode").results(Button))
+            selected = [
+                b for b in buttons if b.has_class("console-switcher-mode-current")
+            ]
+            assert len(selected) == 1
+            inactive = [b for b in buttons if b is not selected[0]]
+            for focus in (screen.query_one("#console-switcher-query"), inactive[0]):
+                screen.set_focus(focus)
+                await pilot.pause()
+                app.export_screenshot()
+                frame = "\n".join(
+                    strip.text for strip in screen._compositor.render_strips()
+                )
+                assert f"[{label}]" in frame, (
+                    screen.query_one("#console-switcher-modal").border_title,
+                    frame,
+                )
+                title_segments = [
+                    segment
+                    for strip in screen._compositor.render_strips()
+                    for segment in strip
+                    if f"[{label}]" in segment.text
+                ]
+                assert title_segments
+                for segment in title_segments:
+                    foreground = _luminance(segment.style.color.triplet)
+                    background = _luminance(segment.style.bgcolor.triplet)
+                    contrast = (max(foreground, background) + 0.05) / (
+                        min(foreground, background) + 0.05
+                    )
+                    assert contrast >= 4.5, (
+                        "mode text must contrast with its background"
+                    )
+                assert selected[0].styles.background != inactive[-1].styles.background
+                assert screen.focused is focus
+            (tmp_path / f"mode-{label.replace(' ', '-')}.svg").write_text(
+                app.export_screenshot()
+            )
+            await pilot.press("f3")
+        await pilot.pause()
+        await pilot.press("escape")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fault", ["deleted", "native-prefix"])
+async def test_history_reuse_preserves_exact_saved_identity(activation_library, fault):  # noqa: F811
+    owner, _, db = activation_library
+    _seed(owner, db)
+    owner.local_chat_conversation_service = ChatConversationService(db)
+    host = ConsoleHarness(owner)
+    async with host.run_test(size=(120, 50)) as pilot:
+        chat = host.screen
+        store = chat._ensure_console_chat_store()
+        prior = store.active_session_id
+        target = "exact" if fault == "deleted" else f"native:{prior}"
+        if fault == "native-prefix":
+            db.add_conversation({"id": target, "title": "Prefix identity fixture"})
+        assert await chat._workspace._resume_console_workspace_conversation(target)
+        warm_id = store.active_session_id
+        await chat._session._activate_native_console_session(prior)
+        page = await chat._workspace.load_console_session_switcher_history(
+            query="", offset=0, limit=50
+        )
+        entry = next(e for e in page.entries if e.conversation_id == target)
+        if fault == "deleted":
+            with db.transaction() as connection:
+                connection.execute(
+                    "UPDATE conversations SET deleted = 1 WHERE id = ?", (target,)
+                )
+        await chat._session._apply_console_switcher_choice(
+            ConsoleSwitcherChoice("activate", entry)
+        )
+        await pilot.pause()
+        assert store.active_session_id == (prior if fault == "deleted" else warm_id)
+        assert (
+            len([s for s in store.sessions() if s.persisted_conversation_id == target])
+            == 1
+        )
+
+
+@pytest.mark.asyncio
+async def test_history_reuse_refreshes_changed_workspace_scope(activation_library):  # noqa: F811
+    owner, _, db = activation_library
+    _seed(owner, db)
+    owner.media_db = _AlwaysExistsMediaDB()
+    owner.local_chat_conversation_service = ChatConversationService(db)
+    host = ConsoleHarness(owner)
+    async with host.run_test(size=(240, 64)) as pilot:
+        chat = host.screen
+        await _open_inspector_and_get_row(chat, pilot)
+        store = chat._ensure_console_chat_store()
+        prior = store.active_session_id
+        assert await chat._workspace._resume_console_workspace_conversation("exact")
+        target = next(s for s in store.sessions() if s.id == store.active_session_id)
+        registry = owner.workspace_registry_service
+        registry.set_workspace_scope(
+            target.workspace_id,
+            RagScope(
+                items=(ScopeItem("media", "old"),), updated_at="2026-09-06T00:00:00Z"
+            ),
+        )
+        await chat._retrieval._resolve_console_effective_scope_state(target)
+        assert chat._console_effective_scope_cache["exact"].item_count == 1
+        await chat._session._activate_native_console_session(prior)
+        registry.set_workspace_scope(
+            target.workspace_id,
+            RagScope(
+                items=(ScopeItem("media", "new-1"), ScopeItem("media", "new-2")),
+                updated_at="2026-09-07T00:00:00Z",
+            ),
+        )
+        page = await chat._workspace.load_console_session_switcher_history(
+            query="Exact", offset=0, limit=50
+        )
+        entry = next(e for e in page.entries if e.conversation_id == "exact")
+        await chat._session._apply_console_switcher_choice(
+            ConsoleSwitcherChoice("activate", entry)
+        )
+        await pilot.pause()
+        assert store.active_session_id == target.id
+        assert chat._console_effective_scope_cache["exact"].item_count == 2
+        assert _static_plain_text(chat.query_one("#console-scope-chip")) == "Scope: 2"

--- a/backlog/tasks/task-31245 - Add-Character-chats-mode-to-CtrlK-switcher.md
+++ b/backlog/tasks/task-31245 - Add-Character-chats-mode-to-CtrlK-switcher.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:09'
-updated_date: '2026-09-07 21:17'
+updated_date: '2026-09-07 21:37'
 labels:
   - console
   - switcher
@@ -55,6 +55,7 @@ and dependency references.
 - [ ] #17 Targeted activation tests release their own SQLite handles only after pending work settles; repeated terminal teardown has no cumulative database-descriptor growth.
 - [x] #18 Reopening an exact saved conversation through History reuses an existing Console session across History and Character modes, without duplicate tabs or lost authority checks.
 - [x] #19 The selected Active, History or Character mode remains unmistakable with a non-color text marker and distinct painted styling at 52x20 and 120x50, independently of keyboard focus.
+- [x] #20 Queued switcher reconciliation can be cancelled before execution without creating an unawaited coroutine, while executed work still refreshes its captured query.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -93,6 +94,14 @@ Resource correction against10c18c7c6: inspection fixture captures its original C
 Activation scoped review I1/M1 correction against cfcb79bd8: commit acknowledgement now matches the same completion-owner identity as activation admission and waits through queued admission; installed callbacks pair per-request completion/waiter even when waiter starts first. Real held ordinary-A/queued-switcher-B regression proves Escape remains effective before B commit and only B linearization freezes controls; ordinary None and precommit settlement preserved. Artifact finalization records corpus-integrity failure before JSON while retaining an earlier exception. ADR120 and AC5/15 already govern; no new ADR or authority. Valid owner RED4failed, focusedGREEN6passed, final affected three-file gate51passed38.63s/no warnings with post-teardown regular7 plateau and lsof0/empty stderr. Seven changed Python paths have no added Ruff diagnostics; five focused files lint/format clean. Existing lesson records reviewer unguarded-import incident without ambient inspection/undo. Full command/provenance receipt: packet/task-5-activation-review-fix-report.md. In Progress/unchecked; native/full UI latency, external evidence, inherited preimport501/500 and size qualifications remain open. No full sweep, timing matrix, native, rebase or remote changes.
 
 Approved native-report follow-up on dev29442a: History validates saved existence then reuses exact persisted identity through guarded warm activation; preserves authority, deletion refusal, intentional cold forks, and refreshes changed workspace scope. Mode title explicitly names Active/History/Character chats with primary text contrast and selected styling independent of focus, without layout rows or cap changes. Review identity/deletion/scope findings fixed; covering48passed1expectedCSSwarning, final color mode2passed and geometry/budget12passed1expectedwarning; boot CSS803784/804000. No added Ruff diagnostics, focused format and all preflight guards pass. Impeccable visual review caught dark border-title inheritance and prompted actual rendered contrast assertions. Existing ADR120/031/097 apply; no new ADR. Evidence/manual handoff: Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md. AC18/19 checked for scoped automated evidence; broader task remains In Progress, native/external gaps unwaived, TASK31966 separate. Original running QA checkout left unchanged.
+
+PR2487 Qodo remediation plan (2026-09-07): rebase onto fetched dev0bb00beaf; preserve existing best-effort scope-display behavior with a local Exception boundary while cancellation and genuine presentation failures still restore the prior session. Add isolated exact-ID selection/mode-state/scope-failure coverage alongside the installed UI regressions, then run targeted checks, reply to both review threads, obtain current-head review and merge after checks. Existing ADR120/031/097; no new ADR or scope expansion.
+
+PR2487 Qodo fixes: conflict-free rebase onto dev0bb00beaf; original patch range-diff equivalent. New scope exception guard preserves incumbent best-effort display semantics; cancellation and actual presentation failure retain rollback. Valid unit and installed-UI RED each failed before fix; covering60passed1expectedCSSwarning82.87s. Added11 isolated decisions and installed History outage regression, no app/DB in unit cases. Independent static review found no remaining issues. Diagnostic statement comparison verified exactly one added fixed-message warning with opaque runtime session ID and incumbent exception logging, no new sink/content/path/secret format arguments; regenerated mandatory inventory. Full evidence in QA follow-up; native/external gaps unchanged.
+
+Bounded verification follow-up: a repeated unit-plus-installed-History run showed an unawaited refresh coroutine. Tracemalloc pinned allocation to console_session_switcher_modal.py reconcile_active_results line574; queued worker cancellation can precede coroutine execution. Plan: add isolated queued-work regression, defer only this allocation through the supported callable worker seam, retain production reconciliation behavior and rerun affected tests. Existing lifecycle contracts apply; no new ADR or GC policy.
+
+Final queued-worker correction uses functools.partial of the async refresh method; Textual rejects ordinary lambdas (caught by seven actual-worker failures and reviewer before publication). Unit regression now checks deferred creation plus async-callable compatibility and captured query. Final12unit+14installed+41activity gate67passed47.28s/no warnings; descriptor plateau unchanged. All added test Ruff/format checks and whitespace pass; preflight clear and no new workspace diagnostics. Ready for remote review/check gate; no native or GC qualification waiver.
 <!-- SECTION:NOTES:END -->
 
 ### Approved native follow-up — 2026-09-07

--- a/backlog/tasks/task-31245 - Add-Character-chats-mode-to-CtrlK-switcher.md
+++ b/backlog/tasks/task-31245 - Add-Character-chats-mode-to-CtrlK-switcher.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-04 02:09'
-updated_date: '2026-09-07 17:49'
+updated_date: '2026-09-07 21:17'
 labels:
   - console
   - switcher
@@ -53,6 +53,8 @@ and dependency references.
 - [ ] #15 Genuine installed switcher activation opens the exact cold or existing Console conversation, preserves composer focus, and rejects stale or unrelated overlay ownership without granting ordinary callers an underlay exception.
 - [ ] #16 Cold target token-estimate preparation runs off the UI thread before session activation, preserves real estimator values, and rejects stale target or settings snapshots.
 - [ ] #17 Targeted activation tests release their own SQLite handles only after pending work settles; repeated terminal teardown has no cumulative database-descriptor growth.
+- [x] #18 Reopening an exact saved conversation through History reuses an existing Console session across History and Character modes, without duplicate tabs or lost authority checks.
+- [x] #19 The selected Active, History or Character mode remains unmistakable with a non-color text marker and distinct painted styling at 52x20 and 120x50, independently of keyboard focus.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -89,4 +91,17 @@ Resource design identifies explicit inspection fixture ownership plus constructo
 Resource correction against10c18c7c6: inspection fixture captures its original ChaChaNotes, collections, evals, workspace, subscriptions and profile-lock owners, disposes only at terminal fixture lifetime after harness/workers stop, and preserves production pooling. Held-reference/worker/same-file observer regression RED then GREEN; both parsed manifests now constrain chardet>=3.0.2,<6. Isolated chardet5.2 overlay imports Requests2.32.5 with warnings as errors; shared venv unchanged. Initial46-pass observer still found+147 regular descriptors; exact cold/warm metadata census identified workspace/subscriptions/lock residual, then final103-pass affected switcher/geometry/inspection/packaging gate had no warnings and regular FD plateau7through every teardown, only first-use+1FIFO/+2sockets. lsof exit0/stderr empty agrees with F_GETPATH. Static no added Ruff diagnostics. Exact logs /tmp/task31245-resource-*.log and complete resource receipt in packet task-5-delivery-report.md; testing-evidence lesson records diagnostic trap. No production/native/scale/rebase/remote changes; task stays In Progress for review and remaining required verification.
 
 Activation scoped review I1/M1 correction against cfcb79bd8: commit acknowledgement now matches the same completion-owner identity as activation admission and waits through queued admission; installed callbacks pair per-request completion/waiter even when waiter starts first. Real held ordinary-A/queued-switcher-B regression proves Escape remains effective before B commit and only B linearization freezes controls; ordinary None and precommit settlement preserved. Artifact finalization records corpus-integrity failure before JSON while retaining an earlier exception. ADR120 and AC5/15 already govern; no new ADR or authority. Valid owner RED4failed, focusedGREEN6passed, final affected three-file gate51passed38.63s/no warnings with post-teardown regular7 plateau and lsof0/empty stderr. Seven changed Python paths have no added Ruff diagnostics; five focused files lint/format clean. Existing lesson records reviewer unguarded-import incident without ambient inspection/undo. Full command/provenance receipt: packet/task-5-activation-review-fix-report.md. In Progress/unchecked; native/full UI latency, external evidence, inherited preimport501/500 and size qualifications remain open. No full sweep, timing matrix, native, rebase or remote changes.
+
+Approved native-report follow-up on dev29442a: History validates saved existence then reuses exact persisted identity through guarded warm activation; preserves authority, deletion refusal, intentional cold forks, and refreshes changed workspace scope. Mode title explicitly names Active/History/Character chats with primary text contrast and selected styling independent of focus, without layout rows or cap changes. Review identity/deletion/scope findings fixed; covering48passed1expectedCSSwarning, final color mode2passed and geometry/budget12passed1expectedwarning; boot CSS803784/804000. No added Ruff diagnostics, focused format and all preflight guards pass. Impeccable visual review caught dark border-title inheritance and prompted actual rendered contrast assertions. Existing ADR120/031/097 apply; no new ADR. Evidence/manual handoff: Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md. AC18/19 checked for scoped automated evidence; broader task remains In Progress, native/external gaps unwaived, TASK31966 separate. Original running QA checkout left unchanged.
 <!-- SECTION:NOTES:END -->
+
+### Approved native follow-up — 2026-09-07
+
+1. Preserve the native report and reproduce same-mode/cross-mode exact-target reopening under the isolated pytest owner.
+2. Make History consult the existing exact-conversation session lookup before cold resume; retain immutable authority checks, missing-target feedback and intentional forks.
+3. Keep current mode text visible in the existing modal border title and apply scoped app-level selected-mode styling, separate from focus, without adding rows or raising CSS budgets.
+4. Verify active/inactive reuse, authority refusal, three-mode painted state at 52x20 and 120x50, focused trust/geometry tests, generated CSS and static checks; publish a separate follow-up PR.
+
+ADR required: no new ADR.
+ADR path: backlog/decisions/120-character-conversation-navigation-and-local-semantic-search.md; backlog/decisions/031-tui-keybinding-and-footer-hint-conventions.md; backlog/decisions/097-boot-budget-ratchets.md.
+Reason: routine corrections to existing exact-resume and visible-state contracts; no new storage, service, permission, navigation or performance policy. GC remains TASK-31966. Native/external qualification is not waived.

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2739,6 +2739,7 @@ class ConsoleSessionController:
                 target.conversation_id,
                 target_scope_type=target.scope_type or None,
                 target_workspace_id=target.workspace_id,
+                reuse_existing=True,
             )
             if resumed is False:
                 # TASK-717: record missing - same honest feedback and broken

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -4266,6 +4266,8 @@ class ConsoleWorkspaceController:
                 self._capture_console_draft_switch_snapshot()
                 controller.switch_session(session_id)
             self._set_active_workspace_for_console_session(session_id)
+            session = next(item for item in store.sessions() if item.id == session_id)
+            await self._refresh_console_effective_scope_and_sync(session)
             self._sync_console_chat_core_state()
             sync_result = self._sync_native_console_chat_ui_fn()
             if inspect.isawaitable(sync_result):
@@ -5208,8 +5210,16 @@ class ConsoleWorkspaceController:
         *,
         target_scope_type: str | None = None,
         target_workspace_id: str | None = None,
+        reuse_existing: bool = False,
     ) -> bool | None:
         """Load a persisted saved conversation into a native Console session.
+
+        Args:
+            conversation_id: Exact persisted conversation identity.
+            target_scope_type: Optional fallback scope for cold hydration.
+            target_workspace_id: Optional fallback workspace for cold hydration.
+            reuse_existing: Prefer an open runtime after validating the saved
+                record. History opts in; explicit fresh-session callers do not.
 
         Returns:
             True on success; None on a transient failure this method already
@@ -5265,6 +5275,21 @@ class ConsoleWorkspaceController:
                 store, prior_active_session_id
             )
             return False
+
+        if reuse_existing:
+            matches = [
+                session
+                for session in store.sessions()
+                if str(session.persisted_conversation_id or "") == target
+            ]
+            if matches:
+                session = next(
+                    (item for item in matches if item.id == store.active_session_id),
+                    matches[0],
+                )
+                return await self.open_console_workspace_conversation(
+                    f"native:{session.id}"
+                )
 
         conversation = tree.get("conversation")
         if not isinstance(conversation, dict):

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -4267,7 +4267,14 @@ class ConsoleWorkspaceController:
                 controller.switch_session(session_id)
             self._set_active_workspace_for_console_session(session_id)
             session = next(item for item in store.sessions() if item.id == session_id)
-            await self._refresh_console_effective_scope_and_sync(session)
+            try:
+                await self._refresh_console_effective_scope_and_sync(session)
+            except Exception:  # noqa: BLE001 - optional display must not block activation
+                logger.opt(exception=True).warning(
+                    "Failed to refresh retrieval scope display on saved "
+                    "conversation activation: {}",
+                    session_id,
+                )
             self._sync_console_chat_core_state()
             sync_result = self._sync_native_console_chat_ui_fn()
             if inspect.isawaitable(sync_result):

--- a/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
@@ -1850,6 +1850,16 @@ class ConsoleSessionSwitcherModal(
         history_is_current = (
             self._mode is SwitcherMode.HISTORY or self._widened_to_history
         )
+        mode_label = (
+            "Character chats"
+            if self._mode is SwitcherMode.CHARACTER_CHATS
+            else "History"
+            if history_is_current
+            else "Active"
+        )
+        self.query_one("#console-switcher-modal", Vertical).border_title = Text(
+            f"Switch or resume [{mode_label}]"
+        )
         active.set_class(
             self._mode is SwitcherMode.ACTIVE and not history_is_current,
             "console-switcher-mode-current",

--- a/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_session_switcher_modal.py
@@ -6,6 +6,7 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
+from functools import partial
 from hashlib import sha1
 from typing import Any, ClassVar
 from uuid import uuid4
@@ -571,7 +572,7 @@ class ConsoleSessionSwitcherModal(
                     else 0
                 )
         self.run_worker(
-            self._refresh_results(query),
+            partial(self._refresh_results, query),
             exclusive=True,
             group="console-session-switcher-reconcile",
         )

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4740,6 +4740,7 @@ ConsoleTerminalWorkspace Button:focus {
 }
 
 #console-switcher-query:focus,
+.console-switcher-mode-current,
 .console-switcher-result-candidate {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
@@ -4752,6 +4753,7 @@ ConsoleTerminalWorkspace Button:focus {
 
 #console-switcher-modal {
     border: tall $ds-grid-line;
+    border-title-color: $ds-text-primary;
     background: $ds-surface-panel;
     color: $ds-text-primary;
 }
@@ -4767,11 +4769,7 @@ ConsoleTerminalWorkspace Button:focus {
     border-left: solid $ds-status-error;
 }
 
-/* TASK-31429 (Qodo review on PR #2393): the conversation row IS the Button
-   (`_conversation_button`), so the former descendant form
-   `.console-workspace-conversation-row Button:focus` matched nothing. Target
-   the row itself; class+pseudo specificity outranks the `-selected` and
-   run-marker hue rules, so focus stays its own visible signal on top. */
+/* TASK-31429: the row IS the Button; class+pseudo beats selected/run hues. */
 .console-workspace-conversation-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -1265,6 +1265,7 @@ ConsoleTerminalWorkspace#console-main-column {
 }
 
 #console-switcher-query:focus,
+.console-switcher-mode-current,
 .console-switcher-result-candidate {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
@@ -1277,6 +1278,7 @@ ConsoleTerminalWorkspace#console-main-column {
 
 #console-switcher-modal {
     border: tall $ds-grid-line;
+    border-title-color: $ds-text-primary;
     background: $ds-surface-panel;
     color: $ds-text-primary;
 }
@@ -1292,11 +1294,7 @@ ConsoleTerminalWorkspace#console-main-column {
     border-left: solid $ds-status-error;
 }
 
-/* TASK-31429 (Qodo review on PR #2393): the conversation row IS the Button
-   (`_conversation_button`), so the former descendant form
-   `.console-workspace-conversation-row Button:focus` matched nothing. Target
-   the row itself; class+pseudo specificity outranks the `-selected` and
-   run-marker hue rules, so focus stays its own visible signal on top. */
+/* TASK-31429: the row IS the Button; class+pseudo beats selected/run hues. */
 .console-workspace-conversation-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;


### PR DESCRIPTION
## Summary

Separate follow-up to merged #2469 for the two issues reported during native QA:

- History reuses the exact existing Console runtime instead of opening duplicate tabs, including cross-mode navigation. Saved-record and authority validation remain in place; intentional fresh-session callers are unchanged.
- The switcher title explicitly names `[Active]`, `[History]`, or `[Character chats]`, with readable contrast and selected-mode styling independent of keyboard focus. No extra rows or shortcuts.
- Review regressions preserve deleted-record refusal, exact IDs beginning with `native:`, and refreshed retrieval scope when reopening an inactive tab after workspace edits.

## Verification

- 48 targeted tests passed after the activation repairs.
- Following the final contrast correction: two painted mode tests passed at 52×20 and 120×50, plus 12 geometry/CSS-budget tests passed.
- No added Ruff diagnostics; focused formatting and whitespace checks pass; all six preflight derived-artifact guards pass.
- Only expected boot-CSS headroom warning: 803,784/804,000 bytes (216 remaining), no cap increase.
- Covering resource observer found a stable seven regular descriptors and no remaining SQLite file handles. Existing isolated compatible qualification dependencies used; shared environment unchanged.
- Independent static review findings addressed. No full-suite claim.

## Scope and manual handoff

The running synthetic native QA app and original checkout were left untouched. Restart on this branch to manually recheck F3 mode identification and exact tab reuse across History/Character chats. Already-created duplicate tabs are not automatically closed.

Native requalification and existing Windows/participant gaps remain explicit. GC investigation stays separate in TASK-31966. No new ADR: existing ADR-120/031/097 govern these routine corrections. TASK-31245 remains In Progress.

Evidence and retest steps: `Docs/QA/task-31245/switcher-reuse-and-mode-follow-up.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the console switcher so resuming a saved History conversation reuses the existing runtime tab instead of opening a duplicate, and makes the selected mode explicitly named so it's identifiable without keyboard focus.

- History validates the saved record before reusing; deleted-record refusal and authority checks are preserved.
- Reopening an inactive tab refreshes the current retrieval scope after workspace edits; a failed scope refresh doesn't block activation.
- The switcher title now shows `[Active]`, `[History]`, or `[Character chats]` with readable contrast and selected styling independent of focus.
- Intentional fresh-session callers keep their behavior; existing duplicate tabs are not automatically closed.
- Queued reconciliation workers defer coroutine creation so cancelling a pending refresh no longer leaks an unawaited coroutine.

<sup>Written for commit bf473367074793d5e556979e44e7f9698c8f1a8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2487?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

