### PR TITLE
fix(tts): repair backend audio delivery, PCM playback and provider switching

### DIFF
--- a/Docs/Features/Speech-Services-Guide.md
+++ b/Docs/Features/Speech-Services-Guide.md
@@ -50,6 +50,23 @@ The TTS Playground allows you to experiment with different voices and settings:
 - **Format**: Choose output format (MP3, WAV, etc.)
 - **Provider Settings**: Adjust provider-specific parameters
 
+### Output formats and playback
+
+WAV, MP3, AAC, FLAC, and Opus output is delivered as one complete audio file,
+including replies generated in several chunks. AAC uses an ADTS container.
+Encoded conversions require the optional audio conversion dependencies and FFmpeg.
+If a generated clip exceeds a backend's buffering limit, shorten the text.
+
+Raw PCM output is signed 16-bit little-endian audio. Kokoro, Chatterbox, Higgs,
+ElevenLabs, AllTalk, and the official OpenAI endpoint declare 24 kHz mono PCM.
+A custom OpenAI-compatible endpoint does not inherit that rate automatically.
+Speech Lab keeps the original PCM file for export and creates a temporary WAV
+for playback when the sample rate is known. Unknown-rate PCM can be exported;
+choose WAV from the provider for playback.
+
+On macOS, Opus/Ogg playback uses **FFplay** (included with FFmpeg). If FFplay
+is unavailable, choose WAV or another format supported by the system player.
+
 ### TTS Settings
 
 Configure default TTS options:
@@ -698,31 +715,25 @@ draft.
 pipeline) can play some responses live through the audio device instead of
 waiting on a finished file.
 
-*What streams today.* Only the audio.cpp adapter's response is eligible —
-its complete PCM16-WAV body validates as a playable stream. tldw_chatbook
-still writes that response to a temporary artifact exactly as before, but
-the instant it validates, playback moves to the live device and the
-now-redundant temp file is discarded immediately instead of being kept for
-file-based playback. That makes playback interruptible at the device — a
-new capture or a new utterance cuts audio within roughly two audio blocks
-instead of waiting on a file — and leaves nothing on disk to replay or
-export for that turn. Latency to first sound is unchanged: audio.cpp still
-delivers one complete WAV per request, not incremental chunks, so there is
-no "starts talking sooner" win here, only the interruptibility one.
+*What streams today.* A complete, validated PCM16-WAV response (including
+native audio.cpp) can use the live sink. Explicitly selected raw PCM can also
+stream when the response declares its sample rate: Kokoro, Chatterbox, Higgs,
+ElevenLabs, AllTalk, and official OpenAI responses now provide that metadata.
+Custom OpenAI-compatible PCM responses with an unknown rate remain ineligible.
+The default spoken-feedback format is unchanged; selecting a provider does not
+automatically switch the request to PCM. TASK-1880's caller-scoped format
+selection remains separate work.
 
-*What still falls back byte-identically to the pre-streaming path* — same
-temp file, same file-based playback, same everything:
+Complete WAV delivery still waits for generation to finish before playback.
+Raw PCM can begin while supported backends deliver samples. The live sink
+makes playback interruptible at the device rather than waiting on a player
+process. A new capture or utterance cuts audio within roughly two audio blocks.
 
-- Every legacy-bridge provider (openai, elevenlabs, kokoro, chatterbox,
-  alltalk, higgs, ...) — that bridge never populates a response sample
-  rate, and without one the sink cannot open. Unblocking these is a filed,
-  three-leg follow-up (TASK-1880) (plumb a sample rate onto legacy-bridge responses,
-  add a caller-scoped raw-PCM request option, and add a PCM-safe legacy
-  fallback) — none of it has shipped yet, so do not expect these providers
-  to stream.
-- Any compressed format (MP3, Opus, AAC, FLAC).
-- `sounddevice` not installed, or the sink otherwise unavailable.
-- A device failure at open or mid-stream.
+*What uses file playback.* Compressed formats (MP3, Opus, AAC, FLAC), unavailable
+`sounddevice`, and device failures use the file-player path. Known-rate raw PCM
+is wrapped in a temporary WAV for that fallback; its original response and
+Speech Lab export stay PCM. Unknown-rate PCM is refused for playback instead
+of being handed to a file player as an untyped byte stream.
 
 *Numbers.* Playback becomes audible once 300 ms of audio is buffered; an
 interrupting stop reaches silence within 2 audio blocks — about 40 ms at

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2192,8 +2192,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 31,
-      "diagnostic_digest": "9fe57d979b3f9ac82ffd",
+      "call_count": 32,
+      "diagnostic_digest": "ff0b29f6200d8c292620",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/audio_player.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2227,8 +2227,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 62,
-      "diagnostic_digest": "7cb62ef6e2c77f418f78",
+      "call_count": 58,
+      "diagnostic_digest": "63af54825bc82c36865a",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/chatterbox.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2255,8 +2255,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 97,
-      "diagnostic_digest": "add1172bc1bb0571dce6",
+      "call_count": 92,
+      "diagnostic_digest": "15a2bc7a4e501acc7bfd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/TTS/backends/higgs.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -9058,21 +9058,21 @@
     {
       "candidates": [
         {
+          "call_digest": "bf464b04876b618b",
+          "method": "warning",
+          "path_expressions": [
+            "reference_audio_path"
+          ],
+          "scope": "ChatterboxTTSBackend._generate_speech_stream",
+          "status": "legacy_unreviewed"
+        },
+        {
           "call_digest": "bda1b91ff41bd04e",
           "method": "error",
           "path_expressions": [
             "wrapper_path"
           ],
           "scope": "ChatterboxTTSBackend._initialize_isolated_process",
-          "status": "legacy_unreviewed"
-        },
-        {
-          "call_digest": "bf464b04876b618b",
-          "method": "warning",
-          "path_expressions": [
-            "reference_audio_path"
-          ],
-          "scope": "ChatterboxTTSBackend.generate_speech_stream",
           "status": "legacy_unreviewed"
         },
         {
@@ -9167,6 +9167,24 @@
           "status": "legacy_unreviewed"
         },
         {
+          "call_digest": "0c2aa89993f5be7b",
+          "method": "info",
+          "path_expressions": [
+            "engine_kwargs.get('model_name_or_path')"
+          ],
+          "scope": "HiggsAudioTTSBackend._load_model",
+          "status": "legacy_unreviewed"
+        },
+        {
+          "call_digest": "9eb058bae2f26bd1",
+          "method": "info",
+          "path_expressions": [
+            "engine_kwargs.get('audio_tokenizer_name_or_path', 'default')"
+          ],
+          "scope": "HiggsAudioTTSBackend._load_model",
+          "status": "legacy_unreviewed"
+        },
+        {
           "call_digest": "df4b0ebd5ff63648",
           "method": "info",
           "path_expressions": [
@@ -9209,24 +9227,6 @@
             "self.model_path"
           ],
           "scope": "HiggsAudioTTSBackend.initialize",
-          "status": "legacy_unreviewed"
-        },
-        {
-          "call_digest": "0c2aa89993f5be7b",
-          "method": "info",
-          "path_expressions": [
-            "engine_kwargs.get('model_name_or_path')"
-          ],
-          "scope": "HiggsAudioTTSBackend.load_model",
-          "status": "legacy_unreviewed"
-        },
-        {
-          "call_digest": "9eb058bae2f26bd1",
-          "method": "info",
-          "path_expressions": [
-            "engine_kwargs.get('audio_tokenizer_name_or_path', 'default')"
-          ],
-          "scope": "HiggsAudioTTSBackend.load_model",
           "status": "legacy_unreviewed"
         }
       ],
@@ -11491,6 +11491,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1348,
-    "task_494_calls": 7679
+    "task_494_calls": 7671
   }
 }

--- a/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
@@ -88,9 +88,10 @@ repeat run after the Qodo fixes; all six complete transcripts passed again.
 - Red-to-green evidence includes real container truncation, codec enum/muxer
   failures, cancellation ownership, typed limits, empty results, missing native
   selection IDs, raw PCM fallback, and macOS Opus/process completion.
-- Targeted new Python files pass full Ruff; all changed files pass syntax and
-  undefined-name checks and formatting. Legacy lint debt was compared with HEAD;
-  no new diagnostics were introduced.
+- New Python files pass full Ruff. Changed Python files pass syntax and
+  undefined-name checks; changed production files and new test modules pass
+  formatting. Existing test-formatting and lint debt were compared with the
+  baseline; no new diagnostics were introduced.
 - Diagnostic statement review removed obsolete Chatterbox/Higgs messages and
   added only fixed Opus guidance plus a numeric player exit code. No new logging
   destination or user-content interpolation was added. The diagnostic inventory
@@ -115,7 +116,7 @@ regressions pass after this fix.
 The fetched dev base also exceeded its CSS budget before this PR's changes:
 804,241 bytes versus 804,000. The CSS files in the original PR matched dev.
 Shortening an existing explanatory comment removes 497 bytes from the boot
-bundle, yielding 803,744 bytes. Both the source and generated bundle have
+CSS total, yielding 803,744 bytes. Both the source and generated bundle have
 identical non-comment CSS to HEAD. No rule or budget constant changed; ADR-097
 permits shedding this existing boot cost. The CSS budget regression passes.
 
@@ -158,3 +159,27 @@ ordering test that relied on five event-loop yields while its fake player could
 already finish. Explicit admission/finish events make that assertion
 deterministic; the entire utterance module and new failure module then passed
 38 tests. This fixture repair does not alter production behavior.
+
+The utterance module now awaits fixture cleanup before interpreter teardown;
+its final 38-test run exits without secure-delete shutdown messages. The old
+event-test file has unchanged inherited formatting debt, and no new lint
+diagnostics were introduced.
+
+
+## Integration gates
+
+The reviewed source revision `e208c06b53` passed PR Fast Lane, derived artifacts,
+UI latency, CSS reproducibility, backlog IDs and Linux/macOS/Windows import
+evidence. All eight Qodo threads have fix/evidence replies and are resolved;
+Qodo reports zero unresolved bugs or rule violations. TASK-32076 is Done.
+The task-record revision rebased onto `28d73ffece` preserved the tested runtime
+and test trees and passed every hosted check as `46156a9565`. Dev then advanced
+with PR #2522, causing a conflict only between appended lesson entries. Both
+entries are preserved on the subsequent rebase onto `e222813571`.
+
+TTS runtime, Speech UI, TTS event-handler and TTS test trees are unchanged.
+The upstream logging/app changes passed an additional **387 targeted tests**,
+including error reporting, spoken feedback, mounted playback, logging and
+startup. All six preflight checks pass. The upstream CSS comment reduction
+lowers the boot-parsed CSS total to **803,443 / 804,000 bytes**; non-comment CSS
+is unchanged. PR checks must remain green before merge.

--- a/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
@@ -1,0 +1,105 @@
+# TTS backend delivery parity — 2026-09-08
+
+TASK-32076 follows the Kokoro repair in PR #2512. It checks all seven registered
+providers for the same effective-selection, whole-utterance, format, and
+operation-ownership failures. This is delivery verification, not a claim that
+all optional neural models or hosted accounts were available for live inference.
+
+## Confirmed defects repaired
+
+- Switching from a legacy provider to audio.cpp copied foreign model/voice IDs
+  into native selection and disabled Generate. Saved same-provider exact pins
+  still refuse unavailable models/voices; provider switching preserves ownership.
+- Chatterbox concatenated WAV containers for long and streaming replies, so
+  decoders stopped at the first chunk. It also called a nonexistent conversion
+  method, ignored `stream=False`, reused a subprocess's canceled response, and
+  retained changed fallback settings after cancellation. WAV encoding no longer
+  depends on TorchCodec. Retried attempts cannot replay partially delivered PCM.
+- ElevenLabs WAV responses were raw PCM; AAC/FLAC/Opus used unsupported wire
+  identifiers. WAV/AAC/FLAC now convert documented 24 kHz PCM; Opus uses its
+  documented wire enum. AllTalk's requested PCM is converted from server WAV to
+  signed 16-bit 24 kHz mono audio.
+- Shared conversion used invalid FFmpeg output format names for raw PCM and AAC.
+- Higgs published error strings or empty results as audio, silently skipped
+  missing dialogue sections, and released task ownership while native threads
+  were still loading or generating. Failures now propagate; cleanup retains
+  threads and loading/generation serialize appropriately.
+- Explicit legacy PCM lacked rate metadata and could reach a file player as raw
+  bytes. Known-rate PCM now has honest metadata and a temporary WAV playback
+  copy. Speech Lab retains the raw export; unknown custom OpenAI PCM is refused
+  for playback. TASK-1880's default/caller-scoped PCM selection remains separate.
+- macOS afplay returned exit code 0 after about two seconds for a valid
+  5.717-second Opus file. Opus now uses the existing FFplay player. Completion
+  checks both the exact process owner and exit status.
+- Buffered operations are bounded and return nonretryable shortening guidance;
+  HTTP success with an empty body is rejected by the remote backends.
+
+## Backend evidence and limits
+
+| Provider | Exercised evidence | Live provider inference in this follow-up |
+| --- | --- | --- |
+| Chatterbox | Repeated six-format single/chunked/streaming output; exact decoded frames; real subprocess protocol; cancellation, retry, limits | Unavailable: chatterbox-tts/model weights absent; inference replaced with deterministic tensors |
+| Higgs | Repeated six-format output; complete dialogue; errors/nonfinite samples; retained loading/generation threads | Unavailable: Boson model/runtime absent; inference replaced with deterministic arrays |
+| ElevenLabs | Documented wire codecs through HTTP transport; six decoded formats; repeated requests; empty/limit errors | No authenticated remote inference performed |
+| AllTalk | Real WAV-to-PCM conversion/resampling; repeated requests; HTTP/error contracts | No configured/running AllTalk server |
+| OpenAI / compatible | Existing real loopback HTTP server and endpoint tests; body delivery, empty errors, official-vs-custom PCM metadata | No authenticated OpenAI inference performed |
+| audio.cpp | Real adapter/catalog/response validation with transport fixtures; fresh and repeated mounted admission; switching/pinned-selection controls | No running audio.cpp service or usable native model found |
+| Kokoro | Existing encoded-output/limit regressions; provider-switch and explicit-language isolation; PCM metadata/playback | Prior PR #2512 supplied real local ONNX playback; this follow-up uses it as a recorded speech fixture |
+
+All seven providers cross the mounted Speech Lab Generate admission path twice.
+The UI matrix also checks native/legacy round trips, exact missing Global/Studio
+pins, and default reply resolution. HTTP/model/device fixtures are identified in
+test docstrings; those tests do not prove hosted-provider availability.
+
+## Playback evidence
+
+The local harness passes a previously generated Kokoro sentence through the real
+backend delivery/encoding code and the actual macOS audio device. Model inference
+and remote HTTP responses use that recorded speech as their only fixture. The
+entire clip is decoded and independently transcribed after playback.
+
+Expected sentence: “This second reply confirms that repeated speech generation
+and playback complete successfully.” Source duration: 5.717 seconds.
+
+| Backend delivery path | Format | Full decode | Player | Player elapsed / exit | Complete transcript |
+| --- | --- | --- | --- | --- | --- |
+| Chatterbox streaming tensors | WAV | 5.717 s | afplay | 6.608 s / 0 | Yes |
+| Higgs arrays | MP3 | 5.717 s | afplay | 6.319 s / 0 | Yes |
+| ElevenLabs PCM conversion | AAC (ADTS) | 5.760 s | afplay | 6.838 s / 0 | Yes |
+| ElevenLabs PCM conversion | FLAC | 5.717 s | afplay | 6.558 s / 0 | Yes |
+| AllTalk WAV conversion + playback wrapper | PCM / WAV | 5.717 s | afplay | 6.578 s / 0 | Yes |
+| OpenAI-compatible body delivery | Opus | 5.717 s | ffplay | 6.133 s / 0 | Yes |
+
+Local evidence: `/private/tmp/tts-backend-parity-playback/evidence.json`, audio
+files in its `artifacts/` directory, and
+`/private/tmp/validate-tts-backend-parity-playback.py`. These are validation
+artifacts, not application data or bundled model weights.
+
+## Automated checks
+
+- Python 3.12 main targeted backend/Console/codec cohort: **744 passed, 1 skipped**
+  (the skip is the optional installed-Chatterbox integration test).
+- Final Chatterbox delivery/cancellation/empty-stream cohort: **30 passed**.
+- Python 3.13 shared backend/provider UI/PCM/recovery cohort: **115 passed,
+  16 skipped** (Higgs fixtures require Torch, absent in that environment).
+- Python 3.13 independent PCM/ownership and adjacent UI/lifecycle cohorts:
+  **116 + 242 + 129 passed**, with overlapping coverage relative to the above.
+- Red-to-green evidence includes real container truncation, codec enum/muxer
+  failures, cancellation ownership, typed limits, empty results, missing native
+  selection IDs, raw PCM fallback, and macOS Opus/process completion.
+- Targeted new Python files pass full Ruff; all changed files pass syntax and
+  undefined-name checks and formatting. Legacy lint debt was compared with HEAD;
+  no new diagnostics were introduced.
+- Diagnostic statement review removed obsolete Chatterbox/Higgs messages and
+  added only fixed Opus guidance plus a numeric player exit code. No new logging
+  destination or user-content interpolation was added. The diagnostic inventory
+  was regenerated after that review.
+
+No full repository test sweep was requested or run. Existing dependency warnings
+and the Studio test's unawaited coroutine warning are documented in the local
+logs. Linux/Windows device playback and unavailable live provider inference
+remain unverified.
+
+ADR required: no. Existing ADRs 023, 039, and 040 govern these repaired delivery,
+settings-ownership, and current-result contracts. No new provider/runtime or
+storage boundary was introduced.

--- a/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
@@ -103,3 +103,17 @@ remain unverified.
 ADR required: no. Existing ADRs 023, 039, and 040 govern these repaired delivery,
 settings-ownership, and current-result contracts. No new provider/runtime or
 storage boundary was introduced.
+
+## PR boot-guard follow-up
+
+CI exposed one extra boot-time module from the new PCM helper. Its imports now
+run only when PCM playback is requested; the existing census also pins the helper
+as absent at `_ui_ready`. The module budget is unchanged. All 4 census tests and 94 PCM/UI/streaming
+regressions pass after this fix.
+
+The fetched dev base also exceeded its CSS budget before this PR's changes:
+804,241 bytes versus 804,000. The CSS files in the original PR matched dev.
+Shortening an existing explanatory comment removes 497 bytes from the boot
+bundle, yielding 803,744 bytes. Both the source and generated bundle have
+identical non-comment CSS to HEAD. No rule or budget constant changed; ADR-097
+permits shedding this existing boot cost. The CSS budget regression passes.

--- a/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md
@@ -63,17 +63,18 @@ and playback complete successfully.” Source duration: 5.717 seconds.
 
 | Backend delivery path | Format | Full decode | Player | Player elapsed / exit | Complete transcript |
 | --- | --- | --- | --- | --- | --- |
-| Chatterbox streaming tensors | WAV | 5.717 s | afplay | 6.608 s / 0 | Yes |
-| Higgs arrays | MP3 | 5.717 s | afplay | 6.319 s / 0 | Yes |
-| ElevenLabs PCM conversion | AAC (ADTS) | 5.760 s | afplay | 6.838 s / 0 | Yes |
-| ElevenLabs PCM conversion | FLAC | 5.717 s | afplay | 6.558 s / 0 | Yes |
-| AllTalk WAV conversion + playback wrapper | PCM / WAV | 5.717 s | afplay | 6.578 s / 0 | Yes |
-| OpenAI-compatible body delivery | Opus | 5.717 s | ffplay | 6.133 s / 0 | Yes |
+| Chatterbox streaming tensors | WAV | 5.717 s | afplay | 6.693 s / 0 | Yes |
+| Higgs arrays | MP3 | 5.717 s | afplay | 6.870 s / 0 | Yes |
+| ElevenLabs PCM conversion | AAC (ADTS) | 5.760 s | afplay | 6.882 s / 0 | Yes |
+| ElevenLabs PCM conversion | FLAC | 5.717 s | afplay | 6.611 s / 0 | Yes |
+| AllTalk WAV conversion + playback wrapper | PCM / WAV | 5.717 s | afplay | 6.575 s / 0 | Yes |
+| OpenAI-compatible body delivery | Opus | 5.717 s | ffplay | 6.046 s / 0 | Yes |
 
-Local evidence: `/private/tmp/tts-backend-parity-playback/evidence.json`, audio
+Local evidence: `/private/tmp/tts-backend-parity-qodo-playback/evidence.json`, audio
 files in its `artifacts/` directory, and
-`/private/tmp/validate-tts-backend-parity-playback.py`. These are validation
-artifacts, not application data or bundled model weights.
+`/private/tmp/validate-tts-backend-qodo-playback.py`. These are validation
+artifacts, not application data or bundled model weights. The table records the
+repeat run after the Qodo fixes; all six complete transcripts passed again.
 
 ## Automated checks
 
@@ -117,3 +118,43 @@ Shortening an existing explanatory comment removes 497 bytes from the boot
 bundle, yielding 803,744 bytes. Both the source and generated bundle have
 identical non-comment CSS to HEAD. No rule or budget constant changed; ADR-097
 permits shedding this existing boot cost. The CSS budget regression passes.
+
+
+## Qodo review follow-up
+
+All eight review comments were checked against the actual callers. Three runtime
+defects were confirmed: a nonzero player exit was ignored by both completion
+consumers; Higgs cleanup returned before native inference finished; and the Higgs
+buffer check undercounted float64 arrays.
+
+- Speech Lab treats player ERROR as terminal, releases the playback copy and
+  lease, resets transport controls, and reports failure. The legacy completion
+  poll rejects ERROR/IDLE immediately and verifies stop, current file, and state
+  again at its deadline. Only a still-playing current clip retains the existing
+  estimated-duration fallback; failed playback never invokes success.
+- Higgs owns one retained cleanup task through caller cancellation. The adapter's
+  foreground deadline stays bounded; cleanup releases the model after native
+  work actually stops. Tests cross the real manager and host shutdown boundaries.
+- Higgs checks both source nbytes and the proposed float32 buffer before
+  finiteness/downmix/conversion, including exact float64 and float16 boundaries.
+- Application-path tests cover PCM conversion, canceled copying, exact release
+  ownership and copy deletion, plus mounted Opus playback through the actual
+  asynchronous and synchronous players with only process/device seams replaced.
+- Direct buffer-limit tests cover below/equal/above values and every public error
+  field. PCM protocol values now have descriptive names, and Chatterbox's public
+  streaming method documents its request and complete-file/raw-PCM yield contract.
+
+Higgs regressions went from 4 failures to 8 passing cases; its affected
+backend/manager/bridge cohort passed 148 tests. Shared limit/PCM checks passed
+43 tests. Playback failure regressions went from 8 failures to 17 passing cases through
+the real application paths. A fresh independent review of these fixes found no
+further actionable issues. All six derived preflight checks pass. The diagnostic
+statement review found no added or changed logging calls, and the inventory
+already matches exactly; no regeneration was necessary.
+
+Playback/lifecycle coverage passed all 304 distinct cases across the broad run
+and focused rerun. The broad run first passed 303 cases and exposed one old
+ordering test that relied on five event-loop yields while its fake player could
+already finish. Explicit admission/finish events make that assertion
+deterministic; the entire utterance module and new failure module then passed
+38 tests. This fixture repair does not alter production behavior.

--- a/Tests/Performance/test_ui_ready_module_census.py
+++ b/Tests/Performance/test_ui_ready_module_census.py
@@ -129,6 +129,8 @@ ABSENT_AT_READY_PREFIXES = (
     "tldw_chatbook.Tool_Packs",
 )
 ABSENT_AT_READY_MODULES = (
+    # PCM wrapping belongs to requested playback, not Console first paint.
+    "tldw_chatbook.TTS.pcm_playback",
     # Inspect's Environment implementation is first-open work, not closed-rail boot.
     "tldw_chatbook.Chat.console_environment_state",
     "tldw_chatbook.UI.Console_Modules.environment",

--- a/Tests/TTS/test_audio_limits.py
+++ b/Tests/TTS/test_audio_limits.py
@@ -1,0 +1,36 @@
+"""The retained-audio limit accepts its boundary and exposes safe recovery data."""
+
+from uuid import UUID
+
+import pytest
+
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_limits import (
+    MAX_BUFFERED_AUDIO_BYTES,
+    check_buffered_audio_size,
+)
+
+
+@pytest.mark.parametrize(
+    "size", [0, MAX_BUFFERED_AUDIO_BYTES - 1, MAX_BUFFERED_AUDIO_BYTES]
+)
+def test_retained_audio_accepts_sizes_up_to_and_including_the_limit(size):
+    check_buffered_audio_size(size)
+
+
+@pytest.mark.parametrize(
+    "size", [MAX_BUFFERED_AUDIO_BYTES + 1, MAX_BUFFERED_AUDIO_BYTES * 2]
+)
+def test_oversized_audio_exposes_the_complete_nonretryable_error_contract(size):
+    with pytest.raises(TTSOperationError) as raised:
+        check_buffered_audio_size(size)
+
+    error = raised.value
+    assert error.code == "request_invalid"
+    assert str(error) == (
+        "Generated audio is too long to buffer. Shorten the text and try again."
+    )
+    assert error.retryable is False
+    assert error.recovery_action == "shorten_text"
+    assert len(error.operation_id) == 32
+    assert UUID(error.operation_id).version == 4

--- a/Tests/TTS/test_audio_player.py
+++ b/Tests/TTS/test_audio_player.py
@@ -17,15 +17,21 @@ legacy-path (the default response format for every provider except
 on Linux and Windows -- reply speech entirely silent on two of three
 platforms.
 """
+
 from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from tldw_chatbook.TTS.audio_player import SimpleAudioPlayer
+from tldw_chatbook.TTS.audio_player import (
+    AudioPlayerInfo,
+    PlaybackState,
+    SimpleAudioPlayer,
+)
 
 
 def test_play_does_not_raise_unbound_local_error_on_a_non_darwin_afplay_path(
-    tmp_path, monkeypatch,
+    tmp_path,
+    monkeypatch,
 ):
     """Deterministic regardless of the host OS this test actually runs on:
     forces the player instance into a non-Darwin/afplay shape directly
@@ -57,3 +63,66 @@ def test_play_does_not_raise_unbound_local_error_on_a_non_darwin_afplay_path(
         "time` collision this pins (task-4 review N1)"
     )
     assert player.get_current_file() == audio_file
+
+
+def test_macos_opus_uses_a_compatible_player(tmp_path, monkeypatch):
+    player = SimpleAudioPlayer()
+    player._system = "Darwin"
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.shutil.which",
+        lambda name: "/test/ffplay" if name == "ffplay" else None,
+    )
+    commands = []
+
+    def spawn(command, **kwargs):
+        commands.append(command)
+        process = MagicMock()
+        process.poll.return_value = 0
+        process.wait.return_value = 0
+        return process
+
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_player.subprocess.Popen", spawn)
+    for suffix in ("opus", "wav"):
+        path = tmp_path / f"reply.{suffix}"
+        path.write_bytes(b"fixture")
+        assert player.play(path)
+    assert commands[0][0] == "/test/ffplay"
+    assert "-autoexit" in commands[0] and "-nodisp" in commands[0]
+    assert commands[1][0] == "/usr/bin/afplay"
+    player.cleanup()
+
+
+def test_macos_opus_without_compatible_player_refuses_playback(tmp_path, monkeypatch):
+    player = SimpleAudioPlayer()
+    player._system = "Darwin"
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_player.shutil.which", lambda _: None)
+    popen = MagicMock()
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_player.subprocess.Popen", popen)
+    path = tmp_path / "reply.opus"
+    path.write_bytes(b"fixture")
+    assert not player.play(path)
+    popen.assert_not_called()
+
+
+def test_player_nonzero_exit_is_failure():
+    player = SimpleAudioPlayer()
+    failed = MagicMock()
+    failed.wait.return_value = 1
+    player._current = AudioPlayerInfo(process=failed, state=PlaybackState.PLAYING)
+    player._monitor_playback()
+    assert player.get_state() == PlaybackState.ERROR
+
+
+def test_previous_monitor_cannot_finish_next_clip():
+    player = SimpleAudioPlayer()
+    old, new = MagicMock(), MagicMock()
+    player._current = AudioPlayerInfo(process=old, state=PlaybackState.PLAYING)
+
+    def wait():
+        player._current = AudioPlayerInfo(process=new, state=PlaybackState.PLAYING)
+        return 0
+
+    old.wait.side_effect = wait
+    player._monitor_playback()
+    assert player.get_state() == PlaybackState.PLAYING
+    assert player._current.process is new

--- a/Tests/TTS/test_backend_audio_formats.py
+++ b/Tests/TTS/test_backend_audio_formats.py
@@ -1,0 +1,394 @@
+"""Decode actual backend bytes; transport fixtures replace only provider inference."""
+
+import asyncio
+import io
+import json
+import threading
+import wave
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.audio_service import AudioService
+from tldw_chatbook.TTS.backends.alltalk import AllTalkTTSBackend
+from tldw_chatbook.TTS.backends.elevenlabs import ElevenLabsTTSBackend
+from tldw_chatbook.TTS.backends.higgs import HiggsAudioTTSBackend
+from tldw_chatbook.TTS.backends.openai import OpenAITTSBackend
+
+np = pytest.importorskip("numpy")
+AudioSegment = pytest.importorskip("pydub").AudioSegment
+
+
+def _pcm(rate=24000):
+    times = np.arange(rate, dtype=np.float64) / rate
+    return (np.sin(2 * np.pi * 440 * times) * 8000).astype("<i2").tobytes()
+
+
+def _wav(pcm, rate=24000):
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as output:
+        output.setparams((1, 2, rate, 0, "NONE", "not compressed"))
+        output.writeframes(pcm)
+    return buffer.getvalue()
+
+
+def _assert_duration(audio, audio_format, seconds=1.0):
+    if audio_format == "pcm":
+        assert len(audio) == pytest.approx(int(seconds * 24000 * 2), abs=2)
+        assert not audio.startswith(b"RIFF")
+    else:
+        # Opus is carried in Ogg; ffmpeg has no "opus" input demuxer.
+        decoded = AudioSegment.from_file(
+            io.BytesIO(audio), format="ogg" if audio_format == "opus" else audio_format
+        )
+        assert len(decoded) / 1000 == pytest.approx(seconds, abs=0.10)
+        assert decoded.rms > 0
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("audio_format", ["pcm", "aac", "wav", "mp3", "flac", "opus"])
+async def test_audio_service_converts_one_complete_utterance(audio_format):
+    pcm = _pcm()
+    result = await AudioService().convert_audio(
+        _wav(pcm), audio_format, source_format="wav", sample_rate=24000
+    )
+    _assert_duration(result, audio_format)
+    if audio_format == "pcm":
+        assert result == pcm
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("audio_format", ["wav", "pcm", "aac", "flac", "opus", "mp3"])
+async def test_elevenlabs_delivers_the_requested_format_repeatedly(audio_format):
+    """The fake server uses documented wire codecs, not the requested UI label."""
+
+    async def handle(request):
+        wire_format = request.url.params["output_format"]
+        if wire_format.startswith("pcm_"):
+            data = _pcm(int(wire_format.split("_")[1]))
+        elif wire_format.startswith("mp3_"):
+            data = await AudioService().convert_audio(
+                _wav(_pcm()), "mp3", source_format="wav"
+            )
+        elif wire_format.startswith("opus_48000_"):
+            data = await AudioService().convert_audio(
+                _wav(_pcm()), "opus", source_format="wav"
+            )
+        else:
+            return httpx.Response(422, json={"detail": "unsupported output format"})
+        return httpx.Response(200, content=data)
+
+    backend = ElevenLabsTTSBackend({"ELEVENLABS_API_KEY": "test-only"})
+    await backend.client.aclose()
+    backend.client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    try:
+        for _ in range(2):
+            request = OpenAISpeechRequest(
+                model="eleven_multilingual_v2",
+                voice="21m00Tcm4TlvDq8ikWAM",
+                input="An entire sentence.",
+                response_format=audio_format,
+            )
+            data = b"".join(
+                [chunk async for chunk in backend.generate_speech_stream(request)]
+            )
+            _assert_duration(data, audio_format)
+    finally:
+        await backend.close()
+
+
+@pytest.mark.asyncio
+async def test_alltalk_pcm_is_raw_audio_at_the_declared_rate():
+    def handle(request):
+        assert json.loads(request.content)["response_format"] == "wav"
+        return httpx.Response(200, content=_wav(_pcm(22050), 22050))
+
+    backend = AllTalkTTSBackend({"ALLTALK_TTS_URL": "http://127.0.0.1:7851"})
+    await backend.client.aclose()
+    backend.client = httpx.AsyncClient(transport=httpx.MockTransport(handle))
+    try:
+        for _ in range(2):
+            request = OpenAISpeechRequest(
+                input="Complete reply.", voice="female_01.wav", response_format="pcm"
+            )
+            data = b"".join(
+                [chunk async for chunk in backend.generate_speech_stream(request)]
+            )
+            _assert_duration(data, "pcm")
+    finally:
+        await backend.close()
+
+
+@pytest.fixture
+def higgs_backend(tmp_path):
+    pytest.importorskip("torch")
+    backend = HiggsAudioTTSBackend(
+        {
+            "HIGGS_DEVICE": "cpu",
+            "HIGGS_VOICE_SAMPLES_DIR": str(tmp_path),
+            "HIGGS_TRACK_PERFORMANCE": False,
+        }
+    )
+    backend.model_loaded = True
+    backend._make_chat_ml_sample = lambda messages: messages
+    backend._prepare_messages = lambda *args: []
+    return backend
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("result", ["exception", "missing", "empty", "nonfinite"])
+async def test_higgs_generation_failure_never_becomes_audio(higgs_backend, result):
+    def infer(*args, **kwargs):
+        if result == "exception":
+            raise RuntimeError("private provider diagnostic")
+        samples = {
+            "missing": None,
+            "empty": np.array([], dtype=np.float32),
+            "nonfinite": np.array([np.nan], dtype=np.float32),
+        }[result]
+        return SimpleNamespace(audio=samples)
+
+    higgs_backend._invoke_serve_engine_generate = infer
+    chunks = []
+    try:
+        with pytest.raises((ValueError, RuntimeError)):
+            async for chunk in higgs_backend.generate_speech_stream(
+                OpenAISpeechRequest(
+                    input="Complete reply.",
+                    voice="professional_female",
+                    response_format="wav",
+                )
+            ):
+                chunks.append(chunk)
+        assert chunks == []
+    finally:
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+async def test_higgs_completed_generation_leaves_no_shutdown_waiters(higgs_backend):
+    higgs_backend._invoke_serve_engine_generate = lambda *a, **k: SimpleNamespace(
+        audio=np.frombuffer(_pcm(), dtype="<i2").astype(np.float32) / 32768
+    )
+    before = asyncio.all_tasks()
+    try:
+        for _ in range(2):
+            audio = b"".join(
+                [
+                    part
+                    async for part in higgs_backend.generate_speech_stream(
+                        OpenAISpeechRequest(
+                            input="Hello.",
+                            voice="professional_female",
+                            response_format="wav",
+                        )
+                    )
+                ]
+            )
+            _assert_duration(audio, "wav")
+        assert not [task for task in asyncio.all_tasks() - before if not task.done()]
+    finally:
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+async def test_higgs_cancel_keeps_inference_owned_until_it_finishes(higgs_backend):
+    started = threading.Event()
+    finish = threading.Event()
+
+    def infer(*args, **kwargs):
+        started.set()
+        assert finish.wait(5)
+        return SimpleNamespace(audio=np.zeros(24000, dtype=np.float32))
+
+    higgs_backend._invoke_serve_engine_generate = infer
+
+    async def drain():
+        return [
+            part
+            async for part in higgs_backend.generate_speech_stream(
+                OpenAISpeechRequest(
+                    input="Hello.", voice="professional_female", response_format="wav"
+                )
+            )
+        ]
+
+    task = asyncio.create_task(drain())
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert higgs_backend._active_tasks
+        assert not task.done()
+    finally:
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["elevenlabs", "alltalk"])
+async def test_remote_buffer_limit_preserves_typed_nonretryable_failure(
+    provider, monkeypatch
+):
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_limits.MAX_BUFFERED_AUDIO_BYTES", 1000)
+    backend = (
+        ElevenLabsTTSBackend({"ELEVENLABS_API_KEY": "test-only"})
+        if provider == "elevenlabs"
+        else AllTalkTTSBackend({"ALLTALK_TTS_URL": "http://127.0.0.1:7851"})
+    )
+    await backend.client.aclose()
+    backend.client = httpx.AsyncClient(
+        transport=httpx.MockTransport(
+            lambda request: httpx.Response(200, content=_wav(_pcm()))
+        )
+    )
+    req = OpenAISpeechRequest(
+        input="Hello.",
+        voice="default",
+        response_format="wav" if provider == "elevenlabs" else "pcm",
+    )
+    try:
+        with pytest.raises(TTSOperationError) as error:
+            _ = [part async for part in backend.generate_speech_stream(req)]
+        assert not error.value.retryable
+        assert error.value.recovery_action == "shorten_text"
+    finally:
+        await backend.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["elevenlabs", "alltalk", "openai"])
+async def test_empty_remote_success_is_rejected(provider):
+    backend = (
+        ElevenLabsTTSBackend({"ELEVENLABS_API_KEY": "test-only"})
+        if provider == "elevenlabs"
+        else OpenAITTSBackend({"OPENAI_API_KEY": "test-only"})
+        if provider == "openai"
+        else AllTalkTTSBackend({"ALLTALK_TTS_URL": "http://127.0.0.1:7851"})
+    )
+    await backend.client.aclose()
+    backend.client = httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, content=b""))
+    )
+    try:
+        with pytest.raises(ValueError):
+            _ = [
+                part
+                async for part in backend.generate_speech_stream(
+                    OpenAISpeechRequest(
+                        input="Hello.", voice="default", response_format="mp3"
+                    )
+                )
+            ]
+    finally:
+        await backend.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("bad_section", [False, True])
+async def test_higgs_multi_speaker_delivers_all_sections_or_fails(
+    higgs_backend, bad_section
+):
+    calls = 0
+
+    def infer(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return SimpleNamespace(
+            audio=None
+            if bad_section and calls == 2
+            else (np.frombuffer(_pcm(), dtype="<i2").astype(np.float32) / 32768)
+        )
+
+    higgs_backend._invoke_serve_engine_generate = infer
+
+    async def generate():
+        return b"".join(
+            [
+                part
+                async for part in higgs_backend.generate_speech_stream(
+                    OpenAISpeechRequest(
+                        input="Speaker1|||Hello. Speaker2|||Goodbye.",
+                        voice="professional_female",
+                        response_format="wav",
+                    )
+                )
+            ]
+        )
+
+    try:
+        if bad_section:
+            with pytest.raises(ValueError):
+                await generate()
+        else:
+            _assert_duration(await generate(), "wav", 2.0)
+    finally:
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel", [False, True])
+async def test_higgs_model_load_retains_thread_and_has_no_shutdown_waiter(
+    higgs_backend, cancel
+):
+    entered = threading.Event()
+    finish = threading.Event()
+
+    class Engine:
+        def __init__(self, **kwargs):
+            entered.set()
+            assert finish.wait(5)
+
+    higgs_backend.model_loaded = False
+    higgs_backend._boson_multimodal = SimpleNamespace()
+    higgs_backend._higgs_serve_engine = Engine
+    before = asyncio.all_tasks()
+    task = asyncio.create_task(higgs_backend.load_model())
+    try:
+        assert await asyncio.to_thread(entered.wait, 2)
+        if cancel:
+            task.cancel()
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert higgs_backend._active_tasks
+            assert not task.done()
+    finally:
+        finish.set()
+        if cancel:
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            await task
+        await higgs_backend.close()
+    assert not [task for task in asyncio.all_tasks() - before if not task.done()]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("audio_format", ["wav", "mp3", "aac", "flac", "opus", "pcm"])
+async def test_higgs_repeated_complete_formats(higgs_backend, audio_format):
+    higgs_backend._invoke_serve_engine_generate = lambda *a, **k: SimpleNamespace(
+        audio=np.frombuffer(_pcm(), dtype="<i2").astype(np.float32) / 32768
+    )
+    try:
+        for _ in range(2):
+            data = b"".join(
+                [
+                    part
+                    async for part in higgs_backend.generate_speech_stream(
+                        OpenAISpeechRequest(
+                            input="Hello.",
+                            voice="professional_female",
+                            response_format=audio_format,
+                        )
+                    )
+                ]
+            )
+            _assert_duration(data, audio_format)
+    finally:
+        await higgs_backend.close()

--- a/Tests/TTS/test_backend_audio_formats.py
+++ b/Tests/TTS/test_backend_audio_formats.py
@@ -17,6 +17,8 @@ from tldw_chatbook.TTS.backends.alltalk import AllTalkTTSBackend
 from tldw_chatbook.TTS.backends.elevenlabs import ElevenLabsTTSBackend
 from tldw_chatbook.TTS.backends.higgs import HiggsAudioTTSBackend
 from tldw_chatbook.TTS.backends.openai import OpenAITTSBackend
+from tldw_chatbook.TTS.legacy_bridge import LegacyBackendHost
+from tldw_chatbook.TTS.TTS_Backends import TTSBackendManager
 
 np = pytest.importorskip("numpy")
 AudioSegment = pytest.importorskip("pydub").AudioSegment
@@ -228,6 +230,175 @@ async def test_higgs_cancel_keeps_inference_owned_until_it_finishes(higgs_backen
         finish.set()
         with pytest.raises(asyncio.CancelledError):
             await task
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+async def test_higgs_manager_close_cannot_retire_running_inference(
+    higgs_backend, monkeypatch
+):
+    started = threading.Event()
+    finish = threading.Event()
+    engine = object()
+    higgs_backend.serve_engine = engine
+    manager = TTSBackendManager({})
+    manager._backends["local_higgs_v2"] = higgs_backend
+    manager._initialized_backends.add("local_higgs_v2")
+
+    def infer(*args, **kwargs):
+        started.set()
+        assert finish.wait(5)
+        return SimpleNamespace(audio=np.zeros(16, dtype=np.float32))
+
+    higgs_backend._invoke_serve_engine_generate = infer
+    original_wait = asyncio.wait
+
+    async def shortened_wait(tasks, *, timeout=None, **kwargs):
+        # Exercise the old five-second timeout without holding the test open.
+        return await original_wait(
+            tasks, timeout=0 if timeout == 5.0 else timeout, **kwargs
+        )
+
+    monkeypatch.setattr(asyncio, "wait", shortened_wait)
+    generation = asyncio.create_task(higgs_backend._run_generation([]))
+    closing = None
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        closing = asyncio.create_task(manager.close_all_backends())
+        await asyncio.wait_for(higgs_backend._shutdown_event.wait(), timeout=1)
+        _, pending = await original_wait({closing}, timeout=0.02)
+
+        assert closing in pending
+        assert await manager.get_backend("local_higgs_v2") is higgs_backend
+        assert higgs_backend.serve_engine is engine
+        assert higgs_backend._active_tasks
+
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await generation
+        await closing
+        assert higgs_backend.serve_engine is None
+        assert not higgs_backend.model_loaded
+        assert manager.get_backend_info("local_higgs_v2") is None
+    finally:
+        finish.set()
+        await asyncio.gather(
+            generation,
+            *([closing] if closing is not None else []),
+            return_exceptions=True,
+        )
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+async def test_higgs_host_deadline_retains_manager_cleanup_until_native_work_finishes(
+    higgs_backend,
+):
+    started = threading.Event()
+    finish = threading.Event()
+    engine = object()
+    higgs_backend.serve_engine = engine
+    manager = TTSBackendManager({})
+    manager._backends["local_higgs_v2"] = higgs_backend
+    manager._initialized_backends.add("local_higgs_v2")
+    host = LegacyBackendHost(
+        provider_id="higgs",
+        app_config={},
+        manager_factory=lambda _: manager,
+        shutdown_timeout_seconds=0.01,
+    )
+
+    def infer(*args, **kwargs):
+        started.set()
+        assert finish.wait(5)
+        return SimpleNamespace(audio=np.zeros(16, dtype=np.float32))
+
+    higgs_backend._invoke_serve_engine_generate = infer
+
+    async def generate():
+        return [
+            part
+            async for part in host.generate(
+                "local_higgs_v2",
+                OpenAISpeechRequest(
+                    input="Hello.", voice="professional_female", response_format="pcm"
+                ),
+                None,
+            )
+        ]
+
+    generation = asyncio.create_task(generate())
+    try:
+        assert await asyncio.to_thread(started.wait, 2)
+        with pytest.raises(TimeoutError, match="manager did not close"):
+            await asyncio.wait_for(host.close(), timeout=1)
+
+        assert host._manager_close_task is not None
+        assert not host._manager_close_task.done()
+        assert await manager.get_backend("local_higgs_v2") is higgs_backend
+        assert higgs_backend.serve_engine is engine
+        assert not generation.done()
+
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await generation
+        with pytest.raises(asyncio.CancelledError):
+            await host._manager_close_task
+        assert higgs_backend.serve_engine is None
+        assert not higgs_backend.model_loaded
+        assert not higgs_backend._active_tasks
+    finally:
+        finish.set()
+        await asyncio.gather(generation, return_exceptions=True)
+        if host._manager_close_task is not None:
+            await asyncio.gather(host._manager_close_task, return_exceptions=True)
+        await higgs_backend.close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dtype", "shape", "oversized"),
+    [
+        (np.float64, (8,), False),
+        (np.float64, (9,), True),
+        (np.float64, (2, 4), False),
+        (np.float64, (2, 5), True),
+        (np.float16, (16,), False),
+        (np.float16, (17,), True),
+    ],
+)
+async def test_higgs_bounds_source_and_float32_audio_before_delivery(
+    higgs_backend, monkeypatch, dtype, shape, oversized
+):
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_limits.MAX_BUFFERED_AUDIO_BYTES", 64)
+    samples = np.full(shape, 0.25, dtype=dtype)
+    higgs_backend._invoke_serve_engine_generate = lambda *a, **k: SimpleNamespace(
+        audio=samples
+    )
+    chunks = []
+
+    async def generate():
+        async for part in higgs_backend.generate_speech_stream(
+            OpenAISpeechRequest(
+                input="Hello.", voice="professional_female", response_format="pcm"
+            )
+        ):
+            chunks.append(part)
+
+    try:
+        if oversized:
+            with pytest.raises(TTSOperationError) as caught:
+                await generate()
+            assert caught.value.code == "request_invalid"
+            assert not caught.value.retryable
+            assert caught.value.recovery_action == "shorten_text"
+            assert chunks == []
+        else:
+            await generate()
+            pcm = np.frombuffer(b"".join(chunks), dtype="<i2")
+            assert len(pcm) == shape[-1]
+            assert np.all(pcm == 8191)
+    finally:
         await higgs_backend.close()
 
 

--- a/Tests/TTS/test_chatterbox_audio_delivery.py
+++ b/Tests/TTS/test_chatterbox_audio_delivery.py
@@ -1,0 +1,340 @@
+"""Exercise real Chatterbox audio handling with only inference/IPC replaced."""
+
+import asyncio
+import base64
+import io
+import json
+import subprocess
+import sys
+import threading
+import wave
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.backends.chatterbox import ChatterboxTTSBackend
+
+torch = pytest.importorskip("torch")
+AudioSegment = pytest.importorskip("pydub").AudioSegment
+
+
+def tone(frequency=440):
+    return torch.sin(torch.arange(12000) * (2 * torch.pi * frequency / 24000)) * 0.2
+
+
+class Model:
+    sr = 24000
+
+    def __init__(self):
+        self.calls = 0
+        self.stream_calls = 0
+
+    def generate(self, text, **kwargs):
+        self.calls += 1
+        return tone()
+
+    def generate_stream(self, text, **kwargs):
+        self.stream_calls += 1
+        for index in range(3):
+            yield tone(220 * (index + 1)), {"chunk_index": index}
+
+
+@pytest.fixture
+def backend(tmp_path):
+    owner = ChatterboxTTSBackend(
+        {
+            "CHATTERBOX_DEVICE": "cpu",
+            "CHATTERBOX_VOICE_DIR": str(tmp_path),
+            "CHATTERBOX_STREAMING": False,
+            "CHATTERBOX_NORMALIZE_AUDIO": False,
+            "CHATTERBOX_ENABLE_CROSSFADE": False,
+            "CHATTERBOX_PREPROCESS_TEXT": False,
+        }
+    )
+    owner.model = Model()
+    owner._initialized = True
+    return owner
+
+
+def request(text="Hello there.", audio_format="wav", stream=True):
+    return OpenAISpeechRequest(
+        input=text,
+        voice="default",
+        model="chatterbox",
+        response_format=audio_format,
+        stream=stream,
+    )
+
+
+async def drain(backend, req=None):
+    return b"".join(
+        [chunk async for chunk in backend.generate_speech_stream(req or request())]
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("audio_format", ["wav", "mp3", "flac", "opus", "aac", "pcm"])
+@pytest.mark.parametrize("mode", ["long", "stream", "single"])
+async def test_complete_chatterbox_utterance_decodes_in_every_format(
+    backend, mode, audio_format
+):
+    text = "Hello there."
+    if mode == "long":
+        backend.max_chunk_size = 20
+        text = "Sentence alpha. Sentence beta. Sentence gamma."
+    backend.streaming_enabled = mode == "stream"
+    expected_seconds = 0.5 if mode == "single" else 1.5
+    for _ in range(2):
+        data = await drain(backend, request(text, audio_format))
+        if audio_format == "pcm":
+            assert len(data) == int(24000 * 2 * expected_seconds)
+            assert not data.startswith(b"RIFF")
+        else:
+            decoded = AudioSegment.from_file(
+                io.BytesIO(data),
+                format="ogg" if audio_format == "opus" else audio_format,
+            )
+            assert len(decoded) / 1000 == pytest.approx(expected_seconds, abs=0.08)
+            assert decoded.rms > 0
+            if audio_format == "wav":
+                with wave.open(io.BytesIO(data)) as wav:
+                    assert wav.getnframes() == 24000 * expected_seconds
+
+
+@pytest.mark.asyncio
+async def test_stream_false_uses_single_inference(backend):
+    backend.streaming_enabled = True
+    await drain(backend, request(stream=False))
+    assert backend.model.stream_calls == 0
+    assert backend.model.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_audio_limit_is_not_retried(backend, monkeypatch):
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_limits.MAX_BUFFERED_AUDIO_BYTES", 1000)
+    with pytest.raises(TTSOperationError) as error:
+        await drain(backend)
+    assert error.value.retryable is False
+    assert backend.model.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_crossfade_error_does_not_return_concatenated_containers(backend):
+    good = backend._tensor_to_wav_bytes(tone(), 24000)
+    with pytest.raises((ValueError, wave.Error, EOFError)):
+        await backend._combine_audio_with_crossfade([good, b"corrupt WAV"])
+
+
+@pytest.mark.asyncio
+async def test_fallback_cancel_preserves_backend_and_request_settings(backend):
+    entered = asyncio.Event()
+    original = (backend.exaggeration, backend.cfg_weight, backend.num_candidates)
+    calls = 0
+
+    async def infer(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise RuntimeError("transient model failure")
+        entered.set()
+        await asyncio.Event().wait()
+
+    backend._generate_single = infer
+    req = request()
+    task = asyncio.create_task(drain(backend, req))
+    await asyncio.wait_for(entered.wait(), 2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert (
+        backend.exaggeration,
+        backend.cfg_weight,
+        backend.num_candidates,
+    ) == original
+    assert not getattr(req, "_is_fallback", False)
+
+
+class Process:
+    def __init__(self):
+        self.returncode = None
+        self.stdout = asyncio.StreamReader()
+        self.sent = asyncio.Event()
+        self.commands = []
+        self.stdin = SimpleNamespace(write=self.write, drain=self.drain)
+        self.waited = False
+
+    def write(self, data):
+        self.commands.append(json.loads(data))
+        self.sent.set()
+
+    async def drain(self):
+        pass
+
+    def terminate(self):
+        self.returncode = -15
+        self.stdout.feed_eof()
+
+    def kill(self):
+        self.terminate()
+
+    async def wait(self):
+        self.waited = True
+        return self.returncode
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure", ["cancel", "timeout"])
+async def test_interrupted_ipc_is_reaped_before_another_request(backend, failure):
+    process = Process()
+    backend.process = process
+    backend.model = "process"
+    if failure == "timeout":
+
+        async def time_out(*args, **kwargs):
+            raise TimeoutError("test deadline")
+
+        backend._read_chunked_audio = time_out
+    task = asyncio.create_task(
+        backend._generate_single_isolated("Request A", None, 0.5, 0.5)
+    )
+    await process.sent.wait()
+    if failure == "cancel":
+        task.cancel()
+    with pytest.raises(asyncio.CancelledError if failure == "cancel" else TimeoutError):
+        await task
+    assert process.waited
+    assert process.returncode is not None
+    assert backend.process is None
+    assert not backend._initialized
+    assert backend.model is None
+
+
+@pytest.mark.asyncio
+async def test_subprocess_transfer_chunks_are_reassembled_once(backend):
+    process = Process()
+    backend.process = process
+    backend.model = "process"
+    audio = backend._tensor_to_wav_bytes(tone(), 24000)
+    encoded = base64.b64encode(audio).decode()
+    for index, part in enumerate((encoded[:16000], encoded[16000:])):
+        process.stdout.feed_data(
+            (
+                json.dumps(
+                    {
+                        "type": "audio_chunk",
+                        "chunk_id": index,
+                        "total_chunks": 2,
+                        "data": part,
+                    }
+                )
+                + "\n"
+            ).encode()
+        )
+    process.stdout.feed_data(b'{"type":"audio_complete","total_chunks":2}\n')
+    assert await drain(backend) == audio
+
+
+@pytest.mark.asyncio
+async def test_subprocess_transfer_is_bounded_before_reassembly(backend, monkeypatch):
+    monkeypatch.setattr("tldw_chatbook.TTS.audio_limits.MAX_BUFFERED_AUDIO_BYTES", 1000)
+    process = Process()
+    backend.process = process
+    process.stdout.feed_data(
+        (json.dumps({"type": "audio", "data": "A" * 2000}) + "\n").encode()
+    )
+    with pytest.raises(TTSOperationError):
+        await backend._read_chunked_audio()
+
+
+@pytest.mark.asyncio
+async def test_pcm_failure_after_delivery_is_not_retried(backend):
+    backend.streaming_enabled = True
+
+    def partial_stream(*args, **kwargs):
+        backend.model.stream_calls += 1
+        yield tone(), {}
+        raise RuntimeError("inference failed after the first audio")
+
+    backend.model.generate_stream = partial_stream
+    delivered = []
+    with pytest.raises(RuntimeError):
+        async for chunk in backend.generate_speech_stream(request(audio_format="pcm")):
+            delivered.append(chunk)
+    assert len(delivered) == 1
+    assert backend.model.stream_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_empty_pcm_stream_uses_fallback_instead_of_succeeding_silently(backend):
+    backend.streaming_enabled = True
+    backend.model.generate_stream = lambda *args, **kwargs: iter(())
+    audio = await drain(backend, request(audio_format="pcm"))
+    assert len(audio) == 12000 * 2
+    assert backend.model.calls > 0
+
+
+@pytest.mark.asyncio
+async def test_stream_cancel_waits_for_inference_thread(backend):
+    entered = threading.Event()
+    finish = threading.Event()
+
+    def generate_stream(*args, **kwargs):
+        entered.set()
+        assert finish.wait(5)
+        yield tone(), {}
+
+    backend.model.generate_stream = generate_stream
+    backend.streaming_enabled = True
+    task = asyncio.create_task(drain(backend))
+    try:
+        assert await asyncio.to_thread(entered.wait, 2)
+        task.cancel()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        assert not task.done()
+    finally:
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+
+def test_isolated_worker_encodes_without_optional_torchcodec():
+    """Run the actual subprocess protocol; replace neural inference only."""
+    script = (
+        Path(__file__).resolve().parents[2]
+        / "tldw_chatbook/TTS/backends/chatterbox_process.py"
+    )
+    bootstrap = """
+import runpy, sys, types, torch
+model = types.SimpleNamespace(sr=24000, generate=lambda *a, **k: torch.ones(12000) * .1)
+tts = types.ModuleType('chatterbox.tts')
+tts.ChatterboxTTS = types.SimpleNamespace(from_pretrained=lambda **k: model)
+sys.modules['chatterbox'] = types.ModuleType('chatterbox')
+sys.modules['chatterbox.tts'] = tts
+def missing_codec(*a, **k):
+    raise ImportError('TorchCodec is required by torchaudio.save')
+sys.modules['torchaudio'] = types.SimpleNamespace(save=missing_codec)
+runpy.run_path(sys.argv[1], run_name='__main__')
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", bootstrap, str(script)],
+        input=(
+            '{"command":"initialize","device":"cpu"}\n'
+            '{"command":"generate","text":"Hello"}\n'
+            '{"command":"shutdown"}\n'
+        ),
+        text=True,
+        capture_output=True,
+        timeout=15,
+        check=True,
+    )
+    messages = [json.loads(line) for line in result.stdout.splitlines()]
+    assert not [message for message in messages if message["type"] == "error"]
+    audio = next(message for message in messages if message["type"] == "audio")
+    with wave.open(io.BytesIO(base64.b64decode(audio["data"]))) as wav:
+        assert wav.getnframes() == 12000
+        assert wav.getframerate() == 24000
+        assert wav.getsampwidth() == 2

--- a/Tests/TTS/test_legacy_pcm_playback.py
+++ b/Tests/TTS/test_legacy_pcm_playback.py
@@ -1,0 +1,373 @@
+"""Real legacy admission and PCM fallback, with only synthesis/device I/O replaced."""
+
+from __future__ import annotations
+
+import asyncio
+import io
+import struct
+import threading
+import wave
+from pathlib import Path
+
+import pytest
+
+from Tests.TTS_Events.test_spoken_feedback_streaming import _RecordingSink
+from tldw_chatbook.Event_Handlers.TTS_Events import tts_events
+from tldw_chatbook.TTS import pcm_playback
+from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_chatbook.TTS.legacy_bridge import legacy_provider_specs
+from tldw_chatbook.TTS.preferences import TTSPreferencesSnapshot
+from tldw_chatbook.TTS.TTS_Generation import TTSService
+
+PCM = struct.pack("<hh", 2000, -2000) * 1200
+SELECTIONS = {
+    "openai": ("tts-1", "alloy"),
+    "elevenlabs": ("eleven_multilingual_v2", "21m00Tcm4TlvDq8ikWAM"),
+    "kokoro": ("kokoro", "af_alloy"),
+    "chatterbox": ("chatterbox", "default"),
+    "higgs": ("higgs-audio-v2", "professional_female"),
+    "alltalk": ("alltalk", "female_01.wav"),
+}
+
+
+def _service(provider, *, endpoint=None, audio_format="pcm", body=PCM):
+    requests = []
+
+    class Backend:
+        def set_progress_callback(self, callback):
+            pass
+
+        async def generate_speech_stream(self, request):
+            requests.append(request)
+            assert request.response_format == audio_format
+            # A transport split may bisect one PCM frame.
+            yield body[:3]
+            yield body[3:]
+
+    class Manager:
+        async def get_backend(self, internal_id):
+            return Backend()
+
+        async def close_all_backends(self):
+            pass
+
+    registry = TTSAdapterRegistry(
+        specs=legacy_provider_specs(
+            {"app_tts": {"OPENAI_BASE_URL": endpoint} if endpoint else {}},
+            manager_factory=lambda _provider, _config: Manager(),
+        ),
+        aliases={},
+    )
+    model, voice = SELECTIONS[provider]
+    service = TTSService(
+        registry,
+        preferences_snapshot=TTSPreferencesSnapshot(
+            provider_id=provider,
+            model_mode="exact",
+            model_id=model,
+            voice_mode="exact",
+            voice_id=voice,
+            response_format=audio_format,
+            speed=1.0,
+        ),
+    )
+    return service, requests
+
+
+def _assert_complete_wav(path):
+    assert path.suffix == ".wav"
+    with wave.open(io.BytesIO(path.read_bytes()), "rb") as audio:
+        assert (audio.getframerate(), audio.getnchannels(), audio.getsampwidth()) == (
+            24000,
+            1,
+            2,
+        )
+        assert audio.getnframes() == 2400
+        assert audio.readframes(2400) == PCM
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", SELECTIONS)
+async def test_known_legacy_pcm_declares_exact_samples_and_preserves_export(provider):
+    service, requests = _service(provider)
+    try:
+        response = await service.synthesize_default(text="A synthetic PCM reply.")
+        try:
+            assert response.sample_rate == 24000
+            assert dict(response.metadata) == {
+                "sample_rate": 24000,
+                "channels": 1,
+                "sample_encoding": "pcm_s16le",
+            }
+            assert response.audio_format == "pcm"
+            assert response.content_type == "application/octet-stream"
+            assert b"".join([part async for part in response.byte_stream]) == PCM
+            assert len(requests) == 1
+        finally:
+            await response.aclose()
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("audio_format", ["pcm", "wav"])
+async def test_custom_openai_endpoint_does_not_claim_an_unknown_pcm_rate(audio_format):
+    service, _requests = _service(
+        "openai", endpoint="http://127.0.0.1:18992/v1", audio_format=audio_format
+    )
+    try:
+        response = await service.synthesize_default(text="Custom endpoint.")
+        try:
+            assert response.sample_rate is None
+            assert dict(response.metadata) == {}
+        finally:
+            await response.aclose()
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+class _Handler(tts_events.TTSEventHandler):
+    def __init__(self, service):
+        super().__init__()
+        self._tts_service = service
+        self.messages = []
+
+    async def post_message(self, message):
+        self.messages.append(message)
+
+    def notify(self, message, severity="information"):
+        pass
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", SELECTIONS)
+async def test_explicit_legacy_pcm_uses_the_existing_sink_without_a_file(
+    provider, monkeypatch
+):
+    service, requests = _service(provider)
+    handler = _Handler(service)
+    sinks = []
+
+    class Sink(_RecordingSink):
+        def __init__(self, **kwargs):
+            super().__init__(**kwargs)
+            sinks.append(self)
+
+    monkeypatch.setattr(tts_events, "sink_available", lambda: True)
+    monkeypatch.setattr(tts_events, "StreamingPcmSink", Sink)
+    try:
+        for _turn in range(2):
+            await handler._generate_tts("Explicit PCM request.", "pcm-stream", None)
+        assert len(requests) == len(sinks) == 2
+        assert all(request.response_format == "pcm" for request in requests)
+        for sink in sinks:
+            assert sink.opened_with == (24000, 1)
+            assert b"".join(sink.fed) == PCM
+        complete = [
+            event
+            for event in handler.messages
+            if isinstance(event, tts_events.TTSCompleteEvent)
+        ]
+        assert len(complete) == 2
+        assert all(
+            event.error is None and event.audio_file is None for event in complete
+        )
+        assert handler._audio_files == {}
+    finally:
+        await handler.cleanup_tts_resources()
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", SELECTIONS)
+@pytest.mark.parametrize("sink_present", [False, True])
+async def test_pcm_file_fallback_is_complete_wav_and_repeated_playable(
+    provider, sink_present, monkeypatch
+):
+    service, requests = _service(provider)
+    handler = _Handler(service)
+    played = []
+
+    class CannotOpenSink(_RecordingSink):
+        _open_should_fail = True
+
+    def play(path):
+        _assert_complete_wav(path)
+        played.append(path)
+
+    monkeypatch.setattr(tts_events, "sink_available", lambda: sink_present)
+    monkeypatch.setattr(tts_events, "StreamingPcmSink", CannotOpenSink)
+    monkeypatch.setattr(tts_events, "play_audio_file", play)
+    try:
+        for turn in range(2):
+            await handler._generate_tts("A synthetic PCM reply.", "pcm-turn", None)
+            complete = [
+                event
+                for event in handler.messages
+                if isinstance(event, tts_events.TTSCompleteEvent)
+            ]
+            assert len(complete) == turn + 1
+            assert complete[-1].error is None
+            path = complete[-1].audio_file
+            assert path is not None
+            _assert_complete_wav(path)
+            await handler.handle_tts_playback(
+                tts_events.TTSPlaybackEvent(message_id="pcm-turn", action="play")
+            )
+            assert len(played) == turn + 1
+        assert len(requests) == 2
+        assert all(request.response_format == "pcm" for request in requests)
+        assert not played[0].exists()
+    finally:
+        await handler.cleanup_tts_resources()
+        await service.close()
+        await service.wait_closed()
+    assert all(not path.exists() for path in played)
+
+
+@pytest.mark.asyncio
+async def test_unknown_custom_pcm_never_publishes_an_unplayable_console_file(
+    monkeypatch,
+):
+    service, _requests = _service("openai", endpoint="http://127.0.0.1:18992/v1")
+    handler = _Handler(service)
+    monkeypatch.setattr(tts_events, "sink_available", lambda: False)
+    try:
+        await handler._generate_tts("Unknown PCM shape.", "unknown", None)
+        complete = [
+            event
+            for event in handler.messages
+            if isinstance(event, tts_events.TTSCompleteEvent)
+        ]
+        assert len(complete) == 1
+        assert complete[0].error
+        assert complete[0].audio_file is None
+        assert handler._audio_files == {}
+    finally:
+        await handler.cleanup_tts_resources()
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b"", PCM + b"\x00"])
+async def test_malformed_pcm_does_not_complete_as_playable_audio(body, monkeypatch):
+    service, _requests = _service("kokoro", body=body)
+    handler = _Handler(service)
+    monkeypatch.setattr(tts_events, "sink_available", lambda: False)
+    try:
+        await handler._generate_tts("Invalid PCM frames.", "bad-pcm", None)
+        complete = [
+            event
+            for event in handler.messages
+            if isinstance(event, tts_events.TTSCompleteEvent)
+        ]
+        assert len(complete) == 1
+        assert complete[0].error and complete[0].audio_file is None
+        assert handler._audio_files == {}
+    finally:
+        await handler.cleanup_tts_resources()
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_late_pcm_copy_cannot_delete_the_next_playback(monkeypatch):
+    service, _requests = _service("kokoro")
+    handler = _Handler(service)
+    original_copy = tts_events.create_pcm16_wav_copy
+    entered = threading.Event()
+    allow_finish = threading.Event()
+    first_copy = []
+    copies = []
+
+    def held_copy(*args):
+        path = original_copy(*args)
+        copies.append(path)
+        if not first_copy:
+            first_copy.append(path)
+            entered.set()
+            assert allow_finish.wait(5)
+        return path
+
+    monkeypatch.setattr(tts_events, "create_pcm16_wav_copy", held_copy)
+    monkeypatch.setattr(tts_events, "sink_available", lambda: False)
+    monkeypatch.setattr(tts_events, "_TTS_IO_CANCELLATION_JOIN_TIMEOUT_SECONDS", 0.01)
+    task = asyncio.create_task(handler._generate_tts("Old PCM.", "same-owner", None))
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        await handler._generate_tts("Next PCM.", "same-owner", None)
+        current = handler._audio_files["same-owner"]
+        _assert_complete_wav(current)
+        allow_finish.set()
+        await handler._drain_retained_tts_artifact_work()
+        assert not first_copy[0].exists()
+        assert handler._audio_files["same-owner"] == current
+        _assert_complete_wav(current)
+    finally:
+        allow_finish.set()
+        await handler.cleanup_tts_resources()
+        await service.close()
+        await service.wait_closed()
+    assert all(not path.exists() for path in copies)
+
+
+@pytest.mark.parametrize(
+    "rate,channels",
+    [(None, 1), (True, 1), (0, 1), (24000.0, 1), (24000, 0), (24000, 3)],
+)
+def test_pcm_playback_copy_refuses_unknown_or_invalid_sample_metadata(
+    rate, channels, tmp_path
+):
+    source = tmp_path / "source.pcm"
+    source.write_bytes(PCM)
+    with pytest.raises(ValueError, match="known sample rate"):
+        pcm_playback.create_pcm16_wav_copy(source, rate, channels)
+    assert source.read_bytes() == PCM
+
+
+def test_pcm_playback_copy_is_complete_stereo_and_preserves_source(tmp_path):
+    source = tmp_path / "stereo.pcm"
+    source.write_bytes(PCM * 20)
+    copied = pcm_playback.create_pcm16_wav_copy(source, 48000, 2)
+    try:
+        with wave.open(str(copied), "rb") as audio:
+            assert audio.getframerate() == 48000
+            assert audio.getnchannels() == 2
+            assert audio.getnframes() == len(PCM) * 20 // 4
+            assert audio.readframes(audio.getnframes()) == PCM * 20
+        assert source.read_bytes() == PCM * 20
+        assert copied.stat().st_mode & 0o777 == 0o600
+    finally:
+        copied.unlink()
+
+
+def test_pcm_copy_writer_failure_removes_only_its_partial_copy(tmp_path, monkeypatch):
+    source = tmp_path / "source.pcm"
+    source.write_bytes(PCM * 20)
+    destinations = []
+    create = pcm_playback.create_secure_temp_file
+
+    def track(*args, **kwargs):
+        result = create(*args, **kwargs, dir=str(tmp_path))
+        destinations.append(result)
+        return result
+
+    write = wave.Wave_write.writeframesraw
+
+    def broken_write(self, chunk):
+        write(self, chunk)
+        raise OSError("Synthetic local copy failure")
+
+    monkeypatch.setattr(pcm_playback, "create_secure_temp_file", track)
+    monkeypatch.setattr(wave.Wave_write, "writeframesraw", broken_write)
+    with pytest.raises(OSError, match="Synthetic"):
+        pcm_playback.create_pcm16_wav_copy(source, 24000)
+    assert destinations and all(not Path(path).exists() for path in destinations)
+    assert source.read_bytes() == PCM * 20

--- a/Tests/TTS/test_legacy_pcm_playback.py
+++ b/Tests/TTS/test_legacy_pcm_playback.py
@@ -278,7 +278,7 @@ async def test_malformed_pcm_does_not_complete_as_playable_audio(body, monkeypat
 async def test_cancelled_late_pcm_copy_cannot_delete_the_next_playback(monkeypatch):
     service, _requests = _service("kokoro")
     handler = _Handler(service)
-    original_copy = tts_events.create_pcm16_wav_copy
+    original_copy = pcm_playback.create_pcm16_wav_copy
     entered = threading.Event()
     allow_finish = threading.Event()
     first_copy = []
@@ -293,7 +293,7 @@ async def test_cancelled_late_pcm_copy_cannot_delete_the_next_playback(monkeypat
             assert allow_finish.wait(5)
         return path
 
-    monkeypatch.setattr(tts_events, "create_pcm16_wav_copy", held_copy)
+    monkeypatch.setattr(pcm_playback, "create_pcm16_wav_copy", held_copy)
     monkeypatch.setattr(tts_events, "sink_available", lambda: False)
     monkeypatch.setattr(tts_events, "_TTS_IO_CANCELLATION_JOIN_TIMEOUT_SECONDS", 0.01)
     task = asyncio.create_task(handler._generate_tts("Old PCM.", "same-owner", None))

--- a/Tests/TTS/test_resolution_failure_diagnostics.py
+++ b/Tests/TTS/test_resolution_failure_diagnostics.py
@@ -40,6 +40,29 @@ def test_console_audio_limit_guidance_uses_the_safe_recovery_action():
 
 
 @pytest.mark.parametrize(
+    "code,recovery,expected",
+    [
+        ("request_invalid", "shorten_text", "shorten the text"),
+        ("audio_response_invalid", "use_wav", "WAV"),
+    ],
+)
+def test_console_audio_recovery_does_not_retry_the_same_invalid_request(
+    code, recovery, expected
+):
+    error = TTSOperationError(
+        code=code,
+        message="PRIVATE provider content must remain hidden",
+        retryable=False,
+        operation_id="fixture",
+        recovery_action=recovery,
+    )
+    copy = TTSEventHandler._tts_error_copy(error)
+    assert expected in copy
+    assert "PRIVATE" not in copy
+    assert "retry" not in copy.lower()
+
+
+@pytest.mark.parametrize(
     "copy", [STTSEventHandler._generation_error_copy, TTSEventHandler._tts_error_copy]
 )
 @pytest.mark.parametrize(

--- a/Tests/TTS_Events/test_file_playback_failures.py
+++ b/Tests/TTS_Events/test_file_playback_failures.py
@@ -1,0 +1,134 @@
+"""Device failure propagates through both public file-playback consumers."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from Tests.TTS_Events import test_spoken_feedback_streaming as streaming_fixture
+from tldw_chatbook.Event_Handlers.TTS_Events import tts_events
+from tldw_chatbook.TTS.audio_player import PlaybackState
+
+handler = streaming_fixture.handler
+
+
+def _player(path, state):
+    player = Mock()
+    player.play.return_value = True
+    player.get_current_file.return_value = path
+    player.get_state.return_value = state
+    return player
+
+
+@pytest.mark.parametrize(
+    "state,timeout,expected",
+    [
+        (PlaybackState.ERROR, 0.03, False),
+        (PlaybackState.ERROR, 0, False),
+        (PlaybackState.IDLE, 0, False),
+        (PlaybackState.PAUSED, 0, False),
+        (PlaybackState.FINISHED, 0, True),
+        (PlaybackState.PLAYING, 0, True),
+    ],
+)
+def test_file_poll_accepts_only_finished_or_still_playing_at_timeout(
+    state, timeout, expected
+):
+    path = Path("synthetic.wav")
+    assert (
+        tts_events._play_legacy_clip_and_await_completion(
+            _player(path, state),
+            path,
+            timeout_seconds=timeout,
+            poll_interval_seconds=0.005,
+        )
+        is expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_utterance_device_failure_never_reports_success(handler, monkeypatch):
+    handler._tts_service = streaming_fixture._FakeService(
+        streaming_fixture._FakeResponse(
+            [b"ID3", b"synthetic"], audio_format="mp3", sample_rate=None
+        )
+    )
+    player = _player(None, PlaybackState.ERROR)
+
+    def play(path):
+        player.get_current_file.return_value = path
+        return True
+
+    player.play.side_effect = play
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: player
+    )
+    monkeypatch.setattr(
+        tts_events, "_legacy_playback_timeout_seconds", lambda *_args: 0.03
+    )
+    release = AsyncMock(wraps=handler._try_secure_delete_tts_artifact)
+    monkeypatch.setattr(handler, "_try_secure_delete_tts_artifact", release)
+    results = []
+    try:
+        await handler.speak_utterance("A synthetic reply.", on_finished=results.append)
+        assert results == [False]
+        assert len(player.play.call_args_list) == 1
+        artifact = player.play.call_args.args[0]
+        await handler.cleanup_tts_resources()
+        assert not artifact.exists()
+        release.assert_awaited_once()
+        assert release.await_args.args == (artifact,)
+        assert release.await_args.kwargs["on_late_success"].args[-1] is None
+        await handler.cleanup_tts_resources()
+        release.assert_awaited_once()
+        assert results == [False]
+    finally:
+        await handler.cleanup_tts_resources()
+
+
+@pytest.mark.asyncio
+async def test_owned_playback_device_failure_releases_artifact_and_reports_failed(
+    handler, monkeypatch, tmp_path
+):
+    artifact = tmp_path / "owned.wav"
+    artifact.write_bytes(b"RIFF synthetic device-transport fixture")
+    states = []
+    lifecycle = tts_events.TTSPlaybackLifecycle(
+        message_id="owned-reply",
+        request_id=1,
+        validator=lambda: True,
+        callback=states.append,
+    )
+    handler._audio_files[lifecycle.message_id] = artifact
+    handler._audio_file_owners[lifecycle.message_id] = lifecycle
+    player = _player(artifact, PlaybackState.ERROR)
+    monkeypatch.setattr(
+        "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: player
+    )
+    monkeypatch.setattr(tts_events, "_LEGACY_PLAYBACK_POLL_MAX_SECONDS", 0.03)
+    release = AsyncMock(wraps=handler._try_secure_delete_tts_artifact)
+    monkeypatch.setattr(handler, "_try_secure_delete_tts_artifact", release)
+    try:
+        await handler.handle_tts_playback(
+            tts_events.TTSPlaybackEvent(
+                action="play",
+                message_id=lifecycle.message_id,
+                playback_lifecycle=lifecycle,
+            )
+        )
+        await handler._active_file_playback_task
+        assert states == ["playing", "failed"]
+        assert handler._active_file_playback_task is None
+        assert handler._active_file_playback_owner is None
+        assert handler._active_file_playback_stop is None
+        assert handler._last_played is None
+        assert not artifact.exists()
+        assert handler._audio_files == {}
+        assert handler._audio_file_owners == {}
+        release.assert_awaited_once()
+        assert release.await_args.args == (artifact,)
+        assert release.await_args.kwargs["on_late_success"].args[-1] is lifecycle
+        await handler.cleanup_tts_resources()
+        release.assert_awaited_once()
+    finally:
+        await handler.cleanup_tts_resources()

--- a/Tests/TTS_Events/test_spoken_feedback_streaming.py
+++ b/Tests/TTS_Events/test_spoken_feedback_streaming.py
@@ -41,9 +41,11 @@ is reported via the file the write loop already produced -- see
 `test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_end`
 and `test_wav_sink_failure_falls_back_to_the_already_written_file_silently`.
 """
+
 from __future__ import annotations
 
 import threading
+import wave
 from collections.abc import AsyncIterator
 from pathlib import Path
 from types import SimpleNamespace
@@ -109,8 +111,15 @@ def test_fake_response_mirrors_the_real_ttsaudioresponse_field_names():
         byte_stream=_empty(),
         sample_rate=RATE,
     )
-    for field in ("provider_id", "model_id", "audio_format", "content_type",
-                  "byte_stream", "sample_rate", "metadata"):
+    for field in (
+        "provider_id",
+        "model_id",
+        "audio_format",
+        "content_type",
+        "byte_stream",
+        "sample_rate",
+        "metadata",
+    ):
         assert hasattr(real, field), f"_FakeResponse's {field!r} is not a real field"
 
 
@@ -164,7 +173,9 @@ class _FakeService:
     def preferences_snapshot(self):
         return SimpleNamespace(provider_id=self._provider_id)
 
-    async def synthesize_default(self, *, text, voice_override=None, progress_sink=None):
+    async def synthesize_default(
+        self, *, text, voice_override=None, progress_sink=None
+    ):
         self.synthesize_default_calls.append((text, voice_override))
         return self._response
 
@@ -181,7 +192,9 @@ class _RecordingSink:
     #: `open()` failure without touching any real audio backend.
     _open_should_fail = False
 
-    def __init__(self, *, on_event, blocksize_ms: int = 20, stream_factory=None) -> None:
+    def __init__(
+        self, *, on_event, blocksize_ms: int = 20, stream_factory=None
+    ) -> None:
         self.on_event = on_event
         self.opened_with: tuple[int, int] | None = None
         #: Fix-round F2 pin: which thread actually called `open()`, so a
@@ -272,8 +285,11 @@ def _spy_sink_class(holder: dict) -> type[_RecordingSink]:
 # (a) pcm response streams through a fake sink -- no file playback.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
-async def test_pcm_response_streams_through_the_sink_with_no_file_playback(handler, monkeypatch):
+async def test_pcm_response_streams_through_the_sink_with_no_file_playback(
+    handler, monkeypatch
+):
     chunks = [bytes([1, 0]) * 50, bytes([2, 0]) * 50]
     response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
     service = _FakeService(response)
@@ -281,7 +297,9 @@ async def test_pcm_response_streams_through_the_sink_with_no_file_playback(handl
     _forbid_legacy_artifact_creation(handler)
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
 
     await handler._generate_tts("Capture ended.", "adhoc", None)
@@ -289,7 +307,9 @@ async def test_pcm_response_streams_through_the_sink_with_no_file_playback(handl
     sink = sink_holder["sink"]
     assert sink.opened_with == (RATE, 1)
     assert b"".join(sink.fed) == b"".join(chunks)
-    assert handler._audio_files == {}, "no artifact should ever be tracked for a streamed response"
+    assert handler._audio_files == {}, (
+        "no artifact should ever be tracked for a streamed response"
+    )
 
     complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
     assert len(complete_events) == 1
@@ -304,15 +324,20 @@ async def test_pcm_response_streams_through_the_sink_with_no_file_playback(handl
 # (b) mp3 response -> legacy `play_audio_file` path, no sink touched.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
-async def test_mp3_response_uses_the_legacy_path_and_never_constructs_a_sink(handler, monkeypatch):
+async def test_mp3_response_uses_the_legacy_path_and_never_constructs_a_sink(
+    handler, monkeypatch
+):
     chunks = [b"ID3", b"restofmp3bytes"]
     response = _FakeResponse(chunks, audio_format="mp3", sample_rate=None)
     service = _FakeService(response)
     handler._tts_service = service
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     # Sink IS available -- eligibility must still be refused for a
     # compressed format regardless, proving the branch keys off the
     # response's own declared format, not just availability.
@@ -322,7 +347,9 @@ async def test_mp3_response_uses_the_legacy_path_and_never_constructs_a_sink(han
         await handler._generate_tts("Discarded.", "adhoc", None)
 
         assert sink_holder == {}, "a compressed format must never even construct a sink"
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1
         assert complete_events[0].error is None
         artifact_path = complete_events[0].audio_file
@@ -335,6 +362,7 @@ async def test_mp3_response_uses_the_legacy_path_and_never_constructs_a_sink(han
 # ---------------------------------------------------------------------------
 # (c) sink open-failure -> legacy path used, exactly one completion posted.
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monkeypatch):
@@ -352,7 +380,9 @@ async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monke
     try:
         await handler._generate_tts("Still responding.", "adhoc", None)
 
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1, (
             "a sink open failure must fall through silently -- exactly one "
             "completion (the legacy path's own) may ever surface, no phantom "
@@ -361,7 +391,12 @@ async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monke
         assert complete_events[0].error is None
         artifact_path = complete_events[0].audio_file
         assert artifact_path is not None and artifact_path.exists()
-        assert artifact_path.read_bytes() == b"".join(chunks)
+        assert artifact_path.suffix == ".wav"
+        with wave.open(str(artifact_path), "rb") as audio:
+            assert audio.getframerate() == RATE
+            assert audio.getnchannels() == 1
+            assert audio.getsampwidth() == 2
+            assert audio.readframes(audio.getnframes()) == b"".join(chunks)
     finally:
         await handler.cleanup_tts_resources()
 
@@ -370,13 +405,16 @@ async def test_sink_open_failure_falls_through_to_the_legacy_path(handler, monke
 # (d) A lifecycle-less stop can only stop an unowned live sink globally.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("message_id", "expected_stop_count"),
     [(None, 1), ("adhoc", 0)],
 )
 async def test_stop_action_stops_whatever_sink_is_currently_registered_live(
-    handler, message_id, expected_stop_count,
+    handler,
+    message_id,
+    expected_stop_count,
 ):
     stop_calls: list[bool] = []
 
@@ -387,7 +425,9 @@ async def test_stop_action_stops_whatever_sink_is_currently_registered_live(
     with streaming_sink_module._LIVE_SINK_LOCK:
         streaming_sink_module._LIVE_SINK = _FakeLiveSink()
 
-    await handler.handle_tts_playback(TTSPlaybackEvent(action="stop", message_id=message_id))
+    await handler.handle_tts_playback(
+        TTSPlaybackEvent(action="stop", message_id=message_id)
+    )
 
     assert stop_calls == [True] * expected_stop_count
 
@@ -397,9 +437,11 @@ async def test_stop_action_stops_whatever_sink_is_currently_registered_live(
 # (the review-contracted `data_bytes` pin).
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_end(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     """WAV eligibility can only be decided from the COMPLETE body (see
     `pcm_stream.sink_plan`'s docstring), so -- unlike pcm -- the wav half of
@@ -422,7 +464,9 @@ async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_en
     # also refusing to read further ones) would still leak trailer bytes
     # fed from a later chunk.
     split = len(body) - 5
-    response = _FakeResponse([body[:split], body[split:]], audio_format="wav", sample_rate=None)
+    response = _FakeResponse(
+        [body[:split], body[split:]], audio_format="wav", sample_rate=None
+    )
     service = _FakeService(response)
     handler._tts_service = service
 
@@ -437,7 +481,9 @@ async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_en
     handler._create_tts_artifact = _spy_create_artifact
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
 
     await handler._generate_tts("Should be spoken.", "adhoc", None)
@@ -448,7 +494,9 @@ async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_en
     assert b"LIST" not in fed
     assert b"INFOtest" not in fed
 
-    assert len(created_paths) == 1, "the legacy write loop must still run, unmodified, for wav"
+    assert len(created_paths) == 1, (
+        "the legacy write loop must still run, unmodified, for wav"
+    )
     assert not created_paths[0].exists(), (
         "the now-redundant artifact must be deleted once it was played live"
     )
@@ -466,9 +514,11 @@ async def test_wav_response_with_a_trailing_chunk_stops_pumped_bytes_at_datas_en
 # upgrade that simply didn't pan out.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_wav_sink_failure_falls_back_to_the_already_written_file_silently(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     data = bytes(range(64))
     body = _wav_with_trailing_chunk(data=data)
@@ -485,7 +535,9 @@ async def test_wav_sink_failure_falls_back_to_the_already_written_file_silently(
     try:
         await handler._generate_tts("Discarded.", "adhoc", None)
 
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1, "no phantom error toast for a silent fallback"
         assert complete_events[0].error is None
         artifact_path = complete_events[0].audio_file
@@ -500,9 +552,11 @@ async def test_wav_sink_failure_falls_back_to_the_already_written_file_silently(
 # even for an otherwise-eligible pcm response.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_sink_unavailable_leaves_an_eligible_pcm_response_on_the_legacy_path(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     chunks = [bytes([5, 0]) * 30]
     response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
@@ -510,17 +564,26 @@ async def test_sink_unavailable_leaves_an_eligible_pcm_response_on_the_legacy_pa
     handler._tts_service = service
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
 
     try:
         await handler._generate_tts("Nothing to read yet.", "adhoc", None)
 
         assert sink_holder == {}
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1
         artifact_path = complete_events[0].audio_file
-        assert artifact_path is not None and artifact_path.read_bytes() == chunks[0]
+        assert artifact_path is not None and artifact_path.suffix == ".wav"
+        with wave.open(str(artifact_path), "rb") as audio:
+            assert audio.getframerate() == RATE
+            assert audio.getnchannels() == 1
+            assert audio.getsampwidth() == 2
+            assert audio.readframes(audio.getnframes()) == chunks[0]
     finally:
         await handler.cleanup_tts_resources()
 
@@ -532,9 +595,11 @@ async def test_sink_unavailable_leaves_an_eligible_pcm_response_on_the_legacy_pa
 # through the same TTSCompleteEvent(error=...) channel, exactly once.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_mid_stream_sink_failure_surfaces_exactly_one_error_completion(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     class _FailingMidStreamSink(_RecordingSink):
         def feed(self, pcm: bytes) -> bool:
@@ -569,8 +634,11 @@ async def test_mid_stream_sink_failure_surfaces_exactly_one_error_completion(
 # a newly-reachable hole (no sink existed in this path before task-4).
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
-async def test_legacy_play_action_stops_a_live_sink_first(handler, monkeypatch, tmp_path):
+async def test_legacy_play_action_stops_a_live_sink_first(
+    handler, monkeypatch, tmp_path
+):
     stop_calls: list[bool] = []
 
     class _FakeLiveSink:
@@ -591,9 +659,13 @@ async def test_legacy_play_action_stops_a_live_sink_first(handler, monkeypatch, 
         "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: fake_player
     )
 
-    await handler.handle_tts_playback(TTSPlaybackEvent(action="play", message_id="msg-1"))
+    await handler.handle_tts_playback(
+        TTSPlaybackEvent(action="play", message_id="msg-1")
+    )
 
-    assert stop_calls == [True], "a live sink must be stopped before legacy file playback starts"
+    assert stop_calls == [True], (
+        "a live sink must be stopped before legacy file playback starts"
+    )
     fake_player.play.assert_called_once()
 
 
@@ -608,9 +680,11 @@ async def test_legacy_play_action_stops_a_live_sink_first(handler, monkeypatch, 
 # would be flaky.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_sink_open_runs_off_the_event_loop_via_the_existing_offload_seam(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     chunks = [bytes([7, 0]) * 10]
     response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
@@ -618,7 +692,9 @@ async def test_sink_open_runs_off_the_event_loop_via_the_existing_offload_seam(
     handler._tts_service = service
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
 
     offload_calls: list[str] = []
@@ -643,8 +719,7 @@ async def test_sink_open_runs_off_the_event_loop_via_the_existing_offload_seam(
     )
     assert sink.opened_on_thread is not None
     assert sink.opened_on_thread is not threading.main_thread(), (
-        "sink.open() ran on the event-loop (main) thread instead of being "
-        "offloaded"
+        "sink.open() ran on the event-loop (main) thread instead of being offloaded"
     )
 
 
@@ -655,6 +730,7 @@ async def test_sink_open_runs_off_the_event_loop_via_the_existing_offload_seam(
 # the WHOLE response body in memory for every wav generation, regressing
 # the bounded-memory write-batching the legacy loop was designed to keep.
 # ---------------------------------------------------------------------------
+
 
 def test_wants_wav_collection_is_gated_on_sink_availability_too(monkeypatch):
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: False)
@@ -680,8 +756,11 @@ def test_wants_wav_collection_is_gated_on_sink_availability_too(monkeypatch):
 # a regression guard against widening the fix too far.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
-async def test_bare_stop_action_also_silences_legacy_file_playback(handler, monkeypatch):
+async def test_bare_stop_action_also_silences_legacy_file_playback(
+    handler, monkeypatch
+):
     stop_calls: list = []
     clip = Path("clip.mp3")
 
@@ -708,7 +787,8 @@ async def test_bare_stop_action_also_silences_legacy_file_playback(handler, monk
 
 @pytest.mark.asyncio
 async def test_message_scoped_stop_does_not_silence_a_different_messages_legacy_playback(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     """Regression guard (task-559 unit 2): F4's fix is scoped to ONLY the
     bare/global stop. A message-scoped stop for message A must still never
@@ -739,8 +819,7 @@ async def test_message_scoped_stop_does_not_silence_a_different_messages_legacy_
     )
 
     assert stop_calls == [], (
-        "stopping message A must never silence a different, "
-        "still-playing message B"
+        "stopping message A must never silence a different, still-playing message B"
     )
     async with handler._audio_files_lock:
         assert handler._last_played == ("message-B", clip)
@@ -766,6 +845,7 @@ async def test_message_scoped_stop_does_not_silence_a_different_messages_legacy_
 # What it proves is narrower and still real: a sink that IS registered as
 # `_LIVE_SINK`, by whatever means, is only interrupted by a global stop.
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
@@ -795,6 +875,7 @@ async def test_real_sink_end_to_end_stop_wiring(handler, message_id, expected_st
 # was simply never generated) must not silence live streaming audio and
 # then play nothing back.
 # ---------------------------------------------------------------------------
+
 
 @pytest.mark.asyncio
 async def test_play_for_a_missing_cached_file_does_not_stop_a_live_sink(handler):
@@ -827,9 +908,11 @@ async def test_play_for_a_missing_cached_file_does_not_stop_a_live_sink(handler)
 # behavioral assertion happens to still pass.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_generate_tts_calls_the_wav_collection_gate_at_its_call_site(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     calls: list[str] = []
     original = tts_events_module._wants_wav_collection
@@ -853,7 +936,9 @@ async def test_generate_tts_calls_the_wav_collection_gate_at_its_call_site(
             "_generate_tts must call _wants_wav_collection at its call "
             "site, not inline the format-only check it wraps"
         )
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1
         artifact_path = complete_events[0].audio_file
         assert artifact_path is not None and artifact_path.read_bytes() == chunks[0]
@@ -868,9 +953,11 @@ async def test_generate_tts_calls_the_wav_collection_gate_at_its_call_site(
 # playback must be silenced, same as a bare/global stop.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_stop_with_empty_string_message_id_is_treated_as_a_bare_stop(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     sink_stop_calls: list[bool] = []
 
@@ -912,9 +999,11 @@ async def test_stop_with_empty_string_message_id_is_treated_as_a_bare_stop(
 # folds it back into "success".
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_a_barged_in_utterance_reports_interrupted_not_success_in_metrics(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     class _BargedInSink(_RecordingSink):
         def feed(self, pcm: bytes) -> bool:
@@ -973,9 +1062,11 @@ async def test_a_barged_in_utterance_reports_interrupted_not_success_in_metrics(
 # review, or the suite itself).
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_no_real_audio_device_guard_blocks_the_reproduced_hazard(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     """Deliberately reproduces the reviewer's exact hazard shape: the REAL
     `StreamingPcmSink` class, the REAL `sink_available()` probe -- no
@@ -1025,7 +1116,9 @@ async def test_no_real_audio_device_guard_blocks_the_reproduced_hazard(
             "the conftest _no_real_audio_device guard failed to prevent a "
             "real sounddevice.OutputStream construction"
         )
-        complete_events = [m for m in handler.messages if isinstance(m, TTSCompleteEvent)]
+        complete_events = [
+            m for m in handler.messages if isinstance(m, TTSCompleteEvent)
+        ]
         assert len(complete_events) == 1
         assert complete_events[0].error is None
         assert complete_events[0].audio_file is not None, (
@@ -1047,9 +1140,11 @@ async def test_no_real_audio_device_guard_blocks_the_reproduced_hazard(
 # (same pattern F8 already established for `"interrupted"`) -- no UI.
 # ---------------------------------------------------------------------------
 
+
 @pytest.mark.asyncio
 async def test_an_underrun_is_logged_at_info_and_bumps_the_metric_on_utterance_end(
-    handler, monkeypatch,
+    handler,
+    monkeypatch,
 ):
     class _UnderrunningSink(_RecordingSink):
         def feed(self, pcm: bytes) -> bool:
@@ -1088,9 +1183,9 @@ async def test_an_underrun_is_logged_at_info_and_bumps_the_metric_on_utterance_e
     finally:
         loguru_logger.remove(handler_id)
 
-    assert any(
-        "42" in line and "underrun" in line.lower() for line in captured_logs
-    ), captured_logs
+    assert any("42" in line and "underrun" in line.lower() for line in captured_logs), (
+        captured_logs
+    )
     assert any(
         name == "tts_generation_total" and labels.get("outcome_code") == "underrun"
         for name, labels in metric_calls
@@ -1103,14 +1198,18 @@ async def test_an_underrun_is_logged_at_info_and_bumps_the_metric_on_utterance_e
 
 
 @pytest.mark.asyncio
-async def test_no_underrun_never_logs_or_bumps_the_underrun_metric(handler, monkeypatch):
+async def test_no_underrun_never_logs_or_bumps_the_underrun_metric(
+    handler, monkeypatch
+):
     chunks = [bytes([1, 0]) * 10]
     response = _FakeResponse(chunks, audio_format="pcm", sample_rate=RATE)
     service = _FakeService(response)
     handler._tts_service = service
 
     sink_holder: dict = {}
-    monkeypatch.setattr(tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder))
+    monkeypatch.setattr(
+        tts_events_module, "StreamingPcmSink", _spy_sink_class(sink_holder)
+    )
     monkeypatch.setattr(tts_events_module, "sink_available", lambda: True)
 
     metric_calls: list[tuple[str, dict]] = []

--- a/Tests/TTS_Events/test_utterance_speech_entry.py
+++ b/Tests/TTS_Events/test_utterance_speech_entry.py
@@ -64,6 +64,15 @@ from Tests.TTS_Events.test_spoken_feedback_streaming import (  # noqa: F401,E402
 )
 
 
+@pytest.fixture(autouse=True)
+async def _retire_utterance_handler(handler, monkeypatch):
+    """Finish owned artifact cleanup while the fake player is still installed."""
+    yield
+    await handler.cleanup_tts_resources()
+    assert not handler._audio_files
+    assert not handler._pending_legacy_cleanup_timers
+
+
 # ---------------------------------------------------------------------------
 # Extra fakes this file needs that the shared harness doesn't provide:
 # a service that can be called more than once (case a: two utterances back
@@ -590,7 +599,16 @@ async def test_last_played_and_the_handoff_event_are_registered_before_the_file_
     any concurrent stop could possibly need to find it."""
     audio_file = tmp_path / "clip.mp3"
     audio_file.write_bytes(b"fake audio data")
-    fake_player = _FakeLegacyPlayer(finishes_after_polls=1)
+    entered = threading.Event()
+    finish = threading.Event()
+
+    class HeldPlayer(_FakeLegacyPlayer):
+        def play(self, file_path):
+            entered.set()
+            assert finish.wait(5), "playback admission was not released"
+            return super().play(file_path)
+
+    fake_player = HeldPlayer(finishes_after_polls=1)
     monkeypatch.setattr(
         "tldw_chatbook.TTS.audio_player.get_audio_player", lambda: fake_player
     )
@@ -601,26 +619,26 @@ async def test_last_played_and_the_handoff_event_are_registered_before_the_file_
             "msg-1", audio_file, "Hi there.", on_finished
         )
     )
-    # Let the task run up to its own first real suspension point
-    # (the executor hop) -- everything before that, including the
-    # `_last_played` assignment and registering the handoff's own event,
-    # runs synchronously with no other await in between, so a handful of
-    # no-op yields reliably lands here without any wall-clock dependency.
-    for _ in range(5):
-        await asyncio.sleep(0)
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        async with handler._audio_files_lock:
+            assert handler._last_played == ("msg-1", audio_file)
+        assert len(handler._legacy_handoff_stop_events) == 1, (
+            "the handoff's own event must be registered before player admission"
+        )
+        assert not task.done()
+        assert results == []
 
-    async with handler._audio_files_lock:
-        assert handler._last_played == ("msg-1", audio_file)
-    assert len(handler._legacy_handoff_stop_events) == 1, (
-        "the handoff's own event must be registered for the duration of "
-        "the play-and-poll call -- this is what F3's fix gates on"
-    )
-
-    await task
-    assert results == [True]
-    assert handler._legacy_handoff_stop_events == set(), (
-        "the event must be discarded once the handoff completes"
-    )
+        finish.set()
+        await task
+        assert results == [True]
+        assert handler._legacy_handoff_stop_events == set(), (
+            "the event must be discarded once the handoff completes"
+        )
+    finally:
+        finish.set()
+        await task
+        await handler.cleanup_tts_resources()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_tts_backend_playground_admission.py
+++ b/Tests/UI/test_tts_backend_playground_admission.py
@@ -1,0 +1,723 @@
+"""Mounted provider admission with real catalogs and synthetic complete audio.
+
+Legacy adapters retain their production request/route checks; only the backend
+host's audio execution is replaced. audio.cpp retains its real HTTP adapter,
+catalog parser, request validation and WAV validation behind a MockTransport.
+These tests make no provider-inference or device-playback claim.
+"""
+
+import asyncio
+import io
+import json
+import struct
+import threading
+import wave
+from contextlib import asynccontextmanager
+from dataclasses import replace
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, Select, TextArea
+from textual.worker import WorkerCancelled
+
+from Tests.UI.speech_playground_fixtures import _resolved, _wait_until
+from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
+    STTSEventHandler,
+    STTSPlaygroundGenerateEvent,
+)
+from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
+from tldw_chatbook.TTS.adapter_types import TTSProviderDescriptor, TTSProviderSpec
+from tldw_chatbook.TTS.adapters.audio_cpp import AudioCppAdapter
+from tldw_chatbook.TTS.audio_cpp_config import AudioCppConfig
+from tldw_chatbook.TTS.audio_cpp_supervisor import AudioCppSupervisor
+from tldw_chatbook.TTS.audio_player import PlaybackState
+from tldw_chatbook.TTS.legacy_bridge import LegacyTTSAdapter
+from tldw_chatbook.TTS.legacy_catalogs import legacy_catalog
+from tldw_chatbook.TTS.playground_types import STTSGeneratedAudio
+from tldw_chatbook.TTS.preferences import TTSPreferencesSnapshot
+from tldw_chatbook.TTS.studio_preferences import (
+    StudioTTSPreferencesSnapshot,
+    StudioTTSSelectionOverrides,
+)
+from tldw_chatbook.TTS.TTS_Generation import TTSService
+from tldw_chatbook.UI.Speech import speech_playback_mixin
+from tldw_chatbook.UI.Speech.speech_playground_pane import SpeechPlaygroundPane
+from tldw_chatbook.UI.stts_playground_catalog import (
+    LOADING_SELECT_VALUE,
+    SERVER_DEFAULT_VOICE_ID,
+    UNAVAILABLE_SELECT_VALUE,
+)
+
+# Independent expected provider defaults, not values calculated by the resolver.
+DEFAULT_SELECTIONS = {
+    "openai": ("tts-1", "alloy", "openai_official_tts-1"),
+    "elevenlabs": (
+        "eleven_multilingual_v2",
+        "21m00Tcm4TlvDq8ikWAM",
+        "elevenlabs_eleven_multilingual_v2",
+    ),
+    "kokoro": ("kokoro", "af_alloy", "local_kokoro_default_onnx"),
+    "chatterbox": ("chatterbox", "default", "local_chatterbox_default"),
+    "higgs": ("higgs-audio-v2", "professional_female", "local_higgs_v2"),
+    "alltalk": ("alltalk", "female_01.wav", "alltalk_default"),
+    "audio_cpp": ("native/model", None, None),
+}
+DEFAULT_OPTIONS = {
+    "openai": {},
+    "elevenlabs": {
+        "stability": 0.5,
+        "similarity_boost": 0.8,
+        "style": 0.0,
+        "use_speaker_boost": True,
+    },
+    "kokoro": {"use_onnx": True},
+    "chatterbox": {
+        "exaggeration": 0.5,
+        "cfg_weight": 0.5,
+        "temperature": 0.5,
+        "num_candidates": 1,
+        "validate_with_whisper": False,
+    },
+    "higgs": {"temperature": 0.7, "top_p": 0.9, "repetition_penalty": 1.1},
+    "alltalk": {},
+    "audio_cpp": {},
+}
+
+
+def _wav_sample():
+    stream = io.BytesIO()
+    with wave.open(stream, "wb") as output:
+        output.setnchannels(1)
+        output.setsampwidth(2)
+        output.setframerate(24_000)
+        output.writeframes(struct.pack("<hh", 2_000, -2_000) * 1_200)
+    return stream.getvalue()
+
+
+def _preferences(provider):
+    model, voice, _internal = DEFAULT_SELECTIONS[provider]
+    return TTSPreferencesSnapshot(
+        provider_id=provider,
+        model_mode="first_available" if provider == "audio_cpp" else "exact",
+        model_id=None if provider == "audio_cpp" else model,
+        voice_mode="server_default" if voice is None else "exact",
+        voice_id=voice,
+        response_format="wav",
+        speed=1.0,
+    )
+
+
+class _AudioHost:
+    def __init__(self, audio):
+        self.audio = audio
+        self.calls = []
+
+    def admitted_outbound_endpoint(self):
+        return "https://tts.example.invalid"
+
+    async def generate(self, internal_model_id, request, progress_sink):
+        assert request.response_format == "wav"
+        self.calls.append((internal_model_id, request))
+        yield self.audio[:101]
+        yield self.audio[101:]
+
+    async def close(self):
+        return None
+
+
+class _RecordingLegacyAdapter(LegacyTTSAdapter):
+    def __init__(self, provider, audio):
+        super().__init__(provider, _AudioHost(audio), legacy_catalog(provider))
+        self.requests = []
+
+    async def synthesize(self, request, progress_sink=None):
+        self.requests.append(request)
+        return await super().synthesize(request, progress_sink)
+
+
+class _ResponseStream(httpx.AsyncByteStream):
+    def __init__(self, body):
+        self.body = body
+
+    async def __aiter__(self):
+        yield self.body
+
+
+def _json_response(value):
+    return httpx.Response(
+        200,
+        headers={"Content-Type": "application/json"},
+        stream=_ResponseStream(json.dumps(value).encode()),
+    )
+
+
+class _RecordingAudioCppAdapter(AudioCppAdapter):
+    def __init__(self, audio):
+        self.requests = []
+        self.http_calls = []
+
+        def respond(request):
+            self.http_calls.append(request)
+            if request.url.path == "/health":
+                return _json_response({"status": "ok", "backend": "cpu", "models": 1})
+            if request.url.path == "/v1/models":
+                return _json_response(
+                    {
+                        "object": "list",
+                        "data": [
+                            {
+                                "id": "native/model",
+                                "object": "model",
+                                "owned_by": "engine",
+                                "family": "pocket_tts",
+                                "task": "tts",
+                                "mode": "native",
+                            }
+                        ],
+                    },
+                )
+            if request.url.path == "/v1/audio/voices":
+                return _json_response({"voices": ["native/voice"]})
+            assert request.url.path == "/v1/audio/speech"
+            assert json.loads(request.content)["response_format"] == "wav"
+            return httpx.Response(
+                200,
+                stream=_ResponseStream(audio),
+                headers={"Content-Type": "audio/wav"},
+            )
+
+        super().__init__(
+            AudioCppConfig.from_mapping(
+                {"mode": "external", "base_url": "http://127.0.0.1:18991"}
+            ),
+            transport=httpx.MockTransport(respond),
+        )
+
+    async def synthesize(self, request, progress_sink=None):
+        self.requests.append(request)
+        return await super().synthesize(request, progress_sink)
+
+
+class _Host(App):
+    def __init__(self, pane):
+        super().__init__()
+        self.pane = pane
+        self.requests = []
+        self.notices = []
+
+    def compose(self) -> ComposeResult:
+        yield self.pane
+
+    def post_message(self, message):
+        if isinstance(message, STTSPlaygroundGenerateEvent):
+            self.requests.append(message.request)
+            return True
+        return super().post_message(message)
+
+    def notify(self, message, *, severity="information", **kwargs):
+        self.notices.append((str(message), severity))
+
+
+@pytest.fixture
+def backend_lab_factory(monkeypatch):
+    @asynccontextmanager
+    async def mount(provider, *, preferences=None, studio=None, wait_ready=True):
+        preferences = preferences or _preferences(provider)
+        studio = studio or StudioTTSPreferencesSnapshot()
+        audio = _wav_sample()
+        adapters = {
+            provider_id: (
+                _RecordingAudioCppAdapter(audio)
+                if provider_id == "audio_cpp"
+                else _RecordingLegacyAdapter(provider_id, audio)
+            )
+            for provider_id in DEFAULT_SELECTIONS
+        }
+        registry = TTSAdapterRegistry(
+            specs=tuple(
+                TTSProviderSpec(
+                    descriptor=TTSProviderDescriptor(
+                        provider_id=provider_id,
+                        display_name=provider_id,
+                        native=provider_id == "audio_cpp",
+                    ),
+                    factory=lambda _config, adapter=adapter: adapter,
+                    initial_config=(
+                        {"mode": "external", "base_url": "http://127.0.0.1:18991"}
+                        if provider_id == "audio_cpp"
+                        else {}
+                    ),
+                    exclusive_reconfigure=True,
+                )
+                for provider_id, adapter in adapters.items()
+            ),
+            aliases={},
+        )
+        service = TTSService(
+            registry,
+            preferences_snapshot=preferences,
+            studio_preferences_loader=lambda: studio,
+            audio_cpp_supervisor=AudioCppSupervisor(source_environment={}),
+        )
+        monkeypatch.setattr(
+            SpeechPlaygroundPane,
+            "_tts_service_factory",
+            lambda self: _resolved(service),
+        )
+        monkeypatch.setattr(
+            SpeechPlaygroundPane, "_check_higgs_installation", lambda self: None
+        )
+        pane = SpeechPlaygroundPane(
+            provider=provider,
+            axis_defaults=SpeechPlaygroundPane._project_axis_defaults(
+                studio, preferences
+            ),
+            studio_preferences=studio,
+            global_preferences=preferences,
+        )
+        app = _Host(pane)
+        handler = STTSEventHandler(app)
+        handler._stts_service = service
+        app._stts_handler = handler
+        try:
+            async with app.run_test(size=(150, 65)) as pilot:
+                await _wait_until(
+                    pilot,
+                    lambda: (
+                        pane.provider == provider
+                        and (
+                            not pane.query_one("#tts-generate-btn", Button).disabled
+                            if wait_ready
+                            else provider in pane._catalogs
+                        )
+                    ),
+                )
+                yield SimpleNamespace(
+                    app=app,
+                    pane=pane,
+                    pilot=pilot,
+                    handler=handler,
+                    service=service,
+                    adapters=adapters,
+                    audio=audio,
+                )
+        finally:
+            await handler.cleanup_tts_resources()
+            await service.close()
+            await service.wait_closed()
+            # The native adapter owns an HTTP client even if no lease used it.
+            await adapters["audio_cpp"].close()
+
+    return mount
+
+
+def _assert_wav(audio):
+    with wave.open(io.BytesIO(audio), "rb") as decoded:
+        assert decoded.getnchannels() == 1
+        assert decoded.getsampwidth() == 2
+        assert decoded.getframerate() == 24_000
+        assert decoded.getnframes() == 2_400
+        assert decoded.readframes(2_400) == struct.pack("<hh", 2_000, -2_000) * 1_200
+
+
+async def _generate(lab):
+    provider = lab.pane.provider
+    lab.pane.query_one("#tts-text-input", TextArea).text = "A synthetic audio reply."
+    await lab.pilot.pause()
+    previous = lab.handler._current_playground_artifact
+    count = len(lab.app.requests)
+    lab.pane.action_generate_tts()
+    assert len(lab.app.requests) == count + 1, lab.app.notices
+    await lab.handler.handle_playground_generate(
+        STTSPlaygroundGenerateEvent(lab.app.requests[-1])
+    )
+    await lab.pilot.pause()
+    artifact = lab.handler._current_playground_artifact
+    assert artifact is not None and artifact is not previous, lab.app.notices
+    assert artifact.operation_id == lab.app.requests[-1].operation_id
+    assert artifact.provider_id == provider
+    assert artifact.audio_format == "wav" and artifact.content_type == "audio/wav"
+    assert artifact.path.read_bytes() == lab.audio
+    _assert_wav(artifact.path.read_bytes())
+    assert not lab.pane.query_one("#tts-generate-btn", Button).disabled
+    assert not lab.pane.query_one("#audio-play-btn", Button).disabled
+    if previous is not None:
+        assert not previous.path.exists()
+    return lab.adapters[provider].requests[-1]
+
+
+def _assert_selection(request, provider):
+    model, voice, internal = DEFAULT_SELECTIONS[provider]
+    assert (request.provider_id, request.model_id, request.voice) == (
+        provider,
+        model,
+        voice,
+    )
+    assert request.speed == 1.0 and request.response_format == "wav"
+    if internal is not None:
+        assert request.options["_legacy_internal_model_id"] == internal
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", DEFAULT_SELECTIONS)
+async def test_fresh_provider_controls_admit_repeated_complete_wav_and_match_defaults(
+    backend_lab_factory, provider
+):
+    async with backend_lab_factory(provider) as lab:
+        language = lab.pane.query_one("#tts-language-select", Select)
+        if provider == "kokoro":
+            assert language.value == "" and not language.disabled
+        else:
+            assert language.disabled
+            assert not lab.pane.query_one(
+                "#speech-axis-cell-tts-language-select"
+            ).display
+        if provider == "audio_cpp":
+            assert (
+                lab.pane.query_one("#tts-voice-select", Select).value
+                is SERVER_DEFAULT_VOICE_ID
+            )
+            assert lab.pane.query_one("#tts-format-select", Select).disabled
+            assert lab.pane.query_one("#tts-speed-input", Input).disabled
+        for _ in range(2):
+            request = await _generate(lab)
+            _assert_selection(request, provider)
+            options = (
+                request.options["_legacy_openai_request"].extra_params or {}
+                if provider != "audio_cpp"
+                else dict(request.options)
+            )
+            assert options == DEFAULT_OPTIONS[provider]
+        response = await lab.service.synthesize_default(text="An automatic reply.")
+        try:
+            automatic_audio = b"".join([chunk async for chunk in response.byte_stream])
+            assert automatic_audio == lab.audio
+            _assert_wav(automatic_audio)
+        finally:
+            await response.aclose()
+        assert len(lab.adapters[provider].requests) == 3
+        _assert_selection(lab.adapters[provider].requests[-1], provider)
+
+
+async def _switch(lab, provider):
+    lab.pane.query_one("#tts-provider-select", Select).value = provider
+    await _wait_until(
+        lab.pilot,
+        lambda: (
+            lab.pane.provider == provider
+            and not lab.pane.query_one("#tts-generate-btn", Button).disabled
+            and bool(lab.pane.query("#speech-param-group"))
+            and lab.pane.query_one("#speech-param-group").provider == provider
+        ),
+    )
+    await lab.pilot.pause()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", DEFAULT_SELECTIONS)
+async def test_provider_round_trip_does_not_carry_foreign_model_voice_or_options(
+    backend_lab_factory, provider
+):
+    async with backend_lab_factory(provider) as lab:
+        first = await _generate(lab)
+        _assert_selection(first, provider)
+        other = "openai" if provider == "audio_cpp" else "audio_cpp"
+        await _switch(lab, other)
+        _assert_selection(await _generate(lab), other)
+        await _switch(lab, provider)
+        _assert_selection(await _generate(lab), provider)
+
+
+@pytest.mark.asyncio
+async def test_explicit_kokoro_language_is_scoped_across_native_round_trip(
+    backend_lab_factory,
+):
+    async with backend_lab_factory("kokoro") as lab:
+        lab.pane.query_one("#tts-language-select", Select).value = "fr"
+        first = await _generate(lab)
+        assert first.options["_legacy_openai_request"].extra_params == {
+            "use_onnx": True,
+            "language": "fr",
+        }
+        await _switch(lab, "audio_cpp")
+        assert dict((await _generate(lab)).options) == {}
+        await _switch(lab, "kokoro")
+        language = lab.pane.query_one("#tts-language-select", Select)
+        assert language.value == "fr"
+        assert language.value not in {LOADING_SELECT_VALUE, UNAVAILABLE_SELECT_VALUE}
+        assert (await _generate(lab)).options[
+            "_legacy_openai_request"
+        ].extra_params == {"use_onnx": True, "language": "fr"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", tuple(DEFAULT_SELECTIONS)[:-1])
+async def test_stale_native_global_selection_does_not_block_selected_legacy_provider(
+    backend_lab_factory, provider
+):
+    stale = replace(
+        _preferences("audio_cpp"),
+        model_mode="exact",
+        model_id="removed/model",
+        voice_mode="exact",
+        voice_id="removed/voice",
+    )
+    async with backend_lab_factory(
+        "audio_cpp", preferences=stale, wait_ready=False
+    ) as lab:
+        assert lab.pane.query_one("#tts-model-select", Select).value == "removed/model"
+        assert lab.pane.query_one("#tts-voice-select", Select).value == "removed/voice"
+        assert lab.pane.query_one("#tts-generate-btn", Button).disabled
+        assert lab.adapters["audio_cpp"].requests == []
+        await _switch(lab, provider)
+        for _ in range(2):
+            _assert_selection(await _generate(lab), provider)
+        assert lab.service.preferences_snapshot() is stale
+        assert lab.adapters["audio_cpp"].requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("owner", ["global", "studio"])
+@pytest.mark.parametrize("missing_axis", ["model", "voice"])
+async def test_missing_exact_native_selection_is_pinned_before_and_after_provider_trip(
+    backend_lab_factory, owner, missing_axis
+):
+    model = "removed/model" if missing_axis == "model" else "native/model"
+    voice = "removed/voice" if missing_axis == "voice" else "native/voice"
+    preferences = replace(
+        _preferences("audio_cpp"),
+        model_mode="exact",
+        model_id=model,
+        voice_mode="exact",
+        voice_id=voice,
+    )
+    studio = StudioTTSPreferencesSnapshot()
+    if owner == "studio":
+        preferences = _preferences("openai")
+        studio = StudioTTSPreferencesSnapshot(
+            selection=StudioTTSSelectionOverrides(
+                provider_id="audio_cpp",
+                model_mode="exact",
+                model_id=model,
+                voice_mode="exact",
+                voice_id=voice,
+                response_format="wav",
+            )
+        )
+    async with backend_lab_factory(
+        "audio_cpp", preferences=preferences, studio=studio, wait_ready=False
+    ) as lab:
+        for visit in range(2):
+            if visit:
+                await _switch(lab, "openai")
+                lab.pane.query_one("#tts-provider-select", Select).value = "audio_cpp"
+            await _wait_until(
+                lab.pilot,
+                lambda: (
+                    lab.pane.provider == "audio_cpp"
+                    and lab.pane.query_one("#tts-model-select", Select).value == model
+                    and lab.pane.query_one("#tts-voice-select", Select).value == voice
+                ),
+            )
+            await lab.pilot.pause()
+            assert lab.pane.query_one("#tts-generate-btn", Button).disabled
+            lab.pane.query_one(
+                "#tts-text-input", TextArea
+            ).text = "Must stay unadmitted."
+            lab.pane.action_generate_tts()
+            assert lab.app.requests == []
+            assert lab.adapters["audio_cpp"].requests == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("voice", ["native/voice", "removed/voice"])
+async def test_returning_to_global_provider_keeps_its_voice_when_studio_owns_another(
+    backend_lab_factory, voice
+):
+    preferences = replace(
+        _preferences("audio_cpp"),
+        model_mode="exact",
+        model_id="native/model",
+        voice_mode="exact",
+        voice_id=voice,
+    )
+    studio = StudioTTSPreferencesSnapshot(
+        selection=StudioTTSSelectionOverrides(provider_id="openai")
+    )
+    async with backend_lab_factory(
+        "openai", preferences=preferences, studio=studio
+    ) as lab:
+        lab.pane.query_one("#tts-provider-select", Select).value = "audio_cpp"
+        await _wait_until(
+            lab.pilot,
+            lambda: (
+                lab.pane.provider == "audio_cpp"
+                and "audio_cpp" in lab.pane._catalogs
+                and ("audio_cpp", "native/model") in lab.pane._discovered_voices
+            ),
+        )
+        await lab.pilot.pause()
+        assert lab.pane.query_one("#tts-voice-select", Select).value == voice
+        if voice == "removed/voice":
+            assert lab.pane.query_one("#tts-generate-btn", Button).disabled
+            assert lab.adapters["audio_cpp"].requests == []
+        else:
+            assert (await _generate(lab)).voice == voice
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider,terminal",
+    [
+        ("kokoro", "stop"),
+        ("kokoro", "finish"),
+        ("kokoro", "failure"),
+        ("openai", "unknown"),
+    ],
+)
+async def test_pcm_lab_playback_preserves_raw_export_and_refuses_unknown_shape(
+    provider, terminal, backend_lab_factory, monkeypatch, tmp_path
+):
+    preferences = replace(_preferences(provider), response_format="pcm")
+    pcm = struct.pack("<hh", 2000, -2000) * 1200
+
+    class Player:
+        def __init__(self):
+            self.played = []
+            self.bodies = []
+            self.state = PlaybackState.IDLE
+
+        async def play(self, path):
+            self.played.append(path)
+            self.bodies.append(path.read_bytes())
+            self.state = PlaybackState.PLAYING
+            return terminal != "failure"
+
+        async def stop(self):
+            self.state = PlaybackState.IDLE
+            return True
+
+        async def get_state(self):
+            return self.state
+
+        async def is_playing(self):
+            return self.state is PlaybackState.PLAYING
+
+        async def get_position(self):
+            return 0
+
+        async def get_duration(self):
+            return 0.1
+
+    async with backend_lab_factory(provider, preferences=preferences) as lab:
+        host = lab.adapters[provider].host
+
+        async def generate(internal_model_id, request, progress_sink):
+            assert request.response_format == "pcm"
+            host.calls.append((internal_model_id, request))
+            yield pcm[:3]
+            yield pcm[3:]
+
+        monkeypatch.setattr(host, "generate", generate)
+        player = Player()
+        lab.app.audio_player = player
+        lab.pane.query_one("#tts-text-input", TextArea).text = "A synthetic PCM reply."
+        lab.pane.action_generate_tts()
+        await lab.handler.handle_playground_generate(
+            STTSPlaygroundGenerateEvent(lab.app.requests[-1])
+        )
+        await lab.pilot.pause()
+        artifact = lab.handler._current_playground_artifact
+        assert artifact is not None
+        assert artifact.audio_format == "pcm"
+        assert artifact.path.suffix == ".pcm"
+        assert artifact.path.read_bytes() == pcm
+
+        exported = tmp_path / "exported.pcm"
+        lab.pane._handle_audio_export(str(exported))
+        assert exported.read_bytes() == pcm
+
+        for attempt in range(2):
+            lab.pane.action_play_audio()
+            await lab.app.workers.wait_for_complete()
+            if provider == "openai":
+                # The fixture's custom origin offers no sample-rate contract.
+                assert player.played == []
+                assert any("PCM" in message for message, _ in lab.app.notices)
+            else:
+                assert len(player.played) == attempt + 1
+                playback_path = player.played[-1]
+                assert playback_path != artifact.path
+                assert playback_path.suffix == ".wav"
+                _assert_wav(player.bodies[-1])
+                if terminal == "stop":
+                    await lab.pane._stop_audio_async()
+                elif terminal == "finish":
+                    player.state = PlaybackState.FINISHED
+                    await _wait_until(
+                        lab.pilot, lambda path=playback_path: not path.exists()
+                    )
+                assert not playback_path.exists()
+            assert artifact.path.read_bytes() == pcm
+            assert exported.read_bytes() == pcm
+
+
+@pytest.mark.asyncio
+async def test_cancelled_lab_pcm_copy_releases_its_lease_after_the_reader_retires(
+    backend_lab_factory, monkeypatch, tmp_path
+):
+    entered = threading.Event()
+    finish = threading.Event()
+    copies = []
+    real_copy = speech_playback_mixin.create_pcm16_wav_copy
+
+    def held_copy(*args):
+        result = real_copy(*args)
+        copies.append(result)
+        entered.set()
+        assert finish.wait(5)
+        return result
+
+    monkeypatch.setattr(speech_playback_mixin, "create_pcm16_wav_copy", held_copy)
+    async with backend_lab_factory("kokoro") as lab:
+        original = tmp_path / "owned.pcm"
+        original.write_bytes(struct.pack("<hh", 2000, -2000) * 1200)
+        artifact = STTSGeneratedAudio(
+            path=original,
+            provider_id="kokoro",
+            model_id="kokoro",
+            voice_id="af_alloy",
+            source_text="A synthetic reply.",
+            operation_id="pcm-copy-cancel",
+            audio_format="pcm",
+            content_type="application/octet-stream",
+            metadata={"sample_rate": 24000, "channels": 1},
+        )
+        lab.handler._accept_playground_artifact(artifact)
+        lab.pane._generation_complete(artifact)
+        lab.app.audio_player = SimpleNamespace(
+            get_state=AsyncMock(return_value=PlaybackState.IDLE),
+            stop=AsyncMock(return_value=True),
+            play=AsyncMock(return_value=True),
+        )
+        try:
+            lab.pane.action_play_audio()
+            assert await asyncio.to_thread(entered.wait, 5)
+            playback_worker = lab.pane._play_worker_task
+            playback_worker.cancel()
+            await lab.pilot.pause()
+            assert original.exists()
+            assert copies[0].exists()
+            assert lab.handler._playground_file_leases[original] == 1
+            finish.set()
+            with pytest.raises(WorkerCancelled):
+                await playback_worker.wait()
+            assert not copies[0].exists()
+            assert original.exists()
+            assert lab.handler._playground_file_leases.get(original, 0) == 0
+            lab.app.audio_player.play.assert_not_called()
+        finally:
+            finish.set()

--- a/Tests/UI/test_tts_backend_playground_admission.py
+++ b/Tests/UI/test_tts_backend_playground_admission.py
@@ -28,6 +28,7 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
 )
+from tldw_chatbook.TTS import pcm_playback
 from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
 from tldw_chatbook.TTS.adapter_types import TTSProviderDescriptor, TTSProviderSpec
 from tldw_chatbook.TTS.adapters.audio_cpp import AudioCppAdapter
@@ -43,7 +44,6 @@ from tldw_chatbook.TTS.studio_preferences import (
     StudioTTSSelectionOverrides,
 )
 from tldw_chatbook.TTS.TTS_Generation import TTSService
-from tldw_chatbook.UI.Speech import speech_playback_mixin
 from tldw_chatbook.UI.Speech.speech_playground_pane import SpeechPlaygroundPane
 from tldw_chatbook.UI.stts_playground_catalog import (
     LOADING_SELECT_VALUE,
@@ -672,7 +672,7 @@ async def test_cancelled_lab_pcm_copy_releases_its_lease_after_the_reader_retire
     entered = threading.Event()
     finish = threading.Event()
     copies = []
-    real_copy = speech_playback_mixin.create_pcm16_wav_copy
+    real_copy = pcm_playback.create_pcm16_wav_copy
 
     def held_copy(*args):
         result = real_copy(*args)
@@ -681,7 +681,7 @@ async def test_cancelled_lab_pcm_copy_releases_its_lease_after_the_reader_retire
         assert finish.wait(5)
         return result
 
-    monkeypatch.setattr(speech_playback_mixin, "create_pcm16_wav_copy", held_copy)
+    monkeypatch.setattr(pcm_playback, "create_pcm16_wav_copy", held_copy)
     async with backend_lab_factory("kokoro") as lab:
         original = tmp_path / "owned.pcm"
         original.write_bytes(struct.pack("<hh", 2000, -2000) * 1200)

--- a/Tests/UI/test_tts_backend_playground_admission.py
+++ b/Tests/UI/test_tts_backend_playground_admission.py
@@ -15,12 +15,12 @@ import wave
 from contextlib import asynccontextmanager
 from dataclasses import replace
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock, Mock
 
 import httpx
 import pytest
 from textual.app import App, ComposeResult
-from textual.widgets import Button, Input, Select, TextArea
+from textual.widgets import Button, Input, Select, Static, TextArea
 from textual.worker import WorkerCancelled
 
 from Tests.UI.speech_playground_fixtures import _resolved, _wait_until
@@ -28,6 +28,7 @@ from tldw_chatbook.Event_Handlers.STTS_Events.stts_events import (
     STTSEventHandler,
     STTSPlaygroundGenerateEvent,
 )
+from tldw_chatbook.TTS import audio_player as audio_player_module
 from tldw_chatbook.TTS import pcm_playback
 from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
 from tldw_chatbook.TTS.adapter_types import TTSProviderDescriptor, TTSProviderSpec
@@ -575,6 +576,7 @@ async def test_returning_to_global_provider_keeps_its_voice_when_studio_owns_ano
         ("kokoro", "stop"),
         ("kokoro", "finish"),
         ("kokoro", "failure"),
+        ("kokoro", "error"),
         ("openai", "unknown"),
     ],
 )
@@ -635,10 +637,13 @@ async def test_pcm_lab_playback_preserves_raw_export_and_refuses_unknown_shape(
         assert artifact.audio_format == "pcm"
         assert artifact.path.suffix == ".pcm"
         assert artifact.path.read_bytes() == pcm
+        release = Mock(wraps=lab.handler.release_playground_result)
+        monkeypatch.setattr(lab.handler, "release_playground_result", release)
 
         exported = tmp_path / "exported.pcm"
         lab.pane._handle_audio_export(str(exported))
         assert exported.read_bytes() == pcm
+        release.reset_mock()
 
         for attempt in range(2):
             lab.pane.action_play_audio()
@@ -655,12 +660,30 @@ async def test_pcm_lab_playback_preserves_raw_export_and_refuses_unknown_shape(
                 _assert_wav(player.bodies[-1])
                 if terminal == "stop":
                     await lab.pane._stop_audio_async()
-                elif terminal == "finish":
-                    player.state = PlaybackState.FINISHED
+                elif terminal in {"finish", "error"}:
+                    player.state = (
+                        PlaybackState.ERROR
+                        if terminal == "error"
+                        else PlaybackState.FINISHED
+                    )
                     await _wait_until(
                         lab.pilot, lambda path=playback_path: not path.exists()
                     )
+                    assert lab.pane._progress_timer_task.done()
                 assert not playback_path.exists()
+            assert release.call_count == attempt + 1
+            assert lab.handler._playground_file_leases.get(artifact.path, 0) == 0
+            assert not lab.pane.query_one("#audio-play-btn", Button).disabled
+            assert lab.pane.query_one("#pause-audio-btn", Button).disabled
+            assert lab.pane.query_one("#stop-audio-btn", Button).disabled
+            if terminal == "error":
+                assert str(
+                    lab.pane.query_one("#audio-player-status", Static).content
+                ) == ("Playback failed")
+                assert (
+                    lab.app.notices.count(("Playback failed", "error")) == attempt + 1
+                )
+                assert ("Playback complete", "information") not in lab.app.notices
             assert artifact.path.read_bytes() == pcm
             assert exported.read_bytes() == pcm
 
@@ -698,6 +721,8 @@ async def test_cancelled_lab_pcm_copy_releases_its_lease_after_the_reader_retire
         )
         lab.handler._accept_playground_artifact(artifact)
         lab.pane._generation_complete(artifact)
+        release = Mock(wraps=lab.handler.release_playground_result)
+        monkeypatch.setattr(lab.handler, "release_playground_result", release)
         lab.app.audio_player = SimpleNamespace(
             get_state=AsyncMock(return_value=PlaybackState.IDLE),
             stop=AsyncMock(return_value=True),
@@ -712,12 +737,113 @@ async def test_cancelled_lab_pcm_copy_releases_its_lease_after_the_reader_retire
             assert original.exists()
             assert copies[0].exists()
             assert lab.handler._playground_file_leases[original] == 1
+            release.assert_not_called()
             finish.set()
             with pytest.raises(WorkerCancelled):
                 await playback_worker.wait()
             assert not copies[0].exists()
             assert original.exists()
             assert lab.handler._playground_file_leases.get(original, 0) == 0
+            release.assert_called_once_with(artifact.operation_id, original)
             lab.app.audio_player.play.assert_not_called()
         finally:
             finish.set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_code", [0, 17, None])
+async def test_opus_lab_action_uses_real_player_and_observes_terminal_failure(
+    exit_code, backend_lab_factory, monkeypatch, tmp_path
+):
+    """Exercise application transport; the fake process makes no codec claim."""
+    player = audio_player_module.SimpleAudioPlayer()
+    player._system = "Darwin"
+    monkeypatch.setattr(audio_player_module, "_audio_player_instance", player)
+    monkeypatch.setattr(
+        audio_player_module.shutil,
+        "which",
+        lambda name: (
+            "/test/ffplay" if name == "ffplay" and exit_code is not None else None
+        ),
+    )
+    finished = threading.Event()
+    process = MagicMock()
+    process.poll.side_effect = lambda: exit_code if finished.is_set() else None
+
+    def wait(timeout=None):
+        assert finished.wait(5 if timeout is None else timeout)
+        return exit_code
+
+    process.wait.side_effect = wait
+    process.terminate.side_effect = finished.set
+    process.kill.side_effect = finished.set
+    spawn = Mock(return_value=process)
+    monkeypatch.setattr(audio_player_module.subprocess, "Popen", spawn)
+
+    async with backend_lab_factory("kokoro") as lab:
+        original = tmp_path / "owned.opus"
+        original.write_bytes(b"OggS synthetic device-transport fixture")
+        artifact = STTSGeneratedAudio(
+            path=original,
+            provider_id="kokoro",
+            model_id="kokoro",
+            voice_id="af_alloy",
+            source_text="A synthetic reply.",
+            operation_id="opus-transport",
+            audio_format="opus",
+            content_type="audio/opus",
+        )
+        lab.handler._accept_playground_artifact(artifact)
+        lab.pane._generation_complete(artifact)
+        release = Mock(wraps=lab.handler.release_playground_result)
+        monkeypatch.setattr(lab.handler, "release_playground_result", release)
+        try:
+            lab.pane.action_play_audio()
+            await lab.app.workers.wait_for_complete()
+            assert isinstance(
+                lab.app.audio_player, audio_player_module.AsyncAudioPlayer
+            )
+            assert lab.app.audio_player._player is player
+            if exit_code is None:
+                spawn.assert_not_called()
+                assert ("Failed to start playback", "error") in lab.app.notices
+            else:
+                assert spawn.call_args.args[0] == [
+                    "/test/ffplay",
+                    "-nodisp",
+                    "-autoexit",
+                    "-loglevel",
+                    "error",
+                    str(original),
+                ]
+                release.assert_not_called()
+                assert lab.handler._playground_file_leases[original] == 1
+                finished.set()
+                await _wait_until(lab.pilot, lab.pane._progress_timer_task.done)
+                expected_state = (
+                    PlaybackState.FINISHED if exit_code == 0 else PlaybackState.ERROR
+                )
+                assert await lab.app.audio_player.get_state() is expected_state
+                expected_notice = (
+                    ("Playback complete", "information")
+                    if exit_code == 0
+                    else ("Playback failed", "error")
+                )
+                assert lab.app.notices.count(expected_notice) == 1
+            release.assert_called_once_with(artifact.operation_id, original)
+            assert lab.handler._playground_file_leases.get(original, 0) == 0
+            assert original.exists()
+            assert not lab.pane.query_one("#audio-play-btn", Button).disabled
+            assert lab.pane.query_one("#pause-audio-btn", Button).disabled
+            assert lab.pane.query_one("#stop-audio-btn", Button).disabled
+            assert lab.pane.query_one("#audio-player-transport").has_class("hidden")
+            if exit_code != 0:
+                assert ("Playback complete", "information") not in lab.app.notices
+                assert (
+                    str(lab.pane.query_one("#audio-player-status", Static).content)
+                    == "Playback failed"
+                )
+            await lab.pane._stop_audio_async()
+            release.assert_called_once_with(artifact.operation_id, original)
+        finally:
+            finished.set()

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12473,6 +12473,26 @@ the entire response survived encoding. Keep inference, codec, device and content
 evidence distinct; these checks used real ONNX inference and codecs, while
 PyTorch coverage replaced only inference and voice loading.
 
+### TASK-32076: A zero player exit does not prove full playback
+
+The TTS backend parity audit produced a valid 5.717-second Opus clip that
+FFmpeg decoded and Whisper transcribed completely. macOS `afplay` returned
+exit code 0 after approximately 2.0 seconds, while `afinfo` could not open the
+file. Switching Opus playback to the existing FFplay path took 6.13 seconds
+and retained the complete transcript. For playback evidence, check decoded
+frames/content **and** player elapsed time/completion; a nonempty file and a
+successful process exit can both conceal an unsupported format. Also retain
+the exact process in completion callbacks: a late previous monitor must not
+finish the next clip.
+
+PR #2520's Qodo review then exposed a second gap: the player correctly reported
+ERROR, but Speech Lab kept polling and spoken feedback reported success at its
+timeout. Mounted playback and public utterance tests reproduced eight failures
+that direct player tests missed. A manager-level Higgs close test also missed
+that its host detaches the manager at shutdown; a real host/manager test proved
+cleanup must remain owned past that deadline. Verify terminal outcomes and
+resource release through the caller that actually owns the operation.
+
 ## Successful tool discovery changes the rendered system row (TASK-32048, 2026-09-08)
 
 The reported third-request `unsupported_surface_change` was reproduced only
@@ -12507,24 +12527,3 @@ had no persisted conversation when the transform ran, so the applier returned
 unchanged text. Persist first, assert transformed wire content, and verify the
 origin's `active_request` row and exact source pin before claiming transform
 coverage. Both corrected controls passed with the discard fix.
-
-
-### TASK-32076: A zero player exit does not prove full playback
-
-The TTS backend parity audit produced a valid 5.717-second Opus clip that
-FFmpeg decoded and Whisper transcribed completely. macOS `afplay` returned
-exit code 0 after approximately 2.0 seconds, while `afinfo` could not open the
-file. Switching Opus playback to the existing FFplay path took 6.13 seconds
-and retained the complete transcript. For playback evidence, check decoded
-frames/content **and** player elapsed time/completion; a nonempty file and a
-successful process exit can both conceal an unsupported format. Also retain
-the exact process in completion callbacks: a late previous monitor must not
-finish the next clip.
-
-PR #2520's Qodo review then exposed a second gap: the player correctly reported
-ERROR, but Speech Lab kept polling and spoken feedback reported success at its
-timeout. Mounted playback and public utterance tests reproduced eight failures
-that direct player tests missed. A manager-level Higgs close test also missed
-that its host detaches the manager at shutdown; a real host/manager test proved
-cleanup must remain owned past that deadline. Verify terminal outcomes and
-resource release through the caller that actually owns the operation.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12520,3 +12520,11 @@ frames/content **and** player elapsed time/completion; a nonempty file and a
 successful process exit can both conceal an unsupported format. Also retain
 the exact process in completion callbacks: a late previous monitor must not
 finish the next clip.
+
+PR #2520's Qodo review then exposed a second gap: the player correctly reported
+ERROR, but Speech Lab kept polling and spoken feedback reported success at its
+timeout. Mounted playback and public utterance tests reproduced eight failures
+that direct player tests missed. A manager-level Higgs close test also missed
+that its host detaches the manager at shutdown; a real host/manager test proved
+cleanup must remain owned past that deadline. Verify terminal outcomes and
+resource release through the caller that actually owns the operation.

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12507,3 +12507,16 @@ had no persisted conversation when the transform ran, so the applier returned
 unchanged text. Persist first, assert transformed wire content, and verify the
 origin's `active_request` row and exact source pin before claiming transform
 coverage. Both corrected controls passed with the discard fix.
+
+
+### TASK-32076: A zero player exit does not prove full playback
+
+The TTS backend parity audit produced a valid 5.717-second Opus clip that
+FFmpeg decoded and Whisper transcribed completely. macOS `afplay` returned
+exit code 0 after approximately 2.0 seconds, while `afinfo` could not open the
+file. Switching Opus playback to the existing FFplay path took 6.13 seconds
+and retained the complete transcript. For playback evidence, check decoded
+frames/content **and** player elapsed time/completion; a nonempty file and a
+successful process exit can both conceal an unsupported format. Also retain
+the exact process in completion callbacks: a late previous monitor must not
+finish the next clip.

--- a/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
+++ b/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
@@ -1,0 +1,49 @@
+---
+id: TASK-32076
+title: Verify and repair TTS backend audio delivery parity
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 18:21'
+updated_date: '2026-09-08 19:15'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users need each retained TTS provider to produce complete playable replies and preserve request ownership across failure or cancellation after similar Kokoro defects were fixed.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every registered TTS provider is checked through effective selection and repeated request admission with actual output contracts documented.
+- [x] #2 Confirmed Chatterbox complete-file encoding, non-WAV conversion, cancellation ownership and retry-state defects have regression coverage and are repaired.
+- [x] #3 Confirmed provider format mismatches and shared codec failures are repaired without mislabeling raw PCM or publishing errors as successful audio.
+- [x] #4 Targeted regression tests and available real playback checks document full decoded duration, content, and model or credential limitations.
+- [x] #5 Supported output formats reach a compatible file player, and completion or failure belongs only to the process that played that clip.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md; backlog/decisions/039-global-and-studio-tts-settings-ownership.md; backlog/decisions/040-speech-lab-current-result-and-auto-play.md
+Reason: Restore existing complete-file, declared-format, effective-selection and operation-ownership contracts; no new provider or storage boundary.
+1. Run the targeted backend baseline and reproduce container truncation, format mismatch, cancellation and false-success cases with real codecs and transport boundaries.
+2. Add failing regressions for confirmed defects; repair Chatterbox output and operation ownership, shared codec mappings, provider format handling and Higgs failure propagation.
+3. Exercise every registered provider from mounted fresh controls through repeated admission and response consumption; check native audio.cpp contracts.
+4. Validate available local inference and playback with complete decoding and transcript checks, documenting unavailable services or model weights.
+5. Run targeted regressions, formatter/lint and required derived checks; record exact evidence and remaining limitations.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Repaired delivery parity across registered TTS providers: Chatterbox produces one complete encoded utterance, uses a real conversion API, retains canceled inference/process ownership, resets fallback state and bounds retained audio; Higgs rejects failed/missing/nonfinite audio and retains loading/generation threads. ElevenLabs and AllTalk now deliver their declared formats, and shared PCM/AAC muxing is correct. Provider switching preserves Global/Studio model and voice ownership. Explicit known-rate PCM supports live/fallback playback without altering raw exports or default request formats. Mac Opus uses FFplay; exact-process completion honors failure exit codes.
+
+Validation: main Python 3.12 targeted cohort: 744 passed, 1 optional Chatterbox skip; final Chatterbox: 30 passed; Python 3.13 shared/PCM/UI: 115 passed, 16 Torch-dependent skips, plus independent PCM/adjacent/UI cohorts: 116 + 242 + 129 passed. Six real device-playback format paths retained full decoded duration and complete independently transcribed content using recorded speech at model/HTTP boundaries. No live Chatterbox/Higgs/remote/audio.cpp inference claim. All derived preflight checks pass; all changed Python formats/syntax checks pass, new files full Ruff clean, zero introduced legacy lint diagnostics. Independent review found no actionable issues and 8 targeted review regressions passed.
+
+ADR required: no; existing 023, 039, 040 govern these repaired contracts. Diagnostic statements reviewed before regeneration: obsolete logs removed; only fixed Opus guidance and numeric process status added, no new logging destination/content interpolation. Evidence and limits: Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md. Updated Speech Services guide and a lesson from the afplay false-success incident. No full test sweep. TASK-1880 remains partly open for caller-scoped/default PCM selection. Task renumbered from 32051 after a 189 remote-ref / all-worktree audit found an unrelated concurrent task with that ID; highest observed was 32075.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
+++ b/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
@@ -5,7 +5,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 18:21'
-updated_date: '2026-09-08 19:27'
+updated_date: '2026-09-08 19:49'
 labels: []
 dependencies: []
 ---
@@ -24,6 +24,7 @@ Users need each retained TTS provider to produce complete playable replies and p
 - [x] #4 Targeted regression tests and available real playback checks document full decoded duration, content, and model or credential limitations.
 - [x] #5 Supported output formats reach a compatible file player, and completion or failure belongs only to the process that played that clip.
 - [ ] #6 The repaired delivery paths preserve boot module and CSS budgets, with PR checks passing before integration.
+- [ ] #7 Qodo review findings are verified and addressed, including failed playback cleanup, retained Higgs shutdown ownership, buffer boundaries, and application-path coverage.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,6 +38,7 @@ Reason: Restore existing complete-file, declared-format, effective-selection and
 3. Exercise every registered provider from mounted fresh controls through repeated admission and response consumption; check native audio.cpp contracts.
 4. Validate available local inference and playback with complete decoding and transcript checks, documenting unavailable services or model weights.
 5. Run targeted regressions, formatter/lint and required derived checks; record exact evidence and remaining limitations.
+6. Address verified PR review findings with failing regressions for terminal playback failures and model shutdown ownership; complete public playback and buffer-boundary coverage before rerunning targeted checks.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -48,5 +50,7 @@ Validation: main Python 3.12 targeted cohort: 744 passed, 1 optional Chatterbox 
 
 ADR required: no; existing 023, 039, 040 govern these repaired contracts. Diagnostic statements reviewed before regeneration: obsolete logs removed; only fixed Opus guidance and numeric process status added, no new logging destination/content interpolation. Evidence and limits: Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md. Updated Speech Services guide and a lesson from the afplay false-success incident. No full test sweep. TASK-1880 remains partly open for caller-scoped/default PCM selection. Task renumbered from 32051 after a 189 remote-ref / all-worktree audit found an unrelated concurrent task with that ID; highest observed was 32075.
 
-PR #2520 follow-up: CI caught the new PCM helper on the boot path (974 modules against 973). Call-site imports and an explicit absent-at-ready pin restore 973/973; 4 census tests and 94 PCM/UI/streaming regressions pass. The unchanged dev CSS base was already 241 bytes over its 804,000 limit; shortening one existing comment saves 497 bytes, preserves every non-comment CSS token, and restores 803,744 bytes. The CSS regression passes. No budget constants were raised; existing ADR-097 governs this fix. PR CI/review results remain pending.
+PR #2520 follow-up: CI caught the new PCM helper on the boot path (974 modules against 973). Call-site imports and an explicit absent-at-ready pin restore 973/973; 4 census tests and 94 PCM/UI/streaming regressions pass. The unchanged dev CSS base was already 241 bytes over its 804,000 limit; shortening one existing comment saves 497 bytes, preserves every non-comment CSS token, and restores 803,744 bytes. The CSS regression passes. No budget constants were raised; existing ADR-097 governs this fix. All PR CI jobs passed on 272f074 before the review follow-up.
+
+Qodo follow-up addresses all eight comments: failed playback now terminates both UI/event consumers and releases artifacts; Higgs retains cleanup through host cancellation and bounds actual source/float32 buffers; public playback, limit-boundary and error-field tests cover the missing paths; PCM protocol constants and Chatterbox request/yield docs are explicit. Higgs/manager/bridge cohort: 148 passed; shared limits/PCM: 43 passed; focused playback: 17 passed. All 304 distinct playback/lifecycle cases passed across broad and focused runs after stabilizing one existing scheduler-racy ordering test (38 passed module rerun). Six actual device formats again preserved full duration and complete transcripts. Fresh independent review found no further actionable issues. All 6 preflight checks, focused formatting/syntax and baseline-relative lint pass; no new logging calls and no inventory regeneration needed. Review-fix commit and its PR gates remain pending.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
+++ b/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32076
 title: Verify and repair TTS backend audio delivery parity
-status: Done
+status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-08 18:21'
-updated_date: '2026-09-08 19:15'
+updated_date: '2026-09-08 19:27'
 labels: []
 dependencies: []
 ---
@@ -23,6 +23,7 @@ Users need each retained TTS provider to produce complete playable replies and p
 - [x] #3 Confirmed provider format mismatches and shared codec failures are repaired without mislabeling raw PCM or publishing errors as successful audio.
 - [x] #4 Targeted regression tests and available real playback checks document full decoded duration, content, and model or credential limitations.
 - [x] #5 Supported output formats reach a compatible file player, and completion or failure belongs only to the process that played that clip.
+- [ ] #6 The repaired delivery paths preserve boot module and CSS budgets, with PR checks passing before integration.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,4 +47,6 @@ Repaired delivery parity across registered TTS providers: Chatterbox produces on
 Validation: main Python 3.12 targeted cohort: 744 passed, 1 optional Chatterbox skip; final Chatterbox: 30 passed; Python 3.13 shared/PCM/UI: 115 passed, 16 Torch-dependent skips, plus independent PCM/adjacent/UI cohorts: 116 + 242 + 129 passed. Six real device-playback format paths retained full decoded duration and complete independently transcribed content using recorded speech at model/HTTP boundaries. No live Chatterbox/Higgs/remote/audio.cpp inference claim. All derived preflight checks pass; all changed Python formats/syntax checks pass, new files full Ruff clean, zero introduced legacy lint diagnostics. Independent review found no actionable issues and 8 targeted review regressions passed.
 
 ADR required: no; existing 023, 039, 040 govern these repaired contracts. Diagnostic statements reviewed before regeneration: obsolete logs removed; only fixed Opus guidance and numeric process status added, no new logging destination/content interpolation. Evidence and limits: Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md. Updated Speech Services guide and a lesson from the afplay false-success incident. No full test sweep. TASK-1880 remains partly open for caller-scoped/default PCM selection. Task renumbered from 32051 after a 189 remote-ref / all-worktree audit found an unrelated concurrent task with that ID; highest observed was 32075.
+
+PR #2520 follow-up: CI caught the new PCM helper on the boot path (974 modules against 973). Call-site imports and an explicit absent-at-ready pin restore 973/973; 4 census tests and 94 PCM/UI/streaming regressions pass. The unchanged dev CSS base was already 241 bytes over its 804,000 limit; shortening one existing comment saves 497 bytes, preserves every non-comment CSS token, and restores 803,744 bytes. The CSS regression passes. No budget constants were raised; existing ADR-097 governs this fix. PR CI/review results remain pending.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
+++ b/backlog/tasks/task-32076 - Verify-and-repair-TTS-backend-audio-delivery-parity.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32076
 title: Verify and repair TTS backend audio delivery parity
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 18:21'
-updated_date: '2026-09-08 19:49'
+updated_date: '2026-09-08 20:31'
 labels: []
 dependencies: []
 ---
@@ -23,8 +23,8 @@ Users need each retained TTS provider to produce complete playable replies and p
 - [x] #3 Confirmed provider format mismatches and shared codec failures are repaired without mislabeling raw PCM or publishing errors as successful audio.
 - [x] #4 Targeted regression tests and available real playback checks document full decoded duration, content, and model or credential limitations.
 - [x] #5 Supported output formats reach a compatible file player, and completion or failure belongs only to the process that played that clip.
-- [ ] #6 The repaired delivery paths preserve boot module and CSS budgets, with PR checks passing before integration.
-- [ ] #7 Qodo review findings are verified and addressed, including failed playback cleanup, retained Higgs shutdown ownership, buffer boundaries, and application-path coverage.
+- [x] #6 The repaired delivery paths preserve boot module and CSS budgets, with PR checks passing before integration.
+- [x] #7 Qodo review findings are verified and addressed, including failed playback cleanup, retained Higgs shutdown ownership, buffer boundaries, and application-path coverage.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -46,11 +46,13 @@ Reason: Restore existing complete-file, declared-format, effective-selection and
 <!-- SECTION:NOTES:BEGIN -->
 Repaired delivery parity across registered TTS providers: Chatterbox produces one complete encoded utterance, uses a real conversion API, retains canceled inference/process ownership, resets fallback state and bounds retained audio; Higgs rejects failed/missing/nonfinite audio and retains loading/generation threads. ElevenLabs and AllTalk now deliver their declared formats, and shared PCM/AAC muxing is correct. Provider switching preserves Global/Studio model and voice ownership. Explicit known-rate PCM supports live/fallback playback without altering raw exports or default request formats. Mac Opus uses FFplay; exact-process completion honors failure exit codes.
 
-Validation: main Python 3.12 targeted cohort: 744 passed, 1 optional Chatterbox skip; final Chatterbox: 30 passed; Python 3.13 shared/PCM/UI: 115 passed, 16 Torch-dependent skips, plus independent PCM/adjacent/UI cohorts: 116 + 242 + 129 passed. Six real device-playback format paths retained full decoded duration and complete independently transcribed content using recorded speech at model/HTTP boundaries. No live Chatterbox/Higgs/remote/audio.cpp inference claim. All derived preflight checks pass; all changed Python formats/syntax checks pass, new files full Ruff clean, zero introduced legacy lint diagnostics. Independent review found no actionable issues and 8 targeted review regressions passed.
+Validation: main Python 3.12 targeted cohort: 744 passed, 1 optional Chatterbox skip; final Chatterbox: 30 passed; Python 3.13 shared/PCM/UI: 115 passed, 16 Torch-dependent skips, plus independent PCM/adjacent/UI cohorts: 116 + 242 + 129 passed. Six real device-playback format paths retained full decoded duration and complete independently transcribed content using recorded speech at model/HTTP boundaries. No live Chatterbox/Higgs/remote/audio.cpp inference claim. All derived preflight checks pass; changed production Python and new test modules pass formatting; all changed Python syntax checks pass, new files full Ruff clean, zero introduced legacy lint diagnostics. Independent review found no actionable issues and 8 targeted review regressions passed.
 
 ADR required: no; existing 023, 039, 040 govern these repaired contracts. Diagnostic statements reviewed before regeneration: obsolete logs removed; only fixed Opus guidance and numeric process status added, no new logging destination/content interpolation. Evidence and limits: Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md. Updated Speech Services guide and a lesson from the afplay false-success incident. No full test sweep. TASK-1880 remains partly open for caller-scoped/default PCM selection. Task renumbered from 32051 after a 189 remote-ref / all-worktree audit found an unrelated concurrent task with that ID; highest observed was 32075.
 
 PR #2520 follow-up: CI caught the new PCM helper on the boot path (974 modules against 973). Call-site imports and an explicit absent-at-ready pin restore 973/973; 4 census tests and 94 PCM/UI/streaming regressions pass. The unchanged dev CSS base was already 241 bytes over its 804,000 limit; shortening one existing comment saves 497 bytes, preserves every non-comment CSS token, and restores 803,744 bytes. The CSS regression passes. No budget constants were raised; existing ADR-097 governs this fix. All PR CI jobs passed on 272f074 before the review follow-up.
 
-Qodo follow-up addresses all eight comments: failed playback now terminates both UI/event consumers and releases artifacts; Higgs retains cleanup through host cancellation and bounds actual source/float32 buffers; public playback, limit-boundary and error-field tests cover the missing paths; PCM protocol constants and Chatterbox request/yield docs are explicit. Higgs/manager/bridge cohort: 148 passed; shared limits/PCM: 43 passed; focused playback: 17 passed. All 304 distinct playback/lifecycle cases passed across broad and focused runs after stabilizing one existing scheduler-racy ordering test (38 passed module rerun). Six actual device formats again preserved full duration and complete transcripts. Fresh independent review found no further actionable issues. All 6 preflight checks, focused formatting/syntax and baseline-relative lint pass; no new logging calls and no inventory regeneration needed. Review-fix commit and its PR gates remain pending.
+Qodo follow-up addresses all eight comments: failed playback now terminates both UI/event consumers and releases artifacts; Higgs retains cleanup through host cancellation and bounds actual source/float32 buffers; public playback, limit-boundary and error-field tests cover the missing paths; PCM protocol constants and Chatterbox request/yield docs are explicit. Higgs/manager/bridge cohort: 148 passed; shared limits/PCM: 43 passed; focused playback: 17 passed. All 304 distinct playback/lifecycle cases passed across broad and focused runs after stabilizing one existing scheduler-racy ordering test (38 passed module rerun). Six actual device formats again preserved full duration and complete transcripts. Fresh independent review found no further actionable issues. All 6 preflight checks, focused formatting/syntax and baseline-relative lint pass; no new logging calls and no inventory regeneration needed. Review fixes e208c06b53 passed all PR CI gates, including PR Fast Lane, derived artifacts, UI latency, CSS, backlog IDs and Linux/macOS/Windows import evidence. All eight Qodo threads are answered and resolved; its summary reports zero unresolved bugs or rule violations. The final task-record/rebase revision must retain these gates before merge. Existing formatting debt in the old utterance test is unchanged; its awaited fixture cleanup now exits without shutdown messages.
+
+Final integration: 46156a9565 passed every hosted gate, but dev advanced with PR #2522 before merge. Rebased onto e222813571 and preserved both appended lesson entries (the sole conflict). TTS runtime, Speech UI, event-handler and test trees remain identical. Additional shared-logging/app integration checks: 387 passed; all six preflight checks pass. Boot CSS is 803,443 / 804,000 bytes after the upstream comment reduction; CSS rules are unchanged.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -58,6 +58,7 @@ from tldw_chatbook.TTS.default_profile_request_resolver import (
     resolve_default_profile,
 )
 from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
+from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
 from tldw_chatbook.TTS.effective_settings import (
     TTSCharacterProfileSelection,
     TTSDefaultProfileSelection,
@@ -192,9 +193,7 @@ class TTSMessageSpeechRequestEvent(Message):
             raise ValueError("outcome_callback must be callable or None")
         if (
             expected_destination_fingerprint is not None
-            and not is_console_speech_destination(
-                expected_destination_fingerprint
-            )
+            and not is_console_speech_destination(expected_destination_fingerprint)
         ):
             raise ValueError(
                 "expected_destination_fingerprint must be canonical or None"
@@ -1297,8 +1296,7 @@ class TTSEventHandler:
         endpoint = normalize_openai_compatible_endpoint(raw_endpoint)
         return ConsoleTTSDestination(
             fingerprint=(
-                "sha256:"
-                f"{openai_destination_fingerprint(provider_id, endpoint)}"
+                f"sha256:{openai_destination_fingerprint(provider_id, endpoint)}"
             ),
             provider_label=provider_label,
             sanitized_destination=endpoint.origin,
@@ -1346,11 +1344,7 @@ class TTSEventHandler:
         if provider_id not in {"openai", "alltalk"}:
             return "http://localhost"
         app_config = applied.get("app_config") if isinstance(applied, Mapping) else None
-        app_tts = (
-            app_config.get("app_tts")
-            if isinstance(app_config, Mapping)
-            else None
-        )
+        app_tts = app_config.get("app_tts") if isinstance(app_config, Mapping) else None
         if isinstance(app_tts, Mapping):
             settings = (
                 ("OPENAI_BASE_URL",)
@@ -1544,9 +1538,7 @@ class TTSEventHandler:
                 voice,
                 resolution,
                 outcome_callback=outcome_callback,
-                expected_destination_fingerprint=(
-                    expected_destination_fingerprint
-                ),
+                expected_destination_fingerprint=(expected_destination_fingerprint),
             )
         task = asyncio.create_task(generation)
         if owner is not None:
@@ -1554,10 +1546,7 @@ class TTSEventHandler:
             self._console_generation_owner = owner
 
             def clear_owner(done: asyncio.Task) -> None:
-                if (
-                    self._console_generation_owner is owner
-                    and owner.task is done
-                ):
+                if self._console_generation_owner is owner and owner.task is done:
                     self._console_generation_owner = None
 
             task.add_done_callback(clear_owner)
@@ -1615,9 +1604,7 @@ class TTSEventHandler:
                 voice,
                 resolution,
                 outcome_callback=outcome_callback,
-                expected_destination_fingerprint=(
-                    expected_destination_fingerprint
-                ),
+                expected_destination_fingerprint=(expected_destination_fingerprint),
                 playback_lifecycle=playback_lifecycle,
                 cancellation_is_success=cancellation_is_success,
             )
@@ -1682,6 +1669,7 @@ class TTSEventHandler:
                 outcome_callback(ok is True)
             except Exception:
                 logger.warning("Console speech outcome callback failed")
+
         provider_id: str | None = None
         # Task-4 review N3: the resolved provider speed, when available --
         # folded into the legacy completion poll's timeout estimate
@@ -1698,9 +1686,7 @@ class TTSEventHandler:
             if expected_destination_fingerprint is None:
                 return True
             try:
-                endpoint = normalize_openai_compatible_endpoint(
-                    admitted_endpoint
-                )
+                endpoint = normalize_openai_compatible_endpoint(admitted_endpoint)
                 admitted_fingerprint = (
                     "sha256:"
                     f"{openai_destination_fingerprint(admitted_provider_id, endpoint)}"
@@ -1725,8 +1711,7 @@ class TTSEventHandler:
                 destination = await self._destination_for_resolution(resolution)
                 if (
                     destination is None
-                    or destination.fingerprint
-                    != expected_destination_fingerprint
+                    or destination.fingerprint != expected_destination_fingerprint
                 ):
                     raise _TTSAutomaticDestinationChangedError
 
@@ -1936,7 +1921,10 @@ class TTSEventHandler:
                     eligible_pcm_plan = sink_plan("pcm", response.sample_rate, None)
 
                 if eligible_pcm_plan is not None:
-                    if playback_lifecycle is not None and not playback_lifecycle.is_current():
+                    if (
+                        playback_lifecycle is not None
+                        and not playback_lifecycle.is_current()
+                    ):
                         outcome_code = "superseded"
                         return
                     streamed_outcome_code = await self._stream_response_via_sink(
@@ -2044,6 +2032,25 @@ class TTSEventHandler:
                         await flush_artifact_batch()
                 await flush_artifact_batch()
 
+                if audio_format == "pcm":
+                    # This cache is a temporary playback fallback. The adapter
+                    # response and Speech Lab's export artifact remain raw PCM.
+                    # Never hand an untyped raw file to a container-only player.
+                    playback_path = await self._run_blocking_tts_io(
+                        lambda: create_pcm16_wav_copy(
+                            created_artifact_path,
+                            response.sample_rate,
+                            response.metadata.get("channels", 1),
+                        ),
+                        on_cancelled_result=cleanup_late_creation,
+                        on_late_cancelled_result=cleanup_late_creation,
+                    )
+                    artifact_path = playback_path
+                    await self._discard_tts_artifact(
+                        normalized_message_id,
+                        created_artifact_path,
+                    )
+
                 # --- streaming PCM sink seam (task-4), WAV half ------------
                 # The response has now been written to `created_artifact_path`
                 # in full, byte-identically to how it always was (see the
@@ -2072,7 +2079,10 @@ class TTSEventHandler:
                     wav_collect = None
                     wav_plan = sink_plan("wav", None, wav_body)
                     if wav_plan is not None:
-                        if playback_lifecycle is not None and not playback_lifecycle.is_current():
+                        if (
+                            playback_lifecycle is not None
+                            and not playback_lifecycle.is_current()
+                        ):
                             outcome_code = "superseded"
                             await self._discard_tts_artifact(
                                 normalized_message_id,
@@ -2194,8 +2204,7 @@ class TTSEventHandler:
         except asyncio.CancelledError as cancellation:
             outcome_code = (
                 "superseded"
-                if cancellation_is_success is not None
-                and cancellation_is_success()
+                if cancellation_is_success is not None and cancellation_is_success()
                 else "cancelled"
             )
             if artifact_path is not None:
@@ -2211,13 +2220,16 @@ class TTSEventHandler:
                             continue
             raise cancellation
         except Exception as error:
-            destination_changed = isinstance(
-                error,
-                (
-                    _TTSAutomaticDestinationChangedError,
-                    TTSConfigurationRevisionError,
-                ),
-            ) and expected_destination_fingerprint is not None
+            destination_changed = (
+                isinstance(
+                    error,
+                    (
+                        _TTSAutomaticDestinationChangedError,
+                        TTSConfigurationRevisionError,
+                    ),
+                )
+                and expected_destination_fingerprint is not None
+            )
             outcome_code = (
                 "destination_changed"
                 if destination_changed
@@ -3055,12 +3067,8 @@ class TTSEventHandler:
         """Release a cache entry only when it still owns the deleted artifact."""
         async with self._audio_files_lock:
             cached_owner = self._audio_file_owners.get(message_id)
-            if (
-                self._audio_files.get(message_id) == artifact_path
-                and (
-                    artifact_owner is _ANY_ARTIFACT_OWNER
-                    or cached_owner is artifact_owner
-                )
+            if self._audio_files.get(message_id) == artifact_path and (
+                artifact_owner is _ANY_ARTIFACT_OWNER or cached_owner is artifact_owner
             ):
                 del self._audio_files[message_id]
                 self._audio_file_owners.pop(message_id, None)
@@ -3203,6 +3211,11 @@ class TTSEventHandler:
         if isinstance(error, TTSOperationError):
             if (
                 error.code == "request_invalid"
+                and error.recovery_action == "shorten_text"
+            ):
+                return "Generated audio is too long to buffer; shorten the text"
+            if (
+                error.code == "request_invalid"
                 and error.recovery_action == "shorten_text_or_use_pcm"
             ):
                 return (
@@ -3218,6 +3231,8 @@ class TTSEventHandler:
             if error.code == "generation_timeout":
                 return "TTS generation timed out; retry"
             if error.code == "audio_response_invalid":
+                if error.recovery_action == "use_wav":
+                    return "Audio encoding failed; choose WAV and generate again"
                 return (
                     "The TTS service returned invalid audio; "
                     "check provider compatibility"
@@ -3383,8 +3398,8 @@ class TTSEventHandler:
 
                             if last_played is not None:
                                 try:
-                                    file_stop_accepted = (
-                                        stop_audio_playback_if_current(last_played[1])
+                                    file_stop_accepted = stop_audio_playback_if_current(
+                                        last_played[1]
                                     )
                                 except Exception as exc:
                                     file_stop_retryable_failure = True
@@ -3411,7 +3426,10 @@ class TTSEventHandler:
                                     self._active_file_playback_owner = None
                                 if self._active_file_playback_stop == handoff:
                                     self._active_file_playback_stop = None
-                                if self._active_file_playback_started is playback_started:
+                                if (
+                                    self._active_file_playback_started
+                                    is playback_started
+                                ):
                                     self._active_file_playback_started = None
 
             if file_stop_accepted and file_owner is not None:
@@ -3488,10 +3506,7 @@ class TTSEventHandler:
                                 and event.message_id not in self._audio_file_owners
                             ):
                                 self._audio_file_owners[event.message_id] = lifecycle
-                            if (
-                                prior_owner is not None
-                                and prior_owner is not lifecycle
-                            ):
+                            if prior_owner is not None and prior_owner is not lifecycle:
                                 if (
                                     prior_handoff is not None
                                     and prior_handoff[0] == prior_owner.message_id
@@ -3655,10 +3670,7 @@ class TTSEventHandler:
                 or file_stop_accepted
                 or stream_stop_accepted
                 or generation_stop_accepted
-                or (
-                    exact_cached_artifact
-                    and self._active_file_playback_owner is None
-                )
+                or (exact_cached_artifact and self._active_file_playback_owner is None)
             )
             if accepted:
                 logger.info(f"Stopped playback for message {event.message_id}")
@@ -3673,10 +3685,7 @@ class TTSEventHandler:
                     event.message_id,
                     artifact_owner=file_owner,
                 )
-            elif (
-                exact_cached_artifact
-                and self._active_file_playback_owner is None
-            ):
+            elif exact_cached_artifact and self._active_file_playback_owner is None:
                 await self._cleanup_audio_file(
                     event.message_id,
                     artifact_owner=event.playback_lifecycle,
@@ -3694,9 +3703,7 @@ class TTSEventHandler:
             event.report_outcome(accepted)
         elif event.action == "stop":
             event.report_outcome(
-                stream_stop_accepted
-                or file_stop_accepted
-                or generation_stop_accepted
+                stream_stop_accepted or file_stop_accepted or generation_stop_accepted
             )
 
     async def _cleanup_audio_file(

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -3992,7 +3992,8 @@ def _play_legacy_clip_and_await_completion(
         poll_interval_seconds: Sleep between checks.
 
     Returns:
-        `False` if `play()` itself never started the clip, if a stop was
+        `False` if `play()` itself never started the clip, if playback
+        reached `ERROR`, if a stop was
         requested (checked immediately after `play()` returns, and on
         every subsequent poll iteration), or if the clip stopped being
         current for any OTHER reason before reaching `FINISHED` --
@@ -4035,9 +4036,25 @@ def _play_legacy_clip_and_await_completion(
             return False
         if player.get_current_file() != audio_file:
             return False
-        if player.get_state() == PlaybackState.FINISHED:
+        state = player.get_state()
+        if state == PlaybackState.FINISHED:
             return True
+        if state in (PlaybackState.ERROR, PlaybackState.IDLE):
+            return False
         time.sleep(poll_interval_seconds)
+    # Recheck terminal state and exact clip ownership after the final sleep.
+    # A failure or stop at the deadline must not become timeout success.
+    if stop_requested is not None and stop_requested.is_set():
+        if player.get_current_file() in (None, audio_file):
+            player.stop()
+        return False
+    if player.get_current_file() != audio_file:
+        return False
+    state = player.get_state()
+    if state == PlaybackState.FINISHED:
+        return True
+    if state != PlaybackState.PLAYING:
+        return False
     # Task-4 review N3: the estimate under-ran -- make that DISTINGUISHABLE
     # in the logs rather than silently indistinguishable from a natural
     # finish (both return `True`). `logger` (loguru) is documented

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -58,7 +58,6 @@ from tldw_chatbook.TTS.default_profile_request_resolver import (
     resolve_default_profile,
 )
 from tldw_chatbook.TTS.pcm_stream import SinkPlan, sink_plan
-from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
 from tldw_chatbook.TTS.effective_settings import (
     TTSCharacterProfileSelection,
     TTSDefaultProfileSelection,
@@ -2033,6 +2032,8 @@ class TTSEventHandler:
                 await flush_artifact_batch()
 
                 if audio_format == "pcm":
+                    from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
+
                     # This cache is a temporary playback fallback. The adapter
                     # response and Speech Lab's export artifact remain raw PCM.
                     # Never hand an untyped raw file to a container-only player.

--- a/tldw_chatbook/TTS/audio_limits.py
+++ b/tldw_chatbook/TTS/audio_limits.py
@@ -1,0 +1,26 @@
+"""Bound retained audio when a backend must assemble one complete container."""
+
+from uuid import uuid4
+
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+
+MAX_BUFFERED_AUDIO_BYTES = 64 * 1024 * 1024
+
+
+def check_buffered_audio_size(size: int) -> None:
+    """Reject an oversized audio buffer before retaining the next chunk.
+
+    Args:
+        size: Combined byte size including the proposed next chunk.
+
+    Raises:
+        TTSOperationError: When complete-file audio exceeds the retained byte limit.
+    """
+    if size > MAX_BUFFERED_AUDIO_BYTES:
+        raise TTSOperationError(
+            code="request_invalid",
+            message="Generated audio is too long to buffer. Shorten the text and try again.",
+            operation_id=uuid4().hex,
+            retryable=False,
+            recovery_action="shorten_text",
+        )

--- a/tldw_chatbook/TTS/audio_player.py
+++ b/tldw_chatbook/TTS/audio_player.py
@@ -142,6 +142,26 @@ class SimpleAudioPlayer:
             logger.error(f"Audio file not found: {file_path}")
             return False
 
+        if self._system == "Darwin":
+            # afplay can exit successfully without decoding Ogg/Opus audio.
+            # ffplay is already a supported player and handles these containers.
+            self._find_player()
+            if file_path.suffix.lower() in {".opus", ".ogg"}:
+                ffplay = shutil.which("ffplay")
+                if ffplay is None:
+                    logger.warning(
+                        "Opus playback requires ffplay; choose WAV output instead"
+                    )
+                    return False
+                self._player_cmd = [
+                    ffplay,
+                    "-nodisp",
+                    "-autoexit",
+                    "-loglevel",
+                    "error",
+                ]
+                self._player_name = "ffplay"
+
         # Check if we have a player
         if not self._player_cmd:
             logger.error("No audio player available")
@@ -219,7 +239,11 @@ class SimpleAudioPlayer:
                 self._current.position = 0.0
 
             # Start monitoring thread
-            monitor = threading.Thread(target=self._monitor_playback, daemon=True)
+            monitor = threading.Thread(
+                target=self._monitor_playback,
+                args=(self._current.process,),
+                daemon=True,
+            )
             monitor.start()
 
             logger.info(
@@ -489,17 +513,27 @@ class SimpleAudioPlayer:
         with self._lock:
             return self._current.file_path
 
-    def _monitor_playback(self) -> None:
+    def _monitor_playback(self, process: subprocess.Popen | None = None) -> None:
         """Monitor playback process"""
-        if self._current.process:
+        process = process if process is not None else self._current.process
+        if process is not None:
             try:
-                self._current.process.wait()
+                exit_code = process.wait()
                 with self._lock:
                     # Only mark as finished if we're still in playing state
                     # (could have been stopped/paused)
-                    if self._current.state == PlaybackState.PLAYING:
-                        self._current.state = PlaybackState.FINISHED
-                        logger.debug("Playback finished naturally")
+                    if (
+                        self._current.process is process
+                        and self._current.state == PlaybackState.PLAYING
+                    ):
+                        self._current.state = (
+                            PlaybackState.FINISHED
+                            if exit_code == 0
+                            else PlaybackState.ERROR
+                        )
+                        logger.debug(
+                            "Playback process finished (exit_code={})", exit_code
+                        )
             except Exception as e:
                 logger.debug(f"Monitor thread interrupted: {e}")
 

--- a/tldw_chatbook/TTS/audio_schemas.py
+++ b/tldw_chatbook/TTS/audio_schemas.py
@@ -55,7 +55,7 @@ class OpenAISpeechRequest(BaseModel):
     )
     response_format: Literal["mp3", "opus", "aac", "flac", "wav", "pcm"] = Field(
         default="mp3",
-        description="The format to return audio in. Supported formats: mp3, opus, flac, wav, pcm. PCM format returns raw 16-bit samples without headers. AAC is not currently supported.",
+        description="The format to return audio in: mp3, opus, aac, flac, wav or pcm. PCM returns raw 16-bit samples without headers; AAC uses an ADTS container.",
     )
     download_format: Optional[Literal["mp3", "opus", "aac", "flac", "wav", "pcm"]] = (
         Field(

--- a/tldw_chatbook/TTS/audio_service.py
+++ b/tldw_chatbook/TTS/audio_service.py
@@ -216,6 +216,14 @@ class AudioService:
             if audio.channels > 1:
                 audio = audio.set_channels(1)
 
+            if target_format == "pcm":
+                # Raw little-endian PCM16 has no container/muxer named "pcm".
+                return audio.set_sample_width(2).raw_data
+
+            if target_format == "aac":
+                output_params["format"] = "adts"
+                output_params["codec"] = "aac"
+
             # Export to target format
             output_buffer = io.BytesIO()
 

--- a/tldw_chatbook/TTS/backends/alltalk.py
+++ b/tldw_chatbook/TTS/backends/alltalk.py
@@ -10,6 +10,8 @@ from loguru import logger
 
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_limits import check_buffered_audio_size
 from tldw_chatbook.TTS.base_backends import APITTSBackend
 
 _DEFAULT_BASE_URL = "http://127.0.0.1:7851"
@@ -19,6 +21,7 @@ _HTTP_LOGGER_NAMES = ("httpx", "httpcore")
 class _AllTalkHTTPPrivacyFilter(logging.Filter):
     def filter(self, _record: logging.LogRecord) -> bool:
         return False
+
 
 #######################################################################################################################
 #
@@ -80,9 +83,7 @@ class AllTalkTTSBackend(APITTSBackend):
         self._http_log_suppression_users += 1
         if self._http_log_suppression_users == 1:
             for logger_name in _HTTP_LOGGER_NAMES:
-                logging.getLogger(logger_name).addFilter(
-                    self._http_privacy_filter
-                )
+                logging.getLogger(logger_name).addFilter(self._http_privacy_filter)
         try:
             yield
         finally:
@@ -192,10 +193,33 @@ class AllTalkTTSBackend(APITTSBackend):
                     response.raise_for_status()
 
                     chunk_size = 8192
+                    buffered = bytearray()
+                    received_bytes = 0
                     async for chunk in response.aiter_bytes(chunk_size=chunk_size):
-                        yield chunk
+                        received_bytes += len(chunk)
+                        if request.response_format == "pcm":
+                            check_buffered_audio_size(len(buffered) + len(chunk))
+                            buffered.extend(chunk)
+                        else:
+                            yield chunk
+
+                    if not received_bytes:
+                        raise ValueError("TTS service returned no audio.")
+
+                    if request.response_format == "pcm":
+                        from tldw_chatbook.TTS.audio_service import get_audio_service
+
+                        yield await get_audio_service().convert_audio(
+                            bytes(buffered),
+                            "pcm",
+                            source_format="wav",
+                            sample_rate=24000,
+                        )
 
             logger.info("AllTalk generation completed (provider=alltalk)")
+
+        except TTSOperationError:
+            raise
 
         except httpx.ConnectError:
             logger.error("AllTalk connection failed (provider=alltalk)")

--- a/tldw_chatbook/TTS/backends/chatterbox.py
+++ b/tldw_chatbook/TTS/backends/chatterbox.py
@@ -12,6 +12,7 @@ import re
 import json
 import base64
 from datetime import datetime
+from uuid import uuid4
 from difflib import SequenceMatcher
 from loguru import logger
 import tempfile  # Still needed for audio file handling
@@ -19,6 +20,9 @@ import contextlib
 
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS._async_lifecycle import join_retained_task
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_limits import check_buffered_audio_size
 from tldw_chatbook.TTS.TTS_Backends import TTSBackendBase
 from tldw_chatbook.TTS.audio_service import get_audio_service
 from tldw_chatbook.config import get_cli_setting
@@ -195,6 +199,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
         # Process management for isolated execution
         self.process: Optional[subprocess.Popen] = None
         self._process_lock = asyncio.Lock()
+        self._generation_lock = asyncio.Lock()
         self._initialized = False
         self._initializing = False
 
@@ -340,7 +345,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
             response = json.loads(line.decode().strip())
             return response
 
-        except asyncio.TimeoutError:
+        except TimeoutError:
             raise TimeoutError(f"No response from subprocess within {timeout} seconds")
         except json.JSONDecodeError as e:
             raise Exception(f"Invalid JSON response: {e}")
@@ -349,6 +354,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
         """Read chunked audio data from subprocess"""
         chunks = {}
         total_chunks = None
+        retained_bytes = 0
 
         while True:
             response = await self._read_response(timeout)
@@ -356,7 +362,8 @@ class ChatterboxTTSBackend(TTSBackendBase):
 
             if msg_type == "audio":
                 # Single message with complete audio
-                return base64.b64decode(response["data"])
+                check_buffered_audio_size(len(response["data"]))
+                return base64.b64decode(response["data"], validate=True)
 
             elif msg_type == "audio_chunk":
                 # Part of a chunked transfer
@@ -364,6 +371,8 @@ class ChatterboxTTSBackend(TTSBackendBase):
                 chunk_data = response.get("data")
 
                 if chunk_id is not None and chunk_data:
+                    retained_bytes += len(chunk_data) - len(chunks.get(chunk_id, ""))
+                    check_buffered_audio_size(retained_bytes)
                     chunks[chunk_id] = chunk_data
 
                     # Track total chunks from first message
@@ -383,14 +392,13 @@ class ChatterboxTTSBackend(TTSBackendBase):
                     )
 
                 # Reassemble chunks in order
-                audio_data = ""
                 for i in range(expected_total):
                     if i not in chunks:
                         raise Exception(f"Missing chunk {i}")
-                    audio_data += chunks[i]
+                audio_data = "".join(chunks[i] for i in range(expected_total))
 
                 # Decode base64 data
-                return base64.b64decode(audio_data)
+                return base64.b64decode(audio_data, validate=True)
 
             elif msg_type == "error":
                 error_msg = response.get("message", "Unknown error")
@@ -790,9 +798,28 @@ class ChatterboxTTSBackend(TTSBackendBase):
             audio_bytes = await self._read_chunked_audio(timeout=60)
             return audio_bytes
 
-        except Exception as e:
-            logger.error(f"Isolated generation failed: {e}")
+        except BaseException:
+            cleanup = asyncio.create_task(self._discard_process())
+            await join_retained_task(cleanup)
             raise
+
+    async def _discard_process(self) -> None:
+        """Reap the current worker before permitting another IPC exchange."""
+        process = self.process
+        if process is None:
+            return
+        if process.returncode is None:
+            process.terminate()
+        try:
+            await asyncio.wait_for(process.wait(), timeout=2.0)
+        except TimeoutError:
+            process.kill()
+            await process.wait()
+        if self.process is process:
+            self.process = None
+            self.model = None
+            self._initialized = False
+            self._initializing = False
 
     async def _generate_single(
         self,
@@ -869,7 +896,9 @@ class ChatterboxTTSBackend(TTSBackendBase):
                         )
 
         # Run in thread with isolation
-        wav = await asyncio.to_thread(generate_with_isolation)
+        generation = asyncio.create_task(asyncio.to_thread(generate_with_isolation))
+        await join_retained_task(generation)
+        wav = generation.result()
 
         # Apply post-processing
         if self.normalize_audio_enabled:
@@ -917,6 +946,8 @@ class ChatterboxTTSBackend(TTSBackendBase):
                     # No validation, just add the candidate
                     candidates.append((audio_bytes, 1.0, ""))
 
+            except TTSOperationError:
+                raise
             except Exception as e:
                 logger.warning(f"Candidate {i + 1} generation failed: {e}")
 
@@ -937,6 +968,17 @@ class ChatterboxTTSBackend(TTSBackendBase):
 
     async def generate_speech_stream(
         self, request: OpenAISpeechRequest
+    ) -> AsyncGenerator[bytes, None]:
+        """Deliver one utterance while retaining exclusive inference ownership."""
+        async with (
+            self._generation_lock,
+            contextlib.aclosing(self._generate_speech_stream(request)) as stream,
+        ):
+            async for chunk in stream:
+                yield chunk
+
+    async def _generate_speech_stream(
+        self, request: OpenAISpeechRequest, *, allow_fallback: bool = True
     ) -> AsyncGenerator[bytes, None]:
         """
         Generate speech using Chatterbox and stream the response.
@@ -1014,6 +1056,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
             if predefined_path.exists():
                 reference_audio_path = str(predefined_path)
 
+        emitted = False
         try:
             # Get extra parameters if available
             exaggeration = self.exaggeration
@@ -1047,6 +1090,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
 
                 # Generate audio for each chunk
                 all_audio_bytes = []
+                retained_bytes = 0
                 for i, chunk in enumerate(chunks):
                     logger.info(f"Processing chunk {i + 1}/{len(chunks)}")
 
@@ -1064,6 +1108,8 @@ class ChatterboxTTSBackend(TTSBackendBase):
                             temperature,
                         )
 
+                    retained_bytes += len(audio_bytes)
+                    check_buffered_audio_size(retained_bytes)
                     all_audio_bytes.append(audio_bytes)
 
                 # Combine all chunks with crossfade if enabled
@@ -1073,42 +1119,57 @@ class ChatterboxTTSBackend(TTSBackendBase):
                         all_audio_bytes
                     )
                 else:
-                    combined_audio = b"".join(all_audio_bytes)
+                    combined_audio = await self._combine_audio_with_crossfade(
+                        all_audio_bytes, crossfade=False
+                    )
 
                 # Convert format if needed
-                if request.response_format != "wav":
-                    output_bytes = await self.audio_service.convert_audio_format(
-                        combined_audio, "wav", request.response_format
-                    )
-                else:
-                    output_bytes = combined_audio
-
+                output_bytes = await self._encode_audio(
+                    combined_audio, request.response_format
+                )
+                emitted = True
                 yield output_bytes
 
             else:
                 # Single chunk generation
                 if (
-                    self.streaming_enabled
+                    request.stream
+                    and self.streaming_enabled
                     and num_candidates <= 1
                     and not validate_with_whisper
                     and hasattr(self.model, "generate_stream")
                 ):
-                    async for audio_chunk, metrics in self._generate_stream_async(
-                        text,
-                        reference_audio_path,
-                        exaggeration,
-                        cfg_weight,
-                    ):
-                        chunk_bytes = self._tensor_to_wav_bytes(
-                            audio_chunk, self.model.sr
+                    audio_chunks = []
+                    retained_bytes = 0
+                    async with contextlib.aclosing(
+                        self._generate_stream_async(
+                            text, reference_audio_path, exaggeration, cfg_weight
                         )
-                        if request.response_format != "wav":
-                            chunk_bytes = await self.audio_service.convert_audio_format(
-                                chunk_bytes,
-                                "wav",
-                                request.response_format,
+                    ) as stream:
+                        async for audio_chunk, _metrics in stream:
+                            chunk_bytes = self._tensor_to_wav_bytes(
+                                audio_chunk, self.model.sr
                             )
-                        yield chunk_bytes
+                            if request.response_format == "pcm":
+                                # Raw samples concatenate safely; file containers do not.
+                                output = await self._encode_audio(chunk_bytes, "pcm")
+                                emitted = True
+                                yield output
+                            else:
+                                retained_bytes += len(chunk_bytes)
+                                check_buffered_audio_size(retained_bytes)
+                                audio_chunks.append(chunk_bytes)
+                    if not emitted and not audio_chunks:
+                        raise ValueError("Chatterbox returned no audio.")
+                    if request.response_format != "pcm":
+                        complete = await self._combine_audio_with_crossfade(
+                            audio_chunks, crossfade=False
+                        )
+                        output = await self._encode_audio(
+                            complete, request.response_format
+                        )
+                        emitted = True
+                        yield output
 
                     await self._report_progress(
                         progress=1.0,
@@ -1140,12 +1201,9 @@ class ChatterboxTTSBackend(TTSBackendBase):
                 )
 
                 # Convert format if needed
-                if request.response_format != "wav":
-                    output_bytes = await self.audio_service.convert_audio_format(
-                        audio_bytes, "wav", request.response_format
-                    )
-                else:
-                    output_bytes = audio_bytes
+                output_bytes = await self._encode_audio(
+                    audio_bytes, request.response_format
+                )
 
                 # Report completion
                 await self._report_progress(
@@ -1156,19 +1214,43 @@ class ChatterboxTTSBackend(TTSBackendBase):
                     metrics={"format": request.response_format},
                 )
 
+                emitted = True
                 yield output_bytes
 
+        except TTSOperationError:
+            raise
         except Exception as e:
             logger.error(f"Chatterbox generation failed: {e}")
-            # Don't try fallback if this is already a fallback attempt
-            if hasattr(request, "_is_fallback") and request._is_fallback:
-                raise ValueError(f"Failed to generate speech: {str(e)}")
-            else:
-                # Try fallback strategy only once
-                logger.info("Attempting fallback generation strategy...")
-                request._is_fallback = True
-                async for chunk in self.generate_speech_stream_with_fallback(request):
+            if emitted or not allow_fallback:
+                raise
+            async with contextlib.aclosing(
+                self.generate_speech_stream_with_fallback(request)
+            ) as stream:
+                async for chunk in stream:
                     yield chunk
+
+    async def _encode_audio(self, wav_bytes: bytes, audio_format: str) -> bytes:
+        """Encode one complete utterance without retrying deterministic codec errors."""
+        check_buffered_audio_size(len(wav_bytes))
+        if audio_format == "wav":
+            return wav_bytes
+        try:
+            return await self.audio_service.convert_audio(
+                wav_bytes,
+                audio_format,
+                source_format="wav",
+                sample_rate=24000 if audio_format == "pcm" else None,
+            )
+        except TTSOperationError:
+            raise
+        except Exception:
+            raise TTSOperationError(
+                code="audio_response_invalid",
+                message="Unable to encode Chatterbox audio. Try WAV output.",
+                retryable=False,
+                operation_id=uuid4().hex,
+                recovery_action="use_wav",
+            ) from None
 
     async def _generate_stream_async(
         self,
@@ -1177,262 +1259,99 @@ class ChatterboxTTSBackend(TTSBackendBase):
         exaggeration: float,
         cfg_weight: float,
     ) -> AsyncGenerator:
-        """Async wrapper for streaming generation with proper thread handling"""
-        import threading
-        import queue
-
-        loop = asyncio.get_event_loop()
-        result_queue = queue.Queue()
-        exception_queue = queue.Queue()
-
-        def producer():
-            """Run sync generator in thread and put results in queue"""
-            try:
-                # Check if model has generate_stream method
-                if hasattr(self.model, "generate_stream"):
-                    if audio_prompt_path:
-                        generator = self.model.generate_stream(
-                            text,
-                            audio_prompt_path=audio_prompt_path,
-                            exaggeration=exaggeration,
-                            cfg_weight=cfg_weight,
-                            chunk_size=self.chunk_size,
-                        )
-                    else:
-                        generator = self.model.generate_stream(
-                            text,
-                            exaggeration=exaggeration,
-                            cfg_weight=cfg_weight,
-                            chunk_size=self.chunk_size,
-                        )
-
-                    # Iterate through generator and put chunks in queue
-                    for chunk, metrics in generator:
-                        result_queue.put((chunk, metrics))
-                else:
-                    # Fallback: generate full audio and chunk it
-                    logger.warning(
-                        "Chatterbox model doesn't support streaming, using chunked output"
-                    )
-
-                    # Run the blocking generate call with complete isolation
-                    # Try to import protect_file_descriptors
-                    try:
-                        from tldw_chatbook.Utils.fd_protection import (
-                            protect_file_descriptors,
-                        )
-
-                        has_protect_fd = True
-                    except ImportError:
-                        has_protect_fd = False
-
-                    # Generate with protection if available
-                    with suppress_output():
-                        if has_protect_fd:
-                            with protect_file_descriptors():
-                                if audio_prompt_path:
-                                    full_audio = self.model.generate(
-                                        text,
-                                        audio_prompt_path=audio_prompt_path,
-                                        exaggeration=exaggeration,
-                                        cfg_weight=cfg_weight,
-                                    )
-                                else:
-                                    full_audio = self.model.generate(
-                                        text,
-                                        exaggeration=exaggeration,
-                                        cfg_weight=cfg_weight,
-                                    )
-                        else:
-                            if audio_prompt_path:
-                                full_audio = self.model.generate(
-                                    text,
-                                    audio_prompt_path=audio_prompt_path,
-                                    exaggeration=exaggeration,
-                                    cfg_weight=cfg_weight,
-                                )
-                            else:
-                                full_audio = self.model.generate(
-                                    text,
-                                    exaggeration=exaggeration,
-                                    cfg_weight=cfg_weight,
-                                )
-
-                    # Chunk the audio
-                    chunk_size = self.chunk_size
-                    for i in range(0, len(full_audio), chunk_size):
-                        chunk = full_audio[i : i + chunk_size]
-                        metrics = {
-                            "chunk_index": i // chunk_size,
-                            "total_samples": len(full_audio),
-                        }
-                        result_queue.put((chunk, metrics))
-
-                # Signal completion
-                result_queue.put(None)
-
-            except Exception as e:
-                exception_queue.put(e)
-                result_queue.put(None)
-
-        # Start producer thread
-        thread = threading.Thread(target=producer)
-        thread.start()
-
-        # Consume from queue asynchronously
-        while True:
-            # Check for exceptions first
-            try:
-                exc = exception_queue.get_nowait()
-                raise exc
-            except queue.Empty:
-                pass
-
-            # Get result with timeout to allow for cancellation
-            try:
-                result = await loop.run_in_executor(
-                    None, lambda: result_queue.get(timeout=0.1)
-                )
-                if result is None:
+        """Advance inference only on demand and join a running step on cancellation."""
+        generator = self.model.generate_stream(
+            text,
+            audio_prompt_path=audio_prompt_path,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            chunk_size=self.chunk_size,
+        )
+        sentinel = object()
+        try:
+            while True:
+                step = asyncio.create_task(asyncio.to_thread(next, generator, sentinel))
+                await join_retained_task(step)
+                result = step.result()
+                if result is sentinel:
                     break
                 yield result
-            except queue.Empty:
-                # Check if thread is still alive
-                if not thread.is_alive():
-                    # Thread died unexpectedly
-                    break
-                continue
+        finally:
+            close = getattr(generator, "close", None)
+            if close is not None:
+                cleanup = asyncio.create_task(asyncio.to_thread(close))
+                await join_retained_task(cleanup)
 
-        # Ensure thread completes
-        thread.join(timeout=1.0)
+    async def _combine_audio_with_crossfade(
+        self, audio_chunks: List[bytes], *, crossfade: bool = True
+    ) -> bytes:
+        """Decode WAV chunks and encode one file; never concatenate containers."""
+        import io
+        import torch
+        import wave
+        import numpy as np
 
-    async def _combine_audio_with_crossfade(self, audio_chunks: List[bytes]) -> bytes:
-        """
-        Combine multiple WAV audio chunks with crossfade.
+        if not audio_chunks:
+            raise ValueError("Chatterbox returned no audio.")
+        if len(audio_chunks) == 1:
+            check_buffered_audio_size(len(audio_chunks[0]))
+            return audio_chunks[0]
+        tensors = []
+        sample_rate = None
+        retained_bytes = 0
+        for chunk in audio_chunks:
+            check_buffered_audio_size(len(chunk) * 2)
+            with wave.open(io.BytesIO(chunk), "rb") as wav:
+                rate = wav.getframerate()
+                channels = wav.getnchannels()
+                width = wav.getsampwidth()
+                if width != 2:
+                    raise ValueError("Chatterbox returned unsupported WAV samples.")
+                raw = wav.readframes(wav.getnframes())
+                if len(raw) != wav.getnframes() * channels * width:
+                    raise ValueError("Chatterbox returned truncated WAV audio.")
+            if sample_rate is not None and rate != sample_rate:
+                raise ValueError("Chatterbox returned inconsistent sample rates.")
+            sample_rate = rate
+            retained_bytes += len(raw) * 2
+            check_buffered_audio_size(retained_bytes)
+            samples = np.frombuffer(raw, dtype="<i2").astype("float32") / 32768.0
+            if channels > 1:
+                samples = samples.reshape(-1, channels).mean(axis=1)
+            tensor = torch.from_numpy(samples)
+            tensors.append(tensor)
+        if crossfade:
+            result = tensors[0]
+            for tensor in tensors[1:]:
+                result = self.crossfade_audio_chunks(
+                    result, tensor, self.crossfade_duration_ms
+                )
+        else:
+            result = torch.cat(tensors)
+        return self._tensor_to_wav_bytes(result, sample_rate)
 
-        Args:
-            audio_chunks: List of WAV audio bytes
-
-        Returns:
-            Combined WAV audio bytes with crossfade applied
-        """
+    def _tensor_to_wav_bytes(self, tensor, sample_rate: int) -> bytes:
+        """Encode finite mono PCM16 WAV without torchaudio's optional codecs."""
         import io
         import wave
         import torch
 
-        try:
-            import torchaudio
-        except ModuleNotFoundError:
-            torchaudio = None
-
-        if len(audio_chunks) <= 1:
-            return b"".join(audio_chunks)
-
-        try:
-            # Load all chunks as tensors
-            tensors = []
-            sample_rate = None
-
-            for chunk_bytes in audio_chunks:
-                # Load WAV from bytes
-                buffer = io.BytesIO(chunk_bytes)
-                if torchaudio is not None:
-                    tensor, sr = torchaudio.load(buffer)
-                else:
-                    import numpy as np
-
-                    with wave.open(buffer, "rb") as wav_file:
-                        sr = wav_file.getframerate()
-                        channels = wav_file.getnchannels()
-                        sample_width = wav_file.getsampwidth()
-                        raw_audio = wav_file.readframes(wav_file.getnframes())
-
-                    if sample_width == 1:
-                        audio = np.frombuffer(raw_audio, dtype=np.uint8).astype(
-                            "float32"
-                        )
-                        audio = (audio - 128.0) / 128.0
-                    elif sample_width == 2:
-                        audio = (
-                            np.frombuffer(raw_audio, dtype="<i2").astype("float32")
-                            / 32768.0
-                        )
-                    elif sample_width == 4:
-                        audio = (
-                            np.frombuffer(raw_audio, dtype="<i4").astype("float32")
-                            / 2147483648.0
-                        )
-                    else:
-                        raise ValueError(
-                            f"Unsupported WAV sample width: {sample_width}"
-                        )
-
-                    if channels > 1:
-                        audio = audio.reshape(-1, channels).T
-                    else:
-                        audio = audio.reshape(1, -1)
-                    tensor = torch.from_numpy(audio)
-
-                # Ensure mono
-                if tensor.shape[0] > 1:
-                    tensor = tensor.mean(dim=0, keepdim=True)
-
-                tensors.append(tensor.squeeze(0))
-                if sample_rate is None:
-                    sample_rate = sr
-
-            # Apply crossfade between consecutive chunks
-            result = tensors[0]
-            for i in range(1, len(tensors)):
-                result = self.crossfade_audio_chunks(
-                    result, tensors[i], self.crossfade_duration_ms
-                )
-
-            # Convert back to WAV bytes
-            result = result.unsqueeze(0)  # Add channel dimension
-            return self._tensor_to_wav_bytes(result, sample_rate)
-
-        except Exception as e:
-            logger.error(f"Failed to apply crossfade: {e}")
-            # Fallback to simple concatenation
-            return b"".join(audio_chunks)
-
-    def _tensor_to_wav_bytes(self, tensor, sample_rate: int) -> bytes:
-        """Convert PyTorch tensor to WAV bytes"""
-        import io
-
-        # Create a bytes buffer
+        check_buffered_audio_size(tensor.numel() * tensor.element_size())
+        if (
+            tensor.dim() not in (1, 2)
+            or tensor.numel() == 0
+            or not torch.isfinite(tensor).all()
+        ):
+            raise ValueError("Chatterbox returned invalid audio samples.")
+        audio = tensor.detach().cpu()
+        if audio.dim() == 2:
+            audio = audio.mean(dim=0)
+        pcm = (audio.clamp(-1.0, 1.0).numpy() * 32767.0).astype("<i2").tobytes()
         buffer = io.BytesIO()
-
-        # Ensure tensor is on CPU and has correct shape
-        if tensor.is_cuda:
-            tensor = tensor.cpu()
-
-        # Add batch dimension if needed
-        if tensor.dim() == 1:
-            tensor = tensor.unsqueeze(0)
-
-        try:
-            import torchaudio
-
-            torchaudio.save(buffer, tensor, sample_rate, format="wav")
-        except ModuleNotFoundError:
-            import wave
-
-            audio = tensor.detach().cpu()
-            if audio.dim() > 1:
-                audio = audio.mean(dim=0)
-            audio = audio.clamp(-1.0, 1.0).numpy()
-            pcm = (audio * 32767.0).astype("<i2").tobytes()
-            with wave.open(buffer, "wb") as wav_file:
-                wav_file.setnchannels(1)
-                wav_file.setsampwidth(2)
-                wav_file.setframerate(int(sample_rate))
-                wav_file.writeframes(pcm)
-
-        # Get bytes
-        buffer.seek(0)
-        return buffer.read()
+        with wave.open(buffer, "wb") as output:
+            output.setparams((1, 2, int(sample_rate), 0, "NONE", "not compressed"))
+            output.writeframes(pcm)
+        return buffer.getvalue()
 
     async def list_voices(self) -> list[str]:
         """List available voices (predefined and custom)"""
@@ -1590,37 +1509,44 @@ class ChatterboxTTSBackend(TTSBackendBase):
             "num_candidates": self.num_candidates,
         }
 
-        for strategy_name, params in strategies:
-            try:
-                logger.info(f"Trying {strategy_name} generation strategy")
-
-                # Update parameters
-                self.exaggeration = params["exaggeration"]
-                self.cfg_weight = params["cfg_weight"]
-                self.num_candidates = params["num_candidates"]
-
-                # Attempt generation
-                async for chunk in self.generate_speech_stream(request):
-                    yield chunk
-
-                # Success - restore original params and exit
-                for key, value in original_params.items():
-                    setattr(self, key, value)
-                return
-
-            except Exception as e:
-                logger.warning(f"{strategy_name} strategy failed: {e}")
-                continue
-
-        # Restore original parameters
-        for key, value in original_params.items():
-            setattr(self, key, value)
-
-        # All strategies failed
+        try:
+            for strategy_name, params in strategies:
+                emitted = False
+                try:
+                    logger.info(f"Trying {strategy_name} generation strategy")
+                    for key, value in params.items():
+                        setattr(self, key, value)
+                    # Per-request overrides otherwise mask the fallback parameters.
+                    attempt = request.model_copy(
+                        update={
+                            "extra_params": {**(request.extra_params or {}), **params}
+                        }
+                    )
+                    async with contextlib.aclosing(
+                        self._generate_speech_stream(attempt, allow_fallback=False)
+                    ) as stream:
+                        async for chunk in stream:
+                            emitted = True
+                            yield chunk
+                    return
+                except TTSOperationError:
+                    raise
+                except Exception as e:
+                    if emitted:
+                        raise
+                    logger.warning(f"{strategy_name} strategy failed: {e}")
+        finally:
+            for key, value in original_params.items():
+                setattr(self, key, value)
         raise ValueError("All generation strategies failed")
 
     async def close(self):
-        """Clean up resources"""
+        """Wait for owned inference before releasing its model and process."""
+        async with self._generation_lock:
+            await self._close_resources()
+
+    async def _close_resources(self):
+        """Clean up resources after the active operation has stopped."""
         # Clean up subprocess if running
         if hasattr(self, "process") and self.process:
             try:
@@ -1636,7 +1562,7 @@ class ChatterboxTTSBackend(TTSBackendBase):
                 self.process.terminate()
                 try:
                     await asyncio.wait_for(self.process.wait(), timeout=2.0)
-                except asyncio.TimeoutError:
+                except TimeoutError:
                     self.process.kill()
                     await self.process.wait()
 

--- a/tldw_chatbook/TTS/backends/chatterbox.py
+++ b/tldw_chatbook/TTS/backends/chatterbox.py
@@ -969,7 +969,16 @@ class ChatterboxTTSBackend(TTSBackendBase):
     async def generate_speech_stream(
         self, request: OpenAISpeechRequest
     ) -> AsyncGenerator[bytes, None]:
-        """Deliver one utterance while retaining exclusive inference ownership."""
+        """Deliver one utterance while retaining exclusive inference ownership.
+
+        Args:
+            request: Text, voice, speed, output format, and streaming preference.
+                Setting ``stream=False`` selects batch inference.
+
+        Yields:
+            One complete encoded file for container formats, or signed 16-bit
+            mono PCM chunks at 24 kHz when raw PCM streaming is requested.
+        """
         async with (
             self._generation_lock,
             contextlib.aclosing(self._generate_speech_stream(request)) as stream,

--- a/tldw_chatbook/TTS/backends/chatterbox_process.py
+++ b/tldw_chatbook/TTS/backends/chatterbox_process.py
@@ -23,6 +23,7 @@ sys.stderr = open(os.devnull, "w")
 import json  # noqa: E402
 import base64  # noqa: E402
 import io  # noqa: E402
+import wave
 import traceback  # noqa: E402
 
 # Create a writer using the saved stdout file descriptor
@@ -101,7 +102,6 @@ def main():
 
         from chatterbox.tts import ChatterboxTTS
         import torch
-        import torchaudio
 
         send_response({"type": "status", "message": "Imports successful"})
     except Exception as e:
@@ -221,13 +221,26 @@ def main():
                     elif hasattr(model, "sr"):
                         sample_rate = model.sr
 
-                    # Save audio to buffer
-                    torchaudio.save(
-                        buffer,
-                        wav.unsqueeze(0) if wav.dim() == 1 else wav,
-                        sample_rate,
-                        format="wav",
+                    # PCM16 WAV needs no optional torchaudio/TorchCodec encoder.
+                    if (
+                        wav.dim() not in (1, 2)
+                        or wav.numel() == 0
+                        or not torch.isfinite(wav).all()
+                    ):
+                        raise ValueError("Model returned invalid audio samples")
+                    audio = wav.detach().cpu()
+                    if audio.dim() == 2:
+                        audio = audio.mean(dim=0)
+                    pcm = (
+                        (audio.clamp(-1.0, 1.0).numpy() * 32767.0)
+                        .astype("<i2")
+                        .tobytes()
                     )
+                    with wave.open(buffer, "wb") as output:
+                        output.setparams(
+                            (1, 2, int(sample_rate), 0, "NONE", "not compressed")
+                        )
+                        output.writeframes(pcm)
 
                     # Get bytes from buffer
                     buffer.seek(0)

--- a/tldw_chatbook/TTS/backends/elevenlabs.py
+++ b/tldw_chatbook/TTS/backends/elevenlabs.py
@@ -8,6 +8,8 @@ from loguru import logger
 
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_limits import check_buffered_audio_size
 from tldw_chatbook.TTS.base_backends import APITTSBackend
 from tldw_chatbook.config import get_cli_setting
 
@@ -191,10 +193,36 @@ class ElevenLabsTTSBackend(APITTSBackend):
 
                 # Stream the audio data
                 chunk_size = 1024
+                converted_format = request.response_format in {"wav", "aac", "flac"}
+                buffered = bytearray()
+                received_bytes = 0
                 async for chunk in response.aiter_bytes(chunk_size=chunk_size):
-                    yield chunk
+                    received_bytes += len(chunk)
+                    if converted_format:
+                        check_buffered_audio_size(len(buffered) + len(chunk))
+                        buffered.extend(chunk)
+                    else:
+                        yield chunk
+
+                if not received_bytes:
+                    raise ValueError("TTS service returned no audio.")
+
+                if converted_format:
+                    from tldw_chatbook.TTS.audio_service import get_audio_service
+
+                    if not buffered or len(buffered) % 2:
+                        raise ValueError("ElevenLabs returned invalid PCM audio.")
+                    yield await get_audio_service().convert_audio(
+                        bytes(buffered),
+                        request.response_format,
+                        source_format="pcm",
+                        sample_rate=24000,
+                    )
 
             logger.info("ElevenLabsTTSBackend: Successfully completed TTS generation")
+
+        except TTSOperationError:
+            raise
 
         except httpx.HTTPStatusError as e:
             # Try to read error content safely
@@ -256,11 +284,11 @@ class ElevenLabsTTSBackend(APITTSBackend):
         # Simple format to ElevenLabs format mapping
         simple_format_map = {
             "mp3": "mp3_44100_192",  # High quality MP3
-            "opus": "opus",
-            "aac": "aac",
-            "flac": "flac",
-            "wav": "pcm_44100",  # WAV is PCM in ElevenLabs
-            "pcm": "pcm_44100",
+            "opus": "opus_48000_128",
+            "aac": "pcm_24000",
+            "flac": "pcm_24000",
+            "wav": "pcm_24000",  # Wrap one complete PCM response locally.
+            "pcm": "pcm_24000",
         }
 
         # If format is already an ElevenLabs format string, validate it

--- a/tldw_chatbook/TTS/backends/higgs.py
+++ b/tldw_chatbook/TTS/backends/higgs.py
@@ -128,6 +128,7 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
         # Shutdown and task tracking
         self._active_tasks = set()
         self._shutdown_event = asyncio.Event()
+        self._close_task: asyncio.Task[None] | None = None
         self._generation_lock = asyncio.Lock()
         self._initialization_lock = asyncio.Lock()
 
@@ -509,13 +510,15 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
         if isinstance(audio_data, torch.Tensor):
             audio_data = audio_data.detach().cpu().numpy()
         audio_data = np.asarray(audio_data)
+        # Bound both the retained source and the proposed float32 conversion.
+        float32_bytes = audio_data.size * np.dtype(np.float32).itemsize
+        check_buffered_audio_size(max(audio_data.nbytes, float32_bytes))
         if (
             audio_data.ndim not in (1, 2)
             or not audio_data.size
             or not np.isfinite(audio_data).all()
         ):
             raise ValueError("Higgs Audio returned invalid audio.")
-        check_buffered_audio_size(audio_data.size * 4)
         if audio_data.ndim == 2:
             audio_data = audio_data.mean(axis=0)
         return audio_data.astype(np.float32)
@@ -1464,19 +1467,21 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
             "model": self.model_path,
         }
 
-    async def close(self):
-        """Clean up resources with proper task cancellation"""
+    async def close(self) -> None:
+        """Retain cleanup through cancellation until native workers have stopped."""
+        self._shutdown_event.set()
+        if self._close_task is None:
+            self._close_task = asyncio.create_task(self._close_resources())
+        await join_retained_task(self._close_task)
+
+    async def _close_resources(self) -> None:
+        """Release the model only after all owned native work finishes."""
         logger.info("HiggsAudioTTSBackend: Starting cleanup...")
 
-        # Signal shutdown to stop new operations
-        self._shutdown_event.set()
-
-        # A canceled to_thread task can still be using the model. Keep the
-        # engine and active-task ownership intact if bounded close must retry.
+        # The host bounds the foreground wait and retains this cleanup on timeout.
+        # A canceled to_thread wrapper cannot stop native work using the model.
         if self._active_tasks:
-            _done, pending = await asyncio.wait(tuple(self._active_tasks), timeout=5.0)
-            if pending:
-                raise TimeoutError("Higgs Audio inference is still stopping.")
+            await asyncio.wait(tuple(self._active_tasks))
 
         # Wait a bit for any ongoing generation to notice shutdown
         await asyncio.sleep(0.1)

--- a/tldw_chatbook/TTS/backends/higgs.py
+++ b/tldw_chatbook/TTS/backends/higgs.py
@@ -65,6 +65,9 @@ except ImportError:
 # Local imports
 from tldw_chatbook.TTS.audio_schemas import OpenAISpeechRequest
 from tldw_chatbook.TTS.base_backends import LocalTTSBackend
+from tldw_chatbook.TTS._async_lifecycle import join_retained_task
+from tldw_chatbook.TTS.adapter_types import TTSOperationError
+from tldw_chatbook.TTS.audio_limits import check_buffered_audio_size
 from tldw_chatbook.TTS.audio_service import get_audio_service
 from tldw_chatbook.TTS.text_processing import (
     TextChunker,
@@ -126,6 +129,7 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
         self._active_tasks = set()
         self._shutdown_event = asyncio.Event()
         self._generation_lock = asyncio.Lock()
+        self._initialization_lock = asyncio.Lock()
 
         # Model configuration
         self.model_path = self.config.get(
@@ -234,7 +238,16 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
         logger.info("═" * 80)
 
     async def load_model(self):
-        """Load the Higgs Audio model"""
+        """Serialize initialization, including completion of a canceled loader."""
+        async with self._initialization_lock:
+            if self.model_loaded:
+                return
+            if self._shutdown_event.is_set():
+                raise asyncio.CancelledError
+            await self._load_model()
+
+    async def _load_model(self):
+        """Load the Higgs Audio model while retaining its worker thread."""
         try:
             # Import Higgs modules
             if self._boson_multimodal is None:
@@ -362,20 +375,9 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
                 load_task = asyncio.create_task(asyncio.to_thread(load_model_thread))
                 self._active_tasks.add(load_task)
 
-                # Wait for either completion or shutdown
-                done, pending = await asyncio.wait(
-                    [load_task, asyncio.create_task(self._shutdown_event.wait())],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-
+                await join_retained_task(load_task)
                 if self._shutdown_event.is_set():
-                    logger.info("Shutdown during model load, cancelling...")
-                    load_task.cancel()
-                    try:
-                        await load_task
-                    except asyncio.CancelledError:
-                        pass
-                    return
+                    raise asyncio.CancelledError
 
                 self.serve_engine = await load_task
 
@@ -428,6 +430,8 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
 
         # Acquire generation lock to track active generation
         async with self._generation_lock:
+            if self._shutdown_event.is_set():
+                raise asyncio.CancelledError
             try:
                 # Parse voice configuration
                 voice_config = await self._prepare_voice_config(request.voice)
@@ -467,6 +471,8 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
                     generation_time = time.time() - start_time
                     self._update_performance_metrics(len(text.split()), generation_time)
 
+            except TTSOperationError:
+                raise
             except Exception as e:
                 logger.error("═" * 60)
                 logger.error("❌ GENERATION FAILED")
@@ -475,7 +481,44 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
                 logger.opt(exception=True).error(
                     f"HiggsAudioTTSBackend: Error during generation: {e}"
                 )
-                yield f"ERROR: Higgs Audio generation failed - {str(e)}".encode("utf-8")
+                raise ValueError("Higgs Audio generation failed.") from None
+
+    async def _run_generation(self, chat_ml_sample: Any, **kwargs) -> Any:
+        """Keep thread-backed inference owned through caller cancellation."""
+        task = asyncio.create_task(
+            asyncio.to_thread(
+                self._invoke_serve_engine_generate, chat_ml_sample, **kwargs
+            )
+        )
+        self._active_tasks.add(task)
+        try:
+            # Canceling an asyncio wrapper cannot stop its native worker thread.
+            # Hold the generation lock until that worker actually finishes.
+            await join_retained_task(task)
+            if self._shutdown_event.is_set():
+                raise asyncio.CancelledError
+            return task.result()
+        finally:
+            self._active_tasks.discard(task)
+
+    @staticmethod
+    def _validated_audio(audio_data: Any) -> Any:
+        """Reject missing, empty or invalid model audio before encoding."""
+        if audio_data is None:
+            raise ValueError("Higgs Audio returned no audio.")
+        if isinstance(audio_data, torch.Tensor):
+            audio_data = audio_data.detach().cpu().numpy()
+        audio_data = np.asarray(audio_data)
+        if (
+            audio_data.ndim not in (1, 2)
+            or not audio_data.size
+            or not np.isfinite(audio_data).all()
+        ):
+            raise ValueError("Higgs Audio returned invalid audio.")
+        check_buffered_audio_size(audio_data.size * 4)
+        if audio_data.ndim == 2:
+            audio_data = audio_data.mean(axis=0)
+        return audio_data.astype(np.float32)
 
     async def _generate_single_speaker_stream(
         self,
@@ -520,44 +563,17 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
             logger.info("🎵 Generating audio with Higgs Audio model...")
             gen_start = time.time()
 
-            # Create generation task with cancellation support
-            gen_task = asyncio.create_task(
-                asyncio.to_thread(
-                    self._invoke_serve_engine_generate,
-                    chat_ml_sample,
-                    max_new_tokens=self.config.get("HIGGS_MAX_NEW_TOKENS", 4096),
-                    temperature=self.config.get("HIGGS_TEMPERATURE", 0.7),
-                    top_p=self.config.get("HIGGS_TOP_P", 0.95),
-                    top_k=self.config.get("HIGGS_TOP_K", 50),
-                    stop_strings=["<|end_of_text|>", "<|eot_id|>"],
-                    force_audio_gen=True,  # Force audio generation
-                    ras_win_len=7,
-                    ras_win_max_num_repeat=2,
-                )
+            output = await self._run_generation(
+                chat_ml_sample,
+                max_new_tokens=self.config.get("HIGGS_MAX_NEW_TOKENS", 4096),
+                temperature=self.config.get("HIGGS_TEMPERATURE", 0.7),
+                top_p=self.config.get("HIGGS_TOP_P", 0.95),
+                top_k=self.config.get("HIGGS_TOP_K", 50),
+                stop_strings=["<|end_of_text|>", "<|eot_id|>"],
+                force_audio_gen=True,
+                ras_win_len=7,
+                ras_win_max_num_repeat=2,
             )
-
-            self._active_tasks.add(gen_task)
-
-            try:
-                # Wait for either generation or shutdown
-                done, pending = await asyncio.wait(
-                    [gen_task, asyncio.create_task(self._shutdown_event.wait())],
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-
-                if self._shutdown_event.is_set():
-                    logger.info("Shutdown during generation, cancelling...")
-                    gen_task.cancel()
-                    try:
-                        await gen_task
-                    except asyncio.CancelledError:
-                        pass
-                    return
-
-                output = await gen_task
-
-            finally:
-                self._active_tasks.discard(gen_task)
 
             gen_elapsed = time.time() - gen_start
             logger.info(f"✓ Audio generated in {gen_elapsed:.1f}s")
@@ -566,15 +582,7 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
             if hasattr(output, "audio") and output.audio is not None:
                 audio_data = output.audio
 
-                # Convert to numpy array if needed
-                if isinstance(audio_data, torch.Tensor):
-                    audio_data = audio_data.cpu().numpy()
-
-                # Ensure audio is in the right format (mono, float32)
-                if len(audio_data.shape) > 1:
-                    audio_data = audio_data.mean(axis=0)  # Convert to mono
-
-                audio_data = audio_data.astype(np.float32)
+                audio_data = self._validated_audio(audio_data)
 
                 # Normalize audio to prevent clipping
                 max_val = np.abs(audio_data).max()
@@ -649,7 +657,7 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
                 )
             else:
                 logger.error("⚠️  No audio generated from model - output.audio is None")
-                yield b""
+                raise ValueError("Higgs Audio returned no audio.")
 
         except Exception as e:
             logger.opt(exception=True).error(
@@ -683,6 +691,7 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
 
             # Generate audio for each section
             all_audio = []
+            retained_bytes = 0
             sample_rate = 24000
 
             for i, (speaker, section_text) in enumerate(sections):
@@ -707,39 +716,20 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
                     logger.info("Shutdown requested during multi-speaker generation")
                     return
 
-                # Create generation task for this section
-                section_task = asyncio.create_task(
-                    asyncio.to_thread(
-                        self._invoke_serve_engine_generate,
-                        chat_ml_sample,
-                        max_new_tokens=self.config.get("HIGGS_MAX_NEW_TOKENS", 4096),
-                        temperature=self.config.get("HIGGS_TEMPERATURE", 0.7),
-                        top_p=self.config.get("HIGGS_TOP_P", 0.95),
-                        top_k=self.config.get("HIGGS_TOP_K", 50),
-                        stop_strings=["<|end_of_text|>", "<|eot_id|>"],
-                        force_audio_gen=True,
-                    )
+                output = await self._run_generation(
+                    chat_ml_sample,
+                    max_new_tokens=self.config.get("HIGGS_MAX_NEW_TOKENS", 4096),
+                    temperature=self.config.get("HIGGS_TEMPERATURE", 0.7),
+                    top_p=self.config.get("HIGGS_TOP_P", 0.95),
+                    top_k=self.config.get("HIGGS_TOP_K", 50),
+                    stop_strings=["<|end_of_text|>", "<|eot_id|>"],
+                    force_audio_gen=True,
                 )
 
-                self._active_tasks.add(section_task)
-
-                try:
-                    output = await section_task
-                finally:
-                    self._active_tasks.discard(section_task)
-
-                if hasattr(output, "audio") and output.audio is not None:
-                    audio_data = output.audio
-
-                    # Convert to numpy
-                    if isinstance(audio_data, torch.Tensor):
-                        audio_data = audio_data.cpu().numpy()
-
-                    # Ensure mono
-                    if len(audio_data.shape) > 1:
-                        audio_data = audio_data.mean(axis=0)
-
-                    all_audio.append(audio_data)
+                audio_data = self._validated_audio(getattr(output, "audio", None))
+                retained_bytes += audio_data.nbytes
+                check_buffered_audio_size(retained_bytes)
+                all_audio.append(audio_data)
 
                 # Report progress
                 progress = (i + 1) / len(sections) * 0.9
@@ -1481,29 +1471,12 @@ class HiggsAudioTTSBackend(LocalTTSBackend):
         # Signal shutdown to stop new operations
         self._shutdown_event.set()
 
-        # Cancel all active tasks with timeout
+        # A canceled to_thread task can still be using the model. Keep the
+        # engine and active-task ownership intact if bounded close must retry.
         if self._active_tasks:
-            logger.info(f"Cancelling {len(self._active_tasks)} active tasks...")
-
-            # Create list to avoid set modification during iteration
-            tasks_to_cancel = list(self._active_tasks)
-
-            # Cancel all tasks
-            for task in tasks_to_cancel:
-                if not task.done():
-                    task.cancel()
-
-            # Wait for cancellation with timeout
-            try:
-                await asyncio.wait_for(
-                    asyncio.gather(*tasks_to_cancel, return_exceptions=True),
-                    timeout=5.0,
-                )
-                logger.info("All tasks cancelled successfully")
-            except asyncio.TimeoutError:
-                logger.warning("Some tasks did not cancel within timeout")
-                # Force clear the tasks
-                self._active_tasks.clear()
+            _done, pending = await asyncio.wait(tuple(self._active_tasks), timeout=5.0)
+            if pending:
+                raise TimeoutError("Higgs Audio inference is still stopping.")
 
         # Wait a bit for any ongoing generation to notice shutdown
         await asyncio.sleep(0.1)

--- a/tldw_chatbook/TTS/backends/openai.py
+++ b/tldw_chatbook/TTS/backends/openai.py
@@ -263,6 +263,9 @@ class OpenAITTSBackend(APITTSBackend):
                             metrics={"chunks": chunk_count},
                         )
 
+                if not total_bytes:
+                    raise ValueError("TTS service returned no audio.")
+
                 # Report completion
                 await self._report_progress(
                     progress=1.0,

--- a/tldw_chatbook/TTS/legacy_bridge.py
+++ b/tldw_chatbook/TTS/legacy_bridge.py
@@ -800,11 +800,29 @@ class LegacyTTSAdapter:
         route = resolve_legacy_route(internal_id)
         if route.provider_id != self.provider_id:
             raise ValueError("Legacy route does not match provider")
+        sample_rate = None
+        metadata = {}
+        if legacy_request.response_format == "pcm" and (
+            self.provider_id != "openai"
+            or normalize_openai_compatible_endpoint(
+                self.admitted_outbound_endpoint()
+            ).official
+        ):
+            # Retained backends normalize PCM to signed little-endian 16-bit,
+            # mono 24 kHz. Custom OpenAI-compatible servers have no such promise.
+            sample_rate = 24_000
+            metadata = {
+                "sample_rate": sample_rate,
+                "channels": 1,
+                "sample_encoding": "pcm_s16le",
+            }
         return TTSAudioResponse(
             provider_id=self.provider_id,
             model_id=request.model_id,
             audio_format=legacy_request.response_format,
             content_type=_content_type(legacy_request.response_format),
+            sample_rate=sample_rate,
+            metadata=metadata,
             byte_stream=self.host.generate(
                 route.internal_model_id,
                 legacy_request,

--- a/tldw_chatbook/TTS/pcm_playback.py
+++ b/tldw_chatbook/TTS/pcm_playback.py
@@ -1,0 +1,67 @@
+"""Containerize known PCM for file playback without changing its source artifact."""
+
+from __future__ import annotations
+
+import os
+import wave
+from pathlib import Path
+
+from tldw_chatbook.Utils.secure_temp_files import (
+    create_secure_temp_file,
+    secure_delete_file,
+)
+
+_COPY_BYTES = 64 * 1024
+
+
+def create_pcm16_wav_copy(
+    source: Path,
+    sample_rate: object,
+    channels: object = 1,
+) -> Path:
+    """Copy declared PCM16 into an owner-only WAV file using bounded reads.
+
+    Args:
+        source: Complete caller-owned raw PCM artifact, retained while copying.
+        sample_rate: Explicit response rate; unknown or invalid rates are refused.
+        channels: Declared mono or stereo channel count.
+
+    Returns:
+        Temporary WAV path. The caller owns its cleanup and the source is unchanged.
+
+    Raises:
+        ValueError: If sample metadata or the complete PCM frame shape is invalid.
+        OSError: If an owned artifact cannot be read or written.
+    """
+    if (
+        type(sample_rate) is not int
+        or type(channels) is not int
+        or channels not in (1, 2)
+        or not 0 < sample_rate <= 0xFFFFFFFF // (2 * channels)
+    ):
+        raise ValueError("PCM playback requires a known sample rate and channel count")
+    with source.open("rb") as raw:
+        size = os.fstat(raw.fileno()).st_size
+        if not 0 < size <= 0xFFFFFFFF - 36 or size % (2 * channels):
+            raise ValueError("PCM playback requires complete signed 16-bit frames")
+        destination = Path(
+            create_secure_temp_file(b"", suffix=".wav", prefix="tts_pcm_playback_")
+        )
+        try:
+            with wave.open(str(destination), "wb") as output:
+                output.setnchannels(channels)
+                output.setsampwidth(2)
+                output.setframerate(sample_rate)
+                remaining = size
+                while remaining:
+                    chunk = raw.read(min(_COPY_BYTES, remaining))
+                    if not chunk:
+                        raise ValueError("PCM source changed before playback")
+                    output.writeframesraw(chunk)
+                    remaining -= len(chunk)
+                if raw.read(1):
+                    raise ValueError("PCM source changed before playback")
+            return destination
+        except BaseException:
+            secure_delete_file(destination)
+            raise

--- a/tldw_chatbook/TTS/pcm_playback.py
+++ b/tldw_chatbook/TTS/pcm_playback.py
@@ -12,6 +12,10 @@ from tldw_chatbook.Utils.secure_temp_files import (
 )
 
 _COPY_BYTES = 64 * 1024
+_PCM16_SAMPLE_WIDTH_BYTES = 2
+_RIFF_UINT32_MAX = (1 << 32) - 1
+# The RIFF size field excludes the initial eight bytes of the 44-byte WAV header.
+_WAV_RIFF_OVERHEAD_BYTES = 36
 
 
 def create_pcm16_wav_copy(
@@ -37,12 +41,17 @@ def create_pcm16_wav_copy(
         type(sample_rate) is not int
         or type(channels) is not int
         or channels not in (1, 2)
-        or not 0 < sample_rate <= 0xFFFFFFFF // (2 * channels)
+        or sample_rate <= 0
+        or sample_rate > _RIFF_UINT32_MAX // (_PCM16_SAMPLE_WIDTH_BYTES * channels)
     ):
         raise ValueError("PCM playback requires a known sample rate and channel count")
+    frame_width_bytes = _PCM16_SAMPLE_WIDTH_BYTES * channels
     with source.open("rb") as raw:
         size = os.fstat(raw.fileno()).st_size
-        if not 0 < size <= 0xFFFFFFFF - 36 or size % (2 * channels):
+        if (
+            not 0 < size <= _RIFF_UINT32_MAX - _WAV_RIFF_OVERHEAD_BYTES
+            or size % frame_width_bytes
+        ):
             raise ValueError("PCM playback requires complete signed 16-bit frames")
         destination = Path(
             create_secure_temp_file(b"", suffix=".wav", prefix="tts_pcm_playback_")
@@ -50,7 +59,7 @@ def create_pcm16_wav_copy(
         try:
             with wave.open(str(destination), "wb") as output:
                 output.setnchannels(channels)
-                output.setsampwidth(2)
+                output.setsampwidth(_PCM16_SAMPLE_WIDTH_BYTES)
                 output.setframerate(sample_rate)
                 remaining = size
                 while remaining:

--- a/tldw_chatbook/UI/Speech/speech_playback_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_playback_mixin.py
@@ -38,7 +38,6 @@ from tldw_chatbook.Widgets.enhanced_file_picker import (
 
 from tldw_chatbook.TTS import STTSGeneratedAudio, STTSPlaygroundResultProjection
 from tldw_chatbook.TTS.playground_types import PROFILE_SAVE_BLOCK_PROVIDER_OPTIONS
-from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
 from tldw_chatbook.Utils.secure_temp_files import secure_delete_file
 
 
@@ -707,6 +706,8 @@ class SpeechPlaybackMixin:
                     logger.debug(f"Player state after stop: {state_after_stop}")
 
                     if audio_path.suffix.lower() == ".pcm":
+                        from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
+
                         metadata = pcm_metadata or {}
                         copy_task = asyncio.create_task(
                             asyncio.to_thread(

--- a/tldw_chatbook/UI/Speech/speech_playback_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_playback_mixin.py
@@ -1160,6 +1160,7 @@ class SpeechPlaybackMixin:
         if not hasattr(self.app, "audio_player"):
             return
 
+        playback_failed = False
         while True:
             try:
                 state = await self.app.audio_player.get_state()
@@ -1184,7 +1185,12 @@ class SpeechPlaybackMixin:
                         progress_bar.remove_class("hidden")
                         time_display.remove_class("hidden")
                         self.query_one("#audio-player-transport").remove_class("hidden")
-                elif state in [PlaybackState.IDLE, PlaybackState.FINISHED]:
+                elif state in (
+                    PlaybackState.IDLE,
+                    PlaybackState.FINISHED,
+                    PlaybackState.ERROR,
+                ):
+                    playback_failed = state == PlaybackState.ERROR
                     self._release_playback_artifact()
 
                     if self._result_transition_operation_id is None:
@@ -1196,11 +1202,14 @@ class SpeechPlaybackMixin:
                         # Reset button states when playback finishes
                         self._sync_idle_transport_actions()
                         self.query_one("#audio-player-status", Static).update(
-                            self._current_result_status_copy()
+                            "Playback failed"
+                            if playback_failed
+                            else self._current_result_status_copy()
                         )
 
-                    # Notify that playback is complete
-                    if state == PlaybackState.FINISHED:
+                    if playback_failed:
+                        self.app.notify("Playback failed", severity="error")
+                    elif state == PlaybackState.FINISHED:
                         self.app.notify("Playback complete", severity="information")
 
                     break
@@ -1219,7 +1228,9 @@ class SpeechPlaybackMixin:
                 self._sync_idle_transport_actions()
                 self.query_one("#audio-player-transport").add_class("hidden")
                 self.query_one("#audio-player-status", Static).update(
-                    self._current_result_status_copy()
+                    "Playback failed"
+                    if playback_failed
+                    else self._current_result_status_copy()
                 )
         except Exception as e:
             logger.debug(f"Could not reset UI on progress timer exit: {e}")

--- a/tldw_chatbook/UI/Speech/speech_playback_mixin.py
+++ b/tldw_chatbook/UI/Speech/speech_playback_mixin.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import math
+from collections.abc import Mapping
 from numbers import Real
 from pathlib import Path
 from typing import Any, Callable, Optional
@@ -37,6 +38,8 @@ from tldw_chatbook.Widgets.enhanced_file_picker import (
 
 from tldw_chatbook.TTS import STTSGeneratedAudio, STTSPlaygroundResultProjection
 from tldw_chatbook.TTS.playground_types import PROFILE_SAVE_BLOCK_PROVIDER_OPTIONS
+from tldw_chatbook.TTS.pcm_playback import create_pcm16_wav_copy
+from tldw_chatbook.Utils.secure_temp_files import secure_delete_file
 
 
 EXAMPLE_TEXTS = [
@@ -646,7 +649,15 @@ class SpeechPlaybackMixin:
 
             # Use the new audio player method
             # Store the worker task so we can check if it's running
-            playback = self._play_audio_async(audio_path, release_artifact)
+            artifact = self.current_audio_artifact
+            pcm_metadata = (
+                artifact.metadata
+                if artifact is not None and artifact.path == audio_path
+                else None
+            )
+            playback = self._play_audio_async(
+                audio_path, release_artifact, pcm_metadata=pcm_metadata
+            )
             try:
                 self._play_worker_task = self.run_worker(
                     playback,
@@ -665,11 +676,16 @@ class SpeechPlaybackMixin:
         self,
         audio_path: Path | None = None,
         release_artifact: Callable[[], None] | None = None,
+        *,
+        pcm_metadata: Mapping[str, object] | None = None,
     ) -> None:
         """Play audio asynchronously using the audio player"""
         try:
             if audio_path is None:
                 audio_path = self._current_generated_audio_path()
+                artifact = self.current_audio_artifact
+                if artifact is not None and artifact.path == audio_path:
+                    pcm_metadata = artifact.metadata
             if audio_path is not None:
                 if audio_path.exists():
                     # Get current player state before stopping
@@ -689,6 +705,46 @@ class SpeechPlaybackMixin:
                     # Check state after stop
                     state_after_stop = await self.app.audio_player.get_state()
                     logger.debug(f"Player state after stop: {state_after_stop}")
+
+                    if audio_path.suffix.lower() == ".pcm":
+                        metadata = pcm_metadata or {}
+                        copy_task = asyncio.create_task(
+                            asyncio.to_thread(
+                                create_pcm16_wav_copy,
+                                audio_path,
+                                metadata.get("sample_rate"),
+                                metadata.get("channels", 1),
+                            )
+                        )
+                        try:
+                            audio_path = await asyncio.shield(copy_task)
+                        except asyncio.CancelledError:
+                            # The source lease outlives its off-thread read.
+                            # Join local artifact I/O before deleting either file.
+                            while not copy_task.done():
+                                try:
+                                    await asyncio.shield(copy_task)
+                                except asyncio.CancelledError:
+                                    continue
+                                except (OSError, ValueError):
+                                    break
+                            if (
+                                not copy_task.cancelled()
+                                and copy_task.exception() is None
+                            ):
+                                secure_delete_file(copy_task.result())
+                            raise
+                        original_release = release_artifact
+                        playback_copy = audio_path
+
+                        def release_copy() -> None:
+                            try:
+                                secure_delete_file(playback_copy)
+                            finally:
+                                if original_release is not None:
+                                    original_release()
+
+                        release_artifact = release_copy
 
                     # Attempt to play the audio file
                     logger.info(f"Attempting to play audio file: {audio_path}")

--- a/tldw_chatbook/UI/Speech/speech_playground_pane.py
+++ b/tldw_chatbook/UI/Speech/speech_playground_pane.py
@@ -130,6 +130,7 @@ def _validate_clone_transcript_input(value: str) -> str:
         raise ValueError("reference_text")
     return validate_reference_text(value)
 
+
 if TYPE_CHECKING:
     pass
 
@@ -560,6 +561,21 @@ class SpeechPlaygroundPane(
             and navigation_provider_id != saved_provider_id
         )
         global_applies = provider_id == global_preferences.provider_id
+        if (
+            key in {"default_model", "default_voice"}
+            and self._selected_provider_id is not None
+            and self._selected_provider_id != provider_id
+        ):
+            # These exact IDs belong to the saved selection's provider.
+            # Returning to the global provider can still inherit its IDs;
+            # another provider must choose its own catalog defaults.
+            if self._selected_provider_id == global_preferences.provider_id:
+                return (
+                    global_preferences.model_id
+                    if key == "default_model"
+                    else global_preferences.voice_id
+                )
+            return default
         if key == "default_model":
             if navigation_changes_provider:
                 return None
@@ -2467,9 +2483,7 @@ class SpeechPlaygroundPane(
             selected_model = self._current_select_value("#tts-model-select")
         except NoMatches:
             selected_model = None
-        selected_model_id = (
-            selected_model if isinstance(selected_model, str) else None
-        )
+        selected_model_id = selected_model if isinstance(selected_model, str) else None
         self.run_worker(
             partial(
                 self._observe_audio_cpp_runtime,

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -55,17 +55,10 @@
     background: $ds-surface-raised;
 }
 
-/* F-054/F-057: these two badges carry whole SENTENCES (the inspector's
-   empty-state explainer, the servers-mode aggregate summary), not one-word
-   chips -- they must wrap at narrow widths instead of clipping mid-word.
-   ID selectors beat the `.ds-status-badge` class rule above on
-   specificity; every other `.ds-status-badge` consumer keeps the fixed
-   height. `width: 1fr` is required alongside: the class rule's
-   `width: auto` would otherwise size the badge to its content's natural
-   width (no wrap at all -- the line just overflows its pane). Kept in
-   lockstep with the matching overrides in MCPInspector.DEFAULT_CSS and
-   MCPServersMode.DEFAULT_CSS, which cover the bare test harnesses that
-   never load this bundle. */
+/* F-054/F-057: sentence badges must wrap. ID rules override the fixed
+   .ds-status-badge size; 1fr avoids intrinsic-width overflow. Keep these
+   overrides in sync with MCPInspector/MCPServersMode.DEFAULT_CSS for
+   standalone harnesses. */
 #mcp-inspector-state,
 #mcp-overview-summary {
     width: 1fr;

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -2279,17 +2279,10 @@ EnhancedFileDialog InputBar Select {
     background: $ds-surface-raised;
 }
 
-/* F-054/F-057: these two badges carry whole SENTENCES (the inspector's
-   empty-state explainer, the servers-mode aggregate summary), not one-word
-   chips -- they must wrap at narrow widths instead of clipping mid-word.
-   ID selectors beat the `.ds-status-badge` class rule above on
-   specificity; every other `.ds-status-badge` consumer keeps the fixed
-   height. `width: 1fr` is required alongside: the class rule's
-   `width: auto` would otherwise size the badge to its content's natural
-   width (no wrap at all -- the line just overflows its pane). Kept in
-   lockstep with the matching overrides in MCPInspector.DEFAULT_CSS and
-   MCPServersMode.DEFAULT_CSS, which cover the bare test harnesses that
-   never load this bundle. */
+/* F-054/F-057: sentence badges must wrap. ID rules override the fixed
+   .ds-status-badge size; 1fr avoids intrinsic-width overflow. Keep these
+   overrides in sync with MCPInspector/MCPServersMode.DEFAULT_CSS for
+   standalone harnesses. */
 #mcp-inspector-state,
 #mcp-overview-summary {
     width: 1fr;


### PR DESCRIPTION
Speak replies and Speech Lab could produce truncated WAV files, mislabeled formats, silent successes, or stale audio after cancellation. Switching from a legacy provider to audio.cpp also carried foreign model/voice IDs into native selection and disabled Generate.

This repairs complete audio delivery and format conversion across Chatterbox, Higgs, ElevenLabs, AllTalk, and OpenAI-compatible responses. Known-rate PCM gets a temporary WAV playback copy while preserving the raw export. Provider switching preserves Global/Studio ownership and exact selections. macOS Opus uses FFplay, and failed playback terminates correctly in both Speech Lab and spoken feedback.

Qodo's eight findings are addressed with retained Higgs cleanup across host cancellation, accurate buffer accounting, application-path playback tests, direct limit/error-contract tests, named PCM constants, and public request/yield documentation. PCM imports stay off the boot path, and a shortened CSS comment restores the existing bundle budget without changing CSS rules or raising limits.

Validation:

- Main Python 3.12 targeted cohort: **744 passed, 1 optional Chatterbox skip**; final Chatterbox cohort: **30 passed**.
- Python 3.13 shared backend/PCM/provider UI cohort: **115 passed, 16 Torch-dependent skips**.
- Review follow-up: **148 backend/manager/bridge tests**, **43 shared limit/PCM tests**, and **304 distinct playback/lifecycle cases** passed across broad and focused runs. Coverage overlaps earlier cohorts; one existing scheduler-racy test was made deterministic.
- **Six formats played twice on the actual macOS device with full duration and complete independently transcribed content.** Recorded speech replaced inference/HTTP responses for these delivery checks. Chatterbox/Higgs models and remote/native services were unavailable for live inference validation.
- Fresh independent review found no further actionable issues. All six derived preflight checks pass; new tests pass Ruff, changed code introduces no lint diagnostics. No logging statements were added or changed by the review fixes.

Evidence and per-provider limits: [verification report](https://github.com/rmusser01/tldw_chatbook/blob/2a87a156753d779c0a742f3fce4bbe737a3f9a2b/Docs/superpowers/qa/tts-backend-parity-2026-09-08/verification.md). TASK-32076; existing ADRs 023, 039, 040 and 097. TASK-1880's caller-scoped/default PCM selection remains separate work. No full repository test sweep was run.

Rebased onto current dev (`e222813571`) after PR #2522 landed. The only conflict was appended lesson entries; both are preserved, with the TTS lesson beside the related Kokoro evidence. TTS runtime, Speech UI, event-handler and TTS test trees are identical to the reviewed source. **387 additional targeted logging/playback/startup tests and all six preflight checks pass.** TASK-32076 is Done, and all eight Qodo review threads are resolved.
