### PR TITLE
docs(backlog): file critique #7 fix tasks (32041-32046)

### DIFF
--- a/backlog/tasks/task-32041 - Library-media-at-235-wide-arrow-Down-leaks-focus-into-the-reader-and-Escape-will-not-close-it.md
+++ b/backlog/tasks/task-32041 - Library-media-at-235-wide-arrow-Down-leaks-focus-into-the-reader-and-Escape-will-not-close-it.md
@@ -1,0 +1,30 @@
+---
+id: TASK-32041
+title: >-
+  Library media: at 235 wide, arrow-Down leaks focus into the reader and Escape
+  will not close it
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:36'
+labels:
+  - library
+  - media
+  - ux
+  - accessibility
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P1 (lead). At 235x52, the first arrow-Down off a focused Media list row defocuses the list into the reader pane instead of advancing the list cursor; four Escapes then neither close the reader nor move a cursor; a Console round-trip strands Library on a provider 'Get started' card that needs Home->Library to recover. The same gestures work correctly at 100x30, so this is a width-dependent focus-routing bug. Keyboard navigation of the list is the core interaction.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 At 235x52, arrow Down/Up move the Media list cursor (visible focus cue) while the list owns focus, rather than leaking focus to the reader
+- [ ] #2 The Escape ladder returns focus predictably from the reader back to the list at every supported width
+- [ ] #3 A Console -> Library round-trip lands on the Media list, not a Get-started card
+- [ ] #4 Painted pins assert cursor movement at 235x52 (parity with the 100x30 behaviour that already works)
+<!-- AC:END -->

--- a/backlog/tasks/task-32042 - Library-Conversations-select-mode-is-a-degraded-truncated-copy-of-Medias.md
+++ b/backlog/tasks/task-32042 - Library-Conversations-select-mode-is-a-degraded-truncated-copy-of-Medias.md
@@ -1,0 +1,26 @@
+---
+id: TASK-32042
+title: 'Library: Conversations select mode is a degraded, truncated copy of Media''s'
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:36'
+labels:
+  - library
+  - conversations
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P1. Conversations' select-mode toolbar renders 'Selec' (truncated 'Select all'), a bare unlabeled marker, and an awkwardly wrapped '0 selected', and its footer omits the space/s hints Media shows. It is the same feature as Media's clean, labelled select mode but inconsistent and less legible. Share the select-toolbar treatment so the two do not diverge.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Conversations select mode shows full, untruncated action labels at supported widths, matching Media's grammar
+- [ ] #2 The select toolbar is built from the shared treatment rather than a divergent per-canvas copy
+- [ ] #3 Painted pins assert the Conversations select actions are legible (no mid-word truncation) at 235x52 and 100x30
+<!-- AC:END -->

--- a/backlog/tasks/task-32043 - Library-media-the-reader-keeps-painting-an-item-after-it-is-filtered-out-or-deleted.md
+++ b/backlog/tasks/task-32043 - Library-media-the-reader-keeps-painting-an-item-after-it-is-filtered-out-or-deleted.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32043
+title: >-
+  Library media: the reader keeps painting an item after it is filtered out or
+  deleted
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:36'
+labels:
+  - library
+  - media
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P2. After a filter that yields zero results, and after deleting the item currently loaded in the reader, the reader keeps painting the now-absent item's content instead of reflecting that nothing is selected. The reader should track the visible set.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 When the loaded media item leaves the visible set (0-result filter or deletion), the reader clears to its no-selection state (or a 'this item was deleted' note with Undo)
+- [ ] #2 Opening or re-filtering to a present item still shows it normally
+- [ ] #3 A pin drives a 0-result filter and a delete-of-loaded-item and asserts the reader no longer paints the absent item
+<!-- AC:END -->

--- a/backlog/tasks/task-32044 - Library-media-a-regional-indicator-flag-keyword-miscounts-by-two-cells-and-overpaints-the-row-frame.md
+++ b/backlog/tasks/task-32044 - Library-media-a-regional-indicator-flag-keyword-miscounts-by-two-cells-and-overpaints-the-row-frame.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32044
+title: >-
+  Library media: a regional-indicator flag keyword miscounts by two cells and
+  overpaints the row frame
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:36'
+labels:
+  - library
+  - media
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P2 (the visible consequence of task-31955's stated flag-pair ceiling). A keyword containing a regional-indicator flag emoji (e.g. the pair rendered as one flag) is width-miscounted: the row frame drifts +2 cells (border at column 237 vs 235) and the reader header overpaints (e.g. 'NoNo analysis yet.'). task-31955 cut keyword reasons by display cells with rich.cells but documented that regional-indicator pairs are not fully handled; this is that ceiling showing a real frame break.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A keyword reason containing a regional-indicator flag emoji does not drift the row frame width or overpaint neighbouring panes at 235x52 or 100x30
+- [ ] #2 The cut is flag-pair-aware (a UAX #29 segmenter, or the reason refuses to paint a half-flag / cuts before the pair) rather than mis-measuring the pair
+- [ ] #3 A pin paints a flag-keyword reason and asserts the row frame stays aligned
+<!-- AC:END -->

--- a/backlog/tasks/task-32045 - Library-media-a-zero-selection-state-dims-the-bulk-actions-with-no-inline-reason.md
+++ b/backlog/tasks/task-32045 - Library-media-a-zero-selection-state-dims-the-bulk-actions-with-no-inline-reason.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32045
+title: >-
+  Library media: a zero-selection state dims the bulk actions with no inline
+  reason
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:37'
+labels:
+  - library
+  - media
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P2. In select mode with nothing selected, Export/Review/Delete are disabled with the '○' marker but no inline reason, while Analyze explains its block. This violates the surface's own 'explain why unavailable' rule that task-31981 established for the analysis actions.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 With zero items selected, the disabled bulk actions carry a short inline reason (e.g. 'Select items to enable') the way the analysis block already does
+- [ ] #2 Selecting an item clears the reason and enables the actions
+- [ ] #3 A painted pin asserts the reason is present with zero selected and gone once an item is selected
+<!-- AC:END -->

--- a/backlog/tasks/task-32046 - Library-media-the-shortcut-focuses-the-rails-global-search-not-the-Media-filter-it-advertises.md
+++ b/backlog/tasks/task-32046 - Library-media-the-shortcut-focuses-the-rails-global-search-not-the-Media-filter-it-advertises.md
@@ -1,0 +1,29 @@
+---
+id: TASK-32046
+title: >-
+  Library media: the / shortcut focuses the rail's global search, not the Media
+  filter it advertises
+status: To Do
+assignee: []
+created_date: '2026-09-08 14:36'
+labels:
+  - library
+  - media
+  - ux
+  - accessibility
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #7 P1 (lead). On the Media list the footer advertises '/ focus search', but pressing / focuses the rail's global 'Search Library…' field two panes away, not the Media 'Title/keyword…' filter the user is looking at, so a filter query does nothing to the list until the misdirection is noticed. Keyboard-first is the product's core and this misfires the headline gesture; it is worst for keyboard-only users, whose focus silently leaves the pane.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Pressing / while the Media list (or another canvas with its own filter) is active focuses THAT canvas's filter input, not the rail's global search
+- [ ] #2 The footer hint's target matches where focus actually lands
+- [ ] #3 A pin drives / on the Media list and asserts the focused widget is the Media filter input, at 235x52 and 100x30
+<!-- AC:END -->


### PR DESCRIPTION
Files critique #7's six priority findings the user chose to burn down (leading with the two P1 keyboard defects: 32046 `/` mis-target, 32041 235-wide arrow/Escape focus routing). No code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds six backlog task files for critique #7's priority findings, including the two P1 keyboard defects: 32046 (`/` focuses the rail's global search rather than the Media filter it advertises) and 32041 (at 235 wide, arrow-Down leaks focus into the reader and Escape won't close it). The remaining tasks track Conversations select-mode parity, reader painting deleted/filtered items, flag-emoji row-width drift, and disabled bulk actions lacking an inline reason. No code changes.

<sup>Written for commit 55396044883765f0fc9785d67b27bf2b11079398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

