### PR TITLE
fix(library-media): restore the reader scroll position across a mode change (task-31968)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -380,7 +380,17 @@ silently replacing it with a partial or broad Library snapshot.
 Reader stays mounted beside Items and keeps one mode visible at a time:
 **Read**, **Analysis**, **Highlights**, or **Info**. The chosen mode persists
 while you move through items. Missing analysis or highlights produces an
-item-specific empty state; it does not silently switch modes.
+item-specific empty state; it does not silently switch modes. Leaving **Read**
+for another mode and returning drops you back at the same place in the text —
+the reading position is restored even though the rendered body has to lay out
+again first.
+
+*Verified against fix/media-crit6-scroll — 2026-09-07 (task-31968: the
+Read → Analysis → Read reading-position restore. Pinned in tests at 235x52 —
+the offset is restored on the real, re-laid-out scroll container after the
+round-trip, and the restore lands synchronously against a laid-out body rather
+than racing the Markdown parse. Confirmed against the scroll container in the
+harness, not re-verified live.)*
 
 Its header is deliberately short: **‹ Back**, the title, the action row, and
 the mode row — five rows above the reading surface, border included. A byline

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1008,14 +1008,21 @@ def test_progress_restores_after_loaded_content_mounts():
         _library_media_read_scroll_by_id={"local:media:7": (2, 19)},
         query_one=lambda *_args, **_kwargs: SimpleNamespace(
             scroller=SimpleNamespace(
-                scroll_to=lambda **kwargs: calls.append(kwargs)
+                # task-31968: the restore reads scroll_y after applying to
+                # decide whether the body laid out short and needs a re-apply;
+                # already at the target here, so it lands once.
+                scroll_x=2,
+                scroll_y=19,
+                scroll_to=lambda **kwargs: calls.append(kwargs),
             )
         ),
     )
 
     LibraryScreen._restore_library_media_loaded_progress(fake, "local:media:7")
 
-    assert calls == [{"x": 2, "y": 19, "animate": False, "force": True}]
+    assert calls == [
+        {"x": 2, "y": 19, "animate": False, "force": True, "immediate": True}
+    ]
 
 
 @pytest.mark.asyncio
@@ -1098,7 +1105,9 @@ def test_mode_change_preserves_per_item_read_scroll_for_session():
     )
     LibraryScreen._restore_library_media_loaded_progress(fake, "local:media:4")
 
-    assert restored == [{"x": 0, "y": 23, "animate": False, "force": True}]
+    assert restored == [
+        {"x": 0, "y": 23, "animate": False, "force": True, "immediate": True}
+    ]
 
 
 def test_external_server_detail_does_not_use_local_progress_seam():

--- a/Tests/UI/test_library_media_reader_scroller_resolution.py
+++ b/Tests/UI/test_library_media_reader_scroller_resolution.py
@@ -364,3 +364,162 @@ async def test_match_scroll_resolves_the_real_scroller_and_maps_through_the_wrap
             ),
         )
         assert raw_view.scroll_offset.y != target_line
+
+
+async def _open_rendered_body_ready(screen, pilot) -> LibraryMediaContentBody:
+    """Return the body once its rendered Markdown has laid out (max scroll > 0).
+
+    Textual's ``Markdown`` widget parses in an executor and mounts its blocks
+    in batches, so the rendered scroller's ``max_scroll_y`` stays 0 for a pump
+    or two after the reader session settles -- an immediate ``scroll_to`` right
+    then clamps to the top. This waits until the body can actually scroll.
+    """
+    await _wait_for_condition(
+        pilot,
+        lambda: (
+            screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).active_mode
+            == "rendered"
+            and screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).scroller.max_scroll_y
+            > 0
+        ),
+        message="Rendered Markdown body never laid out (max_scroll_y stayed 0).",
+    )
+    return screen.query_one(
+        "#library-media-viewer-content", LibraryMediaContentBody
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_analysis_read_round_trip_restores_the_rendered_scroll_offset():
+    """task-31968: Read -> Analysis -> Read must land back on the saved offset.
+
+    The mode-change restore fires on the viewer's post-recompose hook, while
+    the freshly rebuilt Markdown body is still parsing/laying out -- so the
+    container's max scroll is 0 and ``scroll_to`` clamps the captured offset to
+    the top. Drive the real mode buttons and assert the rebuilt, laid-out
+    rendered scroller returns to the captured offset. Before the fix this
+    lands at 0 (the position is lost); after it, the restore re-applies once
+    the rebuilt body has laid out.
+    """
+    app, service = _flow_app(count=4)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        canonical_id, backing_id, _title = _seed_row_document(
+            screen, service, 0, _markdown_wrapping_document(trailing_lines=200)
+        )
+        # The fixture's media items are all video/audio/PDF; force this row's
+        # type into the markdown allowlist so the content sniff applies and the
+        # Reader defaults to the Rendered view (the parse race is Rendered-only).
+        source = next(
+            item for item in service.media_items if item["id"] == f"media-{backing_id}"
+        )
+        source["type"] = "plaintext"
+
+        screen.query_one("#library-media-row-0", Button).press()
+        await _wait_for_detail_call(service, backing_id)
+        service.release(backing_id)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_session.loaded_id == canonical_id,
+            message="Row never settled its detail.",
+        )
+        assert screen._library_media_content_mode == "rendered", (
+            "Fixture must default to Rendered for the round-trip to mean anything."
+        )
+
+        body = await _open_rendered_body_ready(screen, pilot)
+        body.scroller.scroll_to(y=12, animate=False, immediate=True)
+        await pilot.pause()
+        target = int(body.scroller.scroll_y)
+        assert target > 0, "Fixture scroll did not move -- test setup is broken."
+
+        # Read -> Analysis captures the Read offset; Analysis -> Read restores.
+        screen.query_one("#library-media-reader-select-analysis", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_session.mode == "analysis",
+            message="Never switched to Analysis.",
+        )
+        screen.query_one("#library-media-reader-select-read", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_session.mode == "read",
+            message="Never switched back to Read.",
+        )
+
+        # The rebuilt body must lay out AND land back on the captured offset,
+        # read from the real (re-queried) scroll container.
+        await _wait_for_condition(
+            pilot,
+            lambda: int(
+                screen.query_one(
+                    "#library-media-viewer-content", LibraryMediaContentBody
+                ).scroller.scroll_y
+            )
+            == target,
+            message=(
+                "Rendered scroll offset was not restored after the "
+                "Read -> Analysis -> Read round-trip."
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_mode_change_restore_lands_synchronously_on_the_laid_out_body():
+    """task-31968: the restore must apply against the current layout at once.
+
+    The mode-change restore fires on the viewer's post-recompose hook, when
+    the rebuilt Markdown body may not have laid out yet. A single DEFERRED
+    ``scroll_to`` applies a refresh later -- against a body that is still
+    parsing then it clamps to the top and never re-applies, so the reader
+    loses its place. The fix applies immediately (so it can tell an unlaid
+    body, offset clamped short, from a landed one) and re-arms itself until
+    the offset lands.
+
+    This pins the half that is deterministic in this harness: called against
+    an already laid-out rendered scroller, the restore lands the saved offset
+    SYNCHRONOUSLY, with no intervening refresh. The deferred-only restore
+    (``scroll_to`` without ``immediate=True``) leaves the scroller at rest at
+    this point, so this reads 0 and fails. (The full sub-frame parse race is
+    collapsed by ``pilot.pause`` and is not reproducible end-to-end here --
+    see the round-trip test above, a regression guard, and the task notes.)
+    """
+    app, service = _flow_app(count=4)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        canonical_id, backing_id, _title = _seed_row_document(
+            screen, service, 0, _markdown_wrapping_document(trailing_lines=200)
+        )
+        source = next(
+            item for item in service.media_items if item["id"] == f"media-{backing_id}"
+        )
+        source["type"] = "plaintext"
+        screen.query_one("#library-media-row-0", Button).press()
+        await _wait_for_detail_call(service, backing_id)
+        service.release(backing_id)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_media_reader_session.loaded_id == canonical_id,
+            message="Row never settled its detail.",
+        )
+        body = await _open_rendered_body_ready(screen, pilot)
+        body.scroller.scroll_to(y=0, animate=False, immediate=True)
+        await pilot.pause()
+        assert int(body.scroller.scroll_y) == 0, "Fixture must start unscrolled."
+        assert body.scroller.max_scroll_y >= 14, (
+            "Fixture must overflow the reading surface for the offset to land."
+        )
+
+        screen._library_media_read_scroll_by_id[canonical_id] = (0, 14)
+        screen._restore_library_media_loaded_progress(canonical_id)
+        # No pause: the fix applies against the laid-out scroller immediately;
+        # the deferred-only restore would still read 0 here.
+        assert int(body.scroller.scroll_y) == 14

--- a/backlog/tasks/task-31968 - Library-media-the-Readers-reading-position-restore-does-not-land-on-a-mode-change.md
+++ b/backlog/tasks/task-31968 - Library-media-the-Readers-reading-position-restore-does-not-land-on-a-mode-change.md
@@ -3,9 +3,10 @@ id: TASK-31968
 title: >-
   Library media: the Reader's reading-position restore does not land on a mode
   change
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-07 20:27'
+updated_date: '2026-09-08 05:40'
 labels:
   - library
   - media
@@ -22,7 +23,19 @@ Found by PR L (task-31954). On Read → Analysis → Read the reader progress re
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Switching Read → Analysis → Read returns the Reader to the same scroll offset (painted pin, not a state probe)
-- [ ] #2 The restore waits for the rendered body's layout (or re-applies once after the parse settles) rather than racing it
-- [ ] #3 No second scheduler is introduced; the one owner from task-31954 stays the only one
+- [x] #1 Switching Read → Analysis → Read returns the Reader to the same scroll offset (painted pin, not a state probe)
+- [x] #2 The restore waits for the rendered body's layout (or re-applies once after the parse settles) rather than racing it
+- [x] #3 No second scheduler is introduced; the one owner from task-31954 stays the only one
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Trace where the media reader scroll is captured/re-applied on a mode change and why the re-apply lands on an unlaid-out Markdown body. 2. Mirror the NOTES scroll-restore precedent: scroll_to(immediate=True) + a bounded re-apply after the body lays out, staying task-31954's single owner. 3. Painted pin on the real scroll container, red first.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: on Read->Analysis->Read the media reading-position restore fired one deferred scroll_to against a Markdown body still parsing (Textual parses in an executor and mounts blocks across later refreshes), so max_scroll_y was 0 and the offset clamped to the top. Fix in the one shared `_restore_library_media_loaded_progress` (covers mode-change AND initial-load): scroll_to(immediate=True) clamps against current layout, and while `scroller.scroll_y < offset` an inner `settle()` closure re-arms one `call_after_refresh` at a time (<=8 hops, re-checking loaded_id each hop so a stale offset never lands on a newer item), so the offset re-lands as the body grows. Stays task-31954's single owner: settle() is a continuation of the one call, never re-enters the public method, never re-claims `_library_media_progress_restored_id` (AC#3). Determinism ruling: the production race is sub-frame and the pilot harness collapses parse+mount+layout+deferred-scroll into one pause(), so the end-to-end round-trip cannot go RED in-harness (kept as a regression guard); the RED->GREEN pin asserts the deterministic half -- the restore lands synchronously on the REAL laid-out scroll container (reverting immediate=True fails assert 0 == 14). Bounded Minors (not fixed, YAGNI): rapid same-item switching stacks convergent settle loops; a scroll-up within the <=8-hop window is pulled back. Files: tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_media_reader_scroller_resolution.py, Tests/UI/test_library_media_reader_flow.py (progress unit contract).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -35542,20 +35542,54 @@ class LibraryScreen(BaseAppScreen):
         return True
 
     def _restore_library_media_loaded_progress(self, expected_id: str) -> None:
-        """Restore only while the expected local identity still owns Reader."""
+        """Restore the local content offset once its body has laid out.
+
+        task-31968: the rendered Markdown body parses in an executor and
+        mounts its blocks across later refreshes (Textual's
+        ``Markdown.update``), so the scroll container's ``max_scroll_y`` can
+        still be 0 when this first runs on the viewer's post-recompose hook.
+        A single deferred ``scroll_to`` then applies against an unlaid (or
+        still-short) body, clamps the saved offset to the top, and never
+        re-applies once the body grows -- the reader loses its place on a
+        mode change. So apply immediately, and while the offset has not
+        landed on the laid-out body, re-apply after the next refresh until it
+        does (or the bounded budget proves it genuinely cannot).
+
+        This stays task-31954's ONE restore owner: the settle-and-re-apply is
+        an inner continuation of this single call, not a second scheduler --
+        it never re-enters this method, so ``_library_media_progress_restored_id``
+        is still claimed exactly once (by the mode handler) and this restore
+        is still invoked exactly once per owner.
+        """
         session = self._library_media_reader_session
         if session.external_detail or session.loaded_id != expected_id:
             return
         offset = self._library_media_read_scroll_by_id.get(expected_id)
         if offset is None:
             return
-        try:
-            body = self.query_one(
-                "#library-media-viewer-content", LibraryMediaContentBody
+
+        def settle(remaining: int) -> None:
+            # A newer navigation may have superseded this restore while the
+            # body was still laying out; only the loaded owner may land.
+            if self._library_media_reader_session.loaded_id != expected_id:
+                return
+            try:
+                body = self.query_one(
+                    "#library-media-viewer-content", LibraryMediaContentBody
+                )
+            except (NoMatches, QueryError):
+                return
+            scroller = body.scroller
+            # ``immediate=True`` so the clamp happens now against the current
+            # layout -- that synchronous outcome is what lets the guard below
+            # tell an unlaid body (offset clamped short) from a landed one.
+            scroller.scroll_to(
+                x=offset[0], y=offset[1], animate=False, force=True, immediate=True
             )
-        except (NoMatches, QueryError):
-            return
-        body.scroller.scroll_to(x=offset[0], y=offset[1], animate=False, force=True)
+            if remaining > 0 and offset[1] > 0 and int(scroller.scroll_y) < offset[1]:
+                self.call_after_refresh(settle, remaining - 1)
+
+        settle(8)
 
     def _close_library_media_find(self) -> None:
         """Reset the content Find bar: collapsed, no query, first match.


### PR DESCRIPTION
## Summary

Critique #6 fix wave, final P2 (task-31968): switching Read → Analysis → Read in the media reader lost the scroll position — the reader jumped back to the top of the document.

Root cause: on a mode change the reading-position restore fired one deferred `scroll_to` against a Markdown body still parsing (Textual parses in an executor and mounts blocks across later refreshes), so the scroll container's `max_scroll_y` was still 0 and the offset clamped to the top, with no re-application.

Fix, in the one shared `_restore_library_media_loaded_progress` (so it covers both the mode-change and the initial-load paths):
- `scroll_to(immediate=True)` clamps synchronously against the current layout, and
- while the offset has not landed, an inner `settle()` closure re-arms one `call_after_refresh` at a time (bounded to 8 hops, re-checking `loaded_id` each hop), so the offset re-lands as the body grows.

It stays task-31954's single owner: `settle()` is a continuation of the one call, never re-enters the public method and never re-claims `_library_media_progress_restored_id`, and the hop bound terminates on land / id-changed / counter.

## Verification

Task review (Opus): Approved, no Important issues. The reviewer preserved-checked the single-owner invariant (the settle loop is a bounded inner continuation, not a second scheduler; a stale offset cannot land on a newer item via the per-hop `loaded_id` guard), confirmed `immediate=True` is a real Textual `scroll_to` kwarg, and re-verified the pin is RED without the fix (`assert 0 == 14` on the real scroll container).

Determinism ruling (sound, reviewer-confirmed): the production race is sub-frame and the pilot harness collapses parse + mount + layout + deferred scroll into one `pause()`, so the end-to-end round-trip cannot go RED in-harness. It is kept as a regression guard; the RED→GREEN pin asserts the deterministic half — the restore lands synchronously on the real, laid-out scroll container.

| run | result |
|---|---|
| `test_library_media_reader_scroller_resolution.py` (incl. 2 new pins) | 6 passed, red first |
| `test_library_media_return_settlement.py` (scroll-return contract) | 44 passed |

Diagnostic inventory unchanged; no new logger call sites; no CSS; preflight green. Closes task-31968.

Two bounded, pre-existing-in-spirit Minors are left (YAGNI): rapid same-item mode switching stacks convergent settle loops that all target one offset and terminate; a scroll-up within the ≤8-hop window is briefly pulled back to the saved offset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the media reader losing its place on a Read → Analysis → Read mode change; the saved offset is now re-applied until the rebuilt body lays out instead of clamping to the top.

- The old restore fired one deferred `scroll_to` against a Markdown body still parsing, so `max_scroll_y` was 0 and the offset clamped with no re-application.
- The restore now uses `immediate=True` and re-arms a bounded `call_after_refresh` (up to 8 hops) until the offset lands, re-checking `loaded_id` each hop.
- It stays task-31954's single owner: the settle loop is an inner continuation and never re-enters the public method.
- Covers both the mode-change and initial-load paths, which share `_restore_library_media_loaded_progress`.
- Adds a deterministic pin that the restore lands synchronously on the laid-out scroller, plus a round-trip regression guard through the real mode buttons.
- The end-to-end parse race is sub-frame and not reproducible in the pilot harness, so the pin asserts the deterministic half.
- Two known bounded behaviors remain: rapid same-item mode switching stacks convergent settle loops, and a scroll-up within the ≤8-hop window is briefly pulled back.

<sup>Written for commit 4001657a3e1adfdf0f7ccc1df2dcd98ba086a8fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

