### PR TITLE
Fix Console trace recovery and improve send diagnostics

### DIFF
--- a/Tests/Chat/test_console_send_diagnostics.py
+++ b/Tests/Chat/test_console_send_diagnostics.py
@@ -1,0 +1,290 @@
+"""TASK-31977: support evidence must survive the real disk and share sinks."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_durable_commit_diagnostics import (
+    SECRET_IDENTIFIER,
+    _controller_with_failing_commit,
+)
+from Tests.test_logs_share_path_privacy import _Collector
+from tldw_chatbook.Logging_Config import PrivateRotatingFileHandler
+from tldw_chatbook.UI.Logs_Window import LogsWindow
+from tldw_chatbook.Utils.persistent_diagnostics import PersistentDiagnosticFilter
+from tldw_chatbook.Utils.ui_responsiveness import UIResponsivenessMonitor
+
+
+@pytest.fixture
+def sinks(tmp_path):
+    path = tmp_path / "diagnostic.log"
+    handler = PrivateRotatingFileHandler(path, maxBytes=2_000_000, backupCount=1)
+    handler.addFilter(PersistentDiagnosticFilter())
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    root = logging.getLogger()
+    with _Collector() as app:
+        root.addHandler(handler)
+        copied = []
+        window = SimpleNamespace(
+            app_instance=app,
+            app=SimpleNamespace(
+                copy_to_clipboard=copied.append, notify=lambda *a, **k: None
+            ),
+        )
+        try:
+            yield SimpleNamespace(path=path, window=window, copied=copied)
+        finally:
+            root.removeHandler(handler)
+            handler.close()
+
+
+def assert_export(sinks, *tokens):
+    LogsWindow._on_copy_all(sinks.window)
+    for text in (sinks.path.read_text(), sinks.copied[-1]):
+        for token in tokens:
+            assert token in text
+        assert SECRET_IDENTIFIER not in text
+        assert "PRIVATE-DRAFT-31977" not in text
+    return sinks.path.read_text()
+
+
+async def test_pre_trace_commit_failure_reaches_file_and_copy_all(sinks):
+    controller, _store = _controller_with_failing_commit()
+    result = await controller.submit_draft("PRIVATE-DRAFT-31977")
+    assert not result.accepted
+    text = assert_export(
+        sinks,
+        "event=console_send_stage",
+        "phase=controller_submit",
+        "phase=durable_commit",
+        "status=failed",
+        "error_category=validation",
+        "exception_type=ValueError",
+        "app_version=",
+        "python_version=",
+        "capture_enabled=false",
+    )
+    assert "phase=provider_entry" not in text
+
+
+async def test_responsive_refresh_churn_is_exported_once_per_episode(sinks):
+    monitor = UIResponsivenessMonitor()
+    try:
+        for _ in range(100):
+            monitor.record_worker_started("console-sync")
+            monitor.record_worker_finished("console-sync")
+        monitor.record_heartbeat_delta(0.01)
+        for _ in range(100):
+            monitor.record_worker_started("console-sync")
+            monitor.record_worker_finished("console-sync")
+        monitor.record_heartbeat_delta(0.01)
+        for _ in range(100):
+            if "event=ui_refresh_churn" in sinks.path.read_text():
+                break
+            await asyncio.sleep(0.01)
+        assert monitor.snapshot().stalled is False
+        text = assert_export(sinks, "event=ui_refresh_churn", "operation=console_sync")
+        assert text.count("event=ui_refresh_churn") == 1
+    finally:
+        close = getattr(monitor, "close", None)
+        if close is not None:
+            await asyncio.to_thread(close)
+
+
+async def test_failure_is_retained_when_file_threshold_is_warning(sinks):
+    for handler in logging.getLogger().handlers:
+        if isinstance(
+            handler, PrivateRotatingFileHandler
+        ) and handler.baseFilename == str(sinks.path):
+            handler.setLevel(logging.WARNING)
+    controller, _store = _controller_with_failing_commit()
+    await controller.submit_draft("PRIVATE-DRAFT-31977")
+    assert "phase=durable_commit" in sinks.path.read_text()
+    assert "status=failed" in sinks.path.read_text()
+
+
+async def test_diagnostic_sink_failure_does_not_change_send_result(monkeypatch):
+    from tldw_chatbook.Utils import persistent_diagnostics
+
+    def failed_sink(*args, **kwargs):
+        raise OSError("PRIVATE-DRAFT-31977")
+
+    monkeypatch.setattr(persistent_diagnostics, "persist_event", failed_sink)
+    controller, _store = _controller_with_failing_commit()
+    result = await controller.submit_draft("PRIVATE-DRAFT-31977")
+    assert not result.accepted
+    assert result.visible_copy == "Couldn't save the prepared turn. Retry or cancel."
+
+
+async def test_monitor_queue_is_bounded_and_cannot_block_ui(monkeypatch):
+    import threading
+
+    from tldw_chatbook.Utils import persistent_diagnostics
+
+    entered = threading.Event()
+    release = threading.Event()
+    threads = []
+
+    def slow_sink(*args, **kwargs):
+        threads.append(threading.get_ident())
+        entered.set()
+        assert release.wait(2)
+
+    monkeypatch.setattr(persistent_diagnostics, "persist_event", slow_sink)
+    monitor = UIResponsivenessMonitor()
+    try:
+        monitor.record_diagnostic("console", "console_send_stage", phase="ui_submit")
+        assert await asyncio.to_thread(entered.wait, 1)
+        for _ in range(1000):
+            monitor.record_diagnostic(
+                "console", "console_send_stage", phase="ui_submit"
+            )
+        assert monitor._stall_queue.qsize() <= monitor._STALL_QUEUE_DEPTH
+        assert monitor._diagnostic_dropped > 0
+        assert threading.get_ident() not in threads
+    finally:
+        release.set()
+        await asyncio.to_thread(monitor.close)
+
+
+async def test_churn_rearms_only_after_quiet_window_and_ignores_normal_polling(sinks):
+    monitor = UIResponsivenessMonitor()
+    try:
+        for _ in range(5):
+            monitor.record_worker_started("console-sync")
+        monitor.record_heartbeat_delta(0)
+        assert "ui_refresh_churn" not in sinks.path.read_text()
+        for _ in range(10):
+            monitor.record_refresh("screen_recompose")
+        monitor.record_heartbeat_delta(0)
+        monitor.record_heartbeat_delta(0)
+        for _ in range(10):
+            monitor.record_refresh("screen_recompose")
+        monitor.record_heartbeat_delta(0)
+        await asyncio.to_thread(monitor.close)
+        text = assert_export(sinks, "operation=screen_recompose")
+        assert text.count("event=ui_refresh_churn") == 2
+    finally:
+        await asyncio.to_thread(monitor.close)
+
+
+async def test_chained_sqlite_failure_retains_code_without_query_text(sinks):
+    import sqlite3
+
+    from tldw_chatbook.Chat.console_send_diagnostics import (
+        record_send_stage,
+        send_diagnostic_scope,
+    )
+
+    connection = sqlite3.connect(":memory:")
+    try:
+        async with send_diagnostic_scope("controller_submit"):
+            try:
+                try:
+                    connection.execute(
+                        'SELECT "PRIVATE-DRAFT-31977" FROM private_table'
+                    )
+                except sqlite3.OperationalError:
+                    raise RuntimeError("PRIVATE-DRAFT-31977") from None
+            except RuntimeError as error:
+                record_send_stage("trace_reservation", "failed", error=error)
+        assert_export(
+            sinks,
+            "error_category=database",
+            "sqlite_code=1",
+            "exception_type=OperationalError",
+        )
+    finally:
+        connection.close()
+
+
+async def test_sequential_queued_submissions_get_independent_diagnostic_budgets(sinks):
+    import re
+
+    from tldw_chatbook.Chat.console_send_diagnostics import (
+        record_send_stage,
+        send_diagnostic_scope,
+    )
+
+    async with send_diagnostic_scope("ui_submit"):
+        for index in range(8):
+            async with send_diagnostic_scope("controller_submit") as diagnostic:
+                for _ in range(10):
+                    record_send_stage("provider_entry")
+                if index == 7:
+                    record_send_stage(
+                        "trace_reservation",
+                        "failed",
+                        error=ValueError("PRIVATE-DRAFT-31977"),
+                    )
+                # Isolate per-attempt budgets from the separately tested bounded queue.
+                await asyncio.to_thread(diagnostic.monitor._stall_queue.join)
+    text = assert_export(sinks, "status=failed", "phase=trace_reservation")
+    starts = [
+        line
+        for line in text.splitlines()
+        if "phase=controller_submit" in line and "status=entered" in line
+    ]
+    assert len({re.search(r"attempt_token=(\w+)", line)[1] for line in starts}) == 8
+
+
+async def test_failure_keeps_runtime_and_capture_context_at_warning_root(sinks):
+    root = logging.getLogger()
+    previous = root.level
+    root.setLevel(logging.WARNING)
+    try:
+        controller, _store = _controller_with_failing_commit()
+        await controller.submit_draft("PRIVATE-DRAFT-31977")
+        assert_export(
+            sinks,
+            "status=failed",
+            "app_version=",
+            "python_version=",
+            "sqlite_version=",
+            "capture_enabled=false",
+        )
+    finally:
+        root.setLevel(previous)
+
+
+async def test_validation_timeout_survives_warning_logging(monkeypatch, sinks):
+    controller, _store = _controller_with_failing_commit()
+
+    async def stalled_resolution(selection):
+        await asyncio.sleep(10)
+
+    monkeypatch.setattr(
+        controller.provider_gateway, "resolve_for_send", stalled_resolution
+    )
+    monkeypatch.setattr(controller, "PROVIDER_VALIDATION_TIMEOUT_SECONDS", 0.01)
+    root = logging.getLogger()
+    previous = root.level
+    root.setLevel(logging.WARNING)
+    try:
+        result = await controller.submit_draft("PRIVATE-DRAFT-31977")
+        assert not result.accepted
+        assert_export(
+            sinks,
+            "phase=provider_resolution",
+            "status=failed",
+            "error_category=timeout",
+        )
+    finally:
+        root.setLevel(previous)
+
+
+async def test_known_trace_validation_reason_is_identifiable_without_raw_text(sinks):
+    from tldw_chatbook.Chat.console_send_diagnostics import (
+        record_send_stage,
+        send_diagnostic_scope,
+    )
+
+    async with send_diagnostic_scope("controller_submit"):
+        record_send_stage(
+            "trace_reservation", "failed", error=ValueError("trace_owner_unavailable")
+        )
+    assert_export(sinks, "error_category=trace_owner_unavailable")

--- a/Tests/Chat/test_console_trace_runtime.py
+++ b/Tests/Chat/test_console_trace_runtime.py
@@ -2099,3 +2099,86 @@ async def test_owned_retry_preserves_inherited_fork_predecessor_after_rollback(
     await test_production_factory_accepts_active_ancestor_revisions_on_nested_fork(
         tmp_path, make_database, make_gateway, monkeypatch, fork_failure=True,
     )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "first",
+        "foreign_owner",
+        "foreign_gateway",
+        "capture_on",
+        "forged",
+        "rebound",
+        "later_call",
+        "tool_loop",
+        "unknown_dispatch",
+    ],
+)
+async def test_uncaptured_construction_recovery_requires_exact_live_first_call(
+    tmp_path,
+    make_database,
+    make_gateway,
+    scenario,
+):
+    """Construction-failure proof cannot authorize replay or another send."""
+    from tldw_chatbook.Chat.console_trace_errors import TraceCallPersistenceError
+
+    database = make_database(tmp_path / "construction.sqlite", "construction")
+    conversation = database.add_conversation({"title": "construction recovery"})
+    _, revision = _saved_message(database, conversation, "hello")
+    policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+
+    def fail_factory(_request, _resolution, _route):
+        if scenario == "unknown_dispatch":
+            raise TraceCallPersistenceError(
+                boundary=SimpleNamespace(dispatch_outcome="unknown")
+            )
+        raise ValueError("synthetic construction failure")
+
+    gateway = make_gateway(trace_call_boundary_factory=fail_factory)
+    resolution = ConsoleProviderResolution(
+        provider="openai",
+        model="test-model",
+        ready=True,
+        base_url="https://api.openai.com/v1",
+        execution_key="openai",
+        streaming=False,
+    )
+    request = gateway.prepare_chat_request(
+        resolution,
+        _semantic_request([{"role": "user", "content": "hello"}], [revision], policy),
+        route=ConsoleRequestRoute.FRESH,
+        capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+    )
+    owner = object()
+    signals = ConsoleProviderStreamSignals()
+    gateway._bind_trace_preparation(signals, owner)
+    route = (
+        ConsoleRequestRoute.TOOL_LOOP
+        if scenario == "tool_loop"
+        else ConsoleRequestRoute.FRESH
+    )
+    with pytest.raises(TraceCallPersistenceError) as caught:
+        gateway._reserve_trace_call(request, resolution, route, signals=signals)
+    failure = caught.value
+    mode = ConsoleTraceCaptureMode.CAPTURE_OFF
+    if scenario == "foreign_owner":
+        owner = object()
+    elif scenario == "foreign_gateway":
+        gateway = make_gateway(trace_call_boundary_factory=fail_factory)
+    elif scenario == "capture_on":
+        mode = ConsoleTraceCaptureMode.CAPTURE_ON
+    elif scenario == "forged":
+        failure = TraceCallPersistenceError(reservation_status="unknown")
+    elif scenario == "rebound":
+        gateway._bind_trace_preparation(signals, owner)
+    elif scenario == "later_call":
+        with pytest.raises(TraceCallPersistenceError):
+            gateway._reserve_trace_call(request, resolution, route, signals=signals)
+
+    if scenario == "first":
+        gateway._verify_trace_preparation_recovery(owner, failure, signals, mode)
+        # The same proof is single-use, even with the same owner and gateway.
+    with pytest.raises(TraceCallPersistenceError):
+        gateway._verify_trace_preparation_recovery(owner, failure, signals, mode)

--- a/Tests/UI/test_console_send_diagnostic_flow.py
+++ b/Tests/UI/test_console_send_diagnostic_flow.py
@@ -1,0 +1,105 @@
+"""Mounted sends expose pre-provider failures through ordinary support logs."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+
+import pytest
+
+from Tests.Chat.test_console_send_diagnostics import assert_export, sinks  # noqa: F401
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_native_chat_flow import _persist_console_provider_config
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.mark.parametrize("failure", ["resolution", "trace", None])
+async def test_mounted_send_has_diagnostic_evidence_before_provider_entry(
+    monkeypatch,
+    tmp_path,
+    sinks,  # noqa: F811 - imported shared pytest fixture
+    failure,
+):
+    app = _build_test_app()
+    database = CharactersRAGDB(tmp_path / "chat.sqlite", "send-diagnostic")
+    app.chachanotes_db = database
+    _persist_console_provider_config(
+        app,
+        provider="openai",
+        model="gpt-4.1",
+        provider_settings={"api_key": "synthetic-test-key"},
+    )
+    host = ConsoleHarness(app)
+    host.CSS_PATH = TldwCli.CSS_PATH
+    calls = []
+
+    def fail_factory(*args):
+        raise ValueError("PRIVATE-DRAFT-31977")
+
+    if failure == "trace":
+        monkeypatch.setattr(ConsoleTraceBoundaryFactory, "__call__", fail_factory)
+    console = None
+    try:
+        async with host.run_test(size=(80, 24)) as pilot:
+            console = host.screen_stack[-1]
+            await _wait_for_selector(console, pilot, "#console-native-composer")
+            controller = console._ensure_console_chat_controller()
+            gateway = controller.provider_gateway
+            original_resolve = gateway.resolve_for_send
+
+            async def resolve(selection):
+                if failure == "resolution":
+                    raise ValueError("PRIVATE-DRAFT-31977")
+                return replace(await original_resolve(selection), streaming=False)
+
+            monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+
+            def adapter(**kwargs):
+                calls.append(True)
+                return {"choices": [{"message": {"content": "Synthetic response"}}]}
+
+            monkeypatch.setattr(gateway, "_chat_api_call_fn", adapter)
+            controller.store.ensure_session()
+            console._console_composer_or_none().load_draft("PRIVATE-DRAFT-31977")
+            await asyncio.wait_for(
+                console._send_console_message_from_visible_action(),
+                10,
+            )
+            await asyncio.wait_for(host.workers.wait_for_complete(), 10)
+            await pilot.pause(0.3)
+            await asyncio.to_thread(app.ui_responsiveness_monitor.close)
+            assert len(calls) == (0 if failure else 1)
+            expected_phase = (
+                "provider_resolution"
+                if failure == "resolution"
+                else "trace_reservation"
+            )
+            text = assert_export(
+                sinks,
+                "phase=ui_action",
+                "phase=ui_dispatch",
+                "phase=ui_submit",
+                "phase=controller_submit",
+                f"phase={expected_phase}",
+            )
+            if failure:
+                assert "status=failed" in text
+                assert "error_category=validation" in text
+                assert "phase=provider_entry" not in text
+            else:
+                assert "phase=provider_entry" in text
+                assert "status=completed" in text
+            if failure != "resolution":
+                assert "capture_enabled=true" in text
+            assert "synthetic-test-key" not in text
+    finally:
+        if console is not None:
+            await console._console_runtime().dispose()
+        await asyncio.to_thread(app.ui_responsiveness_monitor.close)
+        database.close()

--- a/Tests/UI/test_console_trace_call_recovery.py
+++ b/Tests/UI/test_console_trace_call_recovery.py
@@ -134,3 +134,43 @@ async def test_trace_recovery_refusal_reenables_all_actions() -> None:
         assert "did not complete" in str(
             callout.query_one("#console-trace-status", Static).render()
         )
+
+
+async def test_trace_refusal_copy_survives_transcript_sync_and_is_painted() -> None:
+    """An unchanged trace pause must display the controller's actual refusal."""
+    from tldw_chatbook.Chat.console_chat_controller import ConsoleSubmitResult
+    from tldw_chatbook.UI.Console_Modules.provider_continuation_recovery import (
+        ProviderContinuationTranscriptRegion,
+    )
+
+    class RefusingRegionApp(ConsolidatedCSSApp):
+        def compose(self) -> ComposeResult:
+            yield ProviderContinuationTranscriptRegion(
+                session_surface_builder=lambda: Static("Conversation"),
+                recovery_message_builder=lambda: None,
+                on_recovery_action=lambda *_args: False,
+                trace_recovery_state_builder=lambda: TraceCallRecoveryState(
+                    "preparation-1"
+                ),
+                on_trace_recovery_action=lambda *_args: ConsoleSubmitResult(
+                    False, False, "Trace storage is not writable."
+                ),
+            )
+
+    app = RefusingRegionApp()
+    async with app.run_test(size=(80, 32)) as pilot:
+        card = app.screen.query_one(TraceCallRecoveryCallout)
+        card.query_one("#console-trace-retry", Button).focus()
+        await pilot.press("enter")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        app.screen.query_one(ProviderContinuationTranscriptRegion).sync_recovery()
+        await pilot.pause()
+        assert card.display
+        assert "Trace storage is not writable." in str(
+            card.query_one("#console-trace-status", Static).render()
+        )
+        assert (
+            "Trace&#160;storage&#160;is&#160;not&#160;writable."
+            in app.export_screenshot()
+        )

--- a/Tests/UI/test_console_trace_capture_recovery_flow.py
+++ b/Tests/UI/test_console_trace_capture_recovery_flow.py
@@ -1,0 +1,121 @@
+"""Real accepted sends must survive trace construction failure (TASK-31976)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import replace
+from xml.etree import ElementTree
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_native_chat_flow import _persist_console_provider_config
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole, ConsoleRunStatus
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.UI.Console_Modules.provider_continuation_recovery import (
+    TraceCallRecoveryCallout,
+)
+
+
+@pytest.mark.parametrize("lose_proof", [False, True], ids=["send", "refusal"])
+async def test_first_trace_factory_failure_has_actionable_uncaptured_recovery(
+    monkeypatch,
+    tmp_path,
+    lose_proof,
+):
+    """Catch both the missing-boundary dead end and a silently hidden refusal."""
+    app = _build_test_app()
+    database = CharactersRAGDB(tmp_path / "chat.sqlite", "trace-recovery")
+    app.chachanotes_db = database
+    _persist_console_provider_config(
+        app,
+        provider="openai",
+        model="gpt-4.1",
+        provider_settings={"api_key": "synthetic-test-key"},
+    )
+    host = ConsoleHarness(app)
+    host.CSS_PATH = TldwCli.CSS_PATH
+    factory_attempts = []
+    adapter_calls = []
+
+    def fail_factory(self, request, resolution, route):
+        factory_attempts.append(route)
+        raise ValueError("synthetic trace construction failure")
+
+    def adapter(**kwargs):
+        adapter_calls.append(kwargs)
+        return {"choices": [{"message": {"content": "Recovered reply"}}]}
+
+    monkeypatch.setattr(ConsoleTraceBoundaryFactory, "__call__", fail_factory)
+    console = None
+    try:
+        async with host.run_test(size=(80, 24)) as pilot:
+            console = host.screen_stack[-1]
+            await _wait_for_selector(console, pilot, "#console-native-composer")
+            controller = console._ensure_console_chat_controller()
+            gateway = controller.provider_gateway
+            monkeypatch.setattr(gateway, "_chat_api_call_fn", adapter)
+            original_resolve = gateway.resolve_for_send
+
+            async def resolve(selection):
+                return replace(await original_resolve(selection), streaming=False)
+
+            monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+            session = controller.store.ensure_session()
+            await asyncio.wait_for(
+                console._submit_console_native_draft("Hello", session.id), 10
+            )
+            await pilot.pause()
+            card = console.query_one(TraceCallRecoveryCallout)
+            assert card.display
+            assert adapter_calls == []
+            assert len(factory_attempts) == 1
+            preparation = controller.trace_call_recovery_preparation()
+            assert preparation is not None
+            if lose_proof:
+                continuation = controller._durable_postcommit_continuations[
+                    preparation.preparation_id
+                ]
+                continuation.stream_signals._trace_preparation = None
+
+            button = card.query_one("#console-trace-send-without", Button)
+            button.focus()
+            await pilot.pause()
+            await pilot.press("enter", "enter")
+            await asyncio.wait_for(host.workers.wait_for_complete(), 10)
+            await pilot.pause(0.3)
+
+            if lose_proof:
+                assert adapter_calls == []
+                assert not card.display, (
+                    "Uncertain delivery must hand off to its own recovery card"
+                )
+                frame = " ".join(
+                    ElementTree.fromstring(host.export_screenshot()).itertext()
+                )
+                frame = " ".join(frame.split())
+                assert "delivery status is unknown" in frame
+                assert "Retry anyway" in frame
+                assert "Discard" in frame
+            else:
+                assert len(adapter_calls) == 1
+                assert not card.display
+                assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+                messages = controller.store.messages_for_session(session.id)
+                assert [(m.role, m.content) for m in messages] == [
+                    (ConsoleMessageRole.USER, "Hello"),
+                    (ConsoleMessageRole.ASSISTANT, "Recovered reply"),
+                ]
+                assert len(factory_attempts) == 1, "Capture Off must not retry capture"
+            assert console._console_transcript_sync_timer is None
+    finally:
+        if console is not None:
+            await console._console_runtime().dispose()
+        database.close()

--- a/backlog/decisions/029-local-private-data-boundary.md
+++ b/backlog/decisions/029-local-private-data-boundary.md
@@ -171,3 +171,29 @@ return.
 - [ADR-006: Provider-Aware Generation Settings](006-provider-aware-generation-settings.md)
 - [ADR-012: Provider Credential Settings Boundary](012-provider-credential-settings-boundary.md)
 - [ADR-021: File-Backed Notes Disk Authority and Recovery Replica](021-file-backed-notes-disk-authority-and-recovery.md)
+
+## Amendment (2026-09-07, TASK-31977) — Console send and refresh diagnostics
+
+The owner approved extending the existing diagnostic system after a blocked-send /
+rapid-refresh report produced only launcher start/end markers. Admit
+`console_send_stage`, `ui_refresh_churn`, and `diagnostic_events_dropped` as
+operational events through the existing persistent schema and Logs collector.
+Console stages use fixed phase/status/category tokens, exception class names,
+numeric SQLite error codes, elapsed durations, a random diagnostic attempt token
+(unrelated to conversation/message/workspace identities), capture-enabled state,
+and application/Python/SQLite version tokens. No exception messages, traceback
+locals, private IDs, paths, or provider payloads are admitted.
+
+Reuse the responsiveness monitor's background drain for these events, with a
+bounded nonblocking queue. Diagnostic delivery is best effort, must not change
+send admission or recovery, and must never perform file writes on the UI loop.
+Send attempts have a bounded event allowance; overflow is disclosed without
+recording discarded payloads. Monitor teardown drains with a bounded wait off the
+UI loop. No new file, database, export surface or retention policy is introduced.
+
+The monitor records excessive Console-sync or screen-recompose activity over
+heartbeat windows even when heartbeat lag is below the stall threshold. Emit
+once per continuous excessive-activity episode, rearming after a quiet window;
+ordinary polling and token streaming are not per-frame log events. These are
+observations, not authorization to cancel providers or suppress application
+state updates. Fixes to the actual refresh loop require separate causal evidence.

--- a/backlog/docs/console-send-diagnostics.md
+++ b/backlog/docs/console-send-diagnostics.md
@@ -1,0 +1,66 @@
+# Console send and refresh diagnostics
+
+Console send failures and excessive UI refresh activity are recorded through the
+normal metadata-only diagnostic sink. No separate diagnostic launcher is needed.
+Use the Logs screen's **Copy all (redacted)** action after reproducing a problem.
+The normal persistent application log carries the same structured events when
+file logging is enabled. The descriptive **Copy visible** action has a different
+privacy contract; use Copy all for the support artifact described here.
+
+At INFO, look for `event=console_send_stage` under `diagnostics.console`:
+
+- `ui_action`: the visible Send action was received, before parsing and gating.
+- `ui_dispatch` and `ui_submit`: dispatch to the Console worker and its entry.
+- `controller_submit`: a controller submission began or returned an outcome.
+- `provider_resolution`: provider readiness/validation began.
+- `capture_policy`: whether durable capture was enabled for this attempt.
+- `durable_commit`: saving the accepted turn began, succeeded or failed.
+- `trace_reservation`: pre-provider trace reservation began, succeeded or failed.
+- `trace_dispatch_commit`: the trace's dispatch record was being committed.
+- `provider_entry`: the provider adapter was entered. This is not proof that a
+  remote server received the request or that a response completed.
+
+A random `attempt_token` connects the UI's first submission with its worker and
+provider stages. Further submissions in a queued prompt chain receive separate
+tokens and event allowances. Tokens are unrelated to stored conversation,
+message, workspace or provider-request identifiers. Durations are relative to
+the diagnostic attempt. `dispatched` means queued for execution;
+`not_dispatched` may be an empty input or a handled command, not a send error.
+
+Failed stages are ERROR events, preserving their phase, application/Python/SQLite
+versions, capture mode when already resolved, exception class, and a safe failure
+category even at WARNING logging thresholds. Categories distinguish database,
+storage, validation, timeout and other internal errors. Recognized fixed trace
+validation codes, such as `trace_owner_unavailable`, retain that exact code;
+arbitrary exception messages are never recorded. SQLite failures also carry a
+numeric `sqlite_code`. App version is the running package's source version; it
+is not a verified Git commit or proof that an installation is latest dev.
+
+`event=ui_refresh_churn` under `diagnostics.ui` records excessive activity even
+when the event loop remains responsive. It identifies `console_sync` or
+`screen_recompose`, the count/window duration, active timers/workers and the last
+observed send phase. Detection starts at 20 Console syncs/second or 4 whole-screen
+recompositions/second, evaluated over the existing heartbeat window. These are
+investigation thresholds, not proof of a bug. Ordinary five-per-second polling
+is below the threshold. A continuous episode produces one warning and a quiet
+window rearms it. This observation never cancels providers or skips UI updates.
+`[diagnostics] ui_responsiveness_enabled = false` disables UI churn/stall
+monitoring; ordinary Console failure diagnostics still use normal logging.
+
+Each attempt has a 64-event allowance, and the existing monitor drain has a
+64-record queue. Overflow is disclosed by `diagnostic_events_dropped`; an
+incomplete log must not be interpreted as proof that the provider was never
+entered. Queueing is nonblocking, writes occur off the UI loop, and normal
+shutdown makes a bounded drain attempt. A process kill, unavailable sink, or
+logging threshold above an event's severity can prevent recording. Diagnostics
+do not change send, retry, cancellation or capture policy.
+
+For a useful report, reproduce one fresh-conversation send and copy the logs.
+State whether the capture card appeared, whether the message completed, and
+whether flicker continued after the blocked state. A log with no send-stage
+entries does not establish a successful send.
+
+Governance: ADR-029's TASK-31977 amendment. Trace admission remains governed by
+ADR-097 (the semantic trace ledger), section 15. No prompts, responses,
+credentials, exception messages, traceback locals or private identifiers are
+added to these diagnostics.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12049,3 +12049,41 @@ The SDD controller applied a three-line round-2 fix by hand (a `logger.debug` in
 and committed without `./scripts/preflight.sh`; the next task's implementer hit the diagnostic
 inventory drift and had to re-pin someone else's row. The rule the implementers follow ("any
 `logger.*` change -> read the rows, `--write`") binds the controller too.
+
+
+## Trace recovery tests need the failure before a boundary exists
+
+**TASK-31976, 2026-09-07.** A user reported “Trace capture blocked” on a fresh
+Console send, then no send and no card after choosing Send without capture.
+The existing real trace/agent tests passed because their recovery failures had
+an established boundary. A mounted Console probe with a file-backed database
+and a failure in the first boundary factory reproduced the missing case: the
+controller demanded proof from a boundary that never existed, returned unknown
+delivery, and the UI discarded the result when the trace pause disappeared.
+Zero adapter calls and a rendered frame with no recovery guidance proved the
+failure; disappearance of the card alone would have looked like success.
+
+**What to do.** Cover construction failure separately from reservation/bind
+failure. Keep the real accepted-send, database, and agent paths; replace only
+the external adapter and inject the failing boundary operation. Assert one
+provider call and the completed original turn for successful recovery, or
+painted refusal/recovery actions for a refused action. An internal result or a
+hidden card is not evidence that a message sent or that the user can recover.
+
+## A trace-only probe cannot diagnose a send that never reaches tracing
+
+**TASK-31977, 2026-09-07.** A reporter reproduced Console flicker, but the
+throwaway launcher recorded only start/end: all its hooks began at trace
+reservation. New real-sink tests also showed that an existing durable-commit
+Loguru diagnostic never reached the support artifact. The responsiveness monitor
+recorded stalls but missed repeated syncs on a responsive loop. Instrumenting
+from the visible send action and testing both the private file and actual Copy
+all action produced useful evidence for those earlier failures. Independent
+review then found that nested queued sends shared one event allowance and
+WARNING thresholds dropped the runtime/capture context; separate submission
+budgets and self-contained failure records fixed both regression tests.
+
+**What to do.** Verify the artifact a reporter will share, from the earliest
+user action through refusal or completion. Test a responsive refresh episode
+separately from a stall, and test failure records at WARNING thresholds. A
+start/end-only log is absence of coverage, not proof that the send worked.

--- a/backlog/tasks/task-31976 - Recover-Console-sends-after-trace-boundary-construction-failure.md
+++ b/backlog/tasks/task-31976 - Recover-Console-sends-after-trace-boundary-construction-failure.md
@@ -1,0 +1,47 @@
+---
+id: TASK-31976
+title: Recover Console sends after trace boundary construction failure
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-07 20:53'
+updated_date: '2026-09-07 21:08'
+labels: []
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A fresh Console send can stop at Trace capture blocked, and Send without capture then hides the card without contacting the provider or displaying its refusal. Restore the explicit recovery path while retaining safeguards against uncertain delivery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Send without capture dispatches exactly once after a proven pre-adapter trace construction failure and completes the original accepted turn.
+- [x] #2 Unknown or already-started dispatch remains protected against automatic replay.
+- [x] #3 A refused recovery remains visibly actionable and explains why it did not send; the UI does not silently discard the result.
+- [x] #4 Targeted real-database and mounted-Console regressions cover recovery and timer settlement.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing real-database and mounted-Console regressions for a first-call factory failure followed by Send without capture, plus visible refusal and uncertain-delivery controls.
+2. Preserve exact live ownership and proof of no provider entry across trace construction failure; admit explicit Capture Off only with that proof. Keep uncertain dispatch guarded.
+3. Preserve and show recovery refusal results instead of hiding the trace card on a state transition alone.
+4. Run focused trace/controller/UI tests, lint changed code, self-review the diff, and update task notes and relevant lessons.
+ADR required: no (new ADR).
+ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+Reason: Repair the explicit one-shot Capture Off recovery already required by ADR-097 section 15; no schema, ownership, or dispatch-safety policy change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed the fresh-send recovery dead end under existing ADR-097 section 15. The gateway retains exact live first-call construction-failure proof separately from durable reservation status and consumes it once for explicit Capture Off. Another owner/gateway, a forged failure, Capture On, a later call, rebinding, and uncertain dispatch cannot reuse it. The controller publishes uncertain-delivery handoff state so Retry anyway and Discard render. The trace callout preserves safe refusal copy across transcript refreshes.
+Changes: console_provider_gateway.py, console_chat_controller.py, provider_continuation_recovery.py; real-database proof tests, mounted 80x24 send/handoff tests, and persistent-refusal render coverage. Added the observed test-coverage trap to lessons-testing-evidence.md.
+Verification: original mounted tests failed with zero dispatch and a hidden refusal; they now pass. The new persistent-refusal test also fails against the untouched dev UI. Focused suites: 75 trace/runtime/UI tests, 73 gateway trace/capture tests, 47 controller recovery and continuation UI tests (195 total) passed. Independent code review found no actionable issues. Changed ranges pass Ruff formatting; new-file lint and baseline-relative lint pass with zero introduced diagnostics (237 pre-existing findings in the touched legacy files). git diff --check passes. Full suite not run per repository policy. Existing requests dependency warning remains.
+ADR required: no new ADR; direct repair of backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md. No schema changes. The original reporter-specific trace failure and initial flickering remain unconfirmed; this change fixes the reproduced recovery failure, not an unobserved initial cause.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31977 - Capture-Console-send-failures-and-responsive-refresh-churn-in-existing-diagnostics.md
+++ b/backlog/tasks/task-31977 - Capture-Console-send-failures-and-responsive-refresh-churn-in-existing-diagnostics.md
@@ -1,0 +1,52 @@
+---
+id: TASK-31977
+title: >-
+  Capture Console send failures and responsive refresh churn in existing
+  diagnostics
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-07 21:58'
+updated_date: '2026-09-07 22:26'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reports of blocked sends and flickering can reach support with no useful diagnostic evidence. Extend the existing metadata-only logs and responsiveness monitor so failures before trace setup and excessive refresh activity can be identified from the normal shareable logs.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh Console sends record metadata-only stages and outcomes before trace setup, with safe failure categories.
+- [x] #2 Rapid refresh or recompose activity is diagnosed even when the event loop remains responsive, without unbounded logging or loop-side file writes.
+- [x] #3 The existing persistent log and Logs Copy all export retain diagnostic events, runtime version and capture state without private content.
+- [x] #4 Targeted real-sink, mounted-flow, privacy and failure-isolation checks pass; recovery behavior is unchanged.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Amend ADR-029 for bounded Console lifecycle and UI churn metadata; reuse the current diagnostic sink, collector and monitor drain. ADR required: yes (amend existing backlog/decisions/029-local-private-data-boundary.md). Reason: admit explicit operational event fields and document off-loop delivery, privacy and retention.
+2. Add failing real-file and Copy all tests for pre-trace send failure, trace failure categorization and responsive refresh churn; verify privacy and failure isolation.
+3. Add a lazy per-send diagnostic scope, stage breadcrumbs and typed failure summaries; extend the existing monitor with bounded off-loop diagnostic delivery and churn detection.
+4. Verify mounted sends, existing recovery and responsiveness behavior, privacy, inventory and boot-budget checks; update troubleshooting documentation and task notes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented metadata-only Console send-stage events from the visible action through controller admission, durable commit, trace reservation/dispatch and provider entry. Failure summaries preserve safe categories, allowlisted trace reason codes, SQLite codes, runtime versions and resolved capture state at WARNING logging thresholds. Each subsequent queued controller submission receives its own diagnostic token and event allowance.
+
+Extended the existing UI responsiveness monitor with bounded off-loop delivery and edge-triggered Console-sync / screen-recompose churn events, including the last send stage. Added bounded teardown draining. The normal persistent file and Logs Copy all use their existing privacy boundary and retention; no new export surface or capture policy change.
+
+ADR required: yes, fulfilled by the TASK-31977 amendment to backlog/decisions/029-local-private-data-boundary.md. Added backlog/docs/console-send-diagnostics.md and an incident-backed testing lesson. No new ADR file, database schema or dependencies.
+
+Validation: 133 diagnostic, mounted Console, trace-recovery/runtime, responsiveness and share-path tests passed; 73 gateway trace/capture tests passed; 12 startup/import/CSS budget checks passed (218 total across those runs). New files and the monitor pass Ruff; changed ranges format cleanly; baseline-relative lint found zero introduced findings (917 prior, 915 current in the legacy files). Diagnostic inventory verifies unchanged without regeneration; git diff --check passes. Independent review findings were reproduced RED and fixed; follow-up review found no remaining actionable issue.
+
+Known baseline verification limitation: Tests/test_persistent_diagnostic_boundary.py::test_persona_workspace_diagnostics_do_not_interpolate_private_values fails on an unchanged MCP logging call. Reproduced against the original dev archive; the remaining 47 tests in that targeted run passed. The repository also has pre-existing whole-file lint debt. Task remains In Progress rather than claiming the all-green Definition of Done. The original reporter-specific trace failure/flicker has not been reproduced or fixed by this diagnostic extension.
+
+Prepared together with the previously verified TASK-31976 recovery fix for the user-requested PR against dev. Full suite not run per repository policy; targeted validation and the baseline limitations above accompany the PR.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31977 - Capture-Console-send-failures-and-responsive-refresh-churn-in-existing-diagnostics.md
+++ b/backlog/tasks/task-31977 - Capture-Console-send-failures-and-responsive-refresh-churn-in-existing-diagnostics.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-07 21:58'
-updated_date: '2026-09-07 22:26'
+updated_date: '2026-09-07 22:39'
 labels: []
 dependencies: []
 ---
@@ -49,4 +49,6 @@ Validation: 133 diagnostic, mounted Console, trace-recovery/runtime, responsiven
 Known baseline verification limitation: Tests/test_persistent_diagnostic_boundary.py::test_persona_workspace_diagnostics_do_not_interpolate_private_values fails on an unchanged MCP logging call. Reproduced against the original dev archive; the remaining 47 tests in that targeted run passed. The repository also has pre-existing whole-file lint debt. Task remains In Progress rather than claiming the all-green Definition of Done. The original reporter-specific trace failure/flicker has not been reproduced or fixed by this diagnostic extension.
 
 Prepared together with the previously verified TASK-31976 recovery fix for the user-requested PR against dev. Full suite not run per repository policy; targeted validation and the baseline limitations above accompany the PR.
+
+PR #2490 review follow-up: documented parameter, lifecycle and threading contracts on the new diagnostic APIs; derived both per-attempt overflow checks from one named event limit. Restored the existing ui-stall-persist thread name so the shared drain retains its reviewed boot-census identity without increasing the allowlist or boot budget. The CI boot-worker census exposed the rename; 37 focused diagnostic, mounted-flow, responsiveness and boot-worker tests now pass, with Ruff and formatting clean. No behavioral allowance, ownership, privacy or ADR policy change.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -3003,12 +3003,16 @@ class ConsoleChatController:
         """
         from types import SimpleNamespace
 
+        from .console_send_diagnostics import record_send_stage
+
+        record_send_stage("provider_resolution")
         try:
             return await asyncio.wait_for(
                 self.provider_gateway.resolve_for_send(selection),
                 timeout=self.PROVIDER_VALIDATION_TIMEOUT_SECONDS,
             )
-        except TimeoutError:
+        except TimeoutError as exc:
+            record_send_stage("provider_resolution", "failed", error=exc)
             return SimpleNamespace(
                 ready=False,
                 visible_copy=(
@@ -7084,6 +7088,41 @@ class ConsoleChatController:
         _resume_preparation_id: str | None = None,
         _resume_resolution: Any | None = None,
     ) -> ConsoleSubmitResult:
+        """Observe the whole attempt, including refusals before trace setup."""
+        from .console_send_diagnostics import send_diagnostic_scope
+
+        async with send_diagnostic_scope("controller_submit") as diagnostic:
+            result = await self._submit_draft_lifecycle(
+                draft,
+                session_id=session_id,
+                origin=origin,
+                queue_entry_id=queue_entry_id,
+                queue_authorization=queue_authorization,
+                wake_authorization=wake_authorization,
+                _resume_preparation_id=_resume_preparation_id,
+                _resume_resolution=_resume_resolution,
+            )
+            diagnostic.outcome = (
+                result.terminal_status.value
+                if result.terminal_status is not None
+                else "accepted"
+                if result.accepted
+                else "refused"
+            )
+            return result
+
+    async def _submit_draft_lifecycle(
+        self,
+        draft: str,
+        *,
+        session_id: str | None = None,
+        origin: ConsoleSubmissionOrigin = ConsoleSubmissionOrigin.MANUAL,
+        queue_entry_id: str | None = None,
+        queue_authorization: QueueGenerationAuthorization | None = None,
+        wake_authorization: AgentWakeAuthorization | None = None,
+        _resume_preparation_id: str | None = None,
+        _resume_resolution: Any | None = None,
+    ) -> ConsoleSubmitResult:
         """Fence one complete submit lifecycle for close and shutdown."""
 
         owner_key = session_id or self.store.active_session_id
@@ -7683,6 +7722,12 @@ class ConsoleChatController:
                     "capture_policy_preparation_failed"
                 )
                 capture_mode = ConsoleTraceCaptureMode.CAPTURE_OFF
+        from .console_send_diagnostics import record_send_stage
+
+        record_send_stage(
+            "capture_policy",
+            capture_enabled=capture_mode is ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
         if resumed_preparation is not None:
             pii_redaction_enabled = resumed_preparation.pii_redaction_enabled
             pii_ruleset_revision_id = resumed_preparation.pii_ruleset_revision_id
@@ -9002,6 +9047,9 @@ class ConsoleChatController:
             ),
             contributions=contributions,
         )
+        from .console_send_diagnostics import record_send_stage
+
+        record_send_stage("durable_commit")
         try:
             # TASK-22205: the ~10-statement BEGIN IMMEDIATE turn commit runs
             # off the event loop; the await is the dispatch-ordering barrier.
@@ -9009,6 +9057,7 @@ class ConsoleChatController:
                 self.store.commit_durable_turn, acceptance
             )
         except Exception as exc:  # noqa: BLE001 -- a failed commit is a retry, not a crash
+            record_send_stage("durable_commit", "failed", error=exc)
             # TASK-22251: the user-facing copy stays deliberately generic, but
             # something must record WHICH failure occurred. `commit_durable_turn`
             # is a multi-step transaction -- conversation create, Library-policy
@@ -9033,6 +9082,7 @@ class ConsoleChatController:
                 queue_entry_id=queue_entry_id,
                 preparation_id=preparation.preparation_id,
             )
+        record_send_stage("durable_commit", "succeeded")
         fingerprint = self.store.durable_acceptance_fingerprint_for(
             preparation.preparation_id
         )
@@ -9230,8 +9280,11 @@ class ConsoleChatController:
                 ):
                     raise TraceCallPersistenceError()
                 await self._run_durable_db_call(
-                    verify_recovery, continuation,
+                    verify_recovery,
+                    continuation,
                     self._trace_call_boundaries_by_preparation.get(preparation_id),
+                    continuation.stream_signals,
+                    capture_mode_override or continuation.trace_capture_mode,
                 )
                 # This only proves the missing provider effect may be retried.
                 # Keep the completed checkpoint CAS and its attempt unchanged;
@@ -9239,6 +9292,15 @@ class ConsoleChatController:
                 # An explicit Capture-Off action uses this same ownership proof,
                 # but never re-admits or changes the abandoned trace reservation.
             except TraceCallPersistenceError:
+                visible_copy = (
+                    "Delivery status is unknown. Use Retry anyway or Discard."
+                )
+                # Publish the handoff as well as returning it: the trace pause
+                # has ended, so its card will hide. The dispatch-recovery UI
+                # must repaint the unknown-delivery explanation and actions.
+                self._set_run_state(
+                    ConsoleRunState.blocked(visible_copy), session_id=session_id
+                )
                 self.store.mark_dispatch_recovery_needed(
                     session_id,
                     commit.assistant_message_id,
@@ -9247,7 +9309,7 @@ class ConsoleChatController:
                 return ConsoleSubmitResult(
                     True,
                     True,
-                    "Delivery status is unknown. Use Retry anyway or Discard.",
+                    visible_copy,
                     session_id=session_id,
                     user_message_id=commit.user_message_id,
                     assistant_message_id=commit.assistant_message_id,

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -273,6 +273,10 @@ class _TraceAcceptedPreparation:
     owner: object = field(repr=False)
     boundary: object | None = field(default=None, repr=False)
     claimed: bool = False
+    reservation_attempted: bool = False
+    construction_failure: TraceCallPersistenceError | None = field(
+        default=None, repr=False
+    )
 
 
 class _ProviderAdapterAdmission:
@@ -2347,6 +2351,8 @@ class ConsoleProviderGateway:
     ) -> _AdapterResult:
         """Consume one gateway-issued admission immediately before adapter entry."""
 
+        from .console_send_diagnostics import record_send_stage
+
         if type(admission) is not _ProviderAdapterAdmission:
             raise TraceCallPersistenceError()
         _entry_gate = kwargs.pop("_console_adapter_entry_gate", None)
@@ -2357,6 +2363,7 @@ class ConsoleProviderGateway:
                 admission,
                 self._adapter_admission_issuer,
             )
+            record_send_stage("provider_entry")
             return adapter(*args, **kwargs)
         # Consumption is owned by the gateway, not dynamically dispatched to
         # the presented object's method.  Otherwise a subclass can override
@@ -2368,6 +2375,7 @@ class ConsoleProviderGateway:
             ):
                 raise TraceCallPersistenceError()
             admission._consumed = True
+        record_send_stage("provider_entry")
         return adapter(*args, **kwargs)
 
     def _bind_trace_preparation(
@@ -2390,8 +2398,28 @@ class ConsoleProviderGateway:
             raise TraceCallPersistenceError()
         return scope
 
-    def _verify_trace_preparation_recovery(self, owner: object, boundary: object) -> None:
-        """Prove the exact owner's unbound reservation before local re-entry."""
+    def _verify_trace_preparation_recovery(
+        self,
+        owner: object,
+        boundary: object,
+        signals: object = None,
+        capture_mode: ConsoleTraceCaptureMode = ConsoleTraceCaptureMode.CAPTURE_ON,
+    ) -> None:
+        """Prove an owned reservation or consume first-call Capture Off proof."""
+        if capture_mode is ConsoleTraceCaptureMode.CAPTURE_OFF:
+            scope = self._trace_preparation_scope(signals)
+            if (
+                scope is not None
+                and scope.owner is owner
+                and scope.construction_failure is not None
+                and scope.construction_failure is boundary
+            ):
+                # The first factory invocation failed before returning a boundary.
+                # Its reservation outcome may be unknown, but this live gateway
+                # has not entered the adapter. Consume that exact proof once;
+                # it does not authorize Capture On or a cold/foreign replay.
+                scope.construction_failure = None
+                return
         if boundary is None or getattr(boundary, "_accepted_preparation", None) is not owner:
             raise TraceCallPersistenceError(boundary=boundary)
         verify = getattr(getattr(boundary, "_factory", None), "_verify_owned_recovery", None)
@@ -2430,12 +2458,24 @@ class ConsoleProviderGateway:
     ) -> object:
         """Create and reserve one distinct Capture-On call boundary."""
 
-        if not self.supports_durable_capture:
-            raise TraceCallPersistenceError(reservation_status="not_established")
-        assert self._trace_call_boundary_factory is not None
+        from .console_send_diagnostics import record_send_stage
+
+        record_send_stage("trace_reservation")
+        scope = self._trace_preparation_scope(signals)
+        first_call = (
+            scope is not None
+            and not scope.reservation_attempted
+            and scope.boundary is None
+            and route in {ConsoleRequestRoute.FRESH, ConsoleRequestRoute.AGENT_FIRST}
+        )
+        if scope is not None:
+            scope.reservation_attempted = True
+            scope.construction_failure = None
         boundary: object | None = None
         try:
-            scope = self._trace_preparation_scope(signals)
+            if not self.supports_durable_capture:
+                raise TraceCallPersistenceError(reservation_status="not_established")
+            assert self._trace_call_boundary_factory is not None
             if scope is not None and scope.boundary is not None and not scope.claimed:
                 boundary = scope.boundary
                 recover = getattr(getattr(boundary, "_factory", None), "_recover_owned_boundary", None)
@@ -2452,11 +2492,18 @@ class ConsoleProviderGateway:
                 raise TraceCallPersistenceError()
             reserve()
         except TraceCallPersistenceError as exc:
+            record_send_stage("trace_reservation", "failed", error=exc)
             if exc.boundary is None and boundary is not None:
                 raise TraceCallPersistenceError(boundary=boundary) from None
+            if first_call and boundary is None and exc.boundary is None:
+                scope.construction_failure = exc
             raise
-        except Exception:
-            raise TraceCallPersistenceError(reservation_status="unknown") from None
+        except Exception as exc:  # noqa: BLE001 - preserve content-free trace failure contract
+            record_send_stage("trace_reservation", "failed", error=exc)
+            failure = TraceCallPersistenceError(reservation_status="unknown")
+            if first_call and boundary is None:
+                scope.construction_failure = failure
+            raise failure from None
         metrics = self._trace_compatibility_metrics
         record = getattr(metrics, "record", None)
         if callable(record):
@@ -2467,6 +2514,7 @@ class ConsoleProviderGateway:
                     "trace compatibility metric skipped after {}",
                     type(exc).__name__,
                 )
+        record_send_stage("trace_reservation", "succeeded")
         return boundary
 
     async def aclose(self) -> None:
@@ -5303,6 +5351,9 @@ class ConsoleProviderGateway:
     ) -> None:
         """Commit the normalized dispatch token as the adapter-adjacent step."""
 
+        from .console_send_diagnostics import record_send_stage
+
+        record_send_stage("trace_dispatch_commit")
         if trace_call_boundary is None:
             return
         if bundle is None:
@@ -5317,10 +5368,12 @@ class ConsoleProviderGateway:
                 raise TraceCallPersistenceError()
             mark_dispatch_started(bundle, provenance)
         except TraceCallPersistenceError as exc:
+            record_send_stage("trace_dispatch_commit", "failed", error=exc)
             if exc.boundary is None:
                 raise TraceCallPersistenceError(boundary=trace_call_boundary) from None
             raise
-        except Exception:
+        except Exception as exc:  # noqa: BLE001 - preserve content-free trace failure contract
+            record_send_stage("trace_dispatch_commit", "failed", error=exc)
             raise TraceCallPersistenceError() from None
 
     def _trace_dispatch_admission(

--- a/tldw_chatbook/Chat/console_send_diagnostics.py
+++ b/tldw_chatbook/Chat/console_send_diagnostics.py
@@ -1,0 +1,183 @@
+"""Bounded, content-free breadcrumbs for Console sends (TASK-31977)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import sqlite3
+import sys
+import time
+from collections.abc import AsyncIterator
+from contextvars import ContextVar
+from dataclasses import dataclass, field
+from uuid import uuid4
+
+from tldw_chatbook.Utils.ui_responsiveness import UIResponsivenessMonitor
+
+# Exact code-owned categories only; never derive a token from arbitrary error text.
+_TRACE_FAILURE_CATEGORIES = frozenset(
+    {
+        "trace_provenance_unavailable",
+        "trace_policy_unavailable",
+        "trace_route_unavailable",
+        "trace_route_mismatch",
+        "trace_owner_unavailable",
+        "trace_prefill_unavailable",
+        "trace_turn_unavailable",
+        "trace_revision_unavailable",
+        "trace_primary_run_already_started",
+        "trace_fresh_turn_requires_owned_recovery",
+        "trace_tool_chain_unavailable",
+        "surface_provenance_mismatch",
+        "surface_prefix_mismatch",
+        "unsupported_surface_change",
+        "semantic_revision_value_mismatch",
+    }
+)
+
+
+@dataclass
+class SendDiagnostic:
+    monitor: UIResponsivenessMonitor
+    attempt_token: str = field(default_factory=lambda: uuid4().hex)
+    started: float = field(default_factory=time.monotonic)
+    phase: str = "controller_submit"
+    outcome: str = "completed"
+    count: int = 0
+    submission_started: bool = False
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    def record(self, phase: str, status: str = "entered", **fields: object) -> None:
+        """Record a finite number of code-owned fields for this attempt."""
+        self.phase = phase
+        self.metadata.update(
+            {
+                key: value
+                for key, value in fields.items()
+                if key
+                in {
+                    "app_version",
+                    "python_version",
+                    "sqlite_version",
+                    "capture_enabled",
+                }
+            }
+        )
+        if status == "failed":
+            fields = {**self.metadata, **fields}
+        self.count += 1
+        if self.count > 64:
+            if self.count == 65:
+                self.monitor.record_diagnostic(
+                    "console", "diagnostic_events_dropped", item_count=1
+                )
+            return
+        self.monitor.record_diagnostic(
+            "console",
+            "console_send_stage",
+            phase=phase,
+            status=status,
+            attempt_token=self.attempt_token,
+            level=logging.ERROR if status == "failed" else logging.INFO,
+            duration_ms=int((time.monotonic() - self.started) * 1000),
+            **fields,
+        )
+
+
+_CURRENT: ContextVar[SendDiagnostic | None] = ContextVar(
+    "console_send_diagnostic", default=None
+)
+
+
+def record_send_stage(
+    phase: str,
+    status: str = "entered",
+    *,
+    error: BaseException | None = None,
+    **fields: object,
+) -> None:
+    """Record a stage without changing delivery if diagnostic emission fails."""
+    with contextlib.suppress(Exception):
+        current = _CURRENT.get()
+        if current is None:
+            return
+        if error is not None:
+            # Follow generic wrappers to the cause, but never stringify it.
+            seen: set[int] = set()
+            cause = error
+            while id(cause) not in seen and len(seen) < 8:
+                if isinstance(cause, TimeoutError):
+                    break  # asyncio timeouts chain an internal cancellation.
+                seen.add(id(cause))
+                next_cause = cause.__cause__ or cause.__context__
+                if next_cause is None or id(next_cause) in seen:
+                    break
+                cause = next_cause
+            fields["exception_type"] = type(cause).__name__
+            fields["error_category"] = (
+                "timeout"
+                if isinstance(cause, TimeoutError)
+                else "database"
+                if isinstance(cause, sqlite3.Error)
+                else "storage"
+                if isinstance(cause, OSError)
+                else "validation"
+                if isinstance(cause, (ValueError, TypeError))
+                else "internal"
+            )
+            if (
+                type(cause) is ValueError
+                and len(cause.args) == 1
+                and type(cause.args[0]) is str
+                and cause.args[0] in _TRACE_FAILURE_CATEGORIES
+            ):
+                fields["error_category"] = cause.args[0]
+            code = getattr(cause, "sqlite_errorcode", None)
+            if isinstance(cause, sqlite3.Error) and type(code) is int:
+                fields["sqlite_code"] = code
+        current.record(phase, status, **fields)
+
+
+@contextlib.asynccontextmanager
+async def send_diagnostic_scope(
+    phase: str, monitor: UIResponsivenessMonitor | None = None
+) -> AsyncIterator[SendDiagnostic]:
+    """Share one attempt across UI/controller/workers and flush standalone sends."""
+    current = _CURRENT.get()
+    owns_monitor = current is None and monitor is None
+    token = None
+    if current is None or (phase == "controller_submit" and current.submission_started):
+        if current is not None:
+            monitor = current.monitor
+        from tldw_chatbook import __version__
+
+        current = SendDiagnostic(
+            monitor if monitor is not None else UIResponsivenessMonitor(enabled=False)
+        )
+        token = _CURRENT.set(current)
+        record_send_stage(
+            phase,
+            app_version=__version__,
+            python_version=".".join(str(value) for value in sys.version_info[:3]),
+            sqlite_version=sqlite3.sqlite_version,
+        )
+    else:
+        record_send_stage(phase)
+    if phase == "controller_submit":
+        current.submission_started = True
+    try:
+        yield current
+    except BaseException as error:
+        record_send_stage(current.phase, "failed", error=error)
+        current.outcome = (
+            "cancelled" if isinstance(error, asyncio.CancelledError) else "failed"
+        )
+        raise
+    finally:
+        record_send_stage(phase, current.outcome)
+        if token is not None:
+            _CURRENT.reset(token)
+        if owns_monitor:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(current.monitor.close)

--- a/tldw_chatbook/Chat/console_send_diagnostics.py
+++ b/tldw_chatbook/Chat/console_send_diagnostics.py
@@ -15,6 +15,8 @@ from uuid import uuid4
 
 from tldw_chatbook.Utils.ui_responsiveness import UIResponsivenessMonitor
 
+_SEND_DIAGNOSTIC_EVENT_LIMIT = 64
+
 # Exact code-owned categories only; never derive a token from arbitrary error text.
 _TRACE_FAILURE_CATEGORIES = frozenset(
     {
@@ -49,7 +51,14 @@ class SendDiagnostic:
     metadata: dict[str, object] = field(default_factory=dict)
 
     def record(self, phase: str, status: str = "entered", **fields: object) -> None:
-        """Record a finite number of code-owned fields for this attempt."""
+        """Record bounded metadata for this attempt in its submitting context.
+
+        Args:
+            phase: Code-owned lifecycle stage, never user-provided text.
+            status: Code-owned outcome; ``failed`` retains cached metadata.
+            **fields: Metadata allowed by the persistent diagnostic schema.
+                Exclude content, credentials, paths and private identifiers.
+        """
         self.phase = phase
         self.metadata.update(
             {
@@ -67,8 +76,8 @@ class SendDiagnostic:
         if status == "failed":
             fields = {**self.metadata, **fields}
         self.count += 1
-        if self.count > 64:
-            if self.count == 65:
+        if self.count > _SEND_DIAGNOSTIC_EVENT_LIMIT:
+            if self.count == _SEND_DIAGNOSTIC_EVENT_LIMIT + 1:
                 self.monitor.record_diagnostic(
                     "console", "diagnostic_events_dropped", item_count=1
                 )
@@ -97,7 +106,19 @@ def record_send_stage(
     error: BaseException | None = None,
     **fields: object,
 ) -> None:
-    """Record a stage without changing delivery if diagnostic emission fails."""
+    """Record a stage without changing delivery if diagnostic emission fails.
+
+    Call within ``send_diagnostic_scope`` or its inherited worker context;
+    without an active scope this is a no-op. No file I/O runs on the caller.
+
+    Args:
+        phase: Code-owned lifecycle stage, never user-provided text.
+        status: Code-owned outcome; ``failed`` emits at ERROR severity.
+        error: Optional failure to classify without logging its message.
+        **fields: Metadata allowed by the persistent diagnostic schema, such
+            as runtime versions and capture state. Never pass private content,
+            credentials, paths or database identifiers.
+    """
     with contextlib.suppress(Exception):
         current = _CURRENT.get()
         if current is None:
@@ -143,7 +164,23 @@ def record_send_stage(
 async def send_diagnostic_scope(
     phase: str, monitor: UIResponsivenessMonitor | None = None
 ) -> AsyncIterator[SendDiagnostic]:
-    """Share one attempt across UI/controller/workers and flush standalone sends."""
+    """Share an attempt across nested async scopes and inherited worker contexts.
+
+    Subsequent controller submissions get their own token and event budget.
+    A scope that creates its own monitor drains it off-loop on exit; the app
+    remains responsible for closing a supplied monitor during teardown.
+
+    Args:
+        phase: Code-owned entry stage; ``controller_submit`` marks a submission.
+        monitor: App-owned monitor for an outer UI scope. Nested scopes reuse
+            the current monitor; standalone scopes create a temporary one.
+
+    Yields:
+        The active diagnostic attempt; callers may set its terminal outcome.
+
+    Raises:
+        BaseException: Re-raises exceptions from the wrapped send unchanged.
+    """
     current = _CURRENT.get()
     owns_monitor = current is None and monitor is None
     token = None

--- a/tldw_chatbook/UI/Console_Modules/provider_continuation_recovery.py
+++ b/tldw_chatbook/UI/Console_Modules/provider_continuation_recovery.py
@@ -32,6 +32,14 @@ class TraceCallRecoveryState:
     temporary_capture: bool = False
 
 
+@dataclass(frozen=True, slots=True)
+class TraceCallRecoveryResult:
+    """Keep a controller's safe refusal copy alongside the recovery outcome."""
+
+    completed: bool
+    visible_copy: str = ""
+
+
 def trace_call_recovery_state(
     preparation: ConsoleTurnPreparation | None,
 ) -> TraceCallRecoveryState | None:
@@ -166,6 +174,7 @@ class TraceCallRecoveryCallout(Vertical):
         self.recovery_state = state
         self._on_action = on_action
         self._busy = False
+        self._status_copy = ""
 
     def compose(self) -> ComposeResult:
         yield Static("Trace capture blocked", id="console-trace-title")
@@ -199,6 +208,8 @@ class TraceCallRecoveryCallout(Vertical):
     def sync_recovery(self, state: TraceCallRecoveryState | None) -> None:
         """Update the always-mounted placeholder without recomposition."""
 
+        if state != self.recovery_state:
+            self._status_copy = ""
         self.recovery_state = state
         self.display = state is not None
         temporary = bool(state is not None and state.temporary_capture)
@@ -224,7 +235,7 @@ class TraceCallRecoveryCallout(Vertical):
         self.query_one("#console-trace-status", Static).update(
             "Working… actions are temporarily disabled."
             if self._busy
-            else "Choose one action."
+            else self._status_copy or "Choose one action."
         )
 
     @on(Button.Pressed)
@@ -240,6 +251,7 @@ class TraceCallRecoveryCallout(Vertical):
             return
         event.stop()
         self._busy = True
+        self._status_copy = ""
         self.sync_recovery(state)
         self.run_worker(
             self._dispatch(action, state),
@@ -258,18 +270,28 @@ class TraceCallRecoveryCallout(Vertical):
             raise
         except Exception:
             self._busy = False
-            self.sync_recovery(self.recovery_state)
-            self.query_one("#console-trace-status", Static).update(
+            self._status_copy = (
                 "Recovery did not complete. Try again or cancel the send."
             )
+            self.sync_recovery(self.recovery_state)
             return
         self._busy = False
-        if result:
+        completed = (
+            result.completed
+            if isinstance(result, TraceCallRecoveryResult)
+            else bool(result)
+        )
+        if completed:
             self.display = False
             return
+        self._status_copy = (
+            result.visible_copy
+            if isinstance(result, TraceCallRecoveryResult) and result.visible_copy
+            else "Recovery did not complete. Try again or cancel the send."
+        )
         self.sync_recovery(self.recovery_state)
-        self.query_one("#console-trace-status", Static).update(
-            "Recovery did not complete. Try again or cancel the send."
+        self.call_after_refresh(
+            self.query_one("#console-trace-status", Static).scroll_visible
         )
 
 
@@ -630,12 +652,17 @@ class ProviderContinuationTranscriptRegion(ConsoleTranscriptRegion):
             self._recovery_state()
         )
 
-    async def _recover_trace_call(self, action: str, preparation_id: str) -> bool:
+    async def _recover_trace_call(
+        self, action: str, preparation_id: str
+    ) -> TraceCallRecoveryResult:
         result = self._on_trace_recovery_action(action, preparation_id)
         if inspect.isawaitable(result):
-            await result
+            result = await result
         self.sync_recovery()
-        return self._trace_recovery_state_builder() is None
+        return TraceCallRecoveryResult(
+            completed=self._trace_recovery_state_builder() is None,
+            visible_copy=getattr(result, "visible_copy", ""),
+        )
 
     async def _recover(self, action: str, message_id: str, version: int) -> bool:
         result = self._on_recovery_action(action, message_id, version)

--- a/tldw_chatbook/UI/Navigation/base_app_screen.py
+++ b/tldw_chatbook/UI/Navigation/base_app_screen.py
@@ -320,6 +320,12 @@ class BaseAppScreen(Screen):
         interaction has since legitimately captured (which must be left
         alone).
         """
+        try:
+            monitor = getattr(self.app_instance, "ui_responsiveness_monitor", None)
+            if monitor is not None:
+                monitor.record_refresh("screen_recompose")
+        except Exception:  # noqa: BLE001, S110 - diagnostics cannot interfere with teardown
+            pass
         self.release_mouse_capture_for_teardown()
         await super().recompose()
         self.sweep_stale_mouse_capture()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17914,6 +17914,16 @@ class ChatScreen(BaseAppScreen):
     async def _submit_console_native_draft(
         self, draft: str, session_id: str | None = None
     ) -> None:
+        from tldw_chatbook.Chat.console_send_diagnostics import send_diagnostic_scope
+
+        async with send_diagnostic_scope(
+            "ui_submit", self._ui_responsiveness_monitor()
+        ):
+            await self._submit_console_native_draft_observed(draft, session_id)
+
+    async def _submit_console_native_draft_observed(
+        self, draft: str, session_id: str | None = None
+    ) -> None:
         controller = self._ensure_console_chat_controller()
         self._console_draft_spend_refresh.stop()
         self._start_console_transcript_sync_timer()
@@ -18287,6 +18297,17 @@ class ChatScreen(BaseAppScreen):
         return await self._send_console_message_from_visible_action()
 
     async def _send_console_message_from_visible_action(self) -> bool:
+        """Observe the visible action before command parsing and send gating."""
+        from tldw_chatbook.Chat.console_send_diagnostics import send_diagnostic_scope
+
+        async with send_diagnostic_scope(
+            "ui_action", self._ui_responsiveness_monitor()
+        ) as diagnostic:
+            sent = await self._send_console_message_from_visible_action_observed()
+            diagnostic.outcome = "dispatched" if sent else "not_dispatched"
+            return sent
+
+    async def _send_console_message_from_visible_action_observed(self) -> bool:
         """Route the visible Console send action through the native controller.
 
         Returns:
@@ -18421,8 +18442,14 @@ class ChatScreen(BaseAppScreen):
     ) -> bool:
         """Compatibility delegate for the one typed queue-aware dispatcher."""
 
-        result = await self._prompt_queue.dispatch(draft, stash=stash)
-        return result.status is not ConsolePromptDispatchStatus.REFUSED
+        from tldw_chatbook.Chat.console_send_diagnostics import send_diagnostic_scope
+
+        async with send_diagnostic_scope(
+            "ui_dispatch", self._ui_responsiveness_monitor()
+        ) as diagnostic:
+            result = await self._prompt_queue.dispatch(draft, stash=stash)
+            diagnostic.outcome = result.status.value
+            return result.status is not ConsolePromptDispatchStatus.REFUSED
 
     def _note_console_follow_intent(self) -> None:
         """Stamp a programmatic jump-to-tail intent on the transcript (TASK-336).

--- a/tldw_chatbook/Utils/persistent_diagnostics.py
+++ b/tldw_chatbook/Utils/persistent_diagnostics.py
@@ -52,6 +52,10 @@ _TOKEN_FIELDS = frozenset(
         # label vocabulary in Metrics/metrics_logger.py rather than inventing a
         # second dialect for the same idea.
         "component",
+        "attempt_token",
+        "app_version",
+        "python_version",
+        "sqlite_version",
     }
 )
 _INTEGER_FIELDS = frozenset(
@@ -72,9 +76,10 @@ _INTEGER_FIELDS = frozenset(
         "threshold_ms",
         "mounts",
         "removes",
+        "sqlite_code",
     }
 )
-_BOOLEAN_FIELDS = frozenset({"cache_hit", "streaming", "cancelled"})
+_BOOLEAN_FIELDS = frozenset({"cache_hit", "streaming", "cancelled", "capture_enabled"})
 _LIST_FIELDS = frozenset(
     {
         "argument_names",

--- a/tldw_chatbook/Utils/ui_responsiveness.py
+++ b/tldw_chatbook/Utils/ui_responsiveness.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+import logging
 import queue
 import sys
 import threading
-from dataclasses import dataclass
 import time
+from dataclasses import dataclass
 
 
 @dataclass(frozen=True)
@@ -39,7 +40,7 @@ class UIResponsivenessMonitor:
     #: One stall record at a time in the dispatch queue: a wedged loop cannot
     #: pile up records faster than a background thread drains them, and the
     #: queue itself is bounded so enqueueing can never fail noisily.
-    _STALL_QUEUE_DEPTH = 4
+    _STALL_QUEUE_DEPTH = 64
 
     def __init__(
         self,
@@ -64,36 +65,107 @@ class UIResponsivenessMonitor:
         # contract this class exists to protect. Records are handed to a
         # bounded queue drained by a daemon thread instead; the loop-side
         # cost is an enqueue.
-        self._stall_queue: queue.SimpleQueue[dict[str, object] | None] = (
-            queue.SimpleQueue()
+        self._stall_queue: queue.Queue[tuple[str, str, dict[str, object]]] = (
+            queue.Queue(maxsize=self._STALL_QUEUE_DEPTH)
         )
+        self._diagnostic_lock = threading.Lock()
+        self._diagnostic_closed = False
+        self._diagnostic_dropped = 0
+        self._diagnostic_sink_failed = False
+        self._refresh_counts = {"console_sync": 0, "screen_recompose": 0}
+        self._refresh_breaches: set[str] = set()
+        self._last_send_diagnostic: dict[str, object] = {}
         self._stall_thread: threading.Thread | None = None
         #: Records the drain thread has fully processed (persisted or
         #: failed-and-reported); lets tests and future callers synchronize
         #: with the background dispatch without sleeping.
         self._stall_records_processed = 0
 
-    def _drain_stalls(self) -> None:
-        """Background drain loop: persist queued stall records off the loop."""
-        while True:
-            record = self._stall_queue.get()
+    def record_diagnostic(self, component: str, event: str, **fields: object) -> None:
+        """Queue code-owned metadata without doing file I/O on the caller's loop."""
+        with self._diagnostic_lock:
+            if self._diagnostic_closed:
+                return
+            if event == "console_send_stage":
+                self._last_send_diagnostic = {
+                    name: fields[name]
+                    for name in ("attempt_token", "phase", "status")
+                    if name in fields
+                }
             try:
-                if record is None:
+                self._stall_queue.put_nowait((component, event, fields))
+            except queue.Full:
+                self._diagnostic_dropped += 1
+                return
+            if self._stall_thread is None:
+                self._stall_thread = threading.Thread(
+                    target=self._drain_stalls, name="ui-diagnostic-persist", daemon=True
+                )
+                self._stall_thread.start()
+
+    def _drain_stalls(self) -> None:
+        """Drain bounded diagnostics off the UI loop, including stall events."""
+        while True:
+            try:
+                component, event, record = self._stall_queue.get(timeout=0.1)
+            except queue.Empty:
+                if self._diagnostic_closed:
                     return
+                continue
+            try:
                 from .persistent_diagnostics import persist_event
 
-                persist_event("ui", "event_loop_stall", **record)  # type: ignore[arg-type]
-            except Exception as exc:  # noqa: BLE001 -- never raise from diagnostics
-                lag = record.get("lag_ms") if isinstance(record, dict) else "?"
-                print(
-                    "ui_responsiveness: stall persist failed "
-                    f"(op=persist_event lag_ms={lag} "
-                    f"threshold_ms={self.stall_threshold_ms} "
-                    f"error={type(exc).__name__})",
-                    file=sys.stderr,
-                )
+                persist_event(component, event, **record)
+                with self._diagnostic_lock:
+                    dropped = self._diagnostic_dropped
+                    self._diagnostic_dropped = 0
+                if dropped:
+                    persist_event("ui", "diagnostic_events_dropped", item_count=dropped)
+            except Exception as exc:  # noqa: BLE001 -- diagnostics must not fail the app
+                if not self._diagnostic_sink_failed:
+                    self._diagnostic_sink_failed = True
+                    print(
+                        "ui_responsiveness: diagnostic persist failed "
+                        f"(error={type(exc).__name__})",
+                        file=sys.stderr,
+                    )
             finally:
                 self._stall_records_processed += 1
+                self._stall_queue.task_done()
+
+    def close(self, timeout: float = 1.0) -> None:
+        """Stop accepting events and drain with a bounded wait; call off the UI loop."""
+        with self._diagnostic_lock:
+            self._diagnostic_closed = True
+            thread = self._stall_thread
+        if thread is not None and thread is not threading.current_thread():
+            thread.join(timeout=timeout)
+
+    def record_refresh(self, operation: str) -> None:
+        """Count only fixed UI activity names; do not retain widget identities."""
+        if self.enabled and operation in self._refresh_counts:
+            self._refresh_counts[operation] += 1
+
+    def _check_refresh_churn(self, window_seconds: float) -> None:
+        for operation, threshold in (("console_sync", 20), ("screen_recompose", 4)):
+            count = self._refresh_counts[operation]
+            self._refresh_counts[operation] = 0
+            excessive = count >= threshold * max(1.0, window_seconds)
+            if excessive and operation not in self._refresh_breaches:
+                self._refresh_breaches.add(operation)
+                self.record_diagnostic(
+                    "ui",
+                    "ui_refresh_churn",
+                    level=logging.WARNING,
+                    operation=operation,
+                    item_count=count,
+                    duration_ms=int(window_seconds * 1000),
+                    active_workers=sorted(self._active_workers),
+                    active_timers=sorted(self._active_timers),
+                    **self._last_send_diagnostic,
+                )
+            elif not excessive:
+                self._refresh_breaches.discard(operation)
 
     def _persist_stall(self, lag_ms: int) -> None:
         """Queue one diagnostics record for an observed event-loop stall.
@@ -109,22 +181,7 @@ class UIResponsivenessMonitor:
             "mounts": self._mounts,
             "removes": self._removes,
         }
-        if self._stall_thread is None:
-            self._stall_thread = threading.Thread(
-                target=self._drain_stalls,
-                name="ui-stall-persist",
-                daemon=True,
-            )
-            self._stall_thread.start()
-        try:
-            self._stall_queue.put(record)
-        except Exception as exc:  # noqa: BLE001 -- never raise from diagnostics
-            print(
-                "ui_responsiveness: stall enqueue failed "
-                f"(lag_ms={lag_ms} threshold_ms={self.stall_threshold_ms} "
-                f"error={type(exc).__name__})",
-                file=sys.stderr,
-            )
+        self.record_diagnostic("ui", "event_loop_stall", **record)
 
     def record_timer_created(self, name: str) -> None:
         """Record a timer as active by stable diagnostic name."""
@@ -139,6 +196,8 @@ class UIResponsivenessMonitor:
         """Record a worker as active by stable diagnostic name."""
         if self.enabled:
             self._active_workers.add(name)
+            if name == "console-sync":
+                self.record_refresh("console_sync")
 
     def record_worker_finished(self, name: str) -> None:
         """Record a worker as finished by stable diagnostic name."""
@@ -169,7 +228,8 @@ class UIResponsivenessMonitor:
         """
         if not self.enabled:
             return
-        lag_ms = int(round(delta_seconds * 1000))
+        self._check_refresh_churn(self.heartbeat_interval_seconds + delta_seconds)
+        lag_ms = round(delta_seconds * 1000)
         self._max_heartbeat_lag_ms = max(self._max_heartbeat_lag_ms, lag_ms)
         if lag_ms >= self.stall_threshold_ms:
             if not self._stall_persisted:

--- a/tldw_chatbook/Utils/ui_responsiveness.py
+++ b/tldw_chatbook/Utils/ui_responsiveness.py
@@ -37,9 +37,7 @@ class UIResponsivenessSnapshot:
 class UIResponsivenessMonitor:
     """Collect low-cost counters that make UI stalls diagnosable."""
 
-    #: One stall record at a time in the dispatch queue: a wedged loop cannot
-    #: pile up records faster than a background thread drains them, and the
-    #: queue itself is bounded so enqueueing can never fail noisily.
+    #: Shared bound for queued send, stall and refresh-churn records.
     _STALL_QUEUE_DEPTH = 64
 
     def __init__(
@@ -82,7 +80,17 @@ class UIResponsivenessMonitor:
         self._stall_records_processed = 0
 
     def record_diagnostic(self, component: str, event: str, **fields: object) -> None:
-        """Queue code-owned metadata without doing file I/O on the caller's loop."""
+        """Queue metadata from UI or worker threads without caller-side file I/O.
+
+        A full queue drops the event and counts the loss. Calls after close
+        are ignored. The persistent sink applies the final field allowlist.
+
+        Args:
+            component: Code-owned subsystem token, such as ``console`` or ``ui``.
+            event: Code-owned event token, such as ``console_send_stage``.
+            **fields: Schema-approved metadata and optional logging ``level``.
+                Never include content, credentials, paths or private identifiers.
+        """
         with self._diagnostic_lock:
             if self._diagnostic_closed:
                 return
@@ -99,7 +107,7 @@ class UIResponsivenessMonitor:
                 return
             if self._stall_thread is None:
                 self._stall_thread = threading.Thread(
-                    target=self._drain_stalls, name="ui-diagnostic-persist", daemon=True
+                    target=self._drain_stalls, name="ui-stall-persist", daemon=True
                 )
                 self._stall_thread.start()
 
@@ -134,7 +142,14 @@ class UIResponsivenessMonitor:
                 self._stall_queue.task_done()
 
     def close(self, timeout: float = 1.0) -> None:
-        """Stop accepting events and drain with a bounded wait; call off the UI loop."""
+        """Stop accepting events and drain with a bounded wait off the UI loop.
+
+        The daemon may finish pending writes after the wait expires. Repeated
+        calls are safe; callers must not use this blocking wait on the UI loop.
+
+        Args:
+            timeout: Maximum seconds to wait for the drain thread to exit.
+        """
         with self._diagnostic_lock:
             self._diagnostic_closed = True
             thread = self._stall_thread
@@ -142,7 +157,12 @@ class UIResponsivenessMonitor:
             thread.join(timeout=timeout)
 
     def record_refresh(self, operation: str) -> None:
-        """Count only fixed UI activity names; do not retain widget identities."""
+        """Count fixed activity names on the UI loop without retaining widgets.
+
+        Args:
+            operation: ``console_sync`` or ``screen_recompose``. Other values
+                are ignored, as are all calls when responsiveness is disabled.
+        """
         if self.enabled and operation in self._refresh_counts:
             self._refresh_counts[operation] += 1
 
@@ -193,7 +213,12 @@ class UIResponsivenessMonitor:
         self._active_timers.discard(name)
 
     def record_worker_started(self, name: str) -> None:
-        """Record a worker as active by stable diagnostic name."""
+        """Record an active worker on the UI loop and count Console syncs.
+
+        Args:
+            name: Stable code-owned worker name; ``console-sync`` also records
+                refresh activity. Never include user content or identifiers.
+        """
         if self.enabled:
             self._active_workers.add(name)
             if name == "console-sync":

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -18067,6 +18067,10 @@ class TldwCli(
             )
         self._ui_ready = False
         self._stop_ui_responsiveness_monitor()
+        monitor = self.ui_responsiveness_monitor
+        if monitor is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.to_thread(monitor.close)
 
         # F3/TASK-601: shut down both Library ingest worker boundaries. Final
         # shutdown order, explicit:


### PR DESCRIPTION
A Console send can become stranded when trace-boundary construction fails: **Send without capture** dismisses the recovery card but neither sends the message nor displays the delivery refusal. Preserve a one-shot, gateway-owned proof that the adapter has not been entered so explicit Capture Off can complete the accepted send. When delivery remains uncertain, publish the existing **Retry anyway / Discard** handoff visibly.

Extend the existing diagnostics to make future reports actionable:

- Record metadata-only stages from the visible send action through admission, durable commit, trace reservation and provider entry, including safe error categories and runtime/capture metadata.
- Detect excessive Console syncs and whole-screen recompositions even while the event loop remains responsive. Use bounded, off-loop delivery and one warning per sustained churn episode.
- Keep evidence in the normal persistent log and **Logs → Copy all**, with no prompt text, credentials, raw exception messages or private database identifiers.

The original reporter-specific trace failure and flicker cause remain unconfirmed. The recovery fix covers the reproduced secondary failure; the added diagnostics improve evidence for the initial problem.

Validation:

- 218 targeted tests passed across recovery, diagnostics, gateway trace/capture, mounted Console flows, log sharing, responsiveness and startup/import/CSS budgets.
- Regression tests were observed failing before the fixes; independent reviews found no remaining actionable issues.
- All six derived-artifact preflight guards passed, including diagnostic inventory and task-ID checks.
- Focused Ruff checks and formatting pass; baseline-relative lint adds no findings; `git diff --check` passes.
- Known baseline failure: `Tests/test_persistent_diagnostic_boundary.py::test_persona_workspace_diagnostics_do_not_interpolate_private_values` rejects an unchanged logging call in `Agents/mcp_tool_provider.py`. Reproduced on untouched dev as well. Pre-existing whole-file lint debt remains. No full-suite run.

Tracks TASK-31976 and TASK-31977. The latter stays In Progress because of the documented baseline validation limitation. Implements the existing ADR-097 trace-recovery policy and amends ADR-029 for the bounded diagnostic metadata. Usage: [Console send diagnostics](backlog/docs/console-send-diagnostics.md).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Console send that could get stranded when trace-boundary construction fails: Send without capture now completes the send if the gateway can prove the provider wasn't entered, and shows an actionable Retry anyway / Discard handoff when delivery is uncertain.

**Diagnostics**

- Records metadata-only send stages from the visible action through provider entry, with safe error categories and runtime/capture context.
- Detects excessive Console syncs and screen recompositions even when the event loop is responsive, using bounded off-loop delivery and one warning per sustained episode.
- Keeps evidence in the normal persistent log and Logs → Copy all, without prompt text, credentials, raw exception messages, or private identifiers.

<sup>Written for commit e65e7fd2de6edca2e27a7e2145a6620257adb3c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

Review follow-up (`e65e7fd2d`): addressed both Qodo findings with diagnostic API contracts and a single named event limit. Preserved the existing diagnostic drain thread name after the boot census caught its rename. Rebased onto dev `7d3a33225`; 37 focused diagnostic/UI/boot-worker tests, Ruff/format checks and all six preflight guards passed. Both Qodo review threads have replies and are resolved.
