### PR TITLE
docs(backlog): file critique #6 fix tasks (31976, 31979-31982)

### DIFF
--- a/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
+++ b/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
@@ -1,0 +1,29 @@
+---
+id: TASK-31979
+title: >-
+  Library media: the wide layout truncates a long title while the reader pane
+  sits empty
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:48'
+labels:
+  - library
+  - media
+  - ux
+  - layout
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #6 P2, both assessors. At 235x52 a 98-character title is cut to 47 characters in a fixed 52-column list pane while roughly 120 columns of reader pane hold the single sentence `Select a media item to read it here.`. At 100x30 the same title wraps across three fully readable lines. The wide layout is the one that loses information: the two-pane split reserves reader width that nothing uses when no item is open.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When no media item is open, the list pane is allowed enough width to show substantially more of a long title (or the title wraps rather than truncating)
+- [ ] #2 Opening an item restores the reader pane's width
+- [ ] #3 A pin asserts a long title paints more characters at 235x52 with no item open than the current fixed 52-column pane allows
+<!-- AC:END -->

--- a/backlog/tasks/task-31980 - Library-media-the-permanent-delete-button-carries-no-danger-affordance.md
+++ b/backlog/tasks/task-31980 - Library-media-the-permanent-delete-button-carries-no-danger-affordance.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31980
+title: 'Library media: the permanent-delete button carries no danger affordance'
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:48'
+labels:
+  - library
+  - media
+  - ux
+  - css
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #6 P2, both assessors. The Trash permanent-delete confirmation does the copy well (`This cannot be undone.` over the item's title, type and trashed age, Cancel focused), then paints `Delete permanently` in ordinary body colours (rgb(225,225,225) on rgb(30,30,30), no $error) one space from a fully-styled Cancel that gets the blue focus bar. The theme defines a blocked-error/$error role for exactly this and it is unused here. The most destructive control on the surface is the least-marked one and sits one cell from the safe one. The same shape recurs in the More strip, where Move to trash ends a row of neutral actions with no separation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Delete permanently carries the theme's $error role (text or border, per the contrast rules) so it reads as destructive
+- [ ] #2 At least three cells separate it from Cancel
+- [ ] #3 Destructive entries in the More strip are visually separated from neutral ones
+- [ ] #4 A painted pin asserts the destructive button's colour/role differs from the neutral buttons beside it
+<!-- AC:END -->

--- a/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
+++ b/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31977
+id: TASK-31981
 title: 'Library: a blocked action explains itself only on mouse hover, not inline'
 status: To Do
 assignee: []
@@ -26,3 +26,7 @@ Critique #6 P1, both assessors. Clicking a disabled `○ Generate` in the reader
 - [ ] #3 The pattern matches the existing Export gate's inline-reason treatment
 - [ ] #4 A painted pin asserts the reason text is present on the screen with no hover
 <!-- AC:END -->
+
+## Renumbering provenance
+
+Filed as TASK-31977 during critique #6's fix wave; renumbered to TASK-31981 because a concurrent session landed its own TASK-31977 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.

--- a/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
+++ b/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31977
+title: 'Library: a blocked action explains itself only on mouse hover, not inline'
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:48'
+labels:
+  - library
+  - media
+  - ux
+  - accessibility
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #6 P1, both assessors. Clicking a disabled `○ Generate` in the reader's Analysis pane produces a byte-identical screen; the reason (`No analysis provider is configured.`) appears only on mouse hover, unreachable by a keyboard-first user. The same silence covers `○ Analyze` in select mode. The Export gate already does this correctly two clicks away: `No destination chosen` is printed directly beneath the blocked `○ Export bundle (.zip)`. The product contract says explain why unavailable actions are unavailable, and the design doc says use recovery callouts instead of silent disabled controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A blocked Generate/Analyze action shows its reason as an always-visible line adjacent to the control, not only in a hover tooltip
+- [ ] #2 The reason names a next step where one exists (e.g. Set a provider in Settings)
+- [ ] #3 The pattern matches the existing Export gate's inline-reason treatment
+- [ ] #4 A painted pin asserts the reason text is present on the screen with no hover
+<!-- AC:END -->

--- a/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
+++ b/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
@@ -1,0 +1,27 @@
+---
+id: TASK-31978
+title: 'Library media: a faulting read cascades and its Retry offers no recovery path'
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:48'
+labels:
+  - library
+  - media
+  - robustness
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #6 P1, adjudicated from Assessment A's undo P0. The undo handler itself is correct (it counts rows actually restored and increments the rail by exactly that, `library_screen.py:24537-24552`; the N-of-M receipt counts genuine restore exceptions), and Assessment B got a clean undo on the same code, so the catastrophic case required a real media-DB fault. The deterministic residue: when the media read faults, the failure disables independent controls that did not need that connection (Export, Select, Review these, the facet counts, the whole Trash view); the fault-state Retry repeats one sentence with no attempt counter and no next step; and a restore that returns a non-Mapping is counted as neither success nor failure, so the receipt count can drift. Related: task-31972 (selection reconcile id-shape), task-31942 (analysis-save commit).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A media read failure is scoped to the failing surface; Export, Select, Review, facet counts and Trash remain usable when their own reads succeed
+- [ ] #2 The fault-state Retry either reconnects or, when it cannot, states the recovery action (e.g. Reopen Chatbook to reconnect to the media database) instead of repeating the same sentence
+- [ ] #3 The bulk-undo receipt count reflects rows the write layer actually committed, including a restore that returns an unexpected shape
+- [ ] #4 A test reproduces a faulting media read and asserts the independent controls stay live
+<!-- AC:END -->

--- a/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
+++ b/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31978
+id: TASK-31982
 title: 'Library media: a faulting read cascades and its Retry offers no recovery path'
 status: To Do
 assignee: []
@@ -25,3 +25,7 @@ Critique #6 P1, adjudicated from Assessment A's undo P0. The undo handler itself
 - [ ] #3 The bulk-undo receipt count reflects rows the write layer actually committed, including a restore that returns an unexpected shape
 - [ ] #4 A test reproduces a faulting media read and asserts the independent controls stay live
 <!-- AC:END -->
+
+## Renumbering provenance
+
+Filed as TASK-31978 during critique #6's fix wave; renumbered to TASK-31982 because a concurrent session landed its own TASK-31978 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.

--- a/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
+++ b/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
@@ -1,0 +1,28 @@
+---
+id: TASK-31976
+title: 'Library media: keyboard focus on a list row is invisible against selection'
+status: To Do
+assignee: []
+created_date: '2026-09-07 22:48'
+labels:
+  - library
+  - media
+  - ux
+  - css
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #6 P1 (lead), both assessors. `.library-media-row:focus` and `.library-media-row-selected` share the identical treatment in `_agentic_terminal.tcss` (`background: $ds-focus-bg; color: $ds-focus-fg; text-style: bold underline`), so the row the keyboard is ON is visually indistinguishable from the row that is selected/open. Assessment B measured the focused-row background against the open-item row and found them separated by three units in a single colour channel (rgb(28,70,102) vs rgb(25,68,102)) with bold+underline shared and no glyph, so arrow-key navigation reads as a dead key. In a keyboard-first product this is the sharpest contradiction of the brand. Applies to the sibling row canvases (conversations/notes/prompts) too, which share the same idiom.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A focused list row is visually distinct from a selected/open row at 235x52 and 100x30, with a cue that is not colour-only (a glyph or a clearly separated background, never colour-alone)
+- [ ] #2 Arrow-key movement between rows is visible without a selection change (a painted pin over the real screen asserts the focused row's cue moves on Down/Up)
+- [ ] #3 The compact 2-cell row keeps its label intact (no outline: heavy regression)
+- [ ] #4 The same distinction holds for the conversations, notes and prompts row canvases
+<!-- AC:END -->

--- a/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
+++ b/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-31976
+id: TASK-31983
 title: 'Library media: keyboard focus on a list row is invisible against selection'
 status: To Do
 assignee: []
@@ -26,3 +26,7 @@ Critique #6 P1 (lead), both assessors. `.library-media-row:focus` and `.library-
 - [ ] #3 The compact 2-cell row keeps its label intact (no outline: heavy regression)
 - [ ] #4 The same distinction holds for the conversations, notes and prompts row canvases
 <!-- AC:END -->
+
+## Renumbering provenance
+
+Filed as TASK-31976 during critique #6's fix wave; renumbered to TASK-31983 because a concurrent session landed its own TASK-31976 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.


### PR DESCRIPTION
Files the five critique #6 findings the user chose to burn down (lead: keyboard-focus visibility). No code. The scroll-loss P2 is already task-31968.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Files five critique #6 findings as tracked tasks in `backlog/tasks/`, covering the lead keyboard-focus visibility issue plus four follow-ups. No code changes. The focus task was renumbered 31976→31983, and `task-31981`/`task-31982` were renumbered from 31977/31978 after a concurrent session landed those ids on dev first; each renumbered task documents the provenance in a note.

<sup>Written for commit f66df5eb2bd0b76cd92702b3ade5091324e132e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2492?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

