### PR TITLE
fix(library): show blocked-action reasons inline, not only on hover (task-31981)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -179,7 +179,11 @@ item in one run, in list order, on its own row under Clear/Export/Review:
 - One run at a time: a second press while one is in flight says "Analysis
   already running" rather than starting a second.
 - With no analysis provider configured the action reads **"○ Analyze"** and
-  its tooltip carries the same reason the Reader's Generate gives.
+  an always-visible line beneath it states the reason and the next step
+  ("No analysis provider is configured · Set one in Settings ▸ Providers &
+  Models."), the same wording the Reader's Generate gives — so a
+  keyboard-first user reads why without hovering. The tooltip still carries
+  it too.
 - The run belongs to the Library screen: leaving Library stops it, and a
   notice says where it got to ("Analysis stopped at 3 of 40 · reopen Select
   ▸ Analyze to continue; finished items are skipped"). Items already
@@ -401,9 +405,11 @@ still spans the pane.
   written by hand here, or generated in place: **"Generate"** (**"Regenerate"**
   once one exists) calls the configured analysis provider without leaving
   the reading flow. With no provider configured it reads **"○ Generate"**
-  and its tooltip names the reason (the same wording the Select-mode bulk
-  **Analyze** tooltip and the Import "Analyze N skipped" gate use), so the
-  gap is visible before you click rather than after.
+  and an always-visible line beneath the button names the reason and the
+  next step ("No analysis provider is configured · Set one in Settings ▸
+  Providers & Models.") — the same wording the Select-mode bulk **Analyze**
+  gate and the Import "Analyze N skipped" gate use — so the gap is readable
+  before you click, without hovering. The tooltip still carries it too.
 - **Highlights** — saved quotes from this item ("No highlights yet." when
   empty). Expand the collapsed **"Add highlight"** section, fill "Quote"
   (required), optionally "Note (optional)" and "Color (optional)", and
@@ -440,6 +446,14 @@ at painted column 98. Find on the Markdown item shows "No matches" with
 for Markdown and transcripts" in the row the Rendered|Raw strip occupies for a
 Markdown item. The failed-list placeholder (item 12) is pinned by test, not
 live: forcing it needs the Media page load to fail.)*
+
+*Verified against fix/media-crit6-blockedreason — 2026-09-07 (task-31981,
+critique #6 P1: with no analysis provider configured, the Reader's blocked
+"○ Generate" and the Select-mode bulk "○ Analyze" each paint their reason
+plus next step ("… · Set one in Settings ▸ Providers & Models.") on an
+always-visible line adjacent to the control — no hover needed. Pinned by
+painted-text tests at 235x52 and 100x30, matching the Export gate's inline
+"No destination chosen" grammar.)*
 
 *Verified against fix/media-wave5-h @ a4682f17e — 2026-09-06 (task-31633
 AC#3: More opened live at 235x52 and at 100x30 over a seeded document.

--- a/Tests/Library/test_ingest_analysis.py
+++ b/Tests/Library/test_ingest_analysis.py
@@ -307,7 +307,7 @@ def test_every_not_ready_shape_yields_a_capitalised_sentence() -> None:
 
     assert (
         analysis_unavailable_reason(none_configured)
-        == "No analysis provider is configured."
+        == "No analysis provider is configured · Set one in Settings ▸ Providers & Models."
     )
     assert "local_onnx" in analysis_unavailable_reason(unsupported)
     assert analysis_unavailable_reason(unready).startswith("OpenAI is not ready")
@@ -332,5 +332,5 @@ def test_a_blank_short_reason_falls_back_instead_of_raising() -> None:
         )
         assert (
             analysis_unavailable_reason(resolution)
-            == "No analysis provider is configured."
+            == "No analysis provider is configured · Set one in Settings ▸ Providers & Models."
         ), blank

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -73,6 +73,16 @@ from Tests.UI.test_library_shell import (
 )
 
 
+from tldw_chatbook.Library.ingest_analysis import NO_ANALYSIS_PROVIDER_NEXT_STEP
+
+#: task-31981: the full surfaced reason for the no-provider case, derived
+#: from the source's next-step constant so only the reason half is pinned
+#: here (the "reason · action" join and next step live in the source).
+_NO_PROVIDER_REASON = (
+    f"No analysis provider is configured · {NO_ANALYSIS_PROVIDER_NEXT_STEP}."
+)
+
+
 def _host() -> LibraryProductionCSSHarness:
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_two_media_items())
@@ -1947,7 +1957,7 @@ async def test_generate_is_disabled_with_its_reason_when_no_provider_is_configur
         assert str(generate.label) == expected_label
         # The marker is not just on the widget -- it reaches the glass.
         assert expected_label in _painted(host, generate.region)
-        assert str(generate.tooltip) == "No analysis provider is configured."
+        assert str(generate.tooltip) == _NO_PROVIDER_REASON
         # Belt and braces: the handler refuses with the same sentence.
         warnings: list[str] = []
         screen._notify_library_media_analysis_warning = warnings.append
@@ -1955,8 +1965,68 @@ async def test_generate_is_disabled_with_its_reason_when_no_provider_is_configur
             SimpleNamespace(stop=lambda: None)
         )
         await pilot.pause()
-        assert warnings == ["No analysis provider is configured."]
+        assert warnings == [_NO_PROVIDER_REASON]
         assert screen._library_media_generating_analysis is False
+
+
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)], ids=["wide", "narrow"])
+@pytest.mark.asyncio
+async def test_reader_generate_reason_is_painted_inline_not_hover_only(size):
+    """task-31981 AC#1/#4: the blocked Generate's reason reaches the glass
+    as an always-visible line adjacent to the control, not only as a mouse
+    tooltip a keyboard user can never reach. Painted at both sizes, no hover.
+    AC#2: the reason names the next step (Settings ▸ Providers & Models)."""
+    host = _host()  # the test config configures no analysis provider
+    async with host.run_test(size=size) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _open_first_reader_row(screen, pilot)
+        await _switch_to_analysis(screen, pilot)
+        reason_line = screen.query_one("#library-media-analysis-generate-reason", Static)
+        painted = _painted(host, reason_line.region).replace("\n", " ")
+        assert "No analysis provider is configured" in painted, painted
+        # AC#2: the next step, not just the fault.
+        assert "Settings" in painted, painted
+        assert "Providers & Models" in painted, painted
+
+
+@pytest.mark.asyncio
+async def test_reader_generate_reason_line_is_absent_when_a_provider_is_ready():
+    """task-31981: with a ready provider the inline reason line is gone and
+    Generate is live -- the line is the blocker's carrier, not chrome."""
+    host = _analysed_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        with pytest.MonkeyPatch.context() as mp:
+            mp.setattr(
+                library_screen_module,
+                "analysis_unavailable_reason",
+                lambda *_a, **_k: "",
+            )
+            await _open_first_reader_row(screen, pilot)
+            await _switch_to_analysis(screen, pilot)
+            assert not screen.query("#library-media-analysis-generate-reason")
+            generate = screen.query_one("#library-media-analysis-generate", Button)
+            assert generate.disabled is False
+
+
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)], ids=["wide", "narrow"])
+@pytest.mark.asyncio
+async def test_select_mode_analyze_reason_is_painted_inline_not_hover_only(size):
+    """task-31981 AC#1/#4: the select-mode bulk Analyze gates on the same
+    provider condition, and its reason must paint inline too -- same silence,
+    same fix, at both sizes with no hover."""
+    host = _host()  # the test config configures no analysis provider
+    async with host.run_test(size=size) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._toggle_library_media_select_mode()
+        await _wait_for_selector(screen, pilot, "#library-media-analyze-selected")
+        await pilot.pause()
+        analyze = screen.query_one("#library-media-analyze-selected", Button)
+        assert analyze.disabled is True
+        reason_line = screen.query_one("#library-media-analyze-selected-reason", Static)
+        painted = _painted(host, reason_line.region).replace("\n", " ")
+        assert "No analysis provider is configured" in painted, painted
+        assert "Providers & Models" in painted, painted
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -10693,7 +10693,10 @@ async def test_library_media_generate_analysis_without_provider_notifies_and_ski
             generate = screen.query_one("#library-media-analysis-generate", Button)
             assert generate.disabled is True
             assert str(generate.label) == "○ Generate"
-            assert str(generate.tooltip) == "No analysis provider is configured."
+            assert str(generate.tooltip) == (
+                "No analysis provider is configured "
+                "· Set one in Settings ▸ Providers & Models."
+            )
             screen.handle_library_media_analysis_generate(
                 SimpleNamespace(stop=lambda: None)
             )

--- a/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
+++ b/backlog/tasks/task-31981 - Library-a-blocked-action-explains-itself-only-on-mouse-hover-not-inline.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-31981
 title: 'Library: a blocked action explains itself only on mouse hover, not inline'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-07 22:48'
+updated_date: '2026-09-08 01:52'
 labels:
   - library
   - media
@@ -21,12 +22,44 @@ Critique #6 P1, both assessors. Clicking a disabled `○ Generate` in the reader
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A blocked Generate/Analyze action shows its reason as an always-visible line adjacent to the control, not only in a hover tooltip
-- [ ] #2 The reason names a next step where one exists (e.g. Set a provider in Settings)
-- [ ] #3 The pattern matches the existing Export gate's inline-reason treatment
-- [ ] #4 A painted pin asserts the reason text is present on the screen with no hover
+- [x] #1 A blocked Generate/Analyze action shows its reason as an always-visible line adjacent to the control, not only in a hover tooltip
+- [x] #2 The reason names a next step where one exists (e.g. Set a provider in Settings)
+- [x] #3 The pattern matches the existing Export gate's inline-reason treatment
+- [x] #4 A painted pin asserts the reason text is present on the screen with no hover
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both blocked actions already resolved their reason through one seam
+(`_library_media_analysis_provider_reason` → `analysis_unavailable_reason`)
+and surfaced it only as a tooltip. Fix: render it inline too.
+
+- **Viewer** (`Widgets/Library/library_media_viewer.py`): after the Generate
+  toolbar, yield a `Static(reason, id="library-media-analysis-generate-reason",
+  classes="library-media-action-reason")` when a reason is set.
+- **Select-mode Analyze** (`Widgets/Library/library_media_canvas.py`): after
+  the analyze row, yield the same-class `Static`
+  (`id="library-media-analyze-selected-reason"`).
+- **Next step (AC#2)** (`Library/ingest_analysis.py`): the no-provider case of
+  `analysis_unavailable_reason` now returns "No analysis provider is configured
+  · Set one in Settings ▸ Providers & Models." (established app grammar; the
+  Settings label verified by grep, not invented). The provider-not-ready branch
+  stays bare — its fix depends on the specific gap. Persisted job `short_reason`
+  and the ingest `hint` are untouched.
+- **CSS**: `.library-media-action-reason` added to
+  `css/components/_agentic_terminal.tcss` (mirrors `.library-export-quiet-line`),
+  bundle rebuilt.
+- **Precedent matched**: the Export gate's `Static` "No destination chosen"
+  line under `○ Export bundle (.zip)` (`library_export_canvas.py:174`).
+- **TDD**: painted-text pins at 235x52 and 100x30 in
+  `Tests/UI/test_library_media_render_fixes.py` — red (NoMatches on the reason
+  id, tooltip-only) → green. Pre-existing string assertions updated to the
+  enriched copy. 7 unrelated render_fixes reds are a baseline `█` scrollbar
+  artifact (confirmed identical on baseline).
+- **Docs**: `Docs/User_Guide/library/media-and-conversations.md` updated + stamp.
 
 ## Renumbering provenance
 
 Filed as TASK-31977 during critique #6's fix wave; renumbered to TASK-31981 because a concurrent session landed its own TASK-31977 on dev first (2026-08-21 owner rule, TASK-19601: older arrival keeps the id). No other task references this one.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/ingest_analysis.py
+++ b/tldw_chatbook/Library/ingest_analysis.py
@@ -35,6 +35,13 @@ from tldw_chatbook.Chat.provider_readiness import (
 #: provider at all. Also the substring the panel hint builds on.
 NO_ANALYSIS_PROVIDER_REASON = "no analysis provider is configured"
 
+#: task-31981: the next step for the no-provider case, appended to the
+#: surfaced reason in the app's "reason · action" grammar (see the
+#: watchlists Generate gate's "Settings ▸ Providers & Models" phrasing).
+#: Only this branch has a single obvious fix; the provider-not-ready
+#: branch's fix depends on the specific readiness gap, so it stays bare.
+NO_ANALYSIS_PROVIDER_NEXT_STEP = "Set one in Settings ▸ Providers & Models"
+
 # ---------------------------------------------------------------------------
 # (task-3301 xhigh review round, F10) The full [analysis_defaults] call
 # shape. Defaults mirror the Media viewer's analysis panel
@@ -247,6 +254,10 @@ def analysis_unavailable_reason(resolution: IngestAnalysisResolution) -> str:
     # seam other gates feed resolutions into.
     reason = (resolution.short_reason or "").strip() or NO_ANALYSIS_PROVIDER_REASON
     sentence = reason[0].upper() + reason[1:]
+    if reason == NO_ANALYSIS_PROVIDER_REASON:
+        # task-31981: a blocked Generate/Analyze must name the next step,
+        # not just the fault -- "reason · action" grammar.
+        return f"{sentence} · {NO_ANALYSIS_PROVIDER_NEXT_STEP}."
     return sentence if sentence.endswith(".") else f"{sentence}."
 
 

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -1110,6 +1110,17 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 analyze_row.styles.height = "auto"
                 with analyze_row:
                     yield self._analyze_selected_button()
+                if self.analysis_action_reason:
+                    # task-31981: surface the blocker inline (below its own
+                    # row), not only on the hover tooltip -- the same grammar
+                    # the Reader's Generate gate and the Export gate use, so a
+                    # keyboard-first user sees WHY Analyze is off.
+                    yield Static(
+                        self.analysis_action_reason,
+                        id="library-media-analyze-selected-reason",
+                        classes="library-media-action-reason",
+                        markup=False,
+                    )
                 # task-2853's danger-isolation rule, upgraded: Delete gets a
                 # whole row, so it is never adjacent to any other action.
                 danger_row = Horizontal(

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -1048,6 +1048,17 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                 generate.disabled = True
                 generate.tooltip = reason
             yield generate
+        if reason:
+            # task-31981: the reason must reach a keyboard-first user, not
+            # only a mouse tooltip. Same inline-reason grammar as the Export
+            # gate's "No destination chosen" line under its blocked button
+            # (library_export_canvas.py). The tooltip above stays as a bonus.
+            yield Static(
+                reason,
+                id="library-media-analysis-generate-reason",
+                classes="library-media-action-reason",
+                markup=False,
+            )
 
     def _compose_analysis_edit_form(self) -> ComposeResult:
         """Render the analysis edit ``TextArea`` prefilled with the current analysis.

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -3323,6 +3323,17 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
+/* task-31981: the always-visible reason line under a blocked Generate
+   (Reader Analysis pane) or Analyze (select mode) -- mirrors the Export
+   gate's inline "No destination chosen" line so a keyboard-first user
+   reads WHY the action is off, not just a hover tooltip. */
+.library-media-action-reason {
+    width: 100%;
+    height: auto;
+    color: $ds-text-muted;
+    margin: 0 0 1 0;
+}
+
 .library-export-field {
     width: 100%;
     height: 3;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2143,6 +2143,17 @@ with stray left-edge border fragments), and padding 0 1 so the full
     margin: 0 0 1 0;
 }
 
+/* task-31981: the always-visible reason line under a blocked Generate
+   (Reader Analysis pane) or Analyze (select mode) -- mirrors the Export
+   gate's inline "No destination chosen" line so a keyboard-first user
+   reads WHY the action is off, not just a hover tooltip. */
+.library-media-action-reason {
+    width: 100%;
+    height: auto;
+    color: $ds-text-muted;
+    margin: 0 0 1 0;
+}
+
 .library-export-field {
     width: 100%;
     height: 3;


### PR DESCRIPTION
## Summary

Critique #6 fix wave (task-31981, P1): a blocked action explained itself only via a mouse-hover tooltip, unreachable by a keyboard-first user, and clicking the disabled control did nothing.

Fix: the blocked reason now renders as an always-visible muted `Static` next to the control, in addition to the tooltip, on both surfaces that gate on the analysis provider:
- the reader's Analysis pane `Generate`/`Regenerate` (`#library-media-analysis-generate-reason`), and
- the select-mode bulk `Analyze` (`#library-media-analyze-selected-reason`).

Both read the reason from the one shared `analysis_unavailable_reason` seam, so they cannot disagree. The no-provider copy is enriched to name a next step: `No analysis provider is configured · Set one in Settings ▸ Providers & Models.` — a real route label (verified in `settings_screen.py` and `watchlists_collections_screen.py`), not invented, and no raw exception text. The new `.library-media-action-reason` class byte-matches the existing Export-gate quiet-line precedent, so the surface stays consistent; the bundle is regenerated.

## Verification

Task review (Opus): Approved, no Important issues (one off-by-a-few line reference in prose, no code impact). The reviewer confirmed the reason is always-visible and absent when the control is enabled, the next-step label is real and shared via one seam, the CSS matches the Export precedent and is in sync across source and bundle, and the pins are red-first at both sizes.

| run | result |
|---|---|
| new painted pins (Generate + Analyze reason, both sizes; enabled/no-line case) | 5 passed, red first (`NoMatches` on the new ids pre-fix) |
| `Tests/Library/test_ingest_analysis.py` | 18 passed |
| `Tests/UI/test_library_media_render_fixes.py` | 7 failed, 109 passed — the 7 are a pre-existing media-LIST scrollbar-glyph artifact (`█` in column 0), orthogonal to this diff (none query the reason widgets) |

Diagnostic inventory unchanged (no new logger call sites); CSS bundle reproduces from source; preflight green. Closes task-31981.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blocked Generate/Analyze actions in the Library so their reason is always visible inline next to the control, not only on hover—making it reachable for keyboard-first users (task-31981).

- Adds the reason as a muted `Static` line under both disabled buttons (reader Analysis pane and select-mode bulk Analyze), reading from the same `analysis_unavailable_reason` seam so they can't disagree.
- The no-provider reason now names the next step: "No analysis provider is configured · Set one in Settings ▸ Providers & Models."

<sup>Written for commit f439758330d36c5ac4444d863dd1f7f95abb5358. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

