### PR TITLE
Fix Kokoro speech failures and Console trace recovery

### DIFF
--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -845,9 +845,15 @@ OPENAI_API_KEY_fallback = "sk-your-api-key"
 Kokoro streams raw PCM incrementally. Encoded responses (including WAV, MP3 and
 FLAC) collect the utterance before encoding one complete file in either engine.
 This avoids concatenating separate file headers, which can make decoders stop
-after the first chunk. Encoded output therefore waits for synthesis to finish
-and buffers audio proportional to the utterance length; choose PCM for
-incremental playback.
+after the first chunk. Each encoded request is limited to five minutes of
+24 kHz audio (7,200,000 samples). One growable buffer holds the float32 samples;
+encoding reads it without a second full float-array copy. Voice mixing applies
+the same duration limit to each voice and keeps one running mix, so retained
+audio does not grow with the number of voices. Each buffer retains at most
+28.8 MB of sample data; model inference and codec working memory are separate.
+An oversized request stops without publishing a partial audio file. Shorten
+the text or choose PCM for longer speech and incremental playback. Encoded
+output within the budget still waits for synthesis to finish.
 
 **Configuration:**
 ```toml

--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -842,6 +842,13 @@ OPENAI_API_KEY_fallback = "sk-your-api-key"
 - Voice mixing capabilities (planned)
 - No internet connection required
 
+Kokoro streams raw PCM incrementally. Encoded responses (including WAV, MP3 and
+FLAC) collect the utterance before encoding one complete file in either engine.
+This avoids concatenating separate file headers, which can make decoders stop
+after the first chunk. Encoded output therefore waits for synthesis to finish
+and buffers audio proportional to the utterance length; choose PCM for
+incremental playback.
+
 **Configuration:**
 ```toml
 [app_tts]
@@ -1057,9 +1064,37 @@ The S/TT/S tab provides a comprehensive TTS testing environment:
    - **audio.cpp**: Catalog-selected model, complete WAV, and speed `1.0`
    - **Chatterbox**: Exaggeration, CFG weight, temperature, candidates, validation
    - **ElevenLabs**: Stability, similarity boost, style, speaker boost
-   - **Kokoro**: Language selection
+   - **Kokoro**: Language selection, with **Automatic (from voice)** as the
+     default for both ONNX and PyTorch. Automatic omits the request language
+     override so the backend infers it from the selected voice. Explicit choices
+     submit canonical language codes and remain selected when switching away
+     from Kokoro and back within the Playground session.
+     Fresh Kokoro controls enable **Use ONNX**, matching automatic reply speech.
+     Explicitly disabling the switch still selects the PyTorch backend.
 5. **Audio Controls**: Play, pause, stop, and export generated audio
 6. **Generation Log**: Real-time feedback on TTS processing
+
+### Resolving TTS selection failures
+
+An effective-selection failure happens before audio generation. The UI identifies
+the affected setting and its owner: global **Settings > Speech & TTS**, a voice
+profile, saved Studio preferences, or the current Speech Lab controls. Correct
+invalid or missing selections before generating again; repeating the same
+request does not repair an invalid setting. Catalog failures offer refresh,
+and inconsistent Studio preferences offer reopening Speech Lab.
+
+For Kokoro and the other legacy providers, global **Voice policy** must be
+**Exact**, with a voice value. **Server default** is an audio.cpp policy. Settings
+keep an unsupported saved policy visible for repair and reject it on Save.
+Changing the default provider selects its own model and voice defaults; returning
+to the saved provider restores its saved model and voice choices. Console
+**Speak replies** resolves those global defaults and any applicable voice profile;
+the Playground language selector is local to the Studio request.
+
+Resolution diagnostics record only `resolution_code`, `resolution_axis`, and
+`resolution_source` (plus the existing Console outcome). These bounded fields
+distinguish configuration errors from temporary catalog/state failures without
+logging text, model/voice identifiers, or raw exception messages.
 
 ### Programmatic Usage
 

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -270,6 +270,9 @@ that needs attention; correct it before trying speech again. In **Lab > Speech**
 Kokoro's **Automatic (from voice)** language option follows the selected voice.
 Speech Lab starts with **Use ONNX** enabled, matching automatic reply speech;
 the switch still allows an explicit PyTorch selection.
+Kokoro WAV, MP3 and other encoded files are limited to five minutes per request.
+For longer speech, shorten the text or choose PCM; an oversized encoded request
+fails without playing a truncated file.
 
 ### Rails and handles
 

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -263,6 +263,14 @@ composer-level strip below shows once setup completes.
 | **Speak replies** | Speaks new assistant replies in this conversation. |
 | **Hands-free** | Enters/exits the voice conversation loop (same as Ctrl+Shift+H) — the switch is the touch/soft-keyboard route into the mode. |
 
+For local Kokoro, open **Settings > Speech & TTS** and use **Exact** voice policy
+with a Kokoro voice value. If an older configuration shows **Server default**,
+choose Exact and save. Selection errors identify the setting or voice profile
+that needs attention; correct it before trying speech again. In **Lab > Speech**,
+Kokoro's **Automatic (from voice)** language option follows the selected voice.
+Speech Lab starts with **Use ONNX** enabled, matching automatic reply speech;
+the switch still allows an explicit PyTorch selection.
+
 ### Rails and handles
 
 | Control | What it does |
@@ -423,6 +431,10 @@ configured in **F9 ▸ Providers & Models**.
   from the visible transcript, logs, summaries, ordinary exports, and usage
   details. It still counts against the context window and is evicted atomically
   with its visible owner.
+- **Capture On** preserves the same eligible saved continuation and thinking
+  history as **Capture Off**, including subsequent sends. Provider compatibility
+  and the conversation's thinking-history policy still determine what is
+  replayed; trace masking does not change the provider's selected history.
 - Terminal usage reaches Console when the provider returns it. If a selected
   model has no verified rate, **pricing unknown** means cost was not estimated;
   it never means free.

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1002,15 +1002,15 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 28,
-      "diagnostic_digest": "e900ca7054c98c2d9160",
+      "call_count": 29,
+      "diagnostic_digest": "d6f178afee6348890e84",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 48,
-      "diagnostic_digest": "8355c4da0ee36235c479",
+      "call_count": 50,
+      "diagnostic_digest": "95d2b6a88660ad3919a2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2269,8 +2269,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 70,
-      "diagnostic_digest": "c8c97abdd441f878754e",
+      "call_count": 65,
+      "diagnostic_digest": "83ea677c53d1212fd535",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/kokoro.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -6177,7 +6177,16 @@
     {
       "candidates": [
         {
-          "call_digest": "98ebc7145d856d74",
+          "call_digest": "7195ae005fa5e57b",
+          "method": "error",
+          "path_expressions": [
+            "outcome_code"
+          ],
+          "scope": "TTSEventHandler._generate_tts",
+          "status": "legacy_unreviewed"
+        },
+        {
+          "call_digest": "ef1293cd6664cd2c",
           "method": "error",
           "path_expressions": [
             "outcome_code"
@@ -11478,10 +11487,10 @@
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
     "owner_files": 591,
-    "path_privacy_candidate_calls": 710,
+    "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1348,
-    "task_494_calls": 7681
+    "task_494_calls": 7679
   }
 }

--- a/Tests/ChaChaNotesDB/test_canvas_migration.py
+++ b/Tests/ChaChaNotesDB/test_canvas_migration.py
@@ -1,4 +1,4 @@
-"""Focused v66 -> v68 persistence tests for durable Canvas revisions."""
+"""Canvas v66 -> v68 persistence remains intact across later schema versions."""
 
 from __future__ import annotations
 
@@ -211,7 +211,7 @@ def test_genuine_v66_database_migrates_to_v68_with_complete_canvas_schema(
     migrated = CharactersRAGDB(path, client_id="canvas-v68-migrated")
     try:
         connection = migrated.get_connection()
-        assert _version(path) == 68
+        assert _version(path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
         objects = _canvas_schema(connection)
         assert {
             name for (object_type, name) in objects if object_type == "table"
@@ -242,7 +242,7 @@ def test_fresh_v68_schema_matches_migrated_v66_and_reopen_is_idempotent(
     try:
         fresh_schema = _canvas_schema(fresh.get_connection())
         migrated_schema = _canvas_schema(migrated.get_connection())
-        assert fresh._CURRENT_SCHEMA_VERSION == 68
+        assert fresh._CURRENT_SCHEMA_VERSION >= 68
         assert fresh_schema == migrated_schema
         assert fresh_schema
     finally:
@@ -251,7 +251,7 @@ def test_fresh_v68_schema_matches_migrated_v66_and_reopen_is_idempotent(
 
     reopened = CharactersRAGDB(fresh_path, client_id="canvas-v68-reopen")
     try:
-        assert _version(fresh_path) == 68
+        assert _version(fresh_path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
         assert _canvas_schema(reopened.get_connection()) == fresh_schema
         assert (
             reopened.get_connection().execute("PRAGMA foreign_key_check").fetchall()
@@ -299,7 +299,7 @@ def test_v66_migration_rolls_back_all_ddl_and_version_then_retries(
     )
     retried = CharactersRAGDB(path, client_id="canvas-v68-retry")
     try:
-        assert _version(path) == 68
+        assert _version(path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
         assert _canvas_schema(retried.get_connection())
     finally:
         retried.close_connection()
@@ -347,7 +347,7 @@ def test_v67_migration_preserves_canvas_rows_and_accepts_inert_runtime_profiles(
     migrated = CharactersRAGDB(path, client_id="canvas-v68-migrated")
     try:
         connection = migrated.get_connection()
-        assert _version(path) == 68
+        assert _version(path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
         preserved = connection.execute(
             "SELECT html, runtime_profile FROM canvas_revisions WHERE id = ?",
             (revision_id,),
@@ -449,7 +449,7 @@ def test_v67_to_v68_migration_rolls_back_and_retries(
     monkeypatch.setattr(CharactersRAGDB, "_execute_migration_statements", original)
     retried = CharactersRAGDB(path, client_id="canvas-v68-retry")
     try:
-        assert _version(path) == 68
+        assert _version(path) == CharactersRAGDB._CURRENT_SCHEMA_VERSION
         row = (
             retried.get_connection()
             .execute(

--- a/Tests/Chat/test_console_project_instruction_traces.py
+++ b/Tests/Chat/test_console_project_instruction_traces.py
@@ -322,3 +322,75 @@ async def test_consecutive_project_sends_preserve_each_request(
                 assert expected in wire_rows[-1]["content"]
                 assert sum(expected in str(row.get("content")) for row in rows) == 1
             assert reader.read_calls(first_user.persisted_message_id) == original
+
+
+@pytest.mark.parametrize("prior_response", ["ordinary", "tools", "fallback"])
+@pytest.mark.parametrize("cold_factory", [False, True])
+async def test_transformed_project_sends_preserve_source_and_context(
+    tmp_path, monkeypatch, prior_response, cold_factory
+):
+    """The combined source/context replacement keeps both durable owners."""
+    fallback = prior_response == "fallback"
+    async with _project_console(
+        tmp_path,
+        monkeypatch,
+        tools=prior_response == "tools",
+        response_mode="fallback" if fallback else "complete",
+    ) as app:
+        assert app.store.persist_session_if_needed(app.session.id)
+        app.controller._chat_dictionary_applier = lambda _conversation, text: (
+            text.replace("alias", "expanded")
+        )
+        reader = ConsoleTraceNativeReader(app.db)
+        originals = []
+        for index, text in enumerate(
+            ("alias first", "ordinary next", "alias third", "ordinary last")
+        ):
+            if index == 2:
+                app.project_file.write_text("UPDATED_PROJECT_GUIDANCE_31976")
+            elif index == 3:
+                app.store.set_session_project_instruction_state(
+                    app.session.id,
+                    replace(
+                        app.session.project_instruction_state,
+                        project_instructions_enabled=False,
+                    ),
+                )
+            if cold_factory:
+                app.restart_factory()
+            before_http = len(app.http_payloads)
+            result = await app.controller.submit_draft(text, session_id=app.session.id)
+            assert result.accepted and result.provider_started, app.reservation_errors
+            assert app.controller.run_state.status.value == "completed", (
+                app.reservation_errors
+            )
+            assert len(app.http_payloads) > before_http
+            wire = app.http_payloads[-1]["messages"]
+            expected = text.replace("alias", "expanded")
+            assert any(row.get("content") == expected for row in wire)
+            if index < 3:
+                current_index = next(
+                    i for i, row in enumerate(wire) if row.get("content") == expected
+                )
+                assert (
+                    GUIDANCE if index < 2 else "UPDATED_PROJECT_GUIDANCE_31976"
+                ) in wire[current_index + 1]["content"]
+            else:
+                assert wire[-1]["content"] == expected
+            saved = app.store.get_message(result.user_message_id)
+            assert saved.content == text
+            trace = reader.read_calls(saved.persisted_message_id)
+            assert trace
+            assert all(call.capture.request is not None for call in trace)
+            originals.append((saved.persisted_message_id, trace))
+            for owner_id, original in originals:
+                assert reader.read_calls(owner_id) == original
+        with app.db.transaction() as cursor:
+            pins = cursor.execute(
+                "SELECT c.turn_id, r.source_message_id FROM console_trace_calls c "
+                "JOIN console_trace_events e ON e.call_id = c.call_id "
+                "AND e.event_type = 'call_boundary' "
+                "JOIN console_trace_semantic_revisions r "
+                "ON r.revision_id = e.semantic_revision_id"
+            ).fetchall()
+        assert pins and all(row[0] == row[1] for row in pins)

--- a/Tests/Chat/test_console_trace_current_turn_transforms.py
+++ b/Tests/Chat/test_console_trace_current_turn_transforms.py
@@ -1,0 +1,515 @@
+"""Real-boundary coverage for admitted ephemeral current-user transforms."""
+
+import asyncio
+from dataclasses import replace
+from threading import Event
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_first_send_atomicity import _controller
+from Tests.Chat.test_console_trace_first_send_atomicity import _force_capture_on
+from Tests.Chat.test_console_trace_runtime import (
+    _saved_message,
+    _semantic_request,
+)
+from Tests.Chat.test_console_trace_runtime import (
+    make_database as make_database,  # noqa: PLC0414 - pytest fixture re-export
+)
+from Tests.Chat.test_console_trace_runtime import (
+    make_gateway as make_gateway,  # noqa: PLC0414 - pytest fixture re-export
+)
+from Tests.Chat.test_console_trace_runtime import (
+    test_completed_tool_turn_compound_admission_checks_durable_proof as _tool_successor_case,
+)
+from tldw_chatbook.Chat.console_library_destination import resolve_console_destination
+from tldw_chatbook.Chat.console_prepared_request import thaw_json
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_provenance import (
+    ConsoleRequestRoute,
+    ConsoleTraceCaptureMode,
+    SavedRevisionTraceProvenance,
+)
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+
+
+@pytest.fixture
+async def trace_harness(tmp_path, monkeypatch, request):
+    settings = ConsoleSessionSettings(
+        provider="vllm",
+        model="test-model",
+        base_url="http://127.0.0.1:9099/v1",
+        streaming=bool(getattr(request, "param", False)),
+    )
+    db, store, controller, _ = _controller(tmp_path, initial_settings=settings)
+    assert store.persist_session_if_needed("session-1")
+    entries = []
+    harness = SimpleNamespace(
+        db=db,
+        store=store,
+        controller=controller,
+        entries=entries,
+        factory=ConsoleTraceBoundaryFactory(db),
+        boundaries=[],
+        adapter_error=False,
+        failures=[],
+        partial_received=Event(),
+        release_stream=Event(),
+    )
+
+    def adapter(**kwargs):
+        entries.append(thaw_json(kwargs["messages_payload"]))
+        if settings.streaming:
+
+            def chunks():
+                yield {
+                    "choices": [
+                        {
+                            "delta": {
+                                "content": "partial answer"
+                                if harness.adapter_error == "stopped_partial"
+                                else "answer"
+                            }
+                        }
+                    ]
+                }
+                if harness.adapter_error == "stopped_partial":
+                    assert harness.release_stream.wait(5)
+
+            return chunks()
+        if harness.adapter_error == "stopped":
+            controller._signal_stop(session_id="session-1")
+        elif harness.adapter_error:
+            raise RuntimeError("synthetic provider failure")
+        return {"choices": [{"message": {"content": "answer"}}]}
+
+    def boundary(request, resolution, route):
+        try:
+            result = harness.factory(request, resolution, route)
+        except ValueError as exc:
+            harness.failures.append(str(exc))
+            raise
+        harness.boundaries.append(result)
+        return result
+
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=adapter, trace_call_boundary_factory=boundary
+    )
+
+    async def resolve(_selection):
+        resolution = ConsoleProviderResolution(
+            ready=True,
+            provider=settings.provider,
+            model=settings.model,
+            base_url=settings.base_url,
+            execution_key="vllm",
+            streaming=settings.streaming,
+        )
+        return replace(
+            resolution, resolved_destination=resolve_console_destination(resolution)
+        )
+
+    monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+    if settings.streaming:
+        append = store.append_stream_chunk
+
+        def record_partial(message_id, chunk):
+            result = append(message_id, chunk)
+            harness.partial_received.set()
+            return result
+
+        monkeypatch.setattr(store, "append_stream_chunk", record_partial)
+    controller.provider_gateway = gateway
+    controller._chat_dictionary_applier = lambda _conversation, text: text.replace(
+        "alias", "expanded"
+    )
+    _force_capture_on(monkeypatch)
+    harness.gateway = gateway
+    try:
+        yield harness
+    finally:
+        harness.release_stream.set()
+        await gateway.aclose()
+        db.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cold_factory", [False, True])
+async def test_dictionary_send_and_successors_keep_exact_saved_source(
+    trace_harness, cold_factory
+):
+    db, store, controller, entries = (
+        trace_harness.db,
+        trace_harness.store,
+        trace_harness.controller,
+        trace_harness.entries,
+    )
+    saved_ids = []
+    original_traces = []
+    for text in ("ordinary first", "alias second", "alias third", "ordinary last"):
+        if cold_factory:
+            trace_harness.factory = ConsoleTraceBoundaryFactory(db)
+        result = await controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (text, result, len(entries))
+        saved = store.get_message(result.user_message_id)
+        assert saved.content == text
+        saved_ids.append(saved.persisted_message_id)
+        assert entries[-1][-1] == {
+            "role": "user",
+            "content": text.replace("alias", "expanded"),
+        }
+        reader = ConsoleTraceNativeReader(db)
+        trace = reader.read_calls(saved.persisted_message_id)
+        assert len(trace) == 1
+        assert trace[0].capture.request["messages_payload"] == entries[-1]
+        original_traces.append(trace)
+        for previous_id, previous_trace in zip(saved_ids, original_traces, strict=True):
+            assert reader.read_calls(previous_id) == previous_trace
+
+    assert entries[-1] == [
+        {"role": "user", "content": "ordinary first"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "alias second"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "alias third"},
+        {"role": "assistant", "content": "answer"},
+        {"role": "user", "content": "ordinary last"},
+    ]
+    rows = (
+        db.get_connection()
+        .execute(
+            "SELECT c.turn_id, r.source_message_id FROM console_trace_calls c "
+            "JOIN console_trace_events e ON e.call_id = c.call_id "
+            "AND e.event_type = 'call_boundary' "
+            "JOIN console_trace_semantic_revisions r ON r.revision_id = e.semantic_revision_id "
+            "ORDER BY e.sequence"
+        )
+        .fetchall()
+    )
+    assert [tuple(row) for row in rows] == [
+        (identity, identity) for identity in saved_ids
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change", ["historical_text", "unknown_current", "current_role", "current_image"]
+)
+async def test_source_pin_never_authorizes_changed_history(
+    trace_harness, monkeypatch, change
+):
+    harness = trace_harness
+    first = await harness.controller.submit_draft("alias first", session_id="session-1")
+    assert first.provider_started
+    assert harness.entries[-1][-1]["content"] == "expanded first"
+    persisted_id = harness.store.get_message(first.user_message_id).persisted_message_id
+    original = ConsoleTraceNativeReader(harness.db).read_calls(persisted_id)
+    original_head = (
+        harness.db.get_connection()
+        .execute("SELECT surface_node_id FROM console_trace_calls")
+        .fetchone()[0]
+    )
+    substitute = harness.controller._apply_skill_substitution
+
+    async def tamper(rows):
+        result = await substitute(rows)
+        if change == "historical_text":
+            result[0][0] = {**result[0][0], "content": "changed history"}
+        elif change == "current_role":
+            result[0][-1] = {**result[0][-1], "role": "assistant"}
+        elif change == "current_image":
+            result[0][-1] = {
+                **result[0][-1],
+                "content": [
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "data:image/png;base64,Ynl0ZXM="},
+                    }
+                ],
+            }
+        else:
+            from tldw_chatbook.Chat.console_chat_controller import NATIVE_MESSAGE_ID_KEY
+
+            result[0][-1] = {**result[0][-1], NATIVE_MESSAGE_ID_KEY: "unknown"}
+        return result
+
+    monkeypatch.setattr(harness.controller, "_apply_skill_substitution", tamper)
+    harness.factory = ConsoleTraceBoundaryFactory(harness.db)
+    following = await harness.controller.submit_draft(
+        "ordinary next", session_id="session-1"
+    )
+    assert following.accepted and not following.provider_started
+    assert len(harness.entries) == 1
+    assert harness.failures
+    rows = (
+        harness.db.get_connection()
+        .execute("SELECT surface_node_id FROM console_trace_calls")
+        .fetchall()
+    )
+    assert len(rows) == 1 and rows[0][0] == original_head
+    assert ConsoleTraceNativeReader(harness.db).read_calls(persisted_id) == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("outcome", ["error", "stopped"])
+async def test_next_send_after_failed_transformed_call(trace_harness, outcome):
+    harness = trace_harness
+    harness.adapter_error = outcome
+    first = await harness.controller.submit_draft("alias first", session_id="session-1")
+    assert first.accepted and len(harness.entries) == 1
+    assert harness.entries[0][-1]["content"] == "expanded first"
+    assert (
+        harness.db.get_connection()
+        .execute("SELECT state FROM console_trace_calls")
+        .fetchone()[0]
+        == outcome
+    )
+    harness.adapter_error = False
+    harness.factory = ConsoleTraceBoundaryFactory(harness.db)
+    following = await harness.controller.submit_draft(
+        "ordinary next", session_id="session-1"
+    )
+    assert following.accepted and following.provider_started, (
+        following,
+        harness.failures,
+    )
+    assert len(harness.entries) == 2
+    assert harness.entries[-1][0] == {"role": "user", "content": "alias first"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scenario",
+    [
+        "valid",
+        "cold",
+        "equal_policy_fresh_id",
+        "credential_value",
+        "wrong_policy",
+        "wrong_pii_enabled",
+        "wrong_ruleset_revision",
+        "wrong_response_revision",
+        "incomplete_terminal",
+        "unrelated_reservation",
+        "non_tool_artifact",
+        "changed_prefix",
+        "changed_assistant_envelope",
+        "extra_new_item",
+        "unsupported_route",
+        "foreign_assistant",
+        "rollback_replace",
+        "rollback_append",
+        "rollback_bind",
+        "cold_fresh_reserved",
+        "postcommit_commit",
+        "postcommit_cancel",
+        "postcommit_agent_new_run",
+        "stopped_terminal",
+        "changed_loop_source",
+        "reverted_loop_source",
+    ],
+)
+async def test_transformed_source_tool_successor_checks_durable_proof(
+    tmp_path, make_database, make_gateway, monkeypatch, scenario
+):
+    await _tool_successor_case(
+        tmp_path,
+        make_database,
+        make_gateway,
+        monkeypatch,
+        scenario,
+        current_transform=True,
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change", ["different_message", "edited_revision", "equal_text_revision"]
+)
+async def test_cold_successor_requires_the_pinned_revision_identity(
+    trace_harness, change
+):
+    harness = trace_harness
+    first = await harness.controller.submit_draft("alias first", session_id="session-1")
+    assert first.provider_started
+    assert harness.entries[0][-1]["content"] == "expanded first"
+    source_id = harness.store.get_message(first.user_message_id).persisted_message_id
+    answer_id = harness.store.get_message(
+        first.assistant_message_id
+    ).persisted_message_id
+    database = harness.db
+    source_row = database.get_message_by_id(source_id)
+    conversation = source_row["conversation_id"]
+    source_text = "alias first"
+    if change == "different_message":
+        _, source = _saved_message(database, conversation, source_text)
+    else:
+        assert database.update_message(
+            source_id,
+            {"content": "edited alias first"},
+            source_row["version"],
+            preserve_descendants=True,
+        )
+        source_text = "edited alias first"
+        if change == "equal_text_revision":
+            source_row = database.get_message_by_id(source_id)
+            assert database.update_message(
+                source_id,
+                {"content": "alias first"},
+                source_row["version"],
+                preserve_descendants=True,
+            )
+            source_text = "alias first"
+        revision = (
+            database.get_connection()
+            .execute(
+                "SELECT revision_id FROM console_trace_semantic_revisions WHERE source_message_id = ? ORDER BY revision_sequence DESC LIMIT 1",
+                (source_id,),
+            )
+            .fetchone()[0]
+        )
+        source = SavedRevisionTraceProvenance(revision)
+    answer_revision = (
+        database.get_connection()
+        .execute(
+            "SELECT revision_id FROM console_trace_semantic_revisions WHERE source_message_id = ? ORDER BY revision_sequence DESC LIMIT 1",
+            (answer_id,),
+        )
+        .fetchone()[0]
+    )
+    _, next_user = _saved_message(database, conversation, "next")
+    boundary = harness.boundaries[-1]
+    policy = boundary._request.semantic.provenance.capture_policy
+    request = harness.gateway.prepare_chat_request(
+        boundary._resolution,
+        _semantic_request(
+            [
+                {"role": "user", "content": source_text},
+                {"role": "assistant", "content": "answer"},
+                {"role": "user", "content": "next"},
+            ],
+            [source, SavedRevisionTraceProvenance(answer_revision), next_user],
+            policy,
+        ),
+        route=ConsoleRequestRoute.FRESH,
+        capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+    )
+    with pytest.raises(ValueError):
+        ConsoleTraceBoundaryFactory(database)(
+            request, boundary._resolution, ConsoleRequestRoute.FRESH
+        )
+    assert len(harness.entries) == 1
+
+
+@pytest.mark.asyncio
+async def test_current_transform_rechecks_its_exact_pretransform_source(
+    trace_harness, monkeypatch
+):
+    harness = trace_harness
+    build = harness.controller._build_durable_trace_request
+
+    def change_saved_source(**kwargs):
+        source_id = kwargs["committed_user_id"]
+        source = harness.db.get_message_by_id(source_id)
+        assert harness.db.update_message(
+            source_id,
+            {"content": "a different saved input"},
+            source["version"],
+            preserve_descendants=True,
+        )
+        return build(**kwargs)
+
+    monkeypatch.setattr(
+        harness.controller, "_build_durable_trace_request", change_saved_source
+    )
+    result = await harness.controller.submit_draft(
+        "alias first", session_id="session-1"
+    )
+    assert result.accepted and not result.provider_started
+    assert harness.entries == []
+
+
+@pytest.mark.asyncio
+async def test_transformed_successor_owned_retry_reuses_exact_reservation(
+    trace_harness, monkeypatch
+):
+    harness = trace_harness
+    first = await harness.controller.submit_draft("alias first", session_id="session-1")
+    assert first.provider_started
+    assert harness.entries[0][-1]["content"] == "expanded first"
+    bind = harness.factory.repository.bind_call
+    fail_once = True
+
+    def rollback_once(*args, **kwargs):
+        nonlocal fail_once
+        result = bind(*args, **kwargs)
+        if fail_once:
+            fail_once = False
+            raise RuntimeError("synthetic bind rollback")
+        return result
+
+    monkeypatch.setattr(harness.factory.repository, "bind_call", rollback_once)
+    following = await harness.controller.submit_draft("next", session_id="session-1")
+    assert following.accepted and not following.provider_started
+    assert len(harness.entries) == 1
+    pending_id = harness.boundaries[-1].reserve().call_id
+    retried = await harness.controller.retry_library_preparation(
+        following.preparation_id
+    )
+    assert retried.accepted and retried.provider_started, retried
+    assert len(harness.entries) == 2
+    rows = (
+        harness.db.get_connection()
+        .execute("SELECT call_id, state FROM console_trace_calls")
+        .fetchall()
+    )
+    assert len(rows) == 2
+    assert (pending_id, "complete") in [tuple(row) for row in rows]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("trace_harness", [True], indirect=True)
+async def test_streaming_partial_stop_keeps_verified_assistant_on_next_send(
+    trace_harness,
+):
+    harness = trace_harness
+    harness.adapter_error = "stopped_partial"
+    sending = asyncio.create_task(
+        harness.controller.submit_draft("alias first", session_id="session-1")
+    )
+    try:
+        assert await asyncio.to_thread(harness.partial_received.wait, 5)
+        assert harness.controller.stop_active_run()
+        first = await asyncio.wait_for(sending, 5)
+    finally:
+        harness.release_stream.set()
+    assert first.accepted and first.provider_started
+    assert harness.entries[0][-1]["content"] == "expanded first"
+    saved_assistant = harness.store.get_message(first.assistant_message_id)
+    assert saved_assistant.content == "partial answer"
+    row = (
+        harness.db.get_connection()
+        .execute(
+            "SELECT c.state, r.verification_outcome FROM console_trace_calls c "
+            "JOIN console_trace_response_links r ON r.call_id = c.call_id"
+        )
+        .fetchone()
+    )
+    assert tuple(row) == ("stopped", "verified_equal")
+    harness.adapter_error = False
+    harness.factory = ConsoleTraceBoundaryFactory(harness.db)
+    following = await harness.controller.submit_draft("next", session_id="session-1")
+    assert following.accepted and following.provider_started, (
+        following,
+        harness.failures,
+    )
+    assert harness.entries[-1] == [
+        {"role": "user", "content": "alias first"},
+        {"role": "assistant", "content": "partial answer"},
+        {"role": "user", "content": "next"},
+    ]

--- a/Tests/Chat/test_console_trace_proprietary_settlement.py
+++ b/Tests/Chat/test_console_trace_proprietary_settlement.py
@@ -1,0 +1,122 @@
+"""Hosted reasoning evidence must preserve the saved response and next send."""
+
+import json
+from dataclasses import replace
+
+import pytest
+
+from Tests.Chat.test_console_trace_sidecar_replay import (
+    replay_harness as replay_harness,  # noqa: PLC0414 - pytest fixture re-export
+)
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.Chat.provider_continuation import ContinuationRound
+from tldw_chatbook.Chat.thinking_blocks import ProprietaryThinkingBlock
+from tldw_chatbook.LLM_Calls.hosted_chat import HostedChatTurn
+from tldw_chatbook.LLM_Calls.moonshot import MoonshotResponse
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [False, True], indirect=True)
+@pytest.mark.parametrize("with_checkpoint", [False, True])
+async def test_proprietary_response_preserves_transformed_cold_successor(
+    replay_harness, with_checkpoint, monkeypatch
+):
+    harness = replay_harness
+    gateway = harness.controller.provider_gateway
+    resolve = gateway.resolve_for_send
+    canary = "NEW_PROPRIETARY_REASONING_CANARY"
+    checkpoint = (
+        replace(
+            harness.checkpoint,
+            rounds=(ContinuationRound("answer", (canary,), ()),),
+        )
+        if with_checkpoint
+        else None
+    )
+
+    async def proprietary_resolution(selection):
+        return replace(
+            await resolve(selection),
+            thinking_stream_disposition="proprietary",
+            thinking_round_trip_version=1,
+        )
+
+    def adapter(**kwargs):
+        harness.entries.append(kwargs)
+        return MoonshotResponse(
+            {"choices": [{"message": {"content": "answer"}}]},
+            terminal_turn=HostedChatTurn(
+                text="answer",
+                tool_calls=(),
+                assistant_message={"role": "assistant", "content": "answer"},
+                finish_reason="stop",
+                reasoning_content=canary,
+            ),
+            provider_continuation=checkpoint,
+        )
+
+    monkeypatch.setattr(gateway, "resolve_for_send", proprietary_resolution)
+    monkeypatch.setattr(gateway, "_chat_api_call_fn", adapter)
+    first = await harness.controller.submit_draft(
+        "alias request", session_id="session-1"
+    )
+    assert first.accepted and first.provider_started, (first, harness.failures)
+    assistant = harness.store.get_message(first.assistant_message_id)
+    assert assistant.content == "answer"
+    assert len(assistant.thinking.blocks) == 1
+    block = assistant.thinking.blocks[0]
+    assert isinstance(block, ProprietaryThinkingBlock)
+    assert (block.provider, block.model, block.source_format, block.status) == (
+        "moonshot",
+        "kimi-k3",
+        "reasoning_content",
+        "complete",
+    )
+    row = harness.database.get_message_by_id(assistant.persisted_message_id)
+    assert canary not in row["thinking_blocks_json"]
+    saved_user = harness.store.get_message(first.user_message_id)
+    reader = ConsoleTraceNativeReader(harness.database)
+    old_trace = reader.read_calls(saved_user.persisted_message_id)
+    old_heads = list(
+        harness.database.get_connection().execute(
+            "SELECT call_id, surface_node_id FROM console_trace_calls ORDER BY call_id"
+        )
+    )
+    if harness.capture_on:
+        assert len(old_trace) == 1
+        assert canary not in json.dumps(old_trace[0].capture.response)
+        assert old_trace[0].capture.response["proprietary_thinking_evidence"] == [
+            {
+                "provider": "moonshot",
+                "model": "kimi-k3",
+                "protocol": "chat_completions",
+                "source_format": "reasoning_content",
+            }
+        ]
+
+    harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+    second = await harness.controller.submit_draft(
+        "ordinary successor", session_id="session-1"
+    )
+    assert second.accepted and second.provider_started, (second, harness.failures)
+    assert len(harness.entries) == 2
+    assert tuple(harness.entries[-1]["provider_continuations"]) == (harness.checkpoint,)
+    if harness.capture_on:
+        assert reader.read_calls(saved_user.persisted_message_id) == old_trace
+        connection = harness.database.get_connection()
+        for call_id, head in old_heads:
+            assert (
+                connection.execute(
+                    "SELECT surface_node_id FROM console_trace_calls WHERE call_id = ?",
+                    (call_id,),
+                ).fetchone()[0]
+                == head
+            )
+        assert tuple(
+            connection.execute(
+                "SELECT link_kind, verification_outcome FROM console_trace_response_links "
+                "WHERE call_id = ?",
+                (old_heads[0][0],),
+            ).fetchone()
+        ) == ("revision", "verified_equal")

--- a/Tests/Chat/test_console_trace_runtime.py
+++ b/Tests/Chat/test_console_trace_runtime.py
@@ -16,6 +16,7 @@ from tldw_chatbook.Chat.console_prepared_request import (
     build_console_request,
     prepare_provider_request,
     resolve_request_capacity,
+    thaw_json,
 )
 from tldw_chatbook.Chat.console_provider_gateway import (
     ConsoleProviderGateway,
@@ -32,9 +33,11 @@ from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
     ConsoleTraceCaptureMode,
     ConsoleUnitProvenance,
+    DerivedTraceProvenance,
     ProviderArtifactTraceProvenance,
     SavedRevisionTraceProvenance,
     TraceProvenanceSource,
+    TraceTransformKind,
     request_route_provenance,
 )
 from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
@@ -322,6 +325,7 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
     make_gateway,
     monkeypatch,
     scenario,
+    current_transform=False,
 ):
     """Only the completed run's exact saved answer may collapse its tool suffix."""
     from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
@@ -397,6 +401,13 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
         if canonical_id is not None:
 
             def settle(handoff):
+                if scenario == "stopped_terminal":
+                    handoff = replace(
+                        handoff,
+                        _prepared=replace(
+                            handoff._prepared, outcome=TraceCallState.STOPPED
+                        ),
+                    )
                 if scenario != "incomplete_terminal":
                     assert handoff.settle(canonical_id)
                 return True
@@ -415,9 +426,22 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
             )
         ]
 
-    first_messages = [{"role": "user", "content": "calculate"}]
+    first_messages = [
+        {"role": "user", "content": "compute" if current_transform else "calculate"}
+    ]
+    first_user = (
+        DerivedTraceProvenance(
+            TraceTransformKind.CURRENT_TURN_TEXT,
+            inputs=(user,),
+            artifact=ProviderArtifactTraceProvenance(
+                TraceProvenanceSource.ACTIVE_REQUEST, policy
+            ),
+        )
+        if current_transform
+        else user
+    )
     assert await dispatch(
-        prepare(first_messages, [user], ConsoleRequestRoute.AGENT_FIRST),
+        prepare(first_messages, [first_user], ConsoleRequestRoute.AGENT_FIRST),
         ConsoleRequestRoute.AGENT_FIRST,
     ) == ["42"]
     source = (
@@ -425,12 +449,67 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
         if scenario == "non_tool_artifact"
         else TraceProvenanceSource.TOOL_RESULT
     )
+    if scenario in {"changed_loop_source", "reverted_loop_source"}:
+        original_revision = user.revision_id
+        row = database.get_message_by_id(user_id)
+        assert database.update_message(
+            user_id,
+            {"content": "different saved source"},
+            row["version"],
+            preserve_descendants=True,
+        )
+        if scenario == "reverted_loop_source":
+            row = database.get_message_by_id(user_id)
+            assert database.update_message(
+                user_id,
+                {"content": "calculate"},
+                row["version"],
+                preserve_descendants=True,
+            )
+        revision_id = (
+            database.get_connection()
+            .execute(
+                "SELECT revision_id FROM console_trace_semantic_revisions "
+                "WHERE source_message_id = ? ORDER BY revision_sequence DESC LIMIT 1",
+                (user_id,),
+            )
+            .fetchone()[0]
+        )
+        assert revision_id != original_revision
+        first_user = DerivedTraceProvenance(
+            TraceTransformKind.CURRENT_TURN_TEXT,
+            inputs=(SavedRevisionTraceProvenance(revision_id),),
+            artifact=ProviderArtifactTraceProvenance(
+                TraceProvenanceSource.ACTIVE_REQUEST, policy
+            ),
+        )
     tool_count = 2
     tool_messages = [
         {"role": "tool", "content": f"result-{index}", "tool_call_id": f"call-{index}"}
         for index in range(tool_count)
     ]
     tool_descriptors = [ProviderArtifactTraceProvenance(source, policy)] * tool_count
+    if scenario in {"changed_loop_source", "reverted_loop_source"}:
+        from tldw_chatbook.Chat.console_trace_errors import TraceCallPersistenceError
+
+        with pytest.raises(TraceCallPersistenceError):
+            await dispatch(
+                prepare(
+                    first_messages + tool_messages,
+                    [first_user] + tool_descriptors,
+                    ConsoleRequestRoute.TOOL_LOOP,
+                ),
+                ConsoleRequestRoute.TOOL_LOOP,
+                answer_id,
+            )
+        assert len(adapter_entries) == 1
+        assert (
+            database.get_connection()
+            .execute("SELECT COUNT(*) FROM console_trace_calls")
+            .fetchone()[0]
+            == 1
+        )
+        return
     if scenario == "non_tool_artifact":
         tool_messages = [
             {"role": "assistant", "content": f"ordinary-{index}"}
@@ -439,7 +518,7 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
     assert await dispatch(
         prepare(
             first_messages + tool_messages,
-            [user] + tool_descriptors,
+            [first_user] + tool_descriptors,
             ConsoleRequestRoute.TOOL_LOOP,
         ),
         ConsoleRequestRoute.TOOL_LOOP,
@@ -452,6 +531,8 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
         assert terminal.state is (
             TraceCallState.RESPONSE_STARTED
             if scenario == "incomplete_terminal"
+            else TraceCallState.STOPPED
+            if scenario == "stopped_terminal"
             else TraceCallState.COMPLETE
         )
         link = repository.get_response_link(cursor, terminal.call_id)
@@ -463,7 +544,7 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
     reader = ConsoleTraceNativeReader(database)
     original = reader.read_calls(user_id)
     assert len(original) == (1 if scenario == "incomplete_terminal" else 2)
-    incoming = first_messages + [
+    incoming = [{"role": "user", "content": "calculate"}] + [
         {"role": "assistant", "content": "42"},
         {"role": "user", "content": next_text},
     ]
@@ -706,7 +787,9 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
             assert committed.request_header_id == expected.header.header_id
             assert repository.get_request_header(cursor, committed.request_header_id) == expected.header
             assert committed.dispatch_started_at is not None
-            assert cursor.execute("SELECT COUNT(*) FROM console_trace_surface_nodes").fetchone()[0] == 5
+            assert cursor.execute(
+                "SELECT COUNT(*) FROM console_trace_surface_nodes"
+            ).fetchone()[0] == (6 if current_transform else 5)
             assert cursor.execute("SELECT COUNT(*) FROM console_trace_surface_replacements").fetchone()[0] == 1
             before_reentry = tuple(cursor.execute(
                 "SELECT (SELECT COUNT(*) FROM console_trace_calls), "
@@ -822,7 +905,13 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
             assert reserved.surface_node_id is None
             assert reserved.request_header_id is None
         assert reader.read_calls(user_id) == original
-    elif scenario in {"valid", "cold", "equal_policy_fresh_id", "credential_value"}:
+    elif scenario in {
+        "valid",
+        "cold",
+        "equal_policy_fresh_id",
+        "credential_value",
+        "stopped_terminal",
+    }:
         assert await dispatch(prepared, route) == ["42"]
         assert [dict(row) for row in adapter_entries[-1]] == [
             {"role": "user", "content": "calculate"},
@@ -836,12 +925,9 @@ async def test_completed_tool_turn_compound_admission_checks_durable_proof(
                 ).fetchone()[0]
                 == 1
             )
-            assert (
-                cursor.execute(
-                    "SELECT COUNT(*) FROM console_trace_surface_nodes"
-                ).fetchone()[0]
-                == 5
-            )
+            assert cursor.execute(
+                "SELECT COUNT(*) FROM console_trace_surface_nodes"
+            ).fetchone()[0] == (6 if current_transform else 5)
         assert reader.read_calls(user_id) == original
     else:
         with pytest.raises(ValueError):
@@ -1693,6 +1779,137 @@ def test_production_factory_uses_latest_message_revision_for_turn_identity(
     )
 
     assert boundary.identity.turn_id == current_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", [None, "text", "image", "order"])
+async def test_agent_multimodal_trace_matches_json_values_and_keeps_saved_turn(
+    tmp_path,
+    make_database,
+    make_gateway,
+    change,
+) -> None:
+    """Container freezing must not erase ownership or admit changed image rows."""
+    from copy import deepcopy
+
+    from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentTraceRequestFactory
+
+    database = make_database(tmp_path / "agent-image.sqlite", "agent-image")
+    conversation_id = database.add_conversation({"title": "image trace"})
+    assert conversation_id is not None
+    _prior_id, prior_revision = _saved_message(database, conversation_id, "prior")
+    current_id = database.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "describe this",
+            "image_data": b"image-bytes",
+            "image_mime_type": "image/png",
+        }
+    )
+    assert current_id is not None
+    with database.transaction() as cursor:
+        revision_row = cursor.execute(
+            """SELECT revision_id FROM console_trace_semantic_revisions
+                 WHERE source_message_id = ? ORDER BY revision_sequence DESC LIMIT 1""",
+            (current_id,),
+        ).fetchone()
+    assert revision_row is not None
+    current_revision = SavedRevisionTraceProvenance(str(revision_row[0]))
+    messages = [
+        {"role": "user", "content": "prior"},
+        {
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "describe this"},
+                {
+                    "type": "image_url",
+                    "image_url": {
+                        "url": "data:image/png;base64,aW1hZ2UtYnl0ZXM=",
+                    },
+                },
+            ],
+        },
+    ]
+    policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    admitted = _semantic_request(messages, [prior_revision, current_revision], policy)
+    transport_messages = deepcopy(messages)
+    if change == "text":
+        transport_messages[-1]["content"][0]["text"] = "changed request"
+    elif change == "image":
+        transport_messages[-1]["content"][1]["image_url"]["url"] = (
+            "data:image/png;base64,b3RoZXI="
+        )
+    elif change == "order":
+        transport_messages[-1]["content"].reverse()
+    actor_id, chain_id = new_opaque_id(), new_opaque_id()
+    request = ConsoleAgentTraceRequestFactory(admitted).build(
+        transport_messages,
+        tools=(),
+        route=ConsoleRequestRoute.AGENT_FIRST,
+        actor_id=actor_id,
+        chain_id=chain_id,
+    )
+    factory = ConsoleTraceBoundaryFactory(database)
+    entries = []
+
+    def adapter(**kwargs):
+        entries.append(thaw_json(kwargs["messages_payload"]))
+        return {"choices": [{"message": {"content": "image received"}}]}
+
+    gateway = make_gateway(
+        chat_api_call_fn=adapter,
+        trace_call_boundary_factory=factory,
+    )
+    resolution = ConsoleProviderResolution(
+        provider="openai",
+        model="gpt-test",
+        base_url="https://api.openai.com/v1",
+        ready=True,
+        execution_key="openai",
+        streaming=False,
+    )
+    prepared = gateway.prepare_chat_request(
+        resolution,
+        request,
+        route=ConsoleRequestRoute.AGENT_FIRST,
+        route_actor_id=actor_id,
+        route_chain_id=chain_id,
+        capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+    )
+    if change is not None:
+        assert isinstance(
+            request.provenance.active_request[-1], ProviderArtifactTraceProvenance
+        )
+        with pytest.raises(ValueError, match="trace_turn_unavailable"):
+            factory(prepared, resolution, ConsoleRequestRoute.AGENT_FIRST)
+        with database.transaction() as cursor:
+            assert (
+                cursor.execute("SELECT COUNT(*) FROM console_trace_calls").fetchone()[0]
+                == 0
+            )
+        assert entries == []
+        return
+
+    output = [
+        item
+        async for item in gateway.stream_chat(
+            resolution,
+            prepared,
+            route=ConsoleRequestRoute.AGENT_FIRST,
+            route_actor_id=actor_id,
+            route_chain_id=chain_id,
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+        )
+    ]
+    assert output == ["image received"]
+    assert entries == [messages]
+    assert request.provenance.active_request[-1] == current_revision
+    with database.transaction() as cursor:
+        calls = cursor.execute(
+            "SELECT turn_id, state FROM console_trace_calls"
+        ).fetchall()
+    assert [tuple(row) for row in calls] == [(current_id, "complete")]
 
 
 def test_production_factory_rejects_unsaved_active_message_instead_of_stale_turn(

--- a/Tests/Chat/test_console_trace_service.py
+++ b/Tests/Chat/test_console_trace_service.py
@@ -1433,6 +1433,7 @@ def _completed_run_compound_preparation(
             projection=projection,
             route=ConsoleRequestRoute.FRESH.value,
             policy_id=policy.policy_id,
+            retained_descriptors={},
         )
     admission = SurfaceDeltaAdmission(
         owner_id,
@@ -3414,14 +3415,23 @@ def test_continuation_domain_survives_append_and_reopen(
     ]
 
 
+@pytest.mark.parametrize(
+    ("source_label", "forged_label"),
+    [
+        ("canonical", "forged"),
+        ("Bearer sk-proj-" + "x" * 48, "Bearer sk-proj-" + "y" * 48),
+    ],
+)
 def test_saved_continuation_value_mismatch_rejects_before_any_trace_write(
     db: CharactersRAGDB,
     repository: ConsoleTraceRepository,
+    source_label: str,
+    forged_label: str,
 ) -> None:
     owner_id, segment_id = _owned_segment(db, repository)
     owner = repository.get_owner(db.get_connection().cursor(), owner_id)
     assert owner is not None and owner.conversation_id is not None
-    canonical = _continuation_value("canonical")
+    canonical = _continuation_value(source_label)
     message_id = db.add_message(
         {
             "conversation_id": owner.conversation_id,
@@ -3453,7 +3463,7 @@ def test_saved_continuation_value_mismatch_rejects_before_any_trace_write(
         continuations=(descriptor,),
         metadata=(request_route_provenance(ConsoleRequestRoute.FRESH),),
     )
-    forged = _continuation_value("forged")
+    forged = _continuation_value(forged_label)
     service = ConsoleTraceService(repository)
     preparation_identity = new_opaque_id()
     admission = SurfaceDeltaAdmission(

--- a/Tests/Chat/test_console_trace_settlement.py
+++ b/Tests/Chat/test_console_trace_settlement.py
@@ -59,6 +59,8 @@ def _call(
     sequence: int = 0,
     state: TraceCallState = TraceCallState.DISPATCH_STARTED,
     conversation_id: str | None = None,
+    response_projection: dict[str, object] | None = None,
+    policy: FrozenTracePolicy | None = None,
 ) -> tuple[str, str, str]:
     conversation_id = conversation_id or db.add_conversation({"title": "settlement"})
     assert conversation_id is not None
@@ -70,7 +72,7 @@ def _call(
         }
     )
     assert message_id is not None
-    policy = FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
+    policy = policy or FrozenTracePolicy(new_opaque_id(), "credentials-v1", False, None)
     with db.transaction(immediate=True) as cursor:
         segment = repository.create_segment(cursor)
         owner = repository.attach_owner(
@@ -101,7 +103,11 @@ def _call(
             route_identity="fresh",
             endpoint_identity="public-api",
             generation_parameters={},
-            adapter_defaults={},
+            adapter_defaults=(
+                {}
+                if response_projection is None
+                else {"response_projection": response_projection}
+            ),
             response_format={},
             reasoning_controls={},
             components=(),

--- a/Tests/Chat/test_console_trace_sidecar_redaction.py
+++ b/Tests/Chat/test_console_trace_sidecar_redaction.py
@@ -1,0 +1,224 @@
+"""Provider replay uses exact saved values while trace storage stays redacted."""
+
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_trace_sidecar_replay import (
+    replay_harness as replay_harness,  # noqa: PLC0414 - pytest fixture re-export
+)
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_provenance import (
+    DerivedTraceProvenance,
+    ProviderArtifactTraceProvenance,
+    TraceProvenanceSource,
+    TraceTransformKind,
+)
+from tldw_chatbook.Chat.console_trace_redaction import CredentialSanitizer
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.Chat.provider_continuation import (
+    ProviderContinuationCheckpoint,
+    dump_provider_continuation_json,
+)
+
+
+def _save_reasoning(
+    harness: SimpleNamespace, text: str
+) -> ProviderContinuationCheckpoint:
+    checkpoint = replace(
+        harness.checkpoint,
+        rounds=(replace(harness.checkpoint.rounds[0], reasoning_blocks=(text,)),),
+    )
+    message_id = harness.prior.persisted_message_id
+    saved = harness.database.get_message_by_id(message_id)
+    assert harness.database.update_provider_continuation(
+        message_id=message_id,
+        expected_message_version=saved["version"],
+        provider_continuation_json=dump_provider_continuation_json(checkpoint),
+        content="prior answer",
+    )
+    harness.store._message_or_raise(harness.prior.id).provider_continuation = checkpoint
+    harness.checkpoint = checkpoint
+    return checkpoint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [True], indirect=True)
+async def test_credential_filter_equivalence_cannot_admit_changed_saved_checkpoint(
+    replay_harness,
+):
+    harness = replay_harness
+    canonical = _save_reasoning(harness, "Bearer sk-proj-" + "x" * 48)
+    forged = replace(
+        canonical,
+        rounds=(
+            replace(
+                canonical.rounds[0],
+                reasoning_blocks=("Bearer sk-proj-" + "y" * 48,),
+            ),
+        ),
+    )
+    sanitizer = CredentialSanitizer()
+    canonical_mask = sanitizer.sanitize(
+        json.loads(dump_provider_continuation_json(canonical))
+    )
+    forged_mask = sanitizer.sanitize(
+        json.loads(dump_provider_continuation_json(forged))
+    )
+    assert canonical != forged
+    assert canonical_mask.available and forged_mask.available
+    assert canonical_mask.redacted and canonical_mask.value == forged_mask.value
+    harness.store._message_or_raise(harness.prior.id).provider_continuation = forged
+
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+
+    assert harness.prepared[-1].continuation_groups[0].checkpoint == forged
+    assert result.accepted and not result.provider_started
+    assert harness.entries == []
+    assert (
+        harness.database.get_connection()
+        .execute(
+            "SELECT COUNT(*) FROM console_trace_calls "
+            "WHERE dispatch_started_at IS NOT NULL"
+        )
+        .fetchone()[0]
+        == 0
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [True], indirect=True)
+async def test_unsaved_continuation_owner_cannot_gain_masked_prefix_authority(
+    replay_harness,
+):
+    harness = replay_harness
+    canonical = _save_reasoning(harness, "Bearer sk-proj-" + "x" * 48)
+    first = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert first.provider_started and len(harness.entries) == 1
+    forged = replace(
+        canonical,
+        rounds=(
+            replace(
+                canonical.rounds[0],
+                reasoning_blocks=("Bearer sk-proj-" + "y" * 48,),
+            ),
+        ),
+    )
+    with harness.database.transaction() as cursor:
+        policy_id, owner_id = cursor.execute(
+            "SELECT policy_id, owner_id FROM console_trace_calls"
+        ).fetchone()
+        policy = harness.factory.repository.get_policy(cursor, policy_id)
+        durable_key = tuple(
+            cursor.execute(
+                "SELECT component_kind, reference_kind, artifact_id "
+                "FROM console_trace_surface_nodes WHERE component_kind = 'continuation'"
+            ).fetchone()
+        )
+        durable_values = harness.factory.service._resolve_reference_values(
+            cursor, (durable_key,), owner_id=owner_id
+        )
+        descriptor = DerivedTraceProvenance(
+            TraceTransformKind.CONTINUATION_ATTACHMENT,
+            (
+                ProviderArtifactTraceProvenance(
+                    TraceProvenanceSource.ACTIVE_REQUEST, policy
+                ),
+            ),
+            artifact=ProviderArtifactTraceProvenance(
+                TraceProvenanceSource.CONTINUATION, policy
+            ),
+        )
+        assert not harness.factory.service._durable_reference_matches(
+            cursor,
+            descriptor,
+            json.loads(dump_provider_continuation_json(forged)),
+            durable_key,
+            durable_values,
+            owner_id=owner_id,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [True], indirect=True)
+@pytest.mark.parametrize(
+    ("redaction", "cold"),
+    [("credential", False), ("credential", True), ("pii", True)],
+)
+async def test_redacted_continuation_replays_raw_saved_value_across_successors(
+    replay_harness, redaction, cold
+):
+    harness = replay_harness
+    canary = (
+        "Bearer sk-proj-" + "x" * 48
+        if redaction == "credential"
+        else "replay-owner@example.test"
+    )
+    expected_mask = (
+        "[credential omitted]" if redaction == "credential" else "[PII omitted]"
+    )
+    canonical = _save_reasoning(harness, canary)
+    if redaction == "pii":
+        before = harness.controller.capture_policy_snapshot("session-1")
+        await harness.controller.replace_conversation_trace_privacy(
+            "session-1",
+            capture_enabled=True,
+            pii_redaction_enabled=True,
+            expected_policy_revision=before.policy_revision,
+        )
+        assert harness.controller.capture_policy_snapshot(
+            "session-1"
+        ).pii_redaction_enabled
+
+    previous_traces = []
+    previous_heads = {}
+    for text in ("ordinary request", "ordinary successor"):
+        if cold:
+            harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+        result = await harness.controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (
+            result,
+            harness.failures,
+            harness.build_errors,
+        )
+        issued = harness.entries[-1]["provider_continuations"]
+        assert isinstance(issued, tuple)
+        assert len(issued) == 1 and type(issued[0]) is ProviderContinuationCheckpoint
+        assert issued[0] == canonical
+        assert issued[0].rounds[0].reasoning_blocks == (canary,)
+
+        saved = harness.store.get_message(result.user_message_id)
+        reader = ConsoleTraceNativeReader(harness.database)
+        trace = reader.read_calls(saved.persisted_message_id)
+        assert len(trace) == 1
+        captured = json.dumps(trace[0].capture.request)
+        assert canary not in captured and expected_mask in captured
+        previous_traces.append((saved.persisted_message_id, trace))
+        for message_id, original in previous_traces:
+            assert reader.read_calls(message_id) == original
+
+        heads = dict(
+            harness.database.get_connection().execute(
+                "SELECT call_id, surface_node_id FROM console_trace_calls"
+            )
+        )
+        assert all(heads[call_id] == head for call_id, head in previous_heads.items())
+        previous_heads = heads
+        artifacts = (
+            harness.database.get_connection()
+            .execute("SELECT sanitized_bytes FROM console_trace_artifacts")
+            .fetchall()
+        )
+        assert artifacts
+        assert all(canary.encode() not in bytes(row[0]) for row in artifacts)
+
+    assert len(harness.entries) == 2
+    assert (
+        harness.store.get_message(harness.prior.id).provider_continuation == canonical
+    )

--- a/Tests/Chat/test_console_trace_sidecar_replay.py
+++ b/Tests/Chat/test_console_trace_sidecar_replay.py
@@ -1,0 +1,438 @@
+"""Capture mode must preserve selected private provider history at dispatch."""
+
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_first_send_atomicity import _controller
+from tldw_chatbook.Chat import console_chat_controller as controller_module
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_history_budget import ProviderContinuationSidecar
+from tldw_chatbook.Chat.console_library_destination import resolve_console_destination
+from tldw_chatbook.Chat.console_prepared_request import thaw_json
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+)
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_provenance import ConsoleTraceCaptureMode
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.Chat.provider_continuation import (
+    ContinuationRound,
+    ProviderContinuationCheckpoint,
+    dump_provider_continuation_json,
+)
+from tldw_chatbook.Chat.thinking_blocks import (
+    DisplayableThinkingBlock,
+    ThinkingEnvelope,
+    parse_thinking_blocks_json,
+)
+
+
+@pytest.fixture
+async def replay_harness(tmp_path, monkeypatch, request):
+    capture_on, kind = (
+        request.param
+        if isinstance(request.param, tuple)
+        else (request.param, "continuation")
+    )
+    settings = ConsoleSessionSettings(
+        provider="moonshot" if kind == "continuation" else "vllm",
+        model="kimi-k3" if kind == "continuation" else "local-thinking-model",
+        base_url="https://api.moonshot.ai/v1"
+        if kind == "continuation"
+        else "http://127.0.0.1:9099/v1",
+        streaming=False,
+    )
+    database, store, controller, _ = _controller(tmp_path, initial_settings=settings)
+    assert store.persist_session_if_needed("session-1")
+    store.append_message(
+        "session-1",
+        role=ConsoleMessageRole.USER,
+        content="prior question",
+        persist=True,
+    )
+    prior = store.append_message(
+        "session-1",
+        role=ConsoleMessageRole.ASSISTANT,
+        content="prior answer",
+        persist=True,
+    )
+    checkpoint = ProviderContinuationCheckpoint(
+        schema_version=1,
+        checkpoint_revision=1,
+        provider=settings.provider,
+        protocol="chat_completions",
+        model=settings.model,
+        api_base_url=settings.base_url,
+        state="complete",
+        rounds=(ContinuationRound("prior answer", ("REPLAY_REASONING_CANARY",), ()),),
+    )
+    if kind == "continuation":
+        assert database.update_provider_continuation(
+            message_id=prior.persisted_message_id,
+            expected_message_version=database.get_connection()
+            .execute(
+                "SELECT version FROM messages WHERE id = ?",
+                (prior.persisted_message_id,),
+            )
+            .fetchone()[0],
+            provider_continuation_json=dump_provider_continuation_json(checkpoint),
+            content="prior answer",
+        )
+        store._message_or_raise(prior.id).provider_continuation = checkpoint
+    else:
+        envelope = ThinkingEnvelope(
+            (
+                DisplayableThinkingBlock(
+                    block_id="saved-thinking",
+                    round_ordinal=0,
+                    provider=settings.provider,
+                    model=settings.model,
+                    protocol="chat_completions",
+                    source_format="start_anchored_think",
+                    status="complete",
+                    text="REPLAY_THINKING_CANARY",
+                ),
+            )
+        )
+        store.replace_message_thinking(prior.id, envelope)
+        assert store.persist_selected_generation(prior.id)
+    original_preparation = controller_module.ConsoleTurnPreparation
+
+    def preparation(**kwargs):
+        kwargs["capture_mode"] = (
+            ConsoleTraceCaptureMode.CAPTURE_ON
+            if capture_on
+            else ConsoleTraceCaptureMode.CAPTURE_OFF
+        )
+        return original_preparation(**kwargs)
+
+    monkeypatch.setattr(controller_module, "ConsoleTurnPreparation", preparation)
+    harness = SimpleNamespace(
+        database=database,
+        store=store,
+        controller=controller,
+        checkpoint=checkpoint,
+        prior=prior,
+        capture_on=capture_on,
+        entries=[],
+        failures=[],
+        build_errors=[],
+        prepared=[],
+        reply_text="answer",
+        factory=ConsoleTraceBoundaryFactory(database),
+    )
+    build_trace = controller._build_durable_trace_request
+
+    def record_build(*args, **kwargs):
+        try:
+            return build_trace(*args, **kwargs)
+        except Exception as error:
+            harness.build_errors.append(error)
+            raise
+
+    monkeypatch.setattr(controller, "_build_durable_trace_request", record_build)
+
+    def adapter(**kwargs):
+        harness.entries.append(kwargs)
+        return {"choices": [{"message": {"content": harness.reply_text}}]}
+
+    def boundary(prepared, resolution, route):
+        try:
+            return harness.factory(prepared, resolution, route)
+        except ValueError as error:
+            harness.failures.append(str(error))
+            raise
+
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=adapter, trace_call_boundary_factory=boundary
+    )
+    resolution = ConsoleProviderResolution(
+        ready=True,
+        provider=settings.provider,
+        execution_key=settings.provider,
+        model=settings.model,
+        base_url=settings.base_url,
+        streaming=False,
+        continuation_protocol="chat_completions",
+        thinking_stream_disposition="displayable" if kind == "thinking" else "ignored",
+        thinking_round_trip_version=1 if kind == "thinking" else None,
+    )
+    resolution = replace(
+        resolution, resolved_destination=resolve_console_destination(resolution)
+    )
+
+    async def resolve(_selection):
+        return resolution
+
+    monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+    prepare = gateway.prepare_chat_request
+
+    def record_preparation(*args, **kwargs):
+        prepared = prepare(*args, **kwargs)
+        harness.prepared.append(prepared)
+        return prepared
+
+    monkeypatch.setattr(gateway, "prepare_chat_request", record_preparation)
+    controller.provider_gateway = gateway
+    controller._chat_dictionary_applier = lambda _conversation, text: text.replace(
+        "alias", "expanded"
+    )
+    try:
+        yield harness
+    finally:
+        await gateway.aclose()
+        database.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [False, True], indirect=True)
+@pytest.mark.parametrize("transformed", [False, True])
+async def test_capture_preserves_selected_continuation_and_successor(
+    replay_harness, transformed
+):
+    harness = replay_harness
+    first_text = "alias request" if transformed else "ordinary request"
+    old_traces = []
+    for text in (first_text, "ordinary successor"):
+        harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+        result = await harness.controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (
+            result,
+            harness.failures,
+            harness.build_errors,
+        )
+        call = harness.entries[-1]
+        assert tuple(call.get("provider_continuations", ())) == (harness.checkpoint,)
+        assert len(harness.prepared[-1].continuation_groups) == 1
+        visible = thaw_json(call["messages_payload"])
+        assert visible[-1]["content"] == text.replace("alias", "expanded")
+        assert "REPLAY_REASONING_CANARY" not in repr(visible)
+        saved = harness.store.get_message(result.user_message_id)
+        assert saved.content == text
+        if harness.capture_on:
+            reader = ConsoleTraceNativeReader(harness.database)
+            trace = reader.read_calls(saved.persisted_message_id)
+            assert len(trace) == 1
+            assert trace[0].capture.request["messages_payload"] == visible
+            assert "REPLAY_REASONING_CANARY" in repr(trace[0].capture.request)
+            old_traces.append((saved.persisted_message_id, trace))
+            for message_id, before in old_traces:
+                assert reader.read_calls(message_id) == before
+    assert not harness.failures
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replay_harness", [(False, "thinking"), (True, "thinking")], indirect=True
+)
+@pytest.mark.parametrize("transformed", [False, True])
+async def test_capture_preserves_selected_displayable_thinking(
+    replay_harness, transformed
+):
+    harness = replay_harness
+    old_traces = []
+    for text in (
+        "alias request" if transformed else "ordinary request",
+        "ordinary successor",
+    ):
+        harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+        result = await harness.controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (result, harness.failures)
+        visible = thaw_json(harness.entries[-1]["messages_payload"])
+        assert (
+            visible[1]["content"]
+            == "<think>REPLAY_THINKING_CANARY</think>\nprior answer"
+        )
+        assert visible[-1]["content"] == text.replace("alias", "expanded")
+        assert harness.store.get_message(harness.prior.id).content == "prior answer"
+        if harness.capture_on:
+            saved = harness.store.get_message(result.user_message_id)
+            reader = ConsoleTraceNativeReader(harness.database)
+            trace = reader.read_calls(saved.persisted_message_id)
+            assert len(trace) == 1
+            assert trace[0].capture.request["messages_payload"] == visible
+            old_traces.append((saved.persisted_message_id, trace))
+            for message_id, before in old_traces:
+                assert reader.read_calls(message_id) == before
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replay_harness", [(False, "thinking"), (True, "thinking")], indirect=True
+)
+async def test_transformed_send_replays_new_assistant_thinking_on_cold_successor(
+    replay_harness,
+):
+    harness = replay_harness
+    harness.reply_text = "<think>NEW_ASSISTANT_THINKING_CANARY</think>answer"
+    first = await harness.controller.submit_draft(
+        "alias request", session_id="session-1"
+    )
+    assert first.accepted and first.provider_started, (first, harness.failures)
+    assistant = harness.store.get_message(first.assistant_message_id)
+    assert assistant.content == "answer"
+    assert assistant.thinking.blocks[0].text == "NEW_ASSISTANT_THINKING_CANARY"
+    row = harness.database.get_message_by_id(assistant.persisted_message_id)
+    assert parse_thinking_blocks_json(row["thinking_blocks_json"]) == assistant.thinking
+    saved_user = harness.store.get_message(first.user_message_id)
+    reader = ConsoleTraceNativeReader(harness.database)
+    previous_trace = reader.read_calls(saved_user.persisted_message_id)
+
+    harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+    result = await harness.controller.submit_draft(
+        "ordinary successor", session_id="session-1"
+    )
+    assert result.accepted and result.provider_started, (result, harness.failures)
+    messages = thaw_json(harness.entries[-1]["messages_payload"])
+    assert (
+        messages[-2]["content"]
+        == "<think>NEW_ASSISTANT_THINKING_CANARY</think>\nanswer"
+    )
+    if harness.capture_on:
+        saved = harness.store.get_message(result.user_message_id)
+        trace = reader.read_calls(saved.persisted_message_id)
+        assert len(trace) == 1
+        assert trace[0].capture.request["messages_payload"] == messages
+        assert reader.read_calls(saved_user.persisted_message_id) == previous_trace
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [(True, "thinking")], indirect=True)
+@pytest.mark.parametrize("credential_equivalent", [False, True])
+async def test_capture_rejects_unsaved_thinking_under_saved_owner(
+    replay_harness, credential_equivalent
+):
+    harness = replay_harness
+    canonical = harness.store.get_message(harness.prior.id).thinking
+    if credential_equivalent:
+        canonical = replace(
+            canonical,
+            blocks=(replace(canonical.blocks[0], text="Bearer sk-proj-" + "x" * 48),),
+        )
+        harness.store.replace_message_thinking(harness.prior.id, canonical)
+        assert harness.store.persist_selected_generation(harness.prior.id)
+    forged = replace(
+        canonical,
+        blocks=(
+            replace(
+                canonical.blocks[0],
+                text="Bearer sk-proj-" + "y" * 48
+                if credential_equivalent
+                else "FORGED_THINKING_OWNER_CANARY",
+            ),
+        ),
+    )
+    harness.store.replace_message_thinking(harness.prior.id, forged)
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert result.accepted and not result.provider_started
+    assert harness.entries == []
+    row = harness.database.get_message_by_id(harness.prior.persisted_message_id)
+    assert parse_thinking_blocks_json(row["thinking_blocks_json"]) == canonical
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replay_harness", [(False, "thinking"), (True, "thinking")], indirect=True
+)
+async def test_capture_keeps_excluded_thinking_out_of_request(replay_harness):
+    harness = replay_harness
+    _, persisted = harness.store.set_session_thinking_history_policy(
+        "session-1", "exclude"
+    )
+    assert persisted
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert result.accepted and result.provider_started, (result, harness.failures)
+    assert "REPLAY_THINKING_CANARY" not in repr(harness.entries[-1])
+    assert (
+        harness.store.get_message(harness.prior.id).thinking.blocks[0].text
+        == "REPLAY_THINKING_CANARY"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [False, True], indirect=True)
+@pytest.mark.parametrize("mismatch", ["model", "endpoint"])
+async def test_capture_keeps_incompatible_continuation_out_of_request(
+    replay_harness, mismatch
+):
+    harness = replay_harness
+    checkpoint = replace(
+        harness.checkpoint,
+        **(
+            {"model": "kimi-k2"}
+            if mismatch == "model"
+            else {"api_base_url": "https://different.invalid/v1"}
+        ),
+    )
+    row = harness.database.get_message_by_id(harness.prior.persisted_message_id)
+    assert harness.database.update_provider_continuation(
+        message_id=harness.prior.persisted_message_id,
+        expected_message_version=row["version"],
+        provider_continuation_json=dump_provider_continuation_json(checkpoint),
+        content="prior answer",
+    )
+    harness.store._message_or_raise(harness.prior.id).provider_continuation = checkpoint
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert result.accepted and result.provider_started, (result, harness.failures)
+    assert not harness.entries[-1].get("provider_continuations")
+    assert "REPLAY_REASONING_CANARY" not in repr(harness.entries[-1])
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [False, True], indirect=True)
+async def test_capture_does_not_attach_continuation_for_missing_owner(
+    replay_harness, monkeypatch
+):
+    harness = replay_harness
+    read_sidecars = harness.controller._provider_continuation_sidecar_for_session
+    extra = ProviderContinuationSidecar(
+        "owner-outside-this-conversation",
+        replace(
+            harness.checkpoint,
+            rounds=(
+                ContinuationRound("foreign answer", ("FOREIGN_REASONING_CANARY",), ()),
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        harness.controller,
+        "_provider_continuation_sidecar_for_session",
+        lambda session_id: (*read_sidecars(session_id), extra),
+    )
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert result.accepted and result.provider_started, (result, harness.failures)
+    assert tuple(harness.entries[-1].get("provider_continuations", ())) == (
+        harness.checkpoint,
+    )
+    assert harness.prepared[-1].continuation_groups[0].checkpoint == harness.checkpoint
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [True], indirect=True)
+async def test_capture_rejects_private_sidecar_value_that_disagrees_with_saved_source(
+    replay_harness,
+):
+    harness = replay_harness
+    forged = replace(
+        harness.checkpoint,
+        rounds=(ContinuationRound("prior answer", ("UNSAVED_PRIVATE_CANARY",), ()),),
+    )
+    harness.store._message_or_raise(harness.prior.id).provider_continuation = forged
+    result = await harness.controller.submit_draft(
+        "ordinary request", session_id="session-1"
+    )
+    assert result.accepted and not result.provider_started
+    assert not harness.entries
+    assert harness.prepared[-1].continuation_groups[0].checkpoint == forged

--- a/Tests/Chat/test_console_trace_thinking_settlement.py
+++ b/Tests/Chat/test_console_trace_thinking_settlement.py
@@ -1,0 +1,269 @@
+"""Saved thinking response links require exact typed evidence and frozen meaning."""
+
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Chat.test_console_trace_settlement import _call, _request
+from Tests.Chat.test_console_trace_settlement import (
+    db as db,  # noqa: PLC0414 - pytest fixture re-export
+)
+from Tests.Chat.test_console_trace_sidecar_replay import (
+    replay_harness as replay_harness,  # noqa: PLC0414 - pytest fixture re-export
+)
+from tldw_chatbook.Chat.console_semantic_revision import (
+    project_semantic_revision_trace_message,
+)
+from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy, new_opaque_id
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_redaction import BUILTIN_PII_RULESET_REVISION_ID
+from tldw_chatbook.Chat.console_trace_repository import ConsoleTraceRepository
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+from tldw_chatbook.Chat.console_trace_settlement import (
+    ConsoleTraceSettlementCoordinator,
+)
+from tldw_chatbook.Chat.thinking_blocks import (
+    DisplayableThinkingBlock,
+    ThinkingEnvelope,
+    dump_thinking_blocks_json,
+)
+
+PROFILE = {
+    "version": 1,
+    "thinking_stream_disposition": "displayable",
+    "thinking_round_trip_version": 1,
+    "provider": "openai",
+    "model": "gpt-test",
+    "protocol": "chat_completions",
+    "source_format": "start_anchored_think",
+}
+
+
+@pytest.mark.parametrize(
+    "case",
+    [
+        "exact",
+        "fragmented",
+        "pii",
+        "pii_mismatch",
+        "pii_unavailable",
+        "pii_legacy_mismatch",
+        "pii_legacy_unavailable",
+        "pii_legacy_exact",
+        "pii_legacy_exact_unavailable",
+        "queued",
+        "raw_mismatch",
+        "provider",
+        "model",
+        "format",
+        "status",
+        "round",
+        "legacy",
+        "ignored",
+        "malformed",
+    ],
+)
+def test_saved_thinking_response_projection_requires_exact_evidence(
+    db, case, monkeypatch
+):
+    repository = ConsoleTraceRepository()
+    coordinator = ConsoleTraceSettlementCoordinator(repository)
+    profile = None if "legacy" in case else dict(PROFILE)
+    if case == "ignored":
+        profile["thinking_stream_disposition"] = "ignored"
+    conversation_id, _segment, call_id = _call(
+        db,
+        repository,
+        response_projection=profile,
+        policy=(
+            FrozenTracePolicy(
+                new_opaque_id(), "credentials-v1", True, BUILTIN_PII_RULESET_REVISION_ID
+            )
+            if case.startswith("pii")
+            else None
+        ),
+    )
+    secret = (
+        "trace.person@example.com"
+        if case.startswith("pii")
+        else "Bearer sk-proj-" + "x" * 48
+    )
+    block = DisplayableThinkingBlock(
+        block_id="saved-response-thinking",
+        round_ordinal=0,
+        provider="openai",
+        model="gpt-test",
+        protocol="chat_completions",
+        source_format="start_anchored_think",
+        status="complete",
+        text=secret,
+    )
+    if case in {"provider", "model"}:
+        block = replace(block, **{case: "different"})
+    elif case == "format":
+        block = replace(block, source_format="reasoning_content")
+    elif case == "status":
+        block = replace(block, status="stopped")
+    elif case == "round":
+        block = replace(block, round_ordinal=1)
+    elif case in {"pii_mismatch", "pii_legacy_mismatch"}:
+        block = replace(block, text="other.person@example.com")
+    assistant_id = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "assistant",
+            "content": secret if "legacy_exact" in case else "answer",
+            "thinking_blocks_json": dump_thinking_blocks_json(
+                ThinkingEnvelope((block,))
+            ),
+            "assistant_generation_state": "complete",
+        }
+    )
+    assert assistant_id is not None
+    thinking = {
+        key: PROFILE[key] for key in ("provider", "model", "protocol", "source_format")
+    }
+    thinking["text"] = (
+        "Bearer sk-proj-" + "y" * 48 if case == "raw_mismatch" else secret
+    )
+    response = {"role": "assistant", "content": "answer", "thinking": [thinking]}
+    if "legacy_exact" in case:
+        response = {"role": "assistant", "content": secret}
+    if case == "fragmented":
+        response["thinking"] = [
+            dict(thinking, text=secret[:13]),
+            dict(thinking, text=secret[13:]),
+        ]
+    elif case == "malformed":
+        response["thinking"] = [dict(thinking, unexpected=True)]
+    elif case in {"legacy", "ignored"}:
+        # Existing visible-only references must never gain thinking on read.
+        response.pop("thinking")
+    request = _request(call_id, canonical_message_id=assistant_id, response=response)
+    if case.endswith("unavailable"):
+        monkeypatch.setattr(
+            "tldw_chatbook.Chat.console_trace_settlement.redact_pii_value_for_ruleset_revision",
+            lambda *_args: SimpleNamespace(
+                available=False, omission_reason_code="pii_detector_unavailable"
+            ),
+        )
+    handoff = coordinator.prepare_handoff(db, request)
+    assert secret not in repr(handoff)
+    if case == "queued":
+        settle = coordinator._settle_prepared
+
+        def unavailable(*_args):
+            raise OSError("isolated busy database")
+
+        monkeypatch.setattr(coordinator, "_settle_prepared", unavailable)
+        assert not handoff.settle(assistant_id)
+        assert coordinator.pending_count == 1
+        pending = coordinator._pending[call_id][1]
+        assert secret.encode() not in pending.response_bytes
+        assert pending._response_equality_proof is not None
+        assert pending._response_equality_proof.hex() not in "\n".join(
+            db.get_connection().iterdump()
+        )
+        monkeypatch.setattr(coordinator, "_settle_prepared", settle)
+        assert coordinator.retry_pending() == 1
+    else:
+        assert handoff.settle(assistant_id)
+    cursor = db.get_connection().cursor()
+    call = repository.get_call(cursor, call_id)
+    link = repository.get_response_link(cursor, call_id)
+    assert link is not None
+    expects_revision = case in {
+        "exact",
+        "fragmented",
+        "pii",
+        "queued",
+        "legacy",
+        "pii_legacy_exact",
+    }
+    assert link.link_kind == ("revision" if expects_revision else "artifact")
+    captured = ConsoleTraceNativeReader(db)._reconstruct_response(cursor, call)
+    assert secret not in json.dumps(captured)
+    if case == "pii":
+        assert project_semantic_revision_trace_message(
+            cursor,
+            revision_id=link.semantic_revision_id,
+            expected_conversation_id=conversation_id,
+            policy_id=call.policy_id,
+        ) == {"role": "assistant", "content": "answer"}
+    if case.startswith("pii_"):
+        assert coordinator.submit(db, request)
+        assert (
+            ConsoleTraceNativeReader(db)._reconstruct_response(cursor, call) == captured
+        )
+    if case in {"exact", "fragmented", "pii", "queued"}:
+        assert captured["content"] == "answer" and len(captured["thinking"]) == 1
+        assert captured["thinking"][0]["source_format"] == "start_anchored_think"
+        assert coordinator.submit(db, request)
+        if case != "pii":
+            altered = {
+                **response,
+                "thinking": [{**thinking, "text": "Bearer sk-proj-" + "y" * 48}],
+            }
+            with pytest.raises(ValueError, match="settlement_response_conflict"):
+                coordinator.settle(db, replace(request, response_envelope=altered))
+        # Retiring the locator must retain the same historical response meaning.
+        row = db.get_message_by_id(assistant_id)
+        assert db.update_message(assistant_id, {"content": "edited"}, row["version"])
+        assert (
+            ConsoleTraceNativeReader(db)._reconstruct_response(cursor, call) == captured
+        )
+        # A retired masked body cannot re-prove raw equality for a new handoff.
+        with pytest.raises(ValueError, match="settlement_response_conflict"):
+            coordinator.settle(db, request)
+    elif case == "legacy":
+        assert captured == {"role": "assistant", "content": "answer"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [(True, "thinking")], indirect=True)
+@pytest.mark.parametrize("cold", [False, True])
+@pytest.mark.parametrize("history", ["include", "exclude"])
+async def test_thinking_response_pii_masks_preserve_successor_message_projection(
+    replay_harness,
+    cold,
+    history,
+):
+    harness = replay_harness
+    snapshot = harness.controller.capture_policy_snapshot("session-1")
+    await harness.controller.replace_conversation_trace_privacy(
+        "session-1",
+        capture_enabled=True,
+        pii_redaction_enabled=True,
+        expected_policy_revision=snapshot.policy_revision,
+    )
+    _, persisted = harness.store.set_session_thinking_history_policy(
+        "session-1", history
+    )
+    assert persisted
+    canary = "response.person@example.com"
+    harness.reply_text = f"<think>{canary}</think>answer"
+    previous = []
+    for text in ("alias request", "ordinary successor"):
+        if cold:
+            harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+        result = await harness.controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (result, harness.failures)
+        saved = harness.store.get_message(result.user_message_id)
+        reader = ConsoleTraceNativeReader(harness.database)
+        trace = reader.read_calls(saved.persisted_message_id)
+        assert len(trace) == 1
+        assert "messages_payload" in trace[0].capture.request
+        assert canary not in json.dumps(trace[0].capture.request)
+        assert canary not in json.dumps(trace[0].capture.response)
+        assert "[PII omitted]" in json.dumps(trace[0].capture.response)
+        previous.append((saved.persisted_message_id, trace))
+        for message_id, original in previous:
+            assert reader.read_calls(message_id) == original
+    assert len(harness.entries) == 2
+    if history == "exclude":
+        assert canary not in repr(harness.entries[-1])
+        assert trace[0].capture.request["messages_payload"][-2]["content"] == "answer"
+    else:
+        assert canary in repr(harness.entries[-1])

--- a/Tests/Chat/test_console_trace_transform_continuations.py
+++ b/Tests/Chat/test_console_trace_transform_continuations.py
@@ -1,0 +1,51 @@
+"""Current-user transforms retain an unchanged saved continuation domain."""
+
+import pytest
+
+from Tests.Chat.test_console_trace_sidecar_replay import (
+    replay_harness as replay_harness,  # noqa: PLC0414 - pytest fixture re-export
+)
+from tldw_chatbook.Chat.console_prepared_request import thaw_json
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.console_trace_runtime import ConsoleTraceBoundaryFactory
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("replay_harness", [True], indirect=True)
+@pytest.mark.parametrize("cold_factory", [False, True])
+async def test_transformed_successors_preserve_saved_continuation_domain(
+    replay_harness, cold_factory
+):
+    harness = replay_harness
+    reader = ConsoleTraceNativeReader(harness.database)
+    previous = []
+    for text in ("alias first", "ordinary next", "alias third", "ordinary last"):
+        if cold_factory:
+            harness.factory = ConsoleTraceBoundaryFactory(harness.database)
+        result = await harness.controller.submit_draft(text, session_id="session-1")
+        assert result.accepted and result.provider_started, (
+            text,
+            result,
+            harness.failures,
+            len(harness.entries),
+        )
+        call = harness.entries[-1]
+        assert tuple(call["provider_continuations"]) == (harness.checkpoint,)
+        visible = thaw_json(call["messages_payload"])
+        assert visible[-1]["content"] == text.replace("alias", "expanded")
+        saved = harness.store.get_message(result.user_message_id)
+        assert saved.content == text
+        trace = reader.read_calls(saved.persisted_message_id)
+        assert len(trace) == 1
+        assert trace[0].capture.request["messages_payload"] == visible
+        assert "REPLAY_REASONING_CANARY" in repr(trace[0].capture.request)
+        previous.append((saved.persisted_message_id, trace))
+        for message_id, original in previous:
+            assert reader.read_calls(message_id) == original
+    assert [row["content"] for row in visible if row["role"] == "user"] == [
+        "prior question",
+        "alias first",
+        "ordinary next",
+        "alias third",
+        "ordinary last",
+    ]

--- a/Tests/DB/test_chachanotes_v69_trace_source_pin_migration.py
+++ b/Tests/DB/test_chachanotes_v69_trace_source_pin_migration.py
@@ -1,0 +1,187 @@
+"""Exact call-source pin migration preserves existing nullable boundaries."""
+
+import sqlite3
+
+import pytest
+
+from Tests.ChaChaNotesDB.historical_bootstrap import chachanotes_db_at_version
+from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy, new_opaque_id
+from tldw_chatbook.Chat.console_trace_redaction import CREDENTIAL_FILTER_VERSION
+from tldw_chatbook.Chat.console_trace_repository import ConsoleTraceRepository
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, SchemaError
+
+
+def test_v68_upgrade_preserves_old_boundaries_and_checks_exact_call_source(
+    tmp_path, monkeypatch
+):
+    path = tmp_path / "source-pin.sqlite"
+    with monkeypatch.context() as historical_target:
+        historical_target.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 68)
+        old = CharactersRAGDB(path, "source-pin-old")
+        conversation = old.add_conversation({"title": "source pin"})
+        source = old.add_message(
+            {"conversation_id": conversation, "sender": "user", "content": "source"}
+        )
+        other = old.add_message(
+            {"conversation_id": conversation, "sender": "user", "content": "other"}
+        )
+        foreign_conversation = old.add_conversation({"title": "foreign source"})
+        foreign_source = old.add_message(
+            {
+                "conversation_id": foreign_conversation,
+                "sender": "user",
+                "content": "foreign",
+            }
+        )
+        repository = ConsoleTraceRepository()
+        policy = FrozenTracePolicy(
+            new_opaque_id(), CREDENTIAL_FILTER_VERSION, False, None
+        )
+        with old.transaction() as cursor:
+            revisions = dict(
+                cursor.execute(
+                    "SELECT source_message_id, revision_id FROM console_trace_semantic_revisions"
+                ).fetchall()
+            )
+            repository.ensure_policy(cursor, policy)
+            segment = repository.create_segment(cursor)
+            owner = repository.attach_owner(
+                cursor, conversation_id=conversation, root_segment_id=segment.segment_id
+            )
+            call = repository.reserve_call(
+                cursor,
+                owner_id=owner.owner_id,
+                segment_id=segment.segment_id,
+                turn_id=source,
+                run_id=new_opaque_id(),
+                call_sequence=0,
+                idempotency_key=new_opaque_id(),
+                policy_id=policy.policy_id,
+            )
+            old_event = repository.append_event(
+                cursor,
+                segment_id=segment.segment_id,
+                sequence=0,
+                event_type="call_boundary",
+                call_id=call.call_id,
+            )
+        old.close()
+
+    db = CharactersRAGDB(path, "source-pin-new")
+    try:
+        assert db._get_db_version(db.get_connection()) == 69
+        with db.transaction() as cursor:
+            assert (
+                repository.get_latest_call_boundary(cursor, segment.segment_id)
+                == old_event
+            )
+            pinned = repository.append_event(
+                cursor,
+                segment_id=segment.segment_id,
+                sequence=1,
+                event_type="call_boundary",
+                call_id=call.call_id,
+                semantic_revision_id=revisions[source],
+            )
+            assert pinned.semantic_revision_id == revisions[source]
+        for event_type, revision in (
+            ("call_boundary", revisions[other]),
+            ("call_boundary", revisions[foreign_source]),
+            ("call_outcome", revisions[source]),
+            ("usage", revisions[source]),
+        ):
+            with pytest.raises(sqlite3.IntegrityError), db.transaction() as cursor:
+                repository.append_event(
+                    cursor,
+                    segment_id=segment.segment_id,
+                    sequence=2,
+                    event_type=event_type,
+                    call_id=call.call_id,
+                    semantic_revision_id=revision,
+                )
+        with pytest.raises(sqlite3.IntegrityError), db.transaction() as cursor:
+            cursor.execute(
+                "UPDATE console_trace_events SET semantic_revision_id = ? WHERE event_id = ?",
+                (revisions[other], pinned.event_id),
+            )
+        assert not db.get_connection().execute("PRAGMA foreign_key_check").fetchall()
+    finally:
+        db.close()
+
+
+def _schema(connection):
+    return tuple(
+        tuple(row)
+        for row in connection.execute(
+            "SELECT type, name, tbl_name, sql FROM sqlite_master ORDER BY type, name"
+        )
+    )
+
+
+@pytest.mark.parametrize("fault", ["after_ddl", "version_update"])
+def test_source_pin_migration_failure_restores_v68_and_can_retry(
+    tmp_path, monkeypatch, fault
+):
+    path = tmp_path / "rollback.sqlite"
+    with chachanotes_db_at_version(path, 68) as db:
+        connection = db.get_connection()
+        before = _schema(connection)
+        execute = db._execute_migration_statements
+
+        def fail_migration(cursor, script, label):
+            execute(cursor, script, label)
+            if fault == "after_ddl":
+                raise sqlite3.OperationalError("injected post-DDL failure")
+            cursor.execute(
+                "CREATE TRIGGER reject_source_pin_version BEFORE UPDATE OF version "
+                "ON db_schema_version WHEN NEW.version = 69 BEGIN "
+                "SELECT RAISE(ABORT, 'injected version-update failure'); END"
+            )
+
+        with monkeypatch.context() as injected:
+            injected.setattr(db, "_execute_migration_statements", fail_migration)
+            with pytest.raises(SchemaError):
+                db._migrate_from_v68_to_v69(connection)
+        assert db._get_db_version(connection) == 68
+        assert _schema(connection) == before
+        db._migrate_from_v68_to_v69(connection)
+        assert db._get_db_version(connection) == 69
+        assert not connection.execute("PRAGMA foreign_key_check").fetchall()
+
+
+@pytest.mark.parametrize("damage", ["missing_shape_guard", "renamed_source_column"])
+def test_source_pin_migration_rejects_malformed_predecessor_without_changes(
+    tmp_path, damage
+):
+    with chachanotes_db_at_version(tmp_path / "malformed.sqlite", 68) as db:
+        with db.transaction() as cursor:
+            if damage == "missing_shape_guard":
+                cursor.execute("DROP TRIGGER console_trace_events_shape_guard")
+            else:
+                cursor.execute(
+                    "ALTER TABLE console_trace_semantic_revisions "
+                    "RENAME COLUMN source_message_id TO unexpected_source_message_id"
+                )
+        connection = db.get_connection()
+        before = _schema(connection)
+        with pytest.raises(SchemaError):
+            db._migrate_from_v68_to_v69(connection)
+        assert db._get_db_version(connection) == 68
+        assert _schema(connection) == before
+
+
+def test_source_pin_migration_requires_v68_and_fresh_schema_matches_upgrade(tmp_path):
+    with chachanotes_db_at_version(tmp_path / "upgrade.sqlite", 68) as db:
+        connection = db.get_connection()
+        db._migrate_from_v68_to_v69(connection)
+        upgraded_schema = _schema(connection)
+        with pytest.raises(SchemaError, match="requires schema version 68"):
+            db._migrate_from_v68_to_v69(connection)
+        assert _schema(connection) == upgraded_schema
+
+    fresh = CharactersRAGDB(tmp_path / "fresh.sqlite", "source-pin-fresh")
+    try:
+        assert fresh._get_db_version(fresh.get_connection()) == 69
+        assert _schema(fresh.get_connection()) == upgraded_schema
+    finally:
+        fresh.close()

--- a/Tests/DB/test_character_conversation_search_migration.py
+++ b/Tests/DB/test_character_conversation_search_migration.py
@@ -35,7 +35,10 @@ def test_v66_dispatches_versioned_sql_artifact(monkeypatch, tmp_path: Path) -> N
     monkeypatch.setattr(Path, "read_text", tracked_read)
     db = CharactersRAGDB(tmp_path / "artifact.sqlite", client_id="artifact")
     assert reads == [artifact]
-    assert db._get_db_version(db.get_connection()) == 68
+    assert (
+        db._get_db_version(db.get_connection())
+        == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+    )
 
 
 def _owned_schema(db: CharactersRAGDB) -> dict[str, tuple[tuple[object, ...], ...]]:
@@ -95,7 +98,10 @@ def test_v66_migrates_genuine_v65_once_without_starting_backfill(
     upgraded = CharactersRAGDB(path, client_id="character-search-v66")
     try:
         connection = upgraded.get_connection()
-        assert upgraded._get_db_version(connection) == 68
+        assert (
+            upgraded._get_db_version(connection)
+            == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        )
         assert {
             row[0]
             for row in connection.execute(
@@ -128,7 +134,10 @@ def test_v66_migrates_genuine_v65_once_without_starting_backfill(
 
     reopened = CharactersRAGDB(path, client_id="character-search-v66-reopen")
     try:
-        assert reopened._get_db_version(reopened.get_connection()) == 68
+        assert (
+            reopened._get_db_version(reopened.get_connection())
+            == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        )
         assert (
             reopened.get_connection()
             .execute(
@@ -151,7 +160,7 @@ def test_v66_fresh_schema_matches_migrated_tables_columns_indexes_and_triggers(
     migrated = CharactersRAGDB(historical_path, client_id="migrated")
     fresh = CharactersRAGDB(tmp_path / "fresh.sqlite", client_id="fresh")
     try:
-        assert CharactersRAGDB._CURRENT_SCHEMA_VERSION == 68
+        assert CharactersRAGDB._CURRENT_SCHEMA_VERSION >= 68
         assert _owned_schema(fresh) == _owned_schema(migrated)
         document_columns = {
             row[1]
@@ -275,7 +284,10 @@ def test_canvas_migrations_preserve_character_search_state_from_genuine_v66(
     upgraded = CharactersRAGDB(path, client_id="character-search-state-v68")
     try:
         connection = upgraded.get_connection()
-        assert upgraded._get_db_version(connection) == 68
+        assert (
+            upgraded._get_db_version(connection)
+            == CharactersRAGDB._CURRENT_SCHEMA_VERSION
+        )
         assert (
             tuple(
                 connection.execute(

--- a/Tests/TTS/test_kokoro_encoded_audio.py
+++ b/Tests/TTS/test_kokoro_encoded_audio.py
@@ -1,0 +1,150 @@
+"""Kokoro file responses must decode to the whole generated utterance."""
+
+import io
+import shutil
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from tldw_chatbook.TTS import audio_service
+from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.backends.kokoro import KokoroTTSBackend
+
+
+@pytest.fixture
+def generated_audio(tmp_path):
+    sample_rate = 24000
+    time = np.arange(sample_rate, dtype=np.float32) / sample_rate
+    samples = np.concatenate(
+        [0.2 * np.sin(2 * np.pi * frequency * time) for frequency in (440, 660)]
+    ).astype(np.float32)
+
+    async def create_stream(*args, **kwargs):
+        for start in range(0, len(samples), 3000):
+            yield samples[start : start + 3000], sample_rate
+
+    backend = KokoroTTSBackend(
+        {"KOKORO_USE_ONNX": True, "KOKORO_VOICE_BLENDS_DIR": str(tmp_path / "blends")}
+    )
+    backend.kokoro_instance = SimpleNamespace(create_stream=create_stream)
+    backend.model_loaded = True
+    return backend, samples, sample_rate
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("format_name", ["wav", "flac", "mp3"])
+async def test_encoded_response_decodes_every_generated_sample(
+    generated_audio, monkeypatch, format_name
+):
+    sf = pytest.importorskip("soundfile")
+    if format_name == "mp3":
+        pytest.importorskip("pydub")
+        if shutil.which("ffmpeg") is None:
+            pytest.skip("MP3 encoding requires ffmpeg")
+    else:
+        # Exercise the installed soundfile encoder independently of pydub.
+        monkeypatch.setattr(audio_service, "PYDUB_AVAILABLE", False)
+    backend, expected, sample_rate = generated_audio
+    request = OpenAISpeechRequest(
+        input="A complete two-part utterance.",
+        model="kokoro",
+        voice="af_heart",
+        response_format=format_name,
+    )
+    encoded = b"".join(
+        [chunk async for chunk in backend.generate_speech_stream(request)]
+    )
+    actual, rate = sf.read(io.BytesIO(encoded), dtype="float32")
+    assert rate == sample_rate
+    assert len(actual) == len(expected)
+    if format_name != "mp3":
+        np.testing.assert_allclose(actual, expected, atol=2 / 32767)
+    else:
+        # Lossy encoding may change amplitudes, but must retain both halves.
+        assert np.corrcoef(actual[:sample_rate], expected[:sample_rate])[0, 1] > 0.99
+        assert np.corrcoef(actual[sample_rate:], expected[sample_rate:])[0, 1] > 0.99
+
+
+@pytest.mark.asyncio
+async def test_pcm_response_remains_incremental_and_complete(generated_audio):
+    backend, expected, _ = generated_audio
+    request = OpenAISpeechRequest(
+        input="A complete two-part utterance.",
+        model="kokoro",
+        voice="af_heart",
+        response_format="pcm",
+    )
+    chunks = [chunk async for chunk in backend.generate_speech_stream(request)]
+    assert len(chunks) > 1
+    actual = np.frombuffer(b"".join(chunks), dtype=np.int16)
+    np.testing.assert_array_equal(actual, np.int16(expected * 32767))
+
+
+@pytest.mark.asyncio
+async def test_failed_encoding_does_not_emit_a_partial_audio_file(generated_audio):
+    backend, _, _ = generated_audio
+    backend.audio_service = SimpleNamespace(
+        convert_audio=AsyncMock(side_effect=RuntimeError("encoder failed"))
+    )
+    request = OpenAISpeechRequest(
+        input="A complete two-part utterance.",
+        model="kokoro",
+        voice="af_heart",
+        response_format="mp3",
+    )
+    chunks = [chunk async for chunk in backend.generate_speech_stream(request)]
+    assert not any(chunks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("format_name", ["wav", "flac", "mp3", "pcm"])
+async def test_pytorch_response_preserves_every_text_chunk(
+    generated_audio, monkeypatch, format_name
+):
+    if format_name != "pcm":
+        sf = pytest.importorskip("soundfile")
+        if format_name == "mp3":
+            pytest.importorskip("pydub")
+            if shutil.which("ffmpeg") is None:
+                pytest.skip("MP3 encoding requires ffmpeg")
+        else:
+            monkeypatch.setattr(audio_service, "PYDUB_AVAILABLE", False)
+    backend, expected, sample_rate = generated_audio
+    backend.use_onnx = False
+    backend.kokoro_instance = None
+    backend.kokoro_model_pt = object()
+    backend._torch = SimpleNamespace(Tensor=type("UnusedTensor", (), {}))
+    monkeypatch.setattr(backend, "_download_voice_if_needed", AsyncMock())
+    monkeypatch.setattr(backend, "_load_voice_pack", lambda _voice: object())
+    generated_text = []
+
+    def generate(_model, text, _voice, **_kwargs):
+        start = len(generated_text) * sample_rate
+        generated_text.append(text)
+        return expected[start : start + sample_rate], "fixture phonemes"
+
+    backend._kokoro_pt_modules = {"generate": generate}
+    request = OpenAISpeechRequest(
+        input="sample " * 300,
+        model="kokoro",
+        voice="af_heart",
+        response_format=format_name,
+    )
+    chunks = [chunk async for chunk in backend.generate_speech_stream(request)]
+    # Exercise the actual 150-word PyTorch splitter, replacing model inference.
+    assert [len(text.split()) for text in generated_text] == [150, 150]
+    if format_name == "pcm":
+        assert len(chunks) == 2
+        actual = np.frombuffer(b"".join(chunks), dtype=np.int16)
+        np.testing.assert_array_equal(actual, np.int16(expected * 32767))
+        return
+    actual, rate = sf.read(io.BytesIO(b"".join(chunks)), dtype="float32")
+    assert rate == sample_rate
+    assert len(actual) == len(expected)
+    if format_name != "mp3":
+        np.testing.assert_allclose(actual, expected, atol=2 / 32767)
+    else:
+        assert np.corrcoef(actual[:sample_rate], expected[:sample_rate])[0, 1] > 0.99
+        assert np.corrcoef(actual[sample_rate:], expected[sample_rate:])[0, 1] > 0.99

--- a/Tests/TTS/test_kokoro_encoded_audio_limits.py
+++ b/Tests/TTS/test_kokoro_encoded_audio_limits.py
@@ -1,0 +1,154 @@
+"""Encoded Kokoro requests must stop at the audio budget without partial output."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import numpy as np
+import pytest
+
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.backends import kokoro
+
+
+@pytest.fixture
+def make_backend(tmp_path, monkeypatch):
+    # One second makes boundary checks cheap without synthesizing a long reply.
+    monkeypatch.setattr(
+        kokoro, "KOKORO_MAX_ENCODED_AUDIO_SAMPLES", 24000, raising=False
+    )
+
+    def build(engine, chunks, *, voice_chunks=None):
+        backend = kokoro.KokoroTTSBackend(
+            {
+                "KOKORO_USE_ONNX": engine == "onnx",
+                "KOKORO_VOICE_BLENDS_DIR": str(tmp_path / "blends"),
+            }
+        )
+        backend.model_loaded = True
+        backend.audio_service = SimpleNamespace(
+            convert_audio=AsyncMock(return_value=b"complete encoded file")
+        )
+        calls = []
+        closed = []
+
+        async def create_stream(_text, *, voice, **_kwargs):
+            source = chunks if voice_chunks is None else voice_chunks[voice]
+            try:
+                for samples in source:
+                    calls.append(voice)
+                    yield samples, 24000
+            finally:
+                closed.append(voice)
+
+        if engine == "onnx":
+            backend.kokoro_instance = SimpleNamespace(create_stream=create_stream)
+        else:
+            backend.kokoro_model_pt = object()
+            backend._torch = SimpleNamespace(Tensor=type("UnusedTensor", (), {}))
+            monkeypatch.setattr(backend, "_download_voice_if_needed", AsyncMock())
+            monkeypatch.setattr(backend, "_load_voice_pack", lambda _voice: object())
+
+            def generate(_model, _text, _voice, **_kwargs):
+                samples = chunks[len(calls)]
+                calls.append("af_heart")
+                return samples, "fixture phonemes"
+
+            backend._kokoro_pt_modules = {"generate": generate}
+        request = OpenAISpeechRequest(
+            input="word " * (150 * len(chunks)),
+            model="kokoro",
+            voice="af_heart",
+            response_format="wav",
+        )
+        return backend, request, calls, closed
+
+    return build
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["onnx", "pytorch"])
+async def test_encoded_audio_at_limit_is_complete(make_backend, engine):
+    samples = np.linspace(-0.2, 0.2, 24000, dtype=np.float32)
+    backend, request, calls, closed = make_backend(
+        engine, [samples[:12000], samples[12000:]]
+    )
+    output = [chunk async for chunk in backend.generate_speech_stream(request)]
+    assert output == [b"complete encoded file"]
+    assert len(calls) == 2
+    actual = backend.audio_service.convert_audio.await_args.args[0]
+    np.testing.assert_array_equal(actual, samples)
+    if engine == "onnx":
+        assert closed == ["af_heart"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["onnx", "pytorch"])
+async def test_encoded_audio_over_limit_stops_without_partial_file(
+    make_backend, engine
+):
+    backend, request, calls, closed = make_backend(
+        engine,
+        [np.zeros(24000, dtype=np.float32), np.zeros(1), np.zeros(24000)],
+    )
+    output = []
+    with pytest.raises(TTSOperationError, match="Shorten.*PCM") as caught:
+        async for chunk in backend.generate_speech_stream(request):
+            output.append(chunk)
+    assert caught.value.code == "request_invalid"
+    assert caught.value.retryable is False
+    assert output == []
+    assert len(calls) == 2
+    backend.audio_service.convert_audio.assert_not_awaited()
+    if engine == "onnx":
+        assert closed == ["af_heart"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("engine", ["onnx", "pytorch"])
+async def test_pcm_above_encoded_limit_stays_incremental(make_backend, engine):
+    samples = np.full(24000, 0.2, dtype=np.float32)
+    backend, request, calls, _ = make_backend(engine, [samples, samples])
+    request.response_format = "pcm"
+    output = [chunk async for chunk in backend.generate_speech_stream(request)]
+    assert len(output) == len(calls) == 2
+    assert b"".join(output) == np.int16(np.tile(samples, 2) * 32767).tobytes()
+    backend.audio_service.convert_audio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mixed_voice_limit_stops_before_next_voice(make_backend):
+    chunks = [np.zeros(24000, dtype=np.float32), np.zeros(1)]
+    backend, request, calls, closed = make_backend("onnx", chunks)
+    backend.enable_voice_mixing = True
+    request.voice = "af_heart:0.5,af_bella:0.5"
+    output = []
+    with pytest.raises(TTSOperationError, match="Shorten.*PCM"):
+        async for chunk in backend.generate_speech_stream(request):
+            output.append(chunk)
+    assert output == []
+    assert calls == ["af_heart", "af_heart"]
+    assert closed == ["af_heart"]
+    backend.audio_service.convert_audio.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_mixed_voice_budget_is_output_length_and_retains_padding(make_backend):
+    voices = {
+        "af_heart": [np.full(24000, 0.2, dtype=np.float32)],
+        "af_bella": [np.full(12000, 0.4, dtype=np.float32)],
+        "af_nicole": [np.full(18000, 0.6, dtype=np.float32)],
+    }
+    backend, request, _, closed = make_backend(
+        "onnx", [np.zeros(1)], voice_chunks=voices
+    )
+    backend.enable_voice_mixing = True
+    request.voice = "af_heart:1,af_bella:1,af_nicole:1"
+    output = [chunk async for chunk in backend.generate_speech_stream(request)]
+    assert output == [b"complete encoded file"]
+    assert closed == list(voices)
+    actual = backend.audio_service.convert_audio.await_args.args[0]
+    expected = np.full(24000, 0.2 / 3, dtype=np.float32)
+    expected[:12000] += 0.4 / 3
+    expected[:18000] += 0.6 / 3
+    np.testing.assert_allclose(actual, expected, atol=1e-7)

--- a/Tests/TTS/test_resolution_failure_diagnostics.py
+++ b/Tests/TTS/test_resolution_failure_diagnostics.py
@@ -16,11 +16,27 @@ from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
     TTSEventHandler,
     TTSMessageSpeechRequestEvent,
 )
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
 from tldw_chatbook.TTS.effective_settings import (
     TTSEffectiveResolutionError,
     TTSSelectionSource,
 )
 from tldw_chatbook.TTS.playground_types import STTSPlaygroundRequest
+
+
+def test_console_audio_limit_guidance_uses_the_safe_recovery_action():
+    error = TTSOperationError(
+        code="request_invalid",
+        message="PRIVATE upstream text must not reach Console",
+        retryable=False,
+        operation_id="fixture",
+        recovery_action="shorten_text_or_use_pcm",
+    )
+    copy = TTSEventHandler._tts_error_copy(error)
+    assert "five minutes" in copy
+    assert "shorten" in copy and "PCM" in copy
+    assert "PRIVATE" not in copy
+    assert "retry" not in copy
 
 
 @pytest.mark.parametrize(

--- a/Tests/TTS/test_resolution_failure_diagnostics.py
+++ b/Tests/TTS/test_resolution_failure_diagnostics.py
@@ -1,0 +1,187 @@
+"""Selection failures retain actionable, value-free diagnostics at UI boundaries."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from loguru import logger
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore, ConsoleMessageRole
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSEventHandler,
+    STTSPlaygroundGenerateEvent,
+)
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSCompleteEvent,
+    TTSEventHandler,
+    TTSMessageSpeechRequestEvent,
+)
+from tldw_chatbook.TTS.effective_settings import (
+    TTSEffectiveResolutionError,
+    TTSSelectionSource,
+)
+from tldw_chatbook.TTS.playground_types import STTSPlaygroundRequest
+
+
+@pytest.mark.parametrize(
+    "copy", [STTSEventHandler._generation_error_copy, TTSEventHandler._tts_error_copy]
+)
+@pytest.mark.parametrize(
+    "code,axis,source,words",
+    [
+        (
+            "invalid_selection",
+            "provider_options",
+            TTSSelectionSource.STUDIO_DRAFT,
+            ("options", "Speech Lab"),
+        ),
+        (
+            "unsupported_selection",
+            "voice_mode",
+            TTSSelectionSource.GLOBAL,
+            ("voice", "Settings"),
+        ),
+        (
+            "invalid_selection",
+            "speed",
+            TTSSelectionSource.GLOBAL,
+            ("speed", "Settings"),
+        ),
+        (
+            "missing_exact",
+            "voice_id",
+            TTSSelectionSource.CHARACTER_PROFILE,
+            ("voice", "character"),
+        ),
+        (
+            "missing_exact",
+            "model_id",
+            TTSSelectionSource.DEFAULT_PROFILE,
+            ("model", "default voice profile"),
+        ),
+        (
+            "revision_incoherent",
+            "studio_preferences",
+            TTSSelectionSource.STUDIO_DRAFT,
+            ("Studio", "reopen"),
+        ),
+        (
+            "catalog_unavailable",
+            "provider_catalog",
+            TTSSelectionSource.GLOBAL,
+            ("refresh", "Speech Lab"),
+        ),
+        (
+            "provider_unknown",
+            "provider_id",
+            TTSSelectionSource.STUDIO_SAVED,
+            ("provider", "Studio preferences"),
+        ),
+    ],
+)
+def test_resolution_copy_names_setting_scope_and_recovery(
+    copy, code, axis, source, words
+):
+    error = TTSEffectiveResolutionError(code=code, axis=axis, source=source)
+    error.args = ("PRIVATE_TEXT_OR_PROVIDER_PAYLOAD",)
+    message = copy(error)
+    assert all(word in message for word in words), message
+    assert "PRIVATE" not in message
+    if code not in {"revision_incoherent", "catalog_unavailable"}:
+        assert "retry" not in message.lower()
+
+
+class _App:
+    def __init__(self):
+        self.messages = []
+        self.notices = []
+
+    def post_message(self, message):
+        self.messages.append(message)
+        return True
+
+    def notify(self, message, **kwargs):
+        self.notices.append(str(message))
+
+    def query_one(self, *args):
+        raise LookupError("No Playground mounted")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["studio", "console", "automatic_preflight"])
+async def test_resolution_logs_keep_code_axis_source_without_raw_exception(
+    path, monkeypatch
+):
+    error = TTSEffectiveResolutionError(
+        code="invalid_selection",
+        axis="provider_options",
+        source=TTSSelectionSource.STUDIO_DRAFT,
+    )
+    error.args = ("PRIVATE_TEXT_OR_PROVIDER_PAYLOAD",)
+    app = _App()
+    messages = []
+    sink = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        if path == "studio":
+            handler = STTSEventHandler(app)
+            handler._stts_service = SimpleNamespace(
+                synthesize_exact=AsyncMock(side_effect=error)
+            )
+            request = STTSPlaygroundRequest(
+                operation_id="resolution-error",
+                provider_id="audio_cpp",
+                model_id="model",
+                text="PRIVATE_SOURCE_TEXT",
+                voice_id=None,
+                response_format="wav",
+                speed=1.0,
+                options={},
+            )
+            await handler.handle_playground_generate(
+                STTSPlaygroundGenerateEvent(request)
+            )
+            displayed = " ".join(app.notices)
+        else:
+            handler = TTSEventHandler()
+            handler.app = app
+            handler._tts_service = SimpleNamespace(
+                preferences_snapshot=lambda: SimpleNamespace(provider_id="kokoro"),
+                synthesize_default=AsyncMock(side_effect=error),
+            )
+            if path == "console":
+                await handler._generate_tts("PRIVATE_SOURCE_TEXT", "message", None)
+            else:
+                store = ConsoleChatStore()
+                session = store.create_session()
+                row = store.append_message(
+                    session.id,
+                    role=ConsoleMessageRole.ASSISTANT,
+                    content="PRIVATE_SOURCE_TEXT",
+                )
+                event = TTSMessageSpeechRequestEvent(
+                    store.issue_tts_message_speech_snapshot(row.id),
+                    store.validate_tts_message_speech_snapshot,
+                    expected_destination_fingerprint="sha256:" + "a" * 64,
+                )
+                monkeypatch.setattr(
+                    handler, "_destination_for_resolution", AsyncMock(side_effect=error)
+                )
+                await handler.handle_tts_request(event)
+            completions = [
+                message
+                for message in app.messages
+                if isinstance(message, TTSCompleteEvent)
+            ]
+            assert len(completions) == 1
+            displayed = completions[0].error
+    finally:
+        logger.remove(sink)
+    diagnostic = [message for message in messages if "resolution_code=" in message]
+    assert len(diagnostic) == 1, messages
+    assert "resolution_code=invalid_selection" in diagnostic[0]
+    assert "resolution_axis=provider_options" in diagnostic[0]
+    assert "resolution_source=studio_draft" in diagnostic[0]
+    assert "options" in displayed and "Speech Lab" in displayed
+    assert "PRIVATE" not in " ".join([*messages, displayed])

--- a/Tests/UI/test_kokoro_playground_generation.py
+++ b/Tests/UI/test_kokoro_playground_generation.py
@@ -1,0 +1,259 @@
+"""Kokoro language controls must survive the real Studio admission path."""
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Select, Switch, TextArea
+
+from Tests.TTS.adapter_fakes import FakeAdapter
+from Tests.UI.speech_playground_fixtures import _resolved, _wait_until
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSEventHandler,
+    STTSPlaygroundGenerateEvent,
+)
+from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_chatbook.TTS.adapter_types import TTSProviderDescriptor, TTSProviderSpec
+from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
+from tldw_chatbook.TTS.preferences import TTSPreferencesSnapshot
+from tldw_chatbook.TTS.studio_preferences import StudioTTSPreferencesSnapshot
+from tldw_chatbook.TTS.TTS_Generation import TTSService
+from tldw_chatbook.UI.Speech.speech_playground_pane import SpeechPlaygroundPane
+from tldw_chatbook.UI.stts_playground_catalog import (
+    LOADING_SELECT_VALUE,
+    UNAVAILABLE_SELECT_VALUE,
+)
+
+
+class _RecordingAdapter(FakeAdapter):
+    """Replace only audio execution; keep the provider's real static catalog."""
+
+    def __init__(self, provider_id):
+        super().__init__(provider_id, chunks=(b"test-audio",))
+        self.requests = []
+
+    async def get_catalog(self, refresh=False):
+        return legacy_catalog(self.provider_id)
+
+    async def synthesize(self, request, progress_sink=None):
+        self.requests.append(request)
+        return await super().synthesize(request, progress_sink)
+
+
+class _Host(App):
+    def __init__(self, pane):
+        super().__init__()
+        self.pane = pane
+        self.requests = []
+        self.notices = []
+
+    def compose(self) -> ComposeResult:
+        yield self.pane
+
+    def post_message(self, message):
+        if isinstance(message, STTSPlaygroundGenerateEvent):
+            self.requests.append(message.request)
+            return True
+        return super().post_message(message)
+
+    def notify(self, message, *, severity="information", **kwargs):
+        self.notices.append((str(message), severity))
+
+
+@pytest.fixture
+def lab_factory(monkeypatch):
+    @asynccontextmanager
+    async def mount(initial_provider="kokoro", studio=None):
+        studio = studio or StudioTTSPreferencesSnapshot()
+        preferences = TTSPreferencesSnapshot(
+            provider_id=initial_provider,
+            model_mode="exact",
+            model_id="kokoro" if initial_provider == "kokoro" else "tts-1",
+            voice_mode="exact",
+            voice_id="af_heart" if initial_provider == "kokoro" else "alloy",
+            response_format="wav",
+            speed=1.0,
+        )
+        adapters = {
+            provider: _RecordingAdapter(provider) for provider in ("kokoro", "openai")
+        }
+        registry = TTSAdapterRegistry(
+            specs=tuple(
+                TTSProviderSpec(
+                    descriptor=TTSProviderDescriptor(
+                        provider_id=provider, display_name=provider, native=False
+                    ),
+                    factory=lambda config, adapter=adapter: adapter,
+                    initial_config={},
+                    exclusive_reconfigure=True,
+                )
+                for provider, adapter in adapters.items()
+            ),
+            aliases={},
+        )
+        service = TTSService(
+            registry,
+            preferences_snapshot=preferences,
+            studio_preferences_loader=lambda: studio,
+        )
+        monkeypatch.setattr(
+            SpeechPlaygroundPane,
+            "_tts_service_factory",
+            lambda self: _resolved(service),
+        )
+        monkeypatch.setattr(
+            SpeechPlaygroundPane, "_check_higgs_installation", lambda self: None
+        )
+        pane = SpeechPlaygroundPane(
+            provider=initial_provider,
+            studio_preferences=studio,
+            global_preferences=preferences,
+        )
+        app = _Host(pane)
+        handler = STTSEventHandler(app)
+        handler._stts_service = service
+        app._stts_handler = handler
+        try:
+            async with app.run_test(size=(150, 65)) as pilot:
+                await _wait_until(
+                    pilot,
+                    lambda: (
+                        pane.query_one("#tts-provider-select", Select).value
+                        == initial_provider
+                        and not pane.query_one("#tts-generate-btn", Button).disabled
+                    ),
+                )
+                yield SimpleNamespace(
+                    app=app,
+                    pane=pane,
+                    pilot=pilot,
+                    service=service,
+                    handler=handler,
+                    adapters=adapters,
+                )
+        finally:
+            await handler.cleanup_tts_resources()
+            await service.close()
+            await service.wait_closed()
+
+    return mount
+
+
+async def _switch(lab, provider):
+    lab.pane.query_one("#tts-provider-select", Select).value = provider
+    await _wait_until(
+        lab.pilot,
+        lambda: (
+            lab.pane.provider == provider
+            and not lab.pane.query_one("#tts-generate-btn", Button).disabled
+        ),
+    )
+    await lab.pilot.pause()
+
+
+async def _generate(lab):
+    lab.pane.query_one("#tts-text-input", TextArea).text = "A short test reply."
+    await lab.pilot.pause()
+    count = len(lab.app.requests)
+    lab.pane.action_generate_tts()
+    assert len(lab.app.requests) == count + 1, lab.app.notices
+    await lab.handler.handle_playground_generate(
+        STTSPlaygroundGenerateEvent(lab.app.requests[-1])
+    )
+    await lab.pilot.pause()
+    artifact = lab.handler._current_playground_artifact
+    assert artifact is not None, lab.app.notices
+    assert artifact.path.read_bytes() == b"test-audio"
+    assert not lab.pane.query_one("#tts-generate-btn", Button).disabled
+    return lab.adapters["kokoro"].requests[-1]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_provider", ["kokoro", "openai"])
+@pytest.mark.parametrize("use_onnx", [True, False])
+async def test_automatic_language_generates_repeatedly_through_admission(
+    lab_factory, initial_provider, use_onnx
+):
+    async with lab_factory(initial_provider) as lab:
+        if initial_provider != "kokoro":
+            await _switch(lab, "kokoro")
+        language = lab.pane.query_one("#tts-language-select", Select)
+        assert language.value not in {LOADING_SELECT_VALUE, UNAVAILABLE_SELECT_VALUE}
+        lab.pane.query_one("#tts-kokoro-use-onnx", Switch).value = use_onnx
+        for _ in range(2):
+            request = await _generate(lab)
+            assert "language" not in (
+                request.options["_legacy_openai_request"].extra_params or {}
+            )
+            assert request.options["_legacy_internal_model_id"] == (
+                "local_kokoro_default_onnx"
+                if use_onnx
+                else "local_kokoro_default_pytorch"
+            )
+        assert len(lab.adapters["kokoro"].requests) == 2
+        if initial_provider == "kokoro":
+            response = await lab.service.synthesize_default(text="An automatic reply.")
+            try:
+                assert (
+                    b"".join([chunk async for chunk in response.byte_stream])
+                    == b"test-audio"
+                )
+            finally:
+                await response.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("initial_provider", ["kokoro", "openai"])
+async def test_fresh_kokoro_defaults_to_onnx_and_allows_explicit_pytorch(
+    lab_factory, initial_provider
+):
+    async with lab_factory(initial_provider) as lab:
+        if initial_provider != "kokoro":
+            await _switch(lab, "kokoro")
+        engine = lab.pane.query_one("#tts-kokoro-use-onnx", Switch)
+        assert engine.value is True
+        request = await _generate(lab)
+        assert (
+            request.options["_legacy_internal_model_id"] == "local_kokoro_default_onnx"
+        )
+
+        engine.value = False
+        request = await _generate(lab)
+        assert (
+            request.options["_legacy_internal_model_id"]
+            == "local_kokoro_default_pytorch"
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_language_code_survives_provider_round_trip(lab_factory):
+    async with lab_factory() as lab:
+        language = lab.pane.query_one("#tts-language-select", Select)
+        assert "fr" in language._legal_values
+        language.value = "fr"
+        await lab.pilot.pause()
+        request = await _generate(lab)
+        assert (
+            request.options["_legacy_openai_request"].extra_params["language"] == "fr"
+        )
+        await _switch(lab, "openai")
+        await _switch(lab, "kokoro")
+        assert lab.pane.query_one("#tts-language-select", Select).value == "fr"
+        request = await _generate(lab)
+        assert (
+            request.options["_legacy_openai_request"].extra_params["language"] == "fr"
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "placeholder", [LOADING_SELECT_VALUE, UNAVAILABLE_SELECT_VALUE]
+)
+async def test_transient_language_placeholder_is_omitted(lab_factory, placeholder):
+    async with lab_factory() as lab:
+        language = lab.pane.query_one("#tts-language-select", Select)
+        language.set_options([("Transient language state", placeholder)])
+        language.value = placeholder
+        request = await _generate(lab)
+        assert "language" not in request.options["_legacy_openai_request"].extra_params

--- a/Tests/UI/test_legacy_tts_voice_policy.py
+++ b/Tests/UI/test_legacy_tts_voice_policy.py
@@ -1,0 +1,150 @@
+"""Global voice policies must agree with the effective admission contract."""
+
+import pytest
+from textual.widgets import Input, Select, Static
+
+from Tests.UI.test_kokoro_playground_generation import _RecordingAdapter
+from Tests.UI.test_settings_speech_tts_panel import (
+    _audio_cpp_observation,
+    _audio_cpp_state,
+    _PanelHarness,
+)
+from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_chatbook.TTS.adapter_types import TTSProviderDescriptor, TTSProviderSpec
+from tldw_chatbook.TTS.legacy_catalogs import (
+    LEGACY_DEFAULT_MODELS,
+    LEGACY_DEFAULT_VOICES,
+)
+from tldw_chatbook.TTS.TTS_Generation import TTSService
+from tldw_chatbook.UI.Screens.settings_speech_tts import (
+    GlobalSpeechTTSValidationError,
+    load_global_speech_tts_state,
+)
+from tldw_chatbook.Widgets.Settings_Widgets.speech_tts_settings_panel import (
+    SpeechTTSSettingsPanel,
+)
+
+
+def _legacy_state(provider="kokoro", voice_mode="exact"):
+    return load_global_speech_tts_state(
+        {
+            "COMPREHENSIVE_CONFIG_RAW": {
+                "app_tts": {
+                    "default_provider": provider,
+                    "default_model_mode": "exact",
+                    "default_model": LEGACY_DEFAULT_MODELS[provider],
+                    "default_voice_mode": voice_mode,
+                    **(
+                        {"default_voice": LEGACY_DEFAULT_VOICES[provider]}
+                        if voice_mode == "exact"
+                        else {}
+                    ),
+                    "default_format": "wav",
+                }
+            }
+        }
+    )
+
+
+@pytest.mark.parametrize("provider", LEGACY_DEFAULT_MODELS)
+def test_legacy_defaults_reject_server_default_voice_before_publication(provider):
+    state = _legacy_state(provider, "server_default")
+    with pytest.raises(GlobalSpeechTTSValidationError) as caught:
+        state.defaults.snapshot()
+    assert caught.value.field_id == "voice_mode"
+    assert "Exact" in str(caught.value)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exact_audio_cpp", [False, True])
+async def test_switch_to_kokoro_uses_its_own_admissible_model_and_voice(
+    exact_audio_cpp,
+):
+    state = _audio_cpp_state(
+        model_mode="exact" if exact_audio_cpp else "first_available",
+        model_id="model-a" if exact_audio_cpp else None,
+        voice_mode="exact" if exact_audio_cpp else "server_default",
+        voice_id="voice-a" if exact_audio_cpp else None,
+    )
+    app = _PanelHarness(state=state, observation=_audio_cpp_observation())
+    async with app.run_test(size=(150, 60)) as pilot:
+        app.query_one("#settings-speech-default-provider", Select).value = "kokoro"
+        await pilot.pause()
+        panel = app.query_one(SpeechTTSSettingsPanel)
+        voice = app.query_one("#settings-speech-voice-policy", Select)
+        assert voice._legal_values == {"exact"}
+        assert voice.value == "exact"
+        panel._collect_visible_state()
+        preferences = panel.state.defaults.snapshot()
+        assert preferences.model_id == "kokoro"
+        assert preferences.voice_id == LEGACY_DEFAULT_VOICES["kokoro"]
+        adapter = _RecordingAdapter("kokoro")
+        registry = TTSAdapterRegistry(
+            specs=(
+                TTSProviderSpec(
+                    descriptor=TTSProviderDescriptor(
+                        provider_id="kokoro", display_name="Kokoro", native=False
+                    ),
+                    factory=lambda config: adapter,
+                    initial_config={},
+                    exclusive_reconfigure=True,
+                ),
+            ),
+            aliases={},
+        )
+        service = TTSService(registry, preferences_snapshot=preferences)
+        try:
+            for _ in range(2):
+                response = await service.synthesize_default(text="Speak this reply.")
+                try:
+                    assert (
+                        b"".join([chunk async for chunk in response.byte_stream])
+                        == b"test-audio"
+                    )
+                finally:
+                    await response.aclose()
+        finally:
+            await service.close()
+            await service.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_saved_invalid_kokoro_policy_remains_visible_and_can_be_repaired():
+    app = _PanelHarness(
+        state=_legacy_state(voice_mode="server_default"), configure_provider="kokoro"
+    )
+    async with app.run_test(size=(150, 60)) as pilot:
+        panel = app.query_one(SpeechTTSSettingsPanel)
+        voice = app.query_one("#settings-speech-voice-policy", Select)
+        assert voice.value == "server_default"
+        assert panel.request_save() is None
+        await pilot.pause()
+        assert not app.events
+        error = app.query_one("#settings-speech-voice-policy-error", Static)
+        assert "Exact" in str(error.renderable)
+        voice.value = "exact"
+        await pilot.pause()
+        app.query_one("#settings-speech-voice-value", Input).value = "af_heart"
+        await pilot.pause()
+        status = app.query_one("#settings-speech-default-status", Static)
+        assert "Unsaved" in str(status.renderable)
+        assert panel.request_save() is not None
+        await pilot.pause()
+        assert len(app.events) == 1
+        assert app.events[0].preferences.voice_mode == "exact"
+        assert app.events[0].preferences.voice_id == "af_heart"
+
+
+@pytest.mark.asyncio
+async def test_return_to_saved_kokoro_restores_its_explicit_voice():
+    state = _legacy_state()
+    state.defaults.voice_id = "bf_emma"
+    app = _PanelHarness(state=state)
+    async with app.run_test(size=(150, 60)) as pilot:
+        app.query_one("#settings-speech-default-provider", Select).value = "audio_cpp"
+        await pilot.pause()
+        app.query_one("#settings-speech-default-provider", Select).value = "kokoro"
+        await pilot.pause()
+        assert app.query_one("#settings-speech-voice-policy", Select).value == "exact"
+        assert app.query_one("#settings-speech-voice-value", Input).value == "bf_emma"
+        assert app.query_one("#settings-speech-model-value", Input).value == "kokoro"

--- a/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+++ b/backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
@@ -297,6 +297,130 @@ defines staged verification. This amendment authorizes the contract, not a claim
 that implementation or merge verification is complete. It adds no Canvas
 privileges, dependency, synchronization contract or new persistence registry.
 
+### Amendment recorded 2026-09-08: current-turn transformed request ownership
+
+TASK-32032 reproduced a Capture-On dictionary send failing before provider entry:
+the admitted current user text was transformed after persistence, so its request
+row became an unowned artifact. Preserve that row as a typed current-turn
+transform with exactly one admitted saved-revision source and one policy-owned
+`active_request` artifact. The artifact retains the transformed provider value;
+the source remains the exact saved value. Only the accepted current user owner
+from the pre-transform snapshot may receive this descriptor. Changed historical
+rows, unknown owners, and changes outside the current text field gain no authority.
+
+Record the factory's exact current revision on the existing
+`call_boundary.semantic_revision_id` foreign key, atomically with reservation.
+Schema v69 permits that reference on call boundaries and verifies that its source
+message and conversation own the call. Older NULL boundaries stay readable and
+do not gain a guessed source. Existing event-reference reachability rules govern
+copy-on-write, archival and collection; no new ownership registry is introduced.
+A tool-loop continuation must retain its origin's exact pinned revision; the
+same message identity and equal artifact bytes cannot substitute a newer source
+revision. Legacy NULL boundaries grant no transformed-source continuation proof.
+
+Extend the existing completed-turn witness with an optional exact transformed
+source revision. An eligible next fresh/agent send may replace the prior bounded
+current-request suffix with its exact saved source and append the verified saved
+assistant plus the next admitted user. A next user may itself carry the same
+typed transform. The source must equal the original call-boundary pin, and the
+removed source artifact must belong to that origin call. Any removed tool suffix
+must satisfy the existing same-run tool proof. Require the latest eligible terminal call,
+unchanged prefix, exact tail, attached owner, bounded range, verified assistant
+response link, exact saved values, and equal persisted disclosure settings.
+Recheck the full witness during final persistence and owned pre-dispatch recovery.
+The replacement, appends, header and dispatch binding remain one transaction;
+historical call heads retain their original transformed values.
+An unchanged continuation suffix may follow the current user in physical node
+order. Locate the original last active message at its exact call head, and replace
+only the proven contiguous message range; preserve the continuation domain and
+its values. An unchanged continuation inside a proposed replacement range still
+makes that range ineligible.
+
+If the preceding transformed run ended ERROR, STOPPED or INTERRUPTED and the
+next request has no assistant row for it, the same bounded witness may restore
+only the exact pinned user source and append the next user. Require a settled
+terminal call and the same owner, tail, range, source, policy and tool lineage
+proofs. Do not invent a response link or an assistant row. Pending, reserved,
+dispatch-open, unknown-outcome and superseded calls remain ineligible. A real
+controller regression establishes the durable ERROR outcome before testing its
+successor; provider-shaped error text is not evidence of terminal failure.
+When a stopped/failed run has a saved partial assistant in the next request, that
+row requires the same exact verified response-revision link and value comparison
+as a completed response. Terminal state alone never authorizes assistant content.
+A real streaming-controller Stop regression verifies the saved partial answer,
+durable STOPPED outcome and exact response link before a cold-factory next send.
+
+The source pin retains revision identity only. It creates no new policy binding
+or retained source body. If a later operation needs a retired source projection
+that existing policy retention cannot supply, that operation remains unavailable.
+
+The current-turn source proof and automatic-project-context proof compose over
+one bounded replacement. The exact pinned user source precedes its verified saved
+assistant (when present), the next admitted user and only the declared current
+project-context rows. Each removed source/context/tool artifact must still belong
+to the proven origin or tool chain; changed or disabled project context never
+replaces the saved call owner. An unchanged continuation suffix remains outside
+that message range. Warm/cold controller tests cover ordinary, tool and llama.cpp
+fallback predecessors with current-user dictionary transforms and context renewal.
+This integration preserves both proofs and adds no new ownership authority.
+
+Selected saved continuation values cross the trace service as canonical V1 JSON.
+The service issues an immutable tuple of strictly parsed checkpoint objects for
+provider dispatch; verification still requires that exact issued tuple and checks
+the canonical value against its saved source. This preserves the existing provider
+contract without asking the JSON sanitizer to accept runtime dataclasses.
+Retained saved continuation artifacts are rehydrated from that exact live saved
+source for dispatch, then compared under their frozen artifact masks. Compare
+the raw supplied checkpoint before filtering: equal redacted bytes cannot grant
+source ownership. Provider-only attachment owners retain exact artifact-value
+comparison and receive no saved-source normalization authority.
+When selected displayable thinking actually changes a serialized message, its
+existing MESSAGE_REWRITE descriptor carries a policy-owned thinking artifact of
+the exact final provider message, plus the original owner and typed attachments.
+An unchanged message keeps its original descriptor, including continuation-only
+attachment cases. A rendered thinking message is not an exact raw saved revision.
+These artifacts use existing disclosure and retention policy; no reader-side
+guessing, new retained canonical bodies or new ownership storage is introduced.
+
+For newly captured supported typed-thinking responses, freeze an explicit
+versioned response projection in the existing request-header defaults. Settlement
+and the native reader use that same profile to project the exact saved visible
+answer and strict terminal ThinkingEnvelope. Displayable blocks project their
+exact text and provenance; proprietary blocks project only their content-free
+provider evidence. Only consecutive displayable fragments
+with identical provider, model, protocol and source-format metadata coalesce;
+literal tags are never parsed by the trace ledger. Old headers without this
+profile retain their previous visible-message response projection. Unsupported,
+malformed, differently owned or mismatched thinking remains artifact-backed.
+
+Before filtering the response, the existing ephemeral settlement handoff records
+a process-keyed HMAC of its canonical semantic value, hidden from representations.
+The coordinator compares this proof to the exact saved revision before creating
+a new thinking-response revision link. The proof and process key never enter the
+ledger, diagnostics or exported captures; the existing bounded queue retains
+credential-filtered response bytes and this opaque process-local proof, not raw response
+bodies. Equal credential masks alone cannot establish response-source equality.
+Frozen PII masks use the existing source-span records. Typed-response paths have
+an explicit response-profile prefix, alongside the ordinary visible-message
+paths, so each projection consumes only its own mask domain. Copy-on-write retains
+the same canonical envelope through the response link's existing policy reachability.
+A new handoff cannot establish raw equality from a retired masked body; that
+terminal retry remains unavailable while the original linked capture stays readable.
+
+Every newly stored response applies its frozen PII policy, including verified
+visible-message links and artifact fallbacks without a response profile. If the
+detector is unavailable, persist a bounded content-free omission. Terminal artifact
+retries compare the same policy projection; existing stored captures are not rewritten.
+
+Rejected alternatives: treating transformed text as an exact saved revision,
+disabling capture after failure, accepting arbitrary historical replacements,
+or inferring the source from the current message version or timestamp. A call's
+turn identifies a message but not its historical revision; response links identify
+the assistant, and artifact nodes do not persist transient derived inputs. A
+creation-version-only restriction would exclude supported edited/retry inputs.
+The existing nullable event FK is therefore the smallest precise durable source
+contract. This amendment does not relax other routes or artifact transforms.
+
 ### Amendment recorded 2026-09-05: owner-approved latency reference replacement
 
 For TASK-31742, the owner explicitly approved replacing the latency reference

--- a/backlog/docs/console-send-diagnostics.md
+++ b/backlog/docs/console-send-diagnostics.md
@@ -41,6 +41,22 @@ arbitrary exception messages are never recorded. SQLite failures also carry a
 numeric `sqlite_code`. App version is the running package's source version; it
 is not a verified Git commit or proof that an installation is latest dev.
 
+`trace_turn_unavailable` means the current provider row could not establish one
+saved turn owner at reservation. It does not identify the transformation that
+lost ownership. Include the installed Git revision or package origin and whether
+the request used images, dictionaries, skills, references, world information or
+automatic project instructions;
+request bodies are unnecessary for this metadata report. Unchanged multimodal
+rows must retain their saved owner across frozen/transport JSON representations.
+Admitted current-user text transforms retain their exact saved source while the
+trace stores the transformed provider value as an artifact. Automatic project
+context remains attached to that user and cannot become the saved turn owner.
+Historical requests
+remain unchanged when a later send returns to raw saved history.
+Captured requests also preserve eligible saved thinking and provider continuation
+history. A saved response link requires the supported typed thinking envelope as
+well as its visible answer; selected private history is never diagnostic metadata.
+
 `event=ui_refresh_churn` under `diagnostics.ui` records excessive activity even
 when the event loop remains responsive. It identifies `console_sync` or
 `screen_recompose`, the count/window duration, active timers/workers and the last

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12112,6 +12112,21 @@ rather than a flat window sized to the happy path. The probe already
 records STARTS rather than running state, so waiting cannot miss a worker
 that finishes quickly.
 
+## Frozen JSON and transport JSON need the same representation at an identity comparison
+
+**TASK-32030, 2026-09-07.** An unchanged image prompt became an unowned
+provider artifact in the agent trace builder: its admitted content was frozen
+into tuples, while the transport used lists. Converting only the outer mappings
+to dictionaries left the nested mismatch intact. A production SQLite/gateway
+regression failed at trace reservation, while the equivalent plain-text request
+worked. Freezing the incoming row before the existing exact comparison restored
+its saved revision and allowed one completed provider call. Changed text, image
+data, and content order still failed before reservation.
+
+When immutable request snapshots are matched against transport data, include
+nested JSON arrays in the test and verify the real consuming boundary. A test
+using only strings cannot exercise the representation mismatch.
+
 ## A settled paint does not prove a failed send released its busy state
 
 **TASK-32010, 2026-09-07.** Extending the existing mounted Console diagnostic
@@ -12225,6 +12240,78 @@ records STARTS rather than running state, so waiting cannot miss a worker
 that finishes quickly.
 
 
+## A mounted TTS control test must cross effective selection
+
+**Incident (TASK-32027/32038, 2026-09-08).** Kokoro Playground left its language
+Select in a loading/unavailable enum state, then copied that placeholder into the
+request. Catalog and widget tests passed while actual generation failed with
+TTSEffectiveResolutionError before the adapter was called. A mounted Playground
+test with the real registry, resolver and service reproduced both engines and
+provider-switch paths; replacing only audio execution exposed the boundary. A
+second mounted Settings test found that switching from audio.cpp retained a voice
+policy and identifiers rejected by the same resolver.
+
+**Practice.** For speech selection changes, follow the emitted request through
+real admission and drain the response; substitute only the expensive audio
+backend. Include fresh mounts, provider round trips, invalid saved-state repair
+and repeated generation. A visible selection or emitted event alone is not
+evidence that a reply can be spoken.
+
+## Prove a transform ran before testing its trace ownership
+
+**Incident (TASK-32032, 2026-09-08).** A four-send controller regression correctly
+reproduced dictionary trace admission failure, but isolated first-send negative
+probes initially skipped the dictionary: its applier needs a persisted
+conversation. This made ordinary saved-revision behavior look like transformed
+source behavior. Persisting the synthetic session and asserting the literal
+transformed adapter input exposed the actual error/Stop successor and source
+mutation cases. Check the durable terminal state too; an error-shaped answer can
+still belong to a completed call. Likewise, setting the Stop flag just before a
+synthetic stream ends can race with normal completion. Parking the adapter after
+a visible partial chunk and invoking the real Stop action established the actual
+STOPPED outcome, verified partial-response link and successful successor.
+
+**Practice.** Establish the feature's real prerequisite and provider input before
+using the downstream result as evidence. For a source-identity test, hold the
+owner, source artifact and predecessor fixed; canonical edits may legitimately
+advance the active surface through their own coordinator.
+
+## Compile SQLite trigger references when checking a migration predecessor
+
+**Incident (TASK-32032, 2026-09-08).** A v68 fixture renamed a trace source column.
+SQLite accepted the v69 CREATE TRIGGER statements and foreign_key_check, then
+advanced the schema version despite invalid trigger references. The test was RED
+until a fixed SELECT with LIMIT 0 compiled the required source/shape columns before
+DDL. The malformed predecessor then remained unchanged at v68, and rollback
+tests preserved its original triggers and version.
+
+**Practice.** Trigger creation and a foreign-key audit do not establish that a
+trigger's referenced columns exist. Compile the fixed predecessor contract before
+changing it. This migration uses an existing FK for source identity only; it does
+not add retained source bodies.
+
+## Exercise new provider output when repairing private-history replay
+
+**Incident (TASK-32040, 2026-09-08).** A capture-on replay fixture preserved old
+saved thinking while its adapter returned a plain answer, so it missed the next
+failure: newly generated thinking crossed the real parser and persistence seam,
+but settlement compared only the saved visible answer and recorded an artifact.
+The next transformed-turn successor correctly refused to invent a saved response
+link. Exact typed-envelope projection and a process-local raw-equality proof
+restored that link without inferring meaning from literal thinking tags. A real
+Moonshot response reproduced the same issue with content-free proprietary evidence.
+
+The same tests exposed two privacy traps. A failed saved-source or PII-detector
+check fell back to a credential-only response artifact, retaining synthetic email
+text despite PII being enabled. A direct ordinary-message projection under the
+original response policy also failed because response-only mask paths were shared
+with message paths; fresh controller sends used new policy IDs and hid that
+collision. Policy-aware response storage and explicit mask domains fixed both.
+
+**Practice.** Include newly generated private output, actual parsing and saving,
+then warm/cold replay and original-policy reads. Test detector failures and source
+mismatches as well as the verified-source path; equal filtered values cannot
+establish equal raw source values.
 ## Preserve real project defaults and verify the provider input
 
 **TASK-31976.1, 2026-09-07.** The trace recovery helper disabled project
@@ -12350,3 +12437,22 @@ restored real reads without changing the user environment.
 **What to do.** For subprocess-backed tests, verify package provenance inside
 the child interpreter with its actual isolation flags. A passing parent import
 from the working directory does not prove the helper will execute that code.
+
+## Decode the entire utterance when validating playback
+
+**Incident (TASK-32027/32027.1, 2026-09-08).** Real Kokoro playback first exposed
+a fresh Speech Lab engine mismatch hidden by tests that explicitly set the ONNX
+switch. After fixing that default, MP3 generation produced audible output and
+afplay exited successfully, but independent decoding and local transcription
+read only the first 0.34 seconds. The backend had concatenated separately encoded
+files. Collecting samples and encoding once preserved the full utterance. The
+optional PyTorch text-chunk path had the same defect, including invalid repeated
+WAV headers; real-codec tests reproduced it without downloading a neural model.
+
+**Practice.** Preserve fresh controls in the live harness, cross the actual app
+admission and playback paths, and wait for device drain or file-player completion.
+Also decode the generated file and check its complete duration and content.
+Process exit status, nonzero RMS and a first spoken word do not establish that
+the entire response survived encoding. Keep inference, codec, device and content
+evidence distinct; these checks used real ONNX inference and codecs, while
+PyTorch coverage replaced only inference and voice loading.

--- a/backlog/tasks/task-32027 - Repair-Kokoro-language-selection-in-Speech-Lab-generation.md
+++ b/backlog/tasks/task-32027 - Repair-Kokoro-language-selection-in-Speech-Lab-generation.md
@@ -1,0 +1,56 @@
+---
+id: TASK-32027
+title: Repair Kokoro language selection in Speech Lab generation
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 04:56'
+updated_date: '2026-09-08 15:08'
+labels:
+  - tts
+  - bug
+dependencies: []
+references:
+  - backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Local Kokoro generation in Speech Lab submits a language placeholder and fails before audio generation. Restore usable language selection and reliable repeated generation across provider changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A fresh Kokoro Playground can generate with automatic voice-based language inference using either engine.
+- [x] #2 Explicit language choices submit canonical language codes and survive a provider round trip.
+- [x] #3 Loading or unavailable UI values never become provider language options.
+- [x] #4 Mounted Playground tests exercise real request admission, repeated attempts, and unchanged Console default admission.
+- [x] #5 A fresh Kokoro Playground selects the same ONNX engine as automatic replies; explicitly selecting PyTorch still routes that engine.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+Reason: Routine UI/request-construction repair under existing per-request settings and provider ownership contracts; no new boundary.
+
+1. Promote the mounted reproduction to failing behavior tests for automatic and explicit Kokoro language, provider switches, both engines, and repeated attempts.
+2. Populate canonical language choices with a voice-inference default, preserve valid session choices, and omit placeholders at request construction.
+3. Verify the real admission path, Console control path, affected UI tests and static checks; update TTS guidance and record findings.
+4. Live playback follow-up: reproduce the fresh engine mismatch without setting the switch in the harness; default fresh Kokoro controls to ONNX while preserving explicit PyTorch selection, then validate real local synthesis and playback from the integrated dev tree.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Kokoro Playground now populates canonical language choices, omits Automatic and placeholders from requests, and preserves explicit language selections across provider switches. Fresh controls select ONNX, matching automatic replies; explicitly switching it off still selects PyTorch. These are request/session choices under ADR-039, with no new stored engine preference.
+
+Mounted regressions cross the real registry, resolver, service, event handler and artifact handling. The language tests and two fresh-engine cases failed before their respective fixes; all nine now pass. The integrated dev TTS/UI/admission gate passed 313 tests. Real local ONNX inference subsequently generated and played a fresh Speech Lab sentence and two consecutive Speak replies requests for each of WAV and MP3. All six files decoded to complete 5.632, 6.357 and 5.717-second sentences, and independent local transcription recovered their expected content. WAV Console playback reported two SinkDrained events; Lab and MP3 file playback completed through afplay with exit 0. No real LLM request was needed: synthetic completed assistant rows exercised the actual snapshot/admission/TTS/playback path.
+
+Playback validation also found non-PCM chunk encoding truncation, repaired in TASK-32027.1. The optional PyTorch path has real-codec regression coverage with inference replaced; live neural inference/playback was ONNX only. Updated speech_param_group.py, Playground model/pane/synthesis code, mounted tests, TTS guide, Console guidance and the incident-based testing lesson. Independent review, changed-file formatting, zero introduced baseline-relative Ruff findings and all six derived preflight checks pass. Python 3.12.11/SQLite 3.49.1 differ from the reporter's environment, so the reporter's unspecified retry/selection trigger remains unconfirmed.
+
+Live evidence: /private/tmp/kokoro-playback-validation/{evidence.json,mp3/evidence.json,transcription-evidence.json}; harness /private/tmp/validate-kokoro-playback.py. Targeted test log: /private/tmp/kokoro-pr-tts-gate.log. The complete fix and newer Console integration are isolated on codex/kokoro-speech-trace-recovery; unrelated original-workspace changes are preserved.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32027.1 - Encode-Kokoro-audio-files-as-one-complete-stream.md
+++ b/backlog/tasks/task-32027.1 - Encode-Kokoro-audio-files-as-one-complete-stream.md
@@ -1,0 +1,52 @@
+---
+id: TASK-32027.1
+title: Encode Kokoro audio files as one complete stream
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 14:51'
+updated_date: '2026-09-08 15:08'
+labels:
+  - tts
+  - bug
+dependencies: []
+parent_task_id: TASK-32027
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Kokoro concatenates separately encoded short files for MP3 and other non-PCM formats. Some decoders read only the first chunk despite successful playback process completion. Preserve the complete utterance in the generated audio artifact.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A generated encoded audio file decodes to the complete multi-chunk utterance, and local MP3 playback/transcription retains the full sentences.
+- [x] #2 Raw PCM remains incremental and preserves every generated sample; failed conversion does not return a success-shaped truncated utterance.
+- [x] #3 Targeted codec, TTS and real playback checks document the behavior without requiring model downloads in ordinary regression tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+Reason: Routine repair of the existing complete encoded-audio response contract; no new provider or storage boundary.
+
+1. Reproduce the truncated decoding with a real multi-chunk codec round trip, replacing only Kokoro inference.
+2. Encode non-PCM output as one complete utterance through the existing audio conversion service, retaining streaming PCM.
+3. Verify complete decoded samples and conversion failure behavior, then repeat real Kokoro WAV/MP3 synthesis, app playback and independent local transcription.
+4. Run affected backend, UI/admission, formatting, baseline-relative lint and derived-artifact gates; record live evidence and the memory/latency tradeoff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Kokoro now collects copied float32 samples and encodes each non-PCM utterance once for both ONNX and PyTorch. This preserves one complete file/container instead of concatenating independent encoded chunks. Raw PCM remains incremental. Conversion failure returns no successful partial file; unexpected inference failure likewise cannot publish an encoded prefix. Codec errors retain bounded exception-type diagnostics. Under existing ADR-039, this is a repair of the response contract and needs no new ADR.
+
+Real-codec tests reproduced FLAC/MP3 truncation on ONNX, and truncated FLAC/MP3 plus invalid concatenated WAV on PyTorch. All nine final regression cases pass, including sample-for-sample PCM controls. The ordinary tests replace only inference/voice loading and download no models; MP3 requires optional pydub and ffmpeg. The wider affected backend gate passed 40 tests with one existing live-model test deselected in favor of the isolated live validation. Independent review also proved reused-buffer ownership and zero partial file output on conversion or later inference failure.
+
+Real ONNX playback used kokoro-onnx 0.6.1 and onnxruntime 1.29.0 with an isolated model/config/data directory. A fresh mounted Lab request and two consecutive Speak replies requests each produced valid WAV and MP3 audio through the real service, backend, conversion, completion and playback paths. All six files decoded to complete 5.632, 6.357 and 5.717-second utterances; independent local tiny.en transcription recovered their full expected sentences. WAV Console playback drained the real audio sink twice; Lab and MP3 used afplay with exit 0. The initial 0.341-second MP3 decode failure is therefore resolved, not merely hidden behind successful process exit. Neural inference was real ONNX; PyTorch validation replaced inference while retaining the actual splitter and codecs.
+
+Encoded audio now waits for the complete synthesis and buffers samples proportional to utterance length; PCM remains available for incremental playback. Documented that tradeoff in TTS_MODULE_GUIDE.md and the verification trap in lessons-testing-evidence.md. Changes: TTS/backends/kokoro.py, Tests/TTS/test_kokoro_encoded_audio.py and the reviewed diagnostic inventory. All affected formatting, zero introduced baseline-relative Ruff findings and six derived preflight checks pass. Evidence: /private/tmp/kokoro-encoded-audio-final-green.log, /private/tmp/kokoro-playback-validation/{evidence.json,mp3/evidence.json,transcription-evidence.json}, and /private/tmp/kokoro-encoder-diagnostic-final-review.log.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32027.1 - Encode-Kokoro-audio-files-as-one-complete-stream.md
+++ b/backlog/tasks/task-32027.1 - Encode-Kokoro-audio-files-as-one-complete-stream.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 14:51'
-updated_date: '2026-09-08 15:08'
+updated_date: '2026-09-08 15:50'
 labels:
   - tts
   - bug
@@ -24,6 +24,7 @@ Kokoro concatenates separately encoded short files for MP3 and other non-PCM for
 - [x] #1 A generated encoded audio file decodes to the complete multi-chunk utterance, and local MP3 playback/transcription retains the full sentences.
 - [x] #2 Raw PCM remains incremental and preserves every generated sample; failed conversion does not return a success-shaped truncated utterance.
 - [x] #3 Targeted codec, TTS and real playback checks document the behavior without requiring model downloads in ordinary regression tests.
+- [x] #4 Encoded Kokoro requests cannot grow the retained audio buffer beyond a fixed budget; an oversized request fails without returning a partial file, while complete within-budget output and PCM behavior remain usable.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,6 +38,7 @@ Reason: Routine repair of the existing complete encoded-audio response contract;
 2. Encode non-PCM output as one complete utterance through the existing audio conversion service, retaining streaming PCM.
 3. Verify complete decoded samples and conversion failure behavior, then repeat real Kokoro WAV/MP3 synthesis, app playback and independent local transcription.
 4. Run affected backend, UI/admission, formatting, baseline-relative lint and derived-artifact gates; record live evidence and the memory/latency tradeoff.
+5. PR #2512 Qodo follow-up: reproduce excessive encoded buffering, enforce a fixed audio budget before retaining chunks, close generation on failure, retain complete files within the budget and incremental PCM, and document/test the boundary.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -49,4 +51,8 @@ Real-codec tests reproduced FLAC/MP3 truncation on ONNX, and truncated FLAC/MP3 
 Real ONNX playback used kokoro-onnx 0.6.1 and onnxruntime 1.29.0 with an isolated model/config/data directory. A fresh mounted Lab request and two consecutive Speak replies requests each produced valid WAV and MP3 audio through the real service, backend, conversion, completion and playback paths. All six files decoded to complete 5.632, 6.357 and 5.717-second utterances; independent local tiny.en transcription recovered their full expected sentences. WAV Console playback drained the real audio sink twice; Lab and MP3 used afplay with exit 0. The initial 0.341-second MP3 decode failure is therefore resolved, not merely hidden behind successful process exit. Neural inference was real ONNX; PyTorch validation replaced inference while retaining the actual splitter and codecs.
 
 Encoded audio now waits for the complete synthesis and buffers samples proportional to utterance length; PCM remains available for incremental playback. Documented that tradeoff in TTS_MODULE_GUIDE.md and the verification trap in lessons-testing-evidence.md. Changes: TTS/backends/kokoro.py, Tests/TTS/test_kokoro_encoded_audio.py and the reviewed diagnostic inventory. All affected formatting, zero introduced baseline-relative Ruff findings and six derived preflight checks pass. Evidence: /private/tmp/kokoro-encoded-audio-final-green.log, /private/tmp/kokoro-playback-validation/{evidence.json,mp3/evidence.json,transcription-evidence.json}, and /private/tmp/kokoro-encoder-diagnostic-final-review.log.
+
+PR #2512 Qodo follow-up: replaced retained chunk lists and concatenation copies with one growable float32 buffer and a five-minute (7,200,000-sample) encoded-audio budget. ONNX and PyTorch reject overflow before retaining the next chunk, return the existing nonretryable request_invalid error, and publish no partial file. ONNX closes producers on failure/cancellation; mixed voices use a bounded running mix and one voice buffer rather than retaining every voice. PCM retains its existing incremental single-voice behavior. Console recovery copy and both TTS guides explain shortening the text or choosing PCM. The sample-data budget is 28.8 MB per buffer; neural inference, allocator overhead and codec/mix allocations remain separate. This routine resource guard preserves the existing provider/error contracts and needs no new ADR under ADR-039.
+
+Verification after review fixes: overflow regressions first failed on both engines and mixed voices; all eight boundary/PCM/mixing cases now pass. The combined backend/codec/diagnostic gate passed 68 tests (one separate live-model test deselected); admission/provenance checks passed 225. Independent review and additional probes verified cancellation cleanup, the real full-size boundary, reused sample buffers and bounded mixing across 120 voices. Real ONNX WAV and MP3 synthesis/playback passed again for a fresh mounted Speech Lab request plus two consecutive Speak replies in each format; all six clips retained their previous complete contents and passed fresh local transcription. All six derived checks pass, new tests and affected files are formatted, baseline-relative Ruff has zero introduced findings, and diff checks pass. Evidence: /private/tmp/kokoro-qodo-{final-tts,admission-provenance,preflight,playback-wav,playback-mp3,transcription}.log.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32028 - Explain-TTS-effective-selection-failures-in-Studio-and-Console.md
+++ b/backlog/tasks/task-32028 - Explain-TTS-effective-selection-failures-in-Studio-and-Console.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 04:56'
-updated_date: '2026-09-08 06:01'
+updated_date: '2026-09-08 15:50'
 labels:
   - tts
   - bug
@@ -39,6 +39,7 @@ Reason: Repair bounded, value-free diagnostics and recovery guidance using the e
 1. Add failing tests for actionable scoped resolution copy and bounded diagnostics in Studio and Console.
 2. Reuse a shared fixed-copy mapping for resolution failures and retain code, axis and source at existing log sites.
 3. Verify typed error branches, malicious/raw payload exclusion and unrelated failure handling; refresh the diagnostic inventory if required and document the recovery behavior.
+4. PR #2512 Qodo follow-up: document the public recovery formatter return and privacy contract; verify its existing diagnostic regressions.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -51,4 +52,6 @@ No new ADR: existing ADR-039 settings ownership and ADR-029 metadata-only diagno
 The newer dev schema-v3 diagnostic inventory also tracks heuristic path candidates. Reviewed the added typed-resolution outcome_code branch: TTSEffectiveResolutionError maps to the fixed configuration_invalid outcome; resolution code/axis/source are constructor-validated metadata. Preserved the existing generic-outcome branch and legacy file_path candidate, and refreshed only this owner candidate row/count alongside the two already-reviewed owner digests. No unrelated candidate status or sink topology changed.
 
 Final combined dev verification: all six derived-artifact preflight gates passed, including the schema-v3 diagnostic inventory. The integrated TTS/settings cohort passed 200 tests under Python 3.12.11. Baseline-relative Ruff found zero new findings across all 23 changed Python files in the combined fix.
+
+PR #2512 Qodo follow-up: documented recovery_message with a Google-style Returns section and its fixed, value-free UI contract. The encoded-audio limit added for TASK-32027.1 now has literal Console recovery guidance that excludes upstream private payloads and avoids suggesting retries. The added malicious-payload regression failed before the change and passes afterward; the combined TTS gate passed 68 tests and the adjacent admission/provenance gate passed 225. Public diagnostic calls and inventory are unchanged; formatting, baseline-relative Ruff (zero introduced findings), and all six derived checks pass. No new ADR is required; ADR-039 and the existing typed error boundary remain applicable.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32028 - Explain-TTS-effective-selection-failures-in-Studio-and-Console.md
+++ b/backlog/tasks/task-32028 - Explain-TTS-effective-selection-failures-in-Studio-and-Console.md
@@ -1,0 +1,54 @@
+---
+id: TASK-32028
+title: Explain TTS effective-selection failures in Studio and Console
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 04:56'
+updated_date: '2026-09-08 06:01'
+labels:
+  - tts
+  - bug
+  - diagnostics
+dependencies: []
+references:
+  - backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+TTS selection failures currently collapse to an exception class and generic configuration guidance, preventing users from identifying invalid settings or stale state and encouraging ineffective retries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Studio and Console resolution failures identify the affected setting scope and appropriate recovery action.
+- [x] #2 Failure logs preserve bounded resolution code, axis, and source without text, credentials, raw identifiers, or exception payloads.
+- [x] #3 Targeted tests distinguish invalid selections, missing choices, unavailable catalogs, and stale preferences and retain existing non-resolution failure handling.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+Reason: Repair bounded, value-free diagnostics and recovery guidance using the existing resolution error contract; no new stored data or trust boundary.
+
+1. Add failing tests for actionable scoped resolution copy and bounded diagnostics in Studio and Console.
+2. Reuse a shared fixed-copy mapping for resolution failures and retain code, axis and source at existing log sites.
+3. Verify typed error branches, malicious/raw payload exclusion and unrelated failure handling; refresh the diagnostic inventory if required and document the recovery behavior.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added shared value-free recovery copy to TTSEffectiveResolutionError and used it at the Studio generation, Console generation and trusted automatic-speech preflight boundaries. Invalid settings identify their axis/owner, catalog failures offer refresh and inconsistent Studio state offers reopening Speech Lab. Existing unrelated typed failure handling remains intact. The three diagnostic sites retain only constructor-validated resolution code, axis and source plus the existing Console outcome; raw exception strings, text and identifiers remain excluded.
+All 19 new diagnostics cases failed before implementation and pass afterward. They exercise all three error boundaries with private payload canaries and distinguish invalid/missing/unsupported/catalog/stale settings. Combined TTS focused checks: 216 passed; diagnostic inventory and metadata-only gates: 2 passed. Regenerated only the two reviewed diagnostic owner rows and their count, preserving unrelated inventory work and sink topology. New tests lint/format clean; production changed ranges formatted with zero new Ruff findings, diff check clean and independent privacy review approved.
+No new ADR: existing ADR-039 settings ownership and ADR-029 metadata-only diagnostics apply. Updated TTS_MODULE_GUIDE.md and Console recovery guidance. Production changes are effective_settings.py, stts_events.py and tts_events.py; regression test_resolution_failure_diagnostics.py. Scoped changes also applied to the isolated newer dev worktree.
+
+The newer dev schema-v3 diagnostic inventory also tracks heuristic path candidates. Reviewed the added typed-resolution outcome_code branch: TTSEffectiveResolutionError maps to the fixed configuration_invalid outcome; resolution code/axis/source are constructor-validated metadata. Preserved the existing generic-outcome branch and legacy file_path candidate, and refreshed only this owner candidate row/count alongside the two already-reviewed owner digests. No unrelated candidate status or sink topology changed.
+
+Final combined dev verification: all six derived-artifact preflight gates passed, including the schema-v3 diagnostic inventory. The integrated TTS/settings cohort passed 200 tests under Python 3.12.11. Baseline-relative Ruff found zero new findings across all 23 changed Python files in the combined fix.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32030 - Preserve-Console-trace-ownership-for-unchanged-multimodal-request-rows.md
+++ b/backlog/tasks/task-32030 - Preserve-Console-trace-ownership-for-unchanged-multimodal-request-rows.md
@@ -1,0 +1,47 @@
+---
+id: TASK-32030
+title: Preserve Console trace ownership for unchanged multimodal request rows
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 05:00'
+updated_date: '2026-09-08 05:12'
+labels:
+  - console
+  - bug
+  - tracing
+dependencies: []
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Identical multimodal messages lose saved trace ownership when immutable containers are compared directly to provider payload containers, causing trace reservation to reject a send before generation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An unchanged multimodal active user row retains its authoritative saved revision through trace request construction.
+- [x] #2 Semantically changed provider rows remain artifacts and cannot acquire saved ownership by content similarity.
+- [x] #3 The real trace boundary accepts an unchanged multimodal send while existing ownership and refusal tests remain green.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Add a focused regression that sends unchanged multimodal JSON through the production agent request factory and SQLite trace boundary; add changed-text/image negative controls.
+2. Normalize the immutable and mutable JSON container representations before exact descriptor comparison, retaining ordered matching and the existing saved-owner gates.
+3. Run focused request/trace and existing controller ownership tests, lint and format changed ranges, self-review, and record evidence and limitations.
+ADR required: no new ADR.
+ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+Reason: Correct JSON representation equality under the existing exact semantic ownership contract; no new schema, disclosure, ownership, or dispatch policy.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Normalized each incoming agent JSON row with the existing freeze_json helper before the ordered exact comparison against the frozen admitted request. Unchanged nested image content now retains its saved revision; changed text, image data, and content order remain artifacts and fail before reservation. No trace ownership, schema, disclosure, or dispatch policy changed; existing ADR-097 applies.
+Added a real SQLite, production request-factory and gateway regression in test_console_trace_runtime.py. RED: the unchanged-image case failed at trace reservation while all three changed-content controls passed. GREEN: all four pass and the unchanged row produces one completed call owned by the current saved user. Whole targeted runtime/provenance and production two-turn/tool controller tests: 122 passed in 52.69 seconds. Final focused rerun: 4 passed in 2.47 seconds. Ruff reports zero introduced diagnostics against 23 inherited findings; changed ranges pass formatter checks and git diff --check passes. Self-review completed. Existing requests dependency warning and patch-tool docstring SyntaxWarning are unchanged. No full suite or real provider/profile was used.
+Files: console_agent_bridge.py, test_console_trace_runtime.py, and an incident-based testing lesson. Work is isolated at origin/dev 3cccd9326 because the older shared checkout lacks the semantic trace architecture. The supplied reporter log does not identify whether its trigger was an image message, so reporter-specific resolution remains unconfirmed. A separately reproduced dictionary transform failure is tracked as TASK-32032.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32032 - Preserve-captured-current-turn-transforms-across-successor-sends.md
+++ b/backlog/tasks/task-32032 - Preserve-captured-current-turn-transforms-across-successor-sends.md
@@ -1,0 +1,76 @@
+---
+id: TASK-32032
+title: Preserve captured current-turn transforms across successor sends
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 05:11'
+updated_date: '2026-09-08 14:53'
+labels:
+  - console
+  - bug
+  - tracing
+dependencies: []
+references:
+  - backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+documentation:
+  - backlog/docs/console-send-diagnostics.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Dictionary and other admitted current-turn text transforms must keep their saved turn ownership and remain traceable when later sends return to the ordinary saved history.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 An admitted current-turn dictionary transform reaches the provider with the transformed text while its saved transcript and turn ownership remain unchanged.
+- [x] #2 A following ordinary send completes through the real trace boundary after the transformed turn, with both historical calls reconstructed faithfully.
+- [x] #3 Changed historical rows, unknown current owners, foreign revisions, stale reservations, and mismatched policies remain fail-closed.
+- [x] #4 Targeted real-database regressions and an ADR-097 amendment document and verify the bounded transform and successor transition contract.
+- [x] #5 A later send after a terminal failed or stopped transformed call restores only its pinned saved source, without inventing an assistant response or admitting a pending call.
+- [x] #6 A transformed send and its warm or cold successor preserve eligible saved continuations and their exact owner; an unowned or changed continuation gains no replacement authority.
+- [x] #7 Current dev project-instruction ownership and captured current-turn transforms remain compatible across initial, tool, fallback, retry and successor trace paths, with targeted integration evidence.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+Reason: Record exact saved-source ownership for current-turn provider artifacts and a bounded successor transition; permit that existing semantic-revision FK on call-boundary events with a schema migration.
+
+1. Amend ADR-097 with the admitted current-owner text-transform contract, exact durable source pin, bounded completed-turn transition, recovery/policy guards, and rejected current-version inference.
+2. Add a real controller, gateway, trace factory, and isolated SQLite regression for dictionary dispatch followed by ordinary and transformed sends; establish RED before production edits.
+3. Add the typed source-bearing active-request artifact, preserve only the admitted current owner, and pin the resolved revision atomically at call reservation. Add v68-to-v69 event-shape migration and ownership guard without new tables or columns.
+4. Extend the existing completed-turn witness only for the exact source-artifact-to-source plus linked assistant and next user transition, retaining immutable prior heads and all latest-call, range, source, value, policy, and recovery checks.
+5. Verify cold restart, edited exact source, tool successor, unknown and changed history, foreign source, stale reservation, mismatched policy, and migration rollback/upgrade with targeted real-database tests. Run affected trace suites, baseline-relative lint, changed-range formatting, and diff checks. Update task notes and documentation without commits, merging, or live profile access.
+6. Integrate restored eligible saved continuation groups through the actual controller. Prove transformed warm/cold successors and negative ownership/content controls; if a physical continuation tail exposes a mismatch, preserve the exact unchanged continuation domain and narrow the existing witness to its proven message range without generic artifact admission.
+7. Integrate current dev project-instruction ownership (TASK-31976.1) with the pinned current-turn transform and continuation proof. Preserve both ADR-097 invariants, add combined-path regressions where needed, verify the affected Console/project suites against current dev, and record reviewed integration and publication evidence. User explicitly authorized a PR against dev and playback validation after the original isolated implementation.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Admitted current-user text transforms now retain their exact saved revision while the trace stores the transformed provider value as a policy-owned ACTIVE_REQUEST artifact. Historical or unowned changes do not receive this authority. Schema v69 pins that source on the existing call-boundary revision FK; it adds no table, column, source-body retention or ownership registry.
+
+The existing completed-turn witness restores only the proven source/response/new-user range. It supports ordinary and agent sends, tool-loop completion, cold factories, owned pre-dispatch recovery, settled failures without assistant rows and a real streaming Stop with a verified partial assistant. Exact origin revision, owner, latest call, predecessor, bounded range, terminal state, response linkage and frozen policy semantics remain mandatory. Same-message newer or equal-text reverted revisions cannot replace the origin pin. Retained saved continuations preserve their exact raw source and unchanged suffix; filtered artifact equality grants no authority to unowned continuation descriptors.
+
+Core changes: console_chat_controller.py, console_trace_provenance.py, console_trace_final_values.py, console_trace_runtime.py and console_trace_service.py; ChaChaNotes_DB.py and the v68-to-v69 migration. Regressions are in test_console_trace_current_turn_transforms.py, test_console_trace_transform_continuations.py, test_console_trace_runtime.py, test_console_trace_service.py and the v69 migration tests. ADR required: yes; backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md records the source identity, successor, recovery and privacy contracts. Console send diagnostics and lessons-testing-evidence document the verified failure meaning and testing/migration traps.
+
+Verification: tests first reproduced the real dictionary reservation failure, source substitution, terminal successor and continuation integration failures. Final combined trace/controller/settlement/reader/semantic-revision gate: 372 passed across 13 targeted modules, with four exact independently reproduced clean-dev baseline failures deselected. The baseline failures are the custom-openai-api credential-shape case, two oversized-settlement cases and cold recovery timestamp case. Seven introduced broader-gate failures were repaired and rerun GREEN. Required DB migration/adjacent-version checks: 22 passed; 40 other migration fixture failures were separately reproduced unchanged on clean dev. Independent final review found no remaining actionable defect. Baseline-relative Ruff across 34 changed Python files has 1,015 inherited/current diagnostics and zero introduced; changed ranges/new tests are formatted and git diff --check passes.
+
+Implementation is in /private/tmp/tldw-trace-fix-32029, based on dev 3cccd9326c556a245fc87ab5013c192242e389cf. Verification used isolated real SQLite and the production controller/gateway/trace boundaries, replacing only inference; Python 3.12.11 and SQLite 3.49.1 differ from the reported 3.13.5/3.46.1. The single metadata log does not identify the reporter's exact transform or installed commit. A source pin retains identity only; unavailable retired source projections remain refused. No live profile, full suite, commit, merge or push was used.
+
+Final artifact checks: all six derived preflight gates passed; all ten new test files passed Ruff formatting; baseline-relative Ruff remained 1,015 inherited/current findings across 34 changed Python files with zero introduced findings; git diff --check HEAD passed. The final independent review is clear and the 372-pass targeted trace gate covers the integrated changes.
+
+PR integration, authorized 2026-09-08: preserved the verified 47-file fix as ded80ee8e on codex/kokoro-speech-trace-recovery and integrated dev 5aeac5ab221958ae612dd84ff47e047b23cd3f5d. Resolved the shared project-context witness and provider-input paths by composing the exact source pin with the bounded project/tool suffix; retained runtime credentials for owned retries and raw-before-filter saved continuation checks. The active descriptor index now follows dev project-context ownership while preserving current-user transforms. Both ADR-097 contracts and both lesson incidents are retained. Six added real controller/HTTP/SQLite cases cover dictionary transforms with ordinary, tool and fallback predecessors, warm/cold factories and changed/disabled project guidance.
+
+Current-dev integration validation: 121 project/transform/continuation/redaction cases passed; six added combined-path cases passed; 552 gateway/preparation/thinking/history/grammar cases passed (two numeric-loopback listener cases rerun outside the sandbox and passed). The ten-module trace/settlement/reader gate passed 340 cases with three failures, all reproduced with the same assertion outcomes on an unchanged archive of exact dev 5aeac5ab2: test_oversized_response_is_replaced_by_one_bounded_labeled_artifact, test_queued_settlement_drops_oversized_response_and_usage_values, and test_cold_restart_recovers_open_calls_monotonically_and_idempotently. The previously excluded custom-OpenAI credential case now passes with the upstream correction. No full repository sweep was run. Logs: /private/tmp/console-dev-merge-initial.log, console-dev-combined-green.log, console-dev-merge-adjacent-gate.log, console-dev-merge-loopback.log, console-dev-merge-trace-gate.log and console-dev-current-baseline-failures.log.
+
+All six current-dev derived gates passed, including 591 diagnostic owners and 3,445 task files with no duplicate IDs. Baseline-relative Ruff across 36 changed Python files has 1,014 inherited/current findings with zero introduced; changed Console ranges were formatted with AST equality checked, and the new combined test is fully formatted. Publication and real audio playback are handled by the coordinating task after final integration review.
+
+Final merge review is clear. The independent reviewer compared the runtime, service and witness changes with both parents and passed 43 selected project/source/retained-value/owned-retry/redaction cases. Additional actual-controller warm/cold probes preserved all three together: a saved Moonshot continuation with a credential canary, real bound AGENTS context with credential/PII filtering, and transformed-user restoration on an ordinary successor under one frozen conversation privacy policy; exact raw provider checkpoints and the original trace remained unchanged, and Capture-Off controls passed. All ten added test modules and the new combined-project test passed Ruff formatting. Staged diff --check against origin/dev passes; four first-parent whitespace warnings are unchanged upstream Library/critique files outside the PR diff. Console integration is complete; the coordinating task is completing real audio validation before committing the merge and publishing the PR.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32032 - Preserve-captured-current-turn-transforms-across-successor-sends.md
+++ b/backlog/tasks/task-32032 - Preserve-captured-current-turn-transforms-across-successor-sends.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 05:11'
-updated_date: '2026-09-08 14:53'
+updated_date: '2026-09-08 15:50'
 labels:
   - console
   - bug
@@ -49,6 +49,7 @@ Reason: Record exact saved-source ownership for current-turn provider artifacts 
 5. Verify cold restart, edited exact source, tool successor, unknown and changed history, foreign source, stale reservation, mismatched policy, and migration rollback/upgrade with targeted real-database tests. Run affected trace suites, baseline-relative lint, changed-range formatting, and diff checks. Update task notes and documentation without commits, merging, or live profile access.
 6. Integrate restored eligible saved continuation groups through the actual controller. Prove transformed warm/cold successors and negative ownership/content controls; if a physical continuation tail exposes a mismatch, preserve the exact unchanged continuation domain and narrow the existing witness to its proven message range without generic artifact admission.
 7. Integrate current dev project-instruction ownership (TASK-31976.1) with the pinned current-turn transform and continuation proof. Preserve both ADR-097 invariants, add combined-path regressions where needed, verify the affected Console/project suites against current dev, and record reviewed integration and publication evidence. User explicitly authorized a PR against dev and playback validation after the original isolated implementation.
+8. PR #2512 Qodo follow-up: document accepted descriptors and optional source-revision returns for the two public provenance helpers; verify existing ownership regressions.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -73,4 +74,6 @@ Current-dev integration validation: 121 project/transform/continuation/redaction
 All six current-dev derived gates passed, including 591 diagnostic owners and 3,445 task files with no duplicate IDs. Baseline-relative Ruff across 36 changed Python files has 1,014 inherited/current findings with zero introduced; changed Console ranges were formatted with AST equality checked, and the new combined test is fully formatted. Publication and real audio playback are handled by the coordinating task after final integration review.
 
 Final merge review is clear. The independent reviewer compared the runtime, service and witness changes with both parents and passed 43 selected project/source/retained-value/owned-retry/redaction cases. Additional actual-controller warm/cold probes preserved all three together: a saved Moonshot continuation with a credential canary, real bound AGENTS context with credential/PII filtering, and transformed-user restoration on an ordinary successor under one frozen conversation privacy policy; exact raw provider checkpoints and the original trace remained unchanged, and Capture-Off controls passed. All ten added test modules and the new combined-project test passed Ruff formatting. Staged diff --check against origin/dev passes; four first-parent whitespace warnings are unchanged upstream Library/critique files outside the PR diff. Console integration is complete; the coordinating task is completing real audio validation before committing the merge and publishing the PR.
+
+PR #2512 Qodo follow-up: added Google-style Args and Returns sections to current_turn_source_revision_id and saved_response_source_revision_id, describing accepted provenance descriptors, exact saved owner identifiers and unsupported-shape None results. No ownership or privacy logic changed. The adjacent admission/provenance gate passed 225 tests; the preceding rebased integration gate passed 173 relevant UI/TTS/DB/Console tests. Affected formatting, baseline-relative Ruff with zero new findings and all six derived checks pass. The existing ADR-097 contract is unchanged. Publication notes supersede the earlier no-commit/no-push investigation scope under the user's explicit PR and merge authorization.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32038 - Reject-unsupported-global-TTS-voice-policies-before-saving.md
+++ b/backlog/tasks/task-32038 - Reject-unsupported-global-TTS-voice-policies-before-saving.md
@@ -1,0 +1,52 @@
+---
+id: TASK-32038
+title: Reject unsupported global TTS voice policies before saving
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 05:10'
+updated_date: '2026-09-08 06:06'
+labels:
+  - tts
+  - bug
+  - settings
+dependencies: []
+references:
+  - backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Global Speech and TTS Settings currently allow legacy providers such as Kokoro to save a server-default voice policy that fails every automatic reply at effective selection. Provider changes can also carry that unsupported policy from audio.cpp.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Settings reject unsupported server-default voices with a field-specific recovery message before publishing preferences.
+- [x] #2 Switching from audio.cpp to a legacy provider offers an exact voice and does not retain a foreign exact model or voice; returning to the saved provider restores its saved choices.
+- [x] #3 Mounted Settings and real TTS admission tests cover Kokoro provider transitions, persisted invalid preferences and supported audio.cpp controls.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/039-global-and-studio-tts-settings-ownership.md
+Reason: Align the canonical Settings controls and save validation with the existing provider selection contract; no persistence or provider boundary change.
+
+1. Reproduce unsupported saved Kokoro voice policies and audio.cpp-to-Kokoro transitions in mounted Settings tests and actual effective admission.
+2. Reject unsupported voice omission before publication, offer exact legacy voices, and reset foreign model and voice choices on explicit provider changes while restoring the saved provider choices.
+3. Verify supported audio.cpp policies, stale-value recovery, provider round trips and privacy-safe diagnostics; document the settings repair.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Canonical Speech & TTS Settings now reject server-default voice policies for legacy providers before publication, matching the existing resolver contract. Explicit provider changes choose that provider's canonical model and voice instead of retaining foreign IDs; returning to the saved provider restores its saved choices. Unsupported saved policies remain visible for deliberate correction. A valid repaired draft can replace invalid saved defaults and its status correctly reports Unsaved.
+Ten initial regression cases failed before the production repair. Mounted Settings tests follow the resulting Kokoro defaults through real service admission twice, with only audio execution substituted. They cover both audio.cpp policy shapes, saved-provider round trips and repair/publication of invalid saved preferences. Independent review found the misleading repaired-draft status; its added assertion failed first, then passed after independent draft/baseline validation. Settings model/panel and Console autoplay gate: 320 passed. Final targeted recovery/status gate: 37 passed, 96 deselected. Existing audio.cpp capability policies remain covered. New tests Ruff/formatter clean; no introduced production Ruff diagnostics, changed ranges formatted and diff check clean.
+No new ADR: routine enforcement of ADR-039. Files: settings_speech_tts.py, speech_tts_settings_panel.py and test_legacy_tts_voice_policy.py; updated developer/user TTS recovery guidance and an incident lesson. Changes also applied to the isolated newer dev worktree. No full suite, live provider, personal configuration or audible engine test was used.
+
+Closeout ID audit across 495 refs and 12 worktrees found that the Petdex companion task had claimed TASK-32031 at 2026-09-08 05:09, before this TTS task at 05:10, and was committed as b4e460f75142b37ff3df277fd712bdb1812007f9 on codex/buddy-import-design. The earlier claimant keeps its ID. Renumbered only this TTS task and its scoped lesson reference to TASK-32038 after rechecking the global maximum (32037); preserved creation time, status and acceptance evidence. The unrelated Petdex task and checkout were untouched.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32040 - Preserve-selected-private-history-when-Console-trace-capture-is-enabled.md
+++ b/backlog/tasks/task-32040 - Preserve-selected-private-history-when-Console-trace-capture-is-enabled.md
@@ -1,0 +1,59 @@
+---
+id: TASK-32040
+title: Preserve selected private history when Console trace capture is enabled
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 06:18'
+updated_date: '2026-09-08 07:41'
+labels:
+  - console
+  - trace
+  - bug
+dependencies: []
+references:
+  - backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Capture On currently discards matching saved provider continuation history before dispatch even though the same conversation replays it with Capture Off. Preserve provider behavior and exact saved ownership across capture modes, including affected successor requests.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Matching retained continuation and thinking history reaches the provider with the same values under Capture On and Capture Off.
+- [x] #2 Trace reconstruction retains the exact saved owner and selected private history without exposing it in diagnostics or admitting foreign, changed or unsupported history.
+- [x] #3 Ordinary and transformed successor sends remain valid with retained private history, including cold reconstruction; targeted real-controller and real-database tests cover the behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no new ADR
+ADR path: backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md
+Reason: Repair the existing selected-sidecar replay and exact saved-owner provenance contract; preserve the storage, privacy and provider boundaries.
+
+1. Add failing real-controller and SQLite capture-on/off parity tests for matching saved private continuation history, then cover thinking replay and rejected owners.
+2. Preserve the selected owner bindings while preparing captured semantics, reuse existing private-history selection and attachment behavior, and prevent a prepared request from silently dropping selected sidecars.
+3. Verify provider payloads and trace reconstruction agree, and repair any demonstrated bounded successor transition involving unchanged sidecars without broadening artifact authority.
+4. Run targeted gateway, preparation, trace and controller regressions plus baseline-relative lint, changed-range format, inventory and diff checks; update task notes and user documentation.
+
+Implementation location: /private/tmp/tldw-trace-fix-32029, based on dev 3cccd9326c556a245fc87ab5013c192242e389cf. The older main workspace holds this task record for tracking; the complete Console patch stays in the isolated dev checkout.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Captured requests now retain eligible saved continuation and thinking history with the same provider values as Capture Off. Preparation binds the selected private history to its exact saved revision; admission verifies raw values before credential filtering. Canonical checkpoint decoding restores the existing typed representation without weakening issuance identity, and thinking rewrites retain their exact saved owner.
+
+Warm and cold successors preserve selected history across ordinary and transformed turns. Supported local displayable and hosted proprietary thinking responses use a frozen response projection to verify their complete saved response. A process-local keyed proof compares raw values before filtering and never enters durable storage or diagnostics. New response revision and artifact writes honor frozen PII policy, including older unprofiled headers; failed PII detection omits affected response data. Historical records retain their original interpretation, and request and response mask domains remain distinct.
+
+The controller, preparation, trace runtime/service, semantic revision, settlement and reader changes are covered by real SQLite/controller/gateway regressions in test_console_trace_sidecar_replay.py, test_console_trace_sidecar_redaction.py, test_console_trace_thinking_settlement.py and test_console_trace_proprietary_settlement.py. Positive capture-mode, transformed, cold reconstruction and actual typed-provider response cases accompany negative owner, credential-equivalent forgery, malformed profile and PII controls. ADR required: no new ADR; amended backlog/decisions/097-console-reference-backed-semantic-trace-ledger.md documents repairs to the existing replay, response and privacy contracts. The source-pin schema migration is recorded by TASK-32032. Console documentation and incident-based testing lessons were updated.
+
+Final verification: 372 passed in 13 targeted trace modules, with four exact failures independently reproduced on unchanged dev and excluded (one provider-shape, two oversized-response and one cold-recovery fixture case). Adjacent preparation, gateway, thinking and continuation checks: 517 passed, including the two localhost checks rerun with listener access. All six derived preflight checks passed. Baseline-relative Ruff across 34 changed Python files reports 1,015 inherited/current findings and zero new findings; all ten new test files pass formatting and git diff --check HEAD passes. Independent review found no remaining actionable defect. Tests use real application boundaries with inference replaced; no live profile or full repository suite was used.
+
+Implementation is in /private/tmp/tldw-trace-fix-32029 at dev base 3cccd9326c556a245fc87ab5013c192242e389cf; the older main workspace holds the tracking record. No commit, merge or push was performed. This task was renumbered from TASK-32039 to TASK-32040 after a final cross-ref/worktree audit found concurrent claims to the earlier ID.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -165,6 +165,7 @@ from tldw_chatbook.Chat.console_prepared_request import (
     CONTINUATION_OWNER_KEY,
     PreparedConsoleRequest,
     build_console_request,
+    freeze_json,
 )
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
@@ -2615,12 +2616,14 @@ class ConsoleAgentTraceRequestFactory:
         search_from = 0
         descriptors: list[TraceProvenance] = []
         for message in messages:
+            # Prepared rows are recursively frozen, while agent transport rows
+            # carry mutable JSON arrays. Compare the same representation so an
+            # unchanged multimodal message keeps its admitted saved owner.
+            frozen_message = freeze_json(message)
             descriptor: TraceProvenance | None = None
             for index in range(search_from, len(base_rows)):
                 candidate = base_descriptors[index]
-                if dict(base_rows[index]) == dict(
-                    message
-                ) and _agent_can_reuse_descriptor(
+                if base_rows[index] == frozen_message and _agent_can_reuse_descriptor(
                     candidate,
                     message,
                 ):

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -220,6 +220,7 @@ from tldw_chatbook.Chat.console_prepared_request import (
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
     ConsoleTraceCaptureMode,
+    DerivedTraceProvenance,
     ProviderArtifactTraceProvenance,
     TraceProvenancePersistenceError,
     TraceProvenanceSource,
@@ -450,12 +451,15 @@ from tldw_chatbook.Chat.console_thinking_capture import ThinkingCapture
 from tldw_chatbook.Chat.console_thinking_history import (
     EffectiveThinkingHistoryPolicy,
     ProviderThinkingSidecar,
+    ThinkingReplayTarget,
     effective_thinking_history_policy,
+    resolve_thinking_history,
 )
 from tldw_chatbook.Chat.thinking_blocks import (
     ThinkingEnvelope,
     ThinkingHistoryPolicy,
     normalize_thinking_history_policy,
+    parse_thinking_blocks_json,
 )
 from tldw_chatbook.Chat.provider_readiness import provider_config_key
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
@@ -6081,6 +6085,7 @@ class ConsoleChatController:
         try:
             trace_request = self._build_durable_trace_request(
                 preparation=committing,
+                resolution=resolution,
                 provider_messages=self._provider_messages_with_prefill(
                     continuation.provider_messages,
                     continuation.prefill,
@@ -8714,6 +8719,7 @@ class ConsoleChatController:
         self,
         *,
         preparation: ConsoleTurnPreparation,
+        resolution: Any,
         provider_messages: list[dict[str, Any]],
         trace_source_messages: tuple[dict[str, Any], ...],
         echoed_user_id: str,
@@ -8753,12 +8759,22 @@ class ConsoleChatController:
         }
         saved_positions: list[int] = []
         saved_ids: list[str] = []
+        saved_values: list[dict[str, Any]] = []
+        transformed_positions: set[int] = set()
         visible_messages: list[dict[str, Any]] = []
         for index, row in enumerate(provider_messages):
             visible = provider_row(row)
             visible_messages.append(visible)
             owner_id = row.get(NATIVE_MESSAGE_ID_KEY)
-            if type(owner_id) is not str or source_by_owner.get(owner_id) != visible:
+            if type(owner_id) is not str:
+                continue
+            source = source_by_owner.get(owner_id)
+            transformed = source != visible
+            if transformed and (
+                owner_id != echoed_user_id
+                or source is None
+                or not self._is_current_user_text_transform(source, visible)
+            ):
                 continue
             if owner_id == echoed_user_id:
                 persisted_id = committed_user_id
@@ -8770,6 +8786,72 @@ class ConsoleChatController:
             if type(persisted_id) is str and persisted_id:
                 saved_positions.append(index)
                 saved_ids.append(persisted_id)
+                saved_values.append(source)
+                if transformed:
+                    transformed_positions.add(index)
+
+        selected_owner_ids = {
+            provider_messages[position][NATIVE_MESSAGE_ID_KEY]
+            for position in saved_positions
+        }
+        sidecars, continuation_target = (
+            self._provider_continuation_history_for_resolution(
+                preparation.session_id, resolution
+            )
+        )
+        continuation_groups = (
+            provider_continuation_owner_groups(
+                tuple(
+                    item
+                    for item in sidecars
+                    if item.owner_message_id in selected_owner_ids
+                ),
+                target=continuation_target,
+            )
+            if sidecars and continuation_target is not None
+            else ()
+        )
+        thinking_sidecars = tuple(
+            item
+            for item in self._provider_thinking_sidecar_for_session(
+                preparation.session_id
+            )
+            if item.owner_message_id in selected_owner_ids
+        )
+        thinking = resolve_thinking_history(
+            target=ThinkingReplayTarget(
+                provider=getattr(resolution, "execution_key", None)
+                or resolution.provider,
+                model=resolution.model or "",
+                protocol=(
+                    getattr(resolution, "continuation_protocol", None)
+                    or getattr(resolution, "api_mode", None)
+                    or "chat_completions"
+                ),
+                disposition=getattr(
+                    resolution, "thinking_stream_disposition", "ignored"
+                ),
+                round_trip_version=getattr(
+                    resolution, "thinking_round_trip_version", None
+                ),
+            ),
+            policy=self.store.session_thinking_history_policy(preparation.session_id),
+            sidecars=thinking_sidecars,
+            continuation_required=bool(continuation_groups),
+        )
+        continuation_owner_ids = {
+            group.owner_message_id for group in continuation_groups
+        }
+        thinking_owner_ids = {group.owner_message_id for group in thinking.groups}
+        thinking_by_owner = {
+            item.owner_message_id: item.envelope for item in thinking_sidecars
+        }
+        for position in saved_positions:
+            owner_id = provider_messages[position][NATIVE_MESSAGE_ID_KEY]
+            if owner_id in continuation_owner_ids:
+                visible_messages[position][CONTINUATION_OWNER_KEY] = owner_id
+            if owner_id in thinking_owner_ids:
+                visible_messages[position][THINKING_OWNER_KEY] = owner_id
 
         policy = FrozenTracePolicy(
             policy_id=new_opaque_id(),
@@ -8784,16 +8866,56 @@ class ConsoleChatController:
                     coordinator=coordinator,
                     message_ids=tuple(saved_ids),
                 )
+                for position, descriptor in zip(saved_positions, saved, strict=True):
+                    owner_id = provider_messages[position][NATIVE_MESSAGE_ID_KEY]
+                    if owner_id not in thinking_owner_ids:
+                        continue
+                    row = cursor.execute(
+                        "SELECT m.thinking_blocks_json "
+                        "FROM console_trace_semantic_revisions AS r "
+                        "JOIN messages AS m ON m.id = r.live_message_id "
+                        "WHERE r.revision_id = ? "
+                        "AND r.source_message_id = m.id "
+                        "AND r.source_conversation_id = m.conversation_id",
+                        (descriptor.revision_id,),
+                    ).fetchone()
+                    if (
+                        row is None
+                        or parse_thinking_blocks_json(row[0])
+                        != thinking_by_owner[owner_id]
+                    ):
+                        raise TraceProvenancePersistenceError()
+                if transformed_positions:
+                    from tldw_chatbook.Chat.console_semantic_revision import (
+                        project_semantic_revision_provider_message,
+                    )
+
+                    for position, source, descriptor in zip(
+                        saved_positions, saved_values, saved, strict=True
+                    ):
+                        if position not in transformed_positions:
+                            continue
+                        revision = repository.get_semantic_revision(
+                            cursor, descriptor.revision_id
+                        )
+                        if (
+                            revision is None
+                            or project_semantic_revision_provider_message(
+                                cursor,
+                                revision_id=descriptor.revision_id,
+                                expected_conversation_id=revision.source_conversation_id,
+                            )
+                            != source
+                        ):
+                            raise TraceProvenancePersistenceError()
                 repository.ensure_policy(cursor, policy)
                 if policy.pii_redaction_enabled:
-                    for position, descriptor in zip(
-                        saved_positions,
+                    for source, descriptor in zip(
+                        saved_values,
                         saved,
                         strict=True,
                     ):
-                        credential_projection = CredentialSanitizer().sanitize(
-                            visible_messages[position]
-                        )
+                        credential_projection = CredentialSanitizer().sanitize(source)
                         if not credential_projection.available:
                             repository.bind_revision_policy(
                                 cursor,
@@ -8839,6 +8961,14 @@ class ConsoleChatController:
             raise TraceProvenancePersistenceError() from None
 
         saved_by_position = dict(zip(saved_positions, saved, strict=True))
+        for position in transformed_positions:
+            saved_by_position[position] = DerivedTraceProvenance(
+                TraceTransformKind.CURRENT_TURN_TEXT,
+                inputs=(saved_by_position[position],),
+                artifact=ProviderArtifactTraceProvenance(
+                    TraceProvenanceSource.ACTIVE_REQUEST, policy
+                ),
+            )
         descriptors = tuple(
             saved_by_position.get(index)
             or ProviderArtifactTraceProvenance(
@@ -8856,7 +8986,44 @@ class ConsoleChatController:
             mandatory_provenance=(),
             tool_provenance=(),
             capture_policy=policy,
+            continuation_groups=continuation_groups,
+            thinking_groups=thinking.groups,
+            thinking_policy=thinking.saved_policy,
+            effective_thinking_policy=thinking.effective_policy,
         )
+
+    @staticmethod
+    def _is_current_user_text_transform(
+        source: Mapping[str, Any], visible: Mapping[str, Any]
+    ) -> bool:
+        """Admit text-only changes; retain every role, attachment and sidecar."""
+        if source.get("role") != "user" or {
+            key: value for key, value in source.items() if key != "content"
+        } != {key: value for key, value in visible.items() if key != "content"}:
+            return False
+        before, after = source.get("content"), visible.get("content")
+        if type(before) is str and type(after) is str:
+            return True
+        if (
+            type(before) is not list
+            or type(after) is not list
+            or len(before) != len(after)
+        ):
+            return False
+        for original, transformed in zip(before, after, strict=True):
+            if original == transformed:
+                continue
+            if (
+                type(original) is not dict
+                or type(transformed) is not dict
+                or original.get("type") != "text"
+                or type(original.get("text")) is not str
+                or type(transformed.get("text")) is not str
+                or {key: value for key, value in original.items() if key != "text"}
+                != {key: value for key, value in transformed.items() if key != "text"}
+            ):
+                return False
+        return True
 
     @staticmethod
     def _provider_messages_with_prefill(
@@ -9170,6 +9337,7 @@ class ConsoleChatController:
         try:
             trace_request = self._build_durable_trace_request(
                 preparation=preparation,
+                resolution=resolution,
                 provider_messages=self._provider_messages_with_prefill(
                     provider_messages,
                     prefill,

--- a/tldw_chatbook/Chat/console_prepared_request.py
+++ b/tldw_chatbook/Chat/console_prepared_request.py
@@ -1149,7 +1149,7 @@ def _serialize_provenance(
     *,
     system_message: str | None,
 ) -> ProviderRequestProvenance | None:
-    """Mirror serialization using descriptors without inspecting semantic content."""
+    """Mirror serialization while retaining owners of exact provider rewrites."""
 
     provenance = semantic.provenance
     if provenance is None:
@@ -1162,6 +1162,7 @@ def _serialize_provenance(
     thinking: list[TraceProvenance] = []
     continuations: list[TraceProvenance] = []
     tool_loop: list[int] = []
+    capture_policy = frozen_policy_from_provenance(provenance)
 
     def extend_unit(
         unit: ConsoleConversationUnit,
@@ -1186,6 +1187,9 @@ def _serialize_provenance(
                 unit_provenance.thinking,
                 strict=True,
             )
+        }
+        thinking_groups_by_owner = {
+            group.owner_message_id: group for group in unit.thinking_groups
         }
         continuation_by_owner = {
             group.owner_message_id: descriptor
@@ -1245,12 +1249,23 @@ def _serialize_provenance(
                 for item in (thinking_descriptor, continuation_descriptor)
                 if item is not None
             )
+            thinking_group = thinking_groups_by_owner.get(thinking_owner)
+            content_changed = (
+                thinking_group is not None
+                and serialize_start_anchored_thinking(
+                    message.get("content"), thinking_group
+                )
+                != message.get("content")
+            )
             flattened.append(
                 DerivedTraceProvenance(
                     TraceTransformKind.MESSAGE_REWRITE,
                     (descriptor, *attachments),
+                    artifact=ProviderArtifactTraceProvenance(
+                        TraceProvenanceSource.THINKING, capture_policy
+                    ),
                 )
-                if attachments
+                if content_changed
                 else descriptor
             )
         thinking.extend(unit_provenance.thinking)

--- a/tldw_chatbook/Chat/console_semantic_revision.py
+++ b/tldw_chatbook/Chat/console_semantic_revision.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import base64
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 import json
 import re
@@ -28,6 +28,7 @@ from tldw_chatbook.Chat.console_trace_redaction import (
 from tldw_chatbook.Chat.console_trace_repository import (
     ConsoleTraceRepository,
     SemanticRevisionRecord,
+    TraceCallRecord,
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 
@@ -47,6 +48,7 @@ _INTERNAL_ENVELOPE_KEYS = frozenset(
     {"message_id", "conversation_id", "parent_message_id"}
 )
 _TRACE_REDACTION_POLICY_UNSUPPORTED = "trace_redaction_policy_unsupported"
+TRACE_RESPONSE_PII_FIELD_PREFIX = "response:typed-thinking-v1:"
 
 
 def project_semantic_revision_provider_message(
@@ -55,12 +57,15 @@ def project_semantic_revision_provider_message(
     revision_id: str,
     expected_conversation_id: str,
     policy_id: str | None = None,
+    response_call: TraceCallRecord | None = None,
 ) -> dict[str, object]:
     """Project a live or policy-materialized revision to provider-message shape.
 
     The ownership check precedes the content read. The complete canonical
     semantic envelope is decoded before projection so malformed sidecars or a
     mismatched live locator cannot be mistaken for the referenced revision.
+    A response call selects only its explicit frozen response profile; ordinary
+    request projections and historical calls without that profile stay unchanged.
     """
 
     repository = ConsoleTraceRepository()
@@ -86,7 +91,9 @@ def project_semantic_revision_provider_message(
             raise ValueError("semantic_revision_materialization_unavailable") from exc
         if not isinstance(envelope, dict):
             raise ValueError("semantic_revision_materialization_unavailable")
-        return _project_revision_envelope(revision, envelope)
+        return _project_revision_response_envelope(
+            cursor, revision, envelope, response_call
+        )
     envelope = SemanticRevisionCoordinator._message_envelope(
         cursor, revision.live_message_id
     )
@@ -95,7 +102,107 @@ def project_semantic_revision_provider_message(
         or envelope["conversation_id"] != expected_conversation_id
     ):
         raise ValueError("semantic_revision_locator_mismatch")
-    return _project_revision_envelope(revision, envelope)
+    return _project_revision_response_envelope(
+        cursor, revision, envelope, response_call
+    )
+
+
+def _project_revision_response_envelope(
+    cursor: sqlite3.Cursor,
+    revision: SemanticRevisionRecord,
+    envelope: dict[str, object],
+    call: TraceCallRecord | None,
+) -> dict[str, object]:
+    projected = _project_revision_envelope(revision, envelope)
+    if call is None:
+        return projected
+    repository = ConsoleTraceRepository()
+    header = repository.get_request_header(cursor, call.request_header_id or "")
+    profile = (
+        None if header is None else header.adapter_defaults.get("response_projection")
+    )
+    if profile is None:
+        return projected
+    if (
+        not isinstance(profile, Mapping)
+        or set(profile)
+        != {
+            "version",
+            "thinking_stream_disposition",
+            "thinking_round_trip_version",
+            "provider",
+            "model",
+            "protocol",
+            "source_format",
+        }
+        or type(profile["version"]) is not int
+        or profile["version"] != 1
+        or type(profile["thinking_round_trip_version"]) is not int
+        or profile["thinking_round_trip_version"] != 1
+        or profile["thinking_stream_disposition"] not in {"displayable", "proprietary"}
+        or profile["source_format"]
+        != (
+            "start_anchored_think"
+            if profile["thinking_stream_disposition"] == "displayable"
+            else "reasoning_content"
+        )
+        or profile["provider"] != call.provider_name
+        or profile["model"] != call.model_name
+        or profile["protocol"] not in {"chat_completions", "responses"}
+        or revision.normalized_role != "assistant"
+    ):
+        raise ValueError("response_projection_unavailable")
+    raw_thinking = envelope.get("thinking_blocks")
+    if raw_thinking is None:
+        return projected
+    from tldw_chatbook.Chat.thinking_blocks import (
+        DisplayableThinkingBlock,
+        ProprietaryThinkingBlock,
+        parse_thinking_blocks_json,
+    )
+
+    thinking = parse_thinking_blocks_json(json.dumps(raw_thinking, allow_nan=False))
+    if any(block.round_ordinal > call.call_sequence for block in thinking.blocks):
+        raise ValueError("response_thinking_round_mismatch")
+    blocks = tuple(
+        block for block in thinking.blocks if block.round_ordinal == call.call_sequence
+    )
+    if not blocks:
+        return projected
+    expected_status = {
+        "complete": "complete",
+        "stopped": "stopped",
+        "error": "failed",
+        "interrupted": "failed",
+    }.get(call.outcome or call.state.value)
+    if len(blocks) != 1:
+        raise ValueError("response_thinking_round_mismatch")
+    block = blocks[0]
+    if (
+        not isinstance(
+            block,
+            DisplayableThinkingBlock
+            if profile["thinking_stream_disposition"] == "displayable"
+            else ProprietaryThinkingBlock,
+        )
+        or block.status != expected_status
+        or any(
+            getattr(block, key) != profile[key]
+            for key in ("provider", "model", "protocol", "source_format")
+        )
+    ):
+        raise ValueError("response_thinking_source_mismatch")
+    evidence = {
+        "provider": block.provider,
+        "model": block.model,
+        "protocol": block.protocol,
+        "source_format": block.source_format,
+    }
+    if isinstance(block, DisplayableThinkingBlock):
+        projected["thinking"] = [{**evidence, "text": block.text}]
+    else:
+        projected["proprietary_thinking_evidence"] = [evidence]
+    return projected
 
 
 def project_semantic_revision_provider_messages(
@@ -200,6 +307,7 @@ def project_semantic_revision_trace_message(
     revision_id: str,
     expected_conversation_id: str,
     policy_id: str,
+    response_call: TraceCallRecord | None = None,
 ) -> dict[str, object]:
     """Project one canonical revision through its immutable trace masks.
 
@@ -212,6 +320,8 @@ def project_semantic_revision_trace_message(
         revision_id: Opaque semantic revision to project.
         expected_conversation_id: Conversation that must own the revision.
         policy_id: Frozen trace policy whose credential and PII masks apply.
+        response_call: Optional exact call selecting its frozen response projection
+            and response mask domain; omitted for ordinary request messages.
 
     Returns:
         A provider-message mapping safe for trace disclosure.
@@ -245,6 +355,7 @@ def project_semantic_revision_trace_message(
         revision_id=revision_id,
         expected_conversation_id=expected_conversation_id,
         policy_id=policy_id,
+        response_call=response_call,
     )
     credential_projection = CredentialSanitizer().sanitize(projected)
     if not credential_projection.available or not isinstance(
@@ -264,10 +375,25 @@ def project_semantic_revision_trace_message(
         artifact_id=None,
     )
     by_path: dict[str, list[PIIRedactionSpan]] = {}
+    response_header = (
+        None
+        if response_call is None
+        else repository.get_request_header(
+            cursor, response_call.request_header_id or ""
+        )
+    )
+    response_masks = (
+        response_header is not None
+        and "response_projection" in response_header.adapter_defaults
+    )
     for row in rows:
+        is_response_mask = row.field_path.startswith(TRACE_RESPONSE_PII_FIELD_PREFIX)
+        if is_response_mask != response_masks:
+            continue
         if row.outcome != "applied":
             raise ValueError("redaction_span_unavailable")
-        by_path.setdefault(row.field_path, []).append(
+        field_path = row.field_path.removeprefix(TRACE_RESPONSE_PII_FIELD_PREFIX)
+        by_path.setdefault(field_path, []).append(
             PIIRedactionSpan(
                 row.start_codepoint,
                 row.end_codepoint,

--- a/tldw_chatbook/Chat/console_trace_final_values.py
+++ b/tldw_chatbook/Chat/console_trace_final_values.py
@@ -21,6 +21,8 @@ from tldw_chatbook.Chat.console_trace_provenance import (
     TraceOmissionReason,
     TraceProvenance,
     TraceProvenanceSource,
+    current_turn_source_revision_id,
+    saved_response_source_revision_id,
 )
 from tldw_chatbook.Chat.console_trace_redaction import (
     CredentialSanitizationResult,
@@ -187,13 +189,14 @@ class VerifiedSurfaceReplacementRange:
 
 @dataclass(frozen=True, slots=True)
 class CompletedToolTurnWitness:
-    """Content-free evidence rechecked against the durable call ledger."""
+    """Completed-run evidence for its source, response and project-context range."""
 
     origin_call_id: str
     terminal_call_id: str
-    assistant_revision_id: str
+    assistant_revision_id: str | None
     user_revision_id: str
-    # None preserves the tool-only transition. Zero explicitly renews a
+    source_revision_id: str | None = None
+    # None preserves the tool/source-only transition. Zero explicitly renews a
     # project turn whose next request no longer contains project context.
     project_context_count: int | None = field(default=None, kw_only=True)
 
@@ -201,10 +204,15 @@ class CompletedToolTurnWitness:
         for identity in (
             self.origin_call_id,
             self.terminal_call_id,
-            self.assistant_revision_id,
             self.user_revision_id,
         ):
             SemanticRevisionRef(identity)
+        if self.source_revision_id is not None:
+            SemanticRevisionRef(self.source_revision_id)
+        if self.assistant_revision_id is not None:
+            SemanticRevisionRef(self.assistant_revision_id)
+        elif self.source_revision_id is None:
+            raise ValueError("completed_turn_source")
         if self.project_context_count is not None and (
             type(self.project_context_count) is not int
             or not 0 <= self.project_context_count <= MAX_SURFACE_REPLACEMENT_SPAN
@@ -213,37 +221,36 @@ class CompletedToolTurnWitness:
 
     @property
     def descriptor_count(self) -> int:
-        """Count the saved response/user pair and declared project context.
-
-        Returns:
-            Two saved revisions plus the number of current project-context
-            rows. A tool-only witness has no additional context rows.
-        """
-        return 2 + (self.project_context_count or 0)
+        """Count the proven source/response/user range and current context."""
+        return (
+            1
+            + int(self.assistant_revision_id is not None)
+            + int(self.source_revision_id is not None)
+            + (self.project_context_count or 0)
+        )
 
     def matches_descriptors(self, descriptors: tuple[TraceProvenance, ...]) -> bool:
-        """Check the declared provenance shape without granting transition rights.
-
-        Args:
-            descriptors: Ordered replacement provenance to compare with this
-                witness's saved assistant/user pair and project-context count.
-
-        Returns:
-            True when the exact saved pair is followed only by the declared
-            number of project-instruction artifacts; False otherwise. Durable
-            ownership, policy and value checks are performed by the service.
-        """
+        """Match exact saved owners followed only by declared project context."""
+        source_prefix = (
+            ()
+            if self.source_revision_id is None
+            else (SavedRevisionTraceProvenance(self.source_revision_id),)
+        )
+        user_index = len(source_prefix) + int(self.assistant_revision_id is not None)
         return (
             len(descriptors) == self.descriptor_count
-            and descriptors[:2]
-            == (
-                SavedRevisionTraceProvenance(self.assistant_revision_id),
-                SavedRevisionTraceProvenance(self.user_revision_id),
+            and descriptors[: len(source_prefix)] == source_prefix
+            and (
+                self.assistant_revision_id is None
+                or saved_response_source_revision_id(descriptors[user_index - 1])
+                == self.assistant_revision_id
             )
+            and current_turn_source_revision_id(descriptors[user_index])
+            == self.user_revision_id
             and all(
                 type(item) is ProviderArtifactTraceProvenance
                 and item.source is TraceProvenanceSource.PROJECT_INSTRUCTION
-                for item in descriptors[2:]
+                for item in descriptors[user_index + 1 :]
             )
         )
 
@@ -324,12 +331,6 @@ class VerifiedSurfaceDelta:
                 or len(self.items) != witness.descriptor_count - 1
                 or self.route_identity not in {"agent_first", "fresh"}
                 or self.replacement.item.component_name != "messages_payload"
-                or self.items[0].component_name != "messages_payload"
-                or self.items[0].ordinal != self.replacement.item.ordinal + 1
-                or self.replacement.item.provenance
-                != SavedRevisionTraceProvenance(witness.assistant_revision_id)
-                or self.items[0].provenance
-                != SavedRevisionTraceProvenance(witness.user_revision_id)
                 or any(
                     item.component_name != "messages_payload"
                     or item.ordinal != self.replacement.item.ordinal + offset

--- a/tldw_chatbook/Chat/console_trace_native_reader.py
+++ b/tldw_chatbook/Chat/console_trace_native_reader.py
@@ -384,6 +384,7 @@ class ConsoleTraceNativeReader:
                 revision_id=revision.revision_id,
                 expected_conversation_id=revision.source_conversation_id,
                 policy_id=call.policy_id,
+                response_call=call,
             )
         value = self._decode_artifact(
             self.repository.get_artifact(cursor, response.artifact_id or "")

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -93,6 +93,7 @@ class TraceTransformKind(str, Enum):
     SYSTEM_FRAMING = "system_framing"
     PROVIDER_OVERLAY = "provider_overlay"
     MESSAGE_REWRITE = "message_rewrite"
+    CURRENT_TURN_TEXT = "current_turn_text"
     WINDOWING = "windowing"
 
 
@@ -597,6 +598,17 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
 
     transform = descriptor.transform
     artifact = descriptor.artifact
+    if transform is TraceTransformKind.CURRENT_TURN_TEXT:
+        if (
+            len(descriptor.inputs) != 1
+            or type(descriptor.inputs[0]) is not SavedRevisionTraceProvenance
+            or artifact is None
+            or artifact.source is not TraceProvenanceSource.ACTIVE_REQUEST
+        ):
+            raise TraceProvenanceAlignmentError(
+                "current-turn text requires one saved source and its active artifact"
+            )
+        return
     if transform in {
         TraceTransformKind.THINKING_ATTACHMENT,
         TraceTransformKind.CONTINUATION_ATTACHMENT,
@@ -623,6 +635,9 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
             )
         return
     required_artifacts = {
+        TraceTransformKind.MESSAGE_REWRITE: frozenset(
+            {TraceProvenanceSource.THINKING}
+        ),
         TraceTransformKind.PROVIDER_OVERLAY: frozenset(
             {TraceProvenanceSource.PROVIDER_OVERLAY}
         ),
@@ -640,7 +655,9 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
         ),
     }
     allowed_sources = required_artifacts.get(transform)
-    if allowed_sources is not None:
+    if transform is TraceTransformKind.MESSAGE_REWRITE and artifact is None:
+        pass
+    elif allowed_sources is not None:
         if artifact is None or artifact.source not in allowed_sources:
             raise TraceProvenanceAlignmentError(
                 "derived transform requires its exact provider artifact"
@@ -669,6 +686,41 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
         raise TraceProvenanceAlignmentError(
             "message rewrite sidecar does not match its exact owner"
         )
+    if transform is TraceTransformKind.MESSAGE_REWRITE and artifact is not None and not any(
+        type(item) is DerivedTraceProvenance
+        and item.transform is TraceTransformKind.THINKING_ATTACHMENT
+        for item in descriptor.inputs[1:]
+    ):
+        raise TraceProvenanceAlignmentError(
+            "message rewrite artifact requires its typed thinking attachment"
+        )
+
+
+def current_turn_source_revision_id(descriptor: TraceProvenance) -> str | None:
+    """Return the exact source of a saved or admitted current-user row."""
+    if type(descriptor) is SavedRevisionTraceProvenance:
+        return descriptor.revision_id
+    if (
+        type(descriptor) is DerivedTraceProvenance
+        and descriptor.transform is TraceTransformKind.CURRENT_TURN_TEXT
+    ):
+        return descriptor.inputs[0].revision_id
+    return None
+
+
+def saved_response_source_revision_id(descriptor: TraceProvenance) -> str | None:
+    """Return the exact saved owner of a response or its typed thinking replay."""
+    if type(descriptor) is SavedRevisionTraceProvenance:
+        return descriptor.revision_id
+    if (
+        type(descriptor) is DerivedTraceProvenance
+        and descriptor.transform is TraceTransformKind.MESSAGE_REWRITE
+        and descriptor.artifact is not None
+        and descriptor.artifact.source is TraceProvenanceSource.THINKING
+        and type(descriptor.inputs[0]) is SavedRevisionTraceProvenance
+    ):
+        return descriptor.inputs[0].revision_id
+    return None
 
 
 def _descriptor_matches_category(

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -635,9 +635,7 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
             )
         return
     required_artifacts = {
-        TraceTransformKind.MESSAGE_REWRITE: frozenset(
-            {TraceProvenanceSource.THINKING}
-        ),
+        TraceTransformKind.MESSAGE_REWRITE: frozenset({TraceProvenanceSource.THINKING}),
         TraceTransformKind.PROVIDER_OVERLAY: frozenset(
             {TraceProvenanceSource.PROVIDER_OVERLAY}
         ),
@@ -686,10 +684,14 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
         raise TraceProvenanceAlignmentError(
             "message rewrite sidecar does not match its exact owner"
         )
-    if transform is TraceTransformKind.MESSAGE_REWRITE and artifact is not None and not any(
-        type(item) is DerivedTraceProvenance
-        and item.transform is TraceTransformKind.THINKING_ATTACHMENT
-        for item in descriptor.inputs[1:]
+    if (
+        transform is TraceTransformKind.MESSAGE_REWRITE
+        and artifact is not None
+        and not any(
+            type(item) is DerivedTraceProvenance
+            and item.transform is TraceTransformKind.THINKING_ATTACHMENT
+            for item in descriptor.inputs[1:]
+        )
     ):
         raise TraceProvenanceAlignmentError(
             "message rewrite artifact requires its typed thinking attachment"
@@ -697,7 +699,15 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
 
 
 def current_turn_source_revision_id(descriptor: TraceProvenance) -> str | None:
-    """Return the exact source of a saved or admitted current-user row."""
+    """Return the exact source of a saved or admitted current-user row.
+
+    Args:
+        descriptor: Validated saved-revision or derived trace provenance.
+
+    Returns:
+        The saved revision identifier for a saved row or admitted current-turn
+        text transform, or None for other provenance shapes.
+    """
     if type(descriptor) is SavedRevisionTraceProvenance:
         return descriptor.revision_id
     if (
@@ -709,7 +719,15 @@ def current_turn_source_revision_id(descriptor: TraceProvenance) -> str | None:
 
 
 def saved_response_source_revision_id(descriptor: TraceProvenance) -> str | None:
-    """Return the exact saved owner of a response or its typed thinking replay."""
+    """Return the exact saved owner of a response or its typed thinking replay.
+
+    Args:
+        descriptor: Validated saved-revision or derived trace provenance.
+
+    Returns:
+        The saved revision identifier for a saved response or its typed thinking
+        rewrite, or None when the descriptor has no supported saved owner.
+    """
     if type(descriptor) is SavedRevisionTraceProvenance:
         return descriptor.revision_id
     if (

--- a/tldw_chatbook/Chat/console_trace_runtime.py
+++ b/tldw_chatbook/Chat/console_trace_runtime.py
@@ -10,7 +10,10 @@ from datetime import datetime, timezone
 
 from tldw_chatbook.Chat.console_prepared_request import PreparedProviderRequest
 from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
-from tldw_chatbook.Chat.console_trace_final_values import CompletedToolTurnWitness
+from tldw_chatbook.Chat.console_trace_final_values import (
+    CompletedToolTurnWitness,
+    _checkpoint_semantic_value,
+)
 from tldw_chatbook.Chat.console_trace_models import TraceCallState, new_opaque_id
 from tldw_chatbook.Chat.console_trace_provenance import (
     ConsoleRequestRoute,
@@ -21,8 +24,11 @@ from tldw_chatbook.Chat.console_trace_provenance import (
     SavedRevisionTraceProvenance,
     TraceProvenance,
     TraceProvenanceSource,
+    TraceTransformKind,
+    current_turn_source_revision_id,
     frozen_policy_from_provenance,
     request_route_provenance,
+    saved_response_source_revision_id,
 )
 from tldw_chatbook.Chat.console_trace_repository import (
     ConsoleTraceRepository,
@@ -49,6 +55,15 @@ def _saved_revision_ids(descriptor: TraceProvenance) -> Iterator[str]:
     elif type(descriptor) is DerivedTraceProvenance:
         for nested in descriptor.inputs:
             yield from _saved_revision_ids(nested)
+
+
+def _current_text_revision_ids(descriptor: TraceProvenance) -> Iterator[str]:
+    if type(descriptor) is DerivedTraceProvenance:
+        if descriptor.transform is TraceTransformKind.CURRENT_TURN_TEXT:
+            yield descriptor.inputs[0].revision_id
+        else:
+            for nested in descriptor.inputs:
+                yield from _current_text_revision_ids(nested)
 
 
 class ConsoleTraceBoundaryFactory:
@@ -124,11 +139,15 @@ class ConsoleTraceBoundaryFactory:
         owner = self.repository.get_owner(cursor, reserved.owner_id)
         policy = frozen_policy_from_provenance(boundary._request.semantic.provenance)
         if (
-            revision is None or owner is None
+            revision is None
+            or owner is None
+            or latest.semantic_revision_id != boundary._current_revision_id
             or revision.source_message_id != reserved.turn_id
             or self.repository.get_attached_owner_by_conversation(
-                cursor, revision.source_conversation_id,
-            ) != owner
+                cursor,
+                revision.source_conversation_id,
+            )
+            != owner
             or policy.policy_id != reserved.policy_id
             or self.repository.get_policy(cursor, policy.policy_id) != policy
         ):
@@ -188,7 +207,8 @@ class ConsoleTraceBoundaryFactory:
                         provenance=request.provenance,
                         values=tuple(request.messages_payload)
                         + tuple(
-                            group.checkpoint for group in request.continuation_groups
+                            _checkpoint_semantic_value(group.checkpoint)
+                            for group in request.continuation_groups
                         ),
                         completed_tool_turn=boundary.admission.completed_tool_turn,
                         current_turn_id=reserved.turn_id,
@@ -331,6 +351,16 @@ class ConsoleTraceBoundaryFactory:
             active_revision_ids = message_revision_ids[-1:]
         if len(active_revision_ids) != 1:
             raise ValueError("trace_turn_unavailable")
+        has_current_text_transform = False
+        for index, descriptor in enumerate(provenance.messages_payload):
+            transformed_sources = tuple(_current_text_revision_ids(descriptor))
+            has_current_text_transform |= bool(transformed_sources)
+            if transformed_sources and (
+                transformed_sources != active_revision_ids
+                or (not tool_loop and index != active_descriptor_index)
+                or request.messages_payload[index].get("role") != "user"
+            ):
+                raise ValueError("trace_current_transform_owner")
         revision_ids = message_revision_ids + tuple(
             revision_id
             for descriptor in provenance.continuations
@@ -420,6 +450,20 @@ class ConsoleTraceBoundaryFactory:
                         )
                     ):
                         raise ValueError("trace_tool_chain_unavailable")
+                    origin_pins = cursor.execute(
+                        "SELECT semantic_revision_id FROM console_trace_events "
+                        "WHERE call_id = ? AND event_type = 'call_boundary'",
+                        (origin.call_id,),
+                    ).fetchall()
+                    if (
+                        len(origin_pins) != 1
+                        or (
+                            origin_pins[0][0] is not None
+                            and origin_pins[0][0] != current_revision_id
+                        )
+                        or (has_current_text_transform and origin_pins[0][0] is None)
+                    ):
+                        raise ValueError("trace_tool_chain_source_mismatch")
                     previous = self.repository.get_call_by_logical_identity(
                         cursor,
                         owner_id=owner.owner_id,
@@ -460,19 +504,18 @@ class ConsoleTraceBoundaryFactory:
                     )
                 self.repository.ensure_policy(cursor, policy)
                 continuation_values = tuple(
-                    group.checkpoint for group in request.continuation_groups
+                    _checkpoint_semantic_value(group.checkpoint)
+                    for group in request.continuation_groups
                 )
                 completed_tool_turn = None
                 if (
                     route_record.route
                     in {ConsoleRequestRoute.AGENT_FIRST, ConsoleRequestRoute.FRESH}
                     and active_descriptor_index >= 1
-                    and all(
-                        type(item) is SavedRevisionTraceProvenance
-                        for item in provenance.messages_payload[
-                            active_descriptor_index - 1 : active_descriptor_index + 1
-                        ]
+                    and current_turn_source_revision_id(
+                        provenance.messages_payload[active_descriptor_index]
                     )
+                    == current_revision_id
                 ):
                     latest = self.repository.get_latest_call_boundary(
                         cursor, owner.root_segment_id
@@ -488,26 +531,57 @@ class ConsoleTraceBoundaryFactory:
                         else self.repository.get_run_origin(cursor, terminal.run_id)
                     )
                     if terminal is not None and origin is not None:
-                        completed_tool_turn = CompletedToolTurnWitness(
-                            origin.call_id,
-                            terminal.call_id,
-                            provenance.messages_payload[
-                                active_descriptor_index - 1
-                            ].revision_id,
-                            current_revision_id,
-                            project_context_count=(
-                                len(provenance.messages_payload)
-                                - active_descriptor_index
-                                - 1
-                                if skipped_project_context
-                                or self.service.has_completed_project_context(
-                                    cursor,
-                                    segment_id=owner.root_segment_id,
-                                    terminal_surface_id=terminal.surface_node_id,
-                                )
-                                else None
-                            ),
+                        source_revision_id = None
+                        origin_head = self.service._call_message_tail(cursor, origin)
+                        if (
+                            origin_head is not None
+                            and origin_head.component_kind == "active_request"
+                        ):
+                            source_row = cursor.execute(
+                                "SELECT semantic_revision_id FROM console_trace_events "
+                                "WHERE call_id = ? AND event_type = 'call_boundary'",
+                                (origin.call_id,),
+                            ).fetchall()
+                            if len(source_row) == 1:
+                                source_revision_id = source_row[0][0]
+                        preceding = provenance.messages_payload[
+                            active_descriptor_index - 1
+                        ]
+                        preceding_id = saved_response_source_revision_id(preceding)
+                        preceding_revision = (
+                            self.repository.get_semantic_revision(cursor, preceding_id)
+                            if preceding_id is not None
+                            else None
                         )
+                        assistant_revision_id = (
+                            preceding_revision.revision_id
+                            if preceding_revision is not None
+                            and preceding_revision.normalized_role == "assistant"
+                            else None
+                        )
+                        if (
+                            assistant_revision_id is not None
+                            or source_revision_id is not None
+                        ):
+                            completed_tool_turn = CompletedToolTurnWitness(
+                                origin.call_id,
+                                terminal.call_id,
+                                assistant_revision_id,
+                                current_revision_id,
+                                source_revision_id=source_revision_id,
+                                project_context_count=(
+                                    len(provenance.messages_payload)
+                                    - active_descriptor_index
+                                    - 1
+                                    if skipped_project_context
+                                    or self.service.has_completed_project_context(
+                                        cursor,
+                                        segment_id=owner.root_segment_id,
+                                        terminal_surface_id=terminal.surface_node_id,
+                                    )
+                                    else None
+                                ),
+                            )
                 admission, surface_boundary = (
                     self.service.prepare_current_surface_delta(
                         cursor,
@@ -547,6 +621,7 @@ class ConsoleTraceBoundaryFactory:
                     sequence=0 if event_tail is None else event_tail.sequence + 1,
                     event_type="call_boundary",
                     call_id=reserved.call_id,
+                    semantic_revision_id=current_revision_id,
                 )
             assert reserved is not None
             return ConsoleTraceCallBoundary(

--- a/tldw_chatbook/Chat/console_trace_service.py
+++ b/tldw_chatbook/Chat/console_trace_service.py
@@ -21,6 +21,7 @@ from tldw_chatbook.Chat.console_semantic_revision import (
 )
 from tldw_chatbook.Chat.console_trace_final_values import (
     _SURFACE_VERIFICATION_ISSUER,
+    _checkpoint_semantic_value,
     CompletedToolTurnWitness,
     FinalValueBinding,
     ProviderCredentialSource,
@@ -72,6 +73,7 @@ from tldw_chatbook.Chat.console_trace_repository import (
     TraceCallRecord,
     TraceEventType,
 )
+from tldw_chatbook.Chat.provider_continuation import parse_provider_continuation_json
 from tldw_chatbook.DB.base_db import operation_owned_connection
 from tldw_chatbook.DB.transaction_observer import (
     current_managed_transaction,
@@ -186,7 +188,9 @@ class _TraceDispatchWriteError(TraceCallPersistenceError):
 class _TraceDispatchCancelled(asyncio.CancelledError):
     """Carry reconciled write state without authorizing adapter entry."""
 
-    def __init__(self, outcome: TraceCallRecord | Literal["rolled_back", "unknown"]) -> None:
+    def __init__(
+        self, outcome: TraceCallRecord | Literal["rolled_back", "unknown"]
+    ) -> None:
         super().__init__()
         self.outcome = outcome
 
@@ -209,8 +213,12 @@ class ConsoleTraceCallBoundary:
     _accepted_preparation: object | None = field(default=None, repr=False)
     _retired: bool = field(default=False, init=False, repr=False)
     _recovery_transferred: bool = field(default=False, init=False, repr=False)
-    _dispatch_outcome: Literal["not_attempted", "rolled_back", "committed", "unknown"] = field(
-        default="not_attempted", init=False, repr=False,
+    _dispatch_outcome: Literal[
+        "not_attempted", "rolled_back", "committed", "unknown"
+    ] = field(
+        default="not_attempted",
+        init=False,
+        repr=False,
     )
     _started: TraceCallRecord | None = field(default=None, init=False, repr=False)
     _unknown: TraceCallRecord | None = field(default=None, init=False, repr=False)
@@ -297,6 +305,7 @@ class ConsoleTraceCallBoundary:
                 bundle=bundle,
                 surface_delta=surface_delta,
                 occurred_at=self.occurred_at_factory(),
+                response_projection=_response_projection_profile(self._resolution),
             )
             self._dispatch_outcome = "committed"
         except _TraceDispatchCancelled as exc:
@@ -327,7 +336,10 @@ class ConsoleTraceCallBoundary:
         if self._started is None:
             raise TraceCallPersistenceError()
         try:
-            with operation_owned_connection(self.database), self.database.transaction(immediate=True) as cursor:  # type: ignore[attr-defined]
+            with (
+                operation_owned_connection(self.database),
+                self.database.transaction(immediate=True) as cursor,
+            ):  # type: ignore[attr-defined]
                 self._unknown = self.service.repository.advance_call_state(
                     cursor,
                     call_id=self._started.call_id,
@@ -348,9 +360,17 @@ class ConsoleTraceCallBoundary:
         if self._reserved.state is TraceCallState.NOT_DISPATCHED:
             return self._reserved
         try:
-            with operation_owned_connection(self.database), self.database.transaction(immediate=True) as cursor:  # type: ignore[attr-defined]
-                durable = self.service.repository.get_call(cursor, self._reserved.call_id)
-                if durable != self._reserved or durable.state is not TraceCallState.RESERVED:
+            with (
+                operation_owned_connection(self.database),
+                self.database.transaction(immediate=True) as cursor,
+            ):  # type: ignore[attr-defined]
+                durable = self.service.repository.get_call(
+                    cursor, self._reserved.call_id
+                )
+                if (
+                    durable != self._reserved
+                    or durable.state is not TraceCallState.RESERVED
+                ):
                     raise TraceCallPersistenceError(boundary=self)
                 self._reserved = self.service.repository.advance_call_state(
                     cursor,
@@ -1169,9 +1189,24 @@ class _ProjectedProviderValues(Sequence[object]):
             owner_id=self._owner_id,
         )
         values: list[object] = []
+        descriptors = dict(self._descriptor_root.iter_entries())
         for sequence, key, value in selected:
             if key is None:
                 values.append(value)
+            elif (
+                key[0] == "continuation"
+                and (reference := _saved_reference_key(descriptors[sequence]))
+                is not None
+                and reference[:2] == ("continuation", "revision")
+            ):
+                values.append(
+                    self._service._expected_descriptor_value(
+                        self._cursor,
+                        self._owner_id,
+                        descriptors[sequence],
+                        self._retained_artifact_values.get(sequence, resolved.get(key)),
+                    )
+                )
             elif sequence in self._retained_artifact_values:
                 values.append(self._retained_artifact_values[sequence])
             else:
@@ -1223,7 +1258,8 @@ class _PreparedSurfaceBoundary:
                     freeze_json(value) for value in messages_payload
                 ),
                 "provider_continuations": tuple(
-                    freeze_json(value) for value in provider_continuations
+                    parse_provider_continuation_json(_thaw(value))
+                    for value in provider_continuations
                 ),
             }
         )
@@ -1270,10 +1306,26 @@ class _PreparedSurfaceBoundary:
             or not isinstance(actual_values, Mapping)
         ):
             return False
-        return all(
+        if not all(
             actual_values.get(name) is value
             for name, value in self._issued_values.items()
-        )
+        ):
+            return False
+        continuation_offset = 0
+        for item in prepared.items:
+            if item.component_name != "provider_continuations":
+                continue
+            supplied = self._delta_values["provider_continuations"][continuation_offset]
+            continuation_offset += 1
+            reference = _saved_reference_key(item.provenance)
+            if reference is None or reference[:2] != ("continuation", "revision"):
+                continue
+            canonical = _checkpoint_semantic_value(
+                self._issued_values["provider_continuations"][item.ordinal]
+            )
+            if _artifact_bytes(canonical) != _artifact_bytes(supplied):
+                return False
+        return True
 
     def _bind_verified_bundle(
         self,
@@ -1633,6 +1685,7 @@ class ConsoleTraceService:
         bundle: ProviderRequestShadowBundle,
         surface_delta: VerifiedSurfaceDelta,
         occurred_at: str,
+        response_projection: Mapping[str, object] | None = None,
     ) -> TraceCallRecord:
         """Persist, bind, and start one reserved call in one transaction."""
 
@@ -1640,7 +1693,10 @@ class ConsoleTraceService:
         persisted = None
         started = None
         try:
-            with trace_critical_write_checkpoint_policy(database), database.transaction(immediate=True) as cursor:  # type: ignore[attr-defined]
+            with (
+                trace_critical_write_checkpoint_policy(database),
+                database.transaction(immediate=True) as cursor,
+            ):  # type: ignore[attr-defined]
                 reserved_call = self.repository.get_call(cursor, call_id)
                 persisted = self.persist_request(
                     cursor,
@@ -1650,6 +1706,7 @@ class ConsoleTraceService:
                     bundle=bundle,
                     surface_delta=surface_delta,
                     reserved_call=reserved_call,
+                    response_projection=response_projection,
                 )
                 self.repository.bind_call(
                     cursor,
@@ -1665,9 +1722,7 @@ class ConsoleTraceService:
                     call_id=call_id,
                     target=TraceCallState.DISPATCH_STARTED,
                     occurred_at=occurred_at,
-                    integrity_state=(
-                        "complete" if bundle.available else "incomplete"
-                    ),
+                    integrity_state=("complete" if bundle.available else "incomplete"),
                     omission_reason_code=(
                         None
                         if bundle.available or bundle.omission_reason is None
@@ -1677,23 +1732,31 @@ class ConsoleTraceService:
             return started
         except asyncio.CancelledError:
             outcome = self._reconcile_dispatch_write(
-                database, reserved_call=reserved_call, persisted=persisted,
-                started=started, surface_delta=surface_delta,
+                database,
+                reserved_call=reserved_call,
+                persisted=persisted,
+                started=started,
+                surface_delta=surface_delta,
             )
             if not isinstance(outcome, TraceCallRecord):
                 self._discard_failed_surface_delta(surface_delta)
             raise _TraceDispatchCancelled(outcome) from None
         except Exception:  # noqa: BLE001 - write/cleanup errors may contain provider values
             outcome = self._reconcile_dispatch_write(
-                database, reserved_call=reserved_call, persisted=persisted,
-                started=started, surface_delta=surface_delta,
+                database,
+                reserved_call=reserved_call,
+                persisted=persisted,
+                started=started,
+                surface_delta=surface_delta,
             )
             if isinstance(outcome, TraceCallRecord):
                 return outcome
             self._discard_failed_surface_delta(surface_delta)
             raise _TraceDispatchWriteError(outcome) from None
 
-    def _discard_failed_surface_delta(self, surface_delta: VerifiedSurfaceDelta) -> None:
+    def _discard_failed_surface_delta(
+        self, surface_delta: VerifiedSurfaceDelta
+    ) -> None:
         """Discard tentative verifier state without changing durable evidence."""
         self._surface_ref_cache.pop(surface_delta.segment_id, None)
         self._child_capabilities.pop(id(surface_delta.child_binding), None)
@@ -1728,12 +1791,16 @@ class ConsoleTraceService:
                 ):
                     return "rolled_back"
                 if (
-                    persisted is None or started is None or durable != started
+                    persisted is None
+                    or started is None
+                    or durable != started
                     or started.state is not TraceCallState.DISPATCH_STARTED
                     or head != persisted.surface_head_id
                     or durable.surface_node_id != persisted.surface_head_id
                     or durable.request_header_id != persisted.header.header_id
-                    or self.repository.get_request_header(cursor, persisted.header.header_id)
+                    or self.repository.get_request_header(
+                        cursor, persisted.header.header_id
+                    )
                     != persisted.header
                     or any(
                         self.repository.get_surface_node(cursor, node.node_id) != node
@@ -1754,11 +1821,16 @@ class ConsoleTraceService:
                     ).fetchone()
                     if (
                         row is None
-                        or tuple(row) != (
-                            expected.replacement_id, expected.segment_id,
-                            replacement.predecessor_head_id, replacement.start_node_id,
-                            replacement.start_sequence, replacement.end_node_id,
-                            replacement.end_sequence, replacement.replacement_node_id,
+                        or tuple(row)
+                        != (
+                            expected.replacement_id,
+                            expected.segment_id,
+                            replacement.predecessor_head_id,
+                            replacement.start_node_id,
+                            replacement.start_sequence,
+                            replacement.end_node_id,
+                            replacement.end_sequence,
+                            replacement.replacement_node_id,
                         )
                         or replacement.predecessor_head_id
                         != surface_delta.predecessor_surface_head_id
@@ -1778,6 +1850,7 @@ class ConsoleTraceService:
         bundle: ProviderRequestShadowBundle,
         surface_delta: VerifiedSurfaceDelta,
         reserved_call: TraceCallRecord | None = None,
+        response_projection: Mapping[str, object] | None = None,
     ) -> PersistedTraceRequest:
         """Persist one verified request boundary in the caller-owned transaction."""
 
@@ -2110,6 +2183,7 @@ class ConsoleTraceService:
             cursor,
             provenance=provenance,
             bundle=bundle,
+            response_projection=response_projection,
             surface_structure=(
                 child_state.surface_structure
                 if child_state is not None
@@ -2369,6 +2443,7 @@ class ConsoleTraceService:
                 values[incoming_index],
                 key,
                 durable_values,
+                owner_id=owner_id,
                 known_credentials=known_credentials,
             )
             if matched and key[1] == "artifact":
@@ -2408,16 +2483,22 @@ class ConsoleTraceService:
             active_changed = len(active) - prefix - suffix
             compound = (
                 completed_tool_turn is not None
+                and active_changed > 0
                 and incoming_changed == completed_tool_turn.descriptor_count
                 and route_identity in {"agent_first", "fresh"}
                 and domains[prefix : prefix + incoming_changed]
                 == ("messages_payload",) * incoming_changed
             )
-            if incoming_changed == 1 and active_changed == 0:
-                # A later turn adds a message before an unchanged provider
-                # continuation. Append only that message: descriptor domains
+            if (
+                incoming_changed >= 1
+                and active_changed == 0
+                and domains[prefix : prefix + incoming_changed]
+                == ("messages_payload",) * incoming_changed
+            ):
+                # A later turn adds messages before an unchanged provider
+                # continuation. Append only those messages: descriptor domains
                 # reconstruct provider order without rewriting the suffix.
-                admitted_to = prefix + 1
+                admitted_to = prefix + incoming_changed
             elif (
                 incoming_changed != 1 and not compound
             ) or not 1 <= active_changed <= MAX_SURFACE_REPLACEMENT_SPAN:
@@ -2460,9 +2541,7 @@ class ConsoleTraceService:
                         domain == domains[prefix] for domain in domains[:prefix]
                     ),
                 )
-                admitted_to = prefix + (
-                    completed_tool_turn.descriptor_count if compound else 1
-                )
+                admitted_to = prefix + (incoming_changed if compound else 1)
 
         if compound:
             assert replacement_range is not None and completed_tool_turn is not None
@@ -2485,6 +2564,19 @@ class ConsoleTraceService:
             expected_head_id=predecessor,
             expected_route=route_identity,
         )
+        if checkpoint is not None and current_policy_id is not None:
+            parent = self._parent_capabilities[id(checkpoint)]
+            current_policy = self.repository.get_policy(cursor, current_policy_id)
+            if any(
+                policy.policy_id != current_policy_id
+                for policy in parent.surface_policies
+            ):
+                if current_policy is None or any(
+                    replace(policy, policy_id=current_policy_id) != current_policy
+                    for policy in parent.surface_policies
+                ):
+                    raise ValueError("trace_policy_mismatch")
+                checkpoint = None
         bootstrap = checkpoint is None and predecessor is not None
         if compound and (
             bootstrap or completed_tool_turn.project_context_count is not None
@@ -2502,15 +2594,21 @@ class ConsoleTraceService:
                 tail=tail,
                 projection=projection,
                 route=route_identity,
-                # Project renewal appends a provider artifact under the new
-                # frozen policy. The proof above established equivalent
-                # filtering; rebind retained descriptors to that same policy
-                # instead of mixing two otherwise-equivalent policy IDs.
-                policy_id=(
-                    current_policy_id
-                    if completed_tool_turn.project_context_count is not None
-                    else terminal.policy_id
-                ),
+                policy_id=current_policy_id,
+                retained_descriptors={
+                    sequence: descriptors[index]
+                    for index, (_ordinal, sequence, _key) in enumerate(
+                        active[:admitted_from]
+                    )
+                }
+                | {
+                    sequence: descriptor
+                    for (_ordinal, sequence, _key), descriptor in zip(
+                        active[len(active) - (len(descriptors) - admitted_to) :],
+                        descriptors[admitted_to:],
+                        strict=True,
+                    )
+                },
             )
             bootstrap = False
         admitted = descriptors[admitted_from:admitted_to]
@@ -2585,6 +2683,40 @@ class ConsoleTraceService:
         self._surface_ref_cache.pop(admission.segment_id, None)
         self._prune_unreferenced_parents()
 
+    def _call_message_tail(
+        self, cursor: sqlite3.Cursor, call: TraceCallRecord
+    ) -> SurfaceNodeRecord | None:
+        """Find the owning message before automatic context at the exact call head."""
+        head = (
+            None
+            if call.surface_node_id is None
+            else self.repository.get_surface_node(cursor, call.surface_node_id)
+        )
+        if (
+            head is None
+            or _surface_reference_domain(self._node_reference_key(head))
+            == "messages_payload"
+            and head.component_kind != "project_instruction"
+        ):
+            return head
+        projection = self._surface_projection(cursor, call.segment_id, head)
+        for sequence, key in reversed(projection.entries):
+            if (
+                _surface_reference_domain(key) != "messages_payload"
+                or key[0] == "project_instruction"
+            ):
+                continue
+            nodes = self.repository.read_lineage_surface_nodes(
+                cursor,
+                segment_id=call.segment_id,
+                start_sequence=sequence,
+                end_sequence=sequence,
+            )
+            if len(nodes) == 1 and self._node_reference_key(nodes[0]) == key:
+                return nodes[0]
+            return None
+        return None
+
     def has_completed_project_context(
         self,
         cursor: sqlite3.Cursor,
@@ -2611,7 +2743,12 @@ class ConsoleTraceService:
         if tail is None:
             return False
         entries = self._surface_projection(cursor, segment_id, tail).entries
-        for _sequence, key in reversed(entries[-MAX_SURFACE_REPLACEMENT_SPAN:]):
+        messages = tuple(
+            entry
+            for entry in entries
+            if _surface_reference_domain(entry[1]) == "messages_payload"
+        )
+        for _sequence, key in reversed(messages[-MAX_SURFACE_REPLACEMENT_SPAN:]):
             if key[1] != "artifact" or key[0] not in {
                 "project_instruction",
                 "tool_call",
@@ -2637,6 +2774,21 @@ class ConsoleTraceService:
         reserved_call: TraceCallRecord | None = None,
     ) -> None:
         """Recheck bounded run evidence; a response link alone grants nothing."""
+        restoring_source = witness.source_revision_id is not None
+        source_after_failure = (
+            restoring_source and witness.assistant_revision_id is None
+        )
+        terminal_states = {TraceCallState.COMPLETE}
+        if restoring_source:
+            terminal_states.update(
+                {
+                    TraceCallState.ERROR,
+                    TraceCallState.STOPPED,
+                    TraceCallState.INTERRUPTED,
+                }
+            )
+        if source_after_failure:
+            terminal_states.remove(TraceCallState.COMPLETE)
         project_transition = witness.project_context_count is not None
         self._validate_owner(cursor, owner_id=owner_id, segment_id=segment_id)
         owner = self.repository.get_owner(cursor, owner_id)
@@ -2740,17 +2892,22 @@ class ConsoleTraceService:
             or chain_terminal is None
             or tail is None
             or latest_id != terminal.call_id
-            or terminal.state is not TraceCallState.COMPLETE
+            or terminal.state not in terminal_states
+            or (restoring_source and terminal.settled_at is None)
             or (
                 chain_terminal.route_identity != "tool_loop"
                 and not (
-                    project_transition
+                    (project_transition or restoring_source)
                     and chain_terminal == origin
                     and chain_terminal.route_identity in {"agent_first", "fresh"}
                 )
             )
             or origin.route_identity
-            not in ({"agent_first", "fresh"} if project_transition else {"agent_first"})
+            not in (
+                {"fresh", "agent_first"}
+                if restoring_source or project_transition
+                else {"agent_first"}
+            )
             or origin.call_sequence != 0
             or self.repository.get_run_origin(cursor, chain_terminal.run_id) != origin
             or (
@@ -2806,46 +2963,89 @@ class ConsoleTraceService:
             )
         ):
             raise ValueError("completed_tool_turn_policy")
-        origin_head = (
+        origin_surface_head = (
             None
             if origin.surface_node_id is None
             else self.repository.get_surface_node(cursor, origin.surface_node_id)
         )
+        origin_head = (
+            self._call_message_tail(cursor, origin)
+            if restoring_source
+            else origin_surface_head
+        )
         if (
             origin_head is None
+            or origin_surface_head is None
             or (
-                plan.start_sequence > origin_head.sequence + 1
+                plan.start_sequence != origin_head.sequence
+                if restoring_source
+                else plan.start_sequence > origin_head.sequence + 1
                 if project_transition
                 else plan.start_sequence != origin_head.sequence + 1
             )
-            or plan.end_sequence != tail.sequence
+            or plan.end_sequence > tail.sequence
             or not 1
             <= plan.end_sequence - plan.start_sequence + 1
             <= MAX_SURFACE_REPLACEMENT_SPAN
         ):
             raise ValueError("completed_tool_turn_range")
-        assistant = self.repository.get_semantic_revision(
-            cursor, witness.assistant_revision_id
+        if restoring_source:
+            source = self.repository.get_semantic_revision(
+                cursor, witness.source_revision_id
+            )
+            pin = cursor.execute(
+                "SELECT semantic_revision_id FROM console_trace_events "
+                "WHERE call_id = ? AND event_type = 'call_boundary'",
+                (origin.call_id,),
+            ).fetchall()
+            if (
+                source is None
+                or len(pin) != 1
+                or pin[0][0] != witness.source_revision_id
+                or source.source_message_id != origin.turn_id
+                or source.source_conversation_id != owner.conversation_id
+                or source.normalized_role != "user"
+                or origin_head.component_kind != "active_request"
+                or origin_head.artifact_id is None
+            ):
+                raise ValueError("completed_turn_source")
+        assistant = (
+            None
+            if witness.assistant_revision_id is None
+            else self.repository.get_semantic_revision(
+                cursor, witness.assistant_revision_id
+            )
         )
         user = self.repository.get_semantic_revision(cursor, witness.user_revision_id)
         link = self.repository.get_response_link(cursor, terminal.call_id)
         if (
-            assistant is None
-            or user is None
-            or link is None
-            or link.link_kind != "revision"
-            or link.verification_outcome != "verified_equal"
-            or link.semantic_revision_id != witness.assistant_revision_id
-            or assistant.normalized_role != "assistant"
+            user is None
+            or (
+                not source_after_failure
+                and (
+                    assistant is None
+                    or link is None
+                    or link.link_kind != "revision"
+                    or link.verification_outcome != "verified_equal"
+                    or link.semantic_revision_id != witness.assistant_revision_id
+                    or assistant.normalized_role != "assistant"
+                    or assistant.source_conversation_id != owner.conversation_id
+                )
+            )
             or user.normalized_role != "user"
-            or assistant.source_conversation_id != owner.conversation_id
             or user.source_conversation_id != owner.conversation_id
             or user.source_message_id != current_turn_id
             or not witness.matches_descriptors(descriptors)
             or len(values) != witness.descriptor_count
         ):
             raise ValueError("completed_tool_turn_revision")
-        for descriptor, value in zip(descriptors[:2], values[:2], strict=True):
+        for descriptor, value in zip(descriptors, values, strict=True):
+            if type(descriptor) is not SavedRevisionTraceProvenance:
+                # The admitted current user and the verified assistant's typed
+                # thinking replay may carry provider artifacts. Their exact
+                # sources, response link and policy are checked above and at
+                # the preparation/final-value boundary.
+                continue
             expected = self._resolve_reference_value(
                 cursor,
                 ("message", "revision", descriptor.revision_id),
@@ -2867,20 +3067,35 @@ class ConsoleTraceService:
                 current_policy.pii_redaction_enabled,
                 current_policy.pii_ruleset_revision_id,
             )
-            for descriptor, value in zip(descriptors[2:], values[2:], strict=True)
+            for descriptor, value in zip(
+                descriptors[
+                    witness.descriptor_count - (witness.project_context_count or 0) :
+                ],
+                values[
+                    witness.descriptor_count - (witness.project_context_count or 0) :
+                ],
+                strict=True,
+            )
         ):
             raise ValueError("completed_project_context_value")
         projection = self._surface_projection(cursor, segment_id, tail)
         suffix = tuple(
             (sequence, key)
             for sequence, key in projection.entries
-            if sequence >= plan.start_sequence
+            if plan.start_sequence <= sequence <= plan.end_sequence
         )
-        if project_transition:
+        if any(
+            sequence > plan.end_sequence
+            and _surface_reference_domain(key) != "provider_continuations"
+            for sequence, key in projection.entries
+        ):
+            raise ValueError("completed_tool_turn_range")
+        if project_transition and not restoring_source:
             prefix = tuple(
                 key
                 for sequence, key in projection.entries
                 if sequence < plan.start_sequence
+                and _surface_reference_domain(key) == "messages_payload"
             )
             prior_user = (
                 self.repository.get_semantic_revision(cursor, prefix[-1][2])
@@ -2899,12 +3114,18 @@ class ConsoleTraceService:
         ) or any(
             key[0]
             not in (
-                {"project_instruction", "tool_call", "tool_result"}
+                {"active_request"}
+                if restoring_source and sequence == origin_head.sequence
+                else {"project_instruction", "tool_call", "tool_result"}
                 if project_transition
                 else {"tool_call", "tool_result"}
             )
             or key[1] != "artifact"
-            or (sequence <= origin_head.sequence and key[0] != "project_instruction")
+            or (
+                sequence <= origin_surface_head.sequence
+                and key[0] != "project_instruction"
+                and not (restoring_source and sequence == origin_head.sequence)
+            )
             for sequence, key in suffix
         ):
             raise ValueError("completed_tool_turn_range")
@@ -2938,7 +3159,12 @@ class ConsoleTraceService:
             )
             or (
                 (row[6], row[7]) != (origin.route_identity, 0)
-                if project_transition and row[0] <= origin_head.sequence
+                if (
+                    restoring_source
+                    and row[0] == origin_head.sequence
+                    or project_transition
+                    and row[0] <= origin_surface_head.sequence
+                )
                 else row[6] != "tool_loop"
                 or not 1 <= row[7] <= chain_terminal.call_sequence
             )
@@ -2975,6 +3201,7 @@ class ConsoleTraceService:
         projection: _SurfaceProjection,
         route: str,
         policy_id: str,
+        retained_descriptors: Mapping[int, TraceProvenance],
     ) -> object:
         """Build a cold compound parent entirely from committed references."""
         policy = self.repository.get_policy(cursor, policy_id)
@@ -2986,7 +3213,9 @@ class ConsoleTraceService:
         message_ordinal = 0
         for sequence, key in projection.entries:
             domain = _surface_reference_domain(key)
-            if key[1] == "revision":
+            if sequence in retained_descriptors:
+                descriptor = retained_descriptors[sequence]
+            elif key[1] == "revision":
                 descriptor = SavedRevisionTraceProvenance(key[2])
                 if domain == "provider_continuations":
                     descriptor = DerivedTraceProvenance(
@@ -3082,6 +3311,7 @@ class ConsoleTraceService:
                 provider_values[ordinal],
                 key,
                 durable_values,
+                owner_id=owner_id,
                 known_credentials=known_credentials,
             ):
                 raise ValueError("surface_prefix_mismatch")
@@ -3289,6 +3519,7 @@ class ConsoleTraceService:
                         value,
                         key,
                         durable_values,
+                        owner_id=admission.owner_id,
                         known_credentials=known_credentials,
                     )
                 ):
@@ -3780,7 +4011,9 @@ class ConsoleTraceService:
             return None
         child = self._child_capabilities.get(id(binding))
         items = (
-            ((delta.replacement.item,) + delta.items) if delta.replacement is not None else delta.items
+            ((delta.replacement.item,) + delta.items)
+            if delta.replacement is not None
+            else delta.items
         )
         signature = tuple(
             (item.component_name, item.ordinal, item.provenance) for item in items
@@ -4535,6 +4768,7 @@ class ConsoleTraceService:
         durable_key: SurfaceReferenceKey,
         durable_values: Mapping[SurfaceReferenceKey, object],
         *,
+        owner_id: str,
         known_credentials: tuple[str, ...] = (),
     ) -> bool:
         artifact = (
@@ -4550,9 +4784,26 @@ class ConsoleTraceService:
                 or durable_key not in durable_values
             ):
                 return False
-            # The provider still receives the original value. Compare only in
-            # the same disclosure projection used by the durable artifact;
-            # otherwise unchanged secret-bearing context looks like an edit.
+            if (
+                type(descriptor) is DerivedTraceProvenance
+                and descriptor.transform is TraceTransformKind.CONTINUATION_ATTACHMENT
+            ):
+                if (_saved_reference_key(descriptor) or ())[:2] != (
+                    "continuation",
+                    "revision",
+                ):
+                    # Masked bytes cannot establish an unsaved attachment's
+                    # source identity. Preserve its exact artifact comparison.
+                    return _artifact_bytes(value) == _artifact_bytes(
+                        durable_values[durable_key]
+                    )
+                canonical = self._expected_descriptor_value(
+                    cursor, owner_id, descriptor, value
+                )
+                if _artifact_bytes(canonical) != _artifact_bytes(value):
+                    return False
+            # Provider input stays raw. Only the durable comparison uses the
+            # frozen disclosure projection, after exact saved-source checks.
             sanitized = CredentialSanitizer(
                 known_credentials=known_credentials
             ).sanitize(value)
@@ -4964,6 +5215,7 @@ class ConsoleTraceService:
         bundle: ProviderRequestShadowBundle,
         surface_structure: Mapping[str, object],
         artifact_policy_id: str | None,
+        response_projection: Mapping[str, object] | None = None,
     ) -> RequestHeaderRecord:
         route = _route(provenance)
         components: list[HeaderComponentRef] = []
@@ -5051,6 +5303,8 @@ class ConsoleTraceService:
         }
         if adapter_system_composition:
             adapter_defaults["system_composition"] = list(adapter_system_composition)
+        if response_projection is not None:
+            adapter_defaults["response_projection"] = dict(response_projection)
         adapter_defaults["artifact_policy_id"] = artifact_policy_id
         literal = bundle.literal_payload_value if bundle.available else None
         if literal is not None:
@@ -5381,6 +5635,43 @@ def _surface_reference_domain(key: SurfaceReferenceKey) -> str:
         if key[0] in {"continuation", TraceTransformKind.CONTINUATION_ATTACHMENT.value}
         else "messages_payload"
     )
+
+
+def _response_projection_profile(resolution: object | None) -> dict[str, object] | None:
+    """Freeze only the existing supported typed-thinking response contract."""
+    if (
+        getattr(resolution, "thinking_stream_disposition", None)
+        not in {"displayable", "proprietary"}
+        or getattr(resolution, "thinking_round_trip_version", None) != 1
+    ):
+        return None
+    from tldw_chatbook.Chat.console_provider_gateway import (
+        _DISPLAYABLE_THINKING_EXECUTION_KEYS,
+        _HOSTED_THINKING_FINISH_POLICIES,
+        _thinking_protocol,
+    )
+
+    execution_key = getattr(resolution, "execution_key", "")
+    disposition = getattr(resolution, "thinking_stream_disposition", None)
+    hosted_policy = _HOSTED_THINKING_FINISH_POLICIES.get(execution_key)
+    if (
+        execution_key not in _DISPLAYABLE_THINKING_EXECUTION_KEYS
+        if disposition == "displayable"
+        else hosted_policy is None
+        or hosted_policy.reasoning_disposition != "proprietary"
+    ):
+        return None
+    return {
+        "version": 1,
+        "thinking_stream_disposition": disposition,
+        "thinking_round_trip_version": 1,
+        "provider": execution_key,
+        "model": getattr(resolution, "model", None),
+        "protocol": _thinking_protocol(resolution),
+        "source_format": "start_anchored_think"
+        if disposition == "displayable"
+        else "reasoning_content",
+    }
 
 
 def _saved_reference_key(

--- a/tldw_chatbook/Chat/console_trace_settlement.py
+++ b/tldw_chatbook/Chat/console_trace_settlement.py
@@ -6,13 +6,16 @@ from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass, field, replace
 import hashlib
+import hmac
 import json
+import secrets
 import sqlite3
 import threading
 from typing import Protocol
 
 from tldw_chatbook.Chat.console_semantic_revision import (
     SemanticRevisionCoordinator,
+    TRACE_RESPONSE_PII_FIELD_PREFIX,
     project_semantic_revision_provider_message,
 )
 from tldw_chatbook.Chat.console_trace_models import (
@@ -24,6 +27,10 @@ from tldw_chatbook.Chat.console_trace_redaction import (
     CREDENTIAL_SANITIZER_UNAVAILABLE,
     CredentialSanitizer,
     CredentialSanitizationResult,
+    PIIRedactionSpan,
+)
+from tldw_chatbook.Chat.console_trace_custom_pii import (
+    redact_pii_value_for_ruleset_revision,
 )
 from tldw_chatbook.Chat.console_trace_repository import (
     ConsoleTraceRepository,
@@ -113,6 +120,7 @@ class _PreparedSettlement:
     canonical_message_id: str | None
     prior_integrity_state: str
     prior_omission_reason_code: str | None
+    _response_equality_proof: bytes | None = field(default=None, repr=False)
 
 
 @dataclass(frozen=True, slots=True)
@@ -165,6 +173,7 @@ class ConsoleTraceSettlementCoordinator:
         self._inflight: dict[str, str] = {}
         self._queue_lock = threading.Lock()
         self._dropped_count = 0
+        self._response_equality_key = secrets.token_bytes(32)
 
     @property
     def pending_count(self) -> int:
@@ -396,6 +405,7 @@ class ConsoleTraceSettlementCoordinator:
             raise TypeError("request")
         response_bytes: bytes | None = None
         response_omission: str | None = None
+        response_equality_proof: bytes | None = None
         if isinstance(request.response_envelope, TraceResponseOmission):
             response_omission = request.response_envelope.reason_code
             response_bytes = _canonical_bytes(
@@ -406,7 +416,17 @@ class ConsoleTraceSettlementCoordinator:
             )
         elif request.response_envelope is not None:
             try:
-                response = self._sanitizer.sanitize(request.response_envelope)
+                semantic_response = _normalize_typed_response(request.response_envelope)
+                try:
+                    raw_bytes = _canonical_bytes(semantic_response)
+                    if len(raw_bytes) <= MAX_TRACE_RESPONSE_BYTES:
+                        response_equality_proof = hmac.digest(
+                            self._response_equality_key, raw_bytes, "sha256"
+                        )
+                except (TypeError, ValueError, OverflowError):
+                    # Preserve the sanitizer's established content-free refusal.
+                    response_equality_proof = None
+                response = self._sanitizer.sanitize(semantic_response)
                 if response.available:
                     response_bytes = _canonical_bytes(response.value)
                     if len(response_bytes) > MAX_TRACE_RESPONSE_BYTES:
@@ -466,6 +486,7 @@ class ConsoleTraceSettlementCoordinator:
             canonical_message_id=request.canonical_message_id,
             prior_integrity_state=request.prior_integrity_state,
             prior_omission_reason_code=request.prior_omission_reason_code,
+            _response_equality_proof=response_equality_proof,
         )
 
     def _prepare_safely(
@@ -626,19 +647,28 @@ class ConsoleTraceSettlementCoordinator:
                         cursor,
                         revision_id=revision.revision_id,
                         expected_conversation_id=owner.conversation_id,
+                        response_call=replace(
+                            call, state=prepared.outcome, outcome=prepared.outcome.value
+                        ),
                     )
                     sanitized = self._sanitizer.sanitize(projected)
                     if (
                         sanitized.available
                         and _canonical_bytes(sanitized.value) == prepared.response_bytes
+                        and self._response_source_equal(
+                            cursor, call, projected, prepared
+                        )
                     ):
+                        self._record_response_pii_spans(
+                            cursor, call, revision.revision_id, sanitized.value
+                        )
                         response = SemanticRevisionRef(revision.revision_id)
                 except Exception:
                     response = None
         if response is None:
             artifact = self.repository.store_sanitized_artifact(
                 cursor,
-                sanitized_bytes=prepared.response_bytes or b"null",
+                sanitized_bytes=self._response_artifact_bytes(cursor, call, prepared),
                 media_type=TRACE_RESPONSE_MEDIA_TYPE,
                 normalization_version=TRACE_RESPONSE_NORMALIZATION_VERSION,
             )
@@ -681,9 +711,9 @@ class ConsoleTraceSettlementCoordinator:
             raise _SettlementConflict("settlement_response_conflict")
         if link.link_kind == "artifact" and link.artifact_id is not None:
             artifact = self.repository.get_artifact(cursor, link.artifact_id)
-            if (
-                artifact is not None
-                and artifact.sanitized_bytes == prepared.response_bytes
+            if artifact is not None and artifact.sanitized_bytes in (
+                prepared.response_bytes,
+                self._response_artifact_bytes(cursor, existing, prepared),
             ):
                 return
         if link.link_kind == "revision" and link.semantic_revision_id is not None:
@@ -695,16 +725,105 @@ class ConsoleTraceSettlementCoordinator:
                         revision_id=link.semantic_revision_id,
                         expected_conversation_id=owner.conversation_id,
                         policy_id=existing.policy_id,
+                        response_call=existing,
                     )
                     sanitized = self._sanitizer.sanitize(projected)
                     if (
                         sanitized.available
                         and _canonical_bytes(sanitized.value) == prepared.response_bytes
+                        and self._response_source_equal(
+                            cursor, existing, projected, prepared
+                        )
                     ):
                         return
                 except Exception:
                     pass
         raise _SettlementConflict("settlement_response_conflict")
+
+    def _response_source_equal(
+        self,
+        cursor: sqlite3.Cursor,
+        call: TraceCallRecord,
+        projected: object,
+        prepared: _PreparedSettlement,
+    ) -> bool:
+        header = self.repository.get_request_header(
+            cursor, call.request_header_id or ""
+        )
+        if header is None or "response_projection" not in header.adapter_defaults:
+            return True
+        return prepared._response_equality_proof is not None and hmac.compare_digest(
+            prepared._response_equality_proof,
+            hmac.digest(
+                self._response_equality_key, _canonical_bytes(projected), "sha256"
+            ),
+        )
+
+    def _record_response_pii_spans(
+        self,
+        cursor: sqlite3.Cursor,
+        call: TraceCallRecord,
+        revision_id: str,
+        projected: object,
+    ) -> None:
+        header = self.repository.get_request_header(
+            cursor, call.request_header_id or ""
+        )
+        policy = self.repository.get_policy(cursor, call.policy_id)
+        if policy is not None and not policy.pii_redaction_enabled:
+            return
+        if policy is None or policy.pii_ruleset_revision_id is None:
+            raise ValueError("response_redaction_unavailable")
+        if not isinstance(projected, Mapping):
+            raise TypeError("response_redaction_unavailable")
+        domains = [("", {key: projected[key] for key in ("role", "content")})]
+        if header is not None and "response_projection" in header.adapter_defaults:
+            domains.append((TRACE_RESPONSE_PII_FIELD_PREFIX, projected))
+        for prefix, value in domains:
+            redaction = redact_pii_value_for_ruleset_revision(
+                value, policy.pii_ruleset_revision_id
+            )
+            if not redaction.available:
+                raise ValueError("response_redaction_unavailable")
+            by_path: dict[str, list[PIIRedactionSpan]] = {}
+            for item in redaction.field_redactions:
+                by_path.setdefault(prefix + item.field_path, []).append(item.span)
+            for field_path, spans in sorted(by_path.items()):
+                self.repository.ensure_redaction_spans(
+                    cursor,
+                    policy_id=policy.policy_id,
+                    semantic_revision_id=revision_id,
+                    artifact_id=None,
+                    field_path=field_path,
+                    spans=spans,
+                )
+
+    def _response_artifact_bytes(
+        self,
+        cursor: sqlite3.Cursor,
+        call: TraceCallRecord,
+        prepared: _PreparedSettlement,
+    ) -> bytes:
+        """Apply the frozen policy to new fallback artifacts, or omit content."""
+        payload = prepared.response_bytes or b"null"
+        policy = self.repository.get_policy(cursor, call.policy_id)
+        if policy is not None and not policy.pii_redaction_enabled:
+            return payload
+        omitted = _canonical_bytes(
+            {"omitted": True, "reason": "pii_detector_unavailable"}
+        )
+        try:
+            if policy is None or policy.pii_ruleset_revision_id is None:
+                raise ValueError("response_redaction_unavailable")
+            redaction = redact_pii_value_for_ruleset_revision(
+                json.loads(payload),
+                policy.pii_ruleset_revision_id,
+            )
+            if redaction.available:
+                return _canonical_bytes(redaction.value)
+        except Exception:  # noqa: BLE001 - detector errors may contain private response values
+            return omitted
+        return omitted
 
     def _verify_dispatch_unknown_retry(
         self,
@@ -771,6 +890,32 @@ class ConsoleTraceSettlementCoordinator:
             self._dropped_count += 1
 
 
+def _normalize_typed_response(value: object) -> object:
+    """Coalesce typed fragments only when every provenance field is identical."""
+    if not isinstance(value, Mapping) or "thinking" not in value:
+        return value
+    entries = value["thinking"]
+    keys = {"text", "provider", "model", "protocol", "source_format"}
+    if not isinstance(entries, (tuple, list)) or not entries:
+        return value
+    coalesced: list[dict[str, str]] = []
+    for entry in entries:
+        if (
+            not isinstance(entry, Mapping)
+            or set(entry) != keys
+            or any(type(item) is not str or not item for item in entry.values())
+        ):
+            return value
+        detached = dict(entry)
+        if coalesced and all(
+            coalesced[-1][key] == detached[key] for key in keys - {"text"}
+        ):
+            coalesced[-1]["text"] += detached["text"]
+        else:
+            coalesced.append(detached)
+    return {**value, "thinking": coalesced}
+
+
 def _canonical_bytes(value: object) -> bytes:
     return json.dumps(
         value,
@@ -792,6 +937,11 @@ def _prepared_settlement_fingerprint(prepared: _PreparedSettlement) -> str:
         "call_id": prepared.call_id,
         "outcome": prepared.outcome.value,
         "response_digest": response_digest,
+        "response_equality_proof": (
+            None
+            if prepared._response_equality_proof is None
+            else prepared._response_equality_proof.hex()
+        ),
         "response_omission": prepared.response_omission,
         "usage": prepared.usage,
         "usage_omission": prepared.usage_omission,

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -660,7 +660,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 68  # Preserve bounded inert Canvas runtime profiles.
+    _CURRENT_SCHEMA_VERSION = 69  # Pin the exact saved source of Console calls.
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -8011,6 +8011,55 @@ UPDATE db_schema_version
                 f"{type(exc).__name__}"
             ) from exc
 
+    def _migrate_from_v68_to_v69(self, conn: sqlite3.Connection) -> None:
+        """Permit the existing event FK to pin a call's exact saved source."""
+
+        self._require_migration_entry_version(conn, 68, "V68→V69")
+        migration_path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v68_to_v69_console_trace_source_pin.sql"
+        )
+        try:
+            with self.transaction() as cursor:
+                # SQLite defers validation of trigger references until use.
+                # Compile them before replacing the guard on a malformed DB.
+                cursor.execute(
+                    "SELECT event.event_type, event.turn_id, event.call_id, "
+                    "event.surface_node_id, event.surface_replacement_id, "
+                    "event.request_header_id, event.semantic_revision_id, "
+                    "event.artifact_id, event.omission_reason_code, "
+                    "revision.source_message_id, revision.source_conversation_id, "
+                    "call.turn_id, owner.conversation_id "
+                    "FROM console_trace_events AS event "
+                    "JOIN console_trace_calls AS call ON call.call_id = event.call_id "
+                    "AND call.segment_id = event.segment_id "
+                    "JOIN console_trace_owners AS owner ON owner.owner_id = call.owner_id "
+                    "JOIN console_trace_semantic_revisions AS revision "
+                    "ON revision.revision_id = event.semantic_revision_id LIMIT 0"
+                )
+                self._execute_migration_statements(
+                    cursor, migration_path.read_text(encoding="utf-8"), "V68→V69"
+                )
+                if cursor.execute("PRAGMA foreign_key_check").fetchall():
+                    raise SchemaError("Trace source migration foreign key audit failed")
+                updated = cursor.execute(
+                    "UPDATE db_schema_version SET version = 69 "
+                    "WHERE schema_name = ? AND version = 68",
+                    (self._SCHEMA_NAME,),
+                )
+                if updated.rowcount != 1:
+                    raise SchemaError("Trace source migration version update failed")
+            if self._get_db_version(conn) != 69:
+                raise SchemaError("Trace source migration version check failed")
+        except SchemaError:
+            raise
+        except Exception as exc:
+            raise SchemaError(
+                f"Migration from V68 to V69 failed for '{self._SCHEMA_NAME}': "
+                f"{type(exc).__name__}"
+            ) from exc
+
     def _migrate_from_v18_to_v19(self, conn: sqlite3.Connection):
         """
         Migrates the database schema from version 18 to version 19.
@@ -8231,6 +8280,7 @@ UPDATE db_schema_version
                     65: self._migrate_from_v65_to_v66,
                     66: self._migrate_from_v66_to_v67,
                     67: self._migrate_from_v67_to_v68,
+                    68: self._migrate_from_v68_to_v69,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/migrations/chachanotes_v68_to_v69_console_trace_source_pin.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v68_to_v69_console_trace_source_pin.sql
@@ -1,0 +1,77 @@
+-- Preserve the exact saved input identity without copying its value.
+DROP TRIGGER console_trace_events_shape_guard;
+
+CREATE TRIGGER console_trace_events_shape_guard
+BEFORE INSERT ON console_trace_events
+WHEN NOT (
+  (NEW.event_type = 'call_boundary' AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NOT NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND NEW.artifact_id IS NULL AND
+   NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type = 'turn_boundary' AND
+   NEW.turn_id IS NOT NULL AND
+   NEW.call_id IS NULL AND NEW.surface_node_id IS NULL AND
+   NEW.surface_replacement_id IS NULL AND NEW.request_header_id IS NULL AND
+   NEW.semantic_revision_id IS NULL AND NEW.artifact_id IS NULL AND
+   NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type IN ('call_outcome', 'usage') AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NOT NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND NEW.semantic_revision_id IS NULL AND
+   NEW.artifact_id IS NULL AND NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type = 'surface_append' AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NULL AND
+   NEW.surface_node_id IS NOT NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND NEW.semantic_revision_id IS NULL AND
+   NEW.artifact_id IS NULL AND NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type = 'surface_replace' AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NOT NULL AND
+   NEW.request_header_id IS NULL AND NEW.semantic_revision_id IS NULL AND
+   NEW.artifact_id IS NULL AND NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type IN ('tool_call', 'tool_result') AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NOT NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND
+   ((NEW.semantic_revision_id IS NOT NULL) +
+    (NEW.artifact_id IS NOT NULL) +
+    (NEW.omission_reason_code IS NOT NULL)) = 1) OR
+  (NEW.event_type IN (
+     'request_header_selection', 'provider_route_selection'
+   ) AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NOT NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NOT NULL AND NEW.semantic_revision_id IS NULL AND
+   NEW.artifact_id IS NULL AND NEW.omission_reason_code IS NULL) OR
+  (NEW.event_type = 'response_selection' AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NOT NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND NEW.omission_reason_code IS NULL AND
+   ((NEW.semantic_revision_id IS NOT NULL) +
+    (NEW.artifact_id IS NOT NULL)) = 1) OR
+  (NEW.event_type = 'gap' AND
+   NEW.turn_id IS NULL AND NEW.call_id IS NULL AND
+   NEW.surface_node_id IS NULL AND NEW.surface_replacement_id IS NULL AND
+   NEW.request_header_id IS NULL AND NEW.semantic_revision_id IS NULL AND
+   NEW.artifact_id IS NULL AND NEW.omission_reason_code IS NOT NULL)
+)
+BEGIN
+  SELECT RAISE(ABORT, 'invalid trace event reference shape');
+END;
+
+CREATE TRIGGER console_trace_call_boundary_source_guard
+BEFORE INSERT ON console_trace_events
+WHEN NEW.event_type = 'call_boundary' AND NEW.semantic_revision_id IS NOT NULL
+ AND NOT EXISTS (
+   SELECT 1 FROM console_trace_calls AS call
+   JOIN console_trace_owners AS owner ON owner.owner_id = call.owner_id
+   JOIN console_trace_semantic_revisions AS revision
+     ON revision.revision_id = NEW.semantic_revision_id
+   WHERE call.call_id = NEW.call_id AND call.segment_id = NEW.segment_id
+     AND revision.source_message_id = call.turn_id
+     AND revision.source_conversation_id = owner.conversation_id
+ )
+BEGIN
+  SELECT RAISE(ABORT, 'trace call boundary source does not own its turn');
+END;

--- a/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
+++ b/tldw_chatbook/Event_Handlers/STTS_Events/stts_events.py
@@ -45,7 +45,10 @@ from tldw_chatbook.TTS.audio_cpp_contract import validate_pcm16_wav
 from tldw_chatbook.TTS.audio_cpp_guided_config import (
     project_audio_cpp_settings_config,
 )
-from tldw_chatbook.TTS.effective_settings import TTSSelectionSource
+from tldw_chatbook.TTS.effective_settings import (
+    TTSEffectiveResolutionError,
+    TTSSelectionSource,
+)
 from tldw_chatbook.TTS.legacy_bridge import (
     legacy_provider_config,
     openai_internal_model_id,
@@ -1619,6 +1622,14 @@ class STTSEventHandler:
                     error.code,
                     error.retryable,
                 )
+            elif isinstance(error, TTSEffectiveResolutionError):
+                logger.error(
+                    "TTS generation failed (resolution_code={}, "
+                    "resolution_axis={}, resolution_source={})",
+                    error.code,
+                    error.axis,
+                    error.source.value if error.source is not None else "provider",
+                )
             else:
                 logger.error(
                     "TTS generation failed ({})",
@@ -1818,6 +1829,8 @@ class STTSEventHandler:
 
     @staticmethod
     def _generation_error_copy(error: Exception) -> str:
+        if isinstance(error, TTSEffectiveResolutionError):
+            return error.recovery_message()
         if isinstance(error, TTSOperationError):
             parts = [str(error)]
             recovery_copy = _RECOVERY_ACTION_COPY.get(error.recovery_action or "")

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -61,6 +61,7 @@ from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
 from tldw_chatbook.TTS.effective_settings import (
     TTSCharacterProfileSelection,
     TTSDefaultProfileSelection,
+    TTSEffectiveResolutionError,
     TTSEffectiveSettingsResolver,
     TTSSelectionOverrides,
 )
@@ -732,16 +733,27 @@ class TTSEventHandler:
                 event.report_outcome(False)
                 raise
             except Exception as error:  # noqa: BLE001 - terminal trust boundary
-                logger.warning(
-                    "Trusted Console speech request failed "
-                    "(exception_category={})",
-                    type(error).__name__,
-                )
+                if isinstance(error, TTSEffectiveResolutionError):
+                    logger.warning(
+                        "Trusted Console speech request failed "
+                        "(resolution_code={}, resolution_axis={}, "
+                        "resolution_source={})",
+                        error.code,
+                        error.axis,
+                        error.source.value if error.source is not None else "provider",
+                    )
+                    message = self._tts_error_copy(error)
+                else:
+                    logger.warning(
+                        "Trusted Console speech request failed (exception_category={})",
+                        type(error).__name__,
+                    )
+                    message = "Speech could not be generated."
                 try:
                     await self._post_tts_message(
                         TTSCompleteEvent(
                             message_id=event.message_id,
-                            error="Speech could not be generated.",
+                            error=message,
                         )
                     )
                 except Exception as post_error:  # noqa: BLE001
@@ -2212,10 +2224,20 @@ class TTSEventHandler:
                 else self._tts_outcome_code(error)
             )
             await self._discard_tts_artifact(normalized_message_id, artifact_path)
-            logger.error(
-                "TTS generation failed (outcome_code={})",
-                outcome_code,
-            )
+            if isinstance(error, TTSEffectiveResolutionError):
+                logger.error(
+                    "TTS generation failed (outcome_code={}, resolution_code={}, "
+                    "resolution_axis={}, resolution_source={})",
+                    outcome_code,
+                    error.code,
+                    error.axis,
+                    error.source.value if error.source is not None else "provider",
+                )
+            else:
+                logger.error(
+                    "TTS generation failed (outcome_code={})",
+                    outcome_code,
+                )
             if not quiet:
                 await self._post_tts_message(
                     TTSCompleteEvent(
@@ -3168,6 +3190,8 @@ class TTSEventHandler:
     @staticmethod
     def _tts_error_copy(error: Exception) -> str:
         """Map failures to fixed actionable UI copy without upstream details."""
+        if isinstance(error, TTSEffectiveResolutionError):
+            return error.recovery_message()
         if isinstance(error, TTSProviderReconfiguringError):
             return "TTS settings are being applied; retry shortly"
         if isinstance(error, TTSProviderUnavailableError):

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -3201,6 +3201,14 @@ class TTSEventHandler:
         if isinstance(error, TTSRegistryClosedError):
             return "The TTS service is unavailable"
         if isinstance(error, TTSOperationError):
+            if (
+                error.code == "request_invalid"
+                and error.recovery_action == "shorten_text_or_use_pcm"
+            ):
+                return (
+                    "Kokoro encoded speech is limited to five minutes; "
+                    "shorten the text or choose PCM for longer speech"
+                )
             if error.code in {"configuration_invalid", "not_configured"}:
                 return "TTS is not configured; open STTS Settings"
             if error.code == "contract_incompatible":

--- a/tldw_chatbook/TTS/backends/kokoro.py
+++ b/tldw_chatbook/TTS/backends/kokoro.py
@@ -798,14 +798,16 @@ class KokoroTTSBackend(LocalTTSBackend):
                     },
                 )
 
-            # For other formats, we need to handle them appropriately
             else:
-                # For WAV format, we need to collect all samples first
-                # For other formats, we can stream with chunked conversion
-                sample_rate = 24000  # Default
+                # File formats need one encoder/container for the complete
+                # utterance. Concatenating separately encoded chunks leaves
+                # headers describing only the first chunk (e.g. MP3 Xing or
+                # FLAC STREAMINFO), so decoders can silently truncate playback.
+                # Raw PCM above remains incremental.
+                sample_rate = 24000
                 token_count = 0
-
-                # Choose generator based on voice configuration
+                total_samples = 0
+                sample_chunks = []
                 if voice_config["is_mixed"]:
                     audio_generator = self._generate_mixed_voice(
                         text, voice_config, speed=request.speed, lang=lang
@@ -818,101 +820,12 @@ class KokoroTTSBackend(LocalTTSBackend):
                         lang=lang,
                     )
 
-                # Estimate total tokens for progress tracking
-                estimated_total_tokens = len(text.split()) * 2  # Rough estimate
-
-                # WAV format needs all samples collected first
-                if request.response_format == "wav":
-                    all_samples = []
-
-                    # Collect all audio samples
-                    async for samples, sr in audio_generator:
-                        sample_rate = sr
-                        all_samples.extend(samples)
-                        token_count += len(samples) // 256
-
-                        # Report progress
-                        progress = (
-                            min(0.95, token_count / estimated_total_tokens)
-                            if estimated_total_tokens > 0
-                            else 0.5
-                        )
-                        await self._report_progress(
-                            progress=progress,
-                            processed=token_count,
-                            total=estimated_total_tokens,
-                            status=f"Collecting audio: {len(all_samples) / sample_rate:.1f}s",
-                            metrics={
-                                "sample_rate": sample_rate,
-                                "samples_collected": len(all_samples),
-                                "format": request.response_format,
-                            },
-                        )
-
-                    # Convert all samples to WAV at once
-                    if all_samples:
-                        try:
-                            full_audio = np.array(all_samples, dtype=np.float32)
-                            audio_bytes = await self.audio_service.convert_audio(
-                                full_audio,
-                                request.response_format,
-                                source_format="pcm",
-                                sample_rate=sample_rate,
-                            )
-                            yield audio_bytes
-
-                            # Log performance
-                            generation_time = time.time() - start_time
-                            audio_duration = len(all_samples) / sample_rate
-                            speed_factor = (
-                                audio_duration / generation_time
-                                if generation_time > 0
-                                else 0
-                            )
-
-                            logger.info(
-                                f"KokoroTTSBackend: Generated {audio_duration:.2f}s of WAV audio in {generation_time:.2f}s "
-                                f"({speed_factor:.1f}x realtime)"
-                            )
-
-                            # Report completion
-                            await self._report_progress(
-                                progress=1.0,
-                                processed=token_count,
-                                total=estimated_total_tokens,
-                                status=f"WAV generation complete: {audio_duration:.1f}s",
-                                metrics={
-                                    "sample_rate": sample_rate,
-                                    "samples_generated": len(all_samples),
-                                    "format": request.response_format,
-                                    "generation_time": generation_time,
-                                    "speed_factor": speed_factor,
-                                },
-                            )
-                        except Exception as e:
-                            logger.error(
-                                f"KokoroTTSBackend: WAV conversion failed: {e}"
-                            )
-                            yield b""
-                    else:
-                        logger.warning("KokoroTTSBackend: No audio generated")
-                        yield b""
-
-                    return  # Exit after yielding WAV
-
-                # For streaming formats (MP3, Opus, etc.), use chunked conversion
-                chunk_buffer = []
-                chunk_size = 8192  # samples per chunk (about 0.34s at 24kHz)
-                total_samples_processed = 0
-                first_chunk_time = None
-
-                # Process audio chunks as they are generated
+                estimated_total_tokens = len(text.split()) * 2
                 async for samples, sr in audio_generator:
                     sample_rate = sr
-                    chunk_buffer.extend(samples)
-                    token_count += len(samples) // 256  # Approximate token count
-
-                    # Report progress
+                    sample_chunks.append(np.array(samples, dtype=np.float32, copy=True))
+                    total_samples += len(samples)
+                    token_count += len(samples) // 256
                     progress = (
                         min(0.95, token_count / estimated_total_tokens)
                         if estimated_total_tokens > 0
@@ -922,119 +835,64 @@ class KokoroTTSBackend(LocalTTSBackend):
                         progress=progress,
                         processed=token_count,
                         total=estimated_total_tokens,
-                        status=f"Generating audio: {token_count} tokens processed",
-                        current_chunk=total_samples_processed // chunk_size,
+                        status=f"Collecting audio: {total_samples / sample_rate:.1f}s",
                         metrics={
                             "sample_rate": sample_rate,
-                            "samples_generated": total_samples_processed,
+                            "samples_collected": total_samples,
                             "format": request.response_format,
                         },
                     )
 
-                    # Yield complete chunks as they become available
-                    while len(chunk_buffer) >= chunk_size:
-                        # Extract a chunk
-                        chunk_array = np.array(
-                            chunk_buffer[:chunk_size], dtype=np.float32
-                        )
-                        chunk_buffer = chunk_buffer[chunk_size:]
-
-                        # Convert chunk to target format
-                        try:
-                            audio_bytes = await self.audio_service.convert_audio(
-                                chunk_array,
-                                request.response_format,
-                                source_format="pcm",
-                                sample_rate=sample_rate,
-                            )
-
-                            # Track first chunk latency
-                            if first_chunk_time is None:
-                                first_chunk_time = time.time() - start_time
-                                logger.debug(
-                                    f"KokoroTTSBackend: First chunk latency: {first_chunk_time:.3f}s"
-                                )
-
-                            yield audio_bytes
-                            total_samples_processed += len(chunk_array)
-
-                        except Exception as e:
-                            logger.error(
-                                f"KokoroTTSBackend: Chunk conversion failed: {e}"
-                            )
-                            # Continue with next chunk instead of failing completely
-                            continue
-
-                # Process any remaining samples in buffer
-                if chunk_buffer:
-                    remaining_array = np.array(chunk_buffer, dtype=np.float32)
-                    try:
-                        audio_bytes = await self.audio_service.convert_audio(
-                            remaining_array,
-                            request.response_format,
-                            source_format="pcm",
-                            sample_rate=sample_rate,
-                        )
-                        yield audio_bytes
-                        total_samples_processed += len(remaining_array)
-                    except Exception as e:
-                        logger.error(
-                            f"KokoroTTSBackend: Final chunk conversion failed: {e}"
-                        )
-
-                # Update performance metrics
-                if self.track_performance:
-                    self._update_performance_metrics(
-                        token_count, time.time() - start_time
-                    )
-
-                # Log performance info
-                if total_samples_processed > 0:
-                    generation_time = time.time() - start_time
-                    tokens_per_second = (
-                        token_count / generation_time if generation_time > 0 else 0
-                    )
-                    audio_duration = total_samples_processed / sample_rate
-                    speed_factor = (
-                        audio_duration / generation_time if generation_time > 0 else 0
-                    )
-
-                    logger.info(
-                        f"KokoroTTSBackend: Streamed {audio_duration:.2f}s of audio in {generation_time:.2f}s "
-                        f"({speed_factor:.1f}x realtime, {tokens_per_second:.1f} tokens/s, "
-                        f"first chunk: {first_chunk_time:.3f}s)"
-                    )
-
-                    # Report completion
-                    await self._report_progress(
-                        progress=1.0,
-                        processed=token_count,
-                        total=estimated_total_tokens,
-                        status=f"Generation complete: {audio_duration:.1f}s of {request.response_format} audio",
-                        metrics={
-                            "sample_rate": sample_rate,
-                            "samples_generated": total_samples_processed,
-                            "format": request.response_format,
-                            "generation_time": generation_time,
-                            "speed_factor": speed_factor,
-                            "first_chunk_latency": first_chunk_time,
-                        },
-                    )
-                else:
+                if not total_samples:
                     logger.warning("KokoroTTSBackend: No audio generated")
-                    await self._report_progress(
-                        progress=1.0,
-                        processed=token_count,
-                        total=estimated_total_tokens,
-                        status=f"Generation complete: no {request.response_format} audio emitted",
-                        metrics={
-                            "sample_rate": sample_rate,
-                            "samples_generated": total_samples_processed,
-                            "format": request.response_format,
-                            "generation_time": time.time() - start_time,
-                        },
+                    yield b""
+                    return
+                full_audio = np.concatenate(sample_chunks)
+                sample_chunks.clear()
+                try:
+                    audio_bytes = await self.audio_service.convert_audio(
+                        full_audio,
+                        request.response_format,
+                        source_format="pcm",
+                        sample_rate=sample_rate,
+                    )
+                except (RuntimeError, ValueError) as error:
+                    logger.error(
+                        "KokoroTTSBackend: Audio conversion failed ({})",
+                        type(error).__name__,
                     )
                     yield b""
+                    return
+                yield audio_bytes
+
+                generation_time = time.time() - start_time
+                audio_duration = total_samples / sample_rate
+                speed_factor = (
+                    audio_duration / generation_time if generation_time > 0 else 0
+                )
+                if self.track_performance:
+                    self._update_performance_metrics(token_count, generation_time)
+                logger.info(
+                    "KokoroTTSBackend: Generated {:.2f}s of {} audio in {:.2f}s "
+                    "({:.1f}x realtime)",
+                    audio_duration,
+                    request.response_format,
+                    generation_time,
+                    speed_factor,
+                )
+                await self._report_progress(
+                    progress=1.0,
+                    processed=token_count,
+                    total=estimated_total_tokens,
+                    status=f"Generation complete: {audio_duration:.1f}s of {request.response_format} audio",
+                    metrics={
+                        "sample_rate": sample_rate,
+                        "samples_generated": total_samples,
+                        "format": request.response_format,
+                        "generation_time": generation_time,
+                        "speed_factor": speed_factor,
+                    },
+                )
 
         except Exception as e:
             logger.opt(exception=True).error(
@@ -1308,6 +1166,7 @@ class KokoroTTSBackend(LocalTTSBackend):
             token_count = 0
             first_chunk_time = None
             total_audio_duration = 0.0
+            sample_chunks = []
             estimated_total_tokens = (
                 sum(len(chunk.split()) for chunk in text_chunks) * 2
             )
@@ -1364,21 +1223,11 @@ class KokoroTTSBackend(LocalTTSBackend):
                     int16_samples = np.int16(audio_data * 32767)
                     yield int16_samples.tobytes()
                 else:
-                    # For other formats, convert chunk
-                    try:
-                        audio_bytes = await self.audio_service.convert_audio(
-                            audio_data,
-                            request.response_format,
-                            source_format="pcm",
-                            sample_rate=24000,
+                    # File containers must describe the complete utterance.
+                    if len(audio_data):
+                        sample_chunks.append(
+                            np.array(audio_data, dtype=np.float32, copy=True)
                         )
-                        yield audio_bytes
-                    except Exception as e:
-                        logger.error(
-                            f"KokoroTTSBackend: PyTorch chunk conversion failed: {e}"
-                        )
-                        # Try to continue with next chunk
-                        continue
 
                 # Track first chunk latency
                 if first_chunk_time is None:
@@ -1392,6 +1241,28 @@ class KokoroTTSBackend(LocalTTSBackend):
                     f"KokoroTTSBackend PyTorch: Processed chunk {i + 1}/{len(text_chunks)} "
                     f"({chunk_duration:.2f}s of audio)"
                 )
+
+            if request.response_format != "pcm":
+                if not sample_chunks:
+                    yield b""
+                    return
+                audio_array = np.concatenate(sample_chunks)
+                sample_chunks.clear()
+                try:
+                    audio_bytes = await self.audio_service.convert_audio(
+                        audio_array,
+                        request.response_format,
+                        source_format="pcm",
+                        sample_rate=24000,
+                    )
+                except (RuntimeError, ValueError) as exc:
+                    logger.error(
+                        "KokoroTTSBackend: PyTorch audio conversion failed ({})",
+                        type(exc).__name__,
+                    )
+                    yield b""
+                    return
+                yield audio_bytes
 
             # Update metrics
             if self.track_performance:

--- a/tldw_chatbook/TTS/backends/kokoro.py
+++ b/tldw_chatbook/TTS/backends/kokoro.py
@@ -14,9 +14,11 @@ import wave
 import tempfile
 import shutil
 import hashlib
+from contextlib import aclosing
 from typing import AsyncGenerator, Optional, Dict, Any, List, Tuple
 from datetime import datetime
 from pathlib import Path
+from uuid import uuid4
 from loguru import logger
 
 # Optional requests import for model downloading
@@ -40,6 +42,7 @@ except ImportError:
 
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
 from tldw_chatbook.TTS.base_backends import LocalTTSBackend
 from tldw_chatbook.TTS.audio_service import get_audio_service
 from tldw_chatbook.TTS.text_processing import TextChunker, TextNormalizer
@@ -75,6 +78,35 @@ KOKORO_DOWNLOAD_TIMEOUT = (
 
 #: Log a progress line at most this often during a long download.
 _KOKORO_PROGRESS_INTERVAL_SECONDS = 2.0
+
+# Encoded requests retain at most five minutes of 24 kHz mono float32 audio
+# (28.8 MB). Raw PCM does not require a complete-file buffer.
+KOKORO_MAX_ENCODED_AUDIO_SAMPLES = 24000 * 300
+
+
+def _check_audio_sample_limit(total_samples: int, max_samples: int | None) -> None:
+    """Reject an encoded utterance before retaining samples beyond its budget."""
+    if max_samples is not None and total_samples > max_samples:
+        raise TTSOperationError(
+            code="request_invalid",
+            message=(
+                "Kokoro encoded audio is limited to five minutes per request. "
+                "Shorten the text or choose PCM for longer speech."
+            ),
+            retryable=False,
+            operation_id=uuid4().hex,
+            recovery_action="shorten_text_or_use_pcm",
+        )
+
+
+def _append_audio_samples(
+    buffer: bytearray, samples: np.ndarray, max_samples: int | None
+) -> None:
+    """Copy samples into one growable float32 buffer within its sample budget."""
+    sample_count = int(np.size(samples))
+    _check_audio_sample_limit(len(buffer) // 4 + sample_count, max_samples)
+    if sample_count:
+        buffer.extend(np.asarray(samples, dtype=np.float32).tobytes())
 
 
 def _kokoro_stream_download(
@@ -807,10 +839,14 @@ class KokoroTTSBackend(LocalTTSBackend):
                 sample_rate = 24000
                 token_count = 0
                 total_samples = 0
-                sample_chunks = []
+                sample_buffer = bytearray()
                 if voice_config["is_mixed"]:
                     audio_generator = self._generate_mixed_voice(
-                        text, voice_config, speed=request.speed, lang=lang
+                        text,
+                        voice_config,
+                        speed=request.speed,
+                        lang=lang,
+                        max_samples=KOKORO_MAX_ENCODED_AUDIO_SAMPLES,
                     )
                 else:
                     audio_generator = self.kokoro_instance.create_stream(
@@ -821,34 +857,36 @@ class KokoroTTSBackend(LocalTTSBackend):
                     )
 
                 estimated_total_tokens = len(text.split()) * 2
-                async for samples, sr in audio_generator:
-                    sample_rate = sr
-                    sample_chunks.append(np.array(samples, dtype=np.float32, copy=True))
-                    total_samples += len(samples)
-                    token_count += len(samples) // 256
-                    progress = (
-                        min(0.95, token_count / estimated_total_tokens)
-                        if estimated_total_tokens > 0
-                        else 0.5
-                    )
-                    await self._report_progress(
-                        progress=progress,
-                        processed=token_count,
-                        total=estimated_total_tokens,
-                        status=f"Collecting audio: {total_samples / sample_rate:.1f}s",
-                        metrics={
-                            "sample_rate": sample_rate,
-                            "samples_collected": total_samples,
-                            "format": request.response_format,
-                        },
-                    )
+                async with aclosing(audio_generator):
+                    async for samples, sr in audio_generator:
+                        sample_rate = sr
+                        _append_audio_samples(
+                            sample_buffer, samples, KOKORO_MAX_ENCODED_AUDIO_SAMPLES
+                        )
+                        total_samples = len(sample_buffer) // 4
+                        token_count += len(samples) // 256
+                        progress = (
+                            min(0.95, token_count / estimated_total_tokens)
+                            if estimated_total_tokens > 0
+                            else 0.5
+                        )
+                        await self._report_progress(
+                            progress=progress,
+                            processed=token_count,
+                            total=estimated_total_tokens,
+                            status=f"Collecting audio: {total_samples / sample_rate:.1f}s",
+                            metrics={
+                                "sample_rate": sample_rate,
+                                "samples_collected": total_samples,
+                                "format": request.response_format,
+                            },
+                        )
 
                 if not total_samples:
                     logger.warning("KokoroTTSBackend: No audio generated")
                     yield b""
                     return
-                full_audio = np.concatenate(sample_chunks)
-                sample_chunks.clear()
+                full_audio = np.frombuffer(sample_buffer, dtype=np.float32)
                 try:
                     audio_bytes = await self.audio_service.convert_audio(
                         full_audio,
@@ -863,6 +901,7 @@ class KokoroTTSBackend(LocalTTSBackend):
                     )
                     yield b""
                     return
+                del full_audio, sample_buffer
                 yield audio_bytes
 
                 generation_time = time.time() - start_time
@@ -894,6 +933,8 @@ class KokoroTTSBackend(LocalTTSBackend):
                     },
                 )
 
+        except TTSOperationError:
+            raise
         except Exception as e:
             logger.opt(exception=True).error(
                 f"KokoroTTSBackend: Error during ONNX generation: {e}"
@@ -952,50 +993,58 @@ class KokoroTTSBackend(LocalTTSBackend):
         }
 
     async def _generate_mixed_voice(
-        self, text: str, voice_config: Dict[str, Any], speed: float, lang: str
+        self,
+        text: str,
+        voice_config: dict[str, Any],
+        speed: float,
+        lang: str,
+        *,
+        max_samples: int | None = None,
     ) -> AsyncGenerator[tuple[np.ndarray, int], None]:
         """Generate audio with mixed voices"""
         if not voice_config["is_mixed"]:
             # Fallback to single voice
-            async for samples, sr in self.kokoro_instance.create_stream(
+            stream = self.kokoro_instance.create_stream(
                 text, voice=voice_config["primary_voice"], speed=speed, lang=lang
-            ):
-                yield samples, sr
+            )
+            total_samples = 0
+            async with aclosing(stream):
+                async for samples, sr in stream:
+                    total_samples += int(np.size(samples))
+                    _check_audio_sample_limit(total_samples, max_samples)
+                    yield samples, sr
             return
 
-        # Collect audio from each voice
-        voice_samples = []
+        # Keep one running mix and one voice buffer, independent of voice count.
+        mixed_audio = np.zeros(0, dtype=np.float32)
         sample_rate = 24000
 
         for voice, weight in voice_config["voices"]:
-            samples_list = []
-            async for samples, sr in self.kokoro_instance.create_stream(
+            sample_buffer = bytearray()
+            stream = self.kokoro_instance.create_stream(
                 text, voice=voice, speed=speed, lang=lang
-            ):
-                sample_rate = sr
-                samples_list.append(samples)
+            )
+            async with aclosing(stream):
+                async for samples, sr in stream:
+                    sample_rate = sr
+                    _append_audio_samples(sample_buffer, samples, max_samples)
+            if not sample_buffer:
+                continue
+            voice_audio = np.frombuffer(sample_buffer, dtype=np.float32)
+            if len(voice_audio) > len(mixed_audio):
+                mixed_audio = np.pad(
+                    mixed_audio, (0, len(voice_audio) - len(mixed_audio))
+                )
+            mixed_audio[: len(voice_audio)] += voice_audio * weight
+            del voice_audio, sample_buffer
 
-            if samples_list:
-                combined = np.concatenate(samples_list)
-                voice_samples.append((combined, weight))
-
-        if not voice_samples:
+        if not len(mixed_audio):
             return
-
-        # Mix the voices
-        max_length = max(len(samples) for samples, _ in voice_samples)
-        mixed_audio = np.zeros(max_length, dtype=np.float32)
-
-        for samples, weight in voice_samples:
-            # Pad if necessary
-            if len(samples) < max_length:
-                samples = np.pad(samples, (0, max_length - len(samples)))
-            mixed_audio += samples * weight
 
         # Normalize to prevent clipping
         max_val = np.abs(mixed_audio).max()
         if max_val > 1.0:
-            mixed_audio = mixed_audio / max_val
+            mixed_audio /= max_val
 
         # Yield in chunks for streaming
         chunk_size = 8192
@@ -1166,7 +1215,7 @@ class KokoroTTSBackend(LocalTTSBackend):
             token_count = 0
             first_chunk_time = None
             total_audio_duration = 0.0
-            sample_chunks = []
+            sample_buffer = bytearray()
             estimated_total_tokens = (
                 sum(len(chunk.split()) for chunk in text_chunks) * 2
             )
@@ -1224,10 +1273,9 @@ class KokoroTTSBackend(LocalTTSBackend):
                     yield int16_samples.tobytes()
                 else:
                     # File containers must describe the complete utterance.
-                    if len(audio_data):
-                        sample_chunks.append(
-                            np.array(audio_data, dtype=np.float32, copy=True)
-                        )
+                    _append_audio_samples(
+                        sample_buffer, audio_data, KOKORO_MAX_ENCODED_AUDIO_SAMPLES
+                    )
 
                 # Track first chunk latency
                 if first_chunk_time is None:
@@ -1243,11 +1291,10 @@ class KokoroTTSBackend(LocalTTSBackend):
                 )
 
             if request.response_format != "pcm":
-                if not sample_chunks:
+                if not sample_buffer:
                     yield b""
                     return
-                audio_array = np.concatenate(sample_chunks)
-                sample_chunks.clear()
+                audio_array = np.frombuffer(sample_buffer, dtype=np.float32)
                 try:
                     audio_bytes = await self.audio_service.convert_audio(
                         audio_array,
@@ -1262,6 +1309,7 @@ class KokoroTTSBackend(LocalTTSBackend):
                     )
                     yield b""
                     return
+                del audio_array, sample_buffer
                 yield audio_bytes
 
             # Update metrics
@@ -1297,6 +1345,8 @@ class KokoroTTSBackend(LocalTTSBackend):
                     },
                 )
 
+        except TTSOperationError:
+            raise
         except Exception as e:
             logger.opt(exception=True).error(
                 f"KokoroTTSBackend: PyTorch generation failed: {e}"

--- a/tldw_chatbook/TTS/effective_settings.py
+++ b/tldw_chatbook/TTS/effective_settings.py
@@ -129,6 +129,50 @@ class TTSEffectiveResolutionError(ValueError):
         location = "provider" if source is None else source.value
         super().__init__(f"TTS {axis} {code.replace('_', ' ')} ({location})")
 
+    def recovery_message(self) -> str:
+        """Return actionable UI copy using only bounded resolution metadata."""
+        location = {
+            TTSSelectionSource.EXPLICIT: "the current speech request",
+            TTSSelectionSource.CHARACTER_PROFILE: "the character voice profile",
+            TTSSelectionSource.DEFAULT_PROFILE: "the default voice profile",
+            TTSSelectionSource.STUDIO_DRAFT: "the Speech Lab controls",
+            TTSSelectionSource.STUDIO_SAVED: "Studio preferences in Speech Lab",
+        }.get(self.source, "Settings > Speech & TTS")
+        if self.code == "catalog_unavailable":
+            return (
+                "TTS model or voice information is unavailable; "
+                "refresh the provider in Speech Lab and try again."
+            )
+        if self.code == "revision_incoherent":
+            if self.axis == "studio_preferences":
+                return (
+                    "Studio preferences could not be loaded consistently; "
+                    "reopen Speech Lab and try again."
+                )
+            return (
+                "TTS settings could not be loaded consistently; "
+                f"check {location} and try again."
+            )
+        setting = {
+            "provider_id": "provider",
+            "model_mode": "model selection",
+            "model_id": "model",
+            "voice_mode": "voice selection",
+            "voice_id": "voice",
+            "response_format": "audio format",
+            "speed": "speech speed",
+            "provider_options": "provider options",
+            "clone_audition": "voice clone audition",
+            "profile_reference": "voice profile reference",
+        }.get(self.axis, "settings")
+        problem = {
+            "invalid_selection": "invalid",
+            "unsupported_selection": "unsupported by this provider",
+            "missing_exact": "missing or no longer available",
+            "provider_unknown": "unavailable",
+        }.get(self.code, "unavailable")
+        return f"TTS {setting}: {problem}; check {location}."
+
 
 def _freeze_value(value: Any) -> Any:
     if isinstance(value, Mapping):

--- a/tldw_chatbook/TTS/effective_settings.py
+++ b/tldw_chatbook/TTS/effective_settings.py
@@ -130,7 +130,12 @@ class TTSEffectiveResolutionError(ValueError):
         super().__init__(f"TTS {axis} {code.replace('_', ' ')} ({location})")
 
     def recovery_message(self) -> str:
-        """Return actionable UI copy using only bounded resolution metadata."""
+        """Return actionable UI copy using only bounded resolution metadata.
+
+        Returns:
+            Guidance identifying the setting scope and recovery action, without
+            request text, raw identifiers, credentials, or exception payloads.
+        """
         location = {
             TTSSelectionSource.EXPLICIT: "the current speech request",
             TTSSelectionSource.CHARACTER_PROFILE: "the character voice profile",

--- a/tldw_chatbook/UI/Screens/settings_speech_tts.py
+++ b/tldw_chatbook/UI/Screens/settings_speech_tts.py
@@ -432,6 +432,12 @@ class GlobalSpeechTTSDefaults:
             self.voice_mode,
             frozenset({"exact", "server_default"}),
         )
+        if provider_id != "audio_cpp" and voice_mode == "server_default":
+            _validation_error(
+                "defaults",
+                "voice_mode",
+                "This provider requires a voice. Choose Exact and enter a voice value.",
+            )
         model_id = (
             _identifier(
                 "defaults",

--- a/tldw_chatbook/UI/Speech/speech_param_group.py
+++ b/tldw_chatbook/UI/Speech/speech_param_group.py
@@ -31,6 +31,7 @@ from .speech_playground_model import params_for_provider
 #: which is what happened for every Chatterbox and Higgs generation while
 #: the rebuild mounted them as bare `Input(id=param)`.
 PARAM_DEFAULTS: dict[str, dict[str, object]] = {
+    "tts-kokoro-use-onnx": {"value": True},
     "tts-stability-input": {"value": "0.5", "placeholder": "0.0-1.0", "type": "number"},
     "tts-similarity-input": {
         "value": "0.8",

--- a/tldw_chatbook/UI/Speech/speech_playground_model.py
+++ b/tldw_chatbook/UI/Speech/speech_playground_model.py
@@ -25,6 +25,18 @@ AXIS_CONTROLS: tuple[str, ...] = (
     "tts-speed-input",
 )
 
+# Empty means omit the request override and infer language from the voice,
+# as both Kokoro engines already do. Values are espeak codes, never labels.
+KOKORO_LANGUAGE_OPTIONS: tuple[tuple[str, str], ...] = (
+    ("Automatic (from voice)", ""),
+    ("American English", "en-us"),
+    ("British English", "en-gb"),
+    ("Japanese", "ja"),
+    ("Chinese", "zh"),
+    ("Spanish", "es"),
+    ("French", "fr"),
+)
+
 #: Post-processing that applies whatever the provider, so it is appended to
 #: every provider's group rather than duplicated into each. A provider switch
 #: must not make normalisation disappear.

--- a/tldw_chatbook/UI/Speech/speech_playground_pane.py
+++ b/tldw_chatbook/UI/Speech/speech_playground_pane.py
@@ -80,7 +80,7 @@ from .audio_cpp_runtime_card import (
 from .speech_catalog_mixin import SpeechCatalogMixin
 from .speech_clone_setup import SpeechCloneSetup
 from .speech_playback_mixin import EXAMPLE_TEXTS, SpeechPlaybackMixin
-from .speech_playground_model import AXIS_CONTROLS
+from .speech_playground_model import AXIS_CONTROLS, KOKORO_LANGUAGE_OPTIONS
 from .speech_profile_mixin import (
     AdoptStudioPreferencesRequested,
     SpeechProfileMixin,
@@ -1340,6 +1340,10 @@ class SpeechPlaygroundPane(
         cell.set_class(not applicable, "hidden")
         cell.display = applicable
         if applicable:
+            language = self.axis_values.get("tts-language-select", "")
+            choices = {value for _label, value in KOKORO_LANGUAGE_OPTIONS}
+            select.set_options(KOKORO_LANGUAGE_OPTIONS)
+            select.value = language if language in choices else ""
             select.disabled = False
             return
         label = AXIS_EMPTY_PROMPTS["tts-language-select"]

--- a/tldw_chatbook/UI/Speech/speech_synthesis_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_synthesis_mixin.py
@@ -355,10 +355,6 @@ class SpeechSynthesisMixin:
             return current
         if not isinstance(current, str):
             return None
-        if select_widget.id == "tts-language-select":
-            for language_id, display_name in select_widget._options:
-                if display_name == current:
-                    return str(language_id)
         return current
 
     def _is_valid_voice(self, voice: object) -> bool:
@@ -453,8 +449,9 @@ class SpeechSynthesisMixin:
         extra_params = {}
         if provider == "kokoro":
             language_select = self.query_one("#tts-language-select", Select)
-            language = self._get_select_key(language_select) or language_select.value
-            extra_params["language"] = language
+            language = self._get_select_key(language_select)
+            if isinstance(language, str) and language:
+                extra_params["language"] = language
             # Add ONNX setting
             use_onnx = self.query_one("#tts-kokoro-use-onnx", Switch).value
             extra_params["use_onnx"] = use_onnx

--- a/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
@@ -70,6 +70,10 @@ from tldw_chatbook.TTS.audio_cpp_recipes import (
     AudioCppMatchState,
     AudioCppReferenceRequirement,
 )
+from tldw_chatbook.TTS.legacy_catalogs import (
+    LEGACY_DEFAULT_MODELS,
+    LEGACY_DEFAULT_VOICES,
+)
 from tldw_chatbook.Third_Party.textual_fspicker import (
     FileOpen,
     Filters,
@@ -1773,15 +1777,16 @@ class SpeechTTSSettingsPanel(Vertical):
         """Return the global-selection draft state independently of setup."""
 
         try:
-            changed = (
-                self.state.defaults.snapshot()
-                != self.original_state.defaults.snapshot()
-            )
+            preferences = self.state.defaults.snapshot()
         except GlobalSpeechTTSValidationError as error:
             if "required" in str(error).lower():
                 return SpeechTTSConfigurationState.INCOMPLETE
             return SpeechTTSConfigurationState.INVALID
-        if changed:
+        try:
+            original_preferences = self.original_state.defaults.snapshot()
+        except GlobalSpeechTTSValidationError:
+            return SpeechTTSConfigurationState.UNSAVED
+        if preferences != original_preferences:
             return SpeechTTSConfigurationState.UNSAVED
         if self.state.defaults_source is GlobalSpeechTTSEffectiveSource.DEFAULT:
             return SpeechTTSConfigurationState.DEFAULT
@@ -2116,10 +2121,13 @@ class SpeechTTSSettingsPanel(Vertical):
                 ("Exact", "exact"),
                 ("First available", "first_available"),
             ]
-            voice_policy_options = [
-                ("Exact", "exact"),
-                ("Server default", "server_default"),
-            ]
+            voice_policy_options = [("Exact", "exact")]
+            if defaults.voice_mode == "server_default":
+                # Keep invalid saved state visible so it can be corrected;
+                # ordinary Save rejects it before publishing preferences.
+                voice_policy_options.append(
+                    ("Server default (unsupported; choose Exact)", "server_default")
+                )
         yield Static("Global defaults", classes="destination-section")
         yield Static(
             f"Default voice setup: {self._defaults_configuration_state().value}.",
@@ -3549,8 +3557,13 @@ class SpeechTTSSettingsPanel(Vertical):
             )
             if "audio_cpp" in proposal.changed_provider_ids:
                 validate_audio_cpp_managed_settings(self.state.providers["audio_cpp"])
+            try:
+                original_preferences = self.original_state.defaults.snapshot()
+            except GlobalSpeechTTSValidationError:
+                # A valid draft must be able to replace invalid saved defaults.
+                original_preferences = None
             defaults_changed = (
-                proposal.preferences != self.original_state.defaults.snapshot()
+                proposal.preferences != original_preferences
                 # `default_profile_id` lives outside `TTSPreferencesSnapshot`
                 # (a distinct precedence rung -- see has_unsaved_changes and
                 # build_global_speech_tts_save_proposal), so the snapshot
@@ -4707,8 +4720,8 @@ class SpeechTTSSettingsPanel(Vertical):
         if event.value == self.state.defaults.provider_id:
             return
         self._collect_visible_state()
+        persisted = self.original_state.defaults
         if event.value == "audio_cpp":
-            persisted = self.original_state.defaults
             if persisted.provider_id == "audio_cpp":
                 self.state.defaults.model_mode = persisted.model_mode
                 self.state.defaults.model_id = persisted.model_id
@@ -4721,6 +4734,17 @@ class SpeechTTSSettingsPanel(Vertical):
                 self.state.defaults.voice_id = None
             self.state.defaults.response_format = "wav"
             self.state.defaults.speed = 1.0
+        elif event.value in LEGACY_DEFAULT_MODELS:
+            if persisted.provider_id == event.value:
+                self.state.defaults.model_mode = persisted.model_mode
+                self.state.defaults.model_id = persisted.model_id
+                self.state.defaults.voice_mode = persisted.voice_mode
+                self.state.defaults.voice_id = persisted.voice_id
+            else:
+                self.state.defaults.model_mode = "exact"
+                self.state.defaults.model_id = LEGACY_DEFAULT_MODELS[event.value]
+                self.state.defaults.voice_mode = "exact"
+                self.state.defaults.voice_id = LEGACY_DEFAULT_VOICES[event.value]
         await self._replace_card_bodies(
             self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
         )


### PR DESCRIPTION
Local Kokoro generation could fail before synthesis when Speech Lab submitted a language placeholder or global settings retained an unsupported voice policy. Fresh Lab controls also selected PyTorch while automatic replies used ONNX. This change restores valid defaults and explicit selections, repairs stale settings, and reports bounded, actionable resolution errors.

Real playback validation exposed a second failure: separately encoded Kokoro chunks were concatenated into one file. MP3 playback exited successfully while decoders read only the first 0.34 seconds. ONNX and PyTorch now encode each complete utterance once. Encoded requests use one growable sample buffer and stop at five minutes of audio with actionable recovery guidance and no partial file; mixed-voice generation retains one running mix and one voice buffer. Single-voice PCM remains incremental for longer speech. The 28.8 MB sample-data budget per encoded buffer excludes neural inference, allocator and codec/mix overhead.

The separate reported Console trace failure is addressed by preserving exact saved ownership for unchanged multimodal rows, transformed current-user prompts, and selected private history across retries and successor sends. These checks compose with dev's project-instruction context handling, keep prior traces immutable, and fail closed when private response values cannot be safely verified. The schema 68→69 migration reuses the existing call-boundary revision reference; it adds no tables, columns, or extra source-text copies. ADR-097 records the contract.

Validation:

- Real local ONNX inference and Mac speaker playback on both Python 3.12.11 and 3.13.13: a fresh mounted Speech Lab request and two consecutive Speak replies requests in each of WAV and MP3 per runtime. All twelve clips decode to complete 5.6–6.4-second sentences and pass independent local transcription. WAV Console playback reports two device drains; file playback exits 0. The harness supplies completed assistant replies through the real app speech handlers without making an LLM request.
- After the Meetings/dev rebase: 293 backend/real-codec/diagnostic/admission/provenance tests passed with the new sherpa-onnx base dependency installed. Added regressions cover the exact encoded sample budget, overflow with no partial output, producer cleanup, multi-voice padding and PCM beyond the encoded budget. A separate Python 3.13.13 gate passed 312 affected TTS/UI/admission/provenance tests. An earlier rebase gate passed 173 affected UI/TTS/DB/Console tests.
- Prior implementation coverage: 313 TTS/UI/admission tests, 40 backend tests, 22 migration tests, and 1,019 passing targeted Console test executions. These cohorts overlap; they are not a unique-test total. PyTorch codec tests replace only neural inference/voice loading.
- Independent review verified encoded-buffer ownership, full-size limit boundaries, producer cancellation and bounded memory across 120 mixed voices. All six repository preflight checks passed; affected files are formatted and baseline-relative Ruff introduces zero findings. No full local suite was run.

All four initial Qodo findings are addressed: the encoded-memory budget and three public docstring contracts. The branch is rebased onto dev at `e5c09b5c828668a45d0d9ee1be955644415fa240`.

Three Console settlement tests also fail unchanged on dev: two oversized-response expectation cases and the cold-restart recovery fixture. They are recorded separately from regression results. Live neural inference was ONNX only; PyTorch has real-codec coverage. Validation used Python 3.12.11/SQLite 3.49.1 and Python 3.13.13/SQLite 3.53.1; the reporter's exact Python 3.13.5/SQLite 3.46.1 patch versions were unavailable. Their logs still do not identify the exact invalid selection or retry action.

Backlog: TASK-32027, TASK-32027.1, TASK-32028, TASK-32030, TASK-32032, TASK-32038, TASK-32040.

The latest rebase also integrates Bulk reader model overrides and child continuation isolation. All 145 affected Console integration tests passed on Python 3.13, with an independent 14-test review and four combined named-child/multimodal probes. The last Library-only rebase preserves all 53 reviewed PR files byte-for-byte. Playback-related TTS/UI/event sources are unchanged from the two runtime playback checks. Fresh local derived checks and baseline-relative Ruff pass.

Final [CI run 34254236307](https://github.com/rmusser01/tldw_chatbook/actions/runs/34254236307) passed: 755 fast-lane tests and all six derived-artifact checks. All four Qodo review threads are resolved.
