### PR TITLE
fix(library): distinct keyboard-focus cue on list rows (task-31983)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -521,7 +521,7 @@ footer; TASK-2856 re-critique round 3: the media viewer's Edit/Delete/Edit
 analysis sub-states now document their own graduated two-Escape behavior
 and footer hint ("back a step") instead of implying a single Escape
 reaches the list from any viewer sub-state)*
-*Verified against fix/media-crit6-focus — 2026-09-07 (task-31976: a focused
+*Verified against fix/media-crit6-focus — 2026-09-07 (task-31983: a focused
 list row now carries a distinct left-edge cursor bar, so keyboard focus reads
 apart from the selected/open row even when a row is both — the bar moves with
 ↑/↓ and never changes the selection. Applied uniformly to the Media,

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -521,6 +521,11 @@ footer; TASK-2856 re-critique round 3: the media viewer's Edit/Delete/Edit
 analysis sub-states now document their own graduated two-Escape behavior
 and footer hint ("back a step") instead of implying a single Escape
 reaches the list from any viewer sub-state)*
+*Verified against fix/media-crit6-focus — 2026-09-07 (task-31976: a focused
+list row now carries a distinct left-edge cursor bar, so keyboard focus reads
+apart from the selected/open row even when a row is both — the bar moves with
+↑/↓ and never changes the selection. Applied uniformly to the Media,
+Conversations, Notes, Notes-folder and Prompts row canvases.)*
 *Verified against dev @ 6b38a13b8 — 2026-08-07 (task-2858 Task 4: rail
 glosses/counts follow one rule across visits (LIB-15); the search box
 selects a stale query on click too, not just on a second "/" (LIB-17);

--- a/Tests/UI/test_library_row_focus_cue_t31976.py
+++ b/Tests/UI/test_library_row_focus_cue_t31976.py
@@ -1,0 +1,183 @@
+"""Library list rows: keyboard focus must be visible against selection -- TASK-31976.
+
+Critique #6 P1. `.library-media-row:focus` and `.library-media-row-selected`
+(and the sibling conversation/notes/notes-folder/prompt canvases) shared the
+IDENTICAL treatment in `_agentic_terminal.tcss`::
+
+    background: $ds-focus-bg; color: $ds-focus-fg; text-style: bold underline;
+
+so the row the keyboard was ON looked exactly like the open/selected row --
+arrow-key navigation read as a dead key. The fix gives ``:focus`` a
+non-colour-only cue -- a ``border-left: thick $ds-action-focus`` left-edge bar
+that ``-selected`` does NOT carry -- so the two states are distinguishable even
+when a row is BOTH focused and selected (the common case: arrow onto the open
+row). The left border replaces the row's 1-column left padding, so the label
+never shifts or is clipped (no ``outline: heavy`` regression).
+
+Painted-frame reads go through the real compositor
+(`Screen._compositor.render_strips()`) against the PRODUCTION bundle + library
+split sheet, the same pattern as `test_compact_focus_outline_render.py` -- the
+`:focus`/`-selected` rules live in `screen_agentic_library.tcss`, so a
+bundle-only harness would see neither.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.containers import Vertical
+from textual.widgets import Button
+
+from Tests.UI.consolidated_css import APP_STYLESHEETS, app_css_text
+
+_APP_CSS_PATHS = [str(path) for path in APP_STYLESHEETS]
+
+# `border-left: thick $ds-action-focus` paints a full-block left edge.
+_THICK_LEFT_GLYPH = "█"  # '█'
+
+
+class _LibraryRowsHost(App):
+    """Three real media rows under the production stylesheet: one open.
+
+    Rows are `Button`s classed `library-media-row` exactly as
+    `library_media_canvas.py` mounts them; the open item additionally carries
+    `library-media-row-selected` the way `button.set_class(...)` toggles it.
+    `AUTO_FOCUS = None` keeps every row genuinely blurred until a test moves
+    focus, so the observed cue is the one a real user's Tab/arrow produces.
+    """
+
+    AUTO_FOCUS = None
+    CSS_PATH = _APP_CSS_PATHS
+
+    def compose(self) -> ComposeResult:
+        with Vertical():
+            yield Button("Media Alpha", id="row-0", classes="library-media-row")
+            yield Button(
+                "Media Bravo",
+                id="row-1",
+                classes="library-media-row library-media-row-selected",
+            )
+            yield Button("Media Charlie", id="row-2", classes="library-media-row")
+
+
+def _strip_rows(app: App) -> list[str]:
+    """Painted frame as one plain-text string per screen row."""
+    strips = app.screen._compositor.render_strips()
+    return ["".join(segment.text for segment in strip) for strip in strips]
+
+
+def _leftmost_char(rows: list[str], widget) -> str:
+    """The single painted cell at the widget's top-left (its border column)."""
+    region = widget.region
+    line = rows[region.y]
+    return line[region.x] if region.x < len(line) else ""
+
+
+@pytest.mark.asyncio
+async def test_focused_row_border_distinct_from_selected_background() -> None:
+    """AC#1 (computed). A focused row carries a left-edge border a selected
+    row does not, and both share the same focus background -- so the cue that
+    separates them is structural, never colour-alone."""
+    app = _LibraryRowsHost()
+    async with app.run_test(size=(235, 52)) as pilot:
+        focused = app.query_one("#row-0", Button)
+        selected = app.query_one("#row-1", Button)
+        focused.focus()
+        await pilot.pause()
+        assert focused.has_focus and not selected.has_focus
+
+        assert focused.styles.border_left[0], (
+            "focused row must carry a left-edge border cue; got "
+            f"{focused.styles.border_left!r}"
+        )
+        assert not selected.styles.border_left[0], (
+            "selected (blurred) row must NOT carry the focus border; got "
+            f"{selected.styles.border_left!r}"
+        )
+        # Same background proves the distinction is the border, not colour.
+        assert focused.styles.background == selected.styles.background
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)])
+async def test_focus_cue_painted_and_moves_at_both_sizes(size) -> None:
+    """AC#1/#2/#3 (painted). The focused row paints a left-edge glyph the
+    blurred/selected rows do not, its label survives intact, and the glyph
+    follows focus onto the next row (including onto the open row -- the
+    focused+selected case) with no selection change."""
+    app = _LibraryRowsHost()
+    async with app.run_test(size=size) as pilot:
+        row0 = app.query_one("#row-0", Button)
+        row1 = app.query_one("#row-1", Button)
+        row0.focus()
+        await pilot.pause()
+
+        rows = _strip_rows(app)
+        assert _leftmost_char(rows, row0) == _THICK_LEFT_GLYPH, (
+            f"focused row's left edge glyph missing at size {size}"
+        )
+        assert _leftmost_char(rows, row1) != _THICK_LEFT_GLYPH, (
+            "blurred selected row must not paint the focus glyph"
+        )
+        # AC#3: the compact 2-cell row keeps its whole label.
+        painted_row0 = rows[row0.region.y] + rows[row0.region.y + 1]
+        assert "Media Alpha" in painted_row0, (
+            f"focused row's label was clipped at size {size}: {painted_row0!r}"
+        )
+
+        # AC#2: move focus onto the open row -- cue follows, selection unchanged.
+        await pilot.press("tab")
+        await pilot.pause()
+        assert row1.has_focus and row1.has_class("library-media-row-selected")
+
+        rows = _strip_rows(app)
+        assert _leftmost_char(rows, row1) == _THICK_LEFT_GLYPH, (
+            "focus cue did not move onto the next (open) row"
+        )
+        assert _leftmost_char(rows, row0) != _THICK_LEFT_GLYPH, (
+            "focus cue lingered on the row focus left"
+        )
+        painted_row1 = rows[row1.region.y] + rows[row1.region.y + 1]
+        assert "Media Bravo" in painted_row1, (
+            "focused+selected row's label was clipped"
+        )
+
+
+def _rule_body(text: str, selector: str) -> str:
+    """First rule body whose comma-joined selector list contains ``selector``."""
+    uncommented = re.sub(r"/\*.*?\*/", "", text, flags=re.DOTALL)
+    for match in re.finditer(r"\{(?P<body>[^{}]*)\}", uncommented, flags=re.DOTALL):
+        prefix = uncommented[: match.start()]
+        start = max(prefix.rfind("}"), prefix.rfind(";")) + 1
+        selectors = [item.strip() for item in prefix[start : match.start()].split(",")]
+        if selector in selectors:
+            return match.group("body")
+    raise AssertionError(f"selector not found: {selector!r}")
+
+
+@pytest.mark.parametrize(
+    "focus_selector",
+    [
+        ".library-media-row:focus",
+        ".library-conversation-row:focus",
+        ".library-notes-row:focus",
+        ".library-notes-folder-row:focus",
+        ".library-prompt-row:focus",
+    ],
+)
+def test_every_sibling_focus_rule_carries_the_border_cue(focus_selector) -> None:
+    """AC#4. The border-left focus cue is uniform across all row canvases,
+    and none of the ``-selected`` rules steal it (they stay background-only)."""
+    css = app_css_text()
+    assert "border-left" in _rule_body(css, focus_selector), (
+        f"{focus_selector} is missing the border-left focus cue"
+    )
+    for selected in (
+        ".library-media-row-selected",
+        ".library-conversation-row-selected",
+    ):
+        assert "border-left" not in _rule_body(css, selected), (
+            f"{selected} must NOT carry the focus border cue"
+        )

--- a/Tests/UI/test_library_row_focus_cue_t31983.py
+++ b/Tests/UI/test_library_row_focus_cue_t31983.py
@@ -1,4 +1,4 @@
-"""Library list rows: keyboard focus must be visible against selection -- TASK-31976.
+"""Library list rows: keyboard focus must be visible against selection -- TASK-31983.
 
 Critique #6 P1. `.library-media-row:focus` and `.library-media-row-selected`
 (and the sibling conversation/notes/notes-folder/prompt canvases) shared the

--- a/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
+++ b/backlog/tasks/task-31983 - Library-media-keyboard-focus-on-a-list-row-is-invisible-against-selection.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31983
 title: 'Library media: keyboard focus on a list row is invisible against selection'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-07 22:48'
+updated_date: '2026-09-07 23:48'
 labels:
   - library
   - media
@@ -21,12 +22,20 @@ Critique #6 P1 (lead), both assessors. `.library-media-row:focus` and `.library-
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A focused list row is visually distinct from a selected/open row at 235x52 and 100x30, with a cue that is not colour-only (a glyph or a clearly separated background, never colour-alone)
-- [ ] #2 Arrow-key movement between rows is visible without a selection change (a painted pin over the real screen asserts the focused row's cue moves on Down/Up)
-- [ ] #3 The compact 2-cell row keeps its label intact (no outline: heavy regression)
-- [ ] #4 The same distinction holds for the conversations, notes and prompts row canvases
+- [x] #1 A focused list row is visually distinct from a selected/open row at 235x52 and 100x30, with a cue that is not colour-only (a glyph or a clearly separated background, never colour-alone)
+- [x] #2 Arrow-key movement between rows is visible without a selection change (a painted pin over the real screen asserts the focused row's cue moves on Down/Up)
+- [x] #3 The compact 2-cell row keeps its label intact (no outline: heavy regression)
+- [x] #4 The same distinction holds for the conversations, notes and prompts row canvases
 <!-- AC:END -->
 
-## Renumbering provenance
+## Implementation Plan
 
-Filed as TASK-31976 during critique #6's fix wave; renumbered to TASK-31983 because a concurrent session landed its own TASK-31976 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the root cause: `.library-media-row:focus` and `.library-media-row-selected` share the identical treatment. 2. Give every list `:focus` a focus-only border-left cursor bar that `-selected` does not carry; swap padding 0 1 -> 0 1 0 0 so the content column is fixed. 3. Apply to media/trash/notes/notes-folder/prompt + a new conversation :focus. 4. Painted pin at 235x52 and 100x30, red first.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+A focus-only `border-left: thick $ds-action-focus` cursor bar (a filled block) now distinguishes the keyboard-focused row from the selected/open row, which keeps its background-only treatment. Padding `0 1` -> `0 1 0 0` puts the bar in the column the left pad vacated, so the content column is identical blurred vs focused (no jump, no clip) and no `outline: heavy`. Applied to `.library-media-row`/`.library-media-trash-row`, `.library-notes-row`, `.library-notes-folder-row`, `.library-prompt-row`, and a newly-added `.library-conversation-row:focus`. Reuses `$ds-action-focus`; the bar is a shape cue, so it survives a monochrome terminal. Bundle regenerated. Pin `test_library_row_focus_cue_t31983.py` (8) asserts the focused row carries the bar and the selected row does not, at both sizes, and that the cue moves without a selection change. Renumbered from task-31976 after a remote id collision. Files: tldw_chatbook/css/components/_agentic_terminal.tcss, tldw_chatbook/css/screen_agentic_library.tcss (bundle), Tests/UI/test_library_row_focus_cue_t31983.py (new), Docs/User_Guide/library.md.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1991,7 +1991,7 @@ ConsoleRunLogModal {
     text-style: bold underline;
 }
 
-/* task-31976 (critique #6 P1, AC#4): the conversations canvas had NO
+/* task-31983 (critique #6 P1, AC#4): the conversations canvas had NO
    dedicated `:focus` rule, so a focused row fell back to the generic
    `*:focus{outline:solid}` and (like the media list) read the same as the
    `-selected` background. Same focus-only left-edge cue as
@@ -2042,7 +2042,7 @@ ConsoleRunLogModal {
    ``*:focus{outline:solid}`` (core/_reset.tcss). `outline: none` suppresses
    the generic fallback (never `outline: heavy`, which eats a compact row's
    label -- round-3 lesson).
-   task-31976 (critique #6 P1): `-selected` above uses this SAME background,
+   task-31983 (critique #6 P1): `-selected` above uses this SAME background,
    so focus and selection were indistinguishable -- the row the keyboard was
    ON looked exactly like the open row and arrow-nav read as a dead key. The
    `border-left: thick $ds-action-focus` bar is the focus-only, non-colour
@@ -2078,7 +2078,7 @@ ConsoleRunLogModal {
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Notes list now parks DOM focus on the first row and
-   Up/Down move it between rows. task-31976: same focus-only border-left cue
+   Up/Down move it between rows. task-31983: same focus-only border-left cue
    (padding compensates so the label holds), distinct from any selection. */
 .library-notes-row:focus {
     background: $ds-focus-bg;
@@ -2115,7 +2115,7 @@ ConsoleRunLogModal {
     color: $ds-text-primary;
 }
 
-/* task-31976: same focus-only border-left cue; this row is height 1, so the
+/* task-31983: same focus-only border-left cue; this row is height 1, so the
    padding swap (0 1 -> 0 1 0 0) keeps the single label cell intact. */
 .library-notes-folder-row:focus {
     background: $ds-focus-bg;
@@ -2210,7 +2210,7 @@ ConsoleRunLogModal {
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Prompts list now parks DOM focus on the first row
-   and Up/Down move it between rows. task-31976: same focus-only border-left
+   and Up/Down move it between rows. task-31983: same focus-only border-left
    cue (padding compensates so the label holds), distinct from selection. */
 .library-prompt-row:focus {
     background: $ds-focus-bg;

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1991,6 +1991,21 @@ ConsoleRunLogModal {
     text-style: bold underline;
 }
 
+/* task-31976 (critique #6 P1, AC#4): the conversations canvas had NO
+   dedicated `:focus` rule, so a focused row fell back to the generic
+   `*:focus{outline:solid}` and (like the media list) read the same as the
+   `-selected` background. Same focus-only left-edge cue as
+   `.library-media-row:focus` -- border replaces the 1-col left padding so
+   the label holds; `outline: none` suppresses the generic fallback. */
+.library-conversation-row:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
+    outline: none;
+}
+
 /* task-4025: the Trash view's rows share the media list's row contract
    verbatim (one comma-joined rule, not a forked copy) -- the trash rows
    keep their OWN class only so `_focus_library_list_entry`'s
@@ -2024,14 +2039,24 @@ ConsoleRunLogModal {
 /* task-2856 AC1/AC4: entering the Media list now parks real DOM focus on
    the first row and Up/Down move it between rows -- previously this class
    had no dedicated ``:focus`` rule at all and fell back to the generic
-   ``*:focus{outline:solid}`` (core/_reset.tcss). Same readable contract
-   ``.library-media-row-selected`` above already uses; `outline: none`
-   suppresses the generic fallback so this is the only cue (never
-   `outline: heavy`, which eats a compact row's label -- round-3 lesson). */
+   ``*:focus{outline:solid}`` (core/_reset.tcss). `outline: none` suppresses
+   the generic fallback (never `outline: heavy`, which eats a compact row's
+   label -- round-3 lesson).
+   task-31976 (critique #6 P1): `-selected` above uses this SAME background,
+   so focus and selection were indistinguishable -- the row the keyboard was
+   ON looked exactly like the open row and arrow-nav read as a dead key. The
+   `border-left: thick $ds-action-focus` bar is the focus-only, non-colour
+   cue `-selected` does NOT carry, so the two stay distinct even when a row
+   is both focused AND selected (arrow onto the open row). The left edge
+   replaces the 1-column left padding (`padding: 0 1` -> `0 1 0 0`), so the
+   label neither shifts nor is clipped and the row never jumps focus<->blur --
+   the house focus convention ($ds-control-edge comment, _variables.tcss). */
 .library-media-row:focus, .library-media-trash-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -2053,11 +2078,14 @@ ConsoleRunLogModal {
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Notes list now parks DOM focus on the first row and
-   Up/Down move it between rows. */
+   Up/Down move it between rows. task-31976: same focus-only border-left cue
+   (padding compensates so the label holds), distinct from any selection. */
 .library-notes-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -2087,10 +2115,14 @@ ConsoleRunLogModal {
     color: $ds-text-primary;
 }
 
+/* task-31976: same focus-only border-left cue; this row is height 1, so the
+   padding swap (0 1 -> 0 1 0 0) keeps the single label cell intact. */
 .library-notes-folder-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -2178,11 +2210,14 @@ ConsoleRunLogModal {
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Prompts list now parks DOM focus on the first row
-   and Up/Down move it between rows. */
+   and Up/Down move it between rows. task-31976: same focus-only border-left
+   cue (padding compensates so the label holds), distinct from selection. */
 .library-prompt-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -894,7 +894,7 @@ $ds-library-source-browser-width: 31;
     text-style: bold underline;
 }
 
-/* task-31976 (critique #6 P1, AC#4): the conversations canvas had NO
+/* task-31983 (critique #6 P1, AC#4): the conversations canvas had NO
    dedicated `:focus` rule, so a focused row fell back to the generic
    `*:focus{outline:solid}` and (like the media list) read the same as the
    `-selected` background. Same focus-only left-edge cue as
@@ -945,7 +945,7 @@ $ds-library-source-browser-width: 31;
    ``*:focus{outline:solid}`` (core/_reset.tcss). `outline: none` suppresses
    the generic fallback (never `outline: heavy`, which eats a compact row's
    label -- round-3 lesson).
-   task-31976 (critique #6 P1): `-selected` above uses this SAME background,
+   task-31983 (critique #6 P1): `-selected` above uses this SAME background,
    so focus and selection were indistinguishable -- the row the keyboard was
    ON looked exactly like the open row and arrow-nav read as a dead key. The
    `border-left: thick $ds-action-focus` bar is the focus-only, non-colour
@@ -981,7 +981,7 @@ $ds-library-source-browser-width: 31;
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Notes list now parks DOM focus on the first row and
-   Up/Down move it between rows. task-31976: same focus-only border-left cue
+   Up/Down move it between rows. task-31983: same focus-only border-left cue
    (padding compensates so the label holds), distinct from any selection. */
 .library-notes-row:focus {
     background: $ds-focus-bg;
@@ -1018,7 +1018,7 @@ $ds-library-source-browser-width: 31;
     color: $ds-text-primary;
 }
 
-/* task-31976: same focus-only border-left cue; this row is height 1, so the
+/* task-31983: same focus-only border-left cue; this row is height 1, so the
    padding swap (0 1 -> 0 1 0 0) keeps the single label cell intact. */
 .library-notes-folder-row:focus {
     background: $ds-focus-bg;
@@ -1107,7 +1107,7 @@ $ds-library-source-browser-width: 31;
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Prompts list now parks DOM focus on the first row
-   and Up/Down move it between rows. task-31976: same focus-only border-left
+   and Up/Down move it between rows. task-31983: same focus-only border-left
    cue (padding compensates so the label holds), distinct from selection. */
 .library-prompt-row:focus {
     background: $ds-focus-bg;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -894,6 +894,21 @@ $ds-library-source-browser-width: 31;
     text-style: bold underline;
 }
 
+/* task-31976 (critique #6 P1, AC#4): the conversations canvas had NO
+   dedicated `:focus` rule, so a focused row fell back to the generic
+   `*:focus{outline:solid}` and (like the media list) read the same as the
+   `-selected` background. Same focus-only left-edge cue as
+   `.library-media-row:focus` -- border replaces the 1-col left padding so
+   the label holds; `outline: none` suppresses the generic fallback. */
+.library-conversation-row:focus {
+    background: $ds-focus-bg;
+    color: $ds-focus-fg;
+    text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
+    outline: none;
+}
+
 /* task-4025: the Trash view's rows share the media list's row contract
    verbatim (one comma-joined rule, not a forked copy) -- the trash rows
    keep their OWN class only so `_focus_library_list_entry`'s
@@ -927,14 +942,24 @@ $ds-library-source-browser-width: 31;
 /* task-2856 AC1/AC4: entering the Media list now parks real DOM focus on
    the first row and Up/Down move it between rows -- previously this class
    had no dedicated ``:focus`` rule at all and fell back to the generic
-   ``*:focus{outline:solid}`` (core/_reset.tcss). Same readable contract
-   ``.library-media-row-selected`` above already uses; `outline: none`
-   suppresses the generic fallback so this is the only cue (never
-   `outline: heavy`, which eats a compact row's label -- round-3 lesson). */
+   ``*:focus{outline:solid}`` (core/_reset.tcss). `outline: none` suppresses
+   the generic fallback (never `outline: heavy`, which eats a compact row's
+   label -- round-3 lesson).
+   task-31976 (critique #6 P1): `-selected` above uses this SAME background,
+   so focus and selection were indistinguishable -- the row the keyboard was
+   ON looked exactly like the open row and arrow-nav read as a dead key. The
+   `border-left: thick $ds-action-focus` bar is the focus-only, non-colour
+   cue `-selected` does NOT carry, so the two stay distinct even when a row
+   is both focused AND selected (arrow onto the open row). The left edge
+   replaces the 1-column left padding (`padding: 0 1` -> `0 1 0 0`), so the
+   label neither shifts nor is clipped and the row never jumps focus<->blur --
+   the house focus convention ($ds-control-edge comment, _variables.tcss). */
 .library-media-row:focus, .library-media-trash-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -956,11 +981,14 @@ $ds-library-source-browser-width: 31;
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Notes list now parks DOM focus on the first row and
-   Up/Down move it between rows. */
+   Up/Down move it between rows. task-31976: same focus-only border-left cue
+   (padding compensates so the label holds), distinct from any selection. */
 .library-notes-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -990,10 +1018,14 @@ $ds-library-source-browser-width: 31;
     color: $ds-text-primary;
 }
 
+/* task-31976: same focus-only border-left cue; this row is height 1, so the
+   padding swap (0 1 -> 0 1 0 0) keeps the single label cell intact. */
 .library-notes-folder-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 
@@ -1075,11 +1107,14 @@ $ds-library-source-browser-width: 31;
 
 /* task-2856 AC1/AC4: same readable-focus contract as .library-media-row:focus
    above -- entering the Prompts list now parks DOM focus on the first row
-   and Up/Down move it between rows. */
+   and Up/Down move it between rows. task-31976: same focus-only border-left
+   cue (padding compensates so the label holds), distinct from selection. */
 .library-prompt-row:focus {
     background: $ds-focus-bg;
     color: $ds-focus-fg;
     text-style: bold underline;
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
     outline: none;
 }
 


### PR DESCRIPTION
## Summary

Critique #6 fix wave, lead task (task-31983, P1): keyboard focus on a Library list row was visually indistinguishable from selection.

Root cause: `.library-media-row:focus` and `.library-media-row-selected` applied the identical treatment in `_agentic_terminal.tcss` (`background: $ds-focus-bg; color: $ds-focus-fg; text-style: bold underline`), so the row the keyboard was on looked exactly like the selected/open row — arrow-key navigation read as a dead key in a keyboard-first product.

Fix: a focus-only `border-left: thick $ds-action-focus` cursor bar (a filled `█` left edge) that `-selected` does not carry, so the bar is the keyboard cursor and the background is selection. The row padding changes `0 1` → `0 1 0 0` so the bar occupies the column the left pad vacated — the content column is unchanged between blurred and focused, so the label never shifts or clips, and no `outline: heavy` (which ate the compact row's label in a prior attempt). Applied uniformly to the media, trash, notes, notes-folder and prompt row rules, plus a newly added `.library-conversation-row:focus` (that canvas had no focus rule before). No new token; reuses `$ds-action-focus`. The bundle is regenerated.

The bar distinguishes by shape, not colour, so it survives a monochrome terminal and satisfies the brand's "color is never the only carrier of meaning."

## Verification

Task review (Opus): Approved, no Important or Minor issues. The reviewer verified the box model keeps the content column fixed (border replaces the vacated pad, adds no column), that a row which is both focused and selected still paints the bar, that the new conversation selector matches real focusable rows, and that the pin is red-first against the identical-style CSS.

| run | result |
|---|---|
| `Tests/UI/test_library_row_focus_cue_t31976.py` (new pin) | 8 passed |
| `Tests/UI/test_library_shell.py -k move_library_list_row_focus` | 2 passed |
| `Tests/UI/test_library_multiselect_media.py` | 103 passed |
| `Tests/UI/test_non_obscuring_focus_contract.py` + `test_compact_focus_outline_render.py` | 102 passed, 2 failed — both pre-existing on base, unrelated native-component contract checks |

CSS bundle reproduces from source (`check_bundle_sync` exit 0); preflight green; no new logger call sites; `Docs/User_Guide/library.md` carries a Verified-against stamp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Library list keyboard focus being invisible against selection (task-31983) — `.library-media-row:focus` and `.library-media-row-selected` shared identical styling, so arrow-key navigation looked like a dead key.

- Adds a focus-only left-edge bar (`border-left: thick $ds-action-focus`) that the `-selected` state never carries; the cue is a shape, so it reads even in a monochrome terminal.
- Swaps row padding `0 1` → `0 1 0 0` so the bar occupies the column the left pad vacated — the label never shifts or clips (no `outline: heavy` regression).
- Applies the cue to the media, trash, notes, notes-folder, and prompt rows, and adds `.library-conversation-row:focus` where that canvas previously had none.
- Adds `test_library_row_focus_cue_t31983.py` (8 tests) asserting the bar paints at 235x52 and 100x30, follows focus onto the selected row without changing selection, and that sibling `-selected` rules never carry it.

<sup>Written for commit 36ea37f4e318f6f35b684a122556162feaebfe96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2493?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

