### PR TITLE
Add Copy selection to the Console selection menu

### DIFF
--- a/Docs/User_Guide/console/text-selection-and-feedback.md
+++ b/Docs/User_Guide/console/text-selection-and-feedback.md
@@ -1,10 +1,10 @@
-# Text selection & feedback — quote, ask, and review agent output
+# Text selection & feedback — copy, quote, ask, and review agent output
 
 ## What this is for
 
 Pick out a phrase, a stack trace, or a chunk of a diff in the transcript and
 do something with *just that part*. Drag-select any text and a small menu
-appears with two families of actions: **bring it into the conversation**
+appears with actions to **copy it to the clipboard**, **bring it into the conversation**
 (quote it, or ask about it in a throwaway side chat that never touches your
 history), and — when the text came from the agent — **review it** the way
 you'd review a pull request, with Request changes / LGTM / Comment.
@@ -15,10 +15,11 @@ supervising an agent run and want your verdict on a specific step recorded.
 
 ## Getting there
 
-Everything here starts from a **mouse drag across transcript text** — there
-is no keyboard entry point yet. Press and hold on the first character, drag
-to the last, and release; the selection highlights and the menu opens just
-below where you released.
+Start with a **mouse drag across transcript text**: press and hold on the
+first character, drag to the last, and release. The selection highlights
+and the menu opens just below where you released. For keyboard selection,
+select a message with **j/k**, press **s**, adjust the selection, then press
+**Enter** to open the same menu.
 
 Two settings feed the side chat (**Settings ▸ Console**, "Side chat model"
 and "Side chat prompt template") — see [Console](../console.md) for the
@@ -31,6 +32,7 @@ point. Which buttons appear depends on what you selected:
 
 | Button | When it appears |
 |---|---|
+| **Copy selection** | Always |
 | **Add to chat** | When the selection can be quoted into the composer |
 | **More Details** | Always |
 | **Ask in Side Chat** | Always |
@@ -41,11 +43,31 @@ point. Which buttons appear depends on what you selected:
 
 If the menu would run off the bottom of the screen it flips to sit entirely
 *above* the selected row, so your highlight stays visible.
+When the transcript is too short to show every action at once, the menu
+scrolls within it; **↑/↓** bring the focused action into view.
 
 The first button takes focus on open: **↑/↓** cycle, **Enter** activates,
 **Esc** closes and returns focus wherever it was before.
 
 ## Features & controls
+
+### Copy selection
+
+Copies the highlighted text to the clipboard, closes the menu, and returns
+focus to where it was before the menu opened. Your composer draft and
+whole-message selection stay unchanged. This is the first menu action, so
+pressing **Enter** after opening the menu activates it.
+
+Copy selection preserves whitespace and copies the full selection without
+the 4000-character quote limit. Markdown selections use the selected source
+text; diff selections copy the highlighted whole diff lines.
+
+Copying uses the terminal's clipboard support (OSC 52), the same as the
+whole-message Copy button. The notification confirms the request was sent;
+it cannot confirm that your terminal accepted it. If the clipboard stays
+empty, use your terminal's native selection and Copy action. In GNOME
+Terminal, hold **Shift while dragging**, then press **Ctrl+Shift+C**. Pressing
+Ctrl+Shift+C after an ordinary Chatbook drag does not copy Chatbook's selection.
 
 ### Add to chat
 
@@ -197,7 +219,8 @@ Inside the menu itself:
   if streaming replaces the row you selected, the quote clamps to the last
   stable text rather than following the new content.
 - **Quotes are capped at 4000 characters.** Longer selections are truncated
-  with a marker before they leave the transcript.
+  with a marker for chat, side chat, notes, and feedback. **Copy selection**
+  copies the full highlighted text.
 - **Request changes / LGTM look broken with no run.** They're disabled on
   purpose — hover for the hint, or use **Comment**.
 - **Keyboard selection always starts at the text's beginning.** Use `o` to

--- a/Docs/User_Guide/console/text-selection-and-feedback.md
+++ b/Docs/User_Guide/console/text-selection-and-feedback.md
@@ -44,7 +44,8 @@ point. Which buttons appear depends on what you selected:
 If the menu would run off the bottom of the screen it flips to sit entirely
 *above* the selected row, so your highlight stays visible.
 When the transcript is too short to show every action at once, the menu
-scrolls within it; **↑/↓** bring the focused action into view.
+scrolls within it; **↑/↓** bring the focused action into view. The full menu
+returns when you make more space available.
 
 The first button takes focus on open: **↑/↓** cycle, **Enter** activates,
 **Esc** closes and returns focus wherever it was before.

--- a/Tests/UI/test_console_keyboard_selection.py
+++ b/Tests/UI/test_console_keyboard_selection.py
@@ -13,6 +13,7 @@ import pytest
 from textual.app import App, ComposeResult
 from textual.events import MouseDown
 
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Chat.console_chat_models import (
     ConsoleChatMessage,
     ConsoleMessageRole,
@@ -30,7 +31,7 @@ _DIFF_OLD = "alpha\nbeta\ngamma\n"
 _DIFF_NEW = "alpha\nBETA\ngamma\ndelta\n"
 
 
-class _KeyboardSelectionApp(App[None]):
+class _KeyboardSelectionApp(ConsolidatedCSSApp):
     def compose(self) -> ComposeResult:
         transcript = ConsoleTranscript(id="console-native-transcript")
         transcript.set_messages(
@@ -582,8 +583,11 @@ async def test_menu_anchor_derives_from_row_region_and_stays_in_transcript():
         await pilot.pause()
         transcript.focus()
         row = transcript.query_one("#console-message-m1")
-        row_region = row.region
         await pilot.press("s")
+        # Selection adds a source highlight and can reflow the row. Capture
+        # its position when Enter will open the menu, after mode entry.
+        row_region = row.region
+        transcript_region = transcript.region
         await pilot.press("enter")
         await pilot.pause()
 
@@ -592,6 +596,8 @@ async def test_menu_anchor_derives_from_row_region_and_stays_in_transcript():
         bounds = transcript.region
         assert bounds.x <= anchor_x <= bounds.right
         assert bounds.y <= anchor_y <= bounds.bottom
+        assert bounds == transcript_region  # the overlay must not shrink its owner
+        assert bounds.contains_region(menu.region)
         # The menu can hop entirely above the row because the keyboard path
         # handed it the row's top, exactly like the mouse path does.
         assert menu._selection_top == row_region.y

--- a/Tests/UI/test_console_selection_copy.py
+++ b/Tests/UI/test_console_selection_copy.py
@@ -1,0 +1,177 @@
+"""Copy a highlighted Console span without changing drafts or truncating text."""
+
+import pytest
+from textual.app import ComposeResult
+from textual.widgets import Markdown, Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.test_console_left_rail import make_console_pilot
+from Tests.UI.test_console_selection_app_smoke import _drag, _seed_rows
+from Tests.UI.test_console_selection_menu import (
+    _finish_drag_selection,
+    _TranscriptMenuApp,
+)
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleChatMessage,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Widgets.Console.console_composer_bar import ConsoleComposerBar
+from tldw_chatbook.Widgets.Console.console_selection_menu import ConsoleSelectionMenu
+from tldw_chatbook.Widgets.Console.console_transcript import (
+    ConsoleMarkdownMessage,
+    ConsoleToolDiffRow,
+    ConsoleTranscript,
+    ConsoleTranscriptMessage,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "role", [ConsoleMessageRole.USER, ConsoleMessageRole.ASSISTANT]
+)
+async def test_mouse_copy_uses_only_the_highlight_and_preserves_the_draft(role):
+    async with make_console_pilot(production_styles=True) as pilot:
+        screen = pilot.app.screen
+        composer = screen.query_one(ConsoleComposerBar)
+        transcript = await _seed_rows(
+            pilot,
+            [ConsoleChatMessage(role=role, content="hello smoke world", id="copy-me")],
+        )
+        row = screen.query_one("#console-message-copy-me")
+        body = (
+            row.query_one(Markdown)
+            if isinstance(row, ConsoleMarkdownMessage)
+            else row.query_one(".console-transcript-message-body", Static)
+        )
+        composer.insert_text("keep this draft")
+        transcript.focus()
+        await pilot.pause()
+
+        await _drag(pilot, body, (3, 0), (11, 0))
+        assert row.get_selection_text() == "lo smoke"
+        await pilot.click("#console-selection-copy")
+        await pilot.pause()
+
+        assert pilot.app.clipboard == "lo smoke"
+        assert composer.draft_text() == "keep this draft"
+        assert row.get_selection_text() == ""
+        assert transcript.selection_manager.state.selection is None
+        assert transcript.selected_message_id is None
+        assert not screen.query(ConsoleSelectionMenu)
+        assert screen.focused is transcript
+
+
+@pytest.mark.asyncio
+async def test_keyboard_selection_enter_copies_and_keeps_the_selected_message():
+    async with make_console_pilot(production_styles=True) as pilot:
+        screen = pilot.app.screen
+        transcript = await _seed_rows(
+            pilot,
+            [
+                ConsoleChatMessage(
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="keyboard journey target",
+                    id="copy-keyboard",
+                )
+            ],
+        )
+        transcript.focus()
+        await pilot.press("j", "s", "l", "l", "enter")
+        await pilot.pause()
+        screen.query_one(ConsoleSelectionMenu)
+        await pilot.press("enter")
+        await pilot.pause()
+
+        assert pilot.app.clipboard == "key"
+        assert transcript.selected_message_id == "copy-keyboard"
+        assert not screen.query(ConsoleSelectionMenu)
+        assert transcript.selection_manager.state.selection is None
+        assert screen.focused is transcript
+
+
+class _LongSelectionApp(ConsolidatedCSSApp):
+    def __init__(self, message: ConsoleChatMessage) -> None:
+        super().__init__()
+        self.message = message
+
+    def compose(self) -> ComposeResult:
+        transcript = ConsoleTranscript(id="console-native-transcript")
+        transcript.set_messages([self.message])
+        yield transcript
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("row_kind", ["plain", "markdown", "diff"])
+async def test_copy_preserves_long_selection_while_quotes_remain_capped(row_kind):
+    selected = "  café λ " * 600 + "\nlast line  "
+    message = ConsoleChatMessage(
+        role=(
+            ConsoleMessageRole.USER
+            if row_kind == "plain"
+            else ConsoleMessageRole.ASSISTANT
+        ),
+        content=f"before:{selected}:after",
+        id="copy-long",
+    )
+    if row_kind == "diff":
+        message = ConsoleChatMessage(
+            role=ConsoleMessageRole.TOOL,
+            content="write_file → /tmp/a.py",
+            id="copy-long",
+            tool_diff=("/tmp/a.py", "x" * 5000 + "\n", "y\n"),
+        )
+        selected = "-" + "x" * 5000
+
+    app = _LongSelectionApp(message)
+    async with app.run_test(size=(100, 40)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        await transcript.refresh_messages()
+        if row_kind == "diff":
+            transcript.toggle_tool_output(message.id)
+            await transcript.refresh_messages()
+        await pilot.pause()
+        row = (
+            transcript.query_one(ConsoleToolDiffRow)
+            if row_kind == "diff"
+            else transcript.query_one(f"#console-message-{message.id}")
+        )
+        start = row.get_display_text().index(selected)
+        end = start + len(selected)
+        transcript.selection_manager.begin_drag(row.id, start)
+        transcript.selection_manager.extend_drag(row.id, end)
+        row.set_selection_range(start, end)
+        selection = transcript.selection_manager.finish_drag()
+        assert selection is not None
+        assert len(row.get_selection_text()) == 4000
+        transcript.post_message(
+            ConsoleTranscript.TranscriptTextSelected(selection, 2, 2)
+        )
+        await pilot.pause()
+        await pilot.click("#console-selection-copy")
+        await pilot.pause()
+
+        assert app.clipboard == selected
+        assert row.get_selection_text() == ""
+        assert not app.query(ConsoleSelectionMenu)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selection_change", ["empty", "removed"])
+async def test_stale_selection_does_not_replace_the_clipboard(selection_change):
+    app = _TranscriptMenuApp()
+    async with app.run_test() as pilot:
+        app.copy_to_clipboard("previous clipboard")
+        await _finish_drag_selection(pilot)
+        row = app.query_one(ConsoleTranscriptMessage)
+        if selection_change == "removed":
+            await row.remove()
+        else:
+            row.clear_selection()
+        await pilot.click("#console-selection-copy")
+        await pilot.pause()
+
+        assert app.clipboard == "previous clipboard"
+        assert not app.query(ConsoleSelectionMenu)
+        assert (
+            app.query_one(ConsoleTranscript).selection_manager.state.selection is None
+        )

--- a/Tests/UI/test_console_selection_copy.py
+++ b/Tests/UI/test_console_selection_copy.py
@@ -89,7 +89,7 @@ async def test_keyboard_selection_enter_copies_and_keeps_the_selected_message():
         assert screen.focused is transcript
 
 
-class _LongSelectionApp(ConsolidatedCSSApp):
+class LongSelectionApp(ConsolidatedCSSApp):
     def __init__(self, message: ConsoleChatMessage) -> None:
         super().__init__()
         self.message = message
@@ -122,7 +122,7 @@ async def test_copy_preserves_long_selection_while_quotes_remain_capped(row_kind
         )
         selected = "-" + "x" * 5000
 
-    app = _LongSelectionApp(message)
+    app = LongSelectionApp(message)
     async with app.run_test(size=(100, 40)) as pilot:
         transcript = app.query_one(ConsoleTranscript)
         await transcript.refresh_messages()

--- a/Tests/UI/test_console_selection_end_to_end.py
+++ b/Tests/UI/test_console_selection_end_to_end.py
@@ -1332,7 +1332,12 @@ async def test_feedback_reaches_the_real_database_unmocked(tmp_path):
             screen = pilot.app.screen
             screen._prompt_queue = _RecordingPromptQueue()
             _stub_comment_modal(screen, "needs a retry bound")
-            store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+            store = ConsoleChatStore(
+                persistence=ChatPersistenceService(
+                    db,
+                    workspace_registry=screen.app_instance.workspace_registry_service,
+                )
+            )
             screen._console_chat_store = store
             controller = screen._ensure_console_chat_controller()
             # The controller caches the store it was built with, so the
@@ -1479,7 +1484,12 @@ async def test_comment_annotation_reaches_the_real_database_unmocked(tmp_path):
             screen = pilot.app.screen
             screen._prompt_queue = _RecordingPromptQueue()
             _stub_comment_modal(screen, "tighten error paths")
-            store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+            store = ConsoleChatStore(
+                persistence=ChatPersistenceService(
+                    db,
+                    workspace_registry=screen.app_instance.workspace_registry_service,
+                )
+            )
             screen._console_chat_store = store
             controller = screen._ensure_console_chat_controller()
             controller.store = store

--- a/Tests/UI/test_console_selection_end_to_end.py
+++ b/Tests/UI/test_console_selection_end_to_end.py
@@ -40,6 +40,7 @@ from textual.app import App, ComposeResult
 from textual.screen import Screen
 from textual.widgets import Button, Input
 
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from Tests.UI.test_console_left_rail import make_console_pilot
 from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -497,7 +498,7 @@ class _StubRunStatusScreen(Screen):
         return self._run_status
 
 
-class _FeedbackTranscriptApp(App[None]):
+class _FeedbackTranscriptApp(ConsolidatedCSSApp):
     """Drag -> menu harness with app-level capture of feedback requests.
 
     The default screen is a plain ``Screen`` (no

--- a/Tests/UI/test_console_selection_menu.py
+++ b/Tests/UI/test_console_selection_menu.py
@@ -653,7 +653,7 @@ async def test_short_owner_box_shrinks_menu_and_keeps_containment(ansi_color):
         assert menu.region.contains_region(copy.region)
 
 
-class _ResizableTranscriptFeedbackApp(_TinyTranscriptFeedbackApp):
+class ResizableTranscriptFeedbackApp(_TinyTranscriptFeedbackApp):
     CSS = """
     ConsoleTranscript { height: 1fr; }
     #composer-standin { height: 25; }
@@ -666,7 +666,7 @@ class _ResizableTranscriptFeedbackApp(_TinyTranscriptFeedbackApp):
 async def test_open_menu_recovers_after_owner_shrink_and_growth(
     ansi_color, resize_target
 ):
-    app = _ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
+    app = ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
     async with app.run_test(size=(80, 32)) as pilot:
         transcript = app.query_one(ConsoleTranscript)
         row = app.query_one("#console-message-m0")
@@ -722,7 +722,7 @@ async def test_open_menu_recovers_after_owner_shrink_and_growth(
 async def test_open_menu_repositions_when_resizing_without_compacting(
     ansi_color, resize_target
 ):
-    app = _ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
+    app = ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
     async with app.run_test(size=(80, 45)) as pilot:
         transcript = app.query_one(ConsoleTranscript)
         row = app.query_one("#console-message-m0")

--- a/Tests/UI/test_console_selection_menu.py
+++ b/Tests/UI/test_console_selection_menu.py
@@ -653,6 +653,116 @@ async def test_short_owner_box_shrinks_menu_and_keeps_containment(ansi_color):
         assert menu.region.contains_region(copy.region)
 
 
+class _ResizableTranscriptFeedbackApp(_TinyTranscriptFeedbackApp):
+    CSS = """
+    ConsoleTranscript { height: 1fr; }
+    #composer-standin { height: 25; }
+    """
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ansi_color", [False, True])
+@pytest.mark.parametrize("resize_target", ["terminal", "transcript"])
+async def test_open_menu_recovers_after_owner_shrink_and_growth(
+    ansi_color, resize_target
+):
+    app = _ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
+    async with app.run_test(size=(80, 32)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        row = app.query_one("#console-message-m0")
+        assert transcript.region.height == 7
+        transcript.selection_manager.begin_drag(row.id, 0)
+        transcript.selection_manager.extend_drag(row.id, 5)
+        row.set_selection_range(0, 5)
+        selection = transcript.selection_manager.finish_drag()
+        assert selection is not None
+        transcript.post_message(
+            ConsoleTranscript.TranscriptTextSelected(selection, 4, 6)
+        )
+        menu = await _wait_for_menu(
+            app,
+            pilot,
+            lambda candidate: (
+                candidate.has_class("shrunk-for-short-owner")
+                and transcript.region.contains_region(candidate.region)
+            ),
+        )
+        await pilot.press("up")  # preserve the focused last action while growing
+        comment = menu.query_one("#console-selection-comment", Button)
+        assert app.focused is comment
+
+        for owner_height in (20, 7, 20):
+            if resize_target == "terminal":
+                await pilot.resize_terminal(80, owner_height + 25)
+            else:
+                app.query_one("#composer-standin").styles.height = 32 - owner_height
+            await pilot.pause()
+            assert transcript.region.height == owner_height
+            assert app.query_one(ConsoleSelectionMenu) is menu
+            assert app.focused is comment
+            if owner_height == 20:
+                assert menu.query_one("#console-selection-feedback-hint").display
+                assert not menu.has_class("shrunk-for-short-owner")
+                assert all(
+                    menu.region.contains_region(button.region)
+                    for button in menu.query(Button)
+                )
+            else:
+                assert menu.has_class("shrunk-for-short-owner")
+                await pilot.press("down", "up")
+                assert app.focused is comment
+                assert menu.region.contains_region(comment.region)
+            assert transcript.region.contains_region(menu.region)
+            assert row.get_selection_text() == "answe"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("ansi_color", [False, True])
+@pytest.mark.parametrize("resize_target", ["terminal", "transcript"])
+async def test_open_menu_repositions_when_resizing_without_compacting(
+    ansi_color, resize_target
+):
+    app = _ResizableTranscriptFeedbackApp(ansi_color=ansi_color)
+    async with app.run_test(size=(80, 45)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        row = app.query_one("#console-message-m0")
+        assert transcript.region.height == 20
+        transcript.selection_manager.begin_drag(row.id, 0)
+        transcript.selection_manager.extend_drag(row.id, 5)
+        row.set_selection_range(0, 5)
+        selection = transcript.selection_manager.finish_drag()
+        assert selection is not None
+        transcript.post_message(
+            ConsoleTranscript.TranscriptTextSelected(selection, 4, 8)
+        )
+        menu = await _wait_for_menu(
+            app,
+            pilot,
+            lambda candidate: transcript.region.contains_region(candidate.region),
+        )
+        assert menu.region.bottom == transcript.region.bottom
+        height = menu.region.height
+        for owner_height in (19, 18):
+            if resize_target == "terminal":
+                await pilot.resize_terminal(80, owner_height + 25)
+            else:
+                app.query_one("#composer-standin").styles.height = 45 - owner_height
+            await pilot.pause()
+            await _wait_for_menu(
+                app,
+                pilot,
+                lambda candidate: candidate.region.bottom == transcript.region.bottom,
+            )
+            assert transcript.region.height == owner_height
+            assert menu.region.height == height
+            assert not menu.has_class("shrunk-for-short-owner")
+            assert transcript.region.contains_region(menu.region)
+            assert menu.region.bottom == transcript.region.bottom
+        await pilot.click(menu.query_one("#console-selection-copy", Button))
+        await pilot.pause()
+        assert app.clipboard == "answe"
+
+
 @pytest.mark.asyncio
 async def test_null_transcript_region_falls_back_to_screen_bounds():
     """Clamp-fix review: a NULL/unmeasured transcript region (textual 8.2.8

--- a/Tests/UI/test_console_selection_menu.py
+++ b/Tests/UI/test_console_selection_menu.py
@@ -95,19 +95,21 @@ async def test_menu_offers_add_to_chat_and_posts_message():
 
 
 @pytest.mark.asyncio
-async def test_menu_offers_three_stacked_options_in_order():
-    """Phase 2: Add to chat, More Details, Ask in Side Chat stack in order."""
+async def test_menu_offers_copy_before_conversation_actions():
+    """Copy is the first action for mouse and keyboard selections."""
     app = _MenuApp()
     async with app.run_test() as pilot:
         del pilot
         buttons = app.query_one(ConsoleSelectionMenu).query("Button")
         assert [button.id for button in buttons] == [
+            "console-selection-copy",
             "console-selection-add-to-chat",
             "console-selection-more-details",
             "console-selection-ask-side-chat",
             "console-selection-create-note",
         ]
         assert [str(button.label) for button in buttons] == [
+            "Copy selection",
             "Add to chat",
             "More Details",
             "Ask in Side Chat",
@@ -598,16 +600,17 @@ class _TinyTranscriptFeedbackApp(ConsolidatedCSSApp):
 
 
 @pytest.mark.asyncio
-async def test_short_owner_box_shrinks_menu_and_keeps_containment():
+@pytest.mark.parametrize("ansi_color", [False, True])
+async def test_short_owner_box_shrinks_menu_and_keeps_containment(ansi_color):
     """Shrink guard: a box shorter than even the compact feedback menu drops
     the container border and hint line (no actions hidden), and the
     re-measured menu stays inside the transcript box."""
-    app = _TinyTranscriptFeedbackApp()
+    app = _TinyTranscriptFeedbackApp(ansi_color=ansi_color)
     async with app.run_test(size=(80, 32)) as pilot:
         transcript = app.query_one(ConsoleTranscript)
         row = app.query_one("#console-message-m0")
         region = transcript.region
-        assert region.height == 7  # box shorter than the 10-row compact menu
+        assert region.height == 7  # box shorter than the 11-row compact menu
         transcript.selection_manager.begin_drag(row.id, 0)
         transcript.selection_manager.extend_drag(row.id, 5)
         row.set_selection_range(0, 5)
@@ -627,12 +630,27 @@ async def test_short_owner_box_shrinks_menu_and_keeps_containment():
         )
         assert menu.has_class("shrunk-for-short-owner")
         assert not menu.query_one("#console-selection-feedback-hint").display
-        # All six actions stay mounted and displayed (no action-hiding).
-        assert len([b for b in menu.query("Button") if b.display]) == 7
+        # All actions remain available, scrolling when they cannot all fit.
+        assert len([b for b in menu.query("Button") if b.display]) == 8
         assert menu.region.height <= region.height
         assert menu.region.bottom <= region.bottom
         assert menu.region.x >= region.x
         assert menu.region.right <= region.right
+
+        copy = menu.query_one("#console-selection-copy", Button)
+        assert menu.region.contains_region(copy.region)
+        assert "Copy selection" in copy.render_line(0).text
+        await pilot.press("up")  # wrap from Copy to the off-screen Comment
+        await pilot.pause()
+        comment = menu.query_one("#console-selection-comment", Button)
+        assert app.focused is comment
+        assert menu.region.contains_region(comment.region)
+        assert "Comment" in comment.render_line(0).text
+        assert menu.region.bottom <= region.bottom
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.focused is copy
+        assert menu.region.contains_region(copy.region)
 
 
 @pytest.mark.asyncio
@@ -830,10 +848,10 @@ async def test_touching_above_row_when_gap_does_not_fit():
     for the menu itself must ABDUT the selected row (touching placement)
     rather than pin to the box bottom and land on top of the highlight --
     the reachable corner on small terminals (box <= ~2x menu height)."""
-    # selection_top tracks the menu's grown height (4 actions -> 6 rows):
-    # the gap row still does not fit (needs top >= 7) but the menu itself
+    # selection_top tracks the menu's grown height (5 actions -> 7 rows):
+    # the gap row still does not fit (needs top >= 8) but the menu itself
     # exactly does (top == height), which is this test's whole scenario.
-    app = _GeometryOwnerApp(selection_top=6, screen_y=10)
+    app = _GeometryOwnerApp(selection_top=7, screen_y=10)
     async with app.run_test(size=(80, 24)) as pilot:
         owner = app.query_one("#owner")
         await pilot.pause()  # owner lays out before the menu mounts
@@ -842,11 +860,11 @@ async def test_touching_above_row_when_gap_does_not_fit():
         await pilot.pause()
         await pilot.pause()  # measured clamp settles
         box = owner.region
-        assert menu.region.height == 6  # base-menu geometry pin (4 actions + border)
-        # Menu occupies rows 0..5: no gap row, but the row at y6 (and its
+        assert menu.region.height == 7  # base-menu geometry pin (5 actions + border)
+        # Menu occupies rows 0..6: no gap row, but the row at y7 (and its
         # highlight strip) stays visible below the menu.
         assert menu.region.y == 0
-        assert menu.region.bottom == 6
+        assert menu.region.bottom == 7
         assert box.contains_region(menu.region)
 
 
@@ -865,7 +883,7 @@ async def test_selection_top_below_box_keeps_menu_contained():
         await pilot.pause()
         await pilot.pause()  # measured clamp settles
         box = owner.region
-        assert menu.region.height == 6  # base-menu geometry pin (4 actions + border)
+        assert menu.region.height == 7  # base-menu geometry pin (5 actions + border)
         assert box.contains_region(menu.region)
         assert menu.region.bottom <= box.bottom
 
@@ -1129,7 +1147,7 @@ async def test_escape_returns_focus_to_previously_focused_transcript():
         await pilot.pause()
         await _finish_drag_selection(pilot)
         menu = app.query_one(ConsoleSelectionMenu)
-        assert app.focused is app.query_one("#console-selection-add-to-chat")  # first button focused for keyboard nav
+        assert app.focused is app.query_one("#console-selection-copy")
         assert menu._previous_focus is transcript  # captured before the grab
 
         await pilot.press("escape")
@@ -1163,6 +1181,7 @@ async def test_escape_with_composer_focus_still_restores_composer():
 NO_RUN_HINT = "No active run — start a run to send review feedback"
 
 _FEEDBACK_BUTTON_IDS = [
+    "console-selection-copy",
     "console-selection-add-to-chat",
     "console-selection-more-details",
     "console-selection-ask-side-chat",
@@ -1215,14 +1234,14 @@ async def test_compact_menu_fits_height_budget():
     The 3-row library Button chrome (line-pad + tall border) stacked the
     feedback variant to ~24 rows -- taller than a short transcript's whole
     box on 24-30 row terminals, so even the owner-box clamp bled the menu
-    over the composer. Compact form: feedback variant <= 10 rows (6
+    over the composer. Compact form: feedback variant <= 11 rows (8
     single-row buttons + 1-row hint + container border), base <= 8.
     """
     app = _FeedbackMenuApp(feedback_available=True, run_active=False)
     async with app.run_test(size=(80, 40)) as pilot:
         del pilot
         menu = app.query_one(ConsoleSelectionMenu)
-        assert menu.region.height <= 10
+        assert menu.region.height <= 11
     app = _FeedbackMenuApp(feedback_available=False, run_active=True)
     async with app.run_test(size=(80, 40)) as pilot:
         del pilot
@@ -1265,7 +1284,7 @@ async def test_ansi_mode_disabled_buttons_stay_borderless_with_labels():
         del pilot
         assert app.native_ansi_color is True  # ANSI mode really pinned
         menu = app.query_one(ConsoleSelectionMenu)
-        assert menu.region.height <= 10  # height budget holds in ANSI mode
+        assert menu.region.height <= 11  # height budget holds in ANSI mode
         for selector, label in (
             ("#console-selection-request-changes", "Request changes"),
             ("#console-selection-lgm", "LGTM"),
@@ -1282,10 +1301,10 @@ async def test_ansi_mode_disabled_buttons_stay_borderless_with_labels():
 
 @pytest.mark.asyncio
 async def test_feedback_buttons_absent_without_availability():
-    """feedback_available=False: only the three base buttons, no hint.
+    """feedback_available=False: only the base buttons, no hint.
 
     (The default-ctor case is guarded by the pre-existing
-    ``test_menu_offers_three_stacked_options_in_order``.)
+    ``test_menu_offers_copy_before_conversation_actions``.)
     """
     app = _FeedbackMenuApp(feedback_available=False, run_active=True)
     async with app.run_test(size=(80, 40)) as pilot:
@@ -1293,6 +1312,7 @@ async def test_feedback_buttons_absent_without_availability():
         menu = app.query_one(ConsoleSelectionMenu)
         ids = [b.id for b in menu.query("Button")]
         assert ids == [
+            "console-selection-copy",
             "console-selection-add-to-chat",
             "console-selection-more-details",
             "console-selection-ask-side-chat",
@@ -1372,6 +1392,7 @@ async def test_key_navigation_down_cycle_skips_disabled_buttons():
             assert not focused.disabled, f"focus landed on disabled {focused.id}"
             focused_ids.add(focused.id)
         assert focused_ids == {
+            "console-selection-copy",
             "console-selection-add-to-chat",
             "console-selection-more-details",
             "console-selection-ask-side-chat",
@@ -1389,7 +1410,7 @@ async def test_key_navigation_up_wrap_skips_disabled_buttons():
         menu = app.query_one(ConsoleSelectionMenu)
         del menu
         await pilot.pause()
-        assert app.focused.id == "console-selection-add-to-chat"  # mount focuses first
+        assert app.focused.id == "console-selection-copy"  # mount focuses first
         await pilot.press("up")
         await pilot.pause()
         assert app.focused.id == "console-selection-comment"

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -367,6 +367,22 @@ Related earlier incident: task-2200 ("`is_mounted` ≠ in-the-DOM").
 
 ---
 
+## Removing menu borders cannot make too many actions fit
+
+**TASK-32033, Copy selection.** Adding the eighth action to the Console
+selection menu made its seven-row transcript fixture fail containment:
+removing the border and hint still left eight action rows, and clamping the
+offset put the last action over the composer. The menu now caps its height
+to the owner and scrolls after the existing compacting pass. The regression
+checks normal and ANSI modes, including keyboard wrap from the first action
+to the last and back, with both focused labels visible inside the owner.
+
+**What to do.** When adding an action to a floating menu, exercise an owner
+shorter than the action count. Compact styling needs a scrolling fallback
+when the actions alone exceed the available rows.
+
+---
+
 ## Related
 
 - `lessons-testing-evidence.md` — includes the Pilot-harness traps (detached widget

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -377,9 +377,17 @@ to the owner and scrolls after the existing compacting pass. The regression
 checks normal and ANSI modes, including keyboard wrap from the first action
 to the last and back, with both focused labels visible inside the owner.
 
+Qodo's follow-up found that the height cap and hidden hint persisted after
+the owner grew. Four resize regressions reproduced this for terminal and
+transcript changes in both color modes. A capped menu may not resize when
+its owner grows, so the fix uses the screen layout signal to detect changed
+owner bounds, clears the temporary constraints, and measures again.
+
 **What to do.** When adding an action to a floating menu, exercise an owner
 shorter than the action count. Compact styling needs a scrolling fallback
-when the actions alone exceed the available rows.
+when the actions alone exceed the available rows. Exercise shrink/grow
+cycles too; the child's own resize event cannot reliably detect available
+space changing around a capped child.
 
 ---
 

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:16'
-updated_date: '2026-09-08 06:52'
+updated_date: '2026-09-08 07:04'
 labels:
   - console
   - clipboard
@@ -41,6 +41,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 6. Per the requested follow-up, trace and repair the three inherited failures before rebasing or merging. Use the existing production-style keyboard harness, sample geometry after selection entry, and wire the real workspace registry into the two real-database stores. Preserve or strengthen the behavioral assertions and rerun the complete selection slice. This is test-harness repair within existing runtime and persistence contracts; no new ADR is required.
 7. Address Qodo's two findings: annotate/document the public compose override, and remeasure the menu when its owner's bounds change. Exercise shrink/grow cycles from terminal and transcript changes in normal and ANSI modes; restore normal sizing without losing focus. Reuse Textual's layout notification and the existing clamp; no new ADR is required.
 8. Document the empty-selection and capped/full-text return contracts on all three modified selection getters, as requested by Qodo's follow-up review. This is documentation only; no new ADR or behavior test is required. Rebase onto the updated dev and repeat the targeted integration and preflight checks.
+9. Rename the two new test harness classes to PascalCase without a leading underscore, as required by Qodo's configured class-name pattern. Update their references and rerun the two affected test modules and preflight. Production behavior is unchanged; no new ADR is required.
 
 ADR required: no
 
@@ -66,14 +67,17 @@ Addressed Qodo's two findings: compose now declares ComposeResult and documents 
 
 Qodo's follow-up requested explicit Returns sections on the three selection getters. Those docstrings now describe each row type's selected text, the capped/full-text option, and the empty-string result. The executable Python AST is unchanged by this documentation correction, with no new Ruff diagnostics and all edited regions formatted.
 
+The final naming review cited an explicit PascalCase pattern for new classes. The two new test harnesses are now LongSelectionApp and ResizableTranscriptFeedbackApp, with all five declarations/references updated. All 63 cases in the two affected test modules pass after the rename (36.29 seconds); production code is unchanged and static checks find no new diagnostics.
+
 Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 
 Verification:
-- All **183 cases pass** across the six targeted selection suites after rebasing onto dev at `aecb14720` (170.00 seconds), including the three inherited failures and all eight resize cases. Each inherited failure was reproduced before its repair and verified passing afterward. The existing requests dependency-version warning remains.
+- All **183 cases pass** across the six targeted selection suites after rebasing onto dev at `8dc5366dc` (135.35 seconds), including the three inherited failures, all eight resize cases, and the renamed test harnesses. Each inherited failure was reproduced before its repair and verified passing afterward. The existing requests dependency-version warning remains.
 - All **55 selection-menu cases pass** after the Qodo follow-up (22.75 seconds). The four compact-to-full resize cases each failed before the owner-bound fix and passed afterward; four additional cases verify settled movement and click handling while the full menu continues to fit.
 - All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
-- All six `scripts/preflight.sh` derived-artifact checks pass on the rebased branch, including stylesheet reproduction and task ID hygiene. Neither rebase changed the patches, confirmed with git range-diff.
+- All six `scripts/preflight.sh` derived-artifact checks pass on the rebased branch, including stylesheet reproduction and task ID hygiene. The rebases changed none of the patches, confirmed with git range-diff.
 - The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the five existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
+- A prior Perf Guard run hit the already documented one-second boot-census sampling race for the serially queued ChaChaNotes FTS worker. Run 34199414350 passed on its second attempt with identical code. The census and boot-worker policy are unchanged by this PR; see the existing lesson in `backlog/docs/lessons-testing-evidence.md`.
 - Clipboard assertions use the real Textual app clipboard in the headless harness. Linux desktop clipboard delivery was not exercised; the user guide explains the existing OSC 52 requirement and terminal-native selection fallback.
 
 ADR check: direct extension of [ADR-068](../decisions/068-console-text-selection-and-annotations.md); no new ADR, storage change, clipboard backend, or shortcut. ADR-031 remains applicable. No full-suite run was performed, per repository policy.

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32033
 title: Add Copy selection to the Console selection menu
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:16'
-updated_date: '2026-09-08 06:36'
+updated_date: '2026-09-08 06:47'
 labels:
   - console
   - clipboard
@@ -40,6 +40,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 5. Regenerate the bundled widget stylesheets and use the production stylesheet harness on current dev. Run the targeted selection suites, scoped lint/format checks, and a production Console rendering/interaction check; self-review the diff and record evidence. Compare any existing test failures against pristine dev.
 6. Per the requested follow-up, trace and repair the three inherited failures before rebasing or merging. Use the existing production-style keyboard harness, sample geometry after selection entry, and wire the real workspace registry into the two real-database stores. Preserve or strengthen the behavioral assertions and rerun the complete selection slice. This is test-harness repair within existing runtime and persistence contracts; no new ADR is required.
 7. Address Qodo's two findings: annotate/document the public compose override, and remeasure the menu when its owner's bounds change. Exercise shrink/grow cycles from terminal and transcript changes in normal and ANSI modes; restore normal sizing without losing focus. Reuse Textual's layout notification and the existing clamp; no new ADR is required.
+8. Document the empty-selection and capped/full-text return contracts on all three modified selection getters, as requested by Qodo's follow-up review. This is documentation only; no new ADR or behavior test is required. Rebase onto the updated dev and repeat the targeted integration and preflight checks.
 
 ADR required: no
 
@@ -62,6 +63,8 @@ The consolidated widget stylesheets are regenerated from the menu source. The ne
 The three inherited failures were repaired at their test setup boundaries. The keyboard harness lacked the consolidated CSS and sampled the row before selection entry added its highlight and reflowed the layout. It now samples the selected row and additionally verifies that the menu stays inside its owner without shrinking it. The two real-database feedback tests now supply the same real workspace registry as ConsoleRuntime; their SQLite event and annotation assertions remain intact. Independent review found no masked production defect or weakened coverage.
 
 Addressed Qodo's two findings: compose now declares ComposeResult and documents its yielded widgets; the menu observes screen layout changes, clears temporary compact styling and height limits when owner bounds change, and remeasures. Offset corrections use the measured position and request layout only when the offset changes. The layout subscription is removed on unmount. Eight resize cases cover terminal and transcript growth/shrinkage in both color modes, restoration of the feedback hint and actions, preserved focus and selection, and clicking Copy after repositioning. Independent review found no remaining actionable issues.
+
+Qodo's follow-up requested explicit Returns sections on the three selection getters. Those docstrings now describe each row type's selected text, the capped/full-text option, and the empty-string result. The executable Python AST is unchanged by this documentation correction, with no new Ruff diagnostics and all edited regions formatted.
 
 Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -27,6 +27,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 - [x] #5 Targeted selection tests and static checks demonstrate no new failures relative to dev, and the user guide explains the action and terminal clipboard limitation.
 - [x] #6 In short transcripts the menu stays within its owner and every action remains reachable by scrolling or keyboard navigation, including ANSI color mode.
 - [x] #7 The previously failing keyboard-anchor and two feedback-persistence tests pass while retaining real menu-containment and SQLite-write coverage.
+- [x] #8 An open menu adapts to terminal and transcript resizing, restores its full action list and feedback hint when space returns, and preserves focus.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -38,6 +39,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 4. Keep the additional menu row inside short transcript bounds with scrolling when compact actions cannot all fit; verify keyboard reachability and ANSI rendering.
 5. Regenerate the bundled widget stylesheets and use the production stylesheet harness on current dev. Run the targeted selection suites, scoped lint/format checks, and a production Console rendering/interaction check; self-review the diff and record evidence. Compare any existing test failures against pristine dev.
 6. Per the requested follow-up, trace and repair the three inherited failures before rebasing or merging. Use the existing production-style keyboard harness, sample geometry after selection entry, and wire the real workspace registry into the two real-database stores. Preserve or strengthen the behavioral assertions and rerun the complete selection slice. This is test-harness repair within existing runtime and persistence contracts; no new ADR is required.
+7. Address Qodo's two findings: annotate/document the public compose override, and remeasure the menu when its owner's bounds change. Exercise shrink/grow cycles from terminal and transcript changes in normal and ANSI modes; restore normal sizing without losing focus. Reuse Textual's layout notification and the existing clamp; no new ADR is required.
 
 ADR required: no
 
@@ -59,10 +61,13 @@ The consolidated widget stylesheets are regenerated from the menu source. The ne
 
 The three inherited failures were repaired at their test setup boundaries. The keyboard harness lacked the consolidated CSS and sampled the row before selection entry added its highlight and reflowed the layout. It now samples the selected row and additionally verifies that the menu stays inside its owner without shrinking it. The two real-database feedback tests now supply the same real workspace registry as ConsoleRuntime; their SQLite event and annotation assertions remain intact. Independent review found no masked production defect or weakened coverage.
 
+Addressed Qodo's two findings: compose now declares ComposeResult and documents its yielded widgets; the menu observes screen layout changes, clears temporary compact styling and height limits when owner bounds change, and remeasures. Offset corrections use the measured position and request layout only when the offset changes. The layout subscription is removed on unmount. Eight resize cases cover terminal and transcript growth/shrinkage in both color modes, restoration of the feedback hint and actions, preserved focus and selection, and clicking Copy after repositioning. Independent review found no remaining actionable issues.
+
 Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 
 Verification:
 - All **175 cases pass** across the six targeted selection suites after repairing the three inherited failures (138.34 seconds). Each of those three was reproduced failing before its repair and verified passing afterward. The existing requests dependency-version warning remains.
+- All **55 selection-menu cases pass** after the Qodo follow-up (22.75 seconds). The four compact-to-full resize cases each failed before the owner-bound fix and passed afterward; four additional cases verify settled movement and click handling while the full menu continues to fit.
 - All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
 - All six `scripts/preflight.sh` derived-artifact checks pass, including stylesheet reproduction and task ID hygiene.
 - The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the five existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32033
 title: Add Copy selection to the Console selection menu
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:16'
-updated_date: '2026-09-08 05:37'
+updated_date: '2026-09-08 06:09'
 labels:
   - console
   - clipboard
@@ -26,6 +26,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 - [x] #4 An empty or vanished selection leaves the clipboard unchanged and dismisses safely.
 - [x] #5 Targeted selection tests and static checks demonstrate no new failures relative to dev, and the user guide explains the action and terminal clipboard limitation.
 - [x] #6 In short transcripts the menu stays within its owner and every action remains reachable by scrolling or keyboard navigation, including ANSI color mode.
+- [x] #7 The previously failing keyboard-anchor and two feedback-persistence tests pass while retaining real menu-containment and SQLite-write coverage.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,6 +37,7 @@ Users selecting part of a Console message need an explicit way to copy that text
 3. Reuse the app clipboard operation and menu dismissal/focus lifecycle; preserve the draft and whole-message selection. Document the action and terminal clipboard requirement.
 4. Keep the additional menu row inside short transcript bounds with scrolling when compact actions cannot all fit; verify keyboard reachability and ANSI rendering.
 5. Regenerate the bundled widget stylesheets and use the production stylesheet harness on current dev. Run the targeted selection suites, scoped lint/format checks, and a production Console rendering/interaction check; self-review the diff and record evidence. Compare any existing test failures against pristine dev.
+6. Per the requested follow-up, trace and repair the three inherited failures before rebasing or merging. Use the existing production-style keyboard harness, sample geometry after selection entry, and wire the real workspace registry into the two real-database stores. Preserve or strengthen the behavioral assertions and rerun the complete selection slice. This is test-harness repair within existing runtime and persistence contracts; no new ADR is required.
 
 ADR required: no
 
@@ -53,15 +55,17 @@ Added Copy selection as the first menu action. Mouse and keyboard activation use
 
 The extra action exposed a seven-row transcript overflow. The menu now scrolls within the owner after its compacting pass, with every action reachable in normal and ANSI modes. The independent review confirmed that fix and found no remaining actionable issues.
 
-The PR is based on dev commit `37bf45fb6232a1d4fb50fdba8f3c19c856ae7664`. Its consolidated widget stylesheets are regenerated from the menu source. The new Copy tests and the existing feedback transcript harness load those production styles.
+The consolidated widget stylesheets are regenerated from the menu source. The new Copy tests and the existing feedback and keyboard transcript harnesses load those production styles.
 
-Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
+The three inherited failures were repaired at their test setup boundaries. The keyboard harness lacked the consolidated CSS and sampled the row before selection entry added its highlight and reflowed the layout. It now samples the selected row and additionally verifies that the menu stays inside its owner without shrinking it. The two real-database feedback tests now supply the same real workspace registry as ConsoleRuntime; their SQLite event and annotation assertions remain intact. Independent review found no masked production defect or weakened coverage.
+
+Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 
 Verification:
-- The six targeted selection suites on the PR tree exercise 175 cases. The sweep passed 170; two Comment-click failures were resolved by loading the consolidated styles in their existing harness, with all **19 affected feedback cases passing** on rerun. The other **three failures reproduce unchanged on pristine dev**: `test_menu_anchor_derives_from_row_region_and_stays_in_transcript` compares an outdated row position, while `test_feedback_reaches_the_real_database_unmocked` and `test_comment_annotation_reaches_the_real_database_unmocked` lack the now-required workspace registry. There are no remaining introduced failures; the existing requests dependency-version warning remains.
+- All **175 cases pass** across the six targeted selection suites after repairing the three inherited failures (138.34 seconds). Each of those three was reproduced failing before its repair and verified passing afterward. The existing requests dependency-version warning remains.
 - All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
 - All six `scripts/preflight.sh` derived-artifact checks pass, including stylesheet reproduction and task ID hygiene.
-- The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the four existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
+- The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the five existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
 - Clipboard assertions use the real Textual app clipboard in the headless harness. Linux desktop clipboard delivery was not exercised; the user guide explains the existing OSC 52 requirement and terminal-native selection fallback.
 
 ADR check: direct extension of [ADR-068](../decisions/068-console-text-selection-and-annotations.md); no new ADR, storage change, clipboard backend, or shortcut. ADR-031 remains applicable. No full-suite run was performed, per repository policy.

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32033
 title: Add Copy selection to the Console selection menu
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:16'
-updated_date: '2026-09-08 06:47'
+updated_date: '2026-09-08 06:52'
 labels:
   - console
   - clipboard
@@ -69,10 +69,10 @@ Qodo's follow-up requested explicit Returns sections on the three selection gett
 Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 
 Verification:
-- All **183 cases pass** across the six targeted selection suites after rebasing onto dev at `c37d61136` (157.15 seconds), including the three inherited failures and all eight resize cases. Each inherited failure was reproduced before its repair and verified passing afterward. The existing requests dependency-version warning remains.
+- All **183 cases pass** across the six targeted selection suites after rebasing onto dev at `aecb14720` (170.00 seconds), including the three inherited failures and all eight resize cases. Each inherited failure was reproduced before its repair and verified passing afterward. The existing requests dependency-version warning remains.
 - All **55 selection-menu cases pass** after the Qodo follow-up (22.75 seconds). The four compact-to-full resize cases each failed before the owner-bound fix and passed afterward; four additional cases verify settled movement and click handling while the full menu continues to fit.
 - All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
-- All six `scripts/preflight.sh` derived-artifact checks pass on the rebased branch, including stylesheet reproduction and task ID hygiene. The rebase changed none of the three patches, confirmed with git range-diff.
+- All six `scripts/preflight.sh` derived-artifact checks pass on the rebased branch, including stylesheet reproduction and task ID hygiene. Neither rebase changed the patches, confirmed with git range-diff.
 - The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the five existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
 - Clipboard assertions use the real Textual app clipboard in the headless harness. Linux desktop clipboard delivery was not exercised; the user guide explains the existing OSC 52 requirement and terminal-native selection fallback.
 

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -1,0 +1,68 @@
+---
+id: TASK-32033
+title: Add Copy selection to the Console selection menu
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 05:16'
+updated_date: '2026-09-08 05:37'
+labels:
+  - console
+  - clipboard
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users selecting part of a Console message need an explicit way to copy that text without relying on the terminal copy shortcut.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Copy selection is available first in the selection menu for all selectable row types regardless of run state.
+- [x] #2 Mouse and keyboard activation copy the exact highlighted text through the existing app clipboard path without quote prefixes or the 4000-character quote cap.
+- [x] #3 Copying closes the menu, clears the text highlight, restores focus, and preserves the composer draft and message selection.
+- [x] #4 An empty or vanished selection leaves the clipboard unchanged and dismisses safely.
+- [x] #5 Targeted selection tests and static checks demonstrate no new failures relative to dev, and the user guide explains the action and terminal clipboard limitation.
+- [x] #6 In short transcripts the menu stays within its owner and every action remains reachable by scrolling or keyboard navigation, including ANSI color mode.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add failing coverage for mouse and keyboard Copy selection, full text from plain/Markdown/diff selections, and empty or removed selections. Update existing menu-order and compact-layout expectations.
+2. Add the menu action through the existing menu-to-transcript message path. Allow row selection readers to return uncapped text for copying while retaining their existing capped defaults for quoting and previews.
+3. Reuse the app clipboard operation and menu dismissal/focus lifecycle; preserve the draft and whole-message selection. Document the action and terminal clipboard requirement.
+4. Keep the additional menu row inside short transcript bounds with scrolling when compact actions cannot all fit; verify keyboard reachability and ANSI rendering.
+5. Regenerate the bundled widget stylesheets and use the production stylesheet harness on current dev. Run the targeted selection suites, scoped lint/format checks, and a production Console rendering/interaction check; self-review the diff and record evidence. Compare any existing test failures against pristine dev.
+
+ADR required: no
+
+ADR path: backlog/decisions/068-console-text-selection-and-annotations.md
+
+Reason: extends the existing row-selection and menu action design without changing ownership, persistence, clipboard transport, or keybinding policy. ADR-031 continues to apply.
+
+Task ID hygiene: the CLI assigned 32032, which was already held by another worktree. Renumbered this newly created task to 32033 after checking local tasks, 176 remote refs, and 11 worktrees.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added Copy selection as the first menu action. Mouse and keyboard activation use the existing app clipboard operation with the exact selected text; plain, Markdown-source, and diff-line selections can now opt out of the quote cap while existing quote/preview callers retain capped defaults. Copy clears the text highlight/menu, restores focus, and preserves drafts and whole-message selection. Empty or removed selections leave the clipboard untouched.
+
+The extra action exposed a seven-row transcript overflow. The menu now scrolls within the owner after its compacting pass, with every action reachable in normal and ANSI modes. The independent review confirmed that fix and found no remaining actionable issues.
+
+The PR is based on dev commit `37bf45fb6232a1d4fb50fdba8f3c19c856ae7664`. Its consolidated widget stylesheets are regenerated from the menu source. The new Copy tests and the existing feedback transcript harness load those production styles.
+
+Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
+
+Verification:
+- The six targeted selection suites on the PR tree exercise 175 cases. The sweep passed 170; two Comment-click failures were resolved by loading the consolidated styles in their existing harness, with all **19 affected feedback cases passing** on rerun. The other **three failures reproduce unchanged on pristine dev**: `test_menu_anchor_derives_from_row_region_and_stays_in_transcript` compares an outdated row position, while `test_feedback_reaches_the_real_database_unmocked` and `test_comment_annotation_reaches_the_real_database_unmocked` lack the now-required workspace registry. There are no remaining introduced failures; the existing requests dependency-version warning remains.
+- All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
+- All six `scripts/preflight.sh` derived-artifact checks pass, including stylesheet reproduction and task ID hygiene.
+- The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the four existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
+- Clipboard assertions use the real Textual app clipboard in the headless harness. Linux desktop clipboard delivery was not exercised; the user guide explains the existing OSC 52 requirement and terminal-native selection fallback.
+
+ADR check: direct extension of [ADR-068](../decisions/068-console-text-selection-and-annotations.md); no new ADR, storage change, clipboard backend, or shortcut. ADR-031 remains applicable. No full-suite run was performed, per repository policy.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
+++ b/backlog/tasks/task-32033 - Add-Copy-selection-to-the-Console-selection-menu.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32033
 title: Add Copy selection to the Console selection menu
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:16'
-updated_date: '2026-09-08 06:09'
+updated_date: '2026-09-08 06:36'
 labels:
   - console
   - clipboard
@@ -66,10 +66,10 @@ Addressed Qodo's two findings: compose now declares ComposeResult and documents 
 Files: `Widgets/Console/console_selection_menu.py`, `Widgets/Console/console_transcript.py`, both generated `css/widget_defaults_*.tcss` files, the new `Tests/UI/test_console_selection_copy.py`, existing selection-menu, keyboard-selection, and end-to-end tests, `Docs/User_Guide/console/text-selection-and-feedback.md`, and `backlog/docs/lessons-textual.md`.
 
 Verification:
-- All **175 cases pass** across the six targeted selection suites after repairing the three inherited failures (138.34 seconds). Each of those three was reproduced failing before its repair and verified passing afterward. The existing requests dependency-version warning remains.
+- All **183 cases pass** across the six targeted selection suites after rebasing onto dev at `c37d61136` (157.15 seconds), including the three inherited failures and all eight resize cases. Each inherited failure was reproduced before its repair and verified passing afterward. The existing requests dependency-version warning remains.
 - All **55 selection-menu cases pass** after the Qodo follow-up (22.75 seconds). The four compact-to-full resize cases each failed before the owner-bound fix and passed afterward; four additional cases verify settled movement and click handling while the full menu continues to fit.
 - All eight new Copy cases pass, including mouse and keyboard journeys with production styles, uncapped plain/Markdown/diff text, and stale selections. Earlier production render probes also verified user and assistant menu containment and first-action focus; SVG/PNG captures are in `/private/tmp/chatbook-copy-selection-32033/`.
-- All six `scripts/preflight.sh` derived-artifact checks pass, including stylesheet reproduction and task ID hygiene.
+- All six `scripts/preflight.sh` derived-artifact checks pass on the rebased branch, including stylesheet reproduction and task ID hygiene. The rebase changed none of the three patches, confirmed with git range-diff.
 - The new Copy test file passes Ruff and formatting. Before/after checks find no new Ruff diagnostics in the five existing Python files; all edited Python regions and scoped whitespace checks pass. Existing lint findings and unrelated formatting drift remain.
 - Clipboard assertions use the real Textual app clipboard in the headless harness. Linux desktop clipboard delivery was not exercised; the user guide explains the existing OSC 52 requirement and terminal-native selection fallback.
 

--- a/tldw_chatbook/Widgets/Console/console_selection_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_selection_menu.py
@@ -88,7 +88,7 @@ def selection_menus_on_screen(screen: "Screen[object]") -> list["ConsoleSelectio
 
 #: Shrink-guard class: added by the measured clamp when the owner box is
 #: shorter than even the compact menu; drops the container border and the
-#: hint line (3 rows) before the top-out tie-break. No actions are hidden.
+#: hint line (3 rows) before scrolling. All actions remain reachable.
 _SHRUNK_CLASS = "shrunk-for-short-owner"
 
 #: Shown (dim, inside the menu) and carried on the disabled buttons'
@@ -208,9 +208,10 @@ class ConsoleSelectionMenu(Vertical):
        specificity decides -- and re-grew tall borders on the run-gated
        pair (2-row border-only boxes, labels clipped, 11-row menu). Per-ID
        rules ((1,0,1)) beat any class/pseudo stack textual throws. Applied
-       to ALL seven action IDs, not just the two gated ones: any action may
+       to ALL action IDs, not just the two gated ones: any action may
        end up disabled, and every action must stay one row in every state
        and color mode. */
+    ConsoleSelectionMenu #console-selection-copy,
     ConsoleSelectionMenu #console-selection-add-to-chat,
     ConsoleSelectionMenu #console-selection-more-details,
     ConsoleSelectionMenu #console-selection-ask-side-chat,
@@ -229,10 +230,11 @@ class ConsoleSelectionMenu(Vertical):
     }
     /* Shrink guard for boxes shorter than even the compact menu: the
        measured clamp adds this class, trading the container border and
-       the hint line for 3 more usable rows (last resort before the
-       top-out tie-break; no actions are ever hidden). */
+       the hint line for 3 more usable rows, with scrolling if the actions
+       still cannot all fit. */
     ConsoleSelectionMenu.shrunk-for-short-owner {
         border: none;
+        overflow-y: auto;
     }
     ConsoleSelectionMenu.shrunk-for-short-owner #console-selection-feedback-hint {
         display: none;
@@ -240,6 +242,9 @@ class ConsoleSelectionMenu(Vertical):
     """
 
     BINDINGS: ClassVar[list[Binding]] = [Binding("escape", "dismiss", show=False)]
+
+    class CopySelection(Message):
+        """User chose 'Copy selection' for the active selection."""
 
     class AddToChat(Message):
         """User chose 'Add to chat' for the active selection."""
@@ -322,8 +327,9 @@ class ConsoleSelectionMenu(Vertical):
         _LIVE_SELECTION_MENUS.add(self)
 
     def compose(self):
+        yield Button("Copy selection", id="console-selection-copy", variant="primary")
         if self._has_add_to_chat:
-            yield Button("Add to chat", id="console-selection-add-to-chat", variant="primary")
+            yield Button("Add to chat", id="console-selection-add-to-chat")
         yield Button("More Details", id="console-selection-more-details")
         yield Button("Ask in Side Chat", id="console-selection-ask-side-chat")
         yield Button("Create note", id="console-selection-create-note")
@@ -425,11 +431,14 @@ class ConsoleSelectionMenu(Vertical):
         # Shrink guard (clamp-fix review): a box shorter than even the
         # compact menu cannot contain it at ANY offset -- trade the
         # container border + hint line for three more usable rows, then
-        # re-measure in a fresh layout pass (the class check stops the
-        # recursion; if it still does not fit, the top-out tie-break below
-        # is the accepted last resort).
+        # re-measure in a fresh layout pass. If the actions still cannot
+        # all fit, constrain the menu height and let it scroll.
         if region.height > bounds.height and not self.has_class(_SHRUNK_CLASS):
             self.add_class(_SHRUNK_CLASS)
+            self.call_after_refresh(self._clamp_within_owner)
+            return
+        if region.height > bounds.height:
+            self.styles.max_height = bounds.height
             self.call_after_refresh(self._clamp_within_owner)
             return
         shift_x = max(0, region.right - bounds.right)
@@ -502,6 +511,10 @@ class ConsoleSelectionMenu(Vertical):
 
     def _post(self, message: Message) -> None:
         (self._owner if self._owner is not None else self).post_message(message)
+
+    @on(Button.Pressed, "#console-selection-copy")
+    def _copy_selection(self) -> None:
+        self._post(self.CopySelection())
 
     @on(Button.Pressed, "#console-selection-add-to-chat")
     def _add_to_chat(self) -> None:

--- a/tldw_chatbook/Widgets/Console/console_selection_menu.py
+++ b/tldw_chatbook/Widgets/Console/console_selection_menu.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, ClassVar
 from weakref import WeakSet
 
 from textual import on
+from textual.app import ComposeResult
 from textual.binding import Binding
 from textual.containers import Vertical
 from textual.dom import NoScreen
@@ -42,6 +43,7 @@ from textual.widgets import Button, Static
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from textual.screen import Screen
+    from textual.signal import Signal
 
 #: Every constructed, not-yet-collected selection menu (TASK-21119).
 #:
@@ -315,6 +317,8 @@ class ConsoleSelectionMenu(Vertical):
         self._feedback_available = feedback_available
         self._run_active = run_active
         self._selection_top = selection_top
+        self._clamp_bounds: Region | None = None
+        self._layout_refresh_signal: Signal[Screen] | None = None
         #: Widget holding focus before the menu grabbed it (captured in
         #: ``on_mount`` BEFORE focusing the first button); ``None`` =
         #: nothing was focused (or the capture raced teardown), so unmount
@@ -326,7 +330,12 @@ class ConsoleSelectionMenu(Vertical):
         # already in the DOM but invisible to the screen's dismissal gate.
         _LIVE_SELECTION_MENUS.add(self)
 
-    def compose(self):
+    def compose(self) -> ComposeResult:
+        """Build selection actions in keyboard navigation order.
+
+        Yields:
+            Action buttons and the no-run hint when feedback is available.
+        """
         yield Button("Copy selection", id="console-selection-copy", variant="primary")
         if self._has_add_to_chat:
             yield Button("Add to chat", id="console-selection-add-to-chat")
@@ -361,6 +370,10 @@ class ConsoleSelectionMenu(Vertical):
             self._previous_focus = self.screen.focused
         except Exception:  # noqa: BLE001 - capture is best-effort during odd teardown
             self._previous_focus = None
+        # A capped menu may keep its size when the transcript grows, so
+        # its own Resize event cannot report every change to owner bounds.
+        self._layout_refresh_signal = self.screen.screen_layout_refresh_signal
+        self._layout_refresh_signal.subscribe(self, self._on_screen_layout_refresh)
         self.absolute_offset = Offset(*self._anchor)
         # Only this widget knows its real extent (border + padding +
         # buttons); pull the anchor back inside the OWNING TRANSCRIPT's
@@ -387,6 +400,9 @@ class ConsoleSelectionMenu(Vertical):
             _event: Textual resize notification; only the settled extent matters.
         """
         self.call_after_refresh(self._clamp_within_owner)
+
+    def _on_screen_layout_refresh(self, _screen: Screen) -> None:
+        self._clamp_within_owner()
 
     def _clamp_within_owner(self) -> None:
         """Shift the anchor so the measured menu fits its clamp box.
@@ -428,6 +444,15 @@ class ConsoleSelectionMenu(Vertical):
         if bounds is None:
             screen_size = self.screen.size
             bounds = Region(0, 0, screen_size.width, screen_size.height)
+        if bounds != self._clamp_bounds:
+            self._clamp_bounds = bounds
+            if self.has_class(_SHRUNK_CLASS):
+                # Remeasure the full menu in the new space. Cache the bounds
+                # first so the resulting layout does not undo a needed cap.
+                self.remove_class(_SHRUNK_CLASS)
+                self.styles.max_height = None
+                self.call_after_refresh(self._clamp_within_owner)
+                return
         # Shrink guard (clamp-fix review): a box shorter than even the
         # compact menu cannot contain it at ANY offset -- trade the
         # container border + hint line for three more usable rows, then
@@ -445,7 +470,10 @@ class ConsoleSelectionMenu(Vertical):
         shift_y = max(0, region.bottom - bounds.bottom)
         if not shift_x and not shift_y:
             return
-        x, y = self._anchor
+        # Use the measured position so repeated callbacks before the next
+        # layout cannot apply the same correction to the anchor twice.
+        x = max(bounds.x, region.x - shift_x)
+        y = max(bounds.y, region.y - shift_y)
         # Bottom overflow: hop entirely above the selected row when the
         # whole menu fits between the box top and the row top; the row (and
         # its highlight strip, which lives inside the row widget) stays
@@ -467,17 +495,13 @@ class ConsoleSelectionMenu(Vertical):
                 # to keep visible (reachable on boxes <= ~2x menu height).
                 above_y = selection_top - region.height
             if above_y >= bounds.y:
-                self._anchor = (
-                    max(bounds.x, x - shift_x),
-                    above_y,
-                )
-                self.absolute_offset = Offset(*self._anchor)
-                return
-        self._anchor = (
-            max(bounds.x, x - shift_x),
-            max(bounds.y, y - shift_y),
-        )
-        self.absolute_offset = Offset(*self._anchor)
+                y = above_y
+        self._anchor = (x, y)
+        offset = Offset(*self._anchor)
+        if self.absolute_offset != offset:
+            self.absolute_offset = offset
+            # absolute_offset is not reactive; update painting and hit tests.
+            self.refresh(layout=True)
 
     def on_key(self, event: Key) -> None:
         """Keyboard navigation: arrows cycle actions; Escape closes.
@@ -565,6 +589,9 @@ class ConsoleSelectionMenu(Vertical):
         self.remove()
 
     def _on_unmount(self) -> None:
+        if self._layout_refresh_signal is not None:
+            self._layout_refresh_signal.unsubscribe(self)
+            self._layout_refresh_signal = None
         # Best-effort registry prune (TASK-21119): dropping the entry keeps
         # the candidate set small, but correctness never depends on it --
         # ``selection_menus_on_screen`` re-checks attachment, and the weak

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1747,6 +1747,10 @@ class ConsoleMarkdownMessage(Vertical):
 
         Args:
             capped: Apply the quote limit; False preserves the full clipboard text.
+
+        Returns:
+            The selected Markdown source, quote-capped when capped is True
+            and otherwise complete, or an empty string when nothing is selected.
         """
         if self._selection_line_range is None:
             return ""
@@ -2106,6 +2110,10 @@ class ConsoleTranscriptMessage(Vertical):
 
         Args:
             capped: Apply the quote limit; False preserves the full clipboard text.
+
+        Returns:
+            The highlighted body text, quote-capped when capped is True and
+            otherwise complete, or an empty string when nothing is selected.
         """
         if self._selection_range is None:
             return ""
@@ -2343,6 +2351,10 @@ class ConsoleToolDiffRow(Vertical):
 
         Args:
             capped: Apply the quote limit; False preserves the full clipboard text.
+
+        Returns:
+            The selected diff lines, quote-capped when capped is True and
+            otherwise complete, or an empty string when nothing is selected.
         """
         if self._selection_range is None:
             return ""

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -1742,14 +1742,19 @@ class ConsoleMarkdownMessage(Vertical):
         """Return the markdown source this row renders (selection domain)."""
         return self._body_text
 
-    def get_selection_text(self) -> str:
-        """Return the selected whole source lines, capped for quoting."""
+    def get_selection_text(self, *, capped: bool = True) -> str:
+        """Return selected source text.
+
+        Args:
+            capped: Apply the quote limit; False preserves the full clipboard text.
+        """
         if self._selection_line_range is None:
             return ""
         start, end = self._selection_line_range
         text = self.get_display_text()
         start, end = max(0, start), min(end, len(text))
-        return cap_quote(text[start:end])
+        selected = text[start:end]
+        return cap_quote(selected) if capped else selected
 
     def set_selection_range(self, start: int, end: int) -> None:
         """Highlight the character range ``[start, end)`` of the source.
@@ -2096,14 +2101,19 @@ class ConsoleTranscriptMessage(Vertical):
         """Return the plain body text this row renders (selection domain)."""
         return self._body_render_content().plain
 
-    def get_selection_text(self) -> str:
-        """Return the currently highlighted text, capped for quoting."""
+    def get_selection_text(self, *, capped: bool = True) -> str:
+        """Return the currently highlighted text.
+
+        Args:
+            capped: Apply the quote limit; False preserves the full clipboard text.
+        """
         if self._selection_range is None:
             return ""
         start, end = sorted(self._selection_range)
         text = self.get_display_text()
         start, end = max(0, start), min(end, len(text))
-        return cap_quote(text[start:end])
+        selected = text[start:end]
+        return cap_quote(selected) if capped else selected
 
     def set_selection_range(self, start: int, end: int) -> None:
         """Highlight ``[start, end)`` in the body and re-render it."""
@@ -2328,14 +2338,19 @@ class ConsoleToolDiffRow(Vertical):
             self._display_text = _tool_diff_display_text(self._diff)
         return self._display_text
 
-    def get_selection_text(self) -> str:
-        """Return the selected whole diff lines, capped for quoting."""
+    def get_selection_text(self, *, capped: bool = True) -> str:
+        """Return the selected whole diff lines.
+
+        Args:
+            capped: Apply the quote limit; False preserves the full clipboard text.
+        """
         if self._selection_range is None:
             return ""
         start, end = self._selection_range
         text = self.get_display_text()
         start, end = max(0, start), min(end, len(text))
-        return cap_quote(text[start:end])
+        selected = text[start:end]
+        return cap_quote(selected) if capped else selected
 
     def set_selection_range(self, start: int, end: int) -> None:
         """Highlight ``[start, end)`` of the projection, snapped to whole lines.
@@ -5919,6 +5934,20 @@ class ConsoleTranscript(VerticalScroll):
         degenerate boxes thinner than the margin.
         """
         return max(low, min(value, max(low, high - margin)))
+
+    @on(ConsoleSelectionMenu.CopySelection)
+    def _selection_copy(self, event: ConsoleSelectionMenu.CopySelection) -> None:
+        """Copy the full highlighted span and dismiss the selection UI."""
+        event.stop()
+        row = self._active_selection_row()
+        if row is not None:
+            text = row.get_selection_text(capped=False)
+            if text:
+                self.app.copy_to_clipboard(text)
+                self.notify("Selection sent to clipboard.")
+        self._remove_selection_menu()
+        self.selection_manager.cancel()
+        self._selection_origin_row = None
 
     @on(ConsoleSelectionMenu.AddToChat)
     def _selection_add_to_chat(self, event: ConsoleSelectionMenu.AddToChat) -> None:

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -2768,15 +2768,15 @@
        specificity decides -- and re-grew tall borders on the run-gated
        pair (2-row border-only boxes, labels clipped, 11-row menu). Per-ID
        rules ((1,0,1)) beat any class/pseudo stack textual throws. Applied
-       to ALL seven action IDs, not just the two gated ones: any action may
+       to ALL action IDs, not just the two gated ones: any action may
        end up disabled, and every action must stay one row in every state
        and color mode. */
 
 
     /* Shrink guard for boxes shorter than even the compact menu: the
        measured clamp adds this class, trading the container border and
-       the hint line for 3 more usable rows (last resort before the
-       top-out tie-break; no actions are ever hidden). */
+       the hint line for 3 more usable rows, with scrolling if the actions
+       still cannot all fit. */
 
 
 

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -2320,9 +2320,10 @@
        specificity decides -- and re-grew tall borders on the run-gated
        pair (2-row border-only boxes, labels clipped, 11-row menu). Per-ID
        rules ((1,0,1)) beat any class/pseudo stack textual throws. Applied
-       to ALL seven action IDs, not just the two gated ones: any action may
+       to ALL action IDs, not just the two gated ones: any action may
        end up disabled, and every action must stay one row in every state
        and color mode. */
+    ConsoleSelectionMenu #console-selection-copy,
     ConsoleSelectionMenu #console-selection-add-to-chat,
     ConsoleSelectionMenu #console-selection-more-details,
     ConsoleSelectionMenu #console-selection-ask-side-chat,
@@ -2341,10 +2342,11 @@
     }
     /* Shrink guard for boxes shorter than even the compact menu: the
        measured clamp adds this class, trading the container border and
-       the hint line for 3 more usable rows (last resort before the
-       top-out tie-break; no actions are ever hidden). */
+       the hint line for 3 more usable rows, with scrolling if the actions
+       still cannot all fit. */
     ConsoleSelectionMenu.shrunk-for-short-owner {
         border: none;
+        overflow-y: auto;
     }
     ConsoleSelectionMenu.shrunk-for-short-owner #console-selection-feedback-hint {
         display: none;


### PR DESCRIPTION
Console text selections now offer **Copy selection** as the first menu action. It copies the full highlighted text through the existing clipboard path, preserves the composer draft and whole-message selection, and closes the selection UI.

Short menus scroll so every action remains reachable. Open menus restore their full contents when the terminal or transcript grows, and reposition when space shrinks. Includes production-styled mouse and keyboard coverage, uncapped plain/Markdown/diff selections, regenerated stylesheets, and user guidance. Implements TASK-32033 within ADR-068.

The keyboard selection test now loads production styles and samples geometry after selection entry. Two real-database feedback tests now receive the runtime's workspace registry; their SQLite write assertions remain intact.

Validation:
- **183 passed** across the six targeted selection suites after rebasing onto latest dev (`8dc5366dc`), including the three repaired tests and eight resize cases.
- All six derived-artifact preflight checks pass.
- No new Ruff diagnostics; changed Python regions and whitespace checks pass.
- Independent review found no remaining actionable issues.

Clipboard delivery depends on the terminal accepting OSC 52. Tests verify Textual's clipboard contents; Linux desktop clipboard delivery was not exercised.
