### PR TITLE
Fix fresh-install startup with shared-writable data ancestors

### DIFF
--- a/.github/workflows/task-32011-linux-storage-evidence.yml
+++ b/.github/workflows/task-32011-linux-storage-evidence.yml
@@ -3,14 +3,16 @@ name: TASK-32011 one-off Linux storage evidence
 on:
   pull_request:
     branches: [dev]
-    types: [labeled]
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
 
 jobs:
   linux-storage:
-    if: github.event.label.name == 'task-32011-linux-evidence'
+    if: >-
+      contains(github.event.pull_request.labels.*.name, 'task-32011-linux-evidence') &&
+      (github.event.action == 'synchronize' || github.event.label.name == 'task-32011-linux-evidence')
     name: Linux storage - Python ${{ matrix.python }}
     runs-on: ubuntu-24.04
     timeout-minutes: 20
@@ -42,6 +44,8 @@ jobs:
         run: |
           python -m pytest \
             Tests/test_database_path_privacy.py \
+            Tests/test_data_root_concurrency.py \
+            Tests/test_prompt_dump_storage.py \
             Tests/test_user_data_dir_isolation.py \
             Tests/test_config_private_bootstrap.py \
             Tests/Utils/test_private_paths.py \

--- a/.github/workflows/task-32011-linux-storage-evidence.yml
+++ b/.github/workflows/task-32011-linux-storage-evidence.yml
@@ -1,0 +1,96 @@
+name: TASK-32011 one-off Linux storage evidence
+
+on:
+  pull_request:
+    branches: [dev]
+    types: [labeled]
+
+permissions:
+  contents: read
+
+jobs:
+  linux-storage:
+    if: github.event.label.name == 'task-32011-linux-evidence'
+    name: Linux storage - Python ${{ matrix.python }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        python: ['3.11', '3.12', '3.13']
+    steps:
+      - name: Check out the exact PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: Install core application and test dependencies
+        run: python -m pip install -e '.[dev]'
+
+      - name: Record tested revision and platform
+        run: |
+          git rev-parse HEAD
+          python --version
+          uname -a
+
+      - name: Run storage, bootstrap, Settings, and logging regressions
+        run: |
+          python -m pytest \
+            Tests/test_database_path_privacy.py \
+            Tests/test_user_data_dir_isolation.py \
+            Tests/test_config_private_bootstrap.py \
+            Tests/Utils/test_private_paths.py \
+            Tests/DB/test_private_sqlite.py \
+            Tests/UI/test_profile_owned_settings_paths.py \
+            Tests/test_logging_private_files.py \
+            --timeout=60 --junitxml="$RUNNER_TEMP/storage-tests.xml" -q
+
+      - name: Prove installed CLI bootstrap under shared-writable ancestors
+        run: |
+          python - <<'PY'
+          import os
+          from pathlib import Path
+          import shutil
+          import stat
+          import subprocess
+          import sys
+          import tempfile
+
+          assert sys.platform == "linux"
+          cli = shutil.which("tldw-cli")
+          assert cli is not None
+          with tempfile.TemporaryDirectory(prefix="tldw-fresh-install-") as tmp:
+              home = Path(tmp) / "home"
+              share = home / ".local/share"
+              share.mkdir(parents=True)
+              share.chmod(0o775)
+              env = dict(os.environ, HOME=str(home), XDG_CONFIG_HOME=str(home / ".config"))
+              env.pop("TLDW_CONFIG_PATH", None)
+              env.pop("XDG_DATA_HOME", None)
+              for mode in (0o775, 0o755):
+                  share.chmod(mode)
+                  result = subprocess.run(
+                      [cli, "--help"], env=env, capture_output=True,
+                      text=True, check=False, timeout=60,
+                  )
+                  assert result.returncode == 0, result.stderr
+                  assert "usage:" in result.stdout.lower(), result.stdout
+                  fallback = home / ".tldw_cli-data"
+                  assert stat.S_IMODE(fallback.stat().st_mode) == 0o700
+                  assert stat.S_IMODE(share.stat().st_mode) == mode
+                  assert not (share / "tldw_cli").exists()
+                  print(f"Installed CLI passed with ancestor mode {mode:04o}; private fallback retained")
+          PY
+
+      - name: Retain test evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: task-32011-linux-python-${{ matrix.python }}
+          path: ${{ runner.temp }}/storage-tests.xml
+          if-no-files-found: warn

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -11433,6 +11433,12 @@
           "kind": "open_private_text_append_stream",
           "method": "open_private_text_append_stream",
           "scope": "_config_interprocess_lock"
+        },
+        {
+          "digest": "19f05166171daf75",
+          "kind": "open_private_text_append_stream",
+          "method": "open_private_text_append_stream",
+          "scope": "_default_data_root_lock"
         }
       ]
     }

--- a/Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md
+++ b/Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md
@@ -1,0 +1,50 @@
+# Fresh-install data root recovery (TASK-32011)
+
+The authorized outcome is an application fix for the reported fresh-install
+failure, requiring no reporter response or manual permission repair.
+
+ADR required: yes
+ADR path: backlog/decisions/127-fresh-install-private-data-root-recovery.md
+Reason: Durable selection of an alternate default storage location under ADR-029.
+
+## Design
+
+Add `_secure_default_data_dir()` beside the existing conventional-path function
+in `config.py`. Keep `_default_base_data_dir()` pure and compatible with existing
+callers. `get_user_data_dir()` delegates only its default branch to the new
+resolver; configured roots and profile child hardening are unchanged.
+Share a read-only `_selected_default_base_data_dir()` helper with Settings storage
+diagnostics, so displaying the active path honors the durable fallback without
+creating directories. This integration requirement was found during review and
+added to TASK-32011 acceptance criteria before changing the Settings implementation.
+
+1. Derive the conventional root from the existing HOME-aware function and the
+   fallback `~/.tldw_cli-data` from that same home.
+2. If the fallback entry exists, refuse if the conventional entry also exists;
+   otherwise secure/reuse the fallback. Presence pins selection across processes.
+3. Otherwise secure/create the conventional root normally.
+4. Only on `UNSAFE_PARENT/shared_writable_parent`, probe the conventional entry.
+   If absent, secure/create the fallback with the unchanged private-path helper.
+   Existing entries and probe errors cannot trigger a fresh empty profile.
+5. Append and secure the same user-profile child as before.
+
+No changes to the directory guard, config-file selection, account/group trust,
+database formats, profile naming, explicit storage settings, or unrelated files.
+Two existing default roots are an explicit conflict, never an implicit migration.
+
+## Implementation and verification plan
+
+1. Write regression tests in `Tests/test_database_path_privacy.py`: conventional
+   fresh bootstrap under permissive umask; writable `.local`/`share`; fallback
+   private modes and persistence; existing conventional and ambiguous roots;
+   unsafe home, links, explicit overrides, and unrelated failures.
+2. Add a fresh-process config-import test using an isolated HOME/config. Persist
+   a SQLite row through the private SQLite owner, restart, repair ancestor modes,
+   and prove the same data/root is retained.
+3. Run the new tests red against the unchanged resolver.
+4. Implement the helper and default-branch delegation, then run focused tests.
+5. Run existing config/private-path/private-SQLite/profile-isolation checks and
+   relevant architecture checks. Run Ruff and formatting checks on changed code;
+   preserve unrelated formatting in the large config module.
+6. Document the fallback and conflicts in README, self-review the diff, and record
+   exact test evidence in TASK-32011. No full-suite sweep is authorized.

--- a/Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md
+++ b/Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md
@@ -48,3 +48,19 @@ Two existing default roots are an explicit conflict, never an implicit migration
    preserve unrelated formatting in the large config module.
 6. Document the fallback and conflicts in README, self-review the diff, and record
    exact test evidence in TASK-32011. No full-suite sweep is authorized.
+
+## Qodo review follow-up
+
+1. Rebase on latest dev, then add a deterministic real two-process regression for
+   a permission repair between conventional-root refusal and fallback creation.
+2. Hold a private HOME-level interprocess lock across selection, root creation,
+   and profile-child creation. Preserve the read-only Settings helper.
+3. Validate probe paths without resolving, share the fallback directory name,
+   and use the SQLite connection transaction context in the subprocess test.
+4. Route explicitly named prompt exports through the selected runtime base,
+   update the compatibility-consumer architecture assertion, and cover custom and
+   fallback roots with actual prompt database files.
+5. Run the label-gated workflow on synchronize events too, retaining exact-head
+   checkout. Include the new race and export regressions in the Linux matrix.
+6. Reply to all six Qodo threads with evidence, rerun required checks on the
+   rebased head, and merge only when review findings and required gates are clear.

--- a/Helper_Scripts/Prompts/Prompts_Dump.py
+++ b/Helper_Scripts/Prompts/Prompts_Dump.py
@@ -24,7 +24,7 @@ sys.path.insert(0, str(project_root))
 
 try:
     from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
-    from tldw_chatbook.config import BASE_DATA_DIR_CLI
+    from tldw_chatbook.config import get_user_data_dir
 except ImportError as e:
     print(f"Error importing required modules: {e}")
     print(f"Please ensure you're running this script from the tldw_chatbook project directory")
@@ -93,7 +93,7 @@ def get_user_db_path(username: str) -> Path:
     Returns:
         Path to the prompts database file
     """
-    user_dir = BASE_DATA_DIR_CLI / username
+    user_dir = get_user_data_dir().parent / username
     # Try the new database name first
     prompts_db = user_dir / "prompts.db"
     if prompts_db.exists():

--- a/README.md
+++ b/README.md
@@ -530,6 +530,16 @@ The default base data directory on a typical Unix-like system is:
 ~/.local/share/tldw_cli/
 ```
 
+On a fresh POSIX install, if existing `.local` or `share` permissions prevent
+private storage, Chatbook automatically uses `~/.tldw_cli-data/<user>/` instead.
+This location remains selected on later launches, including after those
+permissions change. Shared ancestor permissions are left untouched; application
+directories remain owner-only. Settings shows the selected storage location.
+Existing data and explicit `[paths] data_dir` settings are never silently
+bypassed. If both default roots exist, select the intended base explicitly with
+`[paths] data_dir` before restarting. An unsafe home directory still requires a
+safe storage location; Chatbook does not weaken its private-file checks.
+
 Profiles live below it:
 
 ```text

--- a/Tests/Architecture/test_profile_owned_path_inventory.py
+++ b/Tests/Architecture/test_profile_owned_path_inventory.py
@@ -332,7 +332,7 @@ def test_compatibility_and_runtime_policy_constants_have_no_new_runtime_owners()
                 ):
                     runtime_constant_definitions.append(relative_path)
 
-    assert base_data_consumers == [("Helper_Scripts/Prompts/Prompts_Dump.py", 96)]
+    assert base_data_consumers == []
     assert runtime_constant_definitions == ["tldw_chatbook/runtime_policy/bootstrap.py"]
 
     from tldw_chatbook.runtime_policy.bootstrap import default_runtime_policy_path

--- a/Tests/UI/test_profile_owned_settings_paths.py
+++ b/Tests/UI/test_profile_owned_settings_paths.py
@@ -14,6 +14,30 @@ import tldw_chatbook.UI.Screens.settings_screen as settings_screen
 from tldw_chatbook.UI.Screens.settings_screen import SettingsCategoryId, SettingsScreen
 
 
+@pytest.mark.parametrize("fallback_exists", [False, True])
+def test_storage_display_uses_selected_default_without_creating_paths(
+    tmp_path, monkeypatch, fallback_exists
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    fallback = home / ".tldw_cli-data"
+    if fallback_exists:
+        fallback.mkdir(mode=0o700)
+    monkeypatch.setenv("HOME", str(home))
+    window = MagicMock(spec=SettingsScreen)
+    window._read_cli_config_value_without_writes.side_effect = (
+        lambda section, key, default=None: default
+    )
+    window._configured_user_folder_name.return_value = "alice"
+
+    actual = SettingsScreen._configured_user_data_dir_path(window)
+
+    expected = fallback if fallback_exists else home / ".local/share/tldw_cli"
+    assert actual == expected / "alice"
+    assert not actual.exists()
+    assert not (home / ".local").exists()
+
+
 @pytest.mark.parametrize("profile_name", ["alpha", "beta"])
 def test_config_children_follow_effective_profile(
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/test_data_root_concurrency.py
+++ b/Tests/test_data_root_concurrency.py
@@ -1,0 +1,113 @@
+"""Default-root choice stays consistent across concurrent first launches."""
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX namespace and lock contract")
+def test_concurrent_first_starts_agree_when_ancestor_permissions_change(tmp_path):
+    home = tmp_path / "home"
+    shared = home / ".local/share"
+    shared.mkdir(parents=True)
+    shared.chmod(0o775)
+    script = """
+import os
+from pathlib import Path
+import sys
+import time
+import portalocker
+from tldw_chatbook import config
+
+root, role = Path(sys.argv[1]), sys.argv[2]
+home = root / 'home'
+os.environ['HOME'] = str(home)
+config.get_user_folder_name = lambda: 'alice'
+config.get_cli_setting = lambda section, key, default=None: default
+real_secure = config.secure_private_directory
+real_lock = portalocker.lock
+
+def paused_secure(path, **kwargs):
+    if role == 'a' and Path(path) == home / '.tldw_cli-data':
+        (root / 'a-ready').touch()
+        deadline = time.monotonic() + 30
+        while not (root / 'release-a').exists():
+            if time.monotonic() >= deadline:
+                raise RuntimeError('timed out waiting to resume root creation')
+            time.sleep(0.01)
+    return real_secure(path, **kwargs)
+
+def observed_lock(stream, flags):
+    try:
+        return real_lock(stream, flags | portalocker.LockFlags.NON_BLOCKING)
+    except portalocker.exceptions.LockException:
+        # Signal actual OS lock contention, not a guessed sleep interval.
+        (root / 'b-blocked').touch()
+        return real_lock(stream, flags)
+
+config.secure_private_directory = paused_secure
+if role == 'b':
+    portalocker.lock = observed_lock
+selected = config.get_user_data_dir()
+(root / (role + '-result')).write_text(str(selected))
+"""
+    processes = []
+
+    def start(role):
+        bootstrap = tmp_path / f"bootstrap-{role}"
+        config_path = bootstrap / "config/config.toml"
+        config_path.parent.mkdir(parents=True)
+        env = dict(
+            os.environ,
+            HOME=str(bootstrap),
+            TLDW_CONFIG_PATH=str(config_path),
+        )
+        process = subprocess.Popen(
+            [sys.executable, "-c", script, str(tmp_path), role],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        processes.append(process)
+        return process
+
+    def wait_for_signal(*names):
+        deadline = time.monotonic() + 30
+        while not any((tmp_path / name).exists() for name in names):
+            for process in processes:
+                if process.poll() is not None and process.returncode != 0:
+                    _, stderr = process.communicate(timeout=5)
+                    pytest.fail(stderr)
+            assert time.monotonic() < deadline, f"Missing process signal: {names}"
+            time.sleep(0.01)
+
+    try:
+        start("a")
+        wait_for_signal("a-ready")
+        shared.chmod(0o755)
+        start("b")
+        # Without coordination, B creates the conventional root and finishes;
+        # with coordination, it demonstrably blocks on A's OS-backed lock.
+        wait_for_signal("b-blocked", "b-result")
+        (tmp_path / "release-a").touch()
+        for process in processes:
+            _, stderr = process.communicate(timeout=30)
+            assert process.returncode == 0, stderr
+    finally:
+        (tmp_path / "release-a").touch()
+        for process in processes:
+            if process.poll() is None:
+                process.terminate()
+                process.communicate(timeout=5)
+
+    expected = str(home / ".tldw_cli-data/alice")
+    assert (tmp_path / "a-result").read_text() == expected
+    assert (tmp_path / "b-result").read_text() == expected
+    assert not (shared / "tldw_cli").exists()
+    assert (tmp_path / "b-blocked").exists()

--- a/Tests/test_database_path_privacy.py
+++ b/Tests/test_database_path_privacy.py
@@ -283,6 +283,66 @@ def test_recovery_does_not_treat_inaccessible_data_as_missing(tmp_path, monkeypa
     assert not (home / ".tldw_cli-data").exists()
 
 
+def test_data_root_probe_validates_before_accessing_the_filesystem(
+    tmp_path, monkeypatch
+):
+    def unexpected_probe(path):
+        pytest.fail("invalid environment-derived path reached lstat")
+
+    monkeypatch.setattr(Path, "lstat", unexpected_probe)
+    with pytest.raises(ValueError, match="dangerous pattern"):
+        config._data_root_entry_exists(tmp_path / "unsafe;home" / "data")
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX private lock contract")
+def test_default_root_lock_is_private_stable_and_does_not_chmod_home(
+    tmp_path, monkeypatch
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    home.chmod(0o755)
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    first = config.get_user_data_dir()
+    lock = home / ".tldw_cli-data-root.lock"
+    identity = lock.stat().st_ino
+    assert config.get_user_data_dir() == first
+    assert lock.stat().st_ino == identity
+    assert _mode(lock) == 0o600
+    assert _mode(home) == 0o755
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX no-follow lock contract")
+def test_default_root_selection_rejects_symlinked_lock(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    outside = tmp_path / "outside"
+    outside.write_text("keep me")
+    (home / ".tldw_cli-data-root.lock").symlink_to(outside)
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    with pytest.raises(PrivatePathError):
+        config.get_user_data_dir()
+
+    assert outside.read_text() == "keep me"
+    assert not (home / ".local").exists()
+    assert not (home / ".tldw_cli-data").exists()
+
+
+def test_explicit_root_does_not_create_a_default_selection_lock(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    custom = tmp_path / "custom"
+    custom.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, custom)
+
+    assert config.get_user_data_dir() == custom / "alice"
+    assert list(home.iterdir()) == []
+
+
 @pytest.mark.skipif(os.name != "posix", reason="POSIX fresh-install contract")
 def test_fresh_config_import_and_database_survive_restart_and_permission_repair(
     tmp_path,
@@ -304,9 +364,9 @@ assert path.parent.parent.name == '.tldw_cli-data', path
 db = connect_private_sqlite('db.chachanotes.primary', path)
 try:
     if sys.argv[1] == 'create':
-        db.execute('CREATE TABLE recovery_probe (value TEXT)')
-        db.execute('INSERT INTO recovery_probe VALUES (?)', ('survived restart',))
-        db.commit()
+        with db:
+            db.execute('CREATE TABLE recovery_probe (value TEXT)')
+            db.execute('INSERT INTO recovery_probe VALUES (?)', ('survived restart',))
     assert db.execute('SELECT value FROM recovery_probe').fetchone() == ('survived restart',)
 finally:
     db.close()

--- a/Tests/test_database_path_privacy.py
+++ b/Tests/test_database_path_privacy.py
@@ -3,13 +3,18 @@ from __future__ import annotations
 import inspect
 import os
 import stat
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
 
 from tldw_chatbook import config
-from tldw_chatbook.Utils.private_paths import PrivatePathError
-
+from tldw_chatbook.Utils.private_paths import (
+    PrivatePathError,
+    PrivatePathResult,
+    PrivatePathStatus,
+)
 
 DB_PATH_HELPERS = {
     "chachanotes_db_path": (
@@ -98,9 +103,7 @@ def test_default_data_base_falls_back_to_home(
     monkeypatch.delenv("XDG_DATA_HOME", raising=False)
     monkeypatch.setenv("HOME", str(home))
 
-    assert (
-        config._default_base_data_dir() == home / ".local" / "share" / "tldw_cli"
-    )
+    assert config._default_base_data_dir() == home / ".local" / "share" / "tldw_cli"
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX mode contract")
@@ -142,6 +145,196 @@ def test_existing_default_data_directories_are_hardened(
     assert config.get_user_data_dir() == user_dir
     assert _mode(default_base) == 0o700
     assert _mode(user_dir) == 0o700
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX mode contract")
+@pytest.mark.parametrize("ancestor", [".local", ".local/share"])
+@pytest.mark.parametrize("mode", [0o775, 0o770, 0o777, 0o2775])
+def test_fresh_data_root_recovers_without_changing_shared_ancestors(
+    tmp_path, monkeypatch, ancestor, mode
+):
+    home = tmp_path / "home"
+    shared = home / ancestor
+    shared.mkdir(parents=True)
+    shared.chmod(mode)
+    original_mode = _mode(shared)  # Some filesystems strip setgid on chmod.
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    selected = config.get_user_data_dir()
+
+    assert selected == home / ".tldw_cli-data" / "alice"
+    assert _mode(selected.parent) == 0o700
+    assert _mode(selected) == 0o700
+    assert _mode(shared) == original_mode
+    assert not (home / ".local/share/tldw_cli").exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX namespace contract")
+@pytest.mark.parametrize("entry_kind", ["directory", "file", "dangling-symlink"])
+def test_recovery_never_bypasses_existing_conventional_data(
+    tmp_path, monkeypatch, entry_kind
+):
+    home = tmp_path / "home"
+    conventional = home / ".local/share/tldw_cli"
+    conventional.parent.mkdir(parents=True)
+    if entry_kind == "directory":
+        conventional.mkdir()
+        (conventional / "saved-conversation").write_text("keep me")
+    elif entry_kind == "file":
+        conventional.write_text("keep me")
+    else:
+        conventional.symlink_to(home / "missing")
+    conventional.parent.chmod(0o775)
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    with pytest.raises(PrivatePathError, match="shared_writable_parent"):
+        config.get_user_data_dir()
+
+    assert not (home / ".tldw_cli-data").exists()
+    if entry_kind == "directory":
+        assert (conventional / "saved-conversation").read_text() == "keep me"
+
+
+def test_two_default_roots_require_explicit_selection(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    conventional = home / ".local/share/tldw_cli"
+    fallback = home / ".tldw_cli-data"
+    conventional.mkdir(parents=True)
+    fallback.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    with pytest.raises(PrivatePathError, match="ambiguous_default_data_roots"):
+        config.get_user_data_dir()
+
+    assert not (conventional / "alice").exists()
+    assert not (fallback / "alice").exists()
+    _patch_data_dir_settings(monkeypatch, conventional)
+    assert config.get_user_data_dir() == conventional / "alice"
+    _patch_data_dir_settings(monkeypatch, fallback)
+    assert config.get_user_data_dir() == fallback / "alice"
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX symlink contract")
+def test_recovery_rejects_a_fallback_symlink(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    shared = home / ".local/share"
+    shared.mkdir(parents=True)
+    shared.chmod(0o775)
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (home / ".tldw_cli-data").symlink_to(outside, target_is_directory=True)
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+
+    with pytest.raises(PrivatePathError):
+        config.get_user_data_dir()
+
+    assert list(outside.iterdir()) == []
+
+
+def test_recovery_does_not_mask_unrelated_storage_errors(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+    attempted = []
+    failure = PrivatePathError(
+        PrivatePathResult(
+            home / ".local/share/tldw_cli",
+            PrivatePathStatus.OPERATION_FAILED,
+            reason="injected_io_error",
+        )
+    )
+
+    def refuse(path, **kwargs):
+        attempted.append(path)
+        raise failure
+
+    monkeypatch.setattr(config, "secure_private_directory", refuse)
+    with pytest.raises(PrivatePathError) as caught:
+        config.get_user_data_dir()
+
+    assert caught.value is failure
+    assert attempted == [home / ".local/share/tldw_cli"]
+
+
+def test_recovery_does_not_treat_inaccessible_data_as_missing(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    shared = home / ".local/share"
+    shared.mkdir(parents=True)
+    shared.chmod(0o775)
+    conventional = shared / "tldw_cli"
+    monkeypatch.setenv("HOME", str(home))
+    _patch_data_dir_settings(monkeypatch, None)
+    original_lstat = Path.lstat
+
+    def denied_lstat(path):
+        if path == conventional:
+            raise PermissionError("injected inaccessible data root")
+        return original_lstat(path)
+
+    monkeypatch.setattr(Path, "lstat", denied_lstat)
+    with pytest.raises(PermissionError, match="inaccessible data root"):
+        config.get_user_data_dir()
+
+    assert not (home / ".tldw_cli-data").exists()
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX fresh-install contract")
+def test_fresh_config_import_and_database_survive_restart_and_permission_repair(
+    tmp_path,
+):
+    home = tmp_path / "home"
+    shared = home / ".local/share"
+    shared.mkdir(parents=True)
+    shared.chmod(0o775)
+    # Exercise default config bootstrap too, with no inherited test override.
+    env = dict(os.environ, HOME=str(home), XDG_CONFIG_HOME=str(home / ".config"))
+    env.pop("TLDW_CONFIG_PATH", None)
+    env.pop("XDG_DATA_HOME", None)
+    script = """
+import sys
+from tldw_chatbook import config
+from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
+path = config.get_chachanotes_db_path()
+assert path.parent.parent.name == '.tldw_cli-data', path
+db = connect_private_sqlite('db.chachanotes.primary', path)
+try:
+    if sys.argv[1] == 'create':
+        db.execute('CREATE TABLE recovery_probe (value TEXT)')
+        db.execute('INSERT INTO recovery_probe VALUES (?)', ('survived restart',))
+        db.commit()
+    assert db.execute('SELECT value FROM recovery_probe').fetchone() == ('survived restart',)
+finally:
+    db.close()
+print('RECOVERY_OK')
+"""
+    for phase in ("create", "restart", "repaired"):
+        if phase == "repaired":
+            shared.chmod(0o755)
+        result = subprocess.run(
+            [sys.executable, "-c", script, phase],
+            cwd=Path(__file__).resolve().parents[1],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=40,
+        )
+        assert result.returncode == 0, result.stderr
+        assert "RECOVERY_OK" in result.stdout
+        assert _mode(shared) == (0o755 if phase == "repaired" else 0o775)
+
+    fallback = home / ".tldw_cli-data"
+    assert _mode(fallback) == 0o700
+    assert _mode(home / ".config/tldw_cli/config.toml") == 0o600
+    databases = list(fallback.glob("*/tldw_chatbook_ChaChaNotes.db"))
+    assert len(databases) == 1
+    assert _mode(databases[0]) == 0o600
+    assert not (shared / "tldw_cli").exists()
 
 
 @pytest.mark.skipif(os.name != "posix", reason="POSIX namespace contract")

--- a/Tests/test_prompt_dump_storage.py
+++ b/Tests/test_prompt_dump_storage.py
@@ -1,0 +1,36 @@
+"""The named-profile prompt exporter shares the application's storage base."""
+
+from contextlib import closing
+
+import pytest
+
+from Helper_Scripts.Prompts import Prompts_Dump
+from tldw_chatbook import config
+from tldw_chatbook.DB.private_sqlite import connect_private_sqlite
+
+
+@pytest.mark.parametrize("root_kind", ["fallback", "explicit"])
+@pytest.mark.parametrize("filename", ["prompts.db", "tldw_chatbook_prompts.db"])
+def test_named_profile_export_uses_selected_storage(
+    tmp_path, monkeypatch, root_kind, filename
+):
+    home = tmp_path / "home"
+    home.mkdir()
+    base = home / ".tldw_cli-data" if root_kind == "fallback" else tmp_path / "custom"
+    profile = base / "alice"
+    profile.mkdir(parents=True)
+    expected = profile / filename
+    with closing(connect_private_sqlite("db.prompts.primary", expected)) as db, db:
+        db.execute("CREATE TABLE export_probe (value TEXT)")
+    monkeypatch.setenv("HOME", str(home))
+    monkeypatch.setattr(config, "get_user_folder_name", lambda: "current-user")
+
+    def setting(section, key, default=None):
+        if section.lower() == "paths" and key == "data_dir" and root_kind == "explicit":
+            return str(base)
+        return default
+
+    monkeypatch.setattr(config, "get_cli_setting", setting)
+
+    assert Prompts_Dump.get_user_db_path("alice") == expected
+    assert not (home / ".local").exists()

--- a/backlog/decisions/127-fresh-install-private-data-root-recovery.md
+++ b/backlog/decisions/127-fresh-install-private-data-root-recovery.md
@@ -1,0 +1,63 @@
+# ADR-127: Fresh-install private data root recovery
+
+Status: Accepted
+Date: 2026-09-07
+Related task: TASK-32011
+Amends: [ADR-029](029-local-private-data-boundary.md) (default location selection only)
+
+## Context
+
+A fresh installation crashes during config import if an existing `.local` or
+`share` ancestor is group/world-writable. The private-path guard correctly refuses
+that namespace, but startup currently has only one default data location. The
+reporter cannot be contacted to repair their machine. Reproduction with an
+isolated HOME and `share` at `0775` reaches the reported `shared_writable_parent`
+exception before any database is created.
+
+## Decision
+
+Keep `~/.local/share/tldw_cli` as the conventional data root. If securing it fails
+specifically with `unsafe_parent: shared_writable_parent`, and no filesystem entry
+exists at that root, automatically secure `~/.tldw_cli-data` as the default root.
+Both roots remain profile containers: the existing sanitized user name is appended.
+
+The home-level directory is reserved application storage and is secured by the
+same descriptor-based `0700` directory guard. Existing files, SQLite databases,
+and logs retain their `0600` lifecycle. No ancestor permissions are changed and
+no group-membership assumptions or weaker private-path checks are introduced.
+
+Directory presence persists the selection without new config fields or a second
+mutable configuration owner. When only the fallback exists, keep using it even
+if the conventional ancestors are repaired. When both roots exist, refuse the
+ambiguous default; an explicit `[paths] data_dir` can select the intended root.
+Never inspect/migrate database contents or silently hide an existing conventional
+root. Existence probes use `lstat`, count dangling final symlinks as entries, and
+propagate errors other than absence instead of treating inaccessible data as new.
+
+Explicit data roots retain their existing validation and precedence, with no
+fallback. Unsafe HOME/ancestors, symlinks, foreign ownership, unavailable guards,
+and other I/O errors still fail closed. Config-file selection is unchanged; this
+decision addresses the reported data-root failure, not all possible filesystem
+misconfiguration. XDG_DATA_HOME behavior remains unchanged.
+
+## Alternatives
+
+- Allow writable ancestors: loses the guarantee that another local user cannot
+  replace a directory naming private data.
+- Automatically chmod `.local`, `share`, or HOME: changes user-owned sharing
+  policy outside application storage.
+- Infer a private group from its name or account enumeration: depends on mutable
+  local/network account policy and cannot establish filesystem isolation.
+- Use an ephemeral directory: would turn persistent conversations into temporary
+  data and break restart behavior.
+- Retry the conventional root on each launch: silently switches profiles after a
+  permission repair. Fallback presence deliberately prevents that.
+
+## Verification
+
+Real fresh-process config imports and SQLite writes/reopens must succeed with
+writable `.local`/`share`, retain data on restart and after permissions are
+repaired, and leave ancestors untouched. Existing-root, ambiguous-root, explicit
+override, symlink, unsafe-HOME, and non-permission-failure cases must still refuse.
+
+Design and plan: [TASK-32011 design](../../Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md).

--- a/backlog/decisions/127-fresh-install-private-data-root-recovery.md
+++ b/backlog/decisions/127-fresh-install-private-data-root-recovery.md
@@ -34,6 +34,21 @@ Never inspect/migrate database contents or silently hide an existing conventiona
 root. Existence probes use `lstat`, count dangling final symlinks as entries, and
 propagate errors other than absence instead of treating inaccessible data as new.
 
+All default-root selection and profile-directory creation run under a stable
+private `~/.tldw_cli-data-root.lock` interprocess lock. The lock file uses the
+existing no-follow private-file lifecycle and is never replaced or removed on
+release. This serializes concurrent Chatbook starts even across different config
+files, including a start that observes a permission repair while another is
+choosing the fallback. External filesystem mutations remain outside cooperative
+locking and still receive the existing fail-closed handling. Explicit custom
+roots do not acquire this default-location lock. Read-only Settings diagnostics
+do not create or lock storage.
+
+Environment-derived existence probes use central validation with
+`probe_existing=False` before `lstat`, preserving symlink evidence. The prompt
+export helper uses the runtime-selected base for its explicitly named profile;
+the historical conventional-only compatibility constant has no runtime consumers.
+
 Explicit data roots retain their existing validation and precedence, with no
 fallback. Unsafe HOME/ancestors, symlinks, foreign ownership, unavailable guards,
 and other I/O errors still fail closed. Config-file selection is unchanged; this

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -103,6 +103,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-117](117-vllm-lab-console-readiness-and-profiles.md) | Accepted | Treat vLLM setup as a generation-fenced launch-or-connect workflow with verified Console adoption and device-local non-secret launch profiles. |
 | [ADR-118](118-chunking-lab-local-execution-and-recovery.md) | Accepted | Keep Chunking Lab local-first, with faithful full-recipe previews, immutable A/B results, conflict-safe catalog saves, and private recoverable session checkpoints. |
 | [ADR-122](122-bundled-pixel-migu-character-and-buddy.md) | Accepted | Include pixel-migu as optional fresh-profile character and Buddy content using existing ownership and runtime boundaries. |
+| [ADR-127](127-fresh-install-private-data-root-recovery.md) | Accepted | Select durable home-level private storage for fresh installs blocked by shared default ancestors. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
+++ b/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 00:30'
-updated_date: '2026-09-08 01:14'
+updated_date: '2026-09-08 01:52'
 labels:
   - bug
   - storage
@@ -71,4 +71,8 @@ Restored-source verification: 448 targeted tests passed, 2 Windows-only skips; t
 All 15 profile-owned path architecture checks pass in the isolated worktree after the prompt helper census update.
 
 Final Qodo remediation evidence: Ubuntu 24.04 run https://github.com/rmusser01/tldw_chatbook/actions/runs/34175776357 tested c36dcd38388d6fe955d79b4f3412b024d17f444d on Python 3.11, 3.12, and 3.13. Every job passed 446 tests with 4 platform skips, passed installed tldw-cli startup under 0775 and 0755 ancestors, and uploaded JUnit artifacts. This synchronize-triggered run verifies the workflow fix. All six Qodo threads received fix/evidence replies and were resolved. Performance and GGUF platform evidence checks passed. Baseline lint comparison for config.py, Prompts_Dump.py, the architecture test, and its scanner finds no new diagnostics; new storage tests pass lint/format. No production or test code changes follow this evidence; this task-completion commit will receive its own exact-head CI run before merge.
+
+Final required-gate follow-up: PR Fast Lane passed all 755 tests at rebased head f8df957a9. The sole artifact mismatch was the intentional _default_data_root_lock call to open_private_text_append_stream (digest 19f05166171daf75). Reviewed the full reported delta and source: the stable private 0600 lock file is created empty and used only for interprocess locking, with no stream writes in the lock context. The diagnostic statement comparison against dev reports 115 unchanged calls (zero additions, removals, or re-indentations). Regenerated Docs/security/production-diagnostic-inventory.json to record this intended file-stream owner under ADR-127. No runtime behavior changes accompany the pin update.
+
+Inventory regeneration completed with project Python 3.12. Semantic JSON comparison verifies exactly the reviewed _default_data_root_lock sink was added and every other inventory field is unchanged. Rebased cleanly onto dev d547eef4a before regeneration.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
+++ b/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32011
 title: Recover fresh-install data storage from unsafe shared ancestors
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 00:30'
-updated_date: '2026-09-08 01:10'
+updated_date: '2026-09-08 01:14'
 labels:
   - bug
   - storage
@@ -29,7 +29,7 @@ Fresh installs can fail during configuration import when existing .local or shar
 - [x] #5 Settings storage diagnostics show the selected default data location without creating directories.
 - [x] #6 A one-off Linux CI workflow validates the exact PR head against dev on supported Python versions and retains test evidence.
 - [x] #7 Concurrent first starts share one private interprocess lock across default-root and profile creation, so permission repair cannot create conflicting roots.
-- [ ] #8 Environment-derived existence probes use non-resolving central validation; prompt exports honor fallback and explicit roots; labeled CI reruns on subsequent PR commits.
+- [x] #8 Environment-derived existence probes use non-resolving central validation; prompt exports honor fallback and explicit roots; labeled CI reruns on subsequent PR commits.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -69,4 +69,6 @@ Qodo follow-up after rebase onto dev 511044368: all six comments addressed. A st
 Restored-source verification: 448 targeted tests passed, 2 Windows-only skips; three changed/new storage test files pass Ruff lint and formatting. Independent review of the restored code and new regression files found no actionable issues. Updated Linux matrix evidence will be recorded after publishing this revision.
 
 All 15 profile-owned path architecture checks pass in the isolated worktree after the prompt helper census update.
+
+Final Qodo remediation evidence: Ubuntu 24.04 run https://github.com/rmusser01/tldw_chatbook/actions/runs/34175776357 tested c36dcd38388d6fe955d79b4f3412b024d17f444d on Python 3.11, 3.12, and 3.13. Every job passed 446 tests with 4 platform skips, passed installed tldw-cli startup under 0775 and 0755 ancestors, and uploaded JUnit artifacts. This synchronize-triggered run verifies the workflow fix. All six Qodo threads received fix/evidence replies and were resolved. Performance and GGUF platform evidence checks passed. Baseline lint comparison for config.py, Prompts_Dump.py, the architecture test, and its scanner finds no new diagnostics; new storage tests pass lint/format. No production or test code changes follow this evidence; this task-completion commit will receive its own exact-head CI run before merge.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
+++ b/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32011
 title: Recover fresh-install data storage from unsafe shared ancestors
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 00:30'
-updated_date: '2026-09-08 00:45'
+updated_date: '2026-09-08 00:50'
 labels:
   - bug
   - storage
@@ -27,7 +27,7 @@ Fresh installs can fail during configuration import when existing .local or shar
 - [x] #3 The original ownership, symlink, private-mode, and unsafe-home protections remain enforced for all selected storage.
 - [x] #4 Real config-import and SQLite persistence regression tests cover fresh launch and restart, and targeted storage checks pass.
 - [x] #5 Settings storage diagnostics show the selected default data location without creating directories.
-- [ ] #6 A one-off Linux CI workflow validates the exact PR head against dev on supported Python versions and retains test evidence.
+- [x] #6 A one-off Linux CI workflow validates the exact PR head against dev on supported Python versions and retains test evidence.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -58,4 +58,6 @@ Architecture validation: 14 checks pass, including production profile-path inven
 Limitations: recovery applies to absent default data roots, not existing-data migration, unsafe HOME, or config-directory failures. The legacy Helper_Scripts/Prompts/Prompts_Dump.py compatibility-constant consumer remains outside normal runtime root resolution. No full-suite sweep, release, or deployment was performed.
 
 Follow-up: prepare an isolated PR against current origin/dev and run one-off Linux CI at the PR head. Reapplied only this task patch; README and Settings context were adapted to the newer dev layout.
+
+PR #2495 targets dev from isolated branch codex/fresh-install-private-storage. One-off Ubuntu 24.04 run https://github.com/rmusser01/tldw_chatbook/actions/runs/34174533166 passed at cff48b34d14eb0dee7fe083f4e6a6ad9767d6f71 on Python 3.11, 3.12, and 3.13: 437 tests passed and 4 platform-only tests skipped in each job. Each job also launched the installed tldw-cli under ancestor modes 0775 and 0755 and confirmed private fallback retention. JUnit artifacts were uploaded for all three interpreters. This supplies the previously missing native Linux evidence. The isolated current-dev local targeted run passed 439 tests with 2 Windows-only skips.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
+++ b/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32011
 title: Recover fresh-install data storage from unsafe shared ancestors
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 00:30'
-updated_date: '2026-09-08 00:50'
+updated_date: '2026-09-08 01:10'
 labels:
   - bug
   - storage
@@ -28,6 +28,8 @@ Fresh installs can fail during configuration import when existing .local or shar
 - [x] #4 Real config-import and SQLite persistence regression tests cover fresh launch and restart, and targeted storage checks pass.
 - [x] #5 Settings storage diagnostics show the selected default data location without creating directories.
 - [x] #6 A one-off Linux CI workflow validates the exact PR head against dev on supported Python versions and retains test evidence.
+- [x] #7 Concurrent first starts share one private interprocess lock across default-root and profile creation, so permission repair cannot create conflicting roots.
+- [ ] #8 Environment-derived existence probes use non-resolving central validation; prompt exports honor fallback and explicit roots; labeled CI reruns on subsequent PR commits.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,13 +37,14 @@ Fresh installs can fail during configuration import when existing .local or shar
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: yes
 ADR path: backlog/decisions/127-fresh-install-private-data-root-recovery.md
-Reason: Adds a durable default-data location selection rule under the existing ADR-029 private-storage boundary.
+Reason: Adds durable default-data selection under ADR-029; the review follow-up records interprocess coordination in the same ADR.
 
-1. Record selection and conflict semantics in ADR-127 and a focused design/plan.
-2. Add failing fresh-install, restart, existing-root, override, and unsafe-path tests.
-3. Add one default-data resolver that secures the conventional root or selects the home-level fallback only for a missing conventional root rejected as shared-writable.
-4. Verify real config import and SQLite persistence across fresh processes, then run targeted storage and path-owner checks and lint/format checks.
-5. Update storage documentation, review the diff, record evidence and complete the task.
+1. Record selection and conflict semantics; add failing fresh-install, restart, override, and unsafe-path regressions.
+2. Implement secure durable recovery and read-only Settings display without weakening path guards.
+3. Rebase on current dev and reproduce Qodo findings with real concurrent processes and named-profile export tests.
+4. Serialize default-root selection and profile creation, validate lexical probes, centralize the fallback name, and fix export root selection and SQLite test transactions.
+5. Rerun targeted storage and architecture checks, lint/format and independent review.
+6. Rerun the labeled one-off Linux workflow automatically on synchronize, address review threads, record evidence, and merge the validated PR.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -60,4 +63,10 @@ Limitations: recovery applies to absent default data roots, not existing-data mi
 Follow-up: prepare an isolated PR against current origin/dev and run one-off Linux CI at the PR head. Reapplied only this task patch; README and Settings context were adapted to the newer dev layout.
 
 PR #2495 targets dev from isolated branch codex/fresh-install-private-storage. One-off Ubuntu 24.04 run https://github.com/rmusser01/tldw_chatbook/actions/runs/34174533166 passed at cff48b34d14eb0dee7fe083f4e6a6ad9767d6f71 on Python 3.11, 3.12, and 3.13: 437 tests passed and 4 platform-only tests skipped in each job. Each job also launched the installed tldw-cli under ancestor modes 0775 and 0755 and confirmed private fallback retention. JUnit artifacts were uploaded for all three interpreters. This supplies the previously missing native Linux evidence. The isolated current-dev local targeted run passed 439 tests with 2 Windows-only skips.
+
+Qodo follow-up after rebase onto dev 511044368: all six comments addressed. A stable private HOME-level interprocess lock spans default-root selection and profile creation; a deterministic two-process test reproduces the old permission-repair race and verifies OS lock contention with the fix. Lexical existence probes use central validation without resolving symlinks. The fallback directory has a named constant. Prompt exports now honor the selected base while preserving explicit profile names and both database filenames, superseding the earlier legacy-helper limitation. SQLite regression writes use a transaction context. The opt-in Linux workflow also runs on synchronize while its evidence label remains. ADR-127 and the design plan document coordination.
+
+Restored-source verification: 448 targeted tests passed, 2 Windows-only skips; three changed/new storage test files pass Ruff lint and formatting. Independent review of the restored code and new regression files found no actionable issues. Updated Linux matrix evidence will be recorded after publishing this revision.
+
+All 15 profile-owned path architecture checks pass in the isolated worktree after the prompt helper census update.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
+++ b/backlog/tasks/task-32011 - Recover-fresh-install-data-storage-from-unsafe-shared-ancestors.md
@@ -1,0 +1,61 @@
+---
+id: TASK-32011
+title: Recover fresh-install data storage from unsafe shared ancestors
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-08 00:30'
+updated_date: '2026-09-08 00:45'
+labels:
+  - bug
+  - storage
+  - privacy
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fresh installs can fail during configuration import when existing .local or share directories are writable by a group. Make default storage selection recover automatically without requiring contact with the reporter, changing shared ancestor permissions, weakening private-path validation, or hiding existing data.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh installs with group- or world-writable .local or share ancestors automatically use a private home-level data directory without changing those ancestors.
+- [x] #2 The selected fallback remains stable across processes and later permission repairs, while configured roots and existing default data are never silently bypassed.
+- [x] #3 The original ownership, symlink, private-mode, and unsafe-home protections remain enforced for all selected storage.
+- [x] #4 Real config-import and SQLite persistence regression tests cover fresh launch and restart, and targeted storage checks pass.
+- [x] #5 Settings storage diagnostics show the selected default data location without creating directories.
+- [ ] #6 A one-off Linux CI workflow validates the exact PR head against dev on supported Python versions and retains test evidence.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/127-fresh-install-private-data-root-recovery.md
+Reason: Adds a durable default-data location selection rule under the existing ADR-029 private-storage boundary.
+
+1. Record selection and conflict semantics in ADR-127 and a focused design/plan.
+2. Add failing fresh-install, restart, existing-root, override, and unsafe-path tests.
+3. Add one default-data resolver that secures the conventional root or selects the home-level fallback only for a missing conventional root rejected as shared-writable.
+4. Verify real config import and SQLite persistence across fresh processes, then run targeted storage and path-owner checks and lint/format checks.
+5. Update storage documentation, review the diff, record evidence and complete the task.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fresh installations now recover automatically from a missing conventional data root rejected for shared-writable .local/share ancestors by creating ~/.tldw_cli-data with the existing private directory guard. Directory presence retains the selection across processes and permission repairs. Explicit overrides, existing conventional entries, ambiguous roots, inaccessible paths, unsafe HOME, and symlinks retain refusal or explicit-selection behavior. No shared ancestor chmod, weakened guard, or implicit migration was introduced.
+
+Settings storage diagnostics now use the same read-only selected-root helper. This integration was added to acceptance criteria after review identified its independent conventional-path calculation. Source changes are limited to config.py and settings_screen.py; regression coverage is in Tests/test_database_path_privacy.py and Tests/UI/test_profile_owned_settings_paths.py. README documents recovery and conflict handling. ADR-127 (backlog/decisions/127-fresh-install-private-data-root-recovery.md) records the storage decision under ADR-029; the design/plan is Docs/superpowers/specs/2026-09-07-fresh-install-data-root-recovery.md.
+
+Verification: 10 new recovery/conflict/config-import cases failed against the original resolver; the Settings fallback display case failed before its fix. Final targeted command: .venv/bin/python -m pytest Tests/test_database_path_privacy.py Tests/test_user_data_dir_isolation.py Tests/test_config_private_bootstrap.py Tests/Utils/test_private_paths.py Tests/DB/test_private_sqlite.py Tests/UI/test_profile_owned_settings_paths.py Tests/test_logging_private_files.py -q --tb=short -> 427 passed, 1 Windows-only skip. Fresh subprocess config imports write and reopen a private SQLite row across restart and ancestor permission repair. An actual isolated tldw-cli --help invocation exits 0, creates the fallback, keeps the shared ancestor at 0775, and leaves the conventional root absent. Verification ran on macOS POSIX; native Linux execution was not available.
+
+Architecture validation: 14 checks pass, including production profile-path inventory and its CLI. One existing census check fails because its unrestricted rglob reads an untracked, non-UTF-8 joblib fixture inside .claude/worktrees/internal-prompts-p1/.venv; this is unrelated to the patch and was not changed. Ruff passes for the changed storage test file, both test files pass formatting, and baseline comparison of all four changed Python files finds zero new lint findings or formatting deviations. Whole-file lint/format is not clean because config.py and settings_screen.py already carry unrelated debt. git diff --check passes for this change. Independent scoped code review found no remaining actionable findings.
+
+Limitations: recovery applies to absent default data roots, not existing-data migration, unsafe HOME, or config-directory failures. The legacy Helper_Scripts/Prompts/Prompts_Dump.py compatibility-constant consumer remains outside normal runtime root resolution. No full-suite sweep, release, or deployment was performed.
+
+Follow-up: prepare an isolated PR against current origin/dev and run one-off Linux CI at the PR head. Reapplied only this task patch; README and Settings context were adapted to the newer dev layout.
+<!-- SECTION:NOTES:END -->

--- a/scripts/check_profile_owned_path_inventory.py
+++ b/scripts/check_profile_owned_path_inventory.py
@@ -681,7 +681,7 @@ APPROVED_EXCEPTIONS: tuple[ExceptionRule, ...] = (
         "join:.local/share/tldw_cli",
         1,
         Disposition.COMPATIBILITY_CONSTANT,
-        "import-time compatibility constant retained for Prompts_Dump",
+        "legacy import-time compatibility constant; runtime consumers use the resolver",
     ),
     ExceptionRule(
         "tldw_chatbook/config.py",

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -166,7 +166,7 @@ from ...config import (
     ProviderSettingsError,
     CanvasConfigPolicy,
     RuntimeConfigSnapshot,
-    _default_base_data_dir,
+    _selected_default_base_data_dir,
     apply_settings_mutation_to_cli_config,
     apply_console_capture_settings,
     build_canvas_config_policy,
@@ -10154,13 +10154,11 @@ class SettingsScreen(BaseAppScreen):
         return safe_user_name if safe_user_name else "default_user"
 
     def _configured_user_data_dir_path(self) -> Path:
-        """Read-only mirror of get_user_data_dir()'s resolution logic (minus
-        the mkdir side effect), so the Settings display never diverges from
-        the path the app actually uses. Uses _default_base_data_dir() (the
-        same call-time HOME resolution as get_user_data_dir()'s fallback)
-        rather than the import-time-frozen BASE_DATA_DIR_CLI constant --
-        those two can disagree, e.g. under test-isolated HOME (task-519
-        review)."""
+        """Display the selected profile path without creating directories.
+
+        Share HOME resolution and the durable fallback selection with the
+        runtime resolver, including fresh-install recovery under ADR-127.
+        """
         configured_data_dir = self._read_cli_config_value_without_writes(
             "paths", "data_dir", None
         )
@@ -10171,7 +10169,7 @@ class SettingsScreen(BaseAppScreen):
         base_data_dir = (
             Path(str(configured_data_dir)).expanduser()
             if configured_data_dir
-            else _default_base_data_dir()
+            else _selected_default_base_data_dir()
         )
         return validate_path_simple(
             base_data_dir / self._configured_user_folder_name(),

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -8633,6 +8633,57 @@ def _default_base_data_dir() -> Path:
     return base / ".local" / "share" / "tldw_cli"
 
 
+def _data_root_entry_exists(path: Path) -> bool:
+    """Count links as existing data; never interpret access errors as absence."""
+    try:
+        path.lstat()
+    except FileNotFoundError:
+        return False
+    return True
+
+
+def _selected_default_base_data_dir() -> Path:
+    """Read the durable default-root selection without creating directories."""
+    conventional = _default_base_data_dir()
+    fallback = conventional.parents[2] / ".tldw_cli-data"
+    if not _data_root_entry_exists(fallback):
+        return conventional
+    if _data_root_entry_exists(conventional):
+        raise PrivatePathError(
+            PrivatePathResult(
+                conventional,
+                PrivatePathStatus.OPERATION_FAILED,
+                reason="ambiguous_default_data_roots",
+            )
+        )
+    return fallback
+
+
+def _secure_default_data_dir() -> Path:
+    """Recover a fresh install from shared default ancestors (ADR-127)."""
+    selected = _selected_default_base_data_dir()
+    try:
+        return secure_private_directory(
+            selected, create=True, application_owned=True
+        ).lexical_path
+    except PrivatePathError as exc:
+        conventional = _default_base_data_dir()
+        if (
+            selected != conventional
+            or exc.result.status is not PrivatePathStatus.UNSAFE_PARENT
+            or exc.result.reason != "shared_writable_parent"
+            or _data_root_entry_exists(conventional)
+        ):
+            raise
+        # Only a missing conventional root can select a new location. Existing
+        # data, explicit overrides and unrelated failures must never be hidden.
+        # The unchanged guard also refuses a shared/foreign/symlinked HOME.
+        fallback = conventional.parents[2] / ".tldw_cli-data"
+        return secure_private_directory(
+            fallback, create=True, application_owned=True
+        ).lexical_path
+
+
 def get_api_key(api_name: str) -> Optional[str]:
     """
     Get API key for a given provider.
@@ -8734,11 +8785,7 @@ def get_user_data_dir() -> Path:
         base_data_dir = lexical_path(configured_data_dir)
         verify_trusted_directory(base_data_dir, allow_shared_sticky=False)
     else:
-        base_data_dir = secure_private_directory(
-            _default_base_data_dir(),
-            create=True,
-            application_owned=True,
-        ).lexical_path
+        base_data_dir = _secure_default_data_dir()
     user_dir = base_data_dir / user_folder
     return secure_private_directory(
         user_dir,

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -8609,6 +8609,7 @@ def change_encryption_password(old_password: str, new_password: str) -> bool:
 
 # --- CLI Database and Log File Path Getters ---
 BASE_DATA_DIR_CLI = Path.home() / ".local" / "share" / "tldw_cli"  # Renamed for clarity
+_DEFAULT_DATA_FALLBACK_DIRECTORY = ".tldw_cli-data"
 # NOTE: BASE_DATA_DIR_CLI is a module-level constant frozen at IMPORT time
 # (kept for backward compatibility -- some callers reference it directly).
 # get_user_data_dir()'s fallback below does NOT use it; it resolves the
@@ -8635,6 +8636,7 @@ def _default_base_data_dir() -> Path:
 
 def _data_root_entry_exists(path: Path) -> bool:
     """Count links as existing data; never interpret access errors as absence."""
+    path = validate_path_simple(path, require_exists=False, probe_existing=False)
     try:
         path.lstat()
     except FileNotFoundError:
@@ -8645,7 +8647,7 @@ def _data_root_entry_exists(path: Path) -> bool:
 def _selected_default_base_data_dir() -> Path:
     """Read the durable default-root selection without creating directories."""
     conventional = _default_base_data_dir()
-    fallback = conventional.parents[2] / ".tldw_cli-data"
+    fallback = conventional.parents[2] / _DEFAULT_DATA_FALLBACK_DIRECTORY
     if not _data_root_entry_exists(fallback):
         return conventional
     if _data_root_entry_exists(conventional):
@@ -8659,8 +8661,29 @@ def _selected_default_base_data_dir() -> Path:
     return fallback
 
 
+@contextmanager
+def _default_data_root_lock() -> Iterator[None]:
+    """Serialize root selection and profile creation across starts (ADR-127)."""
+    lock_path = validate_path_simple(
+        _default_base_data_dir().parents[2] / ".tldw_cli-data-root.lock",
+        require_exists=False,
+        probe_existing=False,
+    )
+    try:
+        create_private_text(lock_path, "")
+    except FileExistsError:
+        pass
+    # Keep this inode stable across releases and across config-file choices.
+    with open_private_text_append_stream(lock_path) as stream:
+        portalocker.lock(stream, portalocker.LockFlags.EXCLUSIVE)
+        try:
+            yield
+        finally:
+            portalocker.unlock(stream)
+
+
 def _secure_default_data_dir() -> Path:
-    """Recover a fresh install from shared default ancestors (ADR-127)."""
+    """Recover a fresh root while the caller holds _default_data_root_lock."""
     selected = _selected_default_base_data_dir()
     try:
         return secure_private_directory(
@@ -8678,7 +8701,7 @@ def _secure_default_data_dir() -> Path:
         # Only a missing conventional root can select a new location. Existing
         # data, explicit overrides and unrelated failures must never be hidden.
         # The unchanged guard also refuses a shared/foreign/symlinked HOME.
-        fallback = conventional.parents[2] / ".tldw_cli-data"
+        fallback = conventional.parents[2] / _DEFAULT_DATA_FALLBACK_DIRECTORY
         return secure_private_directory(
             fallback, create=True, application_owned=True
         ).lexical_path
@@ -8781,17 +8804,19 @@ def get_user_data_dir() -> Path:
     configured_data_dir = get_cli_setting("paths", "data_dir", None)
     if configured_data_dir is None:
         configured_data_dir = get_cli_setting("Paths", "data_dir", None)
-    if configured_data_dir:
-        base_data_dir = lexical_path(configured_data_dir)
-        verify_trusted_directory(base_data_dir, allow_shared_sticky=False)
-    else:
-        base_data_dir = _secure_default_data_dir()
-    user_dir = base_data_dir / user_folder
-    return secure_private_directory(
-        user_dir,
-        create=True,
-        application_owned=True,
-    ).lexical_path
+    with ExitStack() as stack:
+        if configured_data_dir:
+            base_data_dir = lexical_path(configured_data_dir)
+            verify_trusted_directory(base_data_dir, allow_shared_sticky=False)
+        else:
+            stack.enter_context(_default_data_root_lock())
+            base_data_dir = _secure_default_data_dir()
+        user_dir = base_data_dir / user_folder
+        return secure_private_directory(
+            user_dir,
+            create=True,
+            application_owned=True,
+        ).lexical_path
 
 
 def _get_custom_database_path(


### PR DESCRIPTION
Fresh installs can crash during configuration import when an existing `.local` or `share` directory is group-writable. When the conventional data root is absent and its ancestors fail that check, startup now creates private `~/.tldw_cli-data/<user>/` storage automatically.

The fallback remains selected across restarts and later permission repairs. A private interprocess lock coordinates concurrent first starts through profile creation. Existing data and explicit overrides are never silently bypassed; ambiguous roots fail closed. Settings and named-profile prompt exports use the selected storage base.

All six Qodo findings are addressed, with replies and resolved review threads. Qodo’s final summary at this head reports zero bugs and zero rule violations. Regression coverage includes concurrent processes during permission repair, fresh-process config imports and SQLite persistence, lexical path validation, private lock/symlink checks, and both prompt database filenames under fallback and custom roots. The reviewed persistent-file inventory records the new empty lock stream; no diagnostic statements changed.

Validation:

- Local targeted storage/config/SQLite/Settings/logging tests: 448 passed, 2 platform skips.
- All 15 profile-path architecture checks pass; new/changed storage tests pass Ruff lint and formatting, with no added lint diagnostics in existing production files.
- [One-off Linux CI](https://github.com/rmusser01/tldw_chatbook/actions/runs/34178138870) at final head `d03328aa2`: Python 3.11, 3.12, and 3.13 each passed the storage suite and installed CLI startup before and after ancestor permission repair. JUnit artifacts were retained. The evidence workflow runs on subsequent commits while its opt-in label remains.
- [Final required workflow](https://github.com/rmusser01/tldw_chatbook/actions/runs/34178138890) passed both PR Fast Lane and every derived-artifact check on the corrected head. All other PR checks are green.

One earlier required run encountered a Textual rendering exception in the unchanged MCP preview Escape test. All 13 focused preview tests and five isolated repeats passed locally on Textual 8.2.8, and the subsequent full 755-test CI run passed.

Rebased onto dev `d547eef4a`. Storage decision: ADR-127, under ADR-029. Task: TASK-32011.
