### PR TITLE
fix(library-media): widen the Items list when the Reader has no item open (task-31979)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -68,12 +68,25 @@ list uses the width that frees up:
   comfortable the surplus is split between them, up to a 56-cell ceiling, so
   a 98-character title paints 46 characters at 235 columns (it painted 31
   before, in a fixed 40-cell column).
+- **With no item open, Items takes the empty Reader's width.** When the
+  Reader is only showing "Select a media item to read it here.", the columns
+  it would give a document go to the Items list instead — so on a wide
+  terminal a long title reads in full rather than truncating beside empty
+  space. Opening an item restores the Reader's width, and closing back to the
+  list widens Items again.
 - **Each item is two rows** — its title, then its type and age — with no
   blank row between items, so a 52-row terminal lists 15 items rather than
   11.
 - **The navigation rail joins Media at 112 columns.** Below that the screen
   shows Items and the Reader only, and the Items pane itself collapses below
   88 columns.
+
+*Verified against fix/media-crit6-layout — 2026-09-07 (task-31979: the
+empty-reader widening. Pinned in tests at 235x52 and 100x30 — with no item
+open the Items list absorbs the empty Reader's columns and paints a
+98-character title's tail past column 56; opening an item restores the split;
+the 100x30 layout is unchanged. Confirmed against the resolver and the shell
+paint, not re-verified live.)*
 
 While another row is loading, Items distinguishes a **Loading ·** row
 prefix from the settled **Loaded ·** one. Reader may keep the prior item visible,

--- a/Tests/Library/test_library_adaptive_reader_state.py
+++ b/Tests/Library/test_library_adaptive_reader_state.py
@@ -728,3 +728,52 @@ def test_list_growth_never_shrinks_the_list_or_starves_the_reader(
         + grown.reader_width
         + 2 * MEDIA_READER_LAYOUT_PROFILE.grip_width
     ) == width
+
+
+def test_empty_reader_gives_freed_columns_to_the_items_list_at_235() -> None:
+    """task-31979: with no item open the Reader shows only its placeholder.
+
+    The width it would otherwise reserve for a document is wasted while the
+    Items list truncates long titles, so that width goes to the list instead,
+    down to the Reader's own floor. Opening an item (reader_has_item=True)
+    restores the split unchanged.
+    """
+    prefs = MediaReaderLayoutPreferences()
+    with_item = resolve_media_reader_layout(235, prefs, reader_has_item=True)
+    no_item = resolve_media_reader_layout(235, prefs, reader_has_item=False)
+
+    # Item open: exactly the pre-task split (do not regress it).
+    assert _pane_widths(with_item) == (True, True, 34, 56, 143)
+    # No item open: the Items pane absorbs the freed Reader columns down to
+    # the Reader's floor, so a 98-char title stops truncating at ~56 cells.
+    assert no_item.reader_width == MEDIA_READER_LAYOUT_PROFILE.work_min_width
+    assert no_item.items_width == 153
+    assert no_item.items_width > with_item.items_width
+    # Both panes and the two grips still tile the full terminal width.
+    assert (
+        no_item.library_width
+        + no_item.items_width
+        + no_item.reader_width
+        + 2 * MEDIA_READER_LAYOUT_PROFILE.grip_width
+    ) == 235
+
+
+@pytest.mark.parametrize("width", [60, 80, 100, 120, 160, 235])
+def test_reader_has_item_defaults_to_the_pre_task_behavior(width: int) -> None:
+    """task-31979: the new parameter defaults to True, so every existing
+    caller and every item-open resolution is byte-for-byte unchanged."""
+    prefs = MediaReaderLayoutPreferences()
+    assert resolve_media_reader_layout(width, prefs) == resolve_media_reader_layout(
+        width, prefs, reader_has_item=True
+    )
+
+
+def test_empty_reader_widening_is_off_under_custom_widths() -> None:
+    """task-31979: Custom widths obey the typed number (like the list_grows
+    gate); only Automatic mode adapts to the empty Reader."""
+    custom = MediaReaderLayoutPreferences(
+        custom_widths_enabled=True, library_width=31, items_width=40
+    )
+    assert resolve_media_reader_layout(
+        235, custom, reader_has_item=False
+    ) == resolve_media_reader_layout(235, custom, reader_has_item=True)

--- a/Tests/UI/test_library_media_reader_shell.py
+++ b/Tests/UI/test_library_media_reader_shell.py
@@ -333,6 +333,79 @@ async def test_row_activation_keeps_items_mounted_and_loads_permanent_reader():
         )
 
 
+# task-31979: a title long enough that a fixed ~56-cell list pane truncates it,
+# with a distinctive tail token past column 56 so a painted assertion proves the
+# widened list shows substantially more of it.
+_LONG_MEDIA_TITLE = (
+    "Meeting recording with an intentionally verbose descriptive title "
+    "that overruns the narrow list ZZZTAILMARKER"
+)
+assert len(_LONG_MEDIA_TITLE) >= 90
+assert _LONG_MEDIA_TITLE.index("ZZZTAILMARKER") > 56
+
+
+def _long_title_media_items():
+    items = _two_media_items()
+    items[0] = {**items[0], "title": _LONG_MEDIA_TITLE}
+    return items
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)])
+async def test_empty_reader_lets_the_list_paint_a_long_title_and_restores_on_open(
+    size,
+):
+    """task-31979 AC#1/#2/#3: with no item open the list pane absorbs the empty
+    Reader's width and paints the long title's tail; opening an item narrows the
+    list and restores the Reader's width."""
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, _two_conversations(), media=_long_title_media_items())
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=size) as pilot:
+        screen, shell = await _open_media_shell(host, pilot)
+        items = shell.query_one("#library-media-canvas", LibraryMediaCanvas)
+
+        empty = shell.effective_layout
+        assert screen._library_media_view != "viewer"
+        if size[0] == 235:
+            # Wide terminal: the list absorbs the empty Reader's wasted width
+            # and paints the title's tail token, which sits past column 56.
+            assert empty.items_width > 56
+            assert "ZZZTAILMARKER" in _painted_text_in_region(pilot.app, items.region)
+        else:
+            # 100x30 is already width-starved (nothing to reallocate); the
+            # layout must be byte-for-byte the pre-task default -- no regression.
+            assert empty == resolve_media_reader_layout(
+                shell.region.width, screen._library_media_reader_preferences
+            )
+
+        # Open the long-titled item -> the Reader takes a document again.
+        items.query_one("#library-media-row-0", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-title")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_session.loaded_id is not None,
+            message="Activated media detail never settled into Reader",
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_view == "viewer",
+            message="Opening an item did not enter the viewer",
+        )
+        if size[0] == 235:
+            # Opening restores the split: the list narrows, the Reader widens.
+            await _wait_for_condition(
+                pilot,
+                lambda: shell.effective_layout.reader_width > empty.reader_width,
+                message="Opening an item did not restore the Reader width",
+            )
+            opened = shell.effective_layout
+            assert opened.items_width < empty.items_width
+            assert opened.reader_width > empty.reader_width
+
+
 @pytest.mark.asyncio
 async def test_non_media_library_routes_keep_the_existing_shell():
     host = LibraryProductionCSSHarness(_build_media_test_app())
@@ -379,6 +452,10 @@ async def test_media_shell_resize_uses_resolver_without_reads_or_recompose(size)
                     shell.region.width,
                     screen._library_media_reader_preferences,
                     previous=shell.effective_layout,
+                    # task-31979: _open_media_shell leaves the shell in the
+                    # list view with no item open, so the Reader's wasted
+                    # width flows into the Items list.
+                    reader_has_item=False,
                 )
             ),
             message=f"Media shell did not settle at {size}",

--- a/Tests/UI/test_library_media_return_settlement.py
+++ b/Tests/UI/test_library_media_return_settlement.py
@@ -252,13 +252,20 @@ async def test_viewer_return_capture_is_frozen_receipt_from_normal_media(
                 for item in screen._library_media_browse_controller.retained_items
             ),
         )
+        # task-31979: the signature is derived from the canonical item-open
+        # reader width, not the live tracker's, so the empty-reader list
+        # widening does not read as a layout change across list<->viewer.
+        canonical_reader_width = library_screen_module.resolve_media_reader_layout(
+            int(screen.size.width),
+            screen._library_media_reader_preferences,
+        ).reader_width
         assert layout_signature == (
             int(screen.size.width),
             int(screen.size.height),
             screen._library_notes_compact,
             screen._library_media_reader_preferences,
             library_screen_module.resolve_media_reader_layout(
-                screen._library_media_reader_layout.reader_width,
+                canonical_reader_width,
                 screen._library_media_reader_preferences,
             ),
         )

--- a/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
+++ b/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
@@ -3,9 +3,11 @@ id: TASK-31979
 title: >-
   Library media: the wide layout truncates a long title while the reader pane
   sits empty
-status: To Do
-assignee: []
+status: Done
+assignee:
+  - '@claude'
 created_date: '2026-09-07 22:48'
+updated_date: '2026-09-08 03:25'
 labels:
   - library
   - media
@@ -23,7 +25,27 @@ Critique #6 P2, both assessors. At 235x52 a 98-character title is cut to 47 char
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 When no media item is open, the list pane is allowed enough width to show substantially more of a long title (or the title wraps rather than truncating)
-- [ ] #2 Opening an item restores the reader pane's width
-- [ ] #3 A pin asserts a long title paints more characters at 235x52 with no item open than the current fixed 52-column pane allows
+- [x] #1 When no media item is open, the list pane is allowed enough width to show substantially more of a long title (or the title wraps rather than truncating)
+- [x] #2 Opening an item restores the reader pane's width
+- [x] #3 A pin asserts a long title paints more characters at 235x52 with no item open than the current fixed 52-column pane allows
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add reader_has_item param to resolve_adaptive_reader_layout (default True = current behavior); when items open, reader empty, and not custom, give freed reader columns to items down to work_min floor.\n2. Thread through resolve_media_reader_layout wrapper.\n3. Wire library_screen _sync_library_media_reader_layout_from_shell to pass reader_has_item = (view == viewer).\n4. Update the list-view resize test to expect the widened layout; add resolver unit tests (RED) + painted pin (235x52 no-item shows more chars, opening restores reader).
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added a reader_has_item flag (default True = unchanged) to resolve_adaptive_reader_layout: when the work/Reader pane has no item open and the Items list is open (automatic widths only, matching the list_grows gate), the freed Reader columns go to the list down to work_min_width. Threaded through resolve_media_reader_layout; the Media call site (_sync_library_media_reader_layout_from_shell) passes reader_has_item = (_library_media_view == viewer).
+
+Widths at 235x52: item open 34/56/143 (unchanged pin); no item open 34/153/46 -> a 98-char title paints in full (ellipsized at the pane edge, cap 120) instead of ~56 cells. 100x30 is width-starved (freed=0) so it is byte-for-byte unchanged.
+
+Opening restores the split via a new side-effect-free _restore_library_media_reader_width_on_open (shell.sync_layout only, NO presentation-epoch advance / NO return-settlement re-arm) because the full sync's epoch machinery corrupted the media-return fence mid-open. Because list-view and viewer-view Media layouts now differ, _library_media_layout_signature was made invariant to the widening (derived from the canonical item-open reader width) so an exact scroll return survives the list<->viewer transition.
+
+RULING (scope): the empty-reader widening is applied only on the resolver's main (non-starved) path; the width-starved priority early-return has no surplus to reallocate. Interaction with task-31970's two comfort clamps: unchanged -- the new widening is gated on `not custom_widths_enabled` (Custom obeys), so it never widens a hand-typed width; task-31968/31970 left separate.
+
+Files: tldw_chatbook/Utils/adaptive_reader_state.py, tldw_chatbook/Library/library_media_reader_state.py, tldw_chatbook/UI/Screens/library_screen.py, Docs/User_Guide/library/media-and-conversations.md; tests Tests/Library/test_library_adaptive_reader_state.py (3 new unit tests), Tests/UI/test_library_media_reader_shell.py (painted pin at 235x52 + 100x30, resize-test expectation updated), Tests/UI/test_library_media_return_settlement.py (signature pin updated).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
+++ b/backlog/tasks/task-31979 - Library-media-the-wide-layout-truncates-a-long-title-while-the-reader-pane-sits-empty.md
@@ -41,7 +41,7 @@ Critique #6 P2, both assessors. At 235x52 a 98-character title is cut to 47 char
 <!-- SECTION:NOTES:BEGIN -->
 Added a reader_has_item flag (default True = unchanged) to resolve_adaptive_reader_layout: when the work/Reader pane has no item open and the Items list is open (automatic widths only, matching the list_grows gate), the freed Reader columns go to the list down to work_min_width. Threaded through resolve_media_reader_layout; the Media call site (_sync_library_media_reader_layout_from_shell) passes reader_has_item = (_library_media_view == viewer).
 
-Widths at 235x52: item open 34/56/143 (unchanged pin); no item open 34/153/46 -> a 98-char title paints in full (ellipsized at the pane edge, cap 120) instead of ~56 cells. 100x30 is width-starved (freed=0) so it is byte-for-byte unchanged.
+Widths at 235x52: item open 34/56/143 (unchanged pin); no item open 34/153/46 -> a 98-char title paints in full (ellipsized at the pane edge, floored at work_min_width (list otherwise uncapped)) instead of ~56 cells. 100x30 is width-starved (freed=0) so it is byte-for-byte unchanged.
 
 Opening restores the split via a new side-effect-free _restore_library_media_reader_width_on_open (shell.sync_layout only, NO presentation-epoch advance / NO return-settlement re-arm) because the full sync's epoch machinery corrupted the media-return fence mid-open. Because list-view and viewer-view Media layouts now differ, _library_media_layout_signature was made invariant to the widening (derived from the canonical item-open reader width) so an exact scroll return survives the list<->viewer transition.
 

--- a/tldw_chatbook/Library/library_media_reader_state.py
+++ b/tldw_chatbook/Library/library_media_reader_state.py
@@ -178,6 +178,7 @@ def resolve_media_reader_layout(
     *,
     previous: MediaReaderEffectiveLayout | None = None,
     priority: PaneName | None = None,
+    reader_has_item: bool = True,
 ) -> MediaReaderEffectiveLayout:
     """Resolve Media preferences through the shared adaptive layout policy.
 
@@ -186,6 +187,9 @@ def resolve_media_reader_layout(
         preferences: Persisted manual pane preferences.
         previous: Previously resolved layout used for hysteresis.
         priority: Pane explicitly requested by the user, if any.
+        reader_has_item: Whether the Reader has an item open. When ``False``
+            the empty Reader's wasted width goes to the Items list so a long
+            title stops truncating (task-31979); ``True`` restores the split.
 
     Returns:
         Media-compatible effective pane geometry.
@@ -196,6 +200,7 @@ def resolve_media_reader_layout(
         MEDIA_READER_LAYOUT_PROFILE,
         previous=previous,
         priority=priority,
+        reader_has_item=reader_has_item,
     )
 
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -7744,6 +7744,35 @@ class LibraryScreen(BaseAppScreen):
                 severity="warning",
             )
 
+    def _restore_library_media_reader_width_on_open(self) -> None:
+        """Reclaim the Reader's width when an item opens (task-31979).
+
+        Selecting an item flips the view to the viewer, so the list-view
+        widening -- which hands the empty Reader's columns to the Items list --
+        must be undone. Patched straight onto the shell so it does NOT advance
+        the presentation epoch or re-arm return settlement: the full resolver
+        sync (``_sync_library_media_reader_layout_from_shell``) does both, and
+        doing either mid-open corrupts the media-return settlement fence.
+        """
+        try:
+            shell = self.query_one(
+                "#library-media-reader-shell", LibraryMediaReaderShell
+            )
+        except (NoMatches, QueryError):
+            return
+        if not self._library_adaptive_reader_allocation_is_current(shell):
+            return
+        layout = resolve_media_reader_layout(
+            shell.region.width,
+            self._library_media_reader_preferences,
+            previous=self._library_media_reader_layout,
+            reader_has_item=self._library_media_view == _MEDIA_VIEW_VIEWER,
+        )
+        if layout == self._library_media_reader_layout:
+            return
+        shell.sync_layout(layout)
+        self._library_media_reader_layout = layout
+
     def _sync_library_media_reader_layout_from_shell(
         self,
         priority: Literal["library", "items"] | None = None,
@@ -7795,6 +7824,10 @@ class LibraryScreen(BaseAppScreen):
             self._library_media_reader_preferences,
             previous=previous,
             priority=priority,
+            # task-31979: only the viewer shows a real document; in the list
+            # and trash views the Reader holds just its placeholder, so its
+            # width goes to the Items list to stop long titles truncating.
+            reader_has_item=self._library_media_view == _MEDIA_VIEW_VIEWER,
         )
         layout_changed = layout != self._library_media_reader_layout
         focused = self.focused
@@ -16023,10 +16056,20 @@ class LibraryScreen(BaseAppScreen):
         )
 
     def _library_media_layout_signature(self) -> tuple[object, ...]:
-        """Return terminal allocation plus pure effective Media pane layout."""
-        reader_width = self._library_media_reader_layout.reader_width
+        """Return terminal allocation plus pure effective Media pane layout.
+
+        task-31979: derived from the canonical item-open reader width, not the
+        live tracker's, so the empty-reader list widening -- a deterministic,
+        reversible list-view state that hands the empty Reader's columns to the
+        Items list -- never reads as a layout change that would deny an exact
+        return across the list<->viewer transition.
+        """
+        canonical = resolve_media_reader_layout(
+            int(self.size.width),
+            self._library_media_reader_preferences,
+        )
         pure_layout = resolve_media_reader_layout(
-            reader_width,
+            canonical.reader_width,
             self._library_media_reader_preferences,
         )
         return (
@@ -16640,6 +16683,11 @@ class LibraryScreen(BaseAppScreen):
             if not self.query("#library-media-canvas"):
                 self._sync_library_media_browse_state(None)
             self._sync_library_media_viewer_or_recompose()
+        # task-31979: selecting flips the view to "viewer", so the Reader now
+        # holds a document (or its loading banner) and must reclaim the width
+        # the list-view widening handed to the Items list. The in-place viewer
+        # patch above does not re-run the resolver.
+        self._restore_library_media_reader_width_on_open()
         if immediate:
             self._dispatch_library_media_detail_request(
                 pending.generation, pending.requested_id, canonical_id

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -212,6 +212,7 @@ def resolve_adaptive_reader_layout(
     *,
     previous: AdaptiveReaderEffectiveLayout | None = None,
     priority: PaneName | None = None,
+    reader_has_item: bool = True,
 ) -> AdaptiveReaderEffectiveLayout:
     """Resolve saved pane preferences into one responsive effective layout.
 
@@ -221,6 +222,15 @@ def resolve_adaptive_reader_layout(
         profile: Destination list and work-pane width policy.
         previous: Previously resolved layout used for hysteresis.
         priority: Pane explicitly requested by the user, if any.
+        reader_has_item: Whether the work (Reader) pane has an item open.
+            When ``False`` (the pane shows only its empty-state placeholder)
+            the width normally reserved for a document is given to the Items
+            list instead, down to the work pane's floor, so a long title stops
+            truncating in the wasted space (task-31979). Defaults to ``True``,
+            which reproduces the pre-task split exactly; only the non-starved
+            main path reallocates -- a width-starved priority layout has no
+            surplus to give. Automatic widths only: obeyed as typed under
+            ``custom_widths_enabled``, matching the ``list_grows`` gate.
 
     Returns:
         Current effective pane geometry.
@@ -388,6 +398,16 @@ def resolve_adaptive_reader_layout(
                     items_width,
                 ),
             )
+    if items_open and not reader_has_item and not preferences.custom_widths_enabled:
+        # task-31979: the work (Reader) pane is showing only its empty-state
+        # placeholder, so the width normally held for a document is wasted
+        # while the Items list truncates long titles into ~56 cells. Hand that
+        # freed width to the list, down to the work pane's own floor; selecting
+        # an item (reader_has_item=True) restores the split unchanged. Gated on
+        # automatic widths like the list_grows block above: Custom obeys.
+        freed = width - grip_width - library_width - items_width - work_min_width
+        if freed > 0:
+            items_width += freed
     return AdaptiveReaderEffectiveLayout(
         library_open=library_open,
         items_open=items_open,


### PR DESCRIPTION
## Summary

Critique #6 fix wave (task-31979, P2): at 235x52 the Media Items (list) pane was a fixed ~56 columns and truncated a 98-char title to ~47, while the Reader pane sat empty holding one sentence; at 100x30 the same title wrapped and read fine. The wide layout lost information.

Fix: `resolve_adaptive_reader_layout` takes a new `reader_has_item` flag (defaulting to the old behavior, so every non-media caller is byte-identical). When the Reader has no item open, the list is shown, and widths are automatic, the freed Reader columns go to the Items pane down to `work_min_width`; opening an item restores the split. At 235x52 the Items pane goes 56 → 153, so a 98-char title paints in full; with an item open the split is unchanged (34/56/143, pinned); at 100x30 nothing changes (width-starved, freed = 0). The widening is gated on `not custom_widths_enabled`, so a hand-typed width is never touched (the task-31970 boundary). The restore-on-open helper is side-effect-free (no epoch advance, no settlement re-arm), and the layout signature was made invariant to the widening so exact scroll-return survives the list↔viewer transition.

## Verification

Task review (Opus): Approved, no Important issues (one inaccurate "cap 120" note phrase, corrected — the list is uncapped, the reader is floored at `work_min_width`). The reviewer confirmed all 14 non-media resolver callers are unchanged, the item-open split is byte-identical, the custom-width gate holds, the restore helper mutates no epoch/settlement state, and the scroll-return contract survives.

| run | result |
|---|---|
| resolver unit tests | 346 passed (red first: the new kwarg didn't exist) |
| painted pin (235x52 title paints past col 56 + restore on open; 100x30 unchanged) | 2 passed |
| `test_library_media_return_settlement.py` (scroll-return contract) | 44 passed |

No CSS change; diagnostic inventory unchanged; no new logger call sites; preflight green. Closes task-31979.

A pre-existing failing test, `test_generated_stylesheet_includes_library_media_rules`, is unrelated to this CSS-free diff: it asserts library selectors live in the boot bundle, but the TASK-15450 screen-split moved them to `screen_agentic_library.tcss` (loaded at runtime by LibraryScreen). It is a stale test to retarget separately, not a bundle problem — preflight's bundle-reproducibility check is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the library media wide layout truncating long titles while the Reader pane sits empty (task-31979): the Items list now takes the unused Reader width, and opening an item restores the split.

**Bug Fixes**
- Adds `reader_has_item` to `resolve_adaptive_reader_layout`, defaulting to `True` so non-media callers are byte-identical.
- Widening applies only on the automatic-width path, down to the Reader's `work_min_width` floor; custom widths and width-starved layouts keep the old layout.
- Restores the Reader width on item open with a side-effect-free shell sync (no epoch advance, no settlement re-arm).
- Derives the media-return layout signature from the canonical item-open reader width so exact scroll return survives the list/viewer transition.

<sup>Written for commit b6fcbc43c44af009c0f8edb4ac5d7ecac36e4c13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2499?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

