### PR TITLE
Fix Console caret wrapping and visible send diagnostics

### DIFF
--- a/Tests/Chat/test_console_send_diagnostics.py
+++ b/Tests/Chat/test_console_send_diagnostics.py
@@ -1,4 +1,4 @@
-"""TASK-31977: support evidence must survive the real disk and share sinks."""
+"""Support evidence must survive disk, live logs, and both copy actions."""
 
 from __future__ import annotations
 
@@ -14,7 +14,7 @@ from Tests.Chat.test_console_durable_commit_diagnostics import (
 )
 from Tests.test_logs_share_path_privacy import _Collector
 from tldw_chatbook.Logging_Config import PrivateRotatingFileHandler
-from tldw_chatbook.UI.Logs_Window import LogsWindow
+from tldw_chatbook.UI.Logs_Window import LogRecord, LogsWindow
 from tldw_chatbook.Utils.persistent_diagnostics import PersistentDiagnosticFilter
 from tldw_chatbook.Utils.ui_responsiveness import UIResponsivenessMonitor
 
@@ -34,6 +34,9 @@ def sinks(tmp_path):
             app=SimpleNamespace(
                 copy_to_clipboard=copied.append, notify=lambda *a, **k: None
             ),
+            _visible_records=lambda: [
+                LogRecord(*record) for record in app._log_records
+            ],
         )
         try:
             yield SimpleNamespace(path=path, window=window, copied=copied)
@@ -44,7 +47,8 @@ def sinks(tmp_path):
 
 def assert_export(sinks, *tokens):
     LogsWindow._on_copy_all(sinks.window)
-    for text in (sinks.path.read_text(), sinks.copied[-1]):
+    LogsWindow._on_copy_visible(sinks.window)
+    for text in (sinks.path.read_text(), *sinks.copied[-2:]):
         for token in tokens:
             assert token in text
         assert SECRET_IDENTIFIER not in text
@@ -52,7 +56,7 @@ def assert_export(sinks, *tokens):
     return sinks.path.read_text()
 
 
-async def test_pre_trace_commit_failure_reaches_file_and_copy_all(sinks):
+async def test_pre_trace_commit_failure_reaches_file_and_both_copy_actions(sinks):
     controller, _store = _controller_with_failing_commit()
     result = await controller.submit_draft("PRIVATE-DRAFT-31977")
     assert not result.accepted
@@ -69,6 +73,35 @@ async def test_pre_trace_commit_failure_reaches_file_and_copy_all(sinks):
         "capture_enabled=false",
     )
     assert "phase=provider_entry" not in text
+
+
+async def test_send_and_refresh_keep_the_same_visible_correlation_id(sinks):
+    import re
+
+    from tldw_chatbook.Chat.console_send_diagnostics import send_diagnostic_scope
+
+    monitor = UIResponsivenessMonitor()
+    try:
+        async with send_diagnostic_scope("ui_submit", monitor):
+            for _ in range(100):
+                monitor.record_worker_started("console-sync")
+                monitor.record_worker_finished("console-sync")
+            monitor.record_heartbeat_delta(0.01)
+    finally:
+        await asyncio.to_thread(monitor.close)
+    assert_export(sinks, "event=ui_refresh_churn", "phase=ui_submit", "attempt_id=")
+    for text in (sinks.path.read_text(), *sinks.copied[-2:]):
+        events = [
+            line
+            for line in text.splitlines()
+            if "event=console_send_stage" in line or "event=ui_refresh_churn" in line
+        ]
+        assert len(events) >= 3
+        identifiers = [
+            re.search(r"attempt_id=([0-9a-f]{32})\b", line) for line in events
+        ]
+        assert all(identifiers)
+        assert len({match[1] for match in identifiers}) == 1
 
 
 async def test_responsive_refresh_churn_is_exported_once_per_episode(sinks):
@@ -229,7 +262,7 @@ async def test_sequential_queued_submissions_get_independent_diagnostic_budgets(
         for line in text.splitlines()
         if "phase=controller_submit" in line and "status=entered" in line
     ]
-    assert len({re.search(r"attempt_token=(\w+)", line)[1] for line in starts}) == 8
+    assert len({re.search(r"attempt_id=(\w+)", line)[1] for line in starts}) == 8
 
 
 async def test_failure_keeps_runtime_and_capture_context_at_warning_root(sinks):

--- a/Tests/UI/test_console_composer_blink_wrap.py
+++ b/Tests/UI/test_console_composer_blink_wrap.py
@@ -6,6 +6,7 @@ import asyncio
 from contextlib import closing
 
 import pytest
+from rich.cells import cell_len
 from textual.widgets import Static
 
 from Tests.UI.app_factory import _build_test_app
@@ -72,10 +73,12 @@ def test_blink_preserves_style_after_expanding_pasted_tabs():
         assert painted.plain[8:9] == "b"
 
 
-@pytest.mark.parametrize("tabbed", [False, True])
+@pytest.mark.parametrize(
+    "prefix", ["", "\t", "界\t", "🧪\t", "e\u0301\t", "👩\u200d💻\t", "e\u0301❤️\t"]
+)
 @pytest.mark.parametrize("size", [(80, 24), (97, 30)])
 async def test_failed_enter_restores_draft_without_blink_text_movement(
-    monkeypatch, tmp_path, size, tabbed
+    monkeypatch, tmp_path, size, prefix
 ):
     app = _build_test_app()
     with closing(CharactersRAGDB(tmp_path / "chat.sqlite", "blink-wrap")) as database:
@@ -103,17 +106,18 @@ async def test_failed_enter_restores_draft_without_blink_text_movement(
                 )
                 composer = console._console_composer_or_none()
                 width = composer._draft_render_width()
-                draft = (
-                    "\t" + "x" * (width - 14) + " world"
-                    if tabbed
-                    else "x" * (width - 6) + " world"
-                )
+                prefix_width = cell_len(prefix.expandtabs(8))
+                draft = prefix + "x" * (width - prefix_width - 6) + " world"
                 composer.load_draft(draft)
                 composer.focus()
                 await pilot.pause()
                 await pilot.press("enter")
                 await asyncio.wait_for(host.workers.wait_for_complete(), timeout=10)
-                await pilot.pause(0.3)
+                # Worker completion precedes the poller's final UI reconcile.
+                # Wait for that lifecycle edge, not a fixed number of milliseconds.
+                async with asyncio.timeout(5):
+                    while console._console_transcript_sync_timer is not None:
+                        await pilot.pause(0.05)
                 composer._cursor_blink_timer.pause()
                 assert composer.draft_text() == draft
                 assert controller.run_state.is_send_allowed
@@ -135,8 +139,17 @@ async def test_failed_enter_restores_draft_without_blink_text_movement(
                         <= visible.size.height
                     )
                     assert "world" in visible.renderable.plain
-                    if tabbed:
-                        assert composer._display_index_at(3, 0) == 0
+                    if "❤️" in prefix:
+                        assert composer._display_index_at(1, 0) == 2
+                        assert composer._display_index_at(2, 0) == 2
+                    if prefix:
+                        assert (
+                            composer._display_index_at(prefix_width - 1, 0)
+                            == len(prefix) - 1
+                        )
+                        assert composer._display_index_at(prefix_width, 0) == len(
+                            prefix
+                        )
                     for row, text in enumerate(visible.renderable.plain.splitlines()):
                         if "world" in text:
                             assert (
@@ -145,6 +158,10 @@ async def test_failed_enter_restores_draft_without_blink_text_movement(
                             )
                 _assert_only_caret_changed(*phases)
                 assert composer.draft_text() == draft
+                if "❤️" in prefix:
+                    await pilot.click("#console-command-visible-text", offset=(2, 0))
+                    await pilot.press("!")
+                    assert composer.draft_text() == draft[:2] + "!" + draft[2:]
         finally:
             if console is not None:
                 await console._console_runtime().dispose()

--- a/Tests/UI/test_console_composer_blink_wrap.py
+++ b/Tests/UI/test_console_composer_blink_wrap.py
@@ -1,0 +1,151 @@
+"""Caret blinking must not move the surrounding draft (TASK-32012.1)."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import closing
+
+import pytest
+from textual.widgets import Static
+
+from Tests.UI.app_factory import _build_test_app
+from Tests.UI.test_console_native_chat_flow import _persist_console_provider_config
+from Tests.UI.test_destination_shells import _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+from tldw_chatbook.app import TldwCli
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Widgets.Console import console_composer_bar as module
+
+
+def _assert_only_caret_changed(shown: str, hidden: str, glyph: str = "▌") -> None:
+    assert len(shown) == len(hidden), (shown, hidden)
+    differences = [(a, b) for a, b in zip(shown, hidden) if a != b]
+    assert differences == [(glyph, " ")], (shown, hidden, differences)
+
+
+@pytest.mark.parametrize("ascii_caret", [False, True])
+@pytest.mark.parametrize(
+    "draft,width,cursor,ghost",
+    [
+        ("hello world", 11, 11, ""),
+        ("hello world again", 8, 7, ""),
+        ("one two three four " * 12, 20, 170, ""),
+        ("測試 hello world", 14, 14, ""),
+        ("🧪 hello world", 13, 13, ""),
+        ("literal ▌ and | hello world", 12, 17, ""),
+        ("hello", 11, 5, " world again"),
+        ("a\tb", 20, 3, ""),
+        ("a\tb\nhello world", 20, 15, ""),
+        ("", 11, 0, ""),
+    ],
+)
+def test_blink_preserves_wrapped_text_and_styles(
+    monkeypatch, ascii_caret, draft, width, cursor, ghost
+):
+    glyph = "|" if ascii_caret else "▌"
+    monkeypatch.setattr(module, "resolve_glyph", lambda value: glyph)
+    args = {
+        "width": width,
+        "focused": True,
+        "cursor_index": cursor,
+        "ghost_suffix": ghost,
+        "style_ranges": [(0, len(draft), "bold")],
+    }
+    shown = module.ConsoleComposerBar._draft_renderable(
+        draft, cursor_visible=True, **args
+    )
+    hidden = module.ConsoleComposerBar._draft_renderable(
+        draft, cursor_visible=False, **args
+    )
+    _assert_only_caret_changed(shown.plain, hidden.plain, glyph)
+    assert shown.spans == hidden.spans
+
+
+def test_blink_preserves_style_after_expanding_pasted_tabs():
+    for phase in (True, False):
+        painted = module.ConsoleComposerBar._draft_renderable(
+            "a\tb", focused=True, cursor_visible=phase, style_ranges=[(2, 3, "bold")]
+        )
+        assert [(span.start, span.end) for span in painted.spans] == [(8, 9)]
+        assert painted.plain[8:9] == "b"
+
+
+@pytest.mark.parametrize("tabbed", [False, True])
+@pytest.mark.parametrize("size", [(80, 24), (97, 30)])
+async def test_failed_enter_restores_draft_without_blink_text_movement(
+    monkeypatch, tmp_path, size, tabbed
+):
+    app = _build_test_app()
+    with closing(CharactersRAGDB(tmp_path / "chat.sqlite", "blink-wrap")) as database:
+        console = None
+        try:
+            app.chachanotes_db = database
+            _persist_console_provider_config(
+                app,
+                provider="openai",
+                model="gpt-4.1",
+                provider_settings={"api_key": "synthetic-test-key"},
+            )
+            host = ConsoleHarness(app)
+            host.CSS_PATH = TldwCli.CSS_PATH
+            async with host.run_test(size=size) as pilot:
+                console = host.screen
+                await _wait_for_selector(console, pilot, "#console-native-composer")
+                controller = console._ensure_console_chat_controller()
+
+                async def fail_resolution(selection):
+                    raise ValueError("Synthetic validation interruption")
+
+                monkeypatch.setattr(
+                    controller.provider_gateway, "resolve_for_send", fail_resolution
+                )
+                composer = console._console_composer_or_none()
+                width = composer._draft_render_width()
+                draft = (
+                    "\t" + "x" * (width - 14) + " world"
+                    if tabbed
+                    else "x" * (width - 6) + " world"
+                )
+                composer.load_draft(draft)
+                composer.focus()
+                await pilot.pause()
+                await pilot.press("enter")
+                await asyncio.wait_for(host.workers.wait_for_complete(), timeout=10)
+                await pilot.pause(0.3)
+                composer._cursor_blink_timer.pause()
+                assert composer.draft_text() == draft
+                assert controller.run_state.is_send_allowed
+                assert console._console_transcript_sync_timer is None
+
+                visible = composer.query_one("#console-command-visible-text", Static)
+                phases = []
+                for phase in (True, False):
+                    composer._cursor_visible = not phase
+                    composer._toggle_cursor_blink()
+                    await pilot.pause()
+                    phases.append(
+                        "\n".join(
+                            strip.text for strip in console._compositor.render_strips()
+                        )
+                    )
+                    assert (
+                        len(visible.renderable.plain.splitlines())
+                        <= visible.size.height
+                    )
+                    assert "world" in visible.renderable.plain
+                    if tabbed:
+                        assert composer._display_index_at(3, 0) == 0
+                    for row, text in enumerate(visible.renderable.plain.splitlines()):
+                        if "world" in text:
+                            assert (
+                                composer._display_index_at(text.index("world") + 1, row)
+                                == len(draft) - 4
+                            )
+                _assert_only_caret_changed(*phases)
+                assert composer.draft_text() == draft
+        finally:
+            if console is not None:
+                await console._console_runtime().dispose()
+            await asyncio.to_thread(app.ui_responsiveness_monitor.close)

--- a/Tests/UI/test_console_composer_overflow.py
+++ b/Tests/UI/test_console_composer_overflow.py
@@ -533,6 +533,8 @@ async def test_home_on_a_long_draft_keeps_the_caret_and_leading_text_painted():
         composer.load_draft(_BOUNDARY_TEXT)
         composer.focus()
         await pilot.pause()
+        # This checks the Home window's visible caret, not blink timing.
+        composer._cursor_blink_timer.pause()
         composer.move_cursor_home()
         await pilot.pause()
         assert composer.cursor_index == 0

--- a/backlog/decisions/029-local-private-data-boundary.md
+++ b/backlog/decisions/029-local-private-data-boundary.md
@@ -197,3 +197,11 @@ once per continuous excessive-activity episode, rearming after a quiet window;
 ordinary polling and token streaming are not per-frame log events. These are
 observations, not authorization to cancel providers or suppress application
 state updates. Fixes to the actual refresh loop require separate causal evidence.
+
+**TASK-31977.1 field correction (2026-09-07).** Emit the random diagnostic
+correlation value as `attempt_id`, replacing `attempt_token`. The live Logs
+redactor treats an unquoted `*_token` assignment as a credential through the
+end of the line, which removed approved phase and failure fields. The new
+spelling carries exactly the same random value through send and refresh events.
+Credential redaction, metadata admission, retention and excluded data are
+unchanged; no log record receives a redaction exemption.

--- a/backlog/docs/console-send-diagnostics.md
+++ b/backlog/docs/console-send-diagnostics.md
@@ -20,12 +20,17 @@ At INFO, look for `event=console_send_stage` under `diagnostics.console`:
 - `provider_entry`: the provider adapter was entered. This is not proof that a
   remote server received the request or that a response completed.
 
-A random `attempt_token` connects the UI's first submission with its worker and
+A random `attempt_id` connects the UI's first submission with its worker and
 provider stages. Further submissions in a queued prompt chain receive separate
-tokens and event allowances. Tokens are unrelated to stored conversation,
+IDs and event allowances. These IDs are unrelated to stored conversation,
 message, workspace or provider-request identifiers. Durations are relative to
 the diagnostic attempt. `dispatched` means queued for execution;
 `not_dispatched` may be an empty input or a handled command, not a send error.
+
+Older builds use `attempt_token`. Their descriptive Logs view treats that label
+as a credential and removes the rest of the line, including stage and error
+fields; Copy all retains those fields. The `attempt_id` spelling keeps the same
+random correlation value visible without exempting any record from redaction.
 
 Failed stages are ERROR events, preserving their phase, application/Python/SQLite
 versions, capture mode when already resolved, exception class, and a safe failure

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12172,3 +12172,10 @@ stable caret glyph and hide its mapped character afterward. Pasted-tab cases
 caught an offset mistake in the initial fix: tab expansion must be reflected
 in caret/style offsets and reversed for click mapping. Keep these cases plus
 literal caret-like text, Unicode and history suggestions in the regression.
+
+PR #2498 review added a second coordinate check: terminal cells are not Python
+character offsets. Eight mounted CJK/emoji/combining-text cases caught clicks
+landing after the final expanded tab space. A follow-up `❤️` case caught a
+prefix-width cutoff inside its variation-selector sequence. Hit testing now
+uses whole grapheme boundaries measured with the wrapper's cell-width policy;
+clicking either emoji cell and then typing must preserve the emoji.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12136,3 +12136,39 @@ emitted partial spans, alongside full-screen updates, and then completes the sen
 The first implementation caught only one of two heading writers; the real-paint
 assertion remained red until both were guarded. Keep responsive width and
 visibility recalculation outside text equality guards.
+
+## A diagnostic field name can erase the rest of a descriptive log line
+
+**TASK-31977.1, Console flicker investigation, 2026-09-07.** The file and
+Copy all tests retained every send stage, but a full-app Copy visible probe
+lost phase, status and failure fields. Its generic credential redactor treats
+an unquoted `*_token` assignment through end-of-line as sensitive; the random
+`attempt_token` correlation label therefore swallowed every following field.
+Extending the real collector regression to both copy actions reproduced the
+failure. Renaming the emitted field to `attempt_id` preserved the same random
+correlation value across send and refresh events without bypassing redaction.
+
+**What to do.** Exercise each export's actual transformation chain. A
+metadata-only bulk export passing does not prove the descriptive live view
+retains that metadata. Avoid credential-like labels for non-credential IDs;
+keep credential redaction intact and verify both privacy and diagnostic detail.
+
+## Equal widget geometry can hide text moving on every caret blink
+
+**TASK-32012.1, Console flicker investigation, 2026-09-07.** Settled-screen
+probes showed no full-screen updates or repeated geometry changes, and the
+composer's existing blink tests passed. Comparing the text in both phases
+instead found 763 mismatches across 4,092 sampled caret positions. At width 11,
+`hello world` painted `hello ` / `world▌` while visible, then `hello world` /
+` ` while hidden: a space and a block have equal cell widths but different
+word boundaries. Mounted Enter-failure tests reproduced the moving word at
+80×24 and 97×30. Hit testing also missed that word because it wrapped the
+space-based layout. This establishes composer text movement, not the external
+reporter's exact whole-screen flicker.
+
+**What to do.** Compare actual painted characters and their positions across
+animation phases, alongside geometry and compositor activity. Wrap with one
+stable caret glyph and hide its mapped character afterward. Pasted-tab cases
+caught an offset mistake in the initial fix: tab expansion must be reflected
+in caret/style offsets and reversed for click mapping. Keep these cases plus
+literal caret-like text, Unicode and history suggestions in the regression.

--- a/backlog/tasks/task-31977.1 - Preserve-Console-send-stages-in-visible-logs.md
+++ b/backlog/tasks/task-31977.1 - Preserve-Console-send-stages-in-visible-logs.md
@@ -1,0 +1,48 @@
+---
+id: TASK-31977.1
+title: Preserve Console send stages in visible logs
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 01:46'
+updated_date: '2026-09-08 01:52'
+labels: []
+dependencies: []
+parent_task_id: TASK-31977
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+The descriptive Logs view treats the random send correlation token as a credential and removes every later field, so Copy visible loses stages and failure details even though Copy all retains them. Keep approved send diagnostics useful in both existing log views without changing credential redaction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Visible logs and both copy actions retain the random send correlation identifier, stage, status and failure metadata.
+- [x] #2 Credential and private-content protections remain unchanged; send and refresh events use the same random correlation value.
+- [x] #3 Real collector and mounted send regressions cover both copy paths and focused privacy and diagnostic checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes (amend existing ADR-029 for the diagnostic field spelling)
+ADR path: backlog/decisions/029-local-private-data-boundary.md
+Reason: rename the existing random operational correlation field across the send emitter, monitor and metadata schema; no additional data, sink, permission or retention.
+1. Extend the real collector/file/copy-action regression to cover Copy visible and prove stage/failure metadata is currently redacted. Keep the full-app navigation reproduction as investigation evidence.
+2. Rename attempt_token to attempt_id in the diagnostic emitter and schema and preserve it in the monitor last-send context. Leave generic redaction and sink admission unchanged; document old/new log spelling in the existing ADR and support notes.
+3. Verify correlation across send and refresh events, privacy protections, existing mounted sends, and the full-app navigation probe. Run targeted lint, diagnostic inventory and preflight; record limitations and investigation findings.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Renamed the random Console diagnostic correlation field from attempt_token to attempt_id in the send emitter, persistent metadata schema and monitor last-send context. This prevents the existing unquoted credential-assignment redactor from discarding every following field in the live Logs view and Copy visible. The same random identifier still correlates UI/controller/provider and refresh events. Credential redaction and sink admission are unchanged.
+
+Extended the real collector/file regression helper to exercise both copy actions, and added a send/refresh correlation assertion for each output. The new Copy visible check failed on phase=controller_submit before the source change; all 141 targeted send, mounted-flow, log privacy, sanitizer and responsiveness tests pass afterward (43.02s). Four separate full-app OpenRouter fixture cases, with/without prior Logs navigation and with resolution/trace failure, pass (25.88s): both copies retain stage metadata, no stale log widget remains, and no repeated full-screen paint occurs. Ruff and formatting pass all four changed Python files; preflight, diagnostic inventory and whitespace checks pass. No full suite was run.
+
+Updated support documentation, the existing ADR-029 amendment and an incident-backed testing lesson. ADR required: yes, fulfilled by the TASK-31977.1 field correction in backlog/decisions/029-local-private-data-boundary.md. Self-review confirms all three production references use attempt_id and generic credential handling is untouched.
+
+Investigation limits: 12 responsive-threshold OpenRouter fixture cases (79-128 columns, 16-35 rows) passed with zero full-screen updates, at most one geometry adjustment, restored drafts, stopped polling and successful retry. A controlled 97x30 experiment attributed all remaining settled draft paint to the 0.53s caret timer: pausing it reduced partial paints from two per observation window to zero. These are headless local results, not reproduction of the external terminal flicker. The original attachment contains no console_send_stage events at all; this redaction defect explains missing fields within such events, not their total absence.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32012.1 - Keep-Console-draft-wrapping-stable-while-the-caret-blinks.md
+++ b/backlog/tasks/task-32012.1 - Keep-Console-draft-wrapping-stable-while-the-caret-blinks.md
@@ -1,0 +1,47 @@
+---
+id: TASK-32012.1
+title: Keep Console draft wrapping stable while the caret blinks
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-08 02:03'
+updated_date: '2026-09-08 02:19'
+labels: []
+dependencies: []
+parent_task_id: TASK-32012
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A word-boundary draft can visibly jump on every caret blink, including after Enter restores an unsent draft. The visible block and hidden space change word wrapping despite equal widget geometry. Keep the draft stationary while its caret blinks.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Blinking changes only the reserved caret character across word boundaries, Unicode text, long drafts and history suggestions.
+- [x] #2 Composer sizing and clicking remain consistent with its painted text in both blink phases, and Enter failure restores an editable retryable draft.
+- [x] #3 Pasted tabs retain their displayed spacing and style spans while the caret blinks, and their displayed positions map back to the original draft.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: N/A
+Reason: routine composer rendering correction preserving existing draft ownership, input actions and interfaces. ADR-068 was consulted; transcript selection ownership is unaffected.
+1. Reproduce changing word positions across the two blink phases and add a mounted Enter failure regression measuring actual painted rows.
+2. Use the visible caret glyph for one stable wrap in both phases; mask only its mapped output character after wrapping. Align height measurement and click mapping with that same reserved glyph.
+3. Verify both phases, source style spans, literal caret-like text, history suggestions, Unicode, visible-window cropping, ASCII fallback and mounted failed-send recovery. Run focused cursor, geometry and send checks plus preflight; preserve existing baseline lint findings without unrelated cleanup.
+4. Record the causal evidence and limits: this fixes reproduced composer text movement, while the reporter's exact terminal flicker remains unconfirmed.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The composer now wraps the same reserved caret glyph in both blink phases, then masks only the mapped caret character. Word boundaries and the visible window stay fixed. Height measurement and click mapping use that same glyph; pasted-tab expansion is reflected in caret/style coordinates and reversed for clicks into the original draft. The existing blink cache and layout-free repaint remain intact. No new capture tool, logging surface, dependency, storage or input action.
+
+Evidence: the initial 4,092-position probe found 763 text-position mismatches despite stable widget geometry. New mounted Enter -> validation failure -> restored draft regressions reproduced a jumping word at 80x24 and 97x30, and independently caught a click miss on that painted word. Both are now green. Initial tab cases caught an offset error in the first implementation; the final regressions cover tabs before the caret and on prior lines, styled text, literal caret-like characters, ASCII fallback, Unicode, history suggestions, long windows and unchanged canonical drafts. The complete 4,092-position probe now has zero mismatches. This establishes and fixes composer text movement; the external reporter's exact whole-screen flicker and original send failure remain unconfirmed.
+
+Verification: 135 targeted cursor, caret navigation, overflow, history, multiline and mounted send tests passed in 123.46s. After final self-review assertions for visible target text and clicks inside tab spaces, all 25 tests in the new regression file passed again in 11.11s. Preflight, formatting, test-file Ruff and git diff --check passed. Whole-file composer Ruff has the same five findings as HEAD (source/code/message compared), with zero new findings; task remains In Progress under the strict all-green Definition of Done. No full suite was run. Added the incident-backed lesson to backlog/docs/lessons-testing-evidence.md. ADR required: no; routine rendering and coordinate correction, with ADR-068 consulted and its ownership unchanged. Self-review complete.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32012.1 - Keep-Console-draft-wrapping-stable-while-the-caret-blinks.md
+++ b/backlog/tasks/task-32012.1 - Keep-Console-draft-wrapping-stable-while-the-caret-blinks.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 02:03'
-updated_date: '2026-09-08 02:19'
+updated_date: '2026-09-08 02:42'
 labels: []
 dependencies: []
 parent_task_id: TASK-32012
@@ -22,6 +22,7 @@ A word-boundary draft can visibly jump on every caret blink, including after Ent
 - [x] #1 Blinking changes only the reserved caret character across word boundaries, Unicode text, long drafts and history suggestions.
 - [x] #2 Composer sizing and clicking remain consistent with its painted text in both blink phases, and Enter failure restores an editable retryable draft.
 - [x] #3 Pasted tabs retain their displayed spacing and style spans while the caret blinks, and their displayed positions map back to the original draft.
+- [x] #4 Clicks within expanded tab spaces and following text resolve correctly when CJK, emoji or combining characters precede the tab; all tab calculations share one width.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -34,6 +35,7 @@ Reason: routine composer rendering correction preserving existing draft ownershi
 2. Use the visible caret glyph for one stable wrap in both phases; mask only its mapped output character after wrapping. Align height measurement and click mapping with that same reserved glyph.
 3. Verify both phases, source style spans, literal caret-like text, history suggestions, Unicode, visible-window cropping, ASCII fallback and mounted failed-send recovery. Run focused cursor, geometry and send checks plus preflight; preserve existing baseline lint findings without unrelated cleanup.
 4. Record the causal evidence and limits: this fixes reproduced composer text movement, while the reporter's exact terminal flicker remains unconfirmed.
+5. Address review findings by sharing the tab width and translating terminal cells through whole grapheme boundaries before reversing expanded-tab offsets; verify CJK, emoji, combining text and click-then-type behavior.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -43,5 +45,7 @@ The composer now wraps the same reserved caret glyph in both blink phases, then 
 
 Evidence: the initial 4,092-position probe found 763 text-position mismatches despite stable widget geometry. New mounted Enter -> validation failure -> restored draft regressions reproduced a jumping word at 80x24 and 97x30, and independently caught a click miss on that painted word. Both are now green. Initial tab cases caught an offset error in the first implementation; the final regressions cover tabs before the caret and on prior lines, styled text, literal caret-like characters, ASCII fallback, Unicode, history suggestions, long windows and unchanged canonical drafts. The complete 4,092-position probe now has zero mismatches. This establishes and fixes composer text movement; the external reporter's exact whole-screen flicker and original send failure remain unconfirmed.
 
-Verification: 135 targeted cursor, caret navigation, overflow, history, multiline and mounted send tests passed in 123.46s. After final self-review assertions for visible target text and clicks inside tab spaces, all 25 tests in the new regression file passed again in 11.11s. Preflight, formatting, test-file Ruff and git diff --check passed. Whole-file composer Ruff has the same five findings as HEAD (source/code/message compared), with zero new findings; task remains In Progress under the strict all-green Definition of Done. No full suite was run. Added the incident-backed lesson to backlog/docs/lessons-testing-evidence.md. ADR required: no; routine rendering and coordinate correction, with ADR-068 consulted and its ownership unchanged. Self-review complete.
+Review fixes: all tab calculations use one width. Hit testing converts terminal-cell positions to complete grapheme starts before applying cropped-row and reverse-tab offsets. Eight initially failing CJK/emoji/combining tab cases and two additional VS16 click-and-type cases now pass. Failed-send tests wait for the final transcript reconciliation instead of a fixed delay; the existing Home painting test pauses the unrelated blink timer. Independent review reports no remaining blockers.
+
+Verification: the final combined targeted run passed all 277 tests in 160.53s, covering diagnostics, privacy, send flow, composer rendering, cursor navigation, overflow, history and multiline input. Preflight and git diff --check passed. New regression-file lint and formatting pass; composer formatting passes. Compared HEAD/worktree finding signatures: the composer retains five unchanged lint findings, and the existing overflow test retains one unchanged import-order finding and pre-existing formatting differences. Task remains In Progress under the strict all-green Definition of Done. No full suite was run. Added the incident-backed lesson to backlog/docs/lessons-testing-evidence.md. ADR required: no; routine rendering and coordinate correction, with ADR-068 consulted and its ownership unchanged. Self-review complete.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_send_diagnostics.py
+++ b/tldw_chatbook/Chat/console_send_diagnostics.py
@@ -42,7 +42,9 @@ _TRACE_FAILURE_CATEGORIES = frozenset(
 @dataclass
 class SendDiagnostic:
     monitor: UIResponsivenessMonitor
-    attempt_token: str = field(default_factory=lambda: uuid4().hex)
+    # A random correlation ID, never a credential or stored conversation ID.
+    # A *_token log label makes the live-view redactor remove the whole tail.
+    attempt_id: str = field(default_factory=lambda: uuid4().hex)
     started: float = field(default_factory=time.monotonic)
     phase: str = "controller_submit"
     outcome: str = "completed"
@@ -87,7 +89,7 @@ class SendDiagnostic:
             "console_send_stage",
             phase=phase,
             status=status,
-            attempt_token=self.attempt_token,
+            attempt_id=self.attempt_id,
             level=logging.ERROR if status == "failed" else logging.INFO,
             duration_ms=int((time.monotonic() - self.started) * 1000),
             **fields,

--- a/tldw_chatbook/Utils/persistent_diagnostics.py
+++ b/tldw_chatbook/Utils/persistent_diagnostics.py
@@ -52,7 +52,7 @@ _TOKEN_FIELDS = frozenset(
         # label vocabulary in Metrics/metrics_logger.py rather than inventing a
         # second dialect for the same idea.
         "component",
-        "attempt_token",
+        "attempt_id",
         "app_version",
         "python_version",
         "sqlite_version",

--- a/tldw_chatbook/Utils/ui_responsiveness.py
+++ b/tldw_chatbook/Utils/ui_responsiveness.py
@@ -97,7 +97,7 @@ class UIResponsivenessMonitor:
             if event == "console_send_stage":
                 self._last_send_diagnostic = {
                     name: fields[name]
-                    for name in ("attempt_token", "phase", "status")
+                    for name in ("attempt_id", "phase", "status")
                     if name in fields
                 }
             try:

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -17,6 +17,7 @@ import hmac
 import json
 import re
 import secrets
+from bisect import bisect_right
 from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal
@@ -2705,11 +2706,11 @@ class ConsoleComposerBar(Horizontal):
         """Return the wrapped row containing a source-text offset.
 
         For SPLICED offsets only -- callers that pass `line_slices` wrapped
-        from a caret-glyph- or placeholder-spliced `render_text`, together
+        from a caret-glyph-spliced `render_text`, together
         with the matching spliced offset into it (the two current
         production callers, both via `_visible_draft_line_slices(...,
         cursor_index=...)`: `_draft_renderable`'s glyph splice and
-        `_display_index_at`'s space splice). A real character always
+        `_display_index_at`'s glyph splice). A real character always
         occupies the exact offset being looked up under that contract, so
         the "no row contains this offset" fallback below (unconditionally
         the LAST row) is never actually reachable there.
@@ -2849,22 +2850,12 @@ class ConsoleComposerBar(Horizontal):
         ghost_suffix: str = "",
     ) -> Text:
         if text:
-            # While focused, exactly one display cell is always reserved at
-            # the caret position inside the wrapped draft -- the caret glyph
-            # during the visible blink phase, an ordinary space during the
-            # hidden phase -- and it is wrapped in the *same* pass as the
-            # draft itself (rather than appended afterward). That keeps the
-            # two blink phases layout-identical: whichever character reserves
-            # the cell is decided by wrap width alone, never by which literal
-            # character it is, so a blink tick can never change how many
-            # visual rows the draft occupies (which previously could clip or
-            # jitter the composer when the last wrapped line landed exactly
-            # at the wrap width). The glyph is left unstyled: the block
-            # character is prominent enough on its own, and leaving it
-            # unstyled keeps it from being mistaken for a stateful paste
-            # token.
+            # Reserve the same glyph in BOTH blink phases. A space has the
+            # same cell width but different word boundaries: wrapping it
+            # instead makes whole words jump on every blink (TASK-32012.1).
+            # Hide only the mapped caret character AFTER wrapping/windowing.
             if focused:
-                caret_cell = resolve_glyph(cls.CURSOR_GLYPH) if cursor_visible else " "
+                caret_cell = resolve_glyph(cls.CURSOR_GLYPH)
                 caret_position = (
                     len(text)
                     if cursor_index is None
@@ -2898,11 +2889,41 @@ class ConsoleComposerBar(Horizontal):
             else:
                 caret_position = None
                 render_text = text
+            if "\t" in render_text:
+                # Wrapping expands tabs. Put caret/style offsets in that same
+                # coordinate space before selecting or masking a visible row.
+                if caret_position is not None:
+                    caret_position = len(render_text[:caret_position].expandtabs(8))
+                if style_ranges:
+                    style_ranges = [
+                        (
+                            len(render_text[:start].expandtabs(8)),
+                            len(render_text[:end].expandtabs(8)),
+                            style,
+                        )
+                        for start, end, style in style_ranges
+                    ]
+                render_text = render_text.expandtabs(8)
             line_slices = cls._visible_draft_line_slices(
                 render_text,
                 width,
                 cursor_index=caret_position,
             )
+            if caret_position is not None and not cursor_visible:
+                for index, line_slice in enumerate(line_slices):
+                    if line_slice.start <= caret_position < line_slice.end:
+                        offset = (
+                            caret_position
+                            - line_slice.start
+                            + line_slice.synthetic_prefix_columns
+                        )
+                        line_slices[index] = replace(
+                            line_slice,
+                            text=line_slice.text[:offset]
+                            + " "
+                            + line_slice.text[offset + 1 :],
+                        )
+                        break
             # `no_wrap`/`overflow="crop"`: defense-in-depth, not the fix for
             # any known bug reachable through this file's own call sites.
             # Each joined row is already budgeted to fit `width` by
@@ -2986,7 +3007,11 @@ class ConsoleComposerBar(Horizontal):
         # while focused, computed once here (at focus/blur/mutation time,
         # never on a blink tick) so the exactly-at-width case gets its extra
         # row up front instead of only discovering it needs one mid-blink.
-        measured_text = f"{text} " if reserve_trailing_cell else text
+        measured_text = (
+            f"{text}{resolve_glyph(cls.CURSOR_GLYPH)}"
+            if reserve_trailing_cell
+            else text
+        )
         return max(
             cls.MIN_DRAFT_ROWS,
             min(
@@ -3470,9 +3495,8 @@ class ConsoleComposerBar(Horizontal):
         draft plus `_ghost_suffix`'s linear scan over up to 1000 history
         entries -- measured 1.58 ms/tick with a 20 KB draft -- just to flip
         one caret cell. A tick with an unchanged key is now a dict hit; the
-        two phases are cached separately because the caret cell (glyph vs
-        space) participates in the word wrap, so their wrapped output is not
-        derivable from one another by substitution.
+        two phases cache their final caret character separately, while
+        sharing the same wrapping policy.
         """
         phase = bool(getattr(self, "_cursor_visible", True))
         memo_key = self._visible_render_memo_key(draft, width)
@@ -3525,10 +3549,9 @@ class ConsoleComposerBar(Horizontal):
         miss per tick. ``layout=False`` is sound here because the rendered
         SIZE cannot differ between the two blink phases:
 
-        * ``_draft_renderable`` reserves exactly one display cell at the
-          caret position in BOTH phases -- the glyph while visible, a plain
-          space while hidden -- and wraps it in the same pass, so the two
-          phases are cell-identical by construction (see its comment). Both
+        * ``_draft_renderable`` wraps the same caret glyph in BOTH phases,
+          then masks only that character with a space while hidden, so the
+          two phases retain identical word positions and cell widths. Both
           ``CURSOR_GLYPH`` and its ASCII fallback ``|`` are single-width.
         * The Static's geometry is pinned by inline styles rather than
           derived from its content: ``width: 1fr``, ``text_wrap = "nowrap"``,
@@ -5368,14 +5391,19 @@ class ConsoleComposerBar(Horizontal):
                 0, min(self._cursor_display_index(), len(display_text))
             )
             render_text = (
-                f"{display_text[:caret_position]} {display_text[caret_position:]}"
+                f"{display_text[:caret_position]}"
+                f"{resolve_glyph(self.CURSOR_GLYPH)}{display_text[caret_position:]}"
             )
         else:
             render_text = display_text
         visible_slices = self._visible_draft_line_slices(
-            render_text,
+            render_text.expandtabs(8),
             self._draft_render_width(),
-            cursor_index=caret_position,
+            cursor_index=(
+                len(render_text[:caret_position].expandtabs(8))
+                if caret_position is not None
+                else None
+            ),
         )
         if click_y >= len(visible_slices):
             return None
@@ -5390,6 +5418,17 @@ class ConsoleComposerBar(Horizontal):
             )
         else:
             source_index = clicked_slice.start + click_x
+        if "\t" in render_text:
+            # Map expanded display positions back to the original source.
+            # A click inside a tab's spaces belongs to that tab character.
+            source_index = (
+                bisect_right(
+                    range(len(render_text) + 1),
+                    source_index,
+                    key=lambda index: len(render_text[:index].expandtabs(8)),
+                )
+                - 1
+            )
         if caret_position is not None:
             if source_index == caret_position:
                 return caret_position

--- a/tldw_chatbook/Widgets/Console/console_composer_bar.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_bar.py
@@ -22,7 +22,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field, replace
 from typing import Any, Literal
 
-from rich.cells import cell_len
+from rich.cells import cell_len, split_graphemes
 from rich.markup import escape
 from rich.text import Text
 from textual import on
@@ -87,6 +87,7 @@ _PLACEHOLDER_CANDIDATE_PATTERN = re.compile(r"\[\[TLDW_PROTECTED:[^\]]*\]\]")
 #: chunk (terminal cells instead of characters), not in where it is willing
 #: to break.
 _DRAFT_WORD_SPLIT_RE = re.compile(r"([\t\n\x0b\x0c\r ]+)")
+_DRAFT_TAB_WIDTH = 8
 
 #: Modifier prefixes that make a key a CHORD rather than text input, even
 #: when it carries a printable ``character``. Textual's terminal parser
@@ -2588,7 +2589,9 @@ class ConsoleComposerBar(Horizontal):
         # caller in this module) regardless of `replace_whitespace`, which
         # only controls whether *other* whitespace becomes plain spaces.
         chunks = [
-            chunk for chunk in _DRAFT_WORD_SPLIT_RE.split(line.expandtabs(8)) if chunk
+            chunk
+            for chunk in _DRAFT_WORD_SPLIT_RE.split(line.expandtabs(_DRAFT_TAB_WIDTH))
+            if chunk
         ]
         chunks.reverse()
         lines: list[str] = []
@@ -2893,17 +2896,19 @@ class ConsoleComposerBar(Horizontal):
                 # Wrapping expands tabs. Put caret/style offsets in that same
                 # coordinate space before selecting or masking a visible row.
                 if caret_position is not None:
-                    caret_position = len(render_text[:caret_position].expandtabs(8))
+                    caret_position = len(
+                        render_text[:caret_position].expandtabs(_DRAFT_TAB_WIDTH)
+                    )
                 if style_ranges:
                     style_ranges = [
                         (
-                            len(render_text[:start].expandtabs(8)),
-                            len(render_text[:end].expandtabs(8)),
+                            len(render_text[:start].expandtabs(_DRAFT_TAB_WIDTH)),
+                            len(render_text[:end].expandtabs(_DRAFT_TAB_WIDTH)),
                             style,
                         )
                         for start, end, style in style_ranges
                     ]
-                render_text = render_text.expandtabs(8)
+                render_text = render_text.expandtabs(_DRAFT_TAB_WIDTH)
             line_slices = cls._visible_draft_line_slices(
                 render_text,
                 width,
@@ -5397,10 +5402,10 @@ class ConsoleComposerBar(Horizontal):
         else:
             render_text = display_text
         visible_slices = self._visible_draft_line_slices(
-            render_text.expandtabs(8),
+            render_text.expandtabs(_DRAFT_TAB_WIDTH),
             self._draft_render_width(),
             cursor_index=(
-                len(render_text[:caret_position].expandtabs(8))
+                len(render_text[:caret_position].expandtabs(_DRAFT_TAB_WIDTH))
                 if caret_position is not None
                 else None
             ),
@@ -5408,16 +5413,26 @@ class ConsoleComposerBar(Horizontal):
         if click_y >= len(visible_slices):
             return None
         clicked_slice = visible_slices[click_y]
-        if click_x >= len(clicked_slice.text):
+        if click_x >= cell_len(clicked_slice.text):
+            return None
+        # The terminal reports cells; slice and tab-source offsets count
+        # characters. Keep clicks on either cell of an emoji at its start,
+        # using whole grapheme boundaries with the wrapper's cell measurement.
+        for click_index, end, _ in split_graphemes(clicked_slice.text)[0]:
+            if cell_len(clicked_slice.text[:end]) > click_x:
+                break
+        else:
             return None
         if clicked_slice.synthetic_prefix_columns:
-            if click_x < clicked_slice.synthetic_prefix_columns:
+            if click_index < clicked_slice.synthetic_prefix_columns:
                 return None
             source_index = (
-                clicked_slice.start + click_x - clicked_slice.synthetic_prefix_columns
+                clicked_slice.start
+                + click_index
+                - clicked_slice.synthetic_prefix_columns
             )
         else:
-            source_index = clicked_slice.start + click_x
+            source_index = clicked_slice.start + click_index
         if "\t" in render_text:
             # Map expanded display positions back to the original source.
             # A click inside a tab's spaces belongs to that tab character.
@@ -5425,7 +5440,9 @@ class ConsoleComposerBar(Horizontal):
                 bisect_right(
                     range(len(render_text) + 1),
                     source_index,
-                    key=lambda index: len(render_text[:index].expandtabs(8)),
+                    key=lambda index: len(
+                        render_text[:index].expandtabs(_DRAFT_TAB_WIDTH)
+                    ),
                 )
                 - 1
             )


### PR DESCRIPTION
Console caret blinking can move whole words between lines because the visible block and hidden space produce different word boundaries. This keeps one wrap for both phases, hides only the mapped caret character, and aligns sizing and click positions with that wrap. Pasted tabs retain their spacing and style offsets. Clicks use terminal-cell measurements and complete grapheme boundaries, preserving wide emoji and combining text before reversing tab expansion. Mounted regressions reproduce the movement after Enter restores a failed send at 80×24 and 97×30.

The descriptive Logs view and **Copy visible** also lost send stages and failure details because `attempt_token` was treated as a credential assignment. Renaming the existing random correlation field to `attempt_id` preserves those fields across send and refresh events while keeping credential redaction unchanged. Both copy actions and the persistent sink are covered by real collector tests; ADR-029 documents the field correction.

These changes fix reproduced composer movement and missing diagnostic fields. The external reporter's exact whole-screen flicker and original send failure remain unconfirmed.

Validation:

- All 277 targeted diagnostics/privacy/send/composer tests passed after review fixes. After the final clean rebase onto dev d6d792ecd, all 47 focused regressions passed again. No full test sweep was run.
- A 4,092-position rendering probe went from 763 text-position mismatches to zero.
- Qodo's Unicode/tab click finding and independent review's VS16 click-and-type case were reproduced failing before their fixes and now pass at both terminal widths. Both Qodo findings are addressed.
- New regression-file lint and formatting, composer formatting, repository preflight and `git diff --check` pass. Existing full-file findings are unchanged: five composer lint findings, one overflow-test import-order finding and overflow-test formatting differences.

Tasks: TASK-31977.1 and TASK-32012.1.
