### PR TITLE
fix(library-media): honest undo count + fault-Retry recovery step (task-31982)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -220,7 +220,9 @@ the list happens to show now, so a stale page can never be the reason
 Undo is unavailable. If a restore itself fails, the receipt becomes
 "✗ undo failed · n of m · \<reason\>" and "Undo" becomes "Retry undo",
 retrying only the items still outstanding; a later full success clears
-the receipt as normal. "Undo" is the at-point convenience; the durable way
+the receipt as normal. A restore that comes back with nothing usable
+(not just one that errors) counts toward that "n of m" and stays in the
+retry set, so the receipt total never understates what still needs redoing. "Undo" is the at-point convenience; the durable way
 back is the **Trash view** the receipt points at (see "Media Trash"
 below), which lists every deleted item — including ones from earlier
 sessions — and restores them per item. (Re-importing the same file from
@@ -284,7 +286,7 @@ list and dropped both while the confirmation was armed).*
 | "type: All types" | Opens one bounded keyboard list containing the complete type set, with ✓ on the active choice. "All types" means no filter; a stored type literally named "All" remains a separate selectable value. Press Escape (or pick the current choice) to cancel. |
 | "sort: Newest" | Opens the same kind of bounded keyboard list with all four orders (Newest, Oldest, Title A-Z, Title Z-A) fully visible and ✓ on the active one. Escape cancels. |
 | "Previous" / "Next" | Moves through exact 20-item pages after the active query, type, and sort are applied. The final page may contain fewer rows; disabled buttons explain why they cannot move. With only one page, the controls do not render at all — just the item range. |
-| "Retry" | Repeats the failed load. When a load fails, the reason and this Retry sit together in one bordered callout above the rows ("Couldn't load page 1 · database is locked"; red for a hard failure, amber for a timeout) — that is the only Retry on screen, and it also reloads the type list when that is what failed. The reason is the failure's own words only for an operating-system or database error; anything else is named by the kind of failure it is ("the connection failed", "the database could not be read", or "an unexpected error" when it is none of those), so a private path — and the exception's own text — never reaches the screen. If retained rows may be out of date, rows stay open (a row press is a read, never disabled by staleness) but Select, Export, Delete, sort, and Select all stay disabled with a reason until recovery succeeds. A Retry that fails again shows "Couldn't retry · \<reason\>" so a second failed attempt reads differently from the first, instead of repeating the unchanged staleness copy. |
+| "Retry" | Repeats the failed load. When a load fails, the reason and this Retry sit together in one bordered callout above the rows ("Couldn't load page 1 · database is locked"; red for a hard failure, amber for a timeout) — that is the only Retry on screen, and it also reloads the type list when that is what failed. The reason is the failure's own words only for an operating-system or database error; anything else is named by the kind of failure it is ("the connection failed", "the database could not be read", or "an unexpected error" when it is none of those), so a private path — and the exception's own text — never reaches the screen. If retained rows may be out of date, rows stay open (a row press is a read, never disabled by staleness) but Select, Export, Delete, sort, and Select all stay disabled with a reason until recovery succeeds. A Retry that fails again shows "Couldn't retry · \<reason\>" so a second failed attempt reads differently from the first, instead of repeating the unchanged staleness copy. When the fault callout itself fails the same way on a consecutive Retry, the message stops repeating one sentence and names the recovery step — "Couldn't load page 1 · database is locked · reopen Chatbook to reconnect to the media database" — so a persistent fault points somewhere rather than looping. |
 | "Export…" / "Select" | The shared grammar above; Export… is scoped to the active type filter. |
 | "Review these" | Pins the whole filtered list as an ordered review set (see "Review sets" below). Like "Export…" — the other action that acts on the whole filtered list — it renders as "○ Review these" with the failure on its tooltip when the first load failed with nothing behind it, and stays live over rows a later failure retained. |
 | "Trash" | Opens the Trash view — every deleted media item, restorable per item (see "Media Trash" above). Hidden while selecting, like "Export…". It is never disabled by a failed Media load — it is the route to your deleted items exactly when the list is unhappy — whereas "Export…" and "Review these" render as "○ Export…" / "○ Review these" with the reason on their tooltip when the list has nothing to select. |
@@ -325,6 +327,15 @@ same row and the $error border, and it kept that border across a Retry press;
 while "Trash" stayed live. This SUPERSEDES the class-name disclosure recorded
 in the 2026-09-05 stamp below — a non-OS/database failure now reads as the
 kind of failure it is, never as `ValueError`.)*
+
+*Verified against fix/media-crit6-faultscope — 2026-09-07 (task-31982: the
+undo receipt now counts a restore that returns an unexpected shape as a
+still-failed id — "1 of 2" with the id retryable, not a silent clean undo;
+the Media fault callout, on the same reason failing a consecutive Retry,
+appends "· reopen Chatbook to reconnect to the media database" instead of
+repeating; and the facet (media-types) read and the row read are confirmed
+independent — a facet-only failure leaves Export/Review/Select/Trash live
+over the rows that loaded. Confirmed against the product code and its tests.)*
 
 *Verified against fix/media-wave5-g @ c9b3f3a77 — 2026-09-05 (task-31632:
 launched with a scratch profile whose media DB path is a directory; Library ▸

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -2518,6 +2518,98 @@ async def test_media_facet_failure_paints_the_same_callout():
 
 
 @pytest.mark.asyncio
+async def test_repeated_media_load_failure_names_the_reopen_recovery():
+    """task-31982 AC#2: a second consecutive failed Retry stops repeating.
+
+    The critique's residue: the callout's Retry re-issued on the same failed
+    path and repainted the identical sentence with no next step. When the
+    same reason recurs on a consecutive Retry the message must name the
+    recovery action instead -- reopen Chatbook to reconnect to the store.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        controller = screen._library_media_browse_controller
+        calls = await _force_media_page_failure(
+            host, screen, pilot, sqlite3.OperationalError("database is locked")
+        )
+
+        copy = screen.query_one("#library-media-load-failure-copy", Static)
+        first = " ".join(_painted(host, copy.region).split())
+        # The FIRST failure is silent about the recovery step -- one honest
+        # sentence, exactly as before.
+        assert first == "Couldn't load page 1 · database is locked", first
+
+        screen.query_one("#library-media-load-failure").query_one(
+            "#library-media-retry", Button
+        ).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: len(calls) == 2,
+            message="The callout's Retry never re-issued.",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: not controller.loading,
+            message="The retried request never settled.",
+        )
+        await pilot.pause()
+
+        copy = screen.query_one("#library-media-load-failure-copy", Static)
+        second = " ".join(_painted(host, copy.region).split())
+        assert second.startswith("Couldn't load page 1 · database is locked"), second
+        assert "reopen Chatbook to reconnect to the media database" in second, second
+
+
+@pytest.mark.asyncio
+async def test_facet_only_failure_leaves_the_row_supported_actions_live():
+    """task-31982 AC#1/#4: the facet read and the row read are independent.
+
+    ``list_library_media_types`` and ``search_media`` are separate queries on
+    separate worker groups with independent failure fences, so a facet
+    failure over a healthy page must NOT disable the actions the row data
+    supports -- Export, Review, Select and Trash stay live because their own
+    read succeeded.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        controller = screen._library_media_browse_controller
+
+        async def _fails(**_kwargs):
+            raise sqlite3.OperationalError("database is locked")
+
+        host.app_instance.media_reading_scope_service.list_library_media_types = _fails
+        screen._request_library_media_facets()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                controller.facet_failure is not None
+                and not controller.facet_loading
+            ),
+            message="The forced Media facet failure never settled.",
+        )
+        await pilot.pause()
+
+        # The page read succeeded, its rows are retained, and the "nothing to
+        # select" predicate the whole-list gate reads stays False.
+        assert controller.page_failure is None
+        assert len(controller.retained_items) == 2
+        assert not screen._library_media_list_unselectable()
+
+        # ...so every action the row data supports stays live and un-gated.
+        for widget_id, label in (
+            ("#library-media-export", "Export…"),
+            ("#library-media-review", "Review these"),
+            ("#library-media-trash-open", "Trash"),
+            ("#library-media-select-toggle", "Select"),
+        ):
+            button = screen.query_one(widget_id, Button)
+            assert not button.disabled, widget_id
+            assert str(button.label) == label, widget_id
+
+
+@pytest.mark.asyncio
 async def test_media_failure_callout_tint_follows_the_severity():
     """task-31632 AC#1: a timeout and a hard failure do not paint alike."""
     host = _host()

--- a/Tests/UI/test_library_media_side_by_side.py
+++ b/Tests/UI/test_library_media_side_by_side.py
@@ -1345,6 +1345,82 @@ class ReversibleLibraryMediaScopeService(StaticLibraryMediaScopeService):
         return dict(item)
 
 
+class NonMappingRestoreScopeService(ReversibleLibraryMediaScopeService):
+    """An Undo whose restore returns an unexpected shape for ONE id.
+
+    task-31982 AC#3: ``restore_media_item`` here neither raises nor returns a
+    usable Mapping for ``non_mapping_backing_id`` -- it returns ``True``. The
+    undo handler used to count that as neither success nor failure, so the
+    receipt undercounted and the still-failed id dropped from the retry set.
+    """
+
+    def __init__(self, media_items, *, non_mapping_backing_id: int):
+        super().__init__(media_items)
+        self._non_mapping_backing_id = non_mapping_backing_id
+
+    async def restore_media_item(self, *, media_id, **kwargs):
+        item = self.trashed.pop(media_id, None)
+        if media_id == self._non_mapping_backing_id:
+            return True  # unexpected shape: not a Mapping, no exception
+        if item is not None:
+            self.media_items = [*self.media_items, item]
+        return dict(item) if item is not None else {}
+
+
+@pytest.mark.asyncio
+async def test_bulk_undo_counts_a_non_mapping_restore_as_a_still_failed_id() -> None:
+    """task-31982 AC#3: a restore that returns a non-Mapping is a failure.
+
+    Two items are deleted; on Undo the write layer restores one (a Mapping)
+    and returns ``True`` for the other. The receipt must read "1 of 2" with
+    the non-Mapping id still named (retryable), not silently drop it and
+    claim a clean undo.
+    """
+    app = _build_media_test_app()
+    service = NonMappingRestoreScopeService(_two_media_items(), non_mapping_backing_id=1)
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    app.media_reading_scope_service = service
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=NARROW_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-select-toggle", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-delete-selected")
+        screen.query_one("#library-media-select-all", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query_one(
+                "#library-media-delete-selected", Button
+            ).disabled,
+            message="Select all never enabled bulk delete.",
+        )
+        screen.query_one("#library-media-delete-selected", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-bulk-delete-confirm")
+        screen.query_one("#library-media-bulk-delete-confirm", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_media_bulk_delete_in_flight
+                and len(screen._library_media_delete_receipt_ids) == 2
+            ),
+            message="The two-item bulk delete never settled on its receipt.",
+        )
+        await pilot.pause()
+
+        screen.query_one("#library-media-bulk-delete-undo", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                not screen._library_media_bulk_delete_in_flight
+                and screen._library_media_delete_receipt_undo_failure != ""
+            ),
+            message="The undo never reported its non-Mapping failure.",
+        )
+
+        assert screen._library_media_delete_receipt_undo_failure.startswith("1 of 2 ")
+        assert screen._library_media_delete_receipt_ids == ("local:media:1",)
+
+
 @pytest.mark.asyncio
 async def test_full_success_bulk_delete_focuses_undo_and_enter_restores() -> None:
     """task-31220 AC: the confirmation promises "You can undo right away", so

--- a/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
+++ b/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31982
 title: 'Library media: a faulting read cascades and its Retry offers no recovery path'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-07 22:48'
+updated_date: '2026-09-08 00:12'
 labels:
   - library
   - media
@@ -20,12 +21,34 @@ Critique #6 P1, adjudicated from Assessment A's undo P0. The undo handler itself
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A media read failure is scoped to the failing surface; Export, Select, Review, facet counts and Trash remain usable when their own reads succeed
-- [ ] #2 The fault-state Retry either reconnects or, when it cannot, states the recovery action (e.g. Reopen Chatbook to reconnect to the media database) instead of repeating the same sentence
-- [ ] #3 The bulk-undo receipt count reflects rows the write layer actually committed, including a restore that returns an unexpected shape
-- [ ] #4 A test reproduces a faulting media read and asserts the independent controls stay live
+- [x] #1 A media read failure is scoped to the failing surface; Export, Select, Review, facet counts and Trash remain usable when their own reads succeed
+- [x] #2 The fault-state Retry either reconnects or, when it cannot, states the recovery action (e.g. Reopen Chatbook to reconnect to the media database) instead of repeating the same sentence
+- [x] #3 The bulk-undo receipt count reflects rows the write layer actually committed, including a restore that returns an unexpected shape
+- [x] #4 A test reproduces a faulting media read and asserts the independent controls stay live
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Part A (AC#3): in `_undo_library_media_bulk_delete`, count a restore that returns a non-Mapping (no exception) as a failure, not as neither. TDD with a fake `restore_media_item` returning a non-Mapping for one id.
+2. Part B (AC#2): make the Media fault callout name a recovery step when the same reason recurs on a consecutive Retry, instead of repeating one sentence. TDD with two consecutive failed retries.
+3. Part C (AC#1/#4): investigate whether the facet read and the row read are independent, then RULE; pin the ruling with a test.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Three-part fault-scope residue from critique #6 P1. The undo handler was already correct; this is the deterministic remainder.
+
+- **Part A (AC#3)** — `_undo_library_media_bulk_delete` (`UI/Screens/library_screen.py`): a restore that returned a non-Mapping was counted as neither success nor failure, so the `N of M` receipt undercounted and the id silently dropped from the retry set. Added an `else` branch that treats it as a failure (`"restore returned no record"`), keeping the id retryable and the total honest.
+- **Part B (AC#2)** — `UI/Library_Modules/library_media_browse_controller.py`: added `_page_fault_reason`/`_facet_fault_reason` trackers (kept across Retries, since `begin()` clears `page_failure` each request) and a `repeated` flag on `_raised_failure`. When the same reason recurs consecutively, the callout appends `· reopen Chatbook to reconnect to the media database` (new `_REOPEN_RECOVERY`) instead of repeating; no raw exception text (PR G privacy rule). Applied to both the page and facet fences.
+- **Part C (AC#1/#4) — RULING (branch 1):** the facet read (`list_library_media_types`, `_FACET_WORKER_GROUP`) and the row read (`search_media`, `_PAGE_WORKER_GROUP`) are independent queries on separate workers with independent failure state (`page_failure`/`facet_failure`, each cleared by its own success). The whole-list gate is **already** scoped (task-31635 item 6 / task-31960): `_gate_failed_action` fires only on `failure AND list_unselectable` (= failure with no retained rows), Select gates on `rendered_count == 0`, Trash never gates. So a facet-only failure over a healthy page leaves Export/Review/Select/Trash live. AC#1 was therefore already satisfied by shipped code; the residue was the missing pin, added as `test_facet_only_failure_leaves_the_row_supported_actions_live`. **AC#1 text not amended** (branch 2 was not taken).
+
+Tests (TDD, red→green): `Tests/UI/test_library_media_side_by_side.py::test_bulk_undo_counts_a_non_mapping_restore_as_a_still_failed_id` (Part A, + `NonMappingRestoreScopeService`); `Tests/UI/test_library_media_render_fixes.py::{test_repeated_media_load_failure_names_the_reopen_recovery, test_facet_only_failure_leaves_the_row_supported_actions_live}` (Parts B, C). Regression: the three affected files ran whole → 216 passed. Inventory unchanged; preflight passes.
+
+Modified files: `tldw_chatbook/UI/Screens/library_screen.py`, `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py`, `Tests/UI/test_library_media_side_by_side.py`, `Tests/UI/test_library_media_render_fixes.py`, `Docs/User_Guide/library/media-and-conversations.md`.
 
 ## Renumbering provenance
 
 Filed as TASK-31978 during critique #6's fix wave; renumbered to TASK-31982 because a concurrent session landed its own TASK-31978 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
+++ b/backlog/tasks/task-31982 - Library-media-a-faulting-read-cascades-and-its-Retry-offers-no-recovery-path.md
@@ -48,7 +48,8 @@ Tests (TDD, red→green): `Tests/UI/test_library_media_side_by_side.py::test_bul
 
 Modified files: `tldw_chatbook/UI/Screens/library_screen.py`, `tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py`, `Tests/UI/test_library_media_side_by_side.py`, `Tests/UI/test_library_media_render_fixes.py`, `Docs/User_Guide/library/media-and-conversations.md`.
 
+<!-- SECTION:NOTES:END -->
+
 ## Renumbering provenance
 
 Filed as TASK-31978 during critique #6's fix wave; renumbered to TASK-31982 because a concurrent session landed its own TASK-31978 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.
-<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_browse_controller.py
@@ -69,6 +69,13 @@ _CLASS_REASONS: tuple[tuple[type[BaseException], str], ...] = (
     (sqlite3.Error, _DATABASE_UNREADABLE_REASON),
 )
 _UNMAPPED_REASON = "an unexpected error"
+# task-31982 AC#2: the recovery step a repeated failure names instead of
+# repeating its one sentence. A media read faulting the same way on a
+# consecutive Retry is a persistent fault the in-callout Retry cannot clear;
+# the only lever left is reconnecting to the store. Appended as its own
+# ``·`` clause so the callout grammar ("what · why") is unchanged. It carries
+# no exception text (PR G's privacy rule).
+_REOPEN_RECOVERY = "reopen Chatbook to reconnect to the media database"
 # Qodo PR G finding 3: an OSError/sqlite3 message is the reader's own words
 # (kept, unlike other exceptions -- see below), but that text can embed a
 # database or filesystem path. Match POSIX absolute (``/a/b``), home-relative
@@ -179,11 +186,24 @@ def _load_failure(
     )
 
 
-def _raised_failure(what: str, exc: BaseException) -> DestinationRecoveryState:
-    """Name a raised load failure through the shared reason mapping."""
+def _raised_failure(
+    what: str, exc: BaseException, *, repeated: bool = False
+) -> DestinationRecoveryState:
+    """Name a raised load failure through the shared reason mapping.
+
+    Args:
+        what: What could not be loaded, as a clause.
+        exc: The exception the failed request raised.
+        repeated: True when this same reason has just recurred on a
+            consecutive Retry (task-31982 AC#2). The failure then names the
+            reopen recovery step instead of repeating its one sentence.
+    """
+    reason = _retry_failure_reason(exc)
+    if repeated:
+        reason = f"{reason} · {_REOPEN_RECOVERY}"
     return _load_failure(
         what,
-        _retry_failure_reason(exc),
+        reason,
         timed_out=isinstance(exc, TimeoutError),
     )
 
@@ -227,6 +247,13 @@ class LibraryMediaBrowseController:
         # the one the canvas paints.
         self.page_failure: DestinationRecoveryState | None = None
         self.facet_failure: DestinationRecoveryState | None = None
+        # task-31982 AC#2: the reason each fence last failed with, kept
+        # across Retries (``begin`` clears ``page_failure`` on every request,
+        # so it cannot tell a repeat from a first failure). A consecutive
+        # failure with the SAME reason names the reopen recovery step; a
+        # success on either fence clears its own tracker.
+        self._page_fault_reason = ""
+        self._facet_fault_reason = ""
         self._page_generation = 0
 
         self.type_options: tuple[str, ...] = ()
@@ -419,7 +446,12 @@ class LibraryMediaBrowseController:
             self.inflight_scope = None
             if self.freshness != "stale":
                 self.error_copy, failure_what = self._failure_copy(scope)
-                self.page_failure = _raised_failure(failure_what, exc)
+                reason = _retry_failure_reason(exc)
+                repeated = reason == self._page_fault_reason
+                self._page_fault_reason = reason
+                self.page_failure = _raised_failure(
+                    failure_what, exc, repeated=repeated
+                )
             else:
                 # task-31220: on a stale page the stale copy is the ONLY
                 # thing shown, and leaving it untouched is what made Retry
@@ -446,6 +478,7 @@ class LibraryMediaBrowseController:
         self.inflight_scope = None
         self.error_copy = ""
         self.page_failure = None
+        self._page_fault_reason = ""
         self.stale_copy = ""
         self.stale_reason = ""
         self._sync(focus_identity)
@@ -627,7 +660,10 @@ class LibraryMediaBrowseController:
             )
             self.facet_loading = False
             self.facet_error_copy = _FACET_ERROR
-            self.facet_failure = _raised_failure(_FACET_WHAT, exc)
+            reason = _retry_failure_reason(exc)
+            repeated = reason == self._facet_fault_reason
+            self._facet_fault_reason = reason
+            self.facet_failure = _raised_failure(_FACET_WHAT, exc, repeated=repeated)
             self._sync(None)
             return
         if (
@@ -640,6 +676,7 @@ class LibraryMediaBrowseController:
         self.facet_loading = False
         self.facet_error_copy = ""
         self.facet_failure = None
+        self._facet_fault_reason = ""
         self._sync(None)
 
     def invalidate_facets(self, *, fingerprint: str = "") -> int:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -24555,6 +24555,16 @@ class LibraryScreen(BaseAppScreen):
                             restored_items.append(
                                 self._library_media_mutation_summary(media_id, result)
                             )
+                        else:
+                            # task-31982 AC#3: a restore that returned an
+                            # unexpected shape (not a Mapping, no exception)
+                            # committed nothing usable. Counting it as
+                            # neither success nor failure let the receipt
+                            # total drift and dropped the id from the
+                            # retryable set -- it is a failure, mapped like
+                            # the unavailable path so the count stays honest.
+                            failed.append(media_id)
+                            failure_reason = failure_reason or "restore returned no record"
                     except Exception as exc:
                         logger.warning(
                             "Failed to restore a Library media item in bulk-delete "


### PR DESCRIPTION
## Summary

Critique #6 fix wave (task-31982, P1). Adjudicated from a critique where a bulk-delete Undo failed catastrophically under a real media-DB fault while another run got a clean undo on the same code. The undo handler was traced and is correct, so this addresses the deterministic residue, in three parts:

- **Honest undo count (Part A).** In `_undo_library_media_bulk_delete`, a `restore_media_item` that returned a non-`Mapping` (rather than raising) was counted as neither success nor failure, so the `✗ undo failed · N of M` receipt undercounted and the still-failed id was not retryable. A restore that yields no usable record now counts as a failure with a reason; the rail count still increments only by genuinely restored rows.
- **A Retry that names a way out (Part B).** A faulting read's Retry repeated one sentence forever. After a second consecutive same-reason fault on a fence, the message appends `reopen Chatbook to reconnect to the media database`, reusing the redacted reason vocabulary — no raw exception text, and never on the first failure.
- **The cascade was already scoped (Part C).** The claim that a failed read disabled independent controls was investigated: the whole-list gate fires only on a failure with no retained rows (`_gate_failed_action` requires `failure AND list_unselectable`), and the facet read and row read are independent. When the facet read fails but rows are retained, Export/Select/Review/Trash stay live. AC#1 was already satisfied by shipped code (task-31635/31960); this adds the missing pin rather than new gating, so the "cascade" the critique saw was the whole database being down, not a scoping bug.

## Verification

Task review (Opus): Approved, no Important or Minor code issues. The reviewer independently traced the gate predicate and confirmed a facet-only failure leaves the row-supported actions live, that Part B cannot false-trigger on a first failure or leak exception text, and that the non-Mapping branch cannot double-count or crash.

| run | result |
|---|---|
| `test_library_media_browse_controller.py` + `test_library_media_render_fixes.py` + `test_library_media_side_by_side.py` (whole) | 216 passed |
| new pins (non-Mapping count, reopen-step, facet-only-failure) | pass by name, red first for A and B |

Diagnostic inventory unchanged (no new logger call sites); preflight green; no CSS. Closes task-31982.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the bulk-delete Undo receipt to count restores that return no usable record as failures, and makes the Media fault callout name a recovery step after a consecutive same-reason Retry. Adds a test pinning that a facet-only failure leaves row-supported actions live; that behavior was already correct.

**Bug Fixes**
- A restore that returns a non-Mapping now counts as a failure, keeping the undo count honest and the id retryable.
- On a second consecutive failure with the same reason, the fault callout appends "· reopen Chatbook to reconnect to the media database" instead of repeating the same sentence.

<sup>Written for commit b61865bfd91a5f3d96ea75ecefb03c8ab2e4da7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

