### PR TITLE
fix(library): Conversations select-mode toolbar parity with Media (task-32042)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -172,9 +172,12 @@ keyword: quokkasand…`, the title hit painted `article · 1m`.)*
   You can see that on Media, Conversations and Prompts. Notes reserves the
   same width, but its select-mode row overflows the notes pane at every
   width today, so "Clear" and "Export selected" are off-screen there until
-  that row is reworked. On Conversations the pane is narrow enough that the
-  label is clipped either way — "○" alone while disabled, "Exp" once
-  enabled — but it is clipped in the same column, which is the point.
+  that row is reworked. Conversations now splits its select toolbar into
+  content-width rows the same way Media does — a summary row ("N selected",
+  "Select all N shown") above a bulk-action row ("Clear", "Export selected")
+  — so every label paints in full at every supported width (no more the old
+  "Selec"/"Exp" clipping), and the word still holds its column across the
+  disabled flip.
 
 **Media's "Analyze"** (Media only) generates an analysis for every checked
 item in one run, in list order, on its own row under Clear/Export/Review:
@@ -482,6 +485,14 @@ content painted the no-Markdown note above its text; an empty `article` painted 
 it. In Conversations select mode, checking the first row moved the count
 0 → 1 and left the Export selected label's first painted glyph on column
 83 — "○" before, "Exp" (clipped) after.)*
+
+*Verified against fix/media-crit7-convselect — 2026-09-08 (task-32042,
+critique #7 P1: the Conversations select toolbar, once a single 1fr row that
+clipped every action to "Selec"/"Exp", now mirrors Media's multi-row
+content-width treatment. Painted-cell tests at both 235x52 and 100x30 assert
+"Select all N shown", "Clear", and "Export selected" render in full and the
+count reads on one line; the column-hold pin now measures the "Export" word,
+which stays put across the disabled flip.)*
 
 *Verified against fix/media-wave5-j — 2026-09-06 (task-31635 items 1, 5, 13,
 14: a seeded Markdown item and a seeded plain `article` opened live at 235x52.

--- a/Tests/UI/test_library_multiselect_conversations.py
+++ b/Tests/UI/test_library_multiselect_conversations.py
@@ -35,7 +35,7 @@ from Tests.UI.test_library_shell import (
     _build_test_app,
     _active_library_screen,
     _conversation_records,
-    _painted_label_column,
+    _painted_text,
     _seed_conversations,
     _wait_for_condition,
     _two_conversations,
@@ -530,16 +530,30 @@ async def test_library_conversation_stale_state_disables_actions_but_allows_reco
 # ---------------------------------------------------------------------------
 
 
+def _painted_word_column(host, button, word: str) -> int:
+    """Absolute column where ``word`` is painted inside ``button`` (task-31959).
+
+    Mirrors the Notes/Prompts sibling helper: measures the WORD, not the
+    first painted glyph. task-32042 gave the Conversations select toolbar
+    Media's full-label treatment, so "Export selected" no longer clips at
+    the pane's width -- the invariant this pins is that the WORD "Export"
+    holds its column across the disabled flip (the "○ " marker paints two
+    cells to its left while disabled, the reserved pad holds it while
+    enabled), exactly as Notes measures it.
+    """
+    painted = _painted_text(host, button.region)
+    assert word in painted, (word, painted)
+    return button.region.x + painted.index(word)
+
+
 @pytest.mark.asyncio
 async def test_conversations_export_label_holds_its_column_across_the_first_selection():
-    """The painted "Export selected" label starts in the same column.
+    """The painted "Export" word holds its column across the first selection.
 
     Drives the REAL screen, because the shift lives on the in-place
     ``_apply_library_row_toggle`` patch a row press takes -- not on
-    compose. At the conversations pane's own width the label is clipped,
-    so the pin is where it starts painting: "○" at that column while
-    disabled, "Export…" at the SAME column once the first selection
-    enables it.
+    compose. The word stays put ("○ " prefixes it while disabled, the
+    reserved pad holds it while enabled).
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations())
@@ -556,7 +570,7 @@ async def test_conversations_export_label_holds_its_column_across_the_first_sele
             screen, pilot, "#library-conversations-export-selected"
         )
         assert export.disabled
-        before = _painted_label_column(host, export)
+        before = _painted_word_column(host, export, "Export")
 
         screen.query_one("#library-conversation-row-0", Button).press()
         await _wait_for_condition(
@@ -569,8 +583,53 @@ async def test_conversations_export_label_holds_its_column_across_the_first_sele
         await pilot.pause()
 
         export = screen.query_one("#library-conversations-export-selected", Button)
-        after = _painted_label_column(host, export)
+        after = _painted_word_column(host, export, "Export")
         assert after == before, (before, after)
+
+
+# ---------------------------------------------------------------------------
+# task-32042 (critique #7 P1): the Conversations select toolbar was a degraded
+# copy of Media's -- all four actions (count + Select all + Clear + Export
+# selected) shared ONE ds-toolbar row at width:1fr, so at the narrow
+# conversations list pane they split the row evenly and every label truncated
+# ("Selec", "Exp") while "0 selected" wrapped. Media (task-30043) keeps each
+# action at its content width across a multi-row toolbar; this pins the
+# Conversations toolbar to that same treatment at both supported sizes.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)])
+async def test_conversations_select_labels_paint_in_full_like_media(size):
+    """Every Conversations select action paints its full word, unwrapped count."""
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+
+    async with host.run_test(size=size) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+
+        screen.query_one("#library-row-browse-conversations").press()
+        await _wait_for_selector(screen, pilot, "#library-conversation-row-0")
+        screen.query_one("#library-conversations-select-toggle", Button).press()
+
+        count = await _wait_for_selector(
+            screen, pilot, "#library-conversations-selected-count"
+        )
+        select_all = screen.query_one("#library-conversations-select-all", Button)
+        clear = screen.query_one("#library-conversations-select-clear", Button)
+        export = screen.query_one("#library-conversations-export-selected", Button)
+
+        # Full, untruncated action labels (no "Selec"/"Exp" mid-word cuts).
+        assert "Select all 2 shown" in _painted_text(host, select_all.region)
+        assert "Clear" in _painted_text(host, clear.region)
+        assert "Export selected" in _painted_text(host, export.region)
+
+        # "0 selected" reads on one line, not the awkward wrap critique saw.
+        painted_count = _painted_text(host, count.region)
+        assert "0 selected" in painted_count
+        assert count.region.height == 1, painted_count
 
 
 # ---------------------------------------------------------------------------

--- a/backlog/tasks/task-32042 - Library-Conversations-select-mode-is-a-degraded-truncated-copy-of-Medias.md
+++ b/backlog/tasks/task-32042 - Library-Conversations-select-mode-is-a-degraded-truncated-copy-of-Medias.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32042
 title: 'Library: Conversations select mode is a degraded, truncated copy of Media''s'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-08 14:36'
+updated_date: '2026-09-08 17:23'
 labels:
   - library
   - conversations
@@ -20,7 +21,13 @@ Critique #7 P1. Conversations' select-mode toolbar renders 'Selec' (truncated 'S
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Conversations select mode shows full, untruncated action labels at supported widths, matching Media's grammar
-- [ ] #2 The select toolbar is built from the shared treatment rather than a divergent per-canvas copy
-- [ ] #3 Painted pins assert the Conversations select actions are legible (no mid-word truncation) at 235x52 and 100x30
+- [x] #1 Conversations select mode shows full, untruncated action labels at supported widths, matching Media's grammar
+- [x] #2 The select toolbar is built from the shared treatment rather than a divergent per-canvas copy
+- [x] #3 Painted pins assert the Conversations select actions are legible (no mid-word truncation) at 235x52 and 100x30
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Conversations' select-mode toolbar packed all four actions into one `ds-toolbar` row whose scoped CSS forced each child to `width:1fr`, so at the narrow conversations list pane they split evenly (~9 cells each) and truncated to `Selec`/`Exp` with `0 selected` wrapping. Fix (Media parity, task-30043 treatment): split into a summary row (count + `Select all N shown`) above a bulk-action row (`#library-conversations-select-actions`: Clear + Export selected), and change the scoped `#library-conversations-canvas > .ds-toolbar > .library-canvas-action` width from `1fr` to `auto` (min-width:0 kept) so the buttons take their content width. The selector is scoped to #library-conversations-canvas, so Media (its own already-`auto` rule) and Notes/Prompts (no matching selector; base .library-canvas-action carries no width) are unaffected. Kept the `library_disabled_action_label(align=True)` idiom, 'Done stays pressable in select mode', and the `actions_disabled`/empty gating. New pin `test_conversations_select_labels_paint_in_full_like_media` asserts the full labels + one-line count at 235x52 and 100x30 (red first: 'Select all 2 shown' clipped to 'Selec'). The crit6 column-hold pin was correctly adapted from a first-glyph to a word-column measurement (`_painted_word_column(..., 'Export')`, the Notes/Prompts sibling standard) — it still asserts the label holds its column across the 0->1 selection flip; first-glyph diverged by design once the label un-clipped (the align pad reserves the `○ ` width). Bundle rebuilt (conversations rules are in the boot bundle). Files: library_conversations_canvas.py, _agentic_terminal.tcss (+ tldw_cli_modular.tcss bundle), Tests/UI/test_library_multiselect_conversations.py, Docs/User_Guide.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_conversations_canvas.py
@@ -149,9 +149,19 @@ class LibraryConversationsCanvas(
             )
         yield select_btn
         if select_mode:
-            action_row = Horizontal(classes="ds-toolbar")
-            action_row.styles.height = "auto"
-            with action_row:
+            # task-32042 (critique #7 P1): parity with the Media canvas's
+            # select toolbar (task-30043). A single ds-toolbar row of four
+            # actions -- forced to ``width: 1fr`` by the shared CSS -- split
+            # the narrow conversations list pane evenly, so every label
+            # truncated ("Selec"/"Exp") and "0 selected" wrapped. Media keeps
+            # each action at its CONTENT width across a multi-row toolbar; this
+            # mirrors that: summary row (count + Select all), then a bulk-action
+            # row (Clear + Export selected), each row's label sum fitting the
+            # pane's narrow floor. The ``> .ds-toolbar > .library-canvas-action``
+            # width switches to ``auto`` alongside (_agentic_terminal.tcss).
+            summary_row = Horizontal(classes="ds-toolbar")
+            summary_row.styles.height = "auto"
+            with summary_row:
                 # task-2853 review round 2: the SAME unbounded-width defect
                 # proved live in the Media canvas's identical counter --
                 # see library_media_canvas.py's compose() for the live
@@ -177,6 +187,11 @@ class LibraryConversationsCanvas(
                 if actions_disabled:
                     select_all.tooltip = stale_action_reason
                 yield select_all
+            actions_row = Horizontal(
+                id="library-conversations-select-actions", classes="ds-toolbar"
+            )
+            actions_row.styles.height = "auto"
+            with actions_row:
                 clear = Button(
                     library_disabled_action_label("Clear", actions_disabled),
                     id="library-conversations-select-clear",

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1856,9 +1856,15 @@ ConsoleRunLogModal {
     max-width: 100%;
 }
 
+/* task-32042 (critique #7 P1) mirrors task-30043 on the Media canvas: a 1fr
+   squeeze chopped every select-action label to fragments ("Selec"/"Exp") and
+   wrapped "0 selected" at the narrow conversations list pane. The toolbar now
+   splits into content-width rows (library_conversations_canvas.py), so each
+   action keeps its own width (auto, min-width:0 lifting Button's 16-cell floor)
+   and every label paints in full. */
 #library-conversations-canvas > .ds-toolbar > .library-toolbar-count,
 #library-conversations-canvas > .ds-toolbar > .library-canvas-action {
-    width: 1fr;
+    width: auto;
     min-width: 0;
 }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -2876,9 +2876,15 @@ ConsoleRunLogModal {
     max-width: 100%;
 }
 
+/* task-32042 (critique #7 P1) mirrors task-30043 on the Media canvas: a 1fr
+   squeeze chopped every select-action label to fragments ("Selec"/"Exp") and
+   wrapped "0 selected" at the narrow conversations list pane. The toolbar now
+   splits into content-width rows (library_conversations_canvas.py), so each
+   action keeps its own width (auto, min-width:0 lifting Button's 16-cell floor)
+   and every label paints in full. */
 #library-conversations-canvas > .ds-toolbar > .library-toolbar-count,
 #library-conversations-canvas > .ds-toolbar > .library-canvas-action {
-    width: 1fr;
+    width: auto;
     min-width: 0;
 }
 


### PR DESCRIPTION
## Summary

Critique #7 fix wave, final fix (task-32042, P1): Conversations' select-mode toolbar was a truncated copy of Media's — `Selec` (clipped "Select all"), a bare unlabeled marker, and a wrapped "0 selected".

Root cause: the toolbar packed all four actions into one `ds-toolbar` row whose scoped CSS forced each child to `width: 1fr`, so at the narrow conversations list pane they split evenly (~9 cells each) and truncated.

Fix (Media parity, the task-30043 treatment): split into a summary row (count + "Select all N shown") above a bulk-action row (Clear + Export selected), and change the scoped `#library-conversations-canvas > .ds-toolbar > .library-canvas-action` width from `1fr` to `auto` (min-width:0 kept) so buttons take their content width. The selector is scoped to the conversations canvas, so Media (its own already-`auto` rule) and Notes/Prompts are unaffected. The `library_disabled_action_label(align=True)` idiom, "Done stays pressable in select mode", and the empty/`actions_disabled` gating are unchanged.

## Verification

Task review (Sonnet): Approved, no issues. The reviewer confirmed the selector scope can't leak to the other canvases, and — the key scrutiny — that the crit6 column-hold pin was correctly adapted (first-glyph → word column): it still asserts the label holds its column across the 0→1 selection flip; the first glyph diverges by design once the label un-clips (the align pad reserves the `○ ` width), and `_painted_word_column` is the same helper Notes/Prompts use.

| run | result |
|---|---|
| new pin (`..._select_labels_paint_in_full_like_media` wide/narrow) | passed, red first (clipped to `Selec`) |
| `test_library_multiselect_conversations.py` | 19 passed, 1 pre-existing red (a browse-scope fake gap, unrelated) |
| crit6 column-hold pin (`..._export_label_holds_its_column...`) | passed |

CSS bundle reproduces from source; diagnostic inventory unchanged; no new logger call sites; preflight green. Closes task-32042.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Conversations select-mode toolbar so action labels render fully instead of truncating to 'Selec' and 'Exp'.

**Bug Fixes**
- Splits the toolbar into a summary row (count + "Select all N shown") and a bulk-action row (Clear + Export selected).
- Changes the scoped action width from `1fr` to `auto` so each button uses its content width.
- Adds painted-cell tests asserting full labels at both supported pane sizes.
- Adjusts the column-hold test to measure the "Export" word instead of the first glyph.
- Keeps the change scoped to the conversations canvas; Media and other canvases are unaffected.

<sup>Written for commit bc61922098700baf42e9731d8ceefe6d8b61a08c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2516?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

