### PR TITLE
Fix Console trace ownership with project instructions

### DIFF
--- a/Docs/User_Guide/console/semantic-trace-capture.md
+++ b/Docs/User_Guide/console/semantic-trace-capture.md
@@ -11,7 +11,11 @@ whole transcript again on every send.
 Provider-only material has no transcript row to point at. Rendered project
 instructions, RAG or memory context, tool schemas, tool arguments and results,
 provider transformations, and unmatched responses are filtered and saved once
-as trace artifacts. Repeated calls reuse those artifacts where possible.
+as trace artifacts. This includes automatic `AGENTS.md` and `AGENTS.override.md`
+context: each captured call preserves the instructions supplied to that call,
+even if the file changes or project instructions are later disabled. These
+instructions do not become saved user messages. Repeated calls reuse artifacts
+where possible.
 
 A trace describes the final semantic values handed to Chatbook's provider
 adapter. It is not generally a byte-for-byte HTTP log: provider-library framing,

--- a/Tests/Chat/test_console_prepared_request.py
+++ b/Tests/Chat/test_console_prepared_request.py
@@ -445,6 +445,59 @@ def test_known_mandatory_overflow_is_explicit_and_compaction_cannot_remove_it() 
     )
 
 
+@pytest.mark.parametrize("ceiling", [3, 7])
+def test_project_context_cannot_evict_its_current_user(ceiling: int) -> None:
+    """An appended context rider must not turn the user's ask into history."""
+    semantic = build_console_request(
+        [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "current question"},
+            {
+                "role": "user",
+                "content": "project guidance",
+                "_chatbook_ephemeral_origin": "project_instructions",
+            },
+        ]
+    )
+    prepared = prepare_provider_request(
+        semantic,
+        wire_style="distinct_roles",
+        model="m",
+        capacity=_capacity(ceiling),
+        count_fn=_word_count,
+    )
+
+    assert [row["content"] for row in prepared.messages_payload] == [
+        "current question",
+        "project guidance",
+    ]
+    assert prepared.dropped_messages == 2
+    assert prepared.known_overflow is (ceiling == 3)
+
+
+def test_historical_project_context_stays_in_its_complete_turn() -> None:
+    request = build_console_request(
+        [
+            {"role": "user", "content": "old question"},
+            {
+                "role": "user",
+                "content": "old context",
+                "_chatbook_ephemeral_origin": "project_instructions",
+            },
+            {"role": "assistant", "content": "old answer"},
+            {"role": "user", "content": "current question"},
+        ]
+    )
+
+    assert len(request.compactable) == 1
+    assert [row["content"] for row in request.compactable[0].messages] == [
+        "old question",
+        "old context",
+        "old answer",
+    ]
+
+
 def test_unknown_and_user_overridden_limits_are_honestly_labeled() -> None:
     semantic = build_console_request([{"role": "user", "content": "hello"}])
     unknown = prepare_provider_request(

--- a/Tests/Chat/test_console_project_instruction_provider_grammar.py
+++ b/Tests/Chat/test_console_project_instruction_provider_grammar.py
@@ -89,7 +89,7 @@ def test_native_adapter_keeps_native_context_grammar_with_empty_tool_catalog(
         store=None,
         provider_gateway=None,
         resolution=None,
-        assistant_message_id=None,
+        assistant_message_id="grammar-test-assistant",
         should_cancel=lambda: False,
         loop=None,
         native_tools=True,

--- a/Tests/Chat/test_console_project_instruction_traces.py
+++ b/Tests/Chat/test_console_project_instruction_traces.py
@@ -1,0 +1,324 @@
+"""Project context must not replace the saved owner of a captured Console send."""
+
+from __future__ import annotations
+
+import json
+from contextlib import asynccontextmanager, closing
+from dataclasses import replace
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+    ConsoleEgressClass,
+    ConsoleResolvedDestination,
+)
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
+from tldw_chatbook.Workspaces.models import WorkspaceRuntimeBinding
+
+GUIDANCE = "PROJECT_TRACE_GUIDANCE_31976: run the project tests."
+CREDENTIAL = "sk-" + "a" * 48
+CONTACT = "elise@example.test"
+RUNTIME_CREDENTIAL = "local-provider-password-31976"
+
+
+@asynccontextmanager
+async def _project_console(
+    tmp_path,
+    monkeypatch,
+    *,
+    source_name="AGENTS.md",
+    capture_enabled=True,
+    pii_redaction_enabled=False,
+    response_mode="complete",
+    tools=False,
+):
+    """Use real new-session/workspace defaults; replace only provider HTTP."""
+    with (
+        closing(CharactersRAGDB(tmp_path / "chat.sqlite", "project-trace")) as db,
+        closing(
+            AgentRunsDB(tmp_path / "runs.sqlite", client_id="project-trace")
+        ) as runs,
+        closing(
+            WorkspaceDB(tmp_path / "workspaces.sqlite", client_id="project-trace")
+        ) as workspace_db,
+    ):
+        root = tmp_path / "project"
+        root.mkdir()
+        (root / source_name).write_text(
+            f"{GUIDANCE}\nExample credential: {CREDENTIAL}\nContact: {CONTACT}"
+            f"\nRuntime credential: {RUNTIME_CREDENTIAL}"
+        )
+        registry = LocalWorkspaceRegistryService(workspace_db)
+        registry.create_workspace(workspace_id="project-trace", name="Project")
+        registry.save_runtime_binding(
+            WorkspaceRuntimeBinding(
+                workspace_id="project-trace",
+                binding_id="project-folder",
+                binding_kind="local-filesystem",
+                label="Project",
+                locator=str(root),
+                status="ready",
+                metadata={"access": "rw"},
+            )
+        )
+        factory = ConsoleTraceBoundaryFactory(db)
+        reservation_errors = []
+        http_payloads = []
+
+        def boundary(request, resolved, route):
+            try:
+                return factory(request, resolved, route)
+            except Exception as exc:
+                reservation_errors.append(str(exc))
+                raise
+
+        def restart_factory():
+            nonlocal factory
+            factory = ConsoleTraceBoundaryFactory(db)
+
+        def respond(request: httpx.Request) -> httpx.Response:
+            assert request.url.path == "/v1/chat/completions"
+            payload = json.loads(request.content)
+            http_payloads.append(payload)
+            if payload.get("stream"):
+                body = (
+                    ""
+                    if response_mode == "fallback"
+                    else 'data: {"choices":[{"delta":{"content":"Fixture reply"}}]}\n\n'
+                    "data: [DONE]\n\n"
+                )
+                return httpx.Response(
+                    200, text=body, headers={"content-type": "text/event-stream"}
+                )
+            content = (
+                '```tool_call\n{"name": "calculator", "arguments": {"expression": "6*7"}}\n```'
+                if tools and len(http_payloads) == 1
+                else "Fixture reply"
+            )
+            return httpx.Response(
+                200, json={"choices": [{"message": {"content": content}}]}
+            )
+
+        resolution = ConsoleProviderResolution(
+            ready=True,
+            provider="llama_cpp",
+            execution_key="llama_cpp",
+            model="qwen3.7-27b",
+            base_url="http://localhost:8080",
+            api_key=RUNTIME_CREDENTIAL,
+            streaming=response_mode != "complete",
+            resolved_destination=ConsoleResolvedDestination(
+                provider="llama_cpp",
+                model="qwen3.7-27b",
+                endpoint_identity="http://localhost:8080",
+                egress_class=ConsoleEgressClass.ON_DEVICE,
+            ),
+        )
+        async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+            gateway = ConsoleProviderGateway(
+                http_client=client, trace_call_boundary_factory=boundary
+            )
+
+            async def resolve(_selection):
+                return resolution
+
+            monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+            store = ConsoleChatStore(
+                persistence=ChatPersistenceService(db, workspace_registry=registry)
+            )
+            # Use the real new-session defaults: the old helper disabled AGENTS.
+            session = store.create_session(
+                workspace_id="project-trace",
+                settings=ConsoleSessionSettings(
+                    provider="llama_cpp", model="qwen3.7-27b"
+                ),
+            )
+            bridge = ConsoleAgentBridge(
+                agent_runs_db=runs, store=store, provider_gateway=gateway
+            )
+            controller = ConsoleChatController(
+                store=store,
+                provider_gateway=gateway,
+                agent_runtime_enabled=True,
+                agent_bridge=bridge,
+                confirm_project_instruction_dispatch=lambda _notice: "proceed",
+            )
+            controller.app = SimpleNamespace(workspace_registry_service=registry)
+            controller.set_next_trace_privacy(
+                session.id,
+                capture_enabled=capture_enabled,
+                pii_redaction_enabled=pii_redaction_enabled,
+                expected_policy_revision=controller.capture_policy_snapshot(
+                    session.id
+                ).policy_revision,
+            )
+            try:
+                yield SimpleNamespace(
+                    db=db,
+                    store=store,
+                    controller=controller,
+                    session=session,
+                    factory=factory,
+                    http_payloads=http_payloads,
+                    reservation_errors=reservation_errors,
+                    project_file=root / source_name,
+                    restart_factory=restart_factory,
+                )
+            finally:
+                await gateway.aclose()
+
+
+@pytest.mark.parametrize("source_name", ["AGENTS.md", "AGENTS.override.md"])
+@pytest.mark.parametrize("capture_enabled", [False, True])
+@pytest.mark.parametrize("pii_redaction_enabled", [False, True])
+@pytest.mark.parametrize("response_mode", ["stream", "complete", "fallback"])
+async def test_fresh_project_send_preserves_turn_and_captured_context(
+    tmp_path,
+    monkeypatch,
+    source_name,
+    capture_enabled,
+    response_mode,
+    pii_redaction_enabled,
+):
+    async with _project_console(
+        tmp_path,
+        monkeypatch,
+        source_name=source_name,
+        capture_enabled=capture_enabled,
+        response_mode=response_mode,
+        pii_redaction_enabled=pii_redaction_enabled,
+    ) as app:
+        result = await app.controller.submit_draft("Hello", session_id=app.session.id)
+
+        assert result.accepted
+        assert app.controller.run_state.status.value == "completed", (
+            app.reservation_errors
+        )
+        assert len(app.http_payloads) == (2 if response_mode == "fallback" else 1)
+        for payload in app.http_payloads:
+            rows = payload["messages"]
+            assert rows[-2]["content"] == "Hello"
+            assert GUIDANCE in rows[-1]["content"]
+            assert CREDENTIAL in rows[-1]["content"]
+            assert RUNTIME_CREDENTIAL in rows[-1]["content"]
+        messages = app.store.messages_for_session(app.session.id)
+        assert any(message.content == "Fixture reply" for message in messages)
+        assert all(GUIDANCE not in message.content for message in messages)
+        user = next(message for message in messages if message.content == "Hello")
+        captures = ConsoleTraceNativeReader(app.db).read_calls(
+            user.persisted_message_id
+        )
+        with app.db.transaction() as cursor:
+            calls = app.factory.repository.read_conversation_call_lineage(
+                cursor, app.session.persisted_conversation_id
+            )
+        if capture_enabled:
+            assert len(captures) == len(calls) == len(app.http_payloads)
+            assert all(call.turn_id == user.persisted_message_id for call in calls)
+            for call in captures:
+                rows = call.capture.request["messages_payload"]
+                assert rows[-2]["content"] == "Hello"
+                assert GUIDANCE in rows[-1]["content"]
+                assert RUNTIME_CREDENTIAL not in json.dumps(call.capture.request)
+                assert CREDENTIAL not in json.dumps(call.capture.request)
+                assert (CONTACT in rows[-1]["content"]) is not pii_redaction_enabled
+        else:
+            assert captures == ()
+            assert not calls
+
+
+@pytest.mark.parametrize("prior_response", ["ordinary", "tools", "fallback"])
+@pytest.mark.parametrize("context_change", ["same", "changed", "disabled"])
+@pytest.mark.parametrize("cold_factory", [False, True])
+async def test_consecutive_project_sends_preserve_each_request(
+    tmp_path,
+    monkeypatch,
+    prior_response,
+    context_change,
+    cold_factory,
+):
+    tools = prior_response == "tools"
+    fallback = prior_response == "fallback"
+    async with _project_console(
+        tmp_path,
+        monkeypatch,
+        tools=tools,
+        response_mode="fallback" if fallback else "complete",
+    ) as app:
+        first = await app.controller.submit_draft("Hello", session_id=app.session.id)
+        assert first.accepted
+        assert app.controller.run_state.status.value == "completed", (
+            app.reservation_errors
+        )
+        first_user = next(
+            row
+            for row in app.store.messages_for_session(app.session.id)
+            if row.content == "Hello"
+        )
+        reader = ConsoleTraceNativeReader(app.db)
+        original = reader.read_calls(first_user.persisted_message_id)
+        assert len(original) == (2 if tools or fallback else 1)
+        for call in original:
+            assert GUIDANCE in json.dumps(call.capture.request)
+            assert CREDENTIAL not in json.dumps(call.capture.request)
+
+        if context_change == "changed":
+            app.project_file.write_text("UPDATED_PROJECT_GUIDANCE_31976")
+        elif context_change == "disabled":
+            app.store.set_session_project_instruction_state(
+                app.session.id,
+                replace(
+                    app.session.project_instruction_state,
+                    project_instructions_enabled=False,
+                ),
+            )
+
+        for text in ("Next question", "One more question"):
+            if cold_factory:
+                app.restart_factory()
+            before_http = len(app.http_payloads)
+            result = await app.controller.submit_draft(text, session_id=app.session.id)
+            assert result.accepted
+            assert app.controller.run_state.status.value == "completed", (
+                app.reservation_errors
+            )
+            assert len(app.http_payloads) == before_http + (2 if fallback else 1)
+            user = next(
+                row
+                for row in app.store.messages_for_session(app.session.id)
+                if row.content == text
+            )
+            captures = reader.read_calls(user.persisted_message_id)
+            assert len(captures) == (2 if fallback else 1)
+            rows = captures[0].capture.request["messages_payload"]
+            wire_rows = app.http_payloads[-1]["messages"]
+            if context_change == "disabled":
+                assert rows[-1]["content"] == wire_rows[-1]["content"] == text
+                assert GUIDANCE not in json.dumps(rows)
+            else:
+                assert rows[-2]["content"] == wire_rows[-2]["content"] == text
+                expected = (
+                    GUIDANCE
+                    if context_change == "same"
+                    else "UPDATED_PROJECT_GUIDANCE_31976"
+                )
+                assert expected in rows[-1]["content"]
+                assert expected in wire_rows[-1]["content"]
+                assert sum(expected in str(row.get("content")) for row in rows) == 1
+            assert reader.read_calls(first_user.persisted_message_id) == original

--- a/Tests/Chat/test_console_trace_final_values.py
+++ b/Tests/Chat/test_console_trace_final_values.py
@@ -599,8 +599,8 @@ def test_checkpoint_normalization_does_not_construct_arbitrary_sequences() -> No
         (
             "custom-openai-api",
             {"api_key_resolved": True},
-            {"api_key_resolved": True},
-            "credential_decision",
+            {},  # Credential selection survives as metadata, not a credential field.
+            "credential_redaction",
         ),
     ],
 )
@@ -644,6 +644,7 @@ def test_provider_shape_matrix_is_sanitized_and_projected(
     if expected_overlay is not None:
         assert expected_overlay in {item.kind for item in result.overlays}
     if endpoint == "custom-openai-api":
+        assert "api_key_resolved" not in result.handler_kwargs
         assert result.credential_source is ProviderCredentialSource.EXPLICIT_KEYLESS
 
 

--- a/Tests/Chat/test_console_trace_project_provider_input.py
+++ b/Tests/Chat/test_console_trace_project_provider_input.py
@@ -11,9 +11,16 @@ from Tests.Chat.test_console_trace_runtime import (
     _semantic_request,
 )
 from tldw_chatbook.Chat.console_prepared_request import thaw_json
-from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderResolution,
+    ConsoleProviderStreamSignals,
+)
 from tldw_chatbook.Chat.console_trace_errors import TraceCallPersistenceError
-from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy, new_opaque_id
+from tldw_chatbook.Chat.console_trace_models import (
+    FrozenTracePolicy,
+    TraceCallState,
+    new_opaque_id,
+)
 from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
@@ -29,15 +36,19 @@ make_gateway = runtime_fixtures.make_gateway
 
 
 @pytest.mark.parametrize(
-    "cold_factory, pii_enabled, retained_tamper",
+    "cold_factory, pii_enabled, retained_tamper, owned_retry",
     [
-        (False, False, None),
-        (True, False, None),
-        (False, True, None),
-        (True, True, None),
-        (False, True, "context"),
-        (False, True, "saved"),
-        (False, True, "inactive"),
+        (False, False, None, False),
+        (True, False, None, False),
+        (False, True, None, False),
+        (True, True, None, False),
+        (False, True, "context", False),
+        (False, True, "saved", False),
+        (False, True, "inactive", False),
+        (False, False, None, True),
+        (True, False, None, True),
+        (False, True, None, True),
+        (True, True, None, True),
     ],
 )
 async def test_generic_tool_request_retains_raw_project_context(
@@ -48,6 +59,7 @@ async def test_generic_tool_request_retains_raw_project_context(
     cold_factory,
     pii_enabled,
     retained_tamper,
+    owned_retry,
 ):
     database = make_database(tmp_path / "provider-input.sqlite", "provider-input")
     conversation_id = database.add_conversation({"title": "provider input"})
@@ -147,7 +159,7 @@ async def test_generic_tool_request_retains_raw_project_context(
             capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
         )
 
-        async def dispatch(request=prepared, dispatch_route=route):
+        async def dispatch(request=prepared, dispatch_route=route, call_signals=None):
             return [
                 item
                 async for item in gateway.stream_chat(
@@ -157,6 +169,7 @@ async def test_generic_tool_request_retains_raw_project_context(
                     route_actor_id=actor,
                     route_chain_id=chain,
                     capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+                    signals=call_signals,
                 )
             ]
 
@@ -165,7 +178,47 @@ async def test_generic_tool_request_retains_raw_project_context(
                 await dispatch()
             assert len(adapter_inputs) == 2
             return
-        assert await dispatch() == ["ok"]
+        if owned_retry and call_index == 1:
+            accepted_owner = object()
+            signals = ConsoleProviderStreamSignals()
+            gateway._bind_trace_preparation(signals, accepted_owner)
+            original_bind = type(factory.repository).bind_call
+
+            def fail_bind(
+                instance,
+                *args,
+                _original=original_bind,
+                _repository=factory.repository,
+                **kwargs,
+            ):
+                result = _original(instance, *args, **kwargs)
+                if instance is _repository:
+                    raise RuntimeError("synthetic trace bind rollback")
+                return result
+
+            with monkeypatch.context() as patch:
+                patch.setattr(type(factory.repository), "bind_call", fail_bind)
+                with pytest.raises(TraceCallPersistenceError) as failure:
+                    await dispatch(call_signals=signals)
+            failed = failure.value.boundary
+            assert failed.dispatch_outcome == "rolled_back"
+            reserved = failed.reserve()
+            assert len(adapter_inputs) == 1
+            gateway._bind_trace_preparation(signals, accepted_owner, boundary=failed)
+            assert await dispatch(call_signals=signals) == ["ok"]
+            assert len(adapter_inputs) == 2
+            with database.transaction() as cursor:
+                recovered = factory.repository.get_call(cursor, reserved.call_id)
+                assert recovered.idempotency_key == reserved.idempotency_key
+                assert recovered.state is TraceCallState.COMPLETE
+                assert (
+                    cursor.execute(
+                        "SELECT COUNT(*) FROM console_trace_calls"
+                    ).fetchone()[0]
+                    == 2
+                )
+        else:
+            assert await dispatch() == ["ok"]
         assert adapter_inputs[-1] == messages
 
     captures = ConsoleTraceNativeReader(database).read_calls(user_id)

--- a/Tests/Chat/test_console_trace_project_provider_input.py
+++ b/Tests/Chat/test_console_trace_project_provider_input.py
@@ -1,0 +1,177 @@
+"""Trace privacy projections must never replace provider-visible context."""
+
+import json
+from copy import deepcopy
+
+import pytest
+
+from Tests.Chat import test_console_trace_runtime as runtime_fixtures
+from Tests.Chat.test_console_trace_runtime import (
+    _saved_message,
+    _semantic_request,
+)
+from tldw_chatbook.Chat.console_prepared_request import thaw_json
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+from tldw_chatbook.Chat.console_trace_errors import TraceCallPersistenceError
+from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy, new_opaque_id
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_provenance import (
+    ConsoleRequestRoute,
+    ConsoleTraceCaptureMode,
+    ProviderArtifactTraceProvenance,
+    TraceProvenanceSource,
+)
+from tldw_chatbook.Chat.console_trace_redaction import BUILTIN_PII_RULESET_REVISION_ID
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+
+make_database = runtime_fixtures.make_database
+make_gateway = runtime_fixtures.make_gateway
+
+
+@pytest.mark.parametrize(
+    "cold_factory, pii_enabled, retained_tamper",
+    [
+        (False, False, None),
+        (True, False, None),
+        (False, True, None),
+        (True, True, None),
+        (False, True, "context"),
+        (False, True, "saved"),
+        (False, True, "inactive"),
+    ],
+)
+async def test_generic_tool_request_retains_raw_project_context(
+    tmp_path,
+    make_database,
+    make_gateway,
+    monkeypatch,
+    cold_factory,
+    pii_enabled,
+    retained_tamper,
+):
+    database = make_database(tmp_path / "provider-input.sqlite", "provider-input")
+    conversation_id = database.add_conversation({"title": "provider input"})
+    user_id, user = _saved_message(database, conversation_id, "calculate")
+    policy = FrozenTracePolicy(
+        new_opaque_id(),
+        "credentials-v1",
+        pii_enabled,
+        BUILTIN_PII_RULESET_REVISION_ID if pii_enabled else None,
+    )
+    credential = "sk-" + "a" * 48
+    runtime_credential = "local-provider-password-31976"
+    contact = "elise@example.test"
+    context = {
+        "role": "user",
+        "content": f"Project guidance: {credential}; {runtime_credential}; {contact}",
+        "_chatbook_ephemeral_origin": "project_instructions",
+    }
+    messages = [{"role": "user", "content": "calculate"}, context]
+    descriptors = [
+        user,
+        ProviderArtifactTraceProvenance(
+            TraceProvenanceSource.PROJECT_INSTRUCTION, policy
+        ),
+    ]
+    actor, chain = new_opaque_id(), new_opaque_id()
+    factory = ConsoleTraceBoundaryFactory(database)
+    adapter_inputs = []
+
+    def adapter(**kwargs):
+        adapter_inputs.append(deepcopy(thaw_json(kwargs["messages_payload"])))
+        return {"choices": [{"message": {"content": "ok"}}]}
+
+    def boundary(request, resolution, route):
+        return factory(request, resolution, route)
+
+    gateway = make_gateway(
+        chat_api_call_fn=adapter, trace_call_boundary_factory=boundary
+    )
+    resolution = ConsoleProviderResolution(
+        ready=True,
+        provider="openai",
+        model="gpt-test",
+        execution_key="openai",
+        base_url="https://api.openai.com/v1",
+        streaming=False,
+        api_key=runtime_credential,
+    )
+    routes = (ConsoleRequestRoute.AGENT_FIRST, ConsoleRequestRoute.TOOL_LOOP)
+    if retained_tamper:
+        # The third request has a warm checkpoint in the same route; cold
+        # bootstrap independently reconstructs and verifies the incoming rows.
+        routes += (ConsoleRequestRoute.TOOL_LOOP,)
+    for call_index, route in enumerate(routes):
+        if route is ConsoleRequestRoute.TOOL_LOOP:
+            if cold_factory:
+                factory = ConsoleTraceBoundaryFactory(database)
+            messages.append({"role": "tool", "content": "42", "tool_call_id": "call-1"})
+            descriptors.append(
+                ProviderArtifactTraceProvenance(
+                    TraceProvenanceSource.TOOL_RESULT, policy
+                )
+            )
+            if retained_tamper and call_index == 2:
+                original = type(factory.service).prepare_surface_provenance
+
+                def tampered(*args, _original=original, **kwargs):
+                    retained = dict(kwargs["retained_artifact_values"])
+                    sequence = next(iter(retained))
+                    if retained_tamper == "context":
+                        retained[sequence] = {
+                            **context,
+                            "content": "unadmitted guidance",
+                        }
+                    else:
+                        retained[0 if retained_tamper == "saved" else 999] = context
+                    kwargs["retained_artifact_values"] = retained
+                    return _original(*args, **kwargs)
+
+                monkeypatch.setattr(
+                    type(factory.service), "prepare_surface_provenance", tampered
+                )
+        semantic = _semantic_request(
+            messages,
+            descriptors,
+            policy,
+            route=route,
+            actor_id=actor,
+            chain_id=chain,
+        )
+        prepared = gateway.prepare_chat_request(
+            resolution,
+            semantic,
+            route=route,
+            route_actor_id=actor,
+            route_chain_id=chain,
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
+
+        async def dispatch(request=prepared, dispatch_route=route):
+            return [
+                item
+                async for item in gateway.stream_chat(
+                    resolution,
+                    request,
+                    route=dispatch_route,
+                    route_actor_id=actor,
+                    route_chain_id=chain,
+                    capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+                )
+            ]
+
+        if retained_tamper and call_index == 2:
+            with pytest.raises(TraceCallPersistenceError):
+                await dispatch()
+            assert len(adapter_inputs) == 2
+            return
+        assert await dispatch() == ["ok"]
+        assert adapter_inputs[-1] == messages
+
+    captures = ConsoleTraceNativeReader(database).read_calls(user_id)
+    assert len(captures) == 2
+    for call in captures:
+        captured = json.dumps(call.capture.request)
+        assert credential not in captured
+        assert runtime_credential not in captured
+        assert (contact in captured) is not pii_enabled

--- a/Tests/Chat/test_console_trace_project_turn_service.py
+++ b/Tests/Chat/test_console_trace_project_turn_service.py
@@ -1,0 +1,295 @@
+"""Project-context renewal keeps the completed-turn proof closed and bounded."""
+
+from contextlib import closing
+from dataclasses import replace
+
+import pytest
+
+from Tests.Chat.test_console_trace_service import (
+    _completed_run_compound_preparation,
+    _compound_storage_snapshot,
+    _policy,
+    _provenance,
+)
+from tldw_chatbook.Chat.console_trace_final_values import CompletedToolTurnWitness
+from tldw_chatbook.Chat.console_trace_provenance import (
+    ProviderArtifactTraceProvenance,
+    TraceProvenanceSource,
+)
+from tldw_chatbook.Chat.console_trace_repository import ConsoleTraceRepository
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    with closing(
+        CharactersRAGDB(tmp_path / "project-turn.sqlite", "project-turn")
+    ) as database:
+        yield database
+
+
+@pytest.fixture
+def repository():
+    return ConsoleTraceRepository()
+
+
+@pytest.mark.parametrize("count", [-1, 257, True, 1.0, "1"])
+def test_project_turn_witness_rejects_invalid_context_counts(count):
+    from tldw_chatbook.Chat.console_trace_models import new_opaque_id
+
+    with pytest.raises(ValueError, match="completed_project_context_count"):
+        CompletedToolTurnWitness(
+            *(new_opaque_id() for _ in range(4)), project_context_count=count
+        )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "valid",
+        "disabled",
+        "missing_tag",
+        "wrong_role",
+        "wrong_policy",
+        "wrong_source",
+        "wrong_count",
+        "wrong_anchor",
+    ],
+)
+def test_project_turn_preparation_validates_current_context_and_prior_anchor(
+    db, repository, scenario
+):
+    """The new context is admitted only after the exact saved response/user pair."""
+    service, admission, _, values = _completed_run_compound_preparation(db, repository)
+    witness = replace(
+        admission.completed_tool_turn,
+        project_context_count=0 if scenario == "disabled" else 1,
+    )
+    with db.transaction() as cursor:
+        origin = repository.get_call(cursor, witness.origin_call_id)
+        policy = repository.get_policy(cursor, origin.policy_id)
+    if scenario == "wrong_policy":
+        policy = replace(_policy(), credential_filter_version="credentials-v2")
+    context = {
+        "role": "assistant" if scenario == "wrong_role" else "user",
+        "content": "current project guidance",
+        "_chatbook_ephemeral_origin": "project_instructions",
+    }
+    if scenario == "missing_tag":
+        context.pop("_chatbook_ephemeral_origin")
+    source = (
+        TraceProvenanceSource.ACTIVE_REQUEST
+        if scenario == "wrong_source"
+        else TraceProvenanceSource.PROJECT_INSTRUCTION
+    )
+    descriptors = admission.descriptors
+    if scenario != "disabled":
+        descriptors += (ProviderArtifactTraceProvenance(source, policy),)
+        values += (context,)
+    if scenario == "wrong_count":
+        witness = replace(witness, project_context_count=2)
+    if scenario in {"wrong_source", "wrong_count"}:
+        with pytest.raises(ValueError, match="surface_delta_shape"):
+            replace(admission, descriptors=descriptors, completed_tool_turn=witness)
+        return
+    if scenario == "wrong_anchor":
+        with db.transaction() as cursor:
+            node = repository.read_lineage_surface_nodes(
+                cursor,
+                segment_id=admission.segment_id,
+                start_sequence=2,
+                end_sequence=2,
+            )[0]
+        admission = replace(
+            admission,
+            replacement_range=replace(
+                admission.replacement_range,
+                start_sequence=2,
+                start_node_id=node.node_id,
+                current_ordinal=2,
+                component_ordinal=2,
+            ),
+        )
+    admission = replace(admission, descriptors=descriptors, completed_tool_turn=witness)
+    with db.transaction() as cursor:
+        before = _compound_storage_snapshot(cursor)
+        if scenario in {"valid", "disabled"}:
+            boundary = service.prepare_surface_provenance(
+                cursor,
+                admission.projection_checkpoint,
+                provenance=_provenance(descriptors),
+                admission=admission,
+                values=values,
+            )
+            actual = boundary._provider_request_surface_values()["messages_payload"]
+            assert tuple(dict(value) for value in actual[-len(values) :]) == values
+        else:
+            expected = (
+                "completed_tool_turn_range"
+                if scenario == "wrong_anchor"
+                else "completed_project_context_value"
+            )
+            with pytest.raises(ValueError, match=expected):
+                service.prepare_surface_provenance(
+                    cursor,
+                    admission.projection_checkpoint,
+                    provenance=_provenance(descriptors),
+                    admission=admission,
+                    values=values,
+                )
+        assert _compound_storage_snapshot(cursor) == before
+
+
+@pytest.mark.parametrize(
+    "fixture_args, expected",
+    [
+        ({"duplicate_append": True}, "completed_tool_turn_lineage"),
+        ({"tool_count": 257}, "completed_tool_turn_range"),
+        ({"artifact_source": "active_request"}, "completed_tool_turn_range"),
+    ],
+)
+def test_project_transition_keeps_old_suffix_lineage_and_span_guards(
+    db, repository, fixture_args, expected
+):
+    """Opting into context renewal cannot admit malformed prior-run evidence."""
+    service, admission, provenance, values = _completed_run_compound_preparation(
+        db, repository, **fixture_args
+    )
+    admission = replace(
+        admission,
+        completed_tool_turn=replace(
+            admission.completed_tool_turn, project_context_count=0
+        ),
+    )
+    with db.transaction() as cursor:
+        before = _compound_storage_snapshot(cursor)
+        with pytest.raises(ValueError, match=expected):
+            service.prepare_surface_provenance(
+                cursor,
+                admission.projection_checkpoint,
+                provenance=provenance,
+                admission=admission,
+                values=values,
+            )
+        assert _compound_storage_snapshot(cursor) == before
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    ["valid", "stream_complete", "wrong_surface", "wrong_turn", "wrong_policy"],
+)
+def test_project_fallback_requires_the_exact_preceding_failed_stream(
+    db, repository, scenario
+):
+    """A fallback response cannot replace artifacts owned by a different stream."""
+    from tldw_chatbook.Chat.console_trace_models import (
+        SemanticRevisionRef,
+        TraceCallState,
+        new_opaque_id,
+    )
+
+    service, admission, provenance, values = _completed_run_compound_preparation(
+        db,
+        repository,
+        terminal_outcome=(
+            TraceCallState.COMPLETE
+            if scenario == "stream_complete"
+            else TraceCallState.ERROR
+        ),
+    )
+    witness = admission.completed_tool_turn
+    with db.transaction() as cursor:
+        failed = repository.get_call(cursor, witness.terminal_call_id)
+        origin = repository.get_call(cursor, witness.origin_call_id)
+        policy_id = failed.policy_id
+        if scenario == "wrong_policy":
+            policy = _policy()
+            repository.ensure_policy(cursor, policy)
+            policy_id = policy.policy_id
+        fallback = repository.reserve_call(
+            cursor,
+            owner_id=failed.owner_id,
+            segment_id=failed.segment_id,
+            turn_id=(new_opaque_id() if scenario == "wrong_turn" else failed.turn_id),
+            run_id=new_opaque_id(),
+            call_sequence=0,
+            idempotency_key=new_opaque_id(),
+            policy_id=policy_id,
+        )
+        event_tail = repository.get_event_tail(cursor, failed.segment_id)
+        repository.append_event(
+            cursor,
+            segment_id=failed.segment_id,
+            sequence=event_tail.sequence + 1,
+            event_type="call_boundary",
+            call_id=fallback.call_id,
+        )
+        header = repository.create_or_reuse_request_header(
+            cursor,
+            provider_name="openai",
+            model_name="gpt-test",
+            route_identity="llama_fallback",
+            endpoint_identity="https://api.example.invalid/v1",
+            generation_parameters={},
+            adapter_defaults={},
+            response_format={},
+            reasoning_controls={},
+            components=(),
+        )
+        repository.bind_call(
+            cursor,
+            call_id=fallback.call_id,
+            surface_node_id=(
+                origin.surface_node_id
+                if scenario == "wrong_surface"
+                else failed.surface_node_id
+            ),
+            request_header_id=header.header_id,
+            provider_name="openai",
+            model_name="gpt-test",
+            route_identity="llama_fallback",
+        )
+        for target in (
+            TraceCallState.DISPATCH_STARTED,
+            TraceCallState.RESPONSE_STARTED,
+            TraceCallState.COMPLETE,
+        ):
+            repository.advance_call_state(
+                cursor,
+                call_id=fallback.call_id,
+                target=target,
+                occurred_at="2026-09-07T00:00:00Z",
+            )
+        repository.store_response_link(
+            cursor,
+            call_id=fallback.call_id,
+            response=SemanticRevisionRef(witness.assistant_revision_id),
+        )
+        admission = replace(
+            admission,
+            completed_tool_turn=replace(
+                witness,
+                origin_call_id=fallback.call_id,
+                terminal_call_id=fallback.call_id,
+                project_context_count=0,
+            ),
+        )
+        before = _compound_storage_snapshot(cursor)
+        if scenario == "valid":
+            service.prepare_surface_provenance(
+                cursor,
+                admission.projection_checkpoint,
+                provenance=provenance,
+                admission=admission,
+                values=values,
+            )
+        else:
+            with pytest.raises(ValueError, match="completed_project_fallback_lineage"):
+                service.prepare_surface_provenance(
+                    cursor,
+                    admission.projection_checkpoint,
+                    provenance=provenance,
+                    admission=admission,
+                    values=values,
+                )
+        assert _compound_storage_snapshot(cursor) == before

--- a/Tests/Chat/test_console_trace_runtime.py
+++ b/Tests/Chat/test_console_trace_runtime.py
@@ -12,6 +12,7 @@ import pytest
 
 from tldw_chatbook.Chat.console_prepared_request import (
     CONTINUATION_OWNER_KEY,
+    ConsoleConversationUnit,
     build_console_request,
     prepare_provider_request,
     resolve_request_capacity,
@@ -30,6 +31,7 @@ from tldw_chatbook.Chat.console_trace_models import (
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
     ConsoleTraceCaptureMode,
+    ConsoleUnitProvenance,
     ProviderArtifactTraceProvenance,
     SavedRevisionTraceProvenance,
     TraceProvenanceSource,
@@ -1736,6 +1738,104 @@ def test_production_factory_rejects_unsaved_active_message_instead_of_stale_turn
             None,
             ConsoleRequestRoute.FRESH,
         )
+
+
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "valid",
+        "unsaved_user",
+        "untagged_context",
+        "wrong_source",
+        "wrong_role",
+        "assistant_owner",
+        "context_only_active",
+    ],
+)
+@pytest.mark.parametrize("wire_style", ["distinct_roles", "single_preamble"])
+def test_project_context_cannot_supply_or_hide_a_missing_turn_owner(
+    tmp_path, make_database, scenario, wire_style
+) -> None:
+    database = make_database(tmp_path / "project-owner.sqlite", "project-owner")
+    conversation_id = database.add_conversation({"title": "project ownership"})
+    _, prior = _saved_message(database, conversation_id, "prior")
+    current_role = "assistant" if scenario == "assistant_owner" else "user"
+    current_id, current = _saved_message(
+        database, conversation_id, "current", sender=current_role
+    )
+    policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    context = {
+        "role": "user",
+        "content": "project guidance",
+        "_chatbook_ephemeral_origin": "project_instructions",
+    }
+    if scenario == "untagged_context":
+        context.pop("_chatbook_ephemeral_origin")
+    if scenario == "wrong_role":
+        context["role"] = "assistant"
+    context_source = (
+        TraceProvenanceSource.ACTIVE_REQUEST
+        if scenario == "wrong_source"
+        else TraceProvenanceSource.PROJECT_INSTRUCTION
+    )
+    semantic = _semantic_request(
+        [
+            {"role": "user", "content": "prior"},
+            {"role": current_role, "content": "current"},
+            context,
+            dict(context),
+        ],
+        [
+            prior,
+            ProviderArtifactTraceProvenance(
+                TraceProvenanceSource.ACTIVE_REQUEST, policy
+            )
+            if scenario == "unsaved_user"
+            else current,
+            ProviderArtifactTraceProvenance(context_source, policy),
+            ProviderArtifactTraceProvenance(context_source, policy),
+        ],
+        policy,
+        route=ConsoleRequestRoute.AGENT_FIRST,
+        actor_id=new_opaque_id(),
+        chain_id=new_opaque_id(),
+    )
+    prepared = prepare_provider_request(
+        semantic,
+        wire_style=wire_style,
+        provider="openai",
+        model="gpt-test",
+        capacity=resolve_request_capacity(context_window_tokens=None),
+        apply_safety_window=False,
+    )
+    if scenario == "context_only_active":
+        # A forged section boundary must not authorize an older compactable user.
+        prepared = replace(
+            prepared,
+            semantic=replace(
+                prepared.semantic,
+                compactable=prepared.semantic.compactable
+                + (ConsoleConversationUnit(prepared.semantic.active_request[:-2]),),
+                active_request=prepared.semantic.active_request[-2:],
+                provenance=replace(
+                    prepared.semantic.provenance,
+                    compactable=prepared.semantic.provenance.compactable
+                    + (
+                        ConsoleUnitProvenance(
+                            prepared.semantic.provenance.active_request[:-2]
+                        ),
+                    ),
+                    active_request=prepared.semantic.provenance.active_request[-2:],
+                ),
+            ),
+        )
+    factory = ConsoleTraceBoundaryFactory(database)
+    if scenario == "valid":
+        boundary = factory(prepared, None, ConsoleRequestRoute.AGENT_FIRST)
+        assert boundary.identity.turn_id == current_id
+    else:
+        with pytest.raises(ValueError, match="trace_turn_unavailable"):
+            factory(prepared, None, ConsoleRequestRoute.AGENT_FIRST)
 
 
 def test_production_factory_batches_revision_owner_lookup_for_long_traces(

--- a/Tests/Chat/test_console_trace_service.py
+++ b/Tests/Chat/test_console_trace_service.py
@@ -1268,6 +1268,8 @@ def _completed_run_compound_preparation(
     *,
     tool_count: int = 2,
     duplicate_append: bool = False,
+    artifact_source: str = "tool_result",
+    terminal_outcome: TraceCallState = TraceCallState.COMPLETE,
 ):
     """Construct durable evidence directly, without provider overlay size limits."""
     owner_id, segment_id = _owned_segment(db, repository)
@@ -1318,7 +1320,7 @@ def _completed_run_compound_preparation(
             event("call_boundary", call_id=call.call_id)
             return call
 
-        def complete(call, node, route):
+        def complete(call, node, route, outcome=TraceCallState.COMPLETE):
             header = repository.create_or_reuse_request_header(
                 cursor,
                 provider_name="openai",
@@ -1343,7 +1345,7 @@ def _completed_run_compound_preparation(
             for target in (
                 TraceCallState.DISPATCH_STARTED,
                 TraceCallState.RESPONSE_STARTED,
-                TraceCallState.COMPLETE,
+                outcome,
             ):
                 repository.advance_call_state(
                     cursor,
@@ -1381,8 +1383,8 @@ def _completed_run_compound_preparation(
                 segment_id=segment_id,
                 sequence=sequence,
                 predecessor_node_id=head.node_id,
-                component_kind="tool_result",
-                reference=TraceContentRef(artifact.artifact_id, "tool_result"),
+                component_kind=artifact_source,
+                reference=TraceContentRef(artifact.artifact_id, artifact_source),
             )
             tool_nodes.append(head)
             # The defect is constructed at insertion time: two real events
@@ -1390,17 +1392,14 @@ def _completed_run_compound_preparation(
             event_count = (2 if sequence == 1 else 0) if duplicate_append else 1
             for _ in range(event_count):
                 event("surface_append", surface_node_id=head.node_id)
-        complete(terminal, head, ConsoleRequestRoute.TOOL_LOOP)
+        complete(terminal, head, ConsoleRequestRoute.TOOL_LOOP, terminal_outcome)
         repository.store_response_link(
             cursor,
             call_id=terminal.call_id,
             response=SemanticRevisionRef(answer.revision_id),
         )
         assert repository.get_run_origin(cursor, run_id).call_id == origin.call_id
-        assert (
-            repository.get_call(cursor, terminal.call_id).state
-            is TraceCallState.COMPLETE
-        )
+        assert repository.get_call(cursor, terminal.call_id).state is terminal_outcome
         assert (
             repository.get_latest_call_boundary(cursor, segment_id).call_id
             == terminal.call_id

--- a/backlog/decisions/069-console-project-instruction-local-state-and-preflight.md
+++ b/backlog/decisions/069-console-project-instruction-local-state-and-preflight.md
@@ -80,6 +80,22 @@ ordinary persistence semantics.
 
 ## Context
 
+### Amendment: capture-enabled trajectory history (TASK-31976.1, 2026-09-07)
+
+The owner explicitly requires traces to retain the project instructions the
+model received. Automatic project context therefore follows ADR-097's normal
+provider-artifact storage and credential/PII redaction rules when Capture On is
+admitted. This supersedes the exclusion from **durable captures** above; Capture
+Off, ordinary conversation messages, summaries, agent steps and logs retain the
+existing nonpersistence rules. Explicit file reads and model quotations remain
+ordinary content. Trace retention does not grant repository text authority.
+
+Tagged project context belongs to the user turn that caused its delivery. It
+does not start a new user turn, become its saved owner, or make that user's
+message independently removable by request windowing. Provider message order
+is preserved; tracing excludes only verified context artifacts when identifying
+the active saved turn and still rejects an unsaved active user message.
+
 ADR-068 established the untrusted project-context boundary, Codex filename
 precedence, lazy nested activation, and nonpersistence requirement. A later
 readiness audit found three implementation-breaking assumptions:

--- a/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+++ b/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
@@ -222,6 +222,29 @@ project-instruction bodies never enter default durable capture.
     chunk-row encoding are deferred to [TASK-24206](../tasks/task-24206%20-%20Add-lossless-chunk-row-encoding-for-streamed-trace-events.md)
     and are not required by the forthcoming ADR-097 implementation umbrella.
 
+### Clarification recorded 2026-09-07: automatic project context
+
+TASK-31976.1 applies decisions 6 and 8 to automatic `AGENTS.md` context: Capture
+On retains the actual provider-visible context as a `project_instruction`
+artifact under the frozen credential/PII policy. The owner explicitly requested
+this trajectory fidelity, superseding ADR-069's earlier durable-capture
+exclusion; its other ephemerality and authority rules remain in force. Capture
+Off retains no such trace artifact. Context rows remain attached to their user
+turn for windowing and cannot replace the admitted saved message as call owner.
+
+When a completed turn is followed by another send, its bounded project/tool
+suffix may be replaced by the saved assistant, new saved user and current project
+context. This requires a witnessed terminal response link, unchanged prefix,
+same disclosure policy and durable attribution of every removed artifact to
+that completed run; it is revalidated when binding and works from durable
+references after a restart. A matching context suffix is still renewed with the
+new turn. Prior call reconstruction remains unchanged. Other replacement shapes
+remain rejected. A completed llama.cpp fallback can witness that response only
+when it immediately follows the failed streaming call with the same owner,
+turn, disclosure policy, surface, provider and model; removed artifacts must
+still belong to the verified source stream run. Artifact equality compares the frozen credential/PII projection
+without modifying the actual provider input.
+
 ### Clarification recorded 2026-09-05: retained soft-delete envelopes
 
 The accepted design's mutation-boundary section and TASK-23113.2 AC8 specify

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12223,3 +12223,20 @@ starts, wait for the expected starts (poll with a generous deadline)
 rather than a flat window sized to the happy path. The probe already
 records STARTS rather than running state, so waiting cannot miss a worker
 that finishes quickly.
+
+
+## Preserve real project defaults and verify the provider input
+
+**TASK-31976.1, 2026-09-07.** The trace recovery helper disabled project
+instructions, so its passing sends missed the production default that selected
+a ready workspace containing AGENTS.md. Real workspace/controller/agent/factory
+tests reproduced trace_turn_unavailable before HTTP: the appended context had
+been mistaken for a saved user turn. Keeping that context exposed consecutive
+turn replacement and filtered-artifact equality failures. Review then found
+that the generic provider path could replay filtered trace artifacts as actual
+provider input; llama.cpp's separate wire path concealed that error.
+
+Use real workspace defaults when testing sends. Assert each reconstructed call
+and the actual provider input across subsequent sends, tool calls, fallback
+and a cold trace factory; test credential and PII filtering with distinct
+secrets in the context. A saved trace alone cannot prove what the model received.

--- a/backlog/tasks/task-31976.1 - Preserve-Console-turn-ownership-when-project-instructions-are-appended.md
+++ b/backlog/tasks/task-31976.1 - Preserve-Console-turn-ownership-when-project-instructions-are-appended.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:15'
-updated_date: '2026-09-08 06:00'
+updated_date: '2026-09-08 06:22'
 labels: []
 dependencies: []
 parent_task_id: TASK-31976
@@ -25,6 +25,7 @@ Fresh Console sends with automatic project instructions fail during trace reserv
 - [x] #3 Capture On records the actual project context as a provider-only trace artifact under normal credential and PII redaction; Capture Off does not persist it.
 - [x] #4 Unowned or mismatched active messages still fail closed; existing fresh, tool-loop and fallback behavior has targeted regression coverage.
 - [x] #5 Consecutive sends preserve prior request reconstruction and renew or remove project context only after verifying the completed response, saved new user, disclosure policy and bounded prior run ownership; tool and cold-factory paths are covered.
+- [x] #6 Owned trace retries preserve runtime credential matching and original provider input after a rolled-back binding, without allocating another call.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,6 +36,7 @@ Fresh Console sends with automatic project instructions fail during trace reserv
 3. Verify reconstruction and streaming fallback; compare artifacts under their frozen disclosure projection.
 4. Extend witnessed completed-turn replacement to bounded project/tool suffixes with saved response linkage, current user, policy and prior run ownership verified at preparation and binding; test consecutive unchanged, changed and disabled context with cold factories.
 5. Run targeted tests, lint/format checks and independent review; record evidence and lessons.
+6. Address PR review: reproduce owned recovery with retained runtime credentials, preserve exact retry reservation and provider entry count, and complete public API docstrings.
 ADR required: yes, amendment to existing ADRs.
 ADR paths: backlog/decisions/069-console-project-instruction-local-state-and-preflight.md and backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md.
 Reason: user requests actual model-visible context in Capture On traces under existing artifact/redaction rules, with a narrowly witnessed completed-project-turn replacement; no schema or authority change.
@@ -52,4 +54,8 @@ Modified prepared request, agent bridge, provenance, runtime, final-value and tr
 Verification: 403 tests passed across the 11 affected Chat modules, plus 7 focused project/trace/provenance bridge tests (410 total). Includes both instruction filenames, Capture On/Off, PII On/Off, streaming/complete/fallback, consecutive same/changed/disabled context, cold factories, tool calls, immutable prior reconstruction and invalid owner/lineage/raw-override controls. The new cases reproduced the failures before fixes. All six scripts/preflight.sh checks passed. New test modules pass Ruff; changed Python ranges pass formatting and git diff --check. Baseline comparison reports zero new Ruff diagnostics (107 existing); pytest reports one existing requests dependency warning. Full repository suite was not run.
 
 Two independent reviews verified the completed-turn proof and raw-provider preservation, including the final redundant-read removal; no actionable findings remain. This fixes the reproduced project-instruction path. The external reporter has not confirmed that setting, so this does not establish that every reported flicker has the same trigger.
+
+PR #2505 Qodo follow-up: verify a retained credential-bearing project artifact through owned recovery, forward the exact admitted resolution credential, and document all new public descriptor/context/credential contracts. Existing ADR069/097 apply; no additional ADR required because this restores the intended retry contract.
+
+Qodo findings addressed: owned recovery now forwards the credential from the equality-checked admitted resolution; all requested public contracts have complete Args/Returns guidance, including the related prepare_surface_provenance parameters. Four new real bind-rollback retry cases failed before the fix and now pass with PII on/off and warm/cold factories. They prove the same reserved call/idempotency key, exactly one resumed provider entry, original provider input and filtered stored context. Validation: 141 targeted tests passed; the strengthened 11-case provider-input/recovery module passed again. Independent review found no blocker; its duplicate-dispatch assertion was added. Latest-dev rebase was already current at 37bf45fb6.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-31976.1 - Preserve-Console-turn-ownership-when-project-instructions-are-appended.md
+++ b/backlog/tasks/task-31976.1 - Preserve-Console-turn-ownership-when-project-instructions-are-appended.md
@@ -1,0 +1,55 @@
+---
+id: TASK-31976.1
+title: Preserve Console turn ownership when project instructions are appended
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 05:15'
+updated_date: '2026-09-08 06:00'
+labels: []
+dependencies: []
+parent_task_id: TASK-31976
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Fresh Console sends with automatic project instructions fail during trace reservation because context is mistaken for the saved active turn. Keep the user turn intact and retain the model-visible instructions in capture-enabled trace history, under the normal disclosure policy.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh sends with AGENTS.md or AGENTS.override.md complete through the real workspace, controller, agent, gateway and trace factory with the saved user as owner.
+- [x] #2 Request windowing keeps automatic project context and its current user together without changing provider message order.
+- [x] #3 Capture On records the actual project context as a provider-only trace artifact under normal credential and PII redaction; Capture Off does not persist it.
+- [x] #4 Unowned or mismatched active messages still fail closed; existing fresh, tool-loop and fallback behavior has targeted regression coverage.
+- [x] #5 Consecutive sends preserve prior request reconstruction and renew or remove project context only after verifying the completed response, saved new user, disclosure policy and bounded prior run ownership; tool and cold-factory paths are covered.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce fresh-send failure using real SQLite, workspace resolution and production boundaries; cover windowing and invalid owners.
+2. Keep project instructions with the saved active user and retain them as credential/PII-filtered project artifacts without changing provider input.
+3. Verify reconstruction and streaming fallback; compare artifacts under their frozen disclosure projection.
+4. Extend witnessed completed-turn replacement to bounded project/tool suffixes with saved response linkage, current user, policy and prior run ownership verified at preparation and binding; test consecutive unchanged, changed and disabled context with cold factories.
+5. Run targeted tests, lint/format checks and independent review; record evidence and lessons.
+ADR required: yes, amendment to existing ADRs.
+ADR paths: backlog/decisions/069-console-project-instruction-local-state-and-preflight.md and backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md.
+Reason: user requests actual model-visible context in Capture On traces under existing artifact/redaction rules, with a narrowly witnessed completed-project-turn replacement; no schema or authority change.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed automatic project context being treated as a new saved user turn. Request grouping keeps context with its real user; trace provenance classifies it as project_instruction; ownership skips only trailing context with matching typed provenance and app marker, refusing unsaved/mismatched owners.
+
+Capture On retains the actual context under mandatory credential and optional frozen PII filtering. Artifact comparisons use that same projection, while verified original artifact values remain only in the immutable dispatch boundary so generic providers receive the original input. Saved revisions cannot be overridden. Completed project/tool turns renew their bounded suffix only after checking saved response linkage, next user, policy and durable run ownership; llama.cpp fallback requires the immediately preceding matching failed stream. Earlier call reconstruction is unchanged. Existing artifact batch-read limits remain intact.
+
+Modified prepared request, agent bridge, provenance, runtime, final-value and trace-service paths; added end-to-end workspace/SQLite/gateway tests, raw generic-provider input tests and negative witness/override controls. Corrected two pre-existing test fixtures after reproducing their failures against HEAD: a missing assistant owner and stale expectations for the credential-filtered keyless flag/overlay. Updated the user guide and testing lesson. ADR required: yes; amended backlog/decisions/069-console-project-instruction-local-state-and-preflight.md and backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md for the user-approved trace fidelity and bounded completed-project transition. No schema, dependency, permission or licence change.
+
+Verification: 403 tests passed across the 11 affected Chat modules, plus 7 focused project/trace/provenance bridge tests (410 total). Includes both instruction filenames, Capture On/Off, PII On/Off, streaming/complete/fallback, consecutive same/changed/disabled context, cold factories, tool calls, immutable prior reconstruction and invalid owner/lineage/raw-override controls. The new cases reproduced the failures before fixes. All six scripts/preflight.sh checks passed. New test modules pass Ruff; changed Python ranges pass formatting and git diff --check. Baseline comparison reports zero new Ruff diagnostics (107 existing); pytest reports one existing requests dependency warning. Full repository suite was not run.
+
+Two independent reviews verified the completed-turn proof and raw-provider preservation, including the final redundant-read removal; no actionable findings remain. This fixes the reproduced project-instruction path. The external reporter has not confirmed that setting, so this does not establish that every reported flicker has the same trigger.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -2534,6 +2534,8 @@ def _activation_event(
 def _agent_artifact_source(message: Mapping[str, Any]) -> TraceProvenanceSource:
     """Classify one agent-owned provider row without retaining its value."""
 
+    if message.get(EPHEMERAL_ORIGIN_KEY) == "project_instructions":
+        return TraceProvenanceSource.PROJECT_INSTRUCTION
     role = message.get("role")
     content = str(message.get("content") or "")
     if role == "system":
@@ -2575,6 +2577,7 @@ def _agent_can_reuse_descriptor(
         }
     return source in {
         TraceProvenanceSource.ACTIVE_REQUEST,
+        TraceProvenanceSource.PROJECT_INSTRUCTION,
         TraceProvenanceSource.PREFILL,
         TraceProvenanceSource.TOOL_CALL,
         TraceProvenanceSource.TOOL_RESULT,

--- a/tldw_chatbook/Chat/console_prepared_request.py
+++ b/tldw_chatbook/Chat/console_prepared_request.py
@@ -15,38 +15,38 @@ from dataclasses import dataclass, field, replace
 from types import MappingProxyType
 from typing import Any, Literal
 
+from tldw_chatbook.Agents.agent_models import FENCE_TOOL_RESULT_PREFIX
+from tldw_chatbook.Agents.agent_runtime import split_visible_text_and_tool_call
+from tldw_chatbook.Chat.attachment_core import image_url_part
 from tldw_chatbook.Chat.console_history_budget import (
     DEFAULT_PER_IMAGE_TOKENS,
     DEFAULT_RESPONSE_RESERVATION,
     count_console_messages_tokens,
     count_provider_continuation_tokens,
 )
-from tldw_chatbook.Chat.provider_continuation import ContinuationOwnerGroup
+from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.console_thinking_history import (
     EffectiveThinkingHistoryPolicy,
     ThinkingOwnerGroup,
     serialize_start_anchored_thinking,
 )
-from tldw_chatbook.Chat.thinking_blocks import ThinkingHistoryPolicy
-from tldw_chatbook.Chat.attachment_core import image_url_part
+from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy
 from tldw_chatbook.Chat.console_trace_provenance import (
-    ConsoleTraceCaptureMode,
     ConsoleRequestProvenance,
+    ConsoleTraceCaptureMode,
     ConsoleUnitProvenance,
     DerivedTraceProvenance,
+    ProviderArtifactTraceProvenance,
     ProviderRequestProvenance,
     SavedRevisionTraceProvenance,
     TraceProvenance,
     TraceProvenanceAlignmentError,
-    TraceTransformKind,
-    ProviderArtifactTraceProvenance,
     TraceProvenanceSource,
+    TraceTransformKind,
     frozen_policy_from_provenance,
 )
-from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy
-from tldw_chatbook.Agents.agent_models import FENCE_TOOL_RESULT_PREFIX
-from tldw_chatbook.Agents.agent_runtime import split_visible_text_and_tool_call
-
+from tldw_chatbook.Chat.provider_continuation import ContinuationOwnerGroup
+from tldw_chatbook.Chat.thinking_blocks import ThinkingHistoryPolicy
 
 MINIMUM_SAFETY_MARGIN_TOKENS = 512
 MEMORY_OPEN_TAG = "<chatbook_conversation_memory>"
@@ -139,6 +139,15 @@ def _freeze_messages(
 def _is_fenced_tool_result(row: Mapping[str, Any]) -> bool:
     return row.get("role") == "user" and str(row.get("content") or "").startswith(
         FENCE_TOOL_RESULT_PREFIX
+    )
+
+
+def _starts_user_turn(row: Mapping[str, Any]) -> bool:
+    """Keep automatic project context in the turn that requested it."""
+    return (
+        row.get("role") == "user"
+        and not _is_fenced_tool_result(row)
+        and row.get(EPHEMERAL_ORIGIN_KEY) != "project_instructions"
     )
 
 
@@ -880,11 +889,7 @@ def build_console_request(
     if not history:
         raise ValueError("A Console provider request requires an active request.")
 
-    starts = [
-        index
-        for index, row in enumerate(history)
-        if row.get("role") == "user" and not _is_fenced_tool_result(row)
-    ]
+    starts = [index for index, row in enumerate(history) if _starts_user_turn(row)]
     active_start = starts[-1] if starts else 0
     compactable_rows = history[:active_start]
     active = history[active_start:]
@@ -915,7 +920,7 @@ def build_console_request(
     current_descriptors: list[TraceProvenance] = []
     for index, row in enumerate(compactable_rows):
         descriptor = compactable_descriptors[index] if capture_on else None
-        if row.get("role") == "user" and not _is_fenced_tool_result(row) and current:
+        if _starts_user_turn(row) and current:
             units.append(
                 ConsoleConversationUnit(
                     tuple(current),

--- a/tldw_chatbook/Chat/console_trace_final_values.py
+++ b/tldw_chatbook/Chat/console_trace_final_values.py
@@ -26,7 +26,11 @@ from tldw_chatbook.Chat.console_trace_redaction import (
     CredentialSanitizationResult,
     CredentialSanitizer,
 )
-from tldw_chatbook.Chat.console_trace_models import SemanticRevisionRef, new_opaque_id
+from tldw_chatbook.Chat.console_trace_models import (
+    MAX_SURFACE_REPLACEMENT_SPAN,
+    SemanticRevisionRef,
+    new_opaque_id,
+)
 from tldw_chatbook.Chat.provider_continuation import (
     ProviderContinuationCheckpoint,
     dump_provider_continuation_json,
@@ -189,6 +193,9 @@ class CompletedToolTurnWitness:
     terminal_call_id: str
     assistant_revision_id: str
     user_revision_id: str
+    # None preserves the tool-only transition. Zero explicitly renews a
+    # project turn whose next request no longer contains project context.
+    project_context_count: int | None = field(default=None, kw_only=True)
 
     def __post_init__(self) -> None:
         for identity in (
@@ -198,6 +205,32 @@ class CompletedToolTurnWitness:
             self.user_revision_id,
         ):
             SemanticRevisionRef(identity)
+        if self.project_context_count is not None and (
+            type(self.project_context_count) is not int
+            or not 0 <= self.project_context_count <= MAX_SURFACE_REPLACEMENT_SPAN
+        ):
+            raise ValueError("completed_project_context_count")
+
+    @property
+    def descriptor_count(self) -> int:
+        """Number of saved response/user and current project-context rows."""
+        return 2 + (self.project_context_count or 0)
+
+    def matches_descriptors(self, descriptors: tuple[TraceProvenance, ...]) -> bool:
+        """Require the exact saved pair followed only by declared context."""
+        return (
+            len(descriptors) == self.descriptor_count
+            and descriptors[:2]
+            == (
+                SavedRevisionTraceProvenance(self.assistant_revision_id),
+                SavedRevisionTraceProvenance(self.user_revision_id),
+            )
+            and all(
+                type(item) is ProviderArtifactTraceProvenance
+                and item.source is TraceProvenanceSource.PROJECT_INSTRUCTION
+                for item in descriptors[2:]
+            )
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -237,11 +270,7 @@ class SurfaceDeltaAdmission:
                 or self.replacement_range is None
                 or self.replacement_range.component_name != "messages_payload"
                 or self.route_identity not in {"agent_first", "fresh"}
-                or self.descriptors
-                != (
-                    SavedRevisionTraceProvenance(witness.assistant_revision_id),
-                    SavedRevisionTraceProvenance(witness.user_revision_id),
-                )
+                or not witness.matches_descriptors(self.descriptors)
             ):
                 raise ValueError("surface_delta_shape")
         elif self.replacement_range is not None and len(self.descriptors) != 1:
@@ -277,7 +306,7 @@ class VerifiedSurfaceDelta:
             if (
                 type(witness) is not CompletedToolTurnWitness
                 or self.replacement is None
-                or len(self.items) != 1
+                or len(self.items) != witness.descriptor_count - 1
                 or self.route_identity not in {"agent_first", "fresh"}
                 or self.replacement.item.component_name != "messages_payload"
                 or self.items[0].component_name != "messages_payload"
@@ -286,6 +315,15 @@ class VerifiedSurfaceDelta:
                 != SavedRevisionTraceProvenance(witness.assistant_revision_id)
                 or self.items[0].provenance
                 != SavedRevisionTraceProvenance(witness.user_revision_id)
+                or any(
+                    item.component_name != "messages_payload"
+                    or item.ordinal != self.replacement.item.ordinal + offset
+                    for offset, item in enumerate(self.items, 1)
+                )
+                or not witness.matches_descriptors(
+                    (self.replacement.item.provenance,)
+                    + tuple(item.provenance for item in self.items)
+                )
             ):
                 raise ValueError("surface_delta_shape")
         elif self.replacement is not None and self.items:
@@ -408,7 +446,12 @@ def build_verified_surface_delta(
         if replacement_range is not None:
             ordinal = replacement_range.current_ordinal
             if (
-                delta_count != (2 if admission.completed_tool_turn is not None else 1)
+                delta_count
+                != (
+                    admission.completed_tool_turn.descriptor_count
+                    if admission.completed_tool_turn is not None
+                    else 1
+                )
                 or ordinal < 0
                 or ordinal >= len(full_messages) + len(full_continuations)
             ):
@@ -457,7 +500,11 @@ def build_verified_surface_delta(
             )
     replacement: VerifiedSurfaceReplacement | None = None
     if admission.replacement_range is not None:
-        if len(items) != (2 if admission.completed_tool_turn is not None else 1):
+        if len(items) != (
+            admission.completed_tool_turn.descriptor_count
+            if admission.completed_tool_turn is not None
+            else 1
+        ):
             raise ValueError("surface_delta_shape")
         replacement_range = admission.replacement_range
         if items[0].component_name != replacement_range.component_name or (

--- a/tldw_chatbook/Chat/console_trace_final_values.py
+++ b/tldw_chatbook/Chat/console_trace_final_values.py
@@ -213,11 +213,26 @@ class CompletedToolTurnWitness:
 
     @property
     def descriptor_count(self) -> int:
-        """Number of saved response/user and current project-context rows."""
+        """Count the saved response/user pair and declared project context.
+
+        Returns:
+            Two saved revisions plus the number of current project-context
+            rows. A tool-only witness has no additional context rows.
+        """
         return 2 + (self.project_context_count or 0)
 
     def matches_descriptors(self, descriptors: tuple[TraceProvenance, ...]) -> bool:
-        """Require the exact saved pair followed only by declared context."""
+        """Check the declared provenance shape without granting transition rights.
+
+        Args:
+            descriptors: Ordered replacement provenance to compare with this
+                witness's saved assistant/user pair and project-context count.
+
+        Returns:
+            True when the exact saved pair is followed only by the declared
+            number of project-instruction artifacts; False otherwise. Durable
+            ownership, policy and value checks are performed by the service.
+        """
         return (
             len(descriptors) == self.descriptor_count
             and descriptors[:2]

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -919,6 +919,7 @@ class ConsoleRequestProvenance:
                 artifact_sources=frozenset(
                     {
                         TraceProvenanceSource.ACTIVE_REQUEST,
+                        TraceProvenanceSource.PROJECT_INSTRUCTION,
                         TraceProvenanceSource.PREFILL,
                         TraceProvenanceSource.TOOL_CALL,
                         TraceProvenanceSource.TOOL_RESULT,
@@ -955,6 +956,7 @@ class ConsoleRequestProvenance:
             artifact_sources=frozenset(
                 {
                     TraceProvenanceSource.ACTIVE_REQUEST,
+                    TraceProvenanceSource.PROJECT_INSTRUCTION,
                     TraceProvenanceSource.PREFILL,
                     TraceProvenanceSource.TOOL_CALL,
                     TraceProvenanceSource.TOOL_RESULT,

--- a/tldw_chatbook/Chat/console_trace_runtime.py
+++ b/tldw_chatbook/Chat/console_trace_runtime.py
@@ -9,15 +9,18 @@ from dataclasses import replace
 from datetime import datetime, timezone
 
 from tldw_chatbook.Chat.console_prepared_request import PreparedProviderRequest
+from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.console_trace_final_values import CompletedToolTurnWitness
 from tldw_chatbook.Chat.console_trace_models import TraceCallState, new_opaque_id
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
     DerivedTraceProvenance,
+    ProviderArtifactTraceProvenance,
     ProviderRequestProvenance,
     RequestRouteTraceProvenance,
     SavedRevisionTraceProvenance,
     TraceProvenance,
+    TraceProvenanceSource,
     frozen_policy_from_provenance,
     request_route_provenance,
 )
@@ -213,7 +216,7 @@ class ConsoleTraceBoundaryFactory:
 
         Args:
             request: Prepared request carrying normalized trace provenance.
-            _resolution: Reserved provider resolution argument.
+            _resolution: Provider resolution supplying transient known credentials.
             route: Dispatch route, when the caller has resolved one.
 
         Returns:
@@ -265,17 +268,53 @@ class ConsoleTraceBoundaryFactory:
         )
         if not message_revision_ids:
             raise ValueError("trace_owner_unavailable")
-        active_descriptor_index = -1
+        active_descriptor_index = len(provenance.messages_payload) - 1
+        # A startup rider is provider-only context appended to the current
+        # user turn. Require both the app's row marker and its typed provenance;
+        # never search backwards past an ordinary unsaved user message.
+        while active_descriptor_index >= 0:
+            descriptor = provenance.messages_payload[active_descriptor_index]
+            message = request.messages_payload[active_descriptor_index]
+            tagged_context = message.get(EPHEMERAL_ORIGIN_KEY) == "project_instructions"
+            context_artifact = (
+                type(descriptor) is ProviderArtifactTraceProvenance
+                and descriptor.source is TraceProvenanceSource.PROJECT_INSTRUCTION
+            )
+            if not tagged_context and not context_artifact:
+                break
+            if not (
+                tagged_context and context_artifact and message.get("role") == "user"
+            ):
+                raise ValueError("trace_turn_unavailable")
+            active_descriptor_index -= 1
+        if active_descriptor_index < 0:
+            raise ValueError("trace_turn_unavailable")
+        skipped_project_context = (
+            active_descriptor_index < len(provenance.messages_payload) - 1
+        )
         if route_record.route is ConsoleRequestRoute.DIRECT_PREFILL:
             if (
-                len(provenance.messages_payload) < 2
-                or not request.messages_payload
-                or request.messages_payload[-1].get("role") != "assistant"
+                active_descriptor_index < 1
+                or request.messages_payload[active_descriptor_index].get("role")
+                != "assistant"
             ):
                 raise ValueError("trace_prefill_unavailable")
             # The final provider row is an unsaved response prefill. The
             # preceding active user revision still owns the durable turn.
-            active_descriptor_index = -2
+            active_descriptor_index -= 1
+        if (
+            skipped_project_context
+            and route_record.route is not ConsoleRequestRoute.TOOL_LOOP
+        ):
+            active_start = len(request.messages_payload) - len(
+                request.semantic.active_request
+            )
+            if (
+                active_descriptor_index < active_start
+                or request.messages_payload[active_descriptor_index].get("role")
+                != "user"
+            ):
+                raise ValueError("trace_turn_unavailable")
         active_revision_ids = tuple(
             _saved_revision_ids(provenance.messages_payload[active_descriptor_index])
         )
@@ -422,10 +461,12 @@ class ConsoleTraceBoundaryFactory:
                 if (
                     route_record.route
                     in {ConsoleRequestRoute.AGENT_FIRST, ConsoleRequestRoute.FRESH}
-                    and len(provenance.messages_payload) >= 2
+                    and active_descriptor_index >= 1
                     and all(
                         type(item) is SavedRevisionTraceProvenance
-                        for item in provenance.messages_payload[-2:]
+                        for item in provenance.messages_payload[
+                            active_descriptor_index - 1 : active_descriptor_index + 1
+                        ]
                     )
                 ):
                     latest = self.repository.get_latest_call_boundary(
@@ -445,8 +486,22 @@ class ConsoleTraceBoundaryFactory:
                         completed_tool_turn = CompletedToolTurnWitness(
                             origin.call_id,
                             terminal.call_id,
-                            provenance.messages_payload[-2].revision_id,
+                            provenance.messages_payload[
+                                active_descriptor_index - 1
+                            ].revision_id,
                             current_revision_id,
+                            project_context_count=(
+                                len(provenance.messages_payload)
+                                - active_descriptor_index
+                                - 1
+                                if skipped_project_context
+                                or self.service.has_completed_project_context(
+                                    cursor,
+                                    segment_id=owner.root_segment_id,
+                                    terminal_surface_id=terminal.surface_node_id,
+                                )
+                                else None
+                            ),
                         )
                 admission, surface_boundary = (
                     self.service.prepare_current_surface_delta(
@@ -460,6 +515,9 @@ class ConsoleTraceBoundaryFactory:
                         completed_tool_turn=completed_tool_turn,
                         current_turn_id=turn_id,
                         current_policy_id=policy.policy_id,
+                        known_credentials=(
+                            getattr(_resolution, "api_key", None) or "",
+                        ),
                     )
                 )
                 reserved = self.repository.reserve_call(

--- a/tldw_chatbook/Chat/console_trace_runtime.py
+++ b/tldw_chatbook/Chat/console_trace_runtime.py
@@ -181,15 +181,20 @@ class ConsoleTraceBoundaryFactory:
                     self.service._retire_preparation(boundary.admission)
                     admission, surface = self.service.prepare_current_surface_delta(
                         cursor,
-                        owner_id=reserved.owner_id, segment_id=reserved.segment_id,
+                        owner_id=reserved.owner_id,
+                        segment_id=reserved.segment_id,
                         route_identity=boundary.admission.route_identity,
-                        preparation_identity=new_opaque_id(), provenance=request.provenance,
-                        values=tuple(request.messages_payload) + tuple(
+                        preparation_identity=new_opaque_id(),
+                        provenance=request.provenance,
+                        values=tuple(request.messages_payload)
+                        + tuple(
                             group.checkpoint for group in request.continuation_groups
                         ),
                         completed_tool_turn=boundary.admission.completed_tool_turn,
-                        current_turn_id=reserved.turn_id, current_policy_id=reserved.policy_id,
+                        current_turn_id=reserved.turn_id,
+                        current_policy_id=reserved.policy_id,
                         reserved_call=reserved,
+                        known_credentials=(getattr(resolution, "api_key", None) or "",),
                     )
                 recovered = ConsoleTraceCallBoundary(
                     service=self.service, database=self.database, identity=boundary.identity,

--- a/tldw_chatbook/Chat/console_trace_service.py
+++ b/tldw_chatbook/Chat/console_trace_service.py
@@ -60,6 +60,7 @@ from tldw_chatbook.Chat.console_trace_provenance import (
     _project_verified_provider_request_provenance,
 )
 from tldw_chatbook.Chat.console_trace_redaction import (
+    CredentialSanitizer,
     PIIRedactionSpan,
 )
 from tldw_chatbook.Chat.console_trace_repository import (
@@ -1095,6 +1096,7 @@ class _ProjectedProviderValues(Sequence[object]):
         "_owner_id",
         "_domain",
         "_cache",
+        "_retained_artifact_values",
     )
 
     def __init__(
@@ -1107,6 +1109,7 @@ class _ProjectedProviderValues(Sequence[object]):
         descriptor_root: _DescriptorRoot,
         owner_id: str,
         domain: str,
+        retained_artifact_values: Mapping[int, object],
     ) -> None:
         self._service = service
         self._cursor = cursor
@@ -1117,6 +1120,7 @@ class _ProjectedProviderValues(Sequence[object]):
         self._owner_id = owner_id
         self._domain = domain
         self._cache: tuple[object, ...] | None = None
+        self._retained_artifact_values = retained_artifact_values
 
     def __repr__(self) -> str:
         return f"<{type(self).__name__}>"
@@ -1157,13 +1161,19 @@ class _ProjectedProviderValues(Sequence[object]):
         )
         resolved = self._service._resolve_reference_values(
             self._cursor,
-            tuple(key for _, key, _ in selected if key is not None),
+            tuple(
+                key
+                for sequence, key, _ in selected
+                if key is not None and sequence not in self._retained_artifact_values
+            ),
             owner_id=self._owner_id,
         )
         values: list[object] = []
-        for _, key, value in selected:
+        for sequence, key, value in selected:
             if key is None:
                 values.append(value)
+            elif sequence in self._retained_artifact_values:
+                values.append(self._retained_artifact_values[sequence])
             else:
                 values.append(resolved[key])
         self._cache = tuple(values)
@@ -2281,6 +2291,7 @@ class ConsoleTraceService:
         current_turn_id: str | None = None,
         current_policy_id: str | None = None,
         reserved_call: TraceCallRecord | None = None,
+        known_credentials: tuple[str, ...] = (),
     ) -> tuple[SurfaceDeltaAdmission, object]:
         """Plan an append, no-op, or one-item bounded surface replacement.
 
@@ -2337,9 +2348,11 @@ class ConsoleTraceService:
             owner_id=owner_id,
         )
 
+        retained_artifact_values: dict[int, object] = {}
+
         def matches(active_index: int, incoming_index: int) -> bool:
             key = active[active_index][2]
-            return _surface_reference_domain(key) == domains[
+            matched = _surface_reference_domain(key) == domains[
                 incoming_index
             ] and self._durable_reference_matches(
                 cursor,
@@ -2347,7 +2360,13 @@ class ConsoleTraceService:
                 values[incoming_index],
                 key,
                 durable_values,
+                known_credentials=known_credentials,
             )
+            if matched and key[1] == "artifact":
+                retained_artifact_values[active[active_index][1]] = values[
+                    incoming_index
+                ]
+            return matched
 
         prefix = 0
         while prefix < min(len(active), len(descriptors)) and matches(prefix, prefix):
@@ -2359,20 +2378,31 @@ class ConsoleTraceService:
         admitted_to = len(descriptors)
         if prefix < len(active):
             suffix = 0
+            project_transition = (
+                completed_tool_turn is not None
+                and completed_tool_turn.project_context_count is not None
+            )
             while (
                 suffix < len(active) - prefix
                 and suffix < len(descriptors) - prefix
+                # Project context is delivered anew for this turn, even when
+                # its bytes equal the previous turn's trailing context.
+                and (
+                    not project_transition
+                    or domains[len(descriptors) - 1 - suffix]
+                    == "provider_continuations"
+                )
                 and matches(len(active) - 1 - suffix, len(descriptors) - 1 - suffix)
             ):
                 suffix += 1
             incoming_changed = len(descriptors) - prefix - suffix
             active_changed = len(active) - prefix - suffix
             compound = (
-                incoming_changed == 2
-                and completed_tool_turn is not None
+                completed_tool_turn is not None
+                and incoming_changed == completed_tool_turn.descriptor_count
                 and route_identity in {"agent_first", "fresh"}
-                and domains[prefix : prefix + 2]
-                == ("messages_payload", "messages_payload")
+                and domains[prefix : prefix + incoming_changed]
+                == ("messages_payload",) * incoming_changed
             )
             if incoming_changed == 1 and active_changed == 0:
                 # A later turn adds a message before an unchanged provider
@@ -2421,7 +2451,9 @@ class ConsoleTraceService:
                         domain == domains[prefix] for domain in domains[:prefix]
                     ),
                 )
-                admitted_to = prefix + (2 if compound else 1)
+                admitted_to = prefix + (
+                    completed_tool_turn.descriptor_count if compound else 1
+                )
 
         if compound:
             assert replacement_range is not None and completed_tool_turn is not None
@@ -2445,7 +2477,9 @@ class ConsoleTraceService:
             expected_route=route_identity,
         )
         bootstrap = checkpoint is None and predecessor is not None
-        if compound and bootstrap:
+        if compound and (
+            bootstrap or completed_tool_turn.project_context_count is not None
+        ):
             assert tail is not None and current_policy_id is not None
             assert completed_tool_turn is not None
             terminal = self.repository.get_call(
@@ -2459,7 +2493,15 @@ class ConsoleTraceService:
                 tail=tail,
                 projection=projection,
                 route=route_identity,
-                policy_id=terminal.policy_id,
+                # Project renewal appends a provider artifact under the new
+                # frozen policy. The proof above established equivalent
+                # filtering; rebind retained descriptors to that same policy
+                # instead of mixing two otherwise-equivalent policy IDs.
+                policy_id=(
+                    current_policy_id
+                    if completed_tool_turn.project_context_count is not None
+                    else terminal.policy_id
+                ),
             )
             bootstrap = False
         admitted = descriptors[admitted_from:admitted_to]
@@ -2517,6 +2559,8 @@ class ConsoleTraceService:
             admission=admission,
             values=delta_values,
             reserved_call=reserved_call,
+            known_credentials=known_credentials,
+            retained_artifact_values=retained_artifact_values,
         )
         return admission, boundary
 
@@ -2531,6 +2575,31 @@ class ConsoleTraceService:
                 self._pending_child_uses.pop(key, None)
         self._surface_ref_cache.pop(admission.segment_id, None)
         self._prune_unreferenced_parents()
+
+    def has_completed_project_context(
+        self,
+        cursor: sqlite3.Cursor,
+        *,
+        segment_id: str,
+        terminal_surface_id: str | None,
+    ) -> bool:
+        """Find a candidate project suffix; this grants no transition authority."""
+        if terminal_surface_id is None:
+            return False
+        tail = self.repository.get_surface_node(cursor, terminal_surface_id)
+        if tail is None:
+            return False
+        entries = self._surface_projection(cursor, segment_id, tail).entries
+        for _sequence, key in reversed(entries[-MAX_SURFACE_REPLACEMENT_SPAN:]):
+            if key[1] != "artifact" or key[0] not in {
+                "project_instruction",
+                "tool_call",
+                "tool_result",
+            }:
+                break
+            if key[0] == "project_instruction":
+                return True
+        return False
 
     def _validate_completed_tool_turn(
         self,
@@ -2547,6 +2616,7 @@ class ConsoleTraceService:
         reserved_call: TraceCallRecord | None = None,
     ) -> None:
         """Recheck bounded run evidence; a response link alone grants nothing."""
+        project_transition = witness.project_context_count is not None
         self._validate_owner(cursor, owner_id=owner_id, segment_id=segment_id)
         owner = self.repository.get_owner(cursor, owner_id)
         origin = self.repository.get_call(cursor, witness.origin_call_id)
@@ -2583,17 +2653,85 @@ class ConsoleTraceService:
             latest_id = None if previous is None else previous[0]
         else:
             latest_id = None if latest is None else latest.call_id
+        chain_terminal = terminal
+        fallback = (
+            project_transition
+            and terminal is not None
+            and terminal.route_identity == "llama_fallback"
+        )
+        if fallback:
+            # The non-streaming retry owns a distinct run ID. Its exact
+            # immediately preceding failed stream owns the unchanged surface;
+            # neither an arbitrary older call nor the response link proves it.
+            fallback_events = cursor.execute(
+                """SELECT sequence FROM console_trace_events
+                   WHERE segment_id = ? AND event_type = 'call_boundary'
+                     AND call_id = ? ORDER BY sequence LIMIT 2""",
+                (segment_id, terminal.call_id),
+            ).fetchall()
+            previous_event = (
+                cursor.execute(
+                    """SELECT call_id FROM console_trace_events
+                       WHERE segment_id = ? AND event_type = 'call_boundary'
+                         AND sequence < ? ORDER BY sequence DESC LIMIT 1""",
+                    (segment_id, fallback_events[0][0]),
+                ).fetchone()
+                if len(fallback_events) == 1
+                else None
+            )
+            chain_terminal = (
+                self.repository.get_call(cursor, previous_event[0])
+                if previous_event is not None
+                else None
+            )
+            if (
+                origin != terminal
+                or terminal.call_sequence != 0
+                or chain_terminal is None
+                or chain_terminal.state is not TraceCallState.ERROR
+                or chain_terminal.route_identity
+                not in {"agent_first", "fresh", "tool_loop"}
+                or (
+                    chain_terminal.owner_id,
+                    chain_terminal.segment_id,
+                    chain_terminal.turn_id,
+                    chain_terminal.policy_id,
+                    chain_terminal.surface_node_id,
+                    chain_terminal.provider_name,
+                    chain_terminal.model_name,
+                )
+                != (
+                    terminal.owner_id,
+                    terminal.segment_id,
+                    terminal.turn_id,
+                    terminal.policy_id,
+                    terminal.surface_node_id,
+                    terminal.provider_name,
+                    terminal.model_name,
+                )
+            ):
+                raise ValueError("completed_project_fallback_lineage")
+            origin = self.repository.get_run_origin(cursor, chain_terminal.run_id)
         if (
             owner is None
             or origin is None
             or terminal is None
+            or chain_terminal is None
             or tail is None
             or latest_id != terminal.call_id
             or terminal.state is not TraceCallState.COMPLETE
-            or terminal.route_identity != "tool_loop"
-            or origin.route_identity != "agent_first"
+            or (
+                chain_terminal.route_identity != "tool_loop"
+                and not (
+                    project_transition
+                    and chain_terminal == origin
+                    and chain_terminal.route_identity in {"agent_first", "fresh"}
+                )
+            )
+            or origin.route_identity
+            not in ({"agent_first", "fresh"} if project_transition else {"agent_first"})
             or origin.call_sequence != 0
-            or self.repository.get_run_origin(cursor, terminal.run_id) != origin
+            or self.repository.get_run_origin(cursor, chain_terminal.run_id) != origin
             or (
                 origin.owner_id,
                 origin.segment_id,
@@ -2602,11 +2740,11 @@ class ConsoleTraceService:
                 origin.policy_id,
             )
             != (
-                terminal.owner_id,
-                terminal.segment_id,
-                terminal.turn_id,
-                terminal.run_id,
-                terminal.policy_id,
+                chain_terminal.owner_id,
+                chain_terminal.segment_id,
+                chain_terminal.turn_id,
+                chain_terminal.run_id,
+                chain_terminal.policy_id,
             )
             or (terminal.owner_id, terminal.segment_id) != (owner_id, segment_id)
             or terminal.turn_id == current_turn_id
@@ -2618,15 +2756,14 @@ class ConsoleTraceService:
             """SELECT call_id, sequence FROM console_trace_events
                 WHERE segment_id = ? AND event_type = 'call_boundary'
                   AND call_id IN (?, ?) ORDER BY sequence LIMIT 3""",
-            (segment_id, origin.call_id, terminal.call_id),
+            (segment_id, origin.call_id, chain_terminal.call_id),
         ).fetchall()
-        if tuple(row[0] for row in boundary_events) != (
-            origin.call_id,
-            terminal.call_id,
+        if tuple(row[0] for row in boundary_events) != tuple(
+            dict.fromkeys((origin.call_id, chain_terminal.call_id))
         ):
             raise ValueError("completed_tool_turn_lineage")
         origin_event_sequence = boundary_events[0][1]
-        terminal_event_sequence = boundary_events[1][1]
+        terminal_event_sequence = boundary_events[-1][1]
         previous_policy = self.repository.get_policy(cursor, terminal.policy_id)
         current_policy = (
             None
@@ -2655,7 +2792,11 @@ class ConsoleTraceService:
         )
         if (
             origin_head is None
-            or plan.start_sequence != origin_head.sequence + 1
+            or (
+                plan.start_sequence > origin_head.sequence + 1
+                if project_transition
+                else plan.start_sequence != origin_head.sequence + 1
+            )
             or plan.end_sequence != tail.sequence
             or not 1
             <= plan.end_sequence - plan.start_sequence + 1
@@ -2679,15 +2820,11 @@ class ConsoleTraceService:
             or assistant.source_conversation_id != owner.conversation_id
             or user.source_conversation_id != owner.conversation_id
             or user.source_message_id != current_turn_id
-            or descriptors
-            != (
-                SavedRevisionTraceProvenance(witness.assistant_revision_id),
-                SavedRevisionTraceProvenance(witness.user_revision_id),
-            )
-            or len(values) != 2
+            or not witness.matches_descriptors(descriptors)
+            or len(values) != witness.descriptor_count
         ):
             raise ValueError("completed_tool_turn_revision")
-        for descriptor, value in zip(descriptors, values, strict=True):
+        for descriptor, value in zip(descriptors[:2], values[:2], strict=True):
             expected = self._resolve_reference_value(
                 cursor,
                 ("message", "revision", descriptor.revision_id),
@@ -2695,17 +2832,59 @@ class ConsoleTraceService:
             )
             if _artifact_bytes(expected) != _artifact_bytes(value):
                 raise ValueError("completed_tool_turn_value")
+        if any(
+            not isinstance(value, Mapping)
+            or value.get("role") != "user"
+            or value.get("_chatbook_ephemeral_origin") != "project_instructions"
+            or (
+                descriptor.policy.credential_filter_version,
+                descriptor.policy.pii_redaction_enabled,
+                descriptor.policy.pii_ruleset_revision_id,
+            )
+            != (
+                current_policy.credential_filter_version,
+                current_policy.pii_redaction_enabled,
+                current_policy.pii_ruleset_revision_id,
+            )
+            for descriptor, value in zip(descriptors[2:], values[2:], strict=True)
+        ):
+            raise ValueError("completed_project_context_value")
         projection = self._surface_projection(cursor, segment_id, tail)
         suffix = tuple(
             (sequence, key)
             for sequence, key in projection.entries
-            if sequence > origin_head.sequence
+            if sequence >= plan.start_sequence
         )
+        if project_transition:
+            prefix = tuple(
+                key
+                for sequence, key in projection.entries
+                if sequence < plan.start_sequence
+            )
+            prior_user = (
+                self.repository.get_semantic_revision(cursor, prefix[-1][2])
+                if prefix and prefix[-1][1] == "revision"
+                else None
+            )
+            if (
+                prior_user is None
+                or prior_user.normalized_role != "user"
+                or prior_user.source_conversation_id != owner.conversation_id
+                or prior_user.source_message_id != terminal.turn_id
+            ):
+                raise ValueError("completed_project_turn_anchor")
         if tuple(sequence for sequence, _ in suffix) != tuple(
             range(plan.start_sequence, plan.end_sequence + 1)
         ) or any(
-            key[0] not in {"tool_call", "tool_result"} or key[1] != "artifact"
-            for _, key in suffix
+            key[0]
+            not in (
+                {"project_instruction", "tool_call", "tool_result"}
+                if project_transition
+                else {"tool_call", "tool_result"}
+            )
+            or key[1] != "artifact"
+            or (sequence <= origin_head.sequence and key[0] != "project_instruction")
+            for sequence, key in suffix
         ):
             raise ValueError("completed_tool_turn_range")
         # Every removed node must have been appended under a durable call from
@@ -2728,16 +2907,20 @@ class ConsoleTraceService:
         if tuple(row[0] for row in rows) != tuple(
             sequence for sequence, _ in suffix
         ) or any(
-            tuple(row[1:7])
+            tuple(row[1:6])
             != (
                 owner_id,
                 segment_id,
                 terminal.turn_id,
-                terminal.run_id,
+                chain_terminal.run_id,
                 terminal.policy_id,
-                "tool_loop",
             )
-            or not 1 <= row[7] <= terminal.call_sequence
+            or (
+                (row[6], row[7]) != (origin.route_identity, 0)
+                if project_transition and row[0] <= origin_head.sequence
+                else row[6] != "tool_loop"
+                or not 1 <= row[7] <= chain_terminal.call_sequence
+            )
             for row in rows
         ):
             raise ValueError("completed_tool_turn_lineage")
@@ -2753,7 +2936,7 @@ class ConsoleTraceService:
                 origin_event_sequence,
                 terminal_event_sequence,
                 owner_id,
-                terminal.run_id,
+                chain_terminal.run_id,
                 terminal.turn_id,
                 terminal.policy_id,
             ),
@@ -2836,7 +3019,10 @@ class ConsoleTraceService:
         provenance: ProviderRequestProvenance,
         admitted: tuple[TraceProvenance, ...],
         values: tuple[object, ...],
-    ) -> tuple[object, ProviderRequestProvenance, tuple[object, ...]]:
+        known_credentials: tuple[str, ...] = (),
+    ) -> tuple[
+        object, ProviderRequestProvenance, tuple[object, ...], dict[int, object]
+    ]:
         projection = self._surface_projection(cursor, segment_id, tail)
         message_descriptors = tuple(provenance.messages_payload)
         continuation_descriptors = tuple(provenance.continuations)
@@ -2864,6 +3050,7 @@ class ConsoleTraceService:
         consumed = {"messages_payload": 0, "provider_continuations": 0}
         prefix_descriptors: list[tuple[int, TraceProvenance]] = []
         prefix_domains: list[tuple[int, str]] = []
+        retained_artifact_values: dict[int, object] = {}
         for sequence, key in projection.entries:
             domain = _surface_reference_domain(key)
             descriptors, provider_values = domain_values[domain]
@@ -2874,10 +3061,13 @@ class ConsoleTraceService:
                 provider_values[ordinal],
                 key,
                 durable_values,
+                known_credentials=known_credentials,
             ):
                 raise ValueError("surface_prefix_mismatch")
             prefix_descriptors.append((sequence, descriptors[ordinal]))
             prefix_domains.append((sequence, domain))
+            if key[1] == "artifact":
+                retained_artifact_values[sequence] = provider_values[ordinal]
             consumed[domain] += 1
         message_delta = message_descriptors[consumed["messages_payload"] :]
         continuation_delta = continuation_descriptors[
@@ -2933,7 +3123,12 @@ class ConsoleTraceService:
                 if index >= consumed["messages_payload"]
             ),
         )
-        return capability, delta_provenance, tuple(delta_values)
+        return (
+            capability,
+            delta_provenance,
+            tuple(delta_values),
+            retained_artifact_values,
+        )
 
     def prepare_surface_provenance(
         self,
@@ -2944,6 +3139,8 @@ class ConsoleTraceService:
         admission: object,
         values: tuple[object, ...],
         reserved_call: TraceCallRecord | None = None,
+        known_credentials: tuple[str, ...] = (),
+        retained_artifact_values: Mapping[int, object] | None = None,
     ) -> _PreparedSurfaceBoundary:
         """Derive one full structural projection from an opaque parent and delta.
 
@@ -2954,6 +3151,7 @@ class ConsoleTraceService:
 
         if type(admission) is not SurfaceDeltaAdmission:
             raise TypeError("admission")
+        retained_artifact_values = dict(retained_artifact_values or {})
         initial_parent = capability is None
         if capability is None:
             owner_id = str(getattr(admission, "owner_id", ""))
@@ -2982,15 +3180,19 @@ class ConsoleTraceService:
                     tool_loop=(),
                 )
             else:
-                capability, provenance, values = self._bootstrap_surface_parent(
-                    cursor,
-                    owner_id=owner_id,
-                    segment_id=segment_id,
-                    tail=tail,
-                    provenance=provenance,
-                    admitted=admitted,
-                    values=values,
+                capability, provenance, values, bootstrap_artifact_values = (
+                    self._bootstrap_surface_parent(
+                        cursor,
+                        owner_id=owner_id,
+                        segment_id=segment_id,
+                        tail=tail,
+                        provenance=provenance,
+                        admitted=admitted,
+                        values=values,
+                        known_credentials=known_credentials,
+                    )
                 )
+                retained_artifact_values.update(bootstrap_artifact_values)
             assert capability is not None
         parent = self._parent_capabilities.get(id(capability))
         admitted = tuple(getattr(admission, "descriptors", ()))
@@ -3012,6 +3214,38 @@ class ConsoleTraceService:
             or len(values) != len(admitted)
         ):
             raise ValueError("surface_checkpoint_identity")
+        if retained_artifact_values:
+            # These values live only in this dispatch boundary. Independently
+            # verify every supplied artifact against the durable disclosure
+            # projection; saved revisions never accept raw-value overrides.
+            parent_keys = dict(parent.root.iter_entries())
+            parent_descriptors = dict(parent.descriptors.iter_entries())
+            durable_values = self._resolve_reference_values(
+                cursor,
+                tuple(
+                    parent_keys[sequence]
+                    for sequence in retained_artifact_values
+                    if sequence in parent_keys
+                ),
+                owner_id=parent.owner_id,
+            )
+            for sequence, value in retained_artifact_values.items():
+                key = parent_keys.get(sequence)
+                descriptor = parent_descriptors.get(sequence)
+                if (
+                    key is None
+                    or key[1] != "artifact"
+                    or descriptor is None
+                    or not self._durable_reference_matches(
+                        cursor,
+                        descriptor,
+                        value,
+                        key,
+                        durable_values,
+                        known_credentials=known_credentials,
+                    )
+                ):
+                    raise ValueError("surface_prefix_mismatch")
         replacement_component_ordinal: int | None = None
         if admission.completed_tool_turn is not None:
             if replacement_range is None:
@@ -3030,8 +3264,13 @@ class ConsoleTraceService:
                 descriptors=admitted,
                 values=values,
                 current_turn_id=None if user is None else user.source_message_id,
-                current_policy_id=(reserved_call.policy_id if reserved_call is not None
-                                   else None if terminal is None else terminal.policy_id),
+                current_policy_id=(
+                    reserved_call.policy_id
+                    if reserved_call is not None
+                    else None
+                    if terminal is None
+                    else terminal.policy_id
+                ),
                 reserved_call=reserved_call,
             )
         if replacement_range is not None:
@@ -3125,7 +3364,11 @@ class ConsoleTraceService:
                 ),
             )
         else:
-            if len(admitted) != (2 if admission.completed_tool_turn is not None else 1):
+            if len(admitted) != (
+                admission.completed_tool_turn.descriptor_count
+                if admission.completed_tool_turn is not None
+                else 1
+            ):
                 raise ValueError("surface_delta_shape")
             descriptor_root = _DescriptorRoot(
                 parent.descriptors,
@@ -3231,6 +3474,7 @@ class ConsoleTraceService:
             descriptor_root,
             parent.owner_id,
             "messages_payload",
+            retained_artifact_values,
         )
         continuation_values = _ProjectedProviderValues(
             self,
@@ -3241,6 +3485,7 @@ class ConsoleTraceService:
             descriptor_root,
             parent.owner_id,
             "provider_continuations",
+            retained_artifact_values,
         )
         boundary = _PreparedSurfaceBoundary(
             self,
@@ -4242,24 +4487,36 @@ class ConsoleTraceService:
         value: object,
         durable_key: SurfaceReferenceKey,
         durable_values: Mapping[SurfaceReferenceKey, object],
+        *,
+        known_credentials: tuple[str, ...] = (),
     ) -> bool:
-        if type(descriptor) is ProviderArtifactTraceProvenance:
-            source = cast(ProviderArtifactTraceProvenance, descriptor).source.value
-            return (
-                durable_key[:2] == (source, "artifact")
-                and durable_key in durable_values
-                and _artifact_bytes(value)
-                == _artifact_bytes(durable_values[durable_key])
+        artifact = (
+            descriptor
+            if type(descriptor) is ProviderArtifactTraceProvenance
+            else descriptor.artifact
+            if type(descriptor) is DerivedTraceProvenance
+            else None
+        )
+        if artifact is not None:
+            if (
+                durable_key[:2] != (artifact.source.value, "artifact")
+                or durable_key not in durable_values
+            ):
+                return False
+            # The provider still receives the original value. Compare only in
+            # the same disclosure projection used by the durable artifact;
+            # otherwise unchanged secret-bearing context looks like an edit.
+            sanitized = CredentialSanitizer(
+                known_credentials=known_credentials
+            ).sanitize(value)
+            if not sanitized.available:
+                return False
+            projected = self._pii_projected_value(
+                sanitized.value, policy=artifact.policy
             )
-        if type(descriptor) is DerivedTraceProvenance:
-            derived = cast(DerivedTraceProvenance, descriptor)
-            if derived.artifact is not None:
-                return (
-                    durable_key[:2] == (derived.artifact.source.value, "artifact")
-                    and durable_key in durable_values
-                    and _artifact_bytes(value)
-                    == _artifact_bytes(durable_values[durable_key])
-                )
+            return _artifact_bytes(projected) == _artifact_bytes(
+                durable_values[durable_key]
+            )
         expected = self._reference_key(cursor, descriptor, value)
         if expected != durable_key:
             return False

--- a/tldw_chatbook/Chat/console_trace_service.py
+++ b/tldw_chatbook/Chat/console_trace_service.py
@@ -2310,6 +2310,15 @@ class ConsoleTraceService:
             provenance: Descriptors aligned with the complete provider surface.
             values: Provider values aligned with message and continuation
                 descriptors.
+            completed_tool_turn: Optional witness for a bounded completed
+                project/tool turn replacement; all evidence is revalidated.
+            current_turn_id: Saved user message that owns the incoming call.
+            current_policy_id: Frozen disclosure policy for the incoming call.
+            reserved_call: Existing live reservation when rebuilding an owned
+                retry, or None for an initial preparation.
+            known_credentials: Transient runtime secrets used only to compare
+                original provider artifacts with their filtered durable values.
+                They are never stored in the admission or trace ledger.
 
         Returns:
             The admitted surface delta and its verification boundary.
@@ -2583,7 +2592,19 @@ class ConsoleTraceService:
         segment_id: str,
         terminal_surface_id: str | None,
     ) -> bool:
-        """Find a candidate project suffix; this grants no transition authority."""
+        """Find a candidate project suffix without granting transition authority.
+
+        Args:
+            cursor: Cursor in the caller-owned transaction used for ledger reads.
+            segment_id: Trace segment whose active surface should be inspected.
+            terminal_surface_id: Surface head of the prior terminal call, or
+                None when that call has no recorded surface.
+
+        Returns:
+            True if the bounded active project/tool suffix contains a project
+            artifact; False if no such suffix or surface exists. A true result
+            is only a candidate hint and does not authorize a transition.
+        """
         if terminal_surface_id is None:
             return False
         tail = self.repository.get_surface_node(cursor, terminal_surface_id)
@@ -3144,9 +3165,35 @@ class ConsoleTraceService:
     ) -> _PreparedSurfaceBoundary:
         """Derive one full structural projection from an opaque parent and delta.
 
-        ``provenance`` is deliberately delta-only for the surface fields.  The
-        returned object is the only provenance object that can extend this
-        capability; callers cannot bless an arbitrary full prefix.
+        ``provenance`` is delta-only for a warm parent. Cold reconstruction
+        also verifies the retained prefix. Callers cannot bless an arbitrary
+        full prefix.
+
+        Args:
+            cursor: Cursor in the caller-owned transaction used to verify refs.
+            capability: Opaque parent checkpoint, or None for a new or cold
+                surface whose parent must be reconstructed from the ledger.
+            provenance: Descriptors for the incoming delta, including the
+                retained prefix when cold reconstruction requires it.
+            admission: Preparation-owned surface delta and optional replacement
+                witness to validate against the parent.
+            values: Original provider values aligned with provenance.
+            reserved_call: Existing live reservation for an owned retry, if any.
+            known_credentials: Transient runtime secrets used to compare raw
+                artifacts with their filtered durable projection; never stored.
+            retained_artifact_values: Optional original artifact values keyed
+                by active physical sequence. Each is independently verified;
+                saved revisions cannot be overridden. Values remain local to
+                the immutable dispatch boundary and are not persisted.
+
+        Returns:
+            An owned boundary with verified provenance and original dispatch
+            values that can extend the admitted parent surface.
+
+        Raises:
+            TypeError: If admission is not a SurfaceDeltaAdmission.
+            ValueError: If the parent, values, provenance or replacement witness
+                cannot be verified against the durable ledger.
         """
 
         if type(admission) is not SurfaceDeltaAdmission:


### PR DESCRIPTION
Fresh Console sends with Capture On could fail with `trace_turn_unavailable` when automatic project instructions were appended after the saved user message. The context row was mistaken for the turn owner. Keep project context grouped with its saved user and identify it explicitly in trace provenance.

Capture On retains the instructions the model received under the existing credential and optional PII filters. Verified original values remain available for provider dispatch, so redacted trace content never replaces model input. Consecutive sends renew project/tool context through a bounded, validated completed-turn transition, including cold factories and llama.cpp streaming fallback; earlier captured requests remain unchanged.

Amends ADR-069 and ADR-097 to document project-context retention and the validated transition. No schema or dependency changes.

Validation:
- 410 targeted tests passed: 403 across the affected Chat modules and 7 focused bridge tests. Coverage includes both instruction filenames, capture/PII settings, windowing, consecutive sends, tool calls, fallback, cold factories, unchanged provider input, and rejected invalid ownership/overrides.
- Review follow-up: 141 targeted tests passed, including four new rollback/retry regressions for credential-bearing project context with PII filtering on/off and warm/cold factories. Recovery reuses the original reservation, preserves provider input, and dispatches exactly one resumed request. The 11-case provider-input module also passed after the final assertion update.
- All six preflight checks passed; changed ranges pass formatting and `git diff --check`. No new Ruff diagnostics against the base (107 existing).
- Independent reviews completed with no outstanding findings. Two stale test fixtures were corrected after confirming their failures against the base version.

This fixes a reproduced trigger for the reported capture failure. The reporter has not yet confirmed their project-instruction setting, so it does not establish the cause of every reported flicker.

Task: TASK-31976.1

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console sends with Capture On failing with `trace_turn_unavailable` when automatic project instructions are appended after the saved user message. Project context now stays grouped with its saved user and is explicitly identified in trace provenance, so the saved user remains the turn owner (TASK-31976.1).

**Bug Fixes**
- Capture On keeps the project instructions the model received under existing credential and PII filters; redacted trace values never replace actual provider input.
- Owned trace retries retain the original credential-matching decision as trace metadata only, never as a provider-facing credential field or handler kwarg.
- Consecutive sends renew project/tool context through a bounded, validated completed-turn transition; earlier captured requests stay unchanged.
- Amends ADR-069 and ADR-097 to document project-context retention; no schema or dependency changes.

<sup>Written for commit 0d0c4086406dc7548190812755f58355c4006714. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2505?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

