### PR TITLE
Console note-action follow-ups: save-as-Note owner, settings jump, boot-census flake, transcript-suite census (TASK-31901/31902)

### DIFF
--- a/Tests/Performance/test_boot_worker_census.py
+++ b/Tests/Performance/test_boot_worker_census.py
@@ -186,7 +186,17 @@ def _recording_thread_start(self):
 threading.Thread.start = _recording_thread_start
 
 
+EXPECTED = [
+    ("_backfill_chachanotes_messages_fts", "chachanotes-fts-backfill"),
+    ("load", "console-prompt-history"),
+    ("run", "scheduling"),
+]
+
+
 async def main() -> None:
+    import asyncio
+    import time
+
     import tldw_chatbook.app
 
     app = tldw_chatbook.app.TldwCli()
@@ -194,8 +204,21 @@ async def main() -> None:
         while not getattr(app, "_ui_ready", False):
             await asyncio.sleep(0.005)
         # Settle window: the deferred-startup timers (0.1-0.2 s) fire inside
-        # it, so their workers are censused too.
-        await asyncio.sleep(1.0)
+        # it, so their workers are censused too. The chachanotes FTS backfill
+        # is THIRD in the strictly-serial staggered fleet (cap 1, behind the
+        # two actor-pack prefetches), so a flat 1.0 s window intermittently
+        # snapshot before it was admitted on slow runners -- the PR #2467 CI
+        # flake. Poll for the expected starts with a generous deadline
+        # instead; a worker that finishes quickly is still censused because
+        # the probe records STARTS, not running state.
+        deadline = time.monotonic() + 30.0
+        while True:
+            started = {(w["name"], w["group"]) for w in records["workers"]}
+            if all(pair in started for pair in EXPECTED):
+                break
+            if time.monotonic() > deadline:
+                break
+            await asyncio.sleep(0.05)
         print("CENSUS_JSON:" + json.dumps(records), flush=True)
 
 

--- a/Tests/UI/test_console_message_controller.py
+++ b/Tests/UI/test_console_message_controller.py
@@ -759,3 +759,27 @@ async def test_fork_requested_dispatches_to_the_named_session_callback_once():
         assert await screen.handle_console_message_action(event) is True
 
     request.assert_called_once_with(message.id)
+
+
+@pytest.mark.asyncio
+async def test_save_as_note_uses_configured_notes_owner():
+    """TASK-31901: save-as Note must persist under app.notes_user_id (the
+    identity local note views read), not current_user/default_user."""
+    app = _build_test_app()
+    app.notes_user_id = "notes-owner-42"
+    app.notes_scope_service = SimpleNamespace(
+        save_note=AsyncMock(return_value={"id": "note-1"})
+    )
+    screen = ChatScreen(app)
+    store = screen._ensure_console_chat_store()
+    session = store.create_session()
+    message = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="saved text"
+    )
+
+    await screen._message._save_console_message_as_note(message.id)
+
+    assert (
+        app.notes_scope_service.save_note.await_args.kwargs["user_id"]
+        == "notes-owner-42"
+    )

--- a/Tests/UI/test_settings_context_memory_controls.py
+++ b/Tests/UI/test_settings_context_memory_controls.py
@@ -633,6 +633,32 @@ async def test_summary_prompt_route_focuses_existing_internal_prompt_editor() ->
 
 
 @pytest.mark.asyncio
+async def test_note_summary_prompt_jump_focuses_registered_prompt() -> None:
+    """TASK-31901: the summarize-to-note jump lands on the
+    console.summarize_note prompt row."""
+    app = _build_test_app()
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(110, 40)) as pilot:
+        await pilot.app.workers.wait_for_complete()
+        screen = _active_destination_screen(host)
+        screen._select_category(SettingsCategoryId.CONSOLE_BEHAVIOR.value)
+        await pilot.pause()
+
+        screen.query_one(
+            "#settings-console-context-edit-note-summary-prompt", Button
+        ).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert screen.active_category == SettingsCategoryId.INTERNAL_PROMPTS.value
+        search = screen.query_one("#internal-prompts-search", Input)
+        assert search.value == "console.summarize_note"
+        focused = screen.focused
+        assert focused is not None
+        assert focused.id == "prompt-row-console__summarize_note"
+
+
+@pytest.mark.asyncio
 async def test_provider_context_window_repair_saves_to_model_capability_authority(
     monkeypatch,
 ) -> None:

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12087,3 +12087,27 @@ budgets and self-contained failure records fixed both regression tests.
 user action through refusal or completion. Test a responsive refresh episode
 separately from a stall, and test failure records at WARNING thresholds. A
 start/end-only log is absence of coverage, not proof that the send worked.
+
+---
+
+---
+
+## A boot census must poll for serially-gated workers, not use a flat settle window
+
+**PR #2467 CI, 2026-09-06.** The "UI latency guardrails" job failed once
+with `census looks degenerate -- boot workers that always start were not
+recorded: [('_backfill_chachanotes_messages_fts', 'chachanotes-fts-backfill')]`
+and passed everywhere else, including the identical commit locally. The
+chachanotes FTS backfill is THIRD in the staggered boot fleet, which
+`boot_worker_policy.py` runs strictly serially (`MAX_CONCURRENT = 1`,
+behind the two actor-pack prefetches whose durations are "milliseconds on
+a healthy profile"). The census probe snapshotted at `_ui_ready` + a flat
+1.0 s; on a contended runner the two prefetches occasionally consumed the
+whole window before the third worker was admitted, and the anti-vacuity
+assert read that as a degenerate census.
+
+**What to do.** When a probe asserts that gated/queued work "always"
+starts, wait for the expected starts (poll with a generous deadline)
+rather than a flat window sized to the happy path. The probe already
+records STARTS rather than running state, so waiting cannot miss a worker
+that finishes quickly.

--- a/backlog/tasks/task-31901 - Console-note-follow-ups-save-as-Note-owner-fix-settings-surface-for-console.summarize_note.md
+++ b/backlog/tasks/task-31901 - Console-note-follow-ups-save-as-Note-owner-fix-settings-surface-for-console.summarize_note.md
@@ -3,11 +3,11 @@ id: TASK-31901
 title: >-
   Console note follow-ups: save-as-Note owner fix + settings surface for
   console.summarize_note
-status: In Progress
+status: Done
 assignee:
   - '@robert'
 created_date: '2026-09-07 06:04'
-updated_date: '2026-09-07 06:06'
+updated_date: '2026-09-07 22:07'
 labels: []
 dependencies: []
 ---
@@ -28,3 +28,9 @@ PR #2467 follow-ups: (1) the pre-existing save-as-Note path saves under current_
 <!-- SECTION:PLAN:BEGIN -->
 1. Fix user_id in _save_console_message_as_note; assert owner in tests\n2. Add summarize_note prompt surface to settings_context_memory\n3. Run targeted tests
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Save-as Note owner fixed (notes_user_id) with test; console.summarize_note surfaced in Settings > Console Behavior with a jump button + test; live smoke passed against local llama.cpp (summary factual, provenance present, zero compaction side-effects, note persisted via real notes facade); boot-census flake fixed by polling. Transcript-suite triage split to TASK-31902.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31901 - Console-note-follow-ups-save-as-Note-owner-fix-settings-surface-for-console.summarize_note.md
+++ b/backlog/tasks/task-31901 - Console-note-follow-ups-save-as-Note-owner-fix-settings-surface-for-console.summarize_note.md
@@ -1,0 +1,30 @@
+---
+id: TASK-31901
+title: >-
+  Console note follow-ups: save-as-Note owner fix + settings surface for
+  console.summarize_note
+status: In Progress
+assignee:
+  - '@robert'
+created_date: '2026-09-07 06:04'
+updated_date: '2026-09-07 06:06'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+PR #2467 follow-ups: (1) the pre-existing save-as-Note path saves under current_user/default_user instead of the configured notes_user_id, making such notes invisible in library views; (2) the new console.summarize_note internal prompt should be surfaced alongside console.rewind_summarize in the context-memory settings screen.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Save-as Note flow persists under app.notes_user_id (default_user only as unavailable fallback), asserted by a test,Context-memory settings screen exposes the console.summarize_note prompt for viewing/editing alongside console.rewind_summarize,Targeted tests green
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Fix user_id in _save_console_message_as_note; assert owner in tests\n2. Add summarize_note prompt surface to settings_context_memory\n3. Run targeted tests
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-31902 - Console-transcript-suite-red-on-dev-31-tests-since-TASK-25812-CSS-split-nobody-owns-them.md
+++ b/backlog/tasks/task-31902 - Console-transcript-suite-red-on-dev-31-tests-since-TASK-25812-CSS-split-nobody-owns-them.md
@@ -1,0 +1,26 @@
+---
+id: TASK-31902
+title: >-
+  Console transcript suite red on dev (31 tests) since TASK-25812 CSS split -
+  nobody owns them
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:04'
+labels:
+  - console
+  - tests
+  - tech-debt
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+31 tests in Tests/UI/test_console_native_transcript.py fail identically on clean dev. Bisected (fresh venv from dev requirements, macOS): first bad commit b62407e25 'perf(css): split the agentic-terminal module off the pre-first-paint parse (TASK-25812) (#2281)'. Suite was fully green at 18384c80d (Aug 29) and red on current dev. The split moved Console styles into css/screen_agentic_console.tcss which production loads via TldwCli.CSS_PATH/ChatScreen.CSS_PATH, but the suite's TranscriptHarness CSS_PATH (_BUNDLE) still points only at tldw_cli_modular.tcss. CI never caught it: test.yml runs the full UI suite only on dev/main pushes, its last dev run (Sep 4, 33894387395) concluded failure on infra with zero recorded test failures in shard artifacts. Adding screen_agentic_console.tcss to the harness bundle is NOT a one-line fix: it regressed the count 31->48 locally, so the harnesses need rewiring onto ConsolidatedCSSApp's production-order bracketing per the lessons-testing-evidence 'same stylesheet sources, same order' lesson. Failure groups: compositor-painting (roleplay tints, rule spans, empty state), More-menu lifecycle (capture/dismiss/keyboard traversal), action-row width budgets (reference terminals), media card fit. Pattern task: TASK-31249 (Library UI test debt census).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 31 tests pass on dev, or are rewritten/removed with reasons recorded (no bare skips),Root cause recorded: exactly which harness/CSS seam diverges from production after TASK-25812,Suite runs green in a fresh venv on clean dev in a single process,test.yml's dev/main UI-shard runs are green again or the infra failure is reported
+<!-- AC:END -->

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -2110,7 +2110,11 @@ class ConsoleMessageController:
                 content=content,
                 note_id=None,
                 version=None,
-                user_id=getattr(self.app_instance, "current_user", None)
+                # Notes are owned by the configured notes identity
+                # (app.notes_user_id drives every local note view/ingest),
+                # NOT current_user -- saving under a different id would
+                # make the note invisible in the library (TASK-31901).
+                user_id=getattr(self.app_instance, "notes_user_id", None)
                 or "default_user",
                 workspace_id=None,
                 keywords=["console"],

--- a/tldw_chatbook/UI/Screens/settings_context_memory.py
+++ b/tldw_chatbook/UI/Screens/settings_context_memory.py
@@ -29,6 +29,9 @@ from ...Utils.token_counter import get_table_model_token_limit
 
 
 SUMMARY_PROMPT_ID = "console.rewind_summarize"
+#: TASK-31901: prompt used by the Console More-menu
+#: "Summarize up to here as note" action (PR #2467).
+NOTE_SUMMARY_PROMPT_ID = "console.summarize_note"
 
 CONTEXT_MEMORY_CONFIG_KEYS = (
     "conversation_budget_mode",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -227,6 +227,7 @@ from .settings_search_index import (
 )
 from .settings_context_memory import (
     CONTEXT_MEMORY_CONFIG_KEYS,
+    NOTE_SUMMARY_PROMPT_ID,
     SUMMARY_PROMPT_ID,
     format_ratio_percent,
     load_context_memory_values,
@@ -16728,6 +16729,15 @@ class SettingsScreen(BaseAppScreen):
                 id="settings-console-context-edit-summary-prompt",
                 tooltip="Open the existing Internal Prompts editor filtered to the Console summary prompt.",
             )
+            yield Button(
+                "Edit summarize-to-note prompt…",
+                id="settings-console-context-edit-note-summary-prompt",
+                tooltip=(
+                    "Open the Internal Prompts editor filtered to the prompt "
+                    "used by the Console message More-menu 'Summarize up to "
+                    "here as note' action."
+                ),
+            )
             yield Static(
                 "Text summary and Hybrid make one extra model call and store generated "
                 "memory with provenance. Visual pages are rendered on-device for one "
@@ -24154,6 +24164,33 @@ class SettingsScreen(BaseAppScreen):
         # panel this reaches for is built by the detail pane's own rebuild
         # (task-15475), which finishes later than a screen callback would.
         self._after_category_panes(_focus_summary_prompt)
+
+    @on(Button.Pressed, "#settings-console-context-edit-note-summary-prompt")
+    def handle_console_context_edit_note_summary_prompt(
+        self, event: Button.Pressed
+    ) -> None:
+        """TASK-31901: same reveal-and-focus jump for the note-summarize
+        prompt used by the Console More-menu note action."""
+        event.stop()
+        self._select_category(SettingsCategoryId.INTERNAL_PROMPTS.value)
+
+        def _focus_note_summary_prompt() -> None:
+            try:
+                panel = self.query_one(
+                    "#settings-internal-prompts-panel", InternalPromptsPanel
+                )
+            except QueryError:
+                self.app.notify(
+                    "Internal Prompts is not available.", severity="warning"
+                )
+                return
+            if not panel.focus_prompt(NOTE_SUMMARY_PROMPT_ID):
+                self.app.notify(
+                    "The Console summarize-to-note prompt is not registered.",
+                    severity="warning",
+                )
+
+        self._after_category_panes(_focus_note_summary_prompt)
 
     @on(Input.Changed, "#settings-console-default-user-display-name")
     def handle_console_default_user_display_name_changed(


### PR DESCRIPTION
## Summary

Follow-ups from PR #2467 (TASK-31901), plus the triage the review surfaced:

- **Fix: save-as-Note owner** — the pre-existing Save as… → Note flow saved under `current_user`/`default_user` instead of the configured `notes_user_id`, making such notes invisible in library views. Now matches the More-menu note actions; owner asserted by a new test.
- **Settings surface** — new "Edit summarize-to-note prompt…" jump button in Settings → Console Behavior, landing on `console.summarize_note` in the Internal Prompts editor (mirrors the existing rewind-summarize jump); test added.
- **Fix: boot-census CI flake** — the census probe snapshotted at `_ui_ready` + a flat 1.0s, but the chachanotes FTS backfill is third in the strictly-serial staggered fleet (cap 1), so slow runners intermittently snapshotted before it was admitted ("census looks degenerate"). The probe now polls for the expected worker starts with a 30s deadline (starts are recorded, not running state, so fast workers stay censused). Verified stable across 4 consecutive runs. Lesson added to `lessons-testing-evidence.md`.
- **TASK-31902 filed (census, not fixed here)**: 31 `test_console_native_transcript.py` tests red on clean dev since `b62407e25` (TASK-25812 CSS split) — bisected with a fresh dev venv; green at 18384c80d (Aug 29). Harness CSS_PATH still loads only the modular bundle while production also loads `screen_agentic_console.tcss`; naïvely adding the sheet regressed 31→48, so the harness rewiring is its own task. CI never gated this: the full UI suite runs only on dev/main pushes and its last dev run failed on infra.

## Live verification

Smoke-tested the merged note actions against a live local llama.cpp (Qwen2.5-0.5B): summary factual (all seeded facts present), provenance header present, `session_context_summary` untouched, zero `console_auxiliary_attempts` rows, transcript note persisted through the real notes facade under the configured owner.

## Tests

`test_console_message_controller.py` (22), `test_settings_context_memory_controls.py` (28), `test_boot_worker_census.py` — all green; transcript suite unchanged (its 31 failures are pre-existing, TASK-31902).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Follows up PR #2467's console note actions with three fixes and closes TASK-31901. Save-as-Note now persists under the configured `notes_user_id` instead of `current_user`, so saved notes appear in library views; Settings gains an "Edit summarize-to-note prompt…" jump that lands on `console.summarize_note`; and the boot-census probe polls for staggered worker starts with a 30s deadline instead of a flat 1.0s settle window, fixing an intermittent CI flake.

**Bug Fixes**
- New tests cover the save-as-Note owner, the settings jump focusing the prompt row, and the census probe's polling for staggered workers.
- The probe records STARTS, so workers that finish quickly stay censused; the polling pattern is recorded in `lessons-testing-evidence.md`.

**Triage**
- Files TASK-31902: 31 pre-existing `test_console_native_transcript.py` failures on dev since the TASK-25812 CSS split; the harness loads only the modular CSS bundle, and naïvely adding the missing sheet regressed the count to 48.

<sup>Written for commit 693f9d6824840f65a2cbd8cfa4c8d89bc743aa6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2489?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

