### PR TITLE
fix(library): Media focus channel stands down when an empty list has no landing; import order (Qodo #2483/#2486)

### DIFF
--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -10,12 +10,12 @@ from unittest.mock import AsyncMock, Mock
 
 import pytest
 from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Button, Checkbox, Select, Static
 
 # Harness apps load the consolidated widget CSS the real app loads
 # (TASK-15450); without it the widgets under test mount unstyled.
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
-from textual.containers import Horizontal
-from textual.widgets import Button, Checkbox, Select, Static
 
 from Tests.UI.app_factory import _build_test_app
 from tldw_chatbook.ACP_Interop.runtime_session import ACPRuntimeSessionState

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -34959,3 +34959,64 @@ async def test_background_recompose_restores_focus_on_an_empty_conversations_lis
             "Conversations list with no focused widget"
         )
         assert focused.is_attached, focused
+
+
+@pytest.mark.asyncio
+async def test_background_recompose_restores_focus_on_a_filtered_empty_media_list():
+    """Qodo #2483: the Media channel stands down when it cannot land.
+
+    A filter MISS is the one empty Media page with no recovery action at
+    all -- the canvas returns right after its query-echoing status line,
+    so NONE of the four controls ``_focus_library_list_entry`` falls back
+    to is composed. The armed channel therefore lands nothing, and
+    standing the screen-level seam down for it left a background
+    recompose inside the settle window with a dead keyboard.
+    """
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_selector(screen, pilot, "#library-media-row-0")
+
+        screen._request_library_media_filter("no-such-media-anywhere")
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query(".library-media-row")
+            and not any(
+                screen.query(selector)
+                for selector in (
+                    "#library-media-type-filter",
+                    "#library-media-empty-clear-type",
+                    "#library-media-empty-import",
+                    "#library-media-retry",
+                )
+            ),
+            message="the filter miss never reached a recovery-less empty page",
+        )
+
+        filter_input = screen.query_one("#library-media-filter", Input)
+        screen.set_focus(filter_input)
+        await pilot.pause()
+        assert screen.focused is filter_input
+
+        # Inside the armed settle window, on a page the channel cannot serve.
+        screen._arm_library_list_entry_focus()
+        assert screen._library_pending_list_entry_focus is True
+
+        screen.refresh(recompose=True)
+        await pilot.pause()
+        await pilot.pause()
+
+        focused = screen.focused
+        assert focused is not None, (
+            "a background recompose inside the armed window left the "
+            "recovery-less empty Media list with no focused widget"
+        )
+        assert focused.is_attached, focused
+        content = screen.query_one("#screen-content")
+        assert content in focused.ancestors, focused.id

--- a/tldw_chatbook/Library/review_set_service.py
+++ b/tldw_chatbook/Library/review_set_service.py
@@ -88,6 +88,10 @@ class ReviewSetService:
         mismatches and re-reads. What a reader must NOT do is stamp a
         revision read AFTER its own load -- that claims a write it never
         saw (fix round 1).
+
+        Returns:
+            int: the number of writes committed through this instance so
+            far; equal values mean nothing has changed since the last read.
         """
         return self._revision
 

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -15,6 +15,7 @@ from .main_navigation import MainNavigationBar
 
 if TYPE_CHECKING:
     from textual.widget import Widget
+
     from tldw_chatbook.app import TldwCli
 
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -9227,7 +9227,9 @@ class LibraryScreen(BaseAppScreen):
 
         (The third case, a row class whose list is EMPTY, is closed at
         the channel itself: notes now falls back to its filter input the
-        way prompts and skills already did.)
+        way prompts and skills already did. Media's empty page has no
+        unconditional control to fall back to, so it is closed in the
+        predicate instead -- it stands down when nothing is there.)
         """
         if self._library_focus_channel_owns_this_window():
             return
@@ -9242,11 +9244,14 @@ class LibraryScreen(BaseAppScreen):
         ``_focus_library_list_entry`` -- deliberately those two and no
         more, so this predicate stays a statement about which route/stage
         the channel serves and never a second copy of its row-picking
-        logic. Two no-landing cases are knowingly left inside "owns":
-        a pending Find focus whose input never mounts, and an empty
-        Media list whose four fallback controls are all absent or
-        disabled -- both narrow, both end at ``None`` rather than at a
-        wrong widget.
+        logic. The one exception is Media's EMPTY page (Qodo #2483): its
+        recovery controls are conditional, and a filter MISS composes none
+        of them, so the channel lands nothing there -- the shared
+        ``_library_media_empty_list_fallback_target`` answers that for
+        both this predicate and the channel itself rather than being
+        re-derived here. One no-landing case is still knowingly left
+        inside "owns": a pending Find focus whose input never mounts --
+        narrow, and it ends at ``None`` rather than at a wrong widget.
         """
         if self._library_media_find_focus_pending:
             return True
@@ -9254,10 +9259,18 @@ class LibraryScreen(BaseAppScreen):
             return False
         if self._library_emergency_stage == "rail-only":
             return False
-        return (
-            _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(self._library_selected_row_id)
-            is not None
+        row_class = _LIBRARY_LIST_ROW_CLASS_BY_ROW_ID.get(
+            self._library_selected_row_id
         )
+        if row_class is None:
+            return False
+        if (
+            row_class == "library-media-row"
+            and not self.query(f".{row_class}")
+            and self._library_media_empty_list_fallback_target() is None
+        ):
+            return False
+        return True
 
     async def action_library_notes_new(self) -> None:
         """Open Create only after the active canonical draft flushes."""
@@ -11184,6 +11197,33 @@ class LibraryScreen(BaseAppScreen):
                 return
             self._focus_library_list_entry()
 
+    def _library_media_empty_list_fallback_target(self) -> Widget | None:
+        """The control an EMPTY Media list can hand keyboard focus to.
+
+        The first of Media's four recovery controls that is both present
+        and enabled, or ``None`` when the page offers none. One owner for
+        both readers: ``_focus_library_list_entry`` lands on it, and
+        ``_library_focus_channel_owns_this_window`` asks whether there is
+        anything to land on at all -- a filter MISS composes no recovery
+        action whatsoever (the canvas returns right after its
+        query-echoing status line), so the answer has to be the same in
+        both places or the seam stands down for a channel that never
+        arrives.
+        """
+        for selector in (
+            "#library-media-type-filter",
+            "#library-media-empty-clear-type",
+            "#library-media-empty-import",
+            "#library-media-retry",
+        ):
+            try:
+                control = self.query_one(selector, Widget)
+            except (NoMatches, QueryError):
+                continue
+            if not getattr(control, "disabled", False):
+                return control
+        return None
+
     def _focus_library_list_entry(self) -> None:
         """Focus the primary list's first row -- see ``_arm_library_list_entry_focus``.
 
@@ -11232,20 +11272,11 @@ class LibraryScreen(BaseAppScreen):
                     self.set_focus(control)
                     return
             if row_class == "library-media-row":
-                for selector in (
-                    "#library-media-type-filter",
-                    "#library-media-empty-clear-type",
-                    "#library-media-empty-import",
-                    "#library-media-retry",
-                ):
-                    try:
-                        control = self.query_one(selector, Widget)
-                    except (NoMatches, QueryError):
-                        continue
-                    if not getattr(control, "disabled", False):
-                        self._library_notes_programmatic_focus_target = control
-                        self.set_focus(control)
-                        return
+                control = self._library_media_empty_list_fallback_target()
+                if control is not None:
+                    self._library_notes_programmatic_focus_target = control
+                    self.set_focus(control)
+                    return
             return
         if (
             row_class == "library-media-row"

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -11204,11 +11204,14 @@ class LibraryScreen(BaseAppScreen):
         and enabled, or ``None`` when the page offers none. One owner for
         both readers: ``_focus_library_list_entry`` lands on it, and
         ``_library_focus_channel_owns_this_window`` asks whether there is
-        anything to land on at all -- a filter MISS composes no recovery
-        action whatsoever (the canvas returns right after its
-        query-echoing status line), so the answer has to be the same in
-        both places or the seam stands down for a channel that never
-        arrives.
+        anything to land on at all -- a filter MISS composes none of these
+        four (the canvas returns right after its query-echoing status
+        line), so the answer has to be the same in both places or the seam
+        stands down for a channel that never arrives. The miss page's own
+        ``#library-media-filter-clear`` is deliberately NOT a fifth entry:
+        with nothing here the shared seam restores the filter ``Input``
+        (the right place to retype), and listing Clear would put the
+        predicate back into "owns" and re-open the gap.
         """
         for selector in (
             "#library-media-type-filter",


### PR DESCRIPTION
## Summary

Follow-up to the media rider PRs L #2483 and M #2486, closing the three Qodo comments they carried.

- **The Media focus channel stands down only when it can land** (Qodo #2483, high). PR L's `restore_focus_after_recompose` stood the shared focus restore down whenever the Library's one-shot list-entry channel was armed. For an EMPTY Media list after a filter miss the canvas composes none of the four fallback controls, so the channel landed nothing and a whole-screen recompose in that window left the keyboard with no target — the bug the seam exists to fix. The empty-list fallback lookup is now one helper used by both the channel and the predicate, and the predicate returns False when that helper has nothing to offer, so the base fallback (first focusable inside the content area) runs. Pinned with a real recompose over a filtered-empty Media list (red first: `focused` was None; on that page the surviving filter `Input` is what the seam restores — the miss page's own Clear button is deliberately not a fifth fallback, since the Input is the better retype target and listing Clear would re-open the gap).
- **Three-group import order restored** in `base_app_screen.py`'s `TYPE_CHECKING` block and `Tests/UI/test_destination_shells.py` (Qodo #2483 / #2486, medium).

## Verification

Task review (Opus): approved. The reviewer re-installed the old predicate in-process and confirmed the new pin fails with `focused` None for the right reason; the helper is a byte-for-byte lift of the loop it replaced (same selectors, order, enabled test, exception handling), the predicate runs two hops after the recompose on a settled DOM and performs no side effects, and the channel cannot land later on the filter-miss path because its own re-request has already run and failed by then. Its one documentation minor (the Clear button on the miss page) is recorded in the helper's docstring.

| run | result |
|---|---|
| `test_library_shell.py -k background_recompose` | 6 passed (incl. the new pin) |
| `test_library_media_render_fixes.py -k empty` | 2 passed |
| `test_destination_shells.py -k load_failure_callout` | 5 passed |
| `test_screen_navigation.py -k "list_entry or focus_library"` | 5 passed, 2 failed — same two names on dev (a test stub lacks `post_message` under Textual 8.2.8) |

Preflight green; no CSS; no new logger call sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the media focus channel so it only stands down when it can actually land focus on an empty list, preventing a background recompose from leaving the keyboard with no target. The channel and the ownership predicate now share a single helper that finds the first enabled fallback control on an empty Media list; when a filter miss composes none, the predicate returns False and the base fallback (first focusable inside the content area) runs. Also restores three-group import order in `base_app_screen.py` and `test_destination_shells.py`, and documents `ReviewSetService.revision`'s return value.

<sup>Written for commit 73c911fa3ad0cd057595ad7dba8248e213286607. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

