### PR TITLE
Fix stuck Console sends and repeated status redraws

### DIFF
--- a/Tests/Chat/test_console_chat_controller.py
+++ b/Tests/Chat/test_console_chat_controller.py
@@ -948,7 +948,8 @@ async def test_not_ready_provider_still_echoes_the_user_message():
 
 
 @pytest.mark.asyncio
-async def test_probe_exception_after_optimistic_echo_marks_row_blocked():
+@pytest.mark.parametrize("switch_session", [False, True])
+async def test_probe_exception_after_optimistic_echo_marks_row_blocked(switch_session):
     """TASK-457(a) (Qodo #777 review): if the readiness probe raises (or is
     cancelled) after the optimistic USER echo, the echoed row must still be
     failed so a never-sent message cannot leak into the next send's provider
@@ -957,14 +958,85 @@ async def test_probe_exception_after_optimistic_echo_marks_row_blocked():
     controller = ConsoleChatController(
         store=store, provider_gateway=RaisingProbeGateway()
     )
+    session = store.ensure_session()
+    other = store.create_session(title="Other") if switch_session else None
+    if other is not None:
+        store.active_session_id = other.id
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.STREAMING, "Streaming response."),
+            session_id=other.id,
+        )
 
     with pytest.raises(RuntimeError):
-        await controller.submit_draft("hello")
+        await controller.submit_draft("hello", session_id=session.id)
 
-    messages = store.messages_for_session(store.active_session_id)
+    messages = store.messages_for_session(session.id)
     assert [message.role.value for message in messages] == ["user"]
     assert messages[0].content == "hello"
     assert messages[0].status == "failed"
+    assert controller.run_state_for(session.id).is_send_allowed
+    assert controller.in_flight_run_count() == int(switch_session)
+    if other is not None:
+        assert controller.run_state.status is ConsoleRunStatus.STREAMING
+
+    payloads = []
+
+    class RetryGateway(StreamingGateway):
+        async def stream_chat(self, resolution, messages, **kwargs):
+            payloads.extend(messages)
+            yield "Recovered"
+
+    controller.provider_gateway = RetryGateway()
+    retried = await controller.submit_draft("retry", session_id=session.id)
+    assert retried.accepted
+    assert [row["content"] for row in payloads if row["role"] == "user"] == ["retry"]
+    if other is not None:
+        assert controller.run_state.status is ConsoleRunStatus.STREAMING
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("interruption", ["cancel", "close", "shutdown"])
+async def test_interrupted_validation_releases_only_its_session(interruption):
+    started = asyncio.Event()
+
+    class WaitingProbeGateway:
+        async def resolve_for_send(self, selection):
+            started.set()
+            await asyncio.Event().wait()
+
+    store = ConsoleChatStore()
+    controller = ConsoleChatController(
+        store=store, provider_gateway=WaitingProbeGateway()
+    )
+    session = store.ensure_session()
+    task = asyncio.create_task(controller.submit_draft("hello", session_id=session.id))
+    await asyncio.wait_for(started.wait(), timeout=1)
+    other = store.create_session(title="Other")
+    store.active_session_id = other.id
+    try:
+        if interruption == "cancel":
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        elif interruption == "close":
+            controller.close_session(session.id)
+            closed_state = controller.run_state_for(session.id)
+            result = await asyncio.wait_for(task, timeout=1)
+            assert result.session_closed
+            assert all(item.id != session.id for item in store.sessions())
+            assert controller.run_state_for(session.id) == closed_state
+        else:
+            await asyncio.wait_for(controller.shutdown(), timeout=1)
+            result = await asyncio.wait_for(task, timeout=1)
+            assert not result.accepted
+        assert controller.in_flight_run_count() == 0
+        if interruption != "close":
+            assert controller.run_state_for(session.id).is_send_allowed
+        assert controller.run_state.status is ConsoleRunStatus.IDLE
+    finally:
+        if not task.done():
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_send_diagnostic_flow.py
+++ b/Tests/UI/test_console_send_diagnostic_flow.py
@@ -10,6 +10,7 @@ import pytest
 from Tests.Chat.test_console_send_diagnostics import assert_export, sinks  # noqa: F401
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_console_native_chat_flow import _persist_console_provider_config
+from Tests.UI.test_console_rail_refresh_scope import count_compositor_updates
 from Tests.UI.test_destination_shells import _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
@@ -20,15 +21,24 @@ from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
 
 @pytest.mark.parametrize("failure", ["resolution", "trace", None])
+@pytest.mark.parametrize(
+    "entrypoint,size",
+    [("direct", (80, 24)), ("enter", (80, 24)), ("enter", (160, 45))],
+)
 async def test_mounted_send_has_diagnostic_evidence_before_provider_entry(
     monkeypatch,
     tmp_path,
     sinks,  # noqa: F811 - imported shared pytest fixture
     failure,
+    entrypoint,
+    size,
 ):
     app = _build_test_app()
     database = CharactersRAGDB(tmp_path / "chat.sqlite", "send-diagnostic")
     app.chachanotes_db = database
+    # A new conversation in an existing profile, as in the reported incident.
+    for index in range(4):
+        assert database.add_conversation({"title": f"Existing conversation {index}"})
     _persist_console_provider_config(
         app,
         provider="openai",
@@ -46,7 +56,7 @@ async def test_mounted_send_has_diagnostic_evidence_before_provider_entry(
         monkeypatch.setattr(ConsoleTraceBoundaryFactory, "__call__", fail_factory)
     console = None
     try:
-        async with host.run_test(size=(80, 24)) as pilot:
+        async with host.run_test(size=size) as pilot:
             console = host.screen_stack[-1]
             await _wait_for_selector(console, pilot, "#console-native-composer")
             controller = console._ensure_console_chat_controller()
@@ -66,13 +76,30 @@ async def test_mounted_send_has_diagnostic_evidence_before_provider_entry(
 
             monkeypatch.setattr(gateway, "_chat_api_call_fn", adapter)
             controller.store.ensure_session()
-            console._console_composer_or_none().load_draft("PRIVATE-DRAFT-31977")
-            await asyncio.wait_for(
-                console._send_console_message_from_visible_action(),
-                10,
-            )
+            composer = console._console_composer_or_none()
+            composer.load_draft("PRIVATE-DRAFT-31977")
+            if entrypoint == "enter":
+                composer.focus()
+                await pilot.pause()
+                await pilot.press("enter")
+            else:
+                await asyncio.wait_for(
+                    console._send_console_message_from_visible_action(),
+                    10,
+                )
             await asyncio.wait_for(host.workers.wait_for_complete(), 10)
             await pilot.pause(0.3)
+            # Count the compositor's actual output, including redraws caused by
+            # focus or child layout; screen-recompose counts alone miss those.
+            updates = {"full": 0, "partial": 0}
+            with count_compositor_updates(updates):
+                await pilot.pause(1.2)
+            assert updates["full"] == 0, updates
+            assert console._console_pending_send_stash is None
+            assert console._console_transcript_sync_timer is None
+            if failure == "resolution":
+                assert composer.draft_text() == "PRIVATE-DRAFT-31977"
+                assert controller.run_state.is_send_allowed
             await asyncio.to_thread(app.ui_responsiveness_monitor.close)
             assert len(calls) == (0 if failure else 1)
             expected_phase = (

--- a/Tests/UI/test_console_send_refresh_scope.py
+++ b/Tests/UI/test_console_send_refresh_scope.py
@@ -2,6 +2,7 @@
 
 import asyncio
 from collections import Counter
+from contextlib import closing
 from dataclasses import replace
 
 import pytest
@@ -25,93 +26,94 @@ async def test_waiting_send_does_not_repaint_unchanged_status(
     monkeypatch, tmp_path, size
 ):
     app = _build_test_app()
-    database = CharactersRAGDB(tmp_path / "chat.sqlite", "send-refresh")
-    app.chachanotes_db = database
-    for index in range(4):
-        database.add_conversation({"title": f"Existing {index}"})
-    _persist_console_provider_config(
-        app,
-        provider="openai",
-        model="gpt-4.1",
-        provider_settings={"api_key": "synthetic-test-key"},
-    )
-    host = ConsoleHarness(app)
-    host.CSS_PATH = TldwCli.CSS_PATH
-    entered, release = asyncio.Event(), asyncio.Event()
-    console = None
-    try:
-        async with host.run_test(size=size) as pilot:
-            console = host.screen_stack[-1]
-            await _wait_for_selector(console, pilot, "#console-native-composer")
-            controller = console._ensure_console_chat_controller()
-            gateway = controller.provider_gateway
-            original_resolve = gateway.resolve_for_send
-
-            async def resolve(selection):
-                entered.set()
-                await release.wait()
-                return replace(await original_resolve(selection), streaming=False)
-
-            monkeypatch.setattr(gateway, "resolve_for_send", resolve)
-            monkeypatch.setattr(
-                gateway,
-                "_chat_api_call_fn",
-                lambda **kw: {
-                    "choices": [{"message": {"content": "Synthetic response"}}],
-                },
+    with closing(CharactersRAGDB(tmp_path / "chat.sqlite", "send-refresh")) as database:
+        entered, release = asyncio.Event(), asyncio.Event()
+        console = None
+        try:
+            app.chachanotes_db = database
+            for index in range(4):
+                database.add_conversation({"title": f"Existing {index}"})
+            _persist_console_provider_config(
+                app,
+                provider="openai",
+                model="gpt-4.1",
+                provider_settings={"api_key": "synthetic-test-key"},
             )
-            composer = console._console_composer_or_none()
-            composer.load_draft("Hello")
-            composer.focus()
-            await pilot.pause()
-            await pilot.press("enter")
-            await asyncio.wait_for(entered.wait(), timeout=2)
-            await pilot.pause(0.5)
-            assert controller.run_state.status is ConsoleRunStatus.VALIDATING
-            assert console._console_transcript_sync_timer is not None
-            regions = {
-                widget_id: console.query_one(f"#{widget_id}").content_region
-                for widget_id in (
-                    "console-transcript-title",
-                    "console-send-disabled-reason",
-                    "footer-key-quit",
+            host = ConsoleHarness(app)
+            host.CSS_PATH = TldwCli.CSS_PATH
+            async with host.run_test(size=size) as pilot:
+                console = host.screen_stack[-1]
+                await _wait_for_selector(console, pilot, "#console-native-composer")
+                controller = console._ensure_console_chat_controller()
+                gateway = controller.provider_gateway
+                original_resolve = gateway.resolve_for_send
+
+                async def resolve(selection):
+                    entered.set()
+                    await release.wait()
+                    return replace(await original_resolve(selection), streaming=False)
+
+                monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+                monkeypatch.setattr(
+                    gateway,
+                    "_chat_api_call_fn",
+                    lambda **kw: {
+                        "choices": [{"message": {"content": "Synthetic response"}}],
+                    },
                 )
-            }
-            assert regions["console-transcript-title"].area
-            assert regions["footer-key-quit"].area
-            # The reason strip intentionally hides when the draft needs its width.
-            regions = {key: region for key, region in regions.items() if region.area}
-            painted = Counter()
-            original_partial = Compositor.render_partial_update
+                composer = console._console_composer_or_none()
+                composer.load_draft("Hello")
+                composer.focus()
+                await pilot.pause()
+                await pilot.press("enter")
+                await asyncio.wait_for(entered.wait(), timeout=2)
+                await pilot.pause(0.5)
+                assert controller.run_state.status is ConsoleRunStatus.VALIDATING
+                assert console._console_transcript_sync_timer is not None
+                regions = {
+                    widget_id: console.query_one(f"#{widget_id}").content_region
+                    for widget_id in (
+                        "console-transcript-title",
+                        "console-send-disabled-reason",
+                        "footer-key-quit",
+                    )
+                }
+                assert regions["console-transcript-title"].area
+                assert regions["footer-key-quit"].area
+                # The reason strip intentionally hides when the draft needs its width.
+                regions = {
+                    key: region for key, region in regions.items() if region.area
+                }
+                painted = Counter()
+                original_partial = Compositor.render_partial_update
 
-            def partial(compositor):
-                update = original_partial(compositor)
-                if update is not None and compositor is console._compositor:
-                    for widget_id, region in regions.items():
-                        if any(
-                            region.overlaps(Region(start, y, end - start, 1))
-                            for y, start, end in update.spans
-                        ):
-                            painted[widget_id] += 1
-                return update
+                def partial(compositor):
+                    update = original_partial(compositor)
+                    if update is not None and compositor is console._compositor:
+                        for widget_id, region in regions.items():
+                            if any(
+                                region.overlaps(Region(start, y, end - start, 1))
+                                for y, start, end in update.spans
+                            ):
+                                painted[widget_id] += 1
+                    return update
 
-            monkeypatch.setattr(Compositor, "render_partial_update", partial)
-            counts = {"full": 0, "partial": 0}
-            with count_compositor_updates(counts):
-                for _ in range(3):
-                    await console._sync_native_console_chat_ui()
-                    await pilot.pause(0.05)
-            assert counts["full"] == 0, counts
-            assert not painted, painted
+                monkeypatch.setattr(Compositor, "render_partial_update", partial)
+                counts = {"full": 0, "partial": 0}
+                with count_compositor_updates(counts):
+                    for _ in range(3):
+                        await console._sync_native_console_chat_ui()
+                        await pilot.pause(0.05)
+                assert counts["full"] == 0, counts
+                assert not painted, painted
 
+                release.set()
+                await asyncio.wait_for(host.workers.wait_for_complete(), timeout=10)
+                await pilot.pause(0.3)
+                assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+                assert console._console_transcript_sync_timer is None
+        finally:
             release.set()
-            await asyncio.wait_for(host.workers.wait_for_complete(), timeout=10)
-            await pilot.pause(0.3)
-            assert controller.run_state.status is ConsoleRunStatus.COMPLETED
-            assert console._console_transcript_sync_timer is None
-    finally:
-        release.set()
-        if console is not None:
-            await console._console_runtime().dispose()
-        await asyncio.to_thread(app.ui_responsiveness_monitor.close)
-        database.close()
+            if console is not None:
+                await console._console_runtime().dispose()
+            await asyncio.to_thread(app.ui_responsiveness_monitor.close)

--- a/Tests/UI/test_console_send_refresh_scope.py
+++ b/Tests/UI/test_console_send_refresh_scope.py
@@ -1,0 +1,117 @@
+"""Unchanged in-flight send status must not repaint visible Console text."""
+
+import asyncio
+from collections import Counter
+from dataclasses import replace
+
+import pytest
+from textual._compositor import Compositor
+from textual.geometry import Region
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_native_chat_flow import _persist_console_provider_config
+from Tests.UI.test_console_rail_refresh_scope import count_compositor_updates
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunStatus
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.mark.parametrize("size", [(80, 24), (128, 24), (160, 45)])
+async def test_waiting_send_does_not_repaint_unchanged_status(
+    monkeypatch, tmp_path, size
+):
+    app = _build_test_app()
+    database = CharactersRAGDB(tmp_path / "chat.sqlite", "send-refresh")
+    app.chachanotes_db = database
+    for index in range(4):
+        database.add_conversation({"title": f"Existing {index}"})
+    _persist_console_provider_config(
+        app,
+        provider="openai",
+        model="gpt-4.1",
+        provider_settings={"api_key": "synthetic-test-key"},
+    )
+    host = ConsoleHarness(app)
+    host.CSS_PATH = TldwCli.CSS_PATH
+    entered, release = asyncio.Event(), asyncio.Event()
+    console = None
+    try:
+        async with host.run_test(size=size) as pilot:
+            console = host.screen_stack[-1]
+            await _wait_for_selector(console, pilot, "#console-native-composer")
+            controller = console._ensure_console_chat_controller()
+            gateway = controller.provider_gateway
+            original_resolve = gateway.resolve_for_send
+
+            async def resolve(selection):
+                entered.set()
+                await release.wait()
+                return replace(await original_resolve(selection), streaming=False)
+
+            monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+            monkeypatch.setattr(
+                gateway,
+                "_chat_api_call_fn",
+                lambda **kw: {
+                    "choices": [{"message": {"content": "Synthetic response"}}],
+                },
+            )
+            composer = console._console_composer_or_none()
+            composer.load_draft("Hello")
+            composer.focus()
+            await pilot.pause()
+            await pilot.press("enter")
+            await asyncio.wait_for(entered.wait(), timeout=2)
+            await pilot.pause(0.5)
+            assert controller.run_state.status is ConsoleRunStatus.VALIDATING
+            assert console._console_transcript_sync_timer is not None
+            regions = {
+                widget_id: console.query_one(f"#{widget_id}").content_region
+                for widget_id in (
+                    "console-transcript-title",
+                    "console-send-disabled-reason",
+                    "footer-key-quit",
+                )
+            }
+            assert regions["console-transcript-title"].area
+            assert regions["footer-key-quit"].area
+            # The reason strip intentionally hides when the draft needs its width.
+            regions = {key: region for key, region in regions.items() if region.area}
+            painted = Counter()
+            original_partial = Compositor.render_partial_update
+
+            def partial(compositor):
+                update = original_partial(compositor)
+                if update is not None and compositor is console._compositor:
+                    for widget_id, region in regions.items():
+                        if any(
+                            region.overlaps(Region(start, y, end - start, 1))
+                            for y, start, end in update.spans
+                        ):
+                            painted[widget_id] += 1
+                return update
+
+            monkeypatch.setattr(Compositor, "render_partial_update", partial)
+            counts = {"full": 0, "partial": 0}
+            with count_compositor_updates(counts):
+                for _ in range(3):
+                    await console._sync_native_console_chat_ui()
+                    await pilot.pause(0.05)
+            assert counts["full"] == 0, counts
+            assert not painted, painted
+
+            release.set()
+            await asyncio.wait_for(host.workers.wait_for_complete(), timeout=10)
+            await pilot.pause(0.3)
+            assert controller.run_state.status is ConsoleRunStatus.COMPLETED
+            assert console._console_transcript_sync_timer is None
+    finally:
+        release.set()
+        if console is not None:
+            await console._console_runtime().dispose()
+        await asyncio.to_thread(app.ui_responsiveness_monitor.close)
+        database.close()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12111,3 +12111,18 @@ starts, wait for the expected starts (poll with a generous deadline)
 rather than a flat window sized to the happy path. The probe already
 records STARTS rather than running state, so waiting cannot miss a worker
 that finishes quickly.
+
+## A settled paint does not prove a failed send released its busy state
+
+**TASK-32010, 2026-09-07.** Extending the existing mounted Console diagnostic
+test to press Enter with capture enabled found zero repeated full-screen
+compositor updates after a readiness exception, yet the transcript's 200ms timer
+kept running. The failed echo was correctly marked unsent, but the controller
+remained VALIDATING and refused another send. Testing slot release and an actual
+controller retry exposed the missing exception cleanup. The same omission also
+affected cancellation before provider entry.
+
+**What to do.** Check send state, retry and timer termination alongside actual
+compositor output. An orphaned polling timer is a concrete lifecycle defect;
+without repeated paint evidence, it does not establish the cause of a reporter's
+visible terminal flicker.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12126,3 +12126,13 @@ affected cancellation before provider entry.
 compositor output. An orphaned polling timer is a concrete lifecycle defect;
 without repeated paint evidence, it does not establish the cause of a reporter's
 visible terminal flicker.
+
+**TASK-32012 follow-up.** Holding provider validation open after Enter still
+produced zero full-screen updates and stable geometry, but actual partial spans
+repainted the unchanged transcript title, composer reason and footer hints about
+five times per second. Suppressing equal text writes at those three widgets in
+the experiment left only caret paints. The mounted regression therefore checks
+emitted partial spans, alongside full-screen updates, and then completes the send.
+The first implementation caught only one of two heading writers; the real-paint
+assertion remained red until both were guarded. Keep responsive width and
+visibility recalculation outside text equality guards.

--- a/backlog/tasks/task-32010 - Release-Console-validation-state-when-the-readiness-probe-raises.md
+++ b/backlog/tasks/task-32010 - Release-Console-validation-state-when-the-readiness-probe-raises.md
@@ -1,0 +1,49 @@
+---
+id: TASK-32010
+title: Release Console validation state when the readiness probe raises
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-08 00:16'
+updated_date: '2026-09-08 00:24'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+An exception during provider readiness validation leaves a failed Console send marked busy, prevents retry, and keeps transcript polling active. Restore terminal state for the owning conversation while preserving cancellation and draft recovery.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A readiness exception releases the failed conversation slot and permits retry; the unsent echo remains excluded from provider history.
+- [x] #2 Cancellation propagates and session close or shutdown does not revive state or disturb another active conversation.
+- [x] #3 Mounted Enter sends retain existing diagnostic evidence, restore failed drafts, stop idle transcript polling, and settle without repeated full-screen redraws at narrow and wide sizes.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A (existing ownership follows backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md; existing diagnostics follow ADR-029).
+Reason: routine bug fix within the existing readiness exception handler; no new runtime, persistence, UI or diagnostic interface.
+1. Extend the existing readiness exception regression to prove terminal state, slot release, retry, cancellation and owning-session isolation. Preserve the failing mounted Enter evidence from TASK-31977.
+2. Release only the owning validation state in its existing exception cleanup, retaining exception propagation and existing failed-echo handling.
+3. Run focused controller lifecycle and mounted Enter tests, check actual compositor output and existing diagnostic privacy, lint changed code and self-review. Document the reproduced defect separately from the reporter-specific flicker, which remains unconfirmed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed a reproducible pre-provider send lifecycle defect: readiness exceptions failed the optimistic user echo but left its session VALIDATING, occupying a send slot and keeping the transcript timer polling every 200ms. The existing exception handler now releases manual/queued validation state to BLOCKED, or STOPPED for cancellation, while preserving exception propagation and failed-echo history exclusion. It targets only the live owning session and does not overwrite an already-terminal state.
+
+Scope: no new capture tool, logging surface, dependency or UI timer workaround. AGENT_WAKE retains its separate coordinator retry lifecycle: applying cleanup to wakes changed immediate retry ordering and failed its existing fairness regression, so that independent lifecycle remains unchanged. ADR required: no; routine cleanup under existing ADR-094 controller ownership and ADR-029 diagnostic privacy.
+
+Extended the existing controller exception regression with real retry/provider-payload assertions and inactive-session isolation; added cancellation, close and shutdown cases. Extended the existing mounted diagnostic test with actual Enter, capture enabled, four persisted conversations, 80x24 and 160x45 layouts, failed-draft restoration, timer termination and the existing actual compositor counter. Added an incident-backed testing lesson.
+
+Evidence: before the fix, three mounted readiness-exception cases left the timer alive; focused exception and cancellation tests left VALIDATING/occupied slots. After the fix, 46 focused lifecycle checks, 20 mounted/diagnostic checks and 5 queue regression checks passed (71 total). The earlier 46 layout/caret investigation checks also passed. Mounted cases observed zero repeated full-screen redraws over a settled 1.2-second window both before and after the cleanup: this proves the polling defect, not the cause of the external reporter's terminal flicker. The supplied startup log does not identify a send-stage exception; reporter-specific root cause remains unresolved.
+
+Verification limits: two broader checks fail identically with the untouched HEAD controller: test_no_unbounded_resolve_for_send_awaits_remain (two pre-existing direct awaits) and test_stop_active_run_cancels_only_viewed_sessions_task (terminal generation persistence fixture failure). The wake fairness check passes both baseline and final patch. Ruff reports zero introduced findings (controller 178 baseline/current; controller tests 17 baseline/current); mounted test lint and formatting pass, changed controller/test ranges format cleanly, task-ID guard and git diff --check pass. Task remains In Progress because the repository Definition of Done requires all-green checks. Full suite was not run. Self-review completed; no PR or merge is part of this follow-up investigation yet.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32012 - Avoid-repainting-unchanged-Console-send-status-text.md
+++ b/backlog/tasks/task-32012 - Avoid-repainting-unchanged-Console-send-status-text.md
@@ -1,0 +1,49 @@
+---
+id: TASK-32012
+title: Avoid repainting unchanged Console send status text
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-08 00:38'
+updated_date: '2026-09-08 00:47'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+During a pending Console send, the transcript heading, composer reason and footer hints repaint unchanged text on every 200ms sync. Measured in-flight partial paints disappear when those duplicate writes are suppressed. Remove that unnecessary terminal output while preserving changing content and responsive layout; the external flicker report remains unconfirmed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Unchanged in-flight Console syncs do not repaint the transcript heading, composer reason or footer hint text.
+- [x] #2 Changed guidance, setup actions, footer hints and terminal widths still update correctly.
+- [x] #3 Mounted Enter regression and focused component checks pass; existing send completion and cancellation behavior is preserved.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: routine equality guards in existing rendered widgets; unchanged ownership, content, privacy and responsive layout.
+1. Preserve the in-flight Enter experiment and add a mounted regression that measures real compositor spans for the three unchanged visible surfaces while validation is active. The existing per-keystroke TASK-21120 dismissal concerns a different workload; this finding measures repeated idle-send paints.
+2. Compare each newly rendered text value with its mounted Static content before update, including styled setup-action content. Keep width, visibility, state and empty-card sync running.
+3. Verify changed text and widths through focused component tests; re-run the mounted real-paint test and failed-send regression; measure post-fix in-flight painting, lint changed ranges and self-review. State that the external terminal flicker remains unconfirmed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added equality checks against each mounted Static widget's current content before writing the transcript heading (both its title and guidance writers), composer disabled-reason content and responsive footer hints. Styled setup actions still participate in equality, and responsive width/visibility calculations and empty-card synchronization still run. No screen-wide throttling, new cache, capture tool, logging surface, ownership change or dependency.
+
+Investigation evidence: holding provider validation open after Enter at four sizes with short and multiline drafts found zero full-screen updates. Apparent rail movement was a single one-row adjustment, not a repeating geometry cycle. Actual partial spans repainted the unchanged heading/reason/footer approximately five times per second; the 128x24 experiment measured 6942 repainted cells over its five-second baseline. Suppressing duplicate writes at just those three widgets left only five caret paints (150 cells total) in a three-second comparison window. This is a demonstrated redraw source; the external reporter's exact visible flicker remains unconfirmed.
+
+The new mounted Enter regression measures actual full/partial compositor output during forced unchanged in-flight syncs and then releases validation and verifies send completion and polling shutdown. Before the fix, 128- and 160-column cases repainted all three surfaces four to five times; the 80-column reason strip is intentionally hidden and its geometry precondition was corrected. The initial implementation left a second heading writer unguarded; all three cases stayed red on heading paint until both writers were covered.
+
+Verification: 15 mounted send, real-paint, diagnostic, title and inline-guidance tests passed after the final change. Another 34 composer-gating, markup, reason-width and footer-content/resizing checks passed (49 targeted checks total). Two broader pre-existing layout tests fail with the original three widget files restored from a846f01b6: test_console_transcript_header_sits_at_top_of_center_panel expects an obsolete one-row spacing, and test_console_transcript_header_and_tabs_have_distinct_visual_roles expects an obsolete tab-strip class. No full test sweep was run.
+
+Static verification: the new test passes Ruff and formatting; changed production ranges format cleanly, git diff --check and the task-ID guard pass. Whole-file Ruff has unchanged existing findings: session surface 20, composer 5, footer 5; no introduced findings. Task remains In Progress under the repository's strict all-green Definition of Done. Added an incident-backed testing lesson and completed self-review. ADR required: no; routine render equality guards preserve existing contracts. The discarded experiment remains outside repository test discovery.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32012 - Avoid-repainting-unchanged-Console-send-status-text.md
+++ b/backlog/tasks/task-32012 - Avoid-repainting-unchanged-Console-send-status-text.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 00:38'
-updated_date: '2026-09-08 00:47'
+updated_date: '2026-09-08 01:00'
 labels: []
 dependencies: []
 ---
@@ -32,6 +32,7 @@ Reason: routine equality guards in existing rendered widgets; unchanged ownershi
 1. Preserve the in-flight Enter experiment and add a mounted regression that measures real compositor spans for the three unchanged visible surfaces while validation is active. The existing per-keystroke TASK-21120 dismissal concerns a different workload; this finding measures repeated idle-send paints.
 2. Compare each newly rendered text value with its mounted Static content before update, including styled setup-action content. Keep width, visibility, state and empty-card sync running.
 3. Verify changed text and widths through focused component tests; re-run the mounted real-paint test and failed-send regression; measure post-fix in-flight painting, lint changed ranges and self-review. State that the external terminal flicker remains unconfirmed.
+4. Address PR #2496 review: manage the mounted regression database with contextlib.closing from acquisition, retaining asynchronous teardown for setup and runtime failures; document the guidance arguments; rerun targeted regressions and preflight before merge.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -46,4 +47,6 @@ The new mounted Enter regression measures actual full/partial compositor output 
 Verification: 15 mounted send, real-paint, diagnostic, title and inline-guidance tests passed after the final change. Another 34 composer-gating, markup, reason-width and footer-content/resizing checks passed (49 targeted checks total). Two broader pre-existing layout tests fail with the original three widget files restored from a846f01b6: test_console_transcript_header_sits_at_top_of_center_panel expects an obsolete one-row spacing, and test_console_transcript_header_and_tabs_have_distinct_visual_roles expects an obsolete tab-strip class. No full test sweep was run.
 
 Static verification: the new test passes Ruff and formatting; changed production ranges format cleanly, git diff --check and the task-ID guard pass. Whole-file Ruff has unchanged existing findings: session surface 20, composer 5, footer 5; no introduced findings. Task remains In Progress under the repository's strict all-green Definition of Done. Added an incident-backed testing lesson and completed self-review. ADR required: no; routine render equality guards preserve existing contracts. The discarded experiment remains outside repository test discovery.
+
+PR #2496 Qodo follow-up: wrapped the mounted regression database in contextlib.closing immediately at acquisition and moved all conversation/provider/harness setup under the existing asynchronous cleanup. Database closure now survives setup and teardown exceptions. Added the Google-style Args contract for sync_inline_guidance. The 17 affected lifecycle, mounted diagnostic and compositor tests pass after these changes; the test file passes Ruff and formatting, and the production surface retains the same 20 baseline lint findings with none introduced. Self-review complete; these review fixes preserve the existing ADR decision and acceptance criteria.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -7611,7 +7611,7 @@ class ConsoleChatController:
                 if resumed_preparation is not None
                 else await self._resolve_for_send_bounded(turn_selection)
             )
-        except BaseException:
+        except BaseException as exc:
             # A readiness probe that raises or is cancelled AFTER the optimistic
             # USER echo must still fail that row — otherwise a never-sent USER
             # message leaks into the NEXT send's provider context (`skip_failed`
@@ -7627,6 +7627,28 @@ class ConsoleChatController:
                     )
                 else:
                     self._mark_transient_echo_blocked(echoed_user.id)
+            # Validation owns a busy slot even before a provider starts. Release
+            # it on failure so retry and the view's idle polling cleanup can run.
+            # A closed session or an already-stopped run keeps its owner's state.
+            # Wakes own a separate retry loop; releasing their slot here would
+            # immediately retry the same failed wake ahead of other pending wakes.
+            if (
+                origin is not ConsoleSubmissionOrigin.AGENT_WAKE
+                and self.run_state_for(session.id).status is ConsoleRunStatus.VALIDATING
+                and any(item.id == session.id for item in self.store.sessions())
+            ):
+                cancelled = isinstance(exc, asyncio.CancelledError)
+                self._set_run_state(
+                    ConsoleRunState(
+                        ConsoleRunStatus.STOPPED
+                        if cancelled
+                        else ConsoleRunStatus.BLOCKED,
+                        "Provider validation was cancelled."
+                        if cancelled
+                        else "Provider validation failed. Try sending again.",
+                    ),
+                    session_id=session.id,
+                )
             raise
         if not getattr(resolution, "ready", False):
             visible_copy = self._blocked_visible_copy(

--- a/tldw_chatbook/Widgets/AppFooterStatus.py
+++ b/tldw_chatbook/Widgets/AppFooterStatus.py
@@ -387,7 +387,8 @@ class AppFooterStatus(Widget):
         width = self.size.width
         if width <= 0:
             # Pre-layout: show the full text; on_resize will refine.
-            self._shortcut_display.update(self._shortcut_text)
+            if self._shortcut_display.content != self._shortcut_text:
+                self._shortcut_display.update(self._shortcut_text)
             return
 
         hard_token = width >= self._TOKEN_MIN_WIDTH and self._show_token_count
@@ -484,7 +485,8 @@ class AppFooterStatus(Widget):
                 self._token_count_display.display = token_vis
                 self._word_count_display.display = word_vis
                 self._db_status_display.display = db_vis
-                self._shortcut_display.update(text)
+                if self._shortcut_display.content != text:
+                    self._shortcut_display.update(text)
                 return
 
     # ------------------------------------------------------------------

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -1909,14 +1909,14 @@ class ConsoleComposerBar(Horizontal):
             # never re-parsed as markup, so a future reason carrying "[...]"
             # cannot smuggle in styling or a second action.
             if self.has_class("console-composer-setup-blocked"):
-                strip.update(
-                    Content.from_markup(
-                        "[@click=app.run_setup_wizard]$reason ›[/]",
-                        reason=reason,
-                    )
+                reason_content = Content.from_markup(
+                    "[@click=app.run_setup_wizard]$reason ›[/]",
+                    reason=reason,
                 )
             else:
-                strip.update(Content(reason))
+                reason_content = Content(reason)
+            if strip.content != reason_content:
+                strip.update(reason_content)
             # TASK-24415: the cap is a function of the live row width so the
             # draft keeps its floor; below a legible budget the strip hides
             # entirely (the Send tooltip still carries the reason).
@@ -1936,7 +1936,8 @@ class ConsoleComposerBar(Horizontal):
                 strip.styles.height = 0
                 strip.styles.min_height = 0
         else:
-            strip.update(Content(""))
+            if strip.content != Content(""):
+                strip.update(Content(""))
             strip.styles.display = "none"
             strip.styles.width = 0
             strip.styles.min_width = 0

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -800,7 +800,9 @@ class ConsoleSessionSurface(Vertical):
         self._session_title = normalized or None
         try:
             header = self.query_one("#console-transcript-title", Static)
-            header.update(self._render_transcript_title())
+            title_content = self._render_transcript_title()
+            if header.content != title_content:
+                header.update(title_content)
         except Exception:
             return
 
@@ -824,7 +826,9 @@ class ConsoleSessionSurface(Vertical):
             title = self.query_one("#console-transcript-title", Static)
         except Exception:
             return
-        title.update(self._render_transcript_title())
+        title_content = self._render_transcript_title()
+        if title.content != title_content:
+            title.update(title_content)
 
         try:
             transcript = self.query_one("#console-native-transcript", ConsoleTranscript)

--- a/tldw_chatbook/Widgets/Console/console_session_surface.py
+++ b/tldw_chatbook/Widgets/Console/console_session_surface.py
@@ -821,7 +821,13 @@ class ConsoleSessionSurface(Vertical):
         provider_action_label: str = "",
         provider_action_tooltip: str = "",
     ) -> None:
-        """Keep guidance out of the title and sync the empty transcript card state."""
+        """Keep guidance out of the title and sync the empty transcript card state.
+
+        Args:
+            card_state: Setup guidance to display when the transcript is empty.
+            provider_action_label: Setup action label; empty hides the action.
+            provider_action_tooltip: Tooltip describing the setup action.
+        """
         try:
             title = self.query_one("#console-transcript-title", Static)
         except Exception:


### PR DESCRIPTION
Provider-readiness exceptions left fresh Console sends stuck in `VALIDATING`, occupying a send slot and keeping the 200ms transcript poll alive. Release the owning manual/queued validation state on failure or cancellation while retaining draft recovery, failed-echo history exclusion and exception propagation. Closed sessions and the separate agent-wake retry lifecycle retain their existing handling.

Pending sends also repainted unchanged transcript headings, composer reasons and footer hints about five times per second. Compare the mounted widgets' rendered content before updating it, while continuing responsive width/visibility calculations and changed-content updates. Both heading writers are covered.

Adds mounted Enter regressions at narrow and wide terminal sizes that check actual compositor output, draft recovery, retry and polling termination. These fixes address reproduced defects; the external reporter's exact visible flicker remains unconfirmed.

Validation:
- Rebased onto dev `511044368`; 17 focused controller and mounted-send tests pass on the rebased head.
- 34 additional composer, reason-width and footer checks passed before the documentation-only rebase; broader lifecycle evidence is recorded in TASK-32010 and TASK-32012.
- All derived-artifact preflight checks pass, including stylesheets, diagnostic inventory and task IDs.
- New tests pass Ruff; changed production ranges format cleanly; no introduced Ruff findings in the legacy files.
- Known baseline failures were reproduced with unchanged source: the unbounded-readiness-await source guard, a stop/persistence fixture, and two obsolete transcript header geometry/class assertions. Legacy whole-file Ruff debt also remains. These limitations are recorded in the task notes.

Full suite not run; verification was targeted per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Releases Console send validation state when the provider readiness probe raises or is cancelled, and stops pending sends from repainting unchanged transcript headings, composer reasons, and footer hints about five times per second.

**Bug Fixes**
- Failed, cancelled, closed, or shutdown-interrupted validation now frees only the owning session's send slot and stops its 200ms transcript poll; draft recovery, failed-echo history exclusion, and exception propagation are unchanged.
- The separate agent-wake retry lifecycle keeps its existing behavior and is excluded from cleanup.
- The transcript title, composer disabled-reason, and footer hint widgets compare their mounted content before updating; responsive width and visibility calculations still run.
- Mounted Enter regressions at narrow and wide terminal sizes verify compositor output, draft recovery, retry, polling termination, and isolation from another active session; the external reporter's exact flicker remains unconfirmed.

<sup>Written for commit b05a389beb603f271d21cb9021f6aa93568103a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

