### PR TITLE
fix(library-media): critique #7 Qodo follow-ups — empty-list gate, / route test, doc, scroll-pin fix (task-32047)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -398,7 +398,7 @@ Screen-level keys only — global keys live in the [guide index](index.md).
 
 | Key | Action |
 |---|---|
-| / | Focus the filter of the list you're on — the Media, Conversations, Prompts, or Notes canvas's own **Title/keyword…** / filter box — so the footer's "/ focus search" lands where you're looking. On the landing, or on a tool canvas with no filter of its own (Skills, Collections, Search / RAG, Study), it focuses the rail's **Search Library…** box instead. Never fires while a text field already has focus. Get started has no hidden search target; use **Explore all tools** or a direct route. |
+| / | Focus the filter of the list you're on — the Media, Conversations, Prompts, or Notes canvas's own **Title/keyword…** / filter box — so the footer's "/ focus search" lands where you're looking. On the landing, or on a canvas `/` isn't wired to (Skills, Collections, Search / RAG, Study), it focuses the rail's **Search Library…** box instead — those canvases have their own filter/query inputs, but `/` does not route to them today. Never fires while a text field already has focus. Get started has no hidden search target; use **Explore all tools** or a direct route. |
 | u | Use Library context in Console — only while the Search / RAG row is selected (the footer hint appears only there) |
 | ↑ / ↓ | Inside a Media, Notes, Prompts, or Skills list, move to the previous/next row (stops at the first/last row — it does not wrap) |
 | Enter | Open the focused list row (same as clicking it) |

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -398,7 +398,7 @@ Screen-level keys only — global keys live in the [guide index](index.md).
 
 | Key | Action |
 |---|---|
-| / | Focus the filter of the list you're on — the Media, Conversations, Prompts, or Notes canvas's own **Title/keyword…** / filter box — so the footer's "/ focus search" lands where you're looking. On the landing (and any canvas with no filter of its own) it focuses the rail's **Search Library…** box instead. Never fires while a text field already has focus. Get started has no hidden search target; use **Explore all tools** or a direct route. |
+| / | Focus the filter of the list you're on — the Media, Conversations, Prompts, or Notes canvas's own **Title/keyword…** / filter box — so the footer's "/ focus search" lands where you're looking. On the landing, or on a tool canvas with no filter of its own (Skills, Collections, Search / RAG, Study), it focuses the rail's **Search Library…** box instead. Never fires while a text field already has focus. Get started has no hidden search target; use **Explore all tools** or a direct route. |
 | u | Use Library context in Console — only while the Search / RAG row is selected (the footer hint appears only there) |
 | ↑ / ↓ | Inside a Media, Notes, Prompts, or Skills list, move to the previous/next row (stops at the first/last row — it does not wrap) |
 | Enter | Open the focused list row (same as clicking it) |
@@ -440,11 +440,13 @@ inside the File Notes surface's own panels and dialogs — see
 **Continue in Study**), Escape returns to the Study decks staging canvas
 here in Library.
 
-*Verified against fix/media-crit7-keyboard — 2026-09-08 (task-32046: `/`
-now focuses the active list canvas's own filter — Media/Prompts share the
-per-canvas route the Conversations and Notes canvases already had — instead
-of the rail's global search two panes away; pinned at 235x52 and 100x30 in
-`test_slash_focuses_the_media_filter_not_the_rail_search`).*
+*Verified against fix/media-crit7-qodo — 2026-09-08 (task-32046 + task-32047
+AC#2/#4: `/` focuses the active list canvas's own filter — Media/Prompts share
+the per-canvas route the Conversations and Notes canvases already had — instead
+of the rail's global search two panes away; the fallback wording now names the
+filterless tool canvases rather than over-claiming "any" canvas. Pinned at
+235x52 and 100x30 in `test_slash_focuses_the_media_filter_not_the_rail_search`
+and `test_slash_focuses_the_prompts_filter_not_the_rail_search`).*
 
 ## Related settings & docs
 

--- a/Tests/UI/test_library_media_reader_scroller_resolution.py
+++ b/Tests/UI/test_library_media_reader_scroller_resolution.py
@@ -426,10 +426,10 @@ async def test_read_analysis_read_round_trip_restores_the_rendered_scroll_offset
         service.release(backing_id)
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_media_reader_session.loaded_id == canonical_id,
+            lambda: screen._media_state.reader_session.loaded_id == canonical_id,
             message="Row never settled its detail.",
         )
-        assert screen._library_media_content_mode == "rendered", (
+        assert screen._media_state.content_mode == "rendered", (
             "Fixture must default to Rendered for the round-trip to mean anything."
         )
 
@@ -443,13 +443,13 @@ async def test_read_analysis_read_round_trip_restores_the_rendered_scroll_offset
         screen.query_one("#library-media-reader-select-analysis", Button).press()
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_media_reader_session.mode == "analysis",
+            lambda: screen._media_state.reader_session.mode == "analysis",
             message="Never switched to Analysis.",
         )
         screen.query_one("#library-media-reader-select-read", Button).press()
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_media_reader_session.mode == "read",
+            lambda: screen._media_state.reader_session.mode == "read",
             message="Never switched back to Read.",
         )
 
@@ -507,7 +507,7 @@ async def test_mode_change_restore_lands_synchronously_on_the_laid_out_body():
         service.release(backing_id)
         await _wait_for_condition(
             pilot,
-            lambda: screen._library_media_reader_session.loaded_id == canonical_id,
+            lambda: screen._media_state.reader_session.loaded_id == canonical_id,
             message="Row never settled its detail.",
         )
         body = await _open_rendered_body_ready(screen, pilot)
@@ -518,7 +518,7 @@ async def test_mode_change_restore_lands_synchronously_on_the_laid_out_body():
             "Fixture must overflow the reading surface for the offset to land."
         )
 
-        screen._library_media_read_scroll_by_id[canonical_id] = (0, 14)
+        screen._media_state.read_scroll_by_id[canonical_id] = (0, 14)
         screen._restore_library_media_loaded_progress(canonical_id)
         # No pause: the fix applies against the laid-out scroller immediately;
         # the deferred-only restore would still read 0 here.

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -2096,6 +2096,60 @@ async def test_select_mode_bulk_reason_is_painted_with_nothing_selected(size):
 
 
 @pytest.mark.asyncio
+async def test_select_mode_empty_refresh_does_not_ask_to_select_nothing():
+    """task-32047 AC#1 (Qodo #7): the zero-selection reason must not paint on a
+    SUCCESSFUL empty list.
+
+    task-32045 made ``Select items to enable.`` visible whenever
+    ``selected_count == 0``, without checking that any row exists -- so select
+    mode surviving a refresh that returns zero rows asked the user to select
+    from nothing. The line stays MOUNTED (height reserved, per task-32045's
+    visibility-not-display layout fix) but paints nothing when there is no
+    selectable row.
+    """
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    service = app.media_reading_scope_service
+    host = LibraryProductionCSSHarness(app)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen._toggle_library_media_select_mode()
+        await _wait_for_selector(screen, pilot, "#library-media-select-actions")
+        await pilot.pause()
+        # Baseline: with rows present and nothing selected, the reason paints.
+        reason = screen.query_one("#library-media-select-bulk-reason", Static)
+        assert reason.styles.visibility == "visible"
+
+        # A successful refresh empties the list while select mode survives.
+        controller = screen._library_media_browse_controller
+        service.media_items = []
+        screen._request_library_media_browse(
+            controller.mutation_refresh_scope,
+            focus_identity=None,
+        )
+        await _wait_for_condition(
+            pilot,
+            lambda: controller.applied_result is not None
+            and controller.applied_result.total == 0
+            and not controller.loading,
+            message="Empty Media refresh never applied while in select mode.",
+        )
+        await pilot.pause()
+
+        assert screen._media_state.select_mode is True
+        empty_reason = screen.query("#library-media-select-bulk-reason")
+        assert empty_reason, "reason line must stay mounted for layout stability"
+        empty_reason_widget = empty_reason.first(Static)
+        # No selectable row -> kept mounted via ``visibility: hidden`` (the
+        # height-reserving mechanism, NOT ``display: none``), painting nothing.
+        assert empty_reason_widget.styles.visibility == "hidden"
+        canvas_region = screen.query_one("#library-media-canvas").region
+        assert "Select items to enable" not in _painted(
+            host, canvas_region
+        ).replace("\n", " ")
+
+
+@pytest.mark.asyncio
 async def test_select_mode_analyze_reason_refreshes_on_resume():
     """task-32039 AC#2: a provider configured mid-session clears the gate on return.
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -6879,7 +6879,11 @@ async def test_slash_focuses_the_media_filter_not_the_rail_search(size):
     away. The footer advertises "/ focus search"; before this fix the key
     landed on ``#library-search-input`` and a filter query did nothing to
     the list. Mirrors the notes ``/`` action; must hold at both the wide
-    three-pane width and the narrow stacked one."""
+    three-pane width and the narrow stacked one.
+
+    Args:
+        size: The ``(width, height)`` terminal viewport under test.
+    """
     app = _build_test_app()
     app.library_new_profile_admission = False
     _seed_conversations(app, _two_conversations(), media=_two_media_items())
@@ -6904,13 +6908,66 @@ async def test_slash_focuses_the_media_filter_not_the_rail_search(size):
 
 
 @pytest.mark.asyncio
+async def test_slash_focuses_the_prompts_filter_not_the_rail_search(tmp_path):
+    """task-32047 AC#2: task-32046 routed `/` to the own-canvas filter for
+    BOTH Media and Prompts, but only Media was pinned. On the Prompts list `/`
+    must focus ``#library-prompts-filter``, not the rail's global
+    ``#library-search-input``. A prompt is seeded so the list (and its filter)
+    is mounted rather than the empty-state recovery."""
+    app = _build_test_app()
+    app.library_new_profile_admission = False
+    _seed_conversations(app, _two_conversations())
+    prompts_db = PromptsDatabase(
+        tmp_path / "slash-prompts.db", client_id="slash-prompts-test"
+    )
+    prompt_id, _uuid, _msg = prompts_db.add_prompt(
+        name="Summarize",
+        author="Alice",
+        details="A summarizer",
+        system_prompt="You are concise.",
+        user_prompt="Summarize: {text}",
+    )
+    app.prompt_scope_service = PromptScopeService(
+        local_service=LocalPromptService(prompts_db),
+        server_service=None,
+    )
+    host = LibraryHarness(app)
+
+    try:
+        async with host.run_test(size=(235, 52)) as pilot:
+            screen = _active_library_screen(host)
+            await _wait_for_library_shell(screen, pilot)
+            screen.query_one("#library-row-browse-prompts").press()
+            await _wait_for_selector(
+                screen, pilot, f"#library-prompt-row-{prompt_id}"
+            )
+            await pilot.pause()
+
+            prompts_filter = screen.query_one("#library-prompts-filter", Input)
+            rail_search = screen.query_one("#library-search-input", Input)
+            assert not prompts_filter.has_focus
+            await pilot.press("/")
+            await pilot.pause()
+            assert prompts_filter.has_focus, (
+                f"/ landed on {screen.focused!r}, expected the Prompts filter"
+            )
+            assert not rail_search.has_focus
+    finally:
+        prompts_db.close_connection()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("size", [(235, 52), (100, 30)])
 async def test_media_list_arrow_keys_move_the_cursor_at_every_width(size):
     """task-32041 AC#1/#4: with the Media list owning focus, Down/Up move
     the list cursor between rows at every supported width -- the 235x52 wide
     three-pane layout as well as the 100x30 stacked one that already worked.
     Focus must stay on a ``.library-media-row`` and never leak into the
-    reader pane."""
+    reader pane.
+
+    Args:
+        size: The ``(width, height)`` terminal viewport under test.
+    """
     app = _build_test_app()
     app.library_new_profile_admission = False
     _seed_conversations(app, _two_conversations(), media=_two_media_items())

--- a/backlog/tasks/task-32047 - Critique-7-Qodo-follow-ups-empty-list-select-reason-route-test-doc-docstrings.md
+++ b/backlog/tasks/task-32047 - Critique-7-Qodo-follow-ups-empty-list-select-reason-route-test-doc-docstrings.md
@@ -3,9 +3,10 @@ id: TASK-32047
 title: >-
   Critique #7 Qodo follow-ups: empty-list select reason, / route test, doc +
   docstrings
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-08 18:01'
+updated_date: '2026-09-08 18:35'
 labels:
   - library
   - media
@@ -22,8 +23,14 @@ Consolidated Qodo follow-ups from the critique #7 fix PRs. (a, BUG) The zero-sel
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The zero-selection reason is shown only when nothing is selected AND at least one selectable row exists; a successful empty list in select mode shows no 'select items' message (kept mounted for layout), with a test for an empty refresh while select mode is active
-- [ ] #2 An integration test opens the Prompts canvas, presses /, and asserts focus lands on the Prompts filter (not the rail search)
-- [ ] #3 The two size-parametrized keyboard tests carry a one-line summary + Args: describing the size tuple
-- [ ] #4 The shortcut guide's `/` description matches the actual per-canvas routing (no over-claimed fallback)
+- [x] #1 The zero-selection reason is shown only when nothing is selected AND at least one selectable row exists; a successful empty list in select mode shows no 'select items' message (kept mounted for layout), with a test for an empty refresh while select mode is active
+- [x] #2 An integration test opens the Prompts canvas, presses /, and asserts focus lands on the Prompts filter (not the rail search)
+- [x] #3 The two size-parametrized keyboard tests carry a one-line summary + Args: describing the size tuple
+- [x] #4 The shortcut guide's `/` description matches the actual per-canvas routing (no over-claimed fallback)
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Consolidated critique #7 Qodo follow-ups. (a, BUG) The zero-selection bulk-action reason (task-32045) is now VISIBLE only when `selected_count==0 AND rendered_count>0 AND not bulk_list_failed` -- a successful EMPTY media list in select mode paints nothing (widget stays mounted via visibility for layout); red-first pin + the empty-refresh case. (b) Added a Prompts `/`-route integration test (seeds a real prompt, opens the canvas, / focuses #library-prompts-filter, not the rail search) -- the route from task-32046 was Media-only pinned. (c) Args: docstrings on the two size-parametrized keyboard tests. (d) library.md `/` fallback reworded to describe the ROUTING (`/` isn't wired to Skills/Collections/Search-RAG/Study, so it focuses the rail search) rather than falsely claiming those canvases lack a filter -- they DO have filter/query inputs, / just doesn't route there (fixed at review after the first wording over-claimed). (e) CORRECTED a controller misdiagnosis: the media scroll-restore pins' RED was NOT a test-fixture backend gap (`Local prompt/study/quiz backend is unavailable` is caught-and-logged noise at library_screen.py:13083, tolerated) -- it was a STALE-ATTRIBUTE migration miss in test_library_media_reader_scroller_resolution.py (`screen._library_media_reader_session/_content_mode/_read_scroll_by_id` -> `screen._media_state.*`, the real LibraryMediaState fields; LibraryScreen defines no such bare attrs). 6-line test-only fix; the file is 6/6 green and the crit6 scroll-restore pins (task-31968) pass again. No production change for (b)-(e); the only production file touched is library_media_canvas.py (item a). Files: library_media_canvas.py, Tests/UI/test_library_shell.py, Tests/UI/test_library_media_render_fixes.py, Tests/UI/test_library_media_reader_scroller_resolution.py, Docs/User_Guide/library.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32047 - Critique-7-Qodo-follow-ups-empty-list-select-reason-route-test-doc-docstrings.md
+++ b/backlog/tasks/task-32047 - Critique-7-Qodo-follow-ups-empty-list-select-reason-route-test-doc-docstrings.md
@@ -1,0 +1,29 @@
+---
+id: TASK-32047
+title: >-
+  Critique #7 Qodo follow-ups: empty-list select reason, / route test, doc +
+  docstrings
+status: To Do
+assignee: []
+created_date: '2026-09-08 18:01'
+labels:
+  - library
+  - media
+  - tech-debt
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Consolidated Qodo follow-ups from the critique #7 fix PRs. (a, BUG) The zero-selection bulk-action reason 'Select items to enable.' (task-32045) shows whenever selected_count==0 without checking whether any rows exist, so a SUCCESSFUL empty media list in select mode asks the user to select from nothing. (b) The `/`-to-canvas-filter fix (task-32046) routes Media AND Prompts but only Media is pinned; the Prompts route is untested. (c) The two new size-parametrized keyboard tests lack Google-style docstring Args for the size tuple. (d) The shortcut guide (library.md) over-claims the `/` fallback for canvases without their own filter. Also fold in the media test-app fixture gap that leaves several media pins red for lacking local prompt/study/quiz scope-service backends, IF that fix is localized to the media test app builder; otherwise leave it as its own rider.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The zero-selection reason is shown only when nothing is selected AND at least one selectable row exists; a successful empty list in select mode shows no 'select items' message (kept mounted for layout), with a test for an empty refresh while select mode is active
+- [ ] #2 An integration test opens the Prompts canvas, presses /, and asserts focus lands on the Prompts filter (not the rail search)
+- [ ] #3 The two size-parametrized keyboard tests carry a one-line summary + Args: describing the size tuple
+- [ ] #4 The shortcut guide's `/` description matches the actual per-canvas routing (no over-claimed fallback)
+<!-- AC:END -->

--- a/backlog/tasks/task-32049 - Flaky-Fast-Lane-test_mcp_workbench-TextArea-preview-fails-on-a-text-area-gutter-COMPONENT_CLASSES-KeyError.md
+++ b/backlog/tasks/task-32049 - Flaky-Fast-Lane-test_mcp_workbench-TextArea-preview-fails-on-a-text-area-gutter-COMPONENT_CLASSES-KeyError.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32049
+title: >-
+  Flaky Fast Lane: test_mcp_workbench TextArea preview fails on a
+  text-area--gutter COMPONENT_CLASSES KeyError
+status: To Do
+assignee: []
+created_date: '2026-09-08 18:01'
+labels:
+  - mcp
+  - tests
+  - flaky
+  - tech-debt
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Intermittent Fast Lane failure, unrelated to Library work, that has blocked PRs twice (#2502, #2515) and cleared on rerun/update-branch. `Tests/UI/test_mcp_workbench.py::test_test_tool_preview_*` raises `KeyError: "No 'text-area--gutter' key in COMPONENT_CLASSES"` under certain test orders — a Textual TextArea component-class registration race: the preview asserts `base_style`/`component_styles` before TextArea's COMPONENT_CLASSES are registered (which happens on mount). Filed as a rider; the fix belongs to whoever owns the MCP workbench tests, not this Library ▸ Media wave.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The MCP-workbench TextArea preview test registers TextArea's COMPONENT_CLASSES (mounts the widget/screen) before asserting its style, or is isolated so test order cannot leave the class unregistered
+- [ ] #2 The test passes reliably across repeated Fast Lane runs (no intermittent text-area--gutter KeyError)
+<!-- AC:END -->

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -1112,7 +1112,11 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 # when the list itself failed to load with nothing to select
                 # (``_gate_failed_action``'s predicate) -- that state already
                 # explains itself via the recovery callout, and "select
-                # items" would be the wrong reason.
+                # items" would be the wrong reason. task-32047 AC#1 (Qodo #7):
+                # also gated on ``rendered_count > 0`` -- select mode surviving
+                # a refresh to a SUCCESSFUL empty list has nothing to select,
+                # so the line paints nothing there too (still mounted, so the
+                # in-place toggle below can only ever fire with rows present).
                 #
                 # Always yielded (visibility toggled, not conditionally
                 # composed, and NOT ``display`` either): a single row-press
@@ -1141,7 +1145,11 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
                 )
                 bulk_reason_line.styles.visibility = (
                     "visible"
-                    if self.canvas.selected_count == 0 and not bulk_list_failed
+                    if (
+                        self.canvas.selected_count == 0
+                        and rendered_count > 0
+                        and not bulk_list_failed
+                    )
                     else "hidden"
                 )
                 yield bulk_reason_line


### PR DESCRIPTION
## Summary

Consolidated critique #7 Qodo follow-ups (task-32047), closing out the critique #7 fix wave.

- **(a, BUG)** The zero-selection bulk-action reason (task-32045) showed whenever nothing was selected, so a successful **empty** media list in select mode asked the user to select from nothing. It is now visible only when `selected_count == 0 AND rendered_count > 0 AND not bulk_list_failed`; the widget stays mounted (visibility, not display) so layout doesn't shift. Red-first pin plus an empty-refresh-in-select-mode case.
- **(b)** Added a Prompts `/`-route integration test — the task-32046 fix routed both Media and Prompts but only Media was pinned.
- **(c)** `Args:` docstrings on the two size-parametrized keyboard tests.
- **(d)** Reworded `library.md`'s `/` fallback to describe the routing (`/` isn't wired to Skills/Collections/Search-RAG/Study, so it focuses the rail search) rather than falsely claiming those canvases have no filter — they do; `/` just doesn't route there. (Corrected at review after the first wording over-claimed.)
- **(e)** Corrected a misdiagnosis: the media scroll-restore pins' RED was **not** a test-fixture backend gap (`Local prompt/study/quiz backend is unavailable` is caught-and-logged noise, tolerated by the count paths). It was a stale `_media_state` attribute in `test_library_media_reader_scroller_resolution.py` (`screen._library_media_reader_session/_content_mode/_read_scroll_by_id` → `screen._media_state.*`, the real fields). A 6-line test-only fix; the file is 6/6 green and the crit6 scroll-restore pins (task-31968) pass again.

Only production change is (a) in `library_media_canvas.py`; (b)–(e) are tests and docs.

## Verification

Task review (Sonnet): Approved after the item-d doc wording was corrected. The reviewer reproduced item a's red→green by reverting the hunk, confirmed the Prompts test is a genuine independent route exercise, and independently verified item e is a real stale-attribute fix (not a weakened test) that turns the scroll pins green for the right reason (they drive the real scroller and assert concrete offsets).

| run | result |
|---|---|
| item a pins (empty-refresh; non-empty still shows) | passed, red first |
| Prompts `/`-route test | passed |
| `test_library_media_reader_scroller_resolution.py` | 6 passed (was 4/6) |

Diagnostic inventory unchanged; no new logger call sites; no CSS; preflight green. Closes task-32047. The recurring MCP-workbench Fast Lane flake is filed separately as task-32049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the select-mode bulk-action reason so a successful empty media list no longer asks the user to "Select items to enable." when there are no rows to select. Also adds a Prompts `/`-route test, tightens the `/` fallback doc, and fixes a stale test attribute that left the scroll-restore pins red.

- Gates the zero-selection reason on `rendered_count > 0` so an empty refresh in select mode paints nothing; the widget stays mounted via visibility so layout doesn't shift.
- Adds an integration test pinning `/` to the Prompts filter instead of the rail search.
- Fixes the scroll-restore tests to use the real `_media_state` fields, turning the file 6/6 green.
- Rewords `library.md`'s `/` fallback to describe routing rather than claiming those canvases lack filters.
- Only production change is the empty-list gate; the rest are tests and docs.

<sup>Written for commit e80cd917d2ff057368298a4a0aebfafa02252611. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

