### PR TITLE
Add independent Buddy management and cross-screen interaction

### DIFF
--- a/.impeccable/critique/2026-09-09T00-37-01Z__widgets-persona-widgets-buddy-management-modal-py.md
+++ b/.impeccable/critique/2026-09-09T00-37-01Z__widgets-persona-widgets-buddy-management-modal-py.md
@@ -1,0 +1,76 @@
+---
+target: tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
+score: 24
+max_score: 40
+p0: 0
+p1: 4
+method: dual-agent
+timestamp: 2026-09-09T00-37-01Z
+slug: widgets-persona-widgets-buddy-management-modal-py
+---
+Method: dual-agent (A: chatbook_design_review · B: chatbook_evidence_review)
+
+# Native Chatbook Buddy and Persona review
+
+Reviewed commit `42f6e22461` on PR [2526](https://github.com/rmusser01/tldw_chatbook/pull/2526), including current dev `565dc49921`. Scope: native Textual Console Menu → Buddy, conversation interaction, workspace inbox/default Persona, and Personas inspector. Flashcards is excluded. The server/shared WebUI work is tracked separately in PR [2933](https://github.com/rmusser01/tldw_server/pull/2933).
+
+## Design assessment
+
+The flow fits Chatbook's terminal workbench: named explicit targets, preserved drafts, meaningful activity groups and independent artwork support controlled work without leaving the current destination. Its main weakness is access to the current state: preview controls can be invisible, old transcript content hides current replies and decisions, and the current Persona is unnamed. Legacy Persona-owned Buddy actions contradict the new model.
+
+These are pre-remediation scores, not a claim about the corrected implementation:
+
+| Heuristic | Score / 4 | Evidence |
+| --- | --- | --- |
+| Visibility of system status | 2 | New replies/decisions and current assignment hidden |
+| Match with real-world expectations | 3 | Explicit conversation/workspace terms |
+| User control and freedom | 3 | Cancel, drafts and navigation continuity |
+| Consistency and standards | 2 | Personas still advertises old ownership |
+| Error prevention | 3 | Explicit identities and validation |
+| Recognition rather than recall | 2 | Current assignment requires reconstruction |
+| Flexibility and efficiency | 2 | Preview clipped; repeated transcript scrolling |
+| Aesthetic and minimalist design | 2 | Secondary controls consume compact reading space |
+| Error recovery | 2 | Import failure loses staged corrections |
+| Help and documentation | 3 | Useful scope copy; impossible legacy recovery instruction |
+| Total | 24/40 | Acceptable, with major gaps to correct |
+
+## Findings and corrections
+
+| ID | Priority | Reproduction and user impact | Approved correction | Verification target |
+| --- | --- | --- | --- | --- |
+| CB-1 | P1 | Preview is outside the body clip at normal and compact sizes. Focus reaches an invisible button; click fails. Broad Select width overrides flex. | Scope flex widths to preview and geometry rows; reserve button and labels. | Actual pointer activation, visible keyboard focus and compact geometry. |
+| CB-2 | P1 | Twenty-message conversation opens at message 00. New reply increases scroll extent without following; pending approval is below all history. | Open at current content; follow when already at end, preserve deliberate reading, expose Latest/new updates and direct pending-decision access. | Long history, new reply, reader scrolled away, actual pending decision. |
+| CB-3 | P1 | Personas inspector enables Use for Buddy but disables current independent Buddy actions with Select the Persona currently used by Buddy. Legacy action writes Persona-owned selection. | Shared management entry and independent artwork copy; manage current Buddy without requiring a Persona owner. | Mounted independent selection and artwork-copy persistence. |
+| CB-4 | P1 | Missing ZIP plus changed width: Apply dismisses, exposes persona_visual_import_invalid, and reopening loses both changes. Saved preferences remain intact. | Keep staged dialog during validation/apply; actionable recovery, duplicate-submit guard, accurate partial-save outcome and safe retry. | Real library failed import, preserved values, successful correction, partial Persona failure. |
+| CB-5 | P2 | Keep current assignment gives no name/None/unavailable state, including workspace defaults. | Display effective current Persona/default for explicit target while keeping unchanged and explicit None distinct. | Conversation and workspace resolution including missing/inactive default. |
+| CB-6 | P2 | Blank transcript equals initial cached empty string, suppressing No messages yet. At 60×20 speech-off controls leave two transcript rows. | Initialize empty state correctly and compact speech-off presentation; keep active queue and consent controls. | Empty and compact dialogs with speech off/on/consent. |
+| CB-7 | P2 | After failed inbox refresh, Open is disabled but Enter invokes retained row opener. This is inconsistent gating, not demonstrated authority bypass. | Apply freshness gating to every pointer/keyboard open and acknowledgement path; recover on fresh snapshot. | Failure → Enter/click → recovery without acknowledgement or focus theft. |
+| CB-8 | P2 | Import and size details precede Follow/Persona; first-time setup presents too many unrelated controls together. | Progressively disclose optional import/geometry; keep installed preview and Dynamic/Static readily accessible. | First-time ordering and keyboard discovery of advanced fields. |
+
+CB-1, CB-4 and CB-6 were independently reproduced by both assessments. CB-2, CB-3 and CB-5 came from A's native workflow review; B independently found CB-7. CB-8 is A's cognitive-load recommendation applied within the approved design.
+
+## Workflow walkthrough
+
+A first-time user can open Console Menu → Buddy, select built-in Pixel Migu, preview, Apply and interact without creating a Persona. In the reviewed baseline, the missing Preview button breaks the safe trial and the failed-import path discards effort. Optional authoring details should follow the common selection path.
+
+An experienced user benefits from exact-target replies while another Console conversation is selected and from separate durable drafts. Reopening at old history and hiding pending decisions adds repeated manual scanning. Keeping current content visible must not pull a reader away from older context they deliberately opened.
+
+A workspace user can group Needs you, Running and Results without marking them read. The default-Persona explanation correctly limits changes to future conversations, but does not identify the current effective default. Voice input remains unavailable for workspace interaction; named queued read-aloud is separate.
+
+A keyboard or compact-terminal user can reach Apply/Cancel and recover focus after Escape, but invisible Preview focus and limited transcript height prevent efficient use. The correction uses terminal cells and native Textual behavior rather than applying browser typography metrics.
+
+## Strengths preserved
+
+- Fresh independent artwork selection leaves Persona records unchanged; Follow remains fixed across navigation.
+- Actual off-screen reply tests preserve both Buddy and Console drafts, route to the exact live/saved target and keep work alive after close.
+- Inbox projection is scoped and read-only on open. Explicit result acknowledgement and supported approvals retain their own authority.
+
+## Evidence and limits
+
+A used isolated full-app profiles and supplementary real-widget/controller probes, with PNG/SVG captures at 120×40, 80×24, 60×20 and long-history probes at 100×36. B mounted three dialogs using production stylesheet sources at 80×24 and 140×45, inspected 17 SVG/compositor captures, traversed focus, and exercised validation, failed refresh and draft recovery. A's direct approval probe used the real approval boundary outside a provider run; its idle label does not establish a normal running approval's status.
+
+The detector ran once and returned exit 0 / `[]`. Python/TCSS are unsupported, so this result provides no native accessibility assurance. Browser overlay injection is inapplicable to a Textual application; mounted native rendering supplied the evidence. B's PNG conversion failed because Cairo/native SVG conversion was unavailable; A's PNGs were rendered with local Menlo. No real-terminal mouse, screen reader, measured native contrast, provider turn, microphone or audio claim is made.
+
+Before fixes, root's targeted combined baseline passed 215 tests in 111.33 seconds. A also passed three real-flow tests and B passed 46 targeted tests; these overlap the baseline and must not be added as unique coverage. No full repository suite was run.
+
+Questions skipped: the user already requested correcting all findings and updating the PR against dev. The existing Buddy design remains the implementation authority.

--- a/Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md
+++ b/Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md
@@ -1,0 +1,88 @@
+Method: dual-agent (A: chatbook_design_review · B: chatbook_evidence_review)
+
+# Native Chatbook Buddy and Persona review
+
+Reviewed commit `42f6e22461` on PR [2526](https://github.com/rmusser01/tldw_chatbook/pull/2526), including current dev `565dc49921`. Scope: native Textual Console Menu → Buddy, conversation interaction, workspace inbox/default Persona, and Personas inspector. Flashcards is excluded. The server/shared WebUI work is tracked separately in PR [2933](https://github.com/rmusser01/tldw_server/pull/2933).
+
+## Design assessment
+
+The flow fits Chatbook's terminal workbench: named explicit targets, preserved drafts, meaningful activity groups and independent artwork support controlled work without leaving the current destination. Its main weakness is access to the current state: preview controls can be invisible, old transcript content hides current replies and decisions, and the current Persona is unnamed. Legacy Persona-owned Buddy actions contradict the new model.
+
+These are pre-remediation scores, not a claim about the corrected implementation:
+
+| Heuristic | Score / 4 | Evidence |
+| --- | --- | --- |
+| Visibility of system status | 2 | New replies/decisions and current assignment hidden |
+| Match with real-world expectations | 3 | Explicit conversation/workspace terms |
+| User control and freedom | 3 | Cancel, drafts and navigation continuity |
+| Consistency and standards | 2 | Personas still advertises old ownership |
+| Error prevention | 3 | Explicit identities and validation |
+| Recognition rather than recall | 2 | Current assignment requires reconstruction |
+| Flexibility and efficiency | 2 | Preview clipped; repeated transcript scrolling |
+| Aesthetic and minimalist design | 2 | Secondary controls consume compact reading space |
+| Error recovery | 2 | Import failure loses staged corrections |
+| Help and documentation | 3 | Useful scope copy; impossible legacy recovery instruction |
+| Total | 24/40 | Acceptable, with major gaps to correct |
+
+## Findings and corrections
+
+| ID | Priority | Reproduction and user impact | Approved correction | Verification target |
+| --- | --- | --- | --- | --- |
+| CB-1 | P1 | Preview is outside the body clip at normal and compact sizes. Focus reaches an invisible button; click fails. Broad Select width overrides flex. | Scope flex widths to preview and geometry rows; reserve button and labels. | Actual pointer activation, visible keyboard focus and compact geometry. |
+| CB-2 | P1 | Twenty-message conversation opens at message 00. New reply increases scroll extent without following; pending approval is below all history. | Open at current content; follow when already at end, preserve deliberate reading, expose Latest/new updates and direct pending-decision access. | Long history, new reply, reader scrolled away, actual pending decision. |
+| CB-3 | P1 | Personas inspector enables Use for Buddy but disables current independent Buddy actions with Select the Persona currently used by Buddy. Legacy action writes Persona-owned selection. | Shared management entry and controls for the current independent Buddy; remove the obsolete Persona-owner selection transaction. | Mounted Manage/Show/Close/Disable actions at 80x24 and 120x40; lower-layer migration/attribution coverage retained. |
+| CB-4 | P1 | Missing ZIP plus changed width: Apply dismisses, exposes persona_visual_import_invalid, and reopening loses both changes. Saved preferences remain intact. | Keep staged dialog during validation/apply; actionable recovery, duplicate-submit guard, accurate partial-save outcome and safe retry. | Real library failed import, preserved values, successful correction, partial Persona failure. |
+| CB-5 | P2 | Keep current assignment gives no name/None/unavailable state, including workspace defaults. | Display effective current Persona/default for explicit target while keeping unchanged and explicit None distinct. | Conversation and workspace resolution including missing/inactive default. |
+| CB-6 | P2 | Blank transcript equals initial cached empty string, suppressing No messages yet. At 60×20 speech-off controls leave two transcript rows. | Initialize empty state correctly and compact speech-off presentation; keep active queue and consent controls. | Empty and compact dialogs with speech off/on/consent. |
+| CB-7 | P2 | After failed inbox refresh, Open is disabled but Enter invokes retained row opener. This is inconsistent gating, not demonstrated authority bypass. | Apply freshness gating to every pointer/keyboard open and acknowledgement path; recover on fresh snapshot. | Failure → Enter/click → recovery without acknowledgement or focus theft. |
+| CB-8 | P2 | Import and size details precede Follow/Persona; first-time setup presents too many unrelated controls together. | Progressively disclose optional import/geometry; keep installed preview and Dynamic/Static readily accessible. | First-time ordering and keyboard discovery of advanced fields. |
+
+CB-1, CB-4 and CB-6 were independently reproduced by both assessments. CB-2, CB-3 and CB-5 came from A's native workflow review; B independently found CB-7. CB-8 is A's cognitive-load recommendation applied within the approved design.
+
+## Workflow walkthrough
+
+A first-time user can open Console Menu → Buddy, select built-in Pixel Migu, preview, Apply and interact without creating a Persona. In the reviewed baseline, the missing Preview button breaks the safe trial and the failed-import path discards effort. Optional authoring details should follow the common selection path.
+
+An experienced user benefits from exact-target replies while another Console conversation is selected and from separate durable drafts. Reopening at old history and hiding pending decisions adds repeated manual scanning. Keeping current content visible must not pull a reader away from older context they deliberately opened.
+
+A workspace user can group Needs you, Running and Results without marking them read. The default-Persona explanation correctly limits changes to future conversations, but does not identify the current effective default. Voice input remains unavailable for workspace interaction; named queued read-aloud is separate.
+
+A keyboard or compact-terminal user can reach Apply/Cancel and recover focus after Escape, but invisible Preview focus and limited transcript height prevent efficient use. The correction uses terminal cells and native Textual behavior rather than applying browser typography metrics.
+
+## Strengths preserved
+
+- Fresh independent artwork selection leaves Persona records unchanged; Follow remains fixed across navigation.
+- Actual off-screen reply tests preserve both Buddy and Console drafts, route to the exact live/saved target and keep work alive after close.
+- Inbox projection is scoped and read-only on open. Explicit result acknowledgement and supported approvals retain their own authority.
+
+## Evidence and limits
+
+A used isolated full-app profiles and supplementary real-widget/controller probes, with PNG/SVG captures at 120×40, 80×24, 60×20 and long-history probes at 100×36. B mounted three dialogs using production stylesheet sources at 80×24 and 140×45, inspected 17 SVG/compositor captures, traversed focus, and exercised validation, failed refresh and draft recovery. A's direct approval probe used the real approval boundary outside a provider run; its idle label does not establish a normal running approval's status.
+
+The detector ran once and returned exit 0 / `[]`. Python/TCSS are unsupported, so this result provides no native accessibility assurance. Browser overlay injection is inapplicable to a Textual application; mounted native rendering supplied the evidence. B's PNG conversion failed because Cairo/native SVG conversion was unavailable; A's PNGs were rendered with local Menlo. No real-terminal mouse, screen reader, measured native contrast, provider turn, microphone or audio claim is made.
+
+Before fixes, root's targeted combined baseline passed 215 tests in 111.33 seconds. A also passed three real-flow tests and B passed 46 targeted tests; these overlap the baseline and must not be added as unique coverage. No full repository suite was run.
+
+Questions skipped: the user already requested correcting all findings and updating the PR against dev. The existing Buddy design remains the implementation authority.
+
+## Remediation result
+
+All eight findings are addressed within the existing ADR-139/ADR-079 contracts. Preview and geometry use scoped flex rules; optional authoring is disclosed after Follow/Persona. Current assignments are named literally, including names containing brackets. Apply retains staged values while saving and recovering, prevents duplicate submission/dismissal, and guards import publication and preference revisions. The Personas inspector manages independent Buddy state without requiring a Persona selection. Workspace activation and acknowledgement share the same freshness gate.
+
+Conversation interaction opens at current content, follows replies only while the reader is at the end, preserves deliberate reading, and exposes Latest/new updates plus a direct pending-decision jump. Empty conversations render their status, and speech-off is compact. Full production CSS initially exposed a second compact defect: the nested approval body clipped buttons despite correct outer coordinates. Buddy-scoped auto-height and flexible decision controls now paint Approve once and Deny at 60x20 and 80x24; the regression checks ancestor clipping as well as position.
+
+Final verification is incremental over frozen production changes:
+
+- Broad affected Buddy library/controller/UI/journey, Personas inspector, CSS integrity and assignment/default group: **384 passed**.
+- After literal-name and smallest-screen scroll fixes, affected management and layout modules: **20 passed**.
+- After the final scoped approval CSS fix, transcript/layout and CSS integrity group: **37 passed**. Counts overlap and must not be added as unique coverage.
+- Coordinator recovery suite: **17 passed**, including a saved-Buddy/failed-Persona outcome and safe retry that keeps the existing Persona assignment.
+- Startup census and creation-default group: **30 passed**, actual UI-ready imports **973/973** with no budget increase.
+- Active Buddy lookup has a real SQLite plan assertion without sqlite_stat1; the index census passes with **282 entries / 67 pins**.
+- Eleven focused Python files pass Ruff and formatting. Baseline-aware lint across all changed Python files introduces no diagnostics (361 before, 358 after); large existing files retain formatting debt. Generated CSS and whitespace checks pass.
+
+Independent code review raised the literal-name parser issue and confirmed its correction. A subsequent scoped review inspected the final 60x20 render and ancestor-aware regression and found no remaining Important or Critical issues in the fixes. Reviewers did not rerun implementer tests; root separately inspected the final compact approval and management previews. The pre-fix heuristic score remains 24/40; no new score is inferred from passing tests.
+
+The previous CI head's unrelated MCP and GGUF cases both pass exact local reruns on merged dev, but macOS execution does not verify the Windows CI job. No full suite, real provider/microphone/audio or packaged-terminal user session was run. Current CI is reported on the PR.
+
+See [implementation plan](../../superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md) for scope and architectural references.

--- a/Docs/Development/Reviews/2026-09-09-buddy-pr-review.md
+++ b/Docs/Development/Reviews/2026-09-09-buddy-pr-review.md
@@ -106,3 +106,17 @@ A separate source reviewer inspected all eleven dispositions, current fixes, fro
 ## Final dev update
 
 Dev advanced once more to `8aa2211f2b78fcb35c9d1d3db6e15d5f1978da0a` while publication was being verified. A second rebase completed without conflicts; range-diff confirms all three Buddy commits replayed unchanged. The new base adds independent Library structural-wait handling. Fresh Buddy management journeys, entry points, conversation modals and actual startup census passed **45 tests in83.26s**; imports remain973/973. The diagnostic inventory verifies again without regeneration. These checks cover the navigation/startup intersection with the new base rather than claiming another full affected-suite run.
+
+## Published startup-budget correction
+
+The Linux/Python3.12 Perf Guard then reported975modules against973: scheduler_heartbeat and emergency_stop were imported by the first scheduler tick before UI readiness. A controlled slow warm boot reproduced the same pair and count locally, with real import-parent traces. The existing coroutine worker now starts after `_ui_ready`, immediately before the existing deferred startup sweep, preserving its app loop, exclusivity, group and dispatch-before-reconciliation ordering. The setup guard rejects admission after an early quit or shutdown request; startup failure also leaves the worker absent. Scheduler and emergency-stop implementations, budget constants and snapshots are unchanged.
+
+All18existing boot guards pass locally (973/973 ready modules,636/660 imported modules,803870/804000CSS bytes). The broader affected startup/scheduler/heartbeat/emergency-stop group passed154cases with4failures; all4new regressions pass. The four failures reproduce identically with the HEAD app loaded after pytest profile isolation and unchanged existing tests/other production modules: a6second worker test waits through a7second splash, two Watchlists fixtures violate the per-source active-run UNIQUE constraint, and one fixture expects a new fetch while another run is still active. This is a controlled HEAD-app comparison, not a pristine whole-repository run. Those separate tests were not modified.
+
+Both changed Python files compile; the new test passes Ruff/formatter, app.py introduces no lint or formatting changes on edited ranges, and diagnostic inventory verification passes without regeneration. No full local suite or local Linux execution is claimed. The synthetic2second stalled mount still counts974from a separate preexisting Console character-context background import; the fix removes the reported scheduler race and does not claim the entire startup graph is timing-independent.
+
+Independent review approved the scheduler deferral with no Critical or Important findings. Frozen hashes match, lifecycle ordering and early-exit/shutdown ownership remain sound; the review retains the stated broader-test and residual slow-mount limits.
+
+## Latest-base publication check
+
+Dev subsequently advanced to `c4a7b1911f14181faa471eb1ea209cfdeed98226` with Library count/read documentation. Rebase preserved all four Buddy commits; only the generated diagnostic summary conflicted. Both reviewed statement sets are retained (1351 TASK-492 /7669 TASK-494 calls), and the checker verifies the result. Scheduler source/test hashes remain identical to independent review. The final-base boot/lifecycle group passed22tests in69.62s at973/973; final Buddy management/entry journeys passed4tests before the independent Library rebase. No budgets were changed.

--- a/Docs/Development/Reviews/2026-09-09-buddy-pr-review.md
+++ b/Docs/Development/Reviews/2026-09-09-buddy-pr-review.md
@@ -1,0 +1,108 @@
+# Buddy PR #2526 — Qodo review corrections
+
+Worktree: `/Users/macbook-dev/Documents/GitHub/tldw_chatbook/.worktrees/buddy-console-management`
+Starting HEAD: `abf47df983a20673efc8de1e0cb3a883e8af2828` (rebased dev integration supplied by root).
+No git mutations, nested agents, full-suite runs, paid providers, microphone devices or live profile changes.
+
+## Dispositions
+
+| Qodo comment | Disposition and evidence |
+| --- | --- |
+| 3962487188, raw Buddy archive paths | Fixed. `read_buddy_archive` lazily calls central `validate_path_simple(..., probe_existing=False)` and passes the returned Path to the existing pinned/no-follow archive reader. Central traversal rejection precedes filesystem opening; selected-file symlinks still fail. The raw-path regression failed before the fix; traversal and no-follow regressions pass. |
+| 3962487197, raw management values | Fixed. Lazy `BuddyManagementInput` in central `Utils/input_validation.py` strictly validates bounded strings, booleans, motion and integer dimensions before constructing the domain choice. Dimension normalization reuses `validate_bounded_integer`; target/artwork/Persona membership and edit authority remain explicit UI checks. Overlong archive input previously constructed a choice and now rejects. Lazy import preserves the boot import boundary. |
+| 3962487211, synchronous saved hydration | Fixed for collection-size-dependent reads. The real local scope-service tree reader is offloaded while preserving local policy checks and memory-DB behavior. `prepare_console_session_data` preloads unpublished nodes/attachments, cursor, continuation/thinking rows and generation sidecars. Buddy rechecks record/profile/runtime and competing exact session bindings after awaits, then calls ordinary hydration/store publication on the app thread. Worker DB connections close on their own threads. Direct hydration callers remain compatible. See the explicit scope limit below. |
+| 3962487220, recorder callback thread | Declined as non-applicable. Installed Textual **8.2.8** `MessagePump.call_later` creates an `events.Callback` and calls `post_message`; `post_message` detects foreign threads and uses `loop.call_soon_threadsafe(self._message_queue.put_nowait, message)`. An actual mounted Textual regression starts the recorder seam in a worker, fires its captured buffer-limit callback in a worker and observes `request_voice` on the app thread. It passes unchanged. Replacing this with blocking `call_from_thread` is unnecessary. |
+| 3962487231, unbounded Buddy enumeration | Fixed. `list_buddies(limit=100, offset=0)` validates a maximum page size of 100; `get_buddy` uses a parameterized exact-ID query instead of enumerating the library. Native Previous/Next controls retrieve pages on demand; a separately looked-up current Buddy and any staged selection remain available across pages. Literal Rich Text labels preserve brackets; selections do not silently truncate. A real SQLite test loads 206 installed rows across pages and proves lookup does not call listing. |
+| 3962487241, Buddy read transaction boundaries | Fixed. Listing, exact lookup and source-key lookup execute inside `db.transaction()`. SQLite trace regression records each library SELECT inside a transaction. Publication/idempotency behavior remains covered by existing library tests. |
+| 3962487249, Workspace schema probe | Fixed narrowly. The v8 `PRAGMA table_info(workspace_records)` detection read uses `WorkspaceDB.transaction()`. Existing initializer/bootstrap semantics and the independent v8 atomic migration runner remain unchanged. Existing fresh/upgrade/restart/failed-version-write tests cover the migration. |
+| 3962487256, v69→v70 migration guards | Fixed. Entry and resulting-version reads occur inside the migration transaction, on `cursor.connection`. A forced resulting-version mismatch previously left version70/schema committed; it now rolls schema and version back to69. |
+| 3962487265, public library documentation | Fixed. Every public BuddyLibrary method now describes arguments, return values and applicable failure modes, including pagination bounds, unavailable identities, publication source guards and non-mutating selection behavior. |
+| 3962487270, Skip priority mismatch | Fixed. Drain and pending Skip share the same question-first selection helper. Paused response→question regression previously spoke the question after Skip and now retains/speaks the response. |
+| 3962487279, forged import provenance | Fixed in **both** import paths. Authoring draft metadata and independent Buddy archive snapshots merge archive context first and assign reserved `untrusted-import` last. Tests use attacker-controlled `source_context.provenance="trusted-builtin"`; authoring review and real Buddy publication preserve the system marker while retaining the independent license field. Both tests failed before their respective fixes. |
+
+## Hydration scope and authority
+
+This change does not claim that every SQLite operation leaves the app loop. Existing small per-conversation project/capture/context/speech policy reads, authority-locked dispatch reconciliation and durable repair/write bookkeeping remain in the established store restoration path. Moving those mutations or lock-coupled reconciliation into a worker would change ownership semantics. The potentially large tree, attachment, continuation/thinking, generation-sidecar and cursor reads now finish before publication. `:memory:` databases retain connection-local inline reads; production file-backed databases use worker connections. This is the bounded seam approved by root under ADR-139, not a new execution/runtime owner.
+
+The ten slow-read regressions cover tree, attachments, cursor, continuations and generation, each in normal and mid-read profile-change cases. They failed on the original synchronous reads. They now prove loop progress while a threading.Event holds the read, exactly one off-app-thread bulk read, UI-thread publication only after release, no publication after profile identity changes, preservation of the unrelated active session, and worker-connection cleanup. Additional tests cover before-first cursor reconstruction with and without preloading and a real `:memory:` database.
+
+## Three existing hydration test contracts corrected
+
+Initial broad gate: **220 passed, 3 failed in 96.16s** (log `/tmp/buddy-review-targeted.log`). The failures were:
+
+1. `test_resume_restores_the_complete_versioned_console_settings_snapshot`: legacy row-only wrapper returned base provider/settings instead of restoring the full legacy serialized dataclass.
+2. `test_canonical_hydration_makes_persisted_generic_console_forkable`: actual assistant kind `generic` versus expected `None`.
+3. `test_settings_replacement_refreshes_the_durable_resume_snapshot`: actual `llama_cpp` versus expected `openai`, because the test used the legacy `console_session_settings` replacement/wrapper instead of canonical safe generation persistence and hydration.
+
+Controlled baseline reproduction: `/tmp/buddy_baseline_plugin.py` executes **HEAD versions of the scope-service, store and hydration modules** in `pytest_configure` after conftest has established isolated test configuration; then runs exactly those three unchanged test functions. All three fail identically (2.43s, `/tmp/buddy-baseline-hydration.log`). This is a controlled module-baseline run, **not** a pristine whole-repository baseline checkout. No source files were swapped during either test run.
+
+Contract evidence: ADR-095 makes safe `console_generation_settings` authoritative, excludes endpoint/identity/prompt/prefill from its payload, and requires current configuration plus row-owned prompt/prefill during resume. The legacy `apply_resume_settings_overrides` docstring explicitly promises only the two row owners. Tests now use `commit_console_settings_live` + `persist_console_settings_commit_serialized` and `hydrate_console_generation_settings` for the round trip, while the wrapper test verifies base settings are preserved. Provider/model/temperature/prompt/prefill assertions remain. ADR-139's explicit None path maps to the current plain `generic/console` store identity; `console_chat_fork` explicitly accepts that identity without Persona/character authority. The fork eligibility assertion remains. All three corrected tests pass (2.73s); no unrelated production settings behavior was changed.
+
+## Verification commands and evidence
+
+All pytest commands use the main venv and worktree imports:
+
+```sh
+PYTHONPATH=.:packages/tldw_profile_core/src /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest <listed files> -q --no-cov --show-capture=no --tb=short
+```
+
+- Initial direct reproductions: Skip mismatch; authoring spoof; path validation bypass; unbounded listing; transaction-free reads; post-commit migration verification; overlong modal path; ten blocking bulk-read cases.
+- Small fixed gates: 4 path/provenance/Skip tests; 3 paging/transaction/migration tests; 13 management modal tests; 13 bulk-read/late-identity/concurrent-loader tests; 3 corrected canonical contracts.
+- Latest narrow final gate: **13 passed in 10.49s**, covering all ten bulk-read cases, before-first cursor through both paths, and real memory-DB hydration.
+- Mounted recorder callback regression passes without production callback changes.
+- Final affected integrated gate: **362 passed, 6 warnings in 189.34s**. Durable log: `task-1-final-tests.log` beside this report. The only later source edits moved one TYPE_CHECKING import and wrapped one expression; post-format checks below passed.
+- Post-format gate: **20 passed, 76 deselected, 2 warnings in 20.70s**. Actual UI-ready count: **973/973 modules**. Durable log: `task-1-census-tests.log`.
+- No unresolved semantic or test failures. Source remains frozen for root's artifact regeneration and independent review.
+- Static baseline comparison after both cosmetic corrections: **19 owned changed Python files parse; zero introduced Ruff diagnostics; zero formatter changes intersect modified ranges**. `task-1-static.json` records per-file evidence; inherited lint/format debt is not being rewritten. Source SHA-256 values are recorded in `task-1-frozen-sources.json`.
+- Baseline reproduction log and isolated loading plugin are preserved as `task-1-baseline-tests.log` and `task-1-baseline-plugin.py`; import/order limitations remain exactly as described above.
+- New Buddy production/test modules pass direct Ruff. `git diff --check` passes.
+
+No new ADR: existing ADR-139 owns the hydration/runtime boundary; ADR-095 supplies the corrected settings-test contract.
+
+
+Final integrated file set (all from the frozen worktree, main venv):
+
+```text
+Tests/Persona_Buddy/test_buddy_library.py
+Tests/Persona_Buddy/test_buddy_speech.py
+Tests/Persona_Visual/test_persona_visual_importer.py
+Tests/Persona_Visual/test_persona_visual_authoring.py
+Tests/Persona_Buddy/test_buddy_management_coordinator.py
+Tests/UI/test_buddy_management_modal.py
+Tests/UI/test_buddy_conversation_modal.py
+Tests/UI/test_buddy_management_journey.py
+Tests/UI/test_buddy_entry_points.py
+Tests/DB/test_workspace_db.py
+Tests/Workspaces/test_workspace_db_connection_reuse.py
+Tests/Chat/test_chat_conversation_scope_service.py
+Tests/Chat/test_console_conversation_hydration.py
+Tests/Chat/test_console_provider_continuation.py
+Tests/Chat/test_console_thinking_persistence.py
+Tests/Chat/test_console_settings_apply_store.py
+Tests/Packaging/test_persona_buddy_import_closure.py
+Tests/Performance/test_app_import_weight.py
+```
+
+Post-format command:
+
+```sh
+PYTHONPATH=.:packages/tldw_profile_core/src /Users/macbook-dev/Documents/GitHub/tldw_chatbook/.venv/bin/python -m pytest Tests/Performance/test_ui_ready_module_census.py Tests/Chat/test_console_conversation_hydration.py Tests/UI/test_buddy_conversation_modal.py -k 'ui_ready or bulk_reads or before_first_cursor or memory_database or legacy_resume_wrapper or canonical_hydration_makes or canonical_settings_apply' -q --no-cov --show-capture=no --tb=short
+```
+
+Self-review checked shared-form authority membership, staging across page changes, unchanged no-follow archive checks, both import provenance routes, explicit record/profile revalidation after bulk reads, memory-DB fallback, continuation quarantine fallback, migration failure rollback and absence of off-thread store publication. No new runtime service, dependency, provider permission or tool authority was introduced.
+
+## Rebase and derived checks
+
+Rebased onto dev `80f29a9a1dcd9307662714233c65605e4c517b11`. The only conflict was the testing-evidence lessons document; both independent additions were retained. The feature branch's prior head is preserved by a local recovery ref.
+
+The failed derived-artifact gate exposed two omitted schema allowlist entries (`buddy_profiles`, `buddy_visual_bindings`) and diagnostic inventory drift. Both table names now have matching migrated declarations. Production diagnostic statement changes across all 57 changed production files were reviewed before regeneration: additions contain fixed status messages, with no new interpolated user content or persistent sink topology change.
+
+All six derived checks pass: generated stylesheets; profile-owned paths (48 occurrences / 46 exceptions); diagnostic inventory (593 owners / 12 sink files); unique Backlog IDs; table allowlist (115 tables); and index decisions (282 names / 67 plan pins). Large Buddy-library pagination is documented in the user guide.
+
+## Independent review
+
+A separate source reviewer inspected all eleven dispositions, current fixes, frozen source hashes and existing verification logs without rerunning tests. No Important or Critical findings remained. The reviewer confirmed both import provenance paths, bounded pagination and exact lookup, migration rollback, question-first Skip, worker-connection cleanup and late authority checks, and the independent ADR-095 evidence behind the three corrected settings tests.
+
+## Final dev update
+
+Dev advanced once more to `8aa2211f2b78fcb35c9d1d3db6e15d5f1978da0a` while publication was being verified. A second rebase completed without conflicts; range-diff confirms all three Buddy commits replayed unchanged. The new base adds independent Library structural-wait handling. Fresh Buddy management journeys, entry points, conversation modals and actual startup census passed **45 tests in83.26s**; imports remain973/973. The diagnostic inventory verifies again without regeneration. These checks cover the navigation/startup intersection with the new base rather than claiming another full affected-suite run.

--- a/Docs/User_Guide/buddies.md
+++ b/Docs/User_Guide/buddies.md
@@ -5,7 +5,9 @@ the target's Persona. The floating Buddy's **⚙** control and Personas → **Ma
 focus the Buddy and press **m** for keyboard access.
 
 Choose installed artwork, preview an expression, and choose **Dynamic** or
-**Static**. **Import pack & size** contains the optional native
+**Static**. Large libraries use **Previous** and **Next** to browse 100 Buddies at
+a time; your current and staged choices remain selected while you browse.
+**Import pack & size** contains the optional native
 `.tldw-persona-vpack` / `.zip` path and terminal-cell dimensions. Global Reduce
 motion also suppresses animation. Apply saves your choices; Cancel discards them.
 If import or saving fails, the form retains your attempted values for correction.

--- a/Docs/User_Guide/buddies.md
+++ b/Docs/User_Guide/buddies.md
@@ -1,0 +1,86 @@
+# Buddies in Console and across screens
+
+Open **Console → Menu → Buddy** to manage Buddy artwork, its follow target and
+the target's Persona. The floating Buddy's **⚙** control opens the same form;
+focus the Buddy and press **m** for keyboard access.
+
+Choose installed artwork or enter a native `.tldw-persona-vpack` / `.zip` path.
+Preview an expression, choose **Dynamic** or **Static**, set its size, and Apply.
+Global Reduce motion also suppresses animation. Cancel discards form changes.
+Pixel Migu is available in a fresh profile. Imported artwork and its creator,
+licence and notices remain in the local Buddy library. Choosing artwork does not
+create or assign a Persona. Existing Persona-backed Buddy selections are copied
+to an independent owner; editing the source Persona does not change that copy.
+
+**Follow** chooses one specific conversation or workspace. Selecting a different
+Console tab or navigating to Watchlists does not change that target. A normal
+conversation's first save preserves its Buddy link for later launches. Temporary
+conversation links last only for the current app run. A missing, deleted or
+inaccessible target is shown as unavailable and is never replaced automatically.
+This version displays one Buddy; multiple simultaneous Buddies are planned later.
+
+Click the Buddy, or focus it and press **Enter**, to interact. Drag its body to
+move it; the lower-right grip resizes it. Closing or hiding it does not stop a run.
+
+## Conversation Buddy
+
+The interaction window shows the pinned conversation's transcript, current work,
+questions and supported approval cards. Type a reply and Send without changing
+the underlying screen. Each conversation keeps its Buddy draft when the window
+closes; its Console composer draft remains separate. Existing permissions still
+apply. If Console has staged inputs the Buddy cannot display, review those in
+Console before sending through the Buddy.
+
+**Dictate** uses existing Console speech recognition. Stop recording, review the
+transcribed draft, then Send. Closing the interaction window discards an active
+recording. This is push-to-talk dictation; it does not enable background listening.
+**Open Console** is the explicit way to switch to the full conversation interface,
+including review operations that require it.
+
+See [conversation interaction details](console/buddy-conversation.md) for quick
+reply restrictions, decision review and dictation setup.
+
+## Workspace Buddy
+
+The workspace inbox separates **Needs you**, **Running**, and unread **Results**.
+It tracks active work and unseen outcomes rather than listing every historical
+conversation. Open a row to review or send a directed text reply. Workspace mode
+does not offer microphone input, including inside a conversation opened from it.
+
+Opening or refreshing the inbox does not clear results. **Mark seen** applies to
+the selected result only. Questions still require an answer, and approvals still
+require their existing confirmation. Updates never take keyboard focus.
+
+## Personas and speech
+
+The management form can keep the current Persona, choose another, or choose
+**None** for the followed conversation. Changes affect future turns and are
+unavailable while a run, queue or decision is active. A Persona change is saved
+atomically with its prompt and settings. Existing memory-write permission requires
+review before assigning a different Persona.
+
+For a workspace, the Persona control is labelled as a default for **future new
+conversations**. The same default is available in workspace creation/details.
+Explicit Persona/None choices override inheritance; existing, moved and copied
+conversations keep their assignment. Clearing a workspace default keeps it cleared.
+
+Optional **Speak responses with conversation names** uses the existing TTS
+configuration. Each spoken update starts with its conversation name, and one queue
+prevents overlapping Buddy responses. Questions take priority over waiting results.
+Use **Pause / Resume**, **Skip**, or **Mute** in the interaction window; Resume
+restarts the interrupted update. If the configured destination needs consent,
+**Confirm speech** opens the existing destination confirmation. It never opens
+automatically or steals focus. Speech waits while Buddy dictation records.
+
+Speech does not acknowledge a result or answer a question. Hiding/disabling the
+Buddy stops its spoken presentation without cancelling conversation work. Closing
+only its interaction window leaves configured speech available. Saved results
+without a live conversation session remain available to review; their bodies are
+not automatically loaded solely for speech.
+
+Normal navigation keeps accepted Console runs, queued follow-ups and pending
+decisions alive. A finite decision timer advances only while the decision is
+actually answerable. Explicit Stop, closing a session, and app shutdown retain
+their cancellation behavior. This feature does not resume unfinished provider
+runs after an app restart. Chatbook currently supports local Buddy interaction;
+the server UX will be ported separately.

--- a/Docs/User_Guide/buddies.md
+++ b/Docs/User_Guide/buddies.md
@@ -1,12 +1,15 @@
 # Buddies in Console and across screens
 
 Open **Console → Menu → Buddy** to manage Buddy artwork, its follow target and
-the target's Persona. The floating Buddy's **⚙** control opens the same form;
+the target's Persona. The floating Buddy's **⚙** control and Personas → **Manage Buddy** open the same form;
 focus the Buddy and press **m** for keyboard access.
 
-Choose installed artwork or enter a native `.tldw-persona-vpack` / `.zip` path.
-Preview an expression, choose **Dynamic** or **Static**, set its size, and Apply.
-Global Reduce motion also suppresses animation. Cancel discards form changes.
+Choose installed artwork, preview an expression, and choose **Dynamic** or
+**Static**. **Import pack & size** contains the optional native
+`.tldw-persona-vpack` / `.zip` path and terminal-cell dimensions. Global Reduce
+motion also suppresses animation. Apply saves your choices; Cancel discards them.
+If import or saving fails, the form retains your attempted values for correction.
+A partial save identifies which settings were saved and which need retrying.
 Pixel Migu is available in a fresh profile. Imported artwork and its creator,
 licence and notices remain in the local Buddy library. Choosing artwork does not
 create or assign a Persona. Existing Persona-backed Buddy selections are copied
@@ -24,8 +27,10 @@ move it; the lower-right grip resizes it. Closing or hiding it does not stop a r
 
 ## Conversation Buddy
 
-The interaction window shows the pinned conversation's transcript, current work,
-questions and supported approval cards. Type a reply and Send without changing
+The interaction window opens at current content and follows new replies while
+you are at the end. Reading older messages preserves your position; **Latest**
+returns to the end and indicates new updates. Pending decisions have a direct
+jump action. Type a reply and Send without changing
 the underlying screen. Each conversation keeps its Buddy draft when the window
 closes; its Console composer draft remains separate. Existing permissions still
 apply. If Console has staged inputs the Buddy cannot display, review those in
@@ -49,11 +54,14 @@ does not offer microphone input, including inside a conversation opened from it.
 
 Opening or refreshing the inbox does not clear results. **Mark seen** applies to
 the selected result only. Questions still require an answer, and approvals still
-require their existing confirmation. Updates never take keyboard focus.
+require their existing confirmation. Updates never take keyboard focus. If a
+refresh fails, retained rows remain visible for context, but opening and marking
+results seen wait for a successful refresh.
 
 ## Personas and speech
 
-The management form can keep the current Persona, choose another, or choose
+The management form names the current Persona or workspace default, including
+None or an unavailable assignment. It can keep the current Persona, choose another, or choose
 **None** for the followed conversation. Changes affect future turns and are
 unavailable while a run, queue or decision is active. A Persona change is saved
 atomically with its prompt and settings. Existing memory-write permission requires
@@ -83,4 +91,5 @@ decisions alive. A finite decision timer advances only while the decision is
 actually answerable. Explicit Stop, closing a session, and app shutdown retain
 their cancellation behavior. This feature does not resume unfinished provider
 runs after an app restart. Chatbook currently supports local Buddy interaction;
-the server UX will be ported separately.
+the corresponding server/shared WebUI changes are tracked in
+[server PR #2933](https://github.com/rmusser01/tldw_server/pull/2933).

--- a/Docs/User_Guide/console.md
+++ b/Docs/User_Guide/console.md
@@ -259,6 +259,7 @@ composer-level strip below shows once setup completes.
 | **Attach context** | Opens the "Console context" rail (staging itself is done from Library) — see [Context & RAG](console/context-and-rag.md). |
 | **Search Library** | Runs a user-initiated **Manual Search Library** request before sending; it remains available regardless of the conversation's automatic or assistant policy — see [Context & RAG](console/context-and-rag.md#per-conversation-library-controls). |
 | **Save as Chatbook** (composer **Menu**) | Saves this run as a Chatbook — see [Artifacts](artifacts.md). |
+| **Buddy** (composer **Menu**) | Manage independent Buddy artwork, follow a conversation/workspace, and change Persona settings — see [Buddies](buddies.md). |
 | **Help** | Opens the Console help panel (same as F1). |
 | **Speak replies** | Speaks new assistant replies in this conversation. |
 | **Hands-free** | Enters/exits the voice conversation loop (same as Ctrl+Shift+H) — the switch is the touch/soft-keyboard route into the mode. |
@@ -474,13 +475,12 @@ requires an override. The default test suite makes no paid request.
 
 ### Leaving Console during a run
 
-Agent runs are screen-scoped: navigating to any other screen cancels every
-in-flight run and denies every pending approval. If runs are active, a
-**Leave Console?** dialog warns you first ("N agent runs will be cancelled
-if you leave Console. Leave anyway?") with **Leave** / **Stay** buttons,
-and a one-time toast on return reports what was cancelled. Details in
+Accepted runs, queues, and pending decisions continue when you navigate to another
+screen or open a modal. A hidden decision raises a notice and waits for you; a finite
+decision timeout counts only while its card is available to answer. **Stop**, session
+close, and application quit retain their cancellation behavior. Details in
 [Agent runs & tools](console/agent-runs-and-tools.md) and the
-[guide index](index.md#console-agent-runs-are-screen-scoped).
+[guide index](index.md#console-runs-continue-during-navigation).
 
 ## Common tasks
 

--- a/Docs/User_Guide/console/agent-runs-and-tools.md
+++ b/Docs/User_Guide/console/agent-runs-and-tools.md
@@ -52,8 +52,8 @@ a one-time banner spells it out:
 
 The number is your configured cap (default 3). Sending past the cap is
 refused with a message like "2 agents already running (…). Wait for one to
-finish or interrupt it." Runs live only while Console stays open — see
-[Console agent runs are screen-scoped](../index.md#console-agent-runs-are-screen-scoped).
+finish or interrupt it." Runs continue when you switch screens — see
+[Console runs continue during navigation](../index.md#console-runs-continue-during-navigation).
 
 **In the reply row itself** — while the turn works, the unfinished
 `Assistant` row shows a live activity line in place of its (empty) text, so
@@ -201,7 +201,8 @@ Region     Which regions? (pick any)
 - By default the question waits as long as it takes. To make an unanswered
   question expire instead, set `ask_user_timeout_seconds` under `[console]`
   in your config; the card then shows *Auto-continues in m:ss* and the run
-  carries on without an answer when it reaches zero.
+  carries on without an answer when it reaches zero. The clock advances only
+  while the question can be answered in the visible conversation.
 - A question for a tab you are not looking at lights that tab's badge and
   shows a toast; visit the tab to answer it. Stopping the run clears the card.
 - Every answered round leaves one line per question in the transcript, so
@@ -252,6 +253,9 @@ pending card; nothing else does. If you'd rather have undecided calls
 auto-denied on a clock, set `[mcp] approval_timeout_seconds` in
 `config.toml` (seconds; `0`, the default, waits indefinitely — the skill
 install and run-script confirm cards follow the same rule).
+Finite clocks pause while no supported view can answer the card, including hidden
+Console, another conversation, or an earlier card of the same kind. A visible
+Buddy interaction card can keep its own decision answerable.
 
 Some short local database mutations have a definitive-after-start contract.
 Before approval, Stop still withdraws the request. After you approve and the
@@ -1175,12 +1179,11 @@ on whatever screen you're on ("Agent in “…” needs approval to use a tool.
 Open Console to review — nothing runs until you answer."), the session
 picks up its usual approval badge, and the round waits for you rather
 than expiring. The tool does not run until you answer it. Nothing
-auto-approves: navigating away from Console again denies the request (the
-same rule as any card you leave unanswered), and so does quitting the
-app. If you have set a positive `[mcp] approval_timeout_seconds`, it
-still expires the request on schedule — being away does not buy the
-request extra time. The shipped default is `0`, which means no deadline:
-the request waits for you.
+auto-approves: navigating away again keeps the request pending. Explicit Stop,
+closing the owning conversation, or quitting the app withdraws it. A positive
+`[mcp] approval_timeout_seconds` counts only time when that conversation's card
+is answerable in Console or a supported Buddy card; hidden time does not consume the budget.
+The shipped default is `0`, which means no deadline: the request waits for you.
 
 **The card is rendered and answerable the first time you open Console —
 no session switch needed.** (Fixed as task-17500, 2026-08-17.) As first
@@ -1735,21 +1738,13 @@ briefing content remains Console-only.
   it takes that session's fleet with it: every live sub-agent, survivors
   included, is cancelled as part of the close (a survivor would otherwise
   outlive its own conversation, with no row left to cancel it from).
-- Leaving the Console screen is different: after the "Leave Console?" confirm,
-  every in-flight **turn** is cancelled and every pending or parked approval is
-  denied — never approved. One thing survives the leave: a background
-  sub-agent that already outlived its turn **keeps running** — its result
-  lands durably, you get the completion toast + `◈` marker wherever you
-  are, and the staged wake is claimed when Console next mounts (see
-  [auto-wake](#when-a-background-sub-agent-finishes--auto-wake)). The next
-  Console mount reports both fates honestly: "N agent runs were cancelled
-  when you left Console." and/or "… sub-agents kept running in the
-  background when you left Console — you'll be notified as they finish."
-  The warning also counts queued sessions and unsent
-  prompts. Staying leaves the queue and manager focus untouched; leaving
-  clears process-memory queues. Closing one tab uses the same count-aware
-  warning for that tab, and quitting the app reports the whole fleet. Details in
-  [Console agent runs are screen-scoped](../index.md#console-agent-runs-are-screen-scoped).
+- Leaving Console or opening a modal keeps accepted turns, queued prompts,
+  sub-agents and pending decisions alive. Hidden decisions notify once and remain
+  available on return. A configured decision timeout pauses while the owning card
+  cannot be answered. A dirty queue-manager edit must be saved or cancelled first.
+  Closing one session and quitting the app retain their count-aware warnings and
+  cancellation boundaries. See
+  [Console runs continue during navigation](../index.md#console-runs-continue-during-navigation).
 
 ### Agent run budget — how long and how expensive one reply may get
 
@@ -1926,7 +1921,7 @@ Enter). Tab-fleet keys (Ctrl+T, Alt+1…9, Ctrl+K) are covered in
 - [Library ▸ Skills](../library/skills.md) — create, import, review, and
   approve skills.
 - [MCP](../mcp.md) 🚧 — servers, tools, and permissions.
-- [Console agent runs are screen-scoped](../index.md#console-agent-runs-are-screen-scoped)
+- [Console runs continue during navigation](../index.md#console-runs-continue-during-navigation)
   — what leaving Console does to runs and approvals.
 - [Console](../console.md) — the screen itself.
 - [Context & RAG](context-and-rag.md#project-instructions) — status states,
@@ -2032,7 +2027,10 @@ the honest-limits bullet corrected @ HEAD — 2026-08-14 (task-16300,
 documentation-only for this page: navigating away from Console under an
 open dialog used to leave the old Console screen resident and running,
 and the bullet had described that leak as intended behavior. Navigation
-now unmounts the outgoing screen, so leaving Console stages. Pinned by
+then unmounted the outgoing screen, so leaving Console staged. TASK-31520
+subsequently introduced deliberate screen reuse; TASK-32078 verifies that
+streams, queues and decisions now continue during ordinary navigation. The
+earlier unmount behavior was pinned by
 `Tests/UI/test_screen_residency.py`; the live off-view evidence above is
 unaffected — it was gathered with a palette covering an open Console and
 a different session tab active, not by navigating away.) The "Change

--- a/Docs/User_Guide/console/buddy-conversation.md
+++ b/Docs/User_Guide/console/buddy-conversation.md
@@ -1,0 +1,34 @@
+# Reply through a conversation Buddy
+
+Click a conversation Buddy, or press Enter while it is focused, to open its named
+conversation over your current destination. The panel shows recent messages,
+activity, questions and supported approval cards. A saved inbox conversation can
+load here without changing the selected Console conversation or workspace.
+
+Type a reply and choose **Send**. Replies belong to this conversation even when
+Console has another conversation selected. A busy or unavailable conversation
+shows its current state instead of sending elsewhere. Closing the panel restores
+focus and keeps its private draft for reopening during this app session. A sent
+turn keeps running after the panel closes.
+
+Quick replies use plain text. For slash commands, `@` references, or staged
+attachments, one-shot prefill and Library evidence, choose **Open Console** and
+review those inputs there. Quick replies preserve both the bound conversation's
+Console draft and any other visible Console composer.
+
+Questions, tool approvals and skill confirmations use the normal Console decision
+cards and permissions. A worktree merge decision offers **Open Console** for its
+existing review flow. Finite decision timers run only while their owning decision
+can be answered; hiding the panel pauses that time. Explicit Stop and app shutdown
+still cancel work.
+
+Where voice capture is available, **Dictate** uses the configured Console speech
+input. Choose **Finish dictation**, review or edit the resulting draft, then
+**Send**. Dictation does not send or answer approvals automatically. Closing or
+covering the panel releases its microphone and discards unfinished dictation.
+Workspace inbox interaction has text controls only.
+
+When Buddy speech is enabled, its Pause, Skip and Mute controls operate the existing
+app-owned speech queue. Playback waits during microphone capture. Closing the
+panel does not stop accepted work or queued speech. Remote speech destinations
+retain their normal confirmation requirements.

--- a/Docs/User_Guide/console/buddy-conversation.md
+++ b/Docs/User_Guide/console/buddy-conversation.md
@@ -5,6 +5,12 @@ conversation over your current destination. The panel shows recent messages,
 activity, questions and supported approval cards. A saved inbox conversation can
 load here without changing the selected Console conversation or workspace.
 
+The transcript opens at current content. It follows new replies while you are at
+the end and preserves your position when reading earlier messages. **Latest**
+returns to the end and indicates updates received while you were reading above.
+Pending decisions offer a direct jump action without scrolling the entire history.
+An empty conversation shows **No messages yet**.
+
 Type a reply and choose **Send**. Replies belong to this conversation even when
 Console has another conversation selected. A busy or unavailable conversation
 shows its current state instead of sending elsewhere. Closing the panel restores

--- a/Docs/User_Guide/console/sessions-tabs-workspaces.md
+++ b/Docs/User_Guide/console/sessions-tabs-workspaces.md
@@ -168,6 +168,17 @@ History remain usable.
 
 ### Workspaces
 
+**Default Persona.** The shared New Workspace dialog lets you create a workspace
+Agent, choose a saved Persona, or select **None**. The Console's **Details →
+Default Persona…** control and **Settings → Workspaces** edit the default for
+future new conversations. Read and write memory requires explicit confirmation.
+Choosing None stays cleared after restart; automatic setup does not recreate it.
+
+New chats, temporary chats and the first chat opened in a workspace use its
+available default once. An explicit Persona or None choice wins. Existing,
+copied and moved conversations keep their assignment when the default changes.
+If a saved default is unavailable, Chatbook reports it and starts with None.
+
 | Control | What it does |
 |---|---|
 | "Switch" / Alt+W | Opens "Change Workspace" — "Switching changes Console context only; Library and Notes stay globally visible." Click a workspace to activate it; the active one is marked "(current)" and the built-in one is listed as "Default (everyday chats)" |

--- a/Docs/User_Guide/index.md
+++ b/Docs/User_Guide/index.md
@@ -33,6 +33,7 @@ can sync with a tldw server you configure).
 |-----|--------|----------------|
 | Ctrl+1 | [Home](home.md) | Triage snapshot: what needs attention, what's running, what's recent, and a suggested next action. |
 | Ctrl+2 | [Console](console.md) | Live agent conversations, approvals, tools, RAG, and runs. |
+| Console → Menu → Buddy | [Buddies](buddies.md) | Manage artwork and Personas; follow and reply to conversations across screens. |
 | Ctrl+3 | [Library](library.md) | Source material, imports, notes, media, conversations, prompts, skills, Search/RAG — plus hand-offs to Study for flashcards and quizzes. |
 | Ctrl+4 | [Artifacts](artifacts.md) 🚧 | Generated outputs, bundles, reports, datasets, and Chatbooks. |
 | Ctrl+5 | [Roleplay](roleplay-chat-dictionaries.md) | Characters, personas, chat dictionaries, and lore/world books. |
@@ -101,37 +102,25 @@ Everything else (Enter/Ctrl+K/Ctrl+T in Console, and the single-letter
 mnemonics like `s`/`r`/`t` on Settings) is screen-specific — see that
 screen's own page for its "Keyboard & commands" table.
 
-## Console agent runs are screen-scoped
+<a id="console-agent-runs-are-screen-scoped"></a>
+## Console runs continue during navigation
 
-Agent **turns** you start in Console — and any approval/confirmation
-they're waiting on — live only as long as the Console screen itself stays
-mounted. Leaving Console for another screen (e.g. Settings, Ctrl+1…Ctrl+0,
-or the command palette) cancels every in-flight turn and denies every
-pending or parked approval for that visit; coming back starts a fresh
-Console. One thing is deliberately **not** screen-scoped: a background
-sub-agent that already outlived its spawning turn keeps running through
-the leave — its result lands durably in the run log, its completion
-raises a toast on whatever screen you're on plus a durable `◈` marker,
-and the supervisor's auto-wake is staged and claimed when Console next
-mounts (see [Console ▸ Agent runs &
-tools](console/agent-runs-and-tools.md)). Guards make all of this visible
-instead of silent:
+Switching to Settings, Home, Library, or another destination keeps accepted
+Console turns, queued prompts, sub-agents, and pending decisions running. Returning
+resumes the same Console with its latest results. Opening or closing a modal also
+preserves work. Console microphone capture and Console automatic speech stop while
+Console is hidden. Optional [Buddy speech](buddies.md) can continue across screens.
 
-- **Before you leave:** if any run is still in flight or waiting on an
-  approval, a confirmation dialog asks "N agent runs will be cancelled if
-  you leave Console. Leave anyway?" — **Leave** proceeds, **Stay** keeps
-  Console (and the fleet) exactly as it was. An idle Console never shows
-  this prompt.
-- **After you return:** the next Console mount reports each fate
-  truthfully, one-time: "N agent runs were cancelled when you left
-  Console." for the turns the teardown killed, and "… sub-agents kept
-  running in the background when you left Console — you'll be notified
-  as they finish." for the survivors it spared — so neither a lost run
-  nor continuing background work is ever silently unexplained.
+A decision that needs your input while Console is hidden raises one notice and a
+navigation badge. Answer it in Console or a supported Buddy interaction card.
+Configured decision timeouts count only while that session's card is available to
+answer; time away from an answerable card does not consume the budget. Nothing is
+approved automatically.
 
-Nothing is ever auto-approved: an approval that gets caught by this
-teardown is always denied, never resolved on your behalf — and an
-auto-wake can never resolve one either.
+**Stop** still interrupts the selected turn and pauses its queue. Closing a session
+cancels its work, and confirmed application quit shuts down the runtime. Continuation
+after an application exit or crash is not guaranteed. An unsaved queue-manager edit
+must still be saved or cancelled before navigation.
 
 Full detail on runs, approvals, and tools:
 [Console ▸ Agent runs & tools](console/agent-runs-and-tools.md).

--- a/Docs/User_Guide/watchlists-quickstart.md
+++ b/Docs/User_Guide/watchlists-quickstart.md
@@ -58,8 +58,8 @@ expect. A normal run may use these tools:
 8. `watchlists_get_briefing`
 
 The exact order and number of status checks can vary. Deny a call if its target
-or arguments do not match your request. Keep Console open until the workflow is
-finished: leaving Console cancels its active turn and any pending approval.
+or arguments do not match your request. The workflow continues if you leave Console;
+pending approvals raise a notice and remain available when you return.
 
 ## 3. Wait for terminal receipts
 

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -344,8 +344,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 84,
-      "diagnostic_digest": "853ce576318d2a12b34a",
+      "call_count": 85,
+      "diagnostic_digest": "ec852e2bf1e3c38faf28",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -365,8 +365,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 1,
-      "diagnostic_digest": "63992940981b5dd325bc",
+      "call_count": 3,
+      "diagnostic_digest": "99e3edd9cda08f76ca01",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_conversation_hydration.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -1584,6 +1584,13 @@
     },
     {
       "call_count": 1,
+      "diagnostic_digest": "3a97353b620a99e83ad7",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Persona_Buddy/library.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
       "diagnostic_digest": "305391130904c7493a5d",
       "owner": "TASK-494",
       "path": "tldw_chatbook/Persona_Buddy/preferences.py",
@@ -2577,8 +2584,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 23,
-      "diagnostic_digest": "6bad02a9cb772ffcdaa7",
+      "call_count": 21,
+      "diagnostic_digest": "2bb0f5baa0001ab6e5b8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Console_Modules/session.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -2976,8 +2983,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 191,
-      "diagnostic_digest": "5726d5f2b86768f24d3c",
+      "call_count": 188,
+      "diagnostic_digest": "8b4266147d5f9495a5f2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/personas_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -4111,7 +4118,7 @@
     },
     {
       "call_count": 394,
-      "diagnostic_digest": "7856c082f9ff9b55f58a",
+      "diagnostic_digest": "a978e0820add790d0dea",
       "owner": "TASK-494",
       "path": "tldw_chatbook/app.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11493,11 +11500,11 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 592,
+    "owner_files": 593,
     "path_privacy_candidate_calls": 711,
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
-    "task_492_calls": 1348,
-    "task_494_calls": 7673
+    "task_492_calls": 1351,
+    "task_494_calls": 7669
   }
 }

--- a/Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md
+++ b/Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md
@@ -1,0 +1,42 @@
+# Conversation Buddy quick interaction
+
+Task: TASK-32082. Approved design:
+`Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md`.
+
+ADR required: no
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: implement the approved projection/command surface over Console ownership.
+
+1. Expose `open_buddy_conversation(app, binding, *, allow_voice=True)` through an
+   app-owned coordinator. Resolve the exact local binding on every command. Keep
+   drafts by explicit conversation, transferring them when the same durable owner
+   gains a canonical binding; never switch ambient Console selection for a reply.
+   Restore explicitly opened saved inbox rows through shared full-tree hydration
+   with activate=False, checking local durable identity/profile after each I/O gap.
+   A cold Home opener may bootstrap the existing launch runtime; inbox snapshots
+   remain provider/bridge-free, and a failed bootstrap retains Open Console recovery.
+2. Add a narrow composer-preserving manual submission option. Carry its state through
+   prepared/durable continuation, suppress Console composer-clearing callbacks and
+   preserve its draft. Reject unseen staged attachments, one-shot prefill or Library
+   evidence visibly; slash commands and @ reference routing require Console. All
+   ordinary admission, tools and provider rules still apply.
+3. Build a bounded native modal with name, transcript, activity, existing question and
+   approval cards, text, Close and Open in Console. Per-round decisions require the
+   exact bound session and current round. Reuse the existing resolver, never grant
+   permissions in the modal. Register only visible decision-view claims so finite
+   answerable-time budgets remain accurate without changing Console selection.
+   Unsupported worktree decisions keep their existing Open Console review and do
+   not acquire an answerable-time claim merely by showing that explanatory copy.
+   Retain decision availability only for an explicitly opened exact live session
+   and binding revision. Cold Buddy targets can park new decisions after close;
+   wake-only no-view sessions retain their existing fail-closed admission.
+4. Reuse ConsoleStreamingDictationSession and its existing availability/config/PCM
+   guards. Capture only after an explicit click; finish into an editable draft and
+   require Send. Discard on close/suspend, stale owner or generation change. Workspace
+   row callers pass allow_voice=False and get no microphone control.
+   Use shared Buddy speech controls and hold playback until microphone cleanup.
+5. Write failing mounted two-session send/approval tests before implementation. Prove
+   unrelated drafts/attachments remain untouched; closing retains accepted work;
+   stale/deleted owner commands fail closed; drafts/focus restore; microphone closes
+   and late results cannot modify a new view. Run targeted UI/controller tests and
+   changed-code lint/format checks only. No full sweep or real-provider claim.

--- a/Docs/superpowers/plans/2026-09-08-buddy-named-speech.md
+++ b/Docs/superpowers/plans/2026-09-08-buddy-named-speech.md
@@ -1,0 +1,34 @@
+# Buddy named speech implementation plan
+
+Task: TASK-32084 (speech AC1–3; root owns integrated journeys and documentation).
+Spec: `Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md`.
+
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: app-owned speech presentation reuses existing TTS destination consent,
+request snapshots and exact playback ownership without changing agent execution.
+
+1. Add a bounded serial queue in `Persona_Buddy/speech.py`. Immutable named items
+   carry exact validity probes; pending questions precede responses. Never enqueue
+   streaming increments. Repeated receipt/message/question keys coalesce. Pause
+   interrupts the current utterance and resumes it from its beginning; skip drops
+   only the current item; mute clears speech while leaving all run state alone.
+2. Extend existing store-issued TTS snapshots with an optional explicit owner ID;
+   omitted owner retains the existing active-session requirement. Reuse every
+   content, variant, authorship and durable-version guard. Test stale owner and
+   default-visible behavior separately.
+3. Add a guarded named-utterance entry to the existing TTS handler. Use configured
+   character/default/global resolution, exact consented destination admission,
+   and request-owned playback lifecycle. Validate after asynchronous resolution
+   and at provider admission; wait for playback completion and stop only this owner.
+4. `UI/Navigation/buddy_speech.py` owns enabled-only periodic projection across
+   navigation. Capture live bound completed messages and current questions, use
+   workspace receipt IDs without acknowledging them, reject profile/rebind/content
+   changes and never enable a microphone. Unknown/unloaded result bodies remain
+   in the inbox for explicit review rather than silently loading another session.
+5. Reuse the sanitized TTS consent modal from an explicit speech-controls action.
+   Destination consent is scoped to the current binding/profile and never inferred
+   from enabling a checkbox. No background notification opens a modal.
+6. Add a small reusable controls widget; root inserts it and awaits coordinator
+   `aclose()` during actual app shutdown. Tests use deterministic fake playback,
+   real store snapshots and isolated native modal controls; no live paid TTS/full suite.

--- a/Docs/superpowers/plans/2026-09-08-buddy-workspace-inbox.md
+++ b/Docs/superpowers/plans/2026-09-08-buddy-workspace-inbox.md
@@ -1,0 +1,30 @@
+# Buddy workspace inbox
+
+Task: TASK-32083. Approved spec: ../specs/2026-09-08-console-buddy-management-design.md.
+
+ADR required: yes; existing ADR applies.
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: explicit workspace scope projects the existing Console execution and receipt owners.
+
+1. Test a pure inbox projection using real session/run/receipt values. Include only
+   local sessions currently in the bound workspace; sessionless unread results
+   require current workspace membership. A repurposed live slot cannot admit a
+   receipt from another conversation. Do not manufacture completion records.
+   Extend the existing ordinary/queued outcome publisher to retain unread results
+   when Console is hidden even if its selected session has not changed.
+2. Add an app-owned coordinator that reads workspace membership off the UI loop,
+   reads live state and immutable receipt snapshots, and keeps result IDs frozen.
+   Opening and refreshing are read-only. Mark seen acknowledges only the selected
+   result after verifying its current owner; it never answers a decision.
+3. Add a native modal with Needs you / Running / Results, stable keyboard selection,
+   a scrollable list and fixed Open / Mark seen / Close actions. Refresh content
+   without grabbing focus. No microphone control is rendered.
+4. Open the shared exact-target conversation modal with allow_voice=False from
+   every workspace row. Retain the inbox beneath it and the original destination
+   beneath both; closing does not touch execution or Console selection.
+5. Verify projection, stale/removed targets, receipt acknowledgement races, and
+   mounted normal/compact layouts. Update task evidence and user documentation.
+
+Integration seam: BuddyInboxEntry carries key, title, group, summary, exact
+BuddyBinding, and immutable receipt IDs. Speech may read entries but must never
+acknowledge them. The manager chooses the binding; neither modal retargets itself.

--- a/Docs/superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md
+++ b/Docs/superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md
@@ -1,0 +1,48 @@
+# Chatbook Buddy and Persona UX review remediation
+
+Spec: Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+Existing PR: https://github.com/rmusser01/tldw_chatbook/pull/2526
+Base reviewed: 42f6e22461 (merged current origin/dev 565dc49921).
+
+ADR required: no new ADR
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md; backlog/decisions/079-workspace-assistant-defaults.md
+Reason: correct usability and recovery within the approved independent artwork, explicit binding, app-owned runtime and existing workspace defaults contracts.
+
+## Global Constraints
+
+- One independent Buddy. Persona artwork actions must not restore Persona-owned selection.
+- Follow is explicit; navigation, closing, hiding and management do not cancel accepted work or silently retarget it.
+- Conversation replies and decisions retain exact identity; workspace has no microphone, including selected conversation dialogs.
+- Workspace Persona defaults affect future new conversations. Keep-current and explicit None remain distinct.
+- Failed Apply preserves staged user input; any partial persisted outcome is stated truthfully.
+- Preserve approvals, asset attribution and existing authority/version checks. No model, microphone, production profile or full-suite calls.
+- Use the existing worktree only. Do not change unrelated main checkout work. Tests targeted to owned behavior.
+
+## Task 1: Address the native Buddy review findings
+
+Read AGENTS.md, PRODUCT.md, DESIGN.md, relevant testing/live lessons and the linked spec/ADRs. Root has reopened TASK-32081, TASK-32082 and TASK-32083 with follow-up acceptance. Do not edit Backlog tasks or this plan; root owns documentation. Record implementation and verification in the assigned report. Do not spawn agents. Do not commit or push; root stages the combined reviewed diff.
+
+Implement all of these bounded findings:
+
+1. Management Preview is clipped even at normal sizes because the broad Select width rule wins. Use correctly scoped flex widths for preview and geometry rows; verify pointer activation and visible keyboard focus at normal and compact sizes with preview callback present.
+2. Current transcript opens at the oldest message and does not follow replies. Open at latest content/pending decision, follow updates only when already at end, preserve deliberate reading position and expose a discoverable Latest/new-updates affordance. Pending decisions must be readily reachable without scrolling an entire history. Keep exact decision identity intact.
+3. Compact dialogs waste space on speech controls while speech is off. Reclaim reading/inbox space with a compact off state; retain consent/recovery/active playback controls and existing queue ownership. Fix initial blank transcript so No messages yet is displayed. Minimum verification sizes 60x20, 80x24 and 120x40 using native Textual, not browser pixel criteria.
+4. Personas inspector still says Use for Buddy, writes PersonaBuddySelection and requires a Persona owner for Show/Close/Disable. Route management through the shared coordinator. If retaining artwork reuse, clearly label it as an independent copy and use the existing library copy/publication path preserving attribution. Ensure current independent Buddy controls work without selecting a fictional Persona owner. Reuse existing boundaries; avoid a new ownership mechanism.
+5. Asynchronous import/apply fails after dismissal, loses the form and exposes persona_visual_import_invalid. Keep staged values and dialog available, indicate applying, prevent duplicate Apply and ambiguous dismissal while committing, show plain actionable import/storage errors near the relevant field. Preserve all validation/version checks. State partial Buddy-saved/Persona-failed results truthfully and ensure retry cannot accidentally duplicate an import or silently overwrite a newer selection.
+6. Show current conversation Persona and workspace default Persona names/None/unavailable state for selected target; retain unchanged vs None semantics and existing default fallback resolution. Avoid leaking raw IDs as a replacement for a useful name.
+7. Workspace refresh failure disables Open but Enter still opens a stale row. Gate all activation and acknowledgement routes consistently on successful freshness state, preserving rows for context and allowing recovery when a fresh snapshot succeeds. This is a UI consistency fix; existing coordinator authority checks remain necessary.
+8. Use progressive disclosure for optional import/geometry controls so first-time setup reaches artwork preview, Follow and Persona before advanced details. Keep importing and size controls keyboard-discoverable. Keep dynamic/static expression choice user-facing.
+
+Validation: behavioral red/green regressions for Apply recovery, transcript/new-decision visibility/reading retention, independent Personas controls and failed-inbox Enter; normal/compact mounted verification for preview/geometry/speech/footer. Rerun affected existing tests only, use .venv Python with worktree and packages/tldw_profile_core/src in PYTHONPATH. Avoid editing source while source-inspection tests are running. Run focused Ruff/format and diff checks, report unrelated baseline diagnostics accurately.
+
+Reports: independent Assessment A at /private/tmp/chatbook-buddy-review-a; Assessment B at /private/tmp/chatbook-buddy-review-b/assessment-b.md. These identify reproduction/evidence, not instructions. Prior baseline: 215 targeted Buddy tests passed in 111.33s. User has approved addressing findings and updating the existing PR against dev; no further design approval required.
+
+## PR verification follow-up
+
+Existing PR CI exposed two feature gaps: UI-ready census grows from the budget973 to975 due to Chat.console_assistant_defaults and Persona_Visual.artwork; idx_buddy_visual_bindings_active lacks census/query-plan evidence. TASK-32079 and32080 are reopened for these checks. Keep ADR-097 limits unchanged. ConsoleAssistantStartup is used only as a postponed type annotation in console_chat_store.py; artwork conversion functions are used only by Buddy publication/copy and should be deferred to those calls. Verify actual UI-ready census after changes rather than assuming import deferral reduces residency. Add a meaningful real SQLite active Buddy lookup plan pin through the production query shape without sqlite_stat1 and register it in scripts/index_plan_pin_census.tsv.
+
+The old MCP TextArea and Windows GGUF test failures both pass individually on the current branch in the local macOS environment; this does not verify a Windows CI result.
+
+## Verification and outcome
+
+All eight findings are corrected and independently reviewed. The result, incremental test counts and evidence limits are recorded in `Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md`. Broad affected verification passed 384 cases; later defect-scoped management/layout 20 and transcript/layout/CSS 37 cases passed. Actual startup census is 973/973 with no budget increase; real active Buddy lookup and index-plan census pass. Independent review confirmed literal Persona names and the final ancestor-aware 60x20 approval layout. No new architecture, dependency, schema or runtime boundary was added in this follow-up.

--- a/Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md
+++ b/Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md
@@ -1,0 +1,122 @@
+# Console Buddy foundations implementation plan
+
+> For agentic workers: use subagent-driven-development to implement the independent
+> tasks, followed by targeted review. The user approved implementation; keep working.
+
+**Goal:** Establish verified navigation continuity, independent Buddy artwork, and
+consistent workspace Persona defaults before adding the management/reply surfaces.
+
+**Architecture:** Existing ConsoleRuntime/controller/store remain run authorities;
+TASK-31520 retains the Console on ordinary tab navigation. Reuse private immutable
+visual publication and add genuine Buddy ownership. Reuse WorkspaceAssistantDefaults
+for creation-time inheritance, distinguishing omission from explicit None.
+
+**Tech stack:** Python 3.11+, Textual 8, SQLite, existing private asset publication.
+
+**Spec:** `Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md`
+
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: new visual ownership and scope; explicit-None provisioning amends ADR-079 §5.
+Existing lifecycle objective: backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md,
+interpreted against actual reusable-screen behavior from TASK-31520.
+
+## Global constraints
+
+- Work only in `.worktrees/buddy-console-management`, based on c0a42150d1.
+- No dummy Personas or implicit active-session reply targets. Persona means assistant
+  identity; User Profile is human identity (ADR-037).
+- Existing, copied, moved conversations retain assignment. No request broadening.
+- Targeted tests only; isolated profile/db; use the main checkout's `.venv` with
+  explicit PYTHONPATH/cwd pointing to this worktree. Verify imported source path.
+- Keep source artwork notices and unknown license values intact. Do not infer licenses.
+- No server changes yet. No unrelated checkout or dependency updates.
+- Add new Console logic in UI/Console_Modules; do not grow ChatScreen unnecessarily.
+
+## Task 1 — TASK-32078: navigation continuity
+
+Files: `Tests/UI/test_console_screen_reuse.py`,
+`Tests/Chat/test_console_runtime_lifetime.py`,
+`Chat/console_chat_controller.py`, `Chat/console_interrupt_rounds.py`,
+`Chat/console_runtime.py`, relevant Console lifecycle module hooks and User Guide.
+
+1. Read TASK-31520 and the existing reuse/navigation, interrupt, notification and quit
+   tests. Baseline reuse tests pass, but did not exercise actual accepted streams.
+2. Add mounted navigation coverage using deterministic stalled gateway execution and
+   real parked decisions. Navigate away, release chunks/resolve on return, assert
+   no duplicate results, loss or retargeting; explicit shutdown must still cancel.
+3. Fix attachment-as-visibility mistakes: a reused hidden Console is not an answerable
+   approval surface. Hidden pending decisions notify once and remain available on
+   return. Follow ADR-094 answerable-time clocks for configured finite timeouts.
+4. Keep normal suspend separate from cancelling final teardown. Verify modal coverage,
+   rapid return and background-session behavior. Update inaccurate current guide copy.
+5. Run focused reuse/interrupt/approval/runtime suites; record evidence and limitations.
+
+Mounted evidence refinement: a queued turn for the original conversation failed
+Canvas selection capture after another conversation became active. Resolve the
+accepted run's exact live session/conversation/branch from ConsoleRuntime separately
+from the browser's active-view resolver. Keep browser operations restricted to their
+existing active-view authority and reject closed or mismatched run owners (ADR-121
+`backlog/decisions/121-local-versioned-canvas-artifacts-and-browser-sandbox.md`
+and ADR-139 execution ownership).
+
+## Task 2 — TASK-32079: independent artwork ownership
+
+Files: `DB/ChaChaNotes_DB.py` and versioned migration, `Persona_Visual/repository.py`,
+`publication.py`, `runtime.py` and shared validation; new `Persona_Buddy/library.py`
+(or narrow equivalent), `Persona_Buddy/preferences.py`, `controller.py`, app composition,
+existing builtin import and focused DB/Persona_Visual/Persona_Buddy tests.
+
+1. Read existing visual publication/identity contracts and task acceptance criteria.
+2. Add a real Buddy record/binding in the next schema migration, including fresh DB
+   parity and source-key uniqueness for idempotent legacy migration. Reuse versioned
+   pack/assets, but copy a Persona graph into an independently owned pack so later
+   publication by the Persona cannot change or invalidate it.
+3. Extend shared snapshot/read/publication/runtime authority explicitly for Buddy
+   owners while preserving Persona APIs. Do not encode Buddy identity as Persona ID.
+4. Expose library list/import/copy/read/select operations for the upcoming modal.
+   Publish native imported artwork without Persona creation; preserve supplied notices
+   and reject invalid/unbounded assets through existing checks. Export/attribution
+   code from earlier approved buddy-import-design work may be adapted where necessary;
+   avoid importing unrelated pending features or their entire branch.
+5. Extend selection/controller to resolve a Buddy independent of Persona service.
+   Migrate selected legacy appearances idempotently, updating config only after commit.
+   Preserve geometry and enabled/open state; retain legacy selection on failure.
+6. Seed independent built-in artwork without changing existing Persona records or user
+   tombstones. Expose display name, stable Buddy ID and immutable graph to the modal.
+7. Exercise migration/restart/publication failure, source deletion/edit, builtin and
+   native import attribution, and existing Persona compatibility using targeted tests.
+
+## Task 3 — TASK-32080: workspace default consistency
+
+Files: `Workspaces/registry_service.py`, `agent_provisioning.py`, `models.py`,
+`DB/Workspace_DB.py` and versioned migration if required; `Chat/console_chat_store.py`,
+`console_chat_controller.py`; `UI/Console_Modules/session.py`, `workspace.py`,
+`Widgets/workspace_create_modal.py`, Console workspace details and canonical Settings.
+
+1. Reuse ADR-079 storage/resolver. Add omission-vs-explicit-None admission to workspace
+   creation and ensure a deliberate clear cannot be backfilled on a later launch.
+2. Resolve eligible new blank conversation identity through a shared creation seam
+   with the explicit target workspace, rather than ambient selection. Existing,
+   restored, forked and explicit Character/Persona/None inputs bypass inheritance.
+3. Persist Persona memory mode consistently in settings and session identity.
+4. Expose optional defaults in shared workspace creation/details by reusing existing
+   Persona selectors and read-write confirmation; preserve canonical Settings controls.
+5. Test Console/Settings/Library creation, first activation, bootstrap, new temporary
+   chats, explicit None, unavailable default, persistence/reopen/fork/move behavior.
+
+## Review and integration
+
+Tasks 1 and 3 share controller.py; implementations coordinate nonoverlapping methods.
+Task 2 owns visual DB migration; Task 3 owns WorkspaceDB migration. Root integrates
+composition/UI wires, reviews cross-task state and runs combined targeted suites.
+Do not stage or commit another worker's incomplete changes. Each task gets a scoped
+review; the completed foundation receives one broader review before UI integration.
+
+## Subsequent approved UI delivery
+
+Continue with TASK-32081 management and scope controls, TASK-32082 conversation replies,
+TASK-32083 workspace inbox, then TASK-32084 named speech and end-to-end validation.
+The spec is authoritative; write the UI implementation plan against the completed
+library/creation interfaces before editing dependent UI. These tasks are intentionally
+separate from the foundation to keep execution and artwork authority reviewable.

--- a/Docs/superpowers/plans/2026-09-08-console-buddy-management-ui.md
+++ b/Docs/superpowers/plans/2026-09-08-console-buddy-management-ui.md
@@ -1,0 +1,57 @@
+# Buddy management UI implementation plan
+
+**Goal:** Expose independently selected Buddy artwork and exact conversation/workspace
+scope through one native management modal without leaving the current destination.
+**Architecture:** A staged form returns a validated choice; an app-owned coordinator
+applies it through BuddyLibrary, controller preference persistence, existing Persona
+services, and scoped lifecycle projection. Modal owns no long-running execution.
+**Tech stack:** Textual native widgets, existing Rich pixel renderer, local config.
+**Spec:** Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: independent artwork, explicit scope and cross-screen management.
+
+## Global constraints
+
+Reuse established modal theme tokens; vertical scroll with fixed action footer;
+keyboard and normal/compact terminal coverage. Apply is the only mutation boundary.
+Temporary conversation bindings stay in memory. Local IDs never match remote IDs.
+No ambient active-session fallback for a binding. No new long-lived ChatScreen fields
+for the feature; app-owned coordinator is the shared entry from both surfaces.
+
+## TASK-32081
+
+1. Add `Persona_Buddy/interaction.py`: immutable scope/preferences contracts,
+   exact session resolution against live ID, binding revision and durable local
+   conversation ID; profile-safe config encoding/decoding; reject invalid targets.
+   Test retargeting, session replacement, restart matching and temporary exclusion.
+   Promote a first-persisted durable conversation ID under the preference Apply
+   lock; retry failed storage without changing the target. Canonicalize restored
+   live IDs in the staged form through the exact resolver, never ambient selection.
+2. Add `Widgets/Persona_Widgets/buddy_management_modal.py`: injected named choices,
+   staged selection/import path, scope, Persona unchanged/None/pick, animation,
+   size and speech preferences. Preview is read-only. Form validates before Apply;
+   Escape/Cancel returns None. No hidden install or Persona mutation on preview.
+3. Add `UI/Navigation/buddy_management.py`: shared opener/read model/apply worker,
+   uses completed BuddyLibrary API and existing Persona services. Apply publication
+   before choosing its committed ID. Preserve old usable selection if validation or
+   publication fails. Config errors remain visible for retry rather than false success.
+4. Add stable composer Buddy action and floating settings control. Integrate through
+   small local imports; preserve existing lazy disabled-Buddy boot behavior. Plain
+   click will open management until the subsequent interaction task is connected.
+5. Filter Buddy adapter events by exact binding and reconcile current scoped runtime
+   snapshot when switching bindings; no unrelated-session state leakage. Add Static
+   option to rendering's existing motion stop boundary; retain current expression.
+6. Integrate explicit target Persona changes through store/service authority with
+   source validation and future-turn application. Preserve accepted turn settings.
+7. Targeted native pilots: menu action, staged Cancel, valid Apply, missing targets,
+   preview, normal and compact scroll/focus, only one visible Buddy, Persona=None.
+
+## Interfaces
+
+Foundation library: list_buddies/get_buddy/get_graph, review_archive then publish_review,
+copy_persona, ensure_builtin. Controller owns actual enabled/open/geometry/selection.
+The `[buddy_interaction]` section owns only scope/animation/notifications, keeping
+content ownership and app presentation separate. Root coordinates application of both
+and rollback/failure reporting; no duplicate caches or hidden Persona selection.

--- a/Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md
+++ b/Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md
@@ -25,3 +25,7 @@ Verify all eleven Chatbook Qodo comments and correct confirmed validation, block
 ## Root integration
 
 Confirm latest dev and rebase, retaining independent conflict additions. Run required derived checks after source is frozen, verify new PR head/checks/Qodo state, then merge only once the requested gates are met. The explicit user request authorizes rebase, lease-protected feature-branch updates and merge; no merge to a different base or administrative bypass.
+
+## Task 2 — published startup-budget regression
+
+The latest Linux/Python3.12 Perf Guard reports975modules at UIready against the973pin; the additions are Scheduling.scheduler_heartbeat and emergency_stop. Local final-base checks report973. Diagnose the startup timing/import boundary, obtain a controlled reproduction or independent cause evidence, and correct the cost without raising the budget or masking the census. Existing ADR-097 governs startup ratchets; no new ADR. Implementer owns the smallest source/test delta, root owns task/docs/artifacts/publication. Run focused startup/lifecycle regressions and changed-scope static checks, then freeze and independently review before pushing.

--- a/Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md
+++ b/Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md
@@ -1,0 +1,27 @@
+# Buddy PR review and merge
+
+Task: TASK-32084
+Spec: Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+ADR required: no new ADR
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: corrections within existing ownership, runtime and interaction contracts.
+
+## Global Constraints
+
+- Preserve independent artwork/Persona identity, exact explicit target, one visible Buddy, navigation continuity, workspace no-microphone and guarded speech.
+- Verify external review claims; do not blindly follow their suggested implementation. Preserve central security and transaction/thread ownership, bounded resource behavior, attribution and public compatibility.
+- No full local test sweep, live provider/microphone/audio or production profile changes. Run affected regressions and existing CI checks. Never bypass branch protection or ignore a required failing check.
+- Work only in this isolated worktree. Implementer owns assigned production/tests; root owns Backlog/docs/derived artifacts, commits, pushes and merge. No nested agents.
+
+## Task 1
+
+Verify all eleven Chatbook Qodo comments and correct confirmed validation, blocking I/O, database, speech-order and import-provenance issues with focused tests. Root owns derived artifact/allowlist CI repair and publication.
+
+1. Read AGENTS, the listed task/spec/ADR and relevant testing lessons. Reproduce each suspected defect or establish source evidence for a non-applicable suggestion.
+2. Make the smallest corrections and add behavior-focused tests. Preserve UI-thread publication after background reads and revalidate authority after awaits.
+3. Run affected tests/static checks, freeze source, and record commands/results and every review disposition.
+4. Independent review before root commits/pushes; resolve Important/Critical findings with scoped rechecks.
+
+## Root integration
+
+Confirm latest dev and rebase, retaining independent conflict additions. Run required derived checks after source is frozen, verify new PR head/checks/Qodo state, then merge only once the requested gates are met. The explicit user request authorizes rebase, lease-protected feature-branch updates and merge; no merge to a different base or administrative bypass.

--- a/Docs/superpowers/specs/2026-09-08-buddy-server-port-contract.md
+++ b/Docs/superpowers/specs/2026-09-08-buddy-server-port-contract.md
@@ -1,0 +1,53 @@
+# Buddy interaction contract for the later tldw_server port
+
+Status: Chatbook behavior contract; server implementation is not part of this change.
+Source: [approved design](2026-09-08-console-buddy-management-design.md) and
+[ADR-139](../../../backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md).
+
+The server port should offer the same user choices: independently owned Buddy
+artwork; explicit conversation/workspace follow; one visible Buddy in v1; optional
+Persona assignment and future-conversation workspace defaults; Dynamic/Static;
+in-place conversation and workspace interaction; opt-in named serial speech.
+
+## Authority and storage
+
+- Use server-owned authenticated principal, workspace and conversation identities.
+  Never accept Chatbook's live session UUID or a browser's currently selected tab
+  as authority. Recheck access and membership before reading, replying, answering
+  decisions, applying Persona changes or acknowledging results.
+- Store Buddy profiles separately from Persona prompts. Reuse validated native
+  pack manifests, immutable asset hashes and preserved artwork attribution; do not
+  import profile paths, local tool permission grants or local receipt identifiers.
+- Store workspace default Persona with an explicit None/optout representation.
+  Resolve once at creation. Explicit request assignment overrides inheritance;
+  restore, move and copy preserve identity.
+- Update a conversation's Persona, prompt and settings atomically with an expected
+  version. Reject busy or stale owners. Fence subsequent run and speech snapshots.
+
+## Runtime and UI
+
+- Server jobs own accepted work independently of route, component, websocket or
+  browser-tab lifetime. Closing an interaction surface never invokes Stop. Preserve
+  the server's explicit cancellation and restart policies; do not infer resumability.
+- Reuse existing approval/question execution authorities and exact round IDs.
+  Viewing or speaking a prompt is never approval. Timers use answerable time where
+  the server supports finite interactive deadlines.
+- Workspace inbox entries derive from live activity and existing unseen outcomes.
+  Acknowledge exact selected result identities, not a whole workspace or conversation.
+  Load saved conversations explicitly without changing the underlying destination.
+- Conversation dictation must stop on interaction close; workspace mode has no
+  microphone input. Reuse the server's configured STT/TTS destination disclosures
+  and permissions. One application playback queue names each conversation, prioritizes
+  questions, and supports pause/resume, skip and mute without affecting jobs.
+- Preserve drafts and keyboard focus; new activity cannot navigate or focus a page.
+  Test ordinary and compact viewports, reduced motion and stale/deleted targets.
+
+## Port acceptance evidence
+
+Exercise two simultaneous conversations while viewing another destination: stream
+and queue completion; question and tool approval; exact-target text reply; stale
+membership/access denial; saved-result opening and individual acknowledgement;
+Persona update rollback; workspace creation precedence; and named speech queue
+ordering/cancellation. Include navigation/socket-disconnection tests against the
+real server job owner, and distinguish deterministic gateway tests from real
+provider/audio verification. Cross-user data isolation must be tested server-side.

--- a/Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+++ b/Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
@@ -1,0 +1,114 @@
+# Console Buddy & Persona management
+
+Status: Approved by the user for implementation on 2026-09-08.
+
+## Outcome
+
+A user can keep one visible Buddy beside any application destination, independently
+of a Persona. Menu → Buddy in the Console and a settings control on the Buddy open
+one Buddy & Persona Management modal. A Buddy explicitly follows one conversation
+or one workspace. Switching screens, hiding the Buddy, or closing its modal does
+not stop accepted work. Chatbook ships first; the same behavior is then ported to
+tldw_server. Multiple visible Buddies are v2.
+
+## Independent artwork
+
+The Buddy has a real local visual owner and a versioned visual binding. Existing
+immutable visual packs, renderers, validation, content attribution, and private
+storage remain authoritative. Selecting artwork does not manufacture a Persona or
+change prompts, models, tools, memory, or permissions. Existing Persona-backed
+Buddy selection is migrated by copying its visual binding/artwork into the Buddy
+owner, preserving attribution and geometry. Removing or editing the source Persona
+does not remove or modify this independent Buddy. Imported packs remain separate
+from the application distribution. A user can preview states before selection.
+
+## Management modal
+
+Use native Textual controls and the application's existing modal/theme conventions.
+The scrollable body has Buddy, Follow, Persona, and Notifications & voice sections.
+A fixed footer provides Apply and Cancel. Nothing mutates on Cancel. The modal
+supports keyboard selection, visible labels, errors beside the affected control,
+small terminals, and returning focus to its opener.
+
+Buddy controls enable/disable, select/import artwork, preview expressions, choose
+Dynamic or Static animation and size. Static and global reduce-motion suppress
+animation without hiding an expression. Follow names an explicit conversation or
+workspace; switching Console selection never retargets it. Persona controls manage
+the selected conversation's assistant assignment, including None, through the
+existing Persona service. Persona changes apply to future turns and never mutate
+a running request. Workspace default Persona is a separate, clearly labelled
+setting for future new conversations.
+
+## Conversation interaction
+
+Clicking a conversation Buddy opens a quick interaction modal for its exact bound
+conversation, displaying the name, transcript, current activity, questions and
+approvals. It permits typed replies and supported voice chat without navigating
+the underlying destination. Replies carry the explicit conversation ID; ambient
+Console selection is never an implicit target. Preserve drafts per target and on
+close, offer Open in Console, and restore the underlying screen and focus. Deleted
+or inaccessible targets are unavailable, never replaced by a nearby conversation.
+Existing tool and approval checks apply unchanged.
+
+## Workspace interaction
+
+A workspace Buddy displays an activity inbox divided into Needs you, Running, and
+Results. Track running conversations, unresolved decisions/questions, and completed
+conversations with unseen results; do not fill the inbox with all historical chats.
+Selecting a row opens that conversation's transcript and typed reply inside the
+modal. No workspace-mode voice input is offered, including while viewing a row.
+Opening the inbox does not acknowledge every result or answer a question.
+
+Optional spoken output uses one application-owned serial queue. Prefix each spoken
+response with its conversation name. Questions take priority; consolidate repeated
+progress. Provide pause, skip, and mute. Speech does not mark a decision answered.
+Notifications do not steal focus. Muting/hiding changes presentation, not execution.
+Use existing TTS configuration and approval/voice authority; no new provider choice
+or dependency is introduced. Background mode never leaves a microphone recording.
+
+## Workspace Persona defaults
+
+Reuse WorkspaceAssistantDefaults (ADR-079) and existing Settings controls. Every
+new conversation creation surface resolves the chosen workspace's default once.
+An explicit Persona or explicit None overrides inheritance. Existing, copied, and
+moved conversations keep their assignments. Changing or clearing the default affects
+future new conversations only. An unavailable default is visibly reported rather
+than replaced with another Persona. Buddy selection remains independent.
+
+## Navigation and runtime
+
+Latest dev c0a42150 reuses and suspends the Console route (TASK-31520). Normal tab
+navigation does not call the cancelling teardown path. Verify this with real mounted
+navigation and active work before changing lifecycle code. Reuse the existing
+ConsoleRuntime/controller/store as execution owners; do not add another job system.
+Buddy UI is a projection and command surface, not a new execution authority.
+
+Runs retain their accepted conversation, workspace, model, instructions, attachments,
+and tool authority. Queues and parked approvals survive navigation under the current
+approval policy. Explicit Stop, session deletion/close, and actual app shutdown keep
+their intended cancellation behavior. A modal must neither reset the queue nor alter
+a running turn's admission context. New async work must not depend on a modal's DOM.
+
+## Boundaries and delivery
+
+No restart-resumption guarantee is added. Ephemeral conversations are not silently
+made durable. Unsupported remote operations display a reason instead of falling back
+to local identity. The server port follows completed Chatbook validation, reusing
+portable pack formats and behavioral contracts while retaining server-owned auth,
+conversation identity, run lifetime and storage. v2 multiple Buddies will reuse explicit
+bindings and the shared speech queue without changing v1 single-Buddy behavior.
+
+## Verification
+
+Targeted tests exercise real navigation with streaming and parked approvals, shutdown,
+independent visual ownership and legacy migration, modal Apply/Cancel and focus,
+workspace default precedence at creation seams, exact-target replies while another
+conversation is selected, inbox acknowledgement, speech ordering and voice restrictions.
+Use isolated test databases/profiles and native Textual pilots at normal and compact
+sizes. Do not run the full repository suite without explicit user authorization.
+
+## Architecture
+
+[ADR-139](../../../backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md)
+records independent ownership and scope. Existing workspace defaults follow
+[ADR-079](../../../backlog/decisions/079-workspace-assistant-defaults.md).

--- a/Tests/App/test_scheduler_startup_deferral.py
+++ b/Tests/App/test_scheduler_startup_deferral.py
@@ -1,0 +1,109 @@
+"""A slow mount must not let the scheduler spend the first-frame budget."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import nullcontext
+
+import pytest
+
+from Tests.Performance import test_ui_ready_module_census as census
+
+_SLOW_MOUNT = """
+    # Give the scheduler a whole tick before post-mount setup, if it was
+    # incorrectly launched in on_mount. A normal fast boot hides this race.
+    tick_finished = asyncio.Event()
+    tick_ready_states = []
+    owner_loop = asyncio.get_running_loop()
+    real_setup = tldw_chatbook.app.TldwCli._post_mount_setup
+    real_tick = tldw_chatbook.app.SchedulerLoop.tick
+
+    async def slow_setup(self):
+        try:
+            await asyncio.wait_for(tick_finished.wait(), timeout=2.0)
+        except asyncio.TimeoutError:
+            pass
+        await real_setup(self)
+
+    async def observed_tick(self):
+        assert asyncio.get_running_loop() is owner_loop
+        tick_ready_states.append(app._ui_ready)
+        await real_tick(self)
+        tick_finished.set()
+
+    tldw_chatbook.app.TldwCli._post_mount_setup = slow_setup
+    tldw_chatbook.app.SchedulerLoop.tick = observed_tick
+"""
+
+_VERIFY_TICK = """
+        await asyncio.wait_for(tick_finished.wait(), timeout=20.0)
+        scheduler_modules = (
+            "tldw_chatbook.emergency_stop",
+            "tldw_chatbook.Scheduling.scheduler_heartbeat",
+        )
+        assert all(name in sys.modules for name in scheduler_modules)
+        assert tick_ready_states and all(tick_ready_states), (
+            "scheduler tick ran before readiness", tick_ready_states,
+            [name for name in scheduler_modules if name in FLAG_TIME_MODULES],
+        )
+        assert app.scheduler_loop.running
+        assert not app.scheduler_worker.is_finished
+"""
+
+
+@pytest.mark.integration
+def test_real_scheduler_waits_for_readiness_on_a_slow_mount(tmp_path, monkeypatch):
+    """Boot twice in an isolated profile; the real first tick still completes.
+
+    Keep the canonical flag-time snapshot and its environment isolation. The
+    delay yields the event loop, so off-thread queue/ledger reads can finish
+    even when UI setup is slow. No scheduler methods are stubbed out.
+    """
+    script = census._CENSUS_SCRIPT.replace(
+        "    app = tldw_chatbook.app.TldwCli()",
+        _SLOW_MOUNT + "    app = tldw_chatbook.app.TldwCli()",
+    ).replace("        # The copy taken", _VERIFY_TICK + "        # The copy taken")
+    monkeypatch.setattr(census, "_CENSUS_SCRIPT", script)
+
+    modules = census._boot_and_census(tmp_path)
+
+    assert "tldw_chatbook.emergency_stop" not in modules
+    assert "tldw_chatbook.Scheduling.scheduler_heartbeat" not in modules
+    assert set(census.EXPECTED_AT_READY) <= set(modules)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("stop_reason", ["quit", "shutdown", "setup_failure"])
+async def test_pre_ready_exit_does_not_start_the_scheduler(monkeypatch, stop_reason):
+    """A late or failed setup cannot start work after quit or shutdown begins."""
+    from Tests.UI.app_factory import _build_test_app
+
+    app = _build_test_app()
+    real_setup = type(app)._post_mount_setup
+    setup_returned = asyncio.Event()
+
+    async def exit_before_setup(self):
+        if stop_reason == "setup_failure":
+            setup_returned.set()
+            raise RuntimeError("injected pre-ready setup failure")
+        if stop_reason == "shutdown":
+            self._shutting_down = True
+        else:
+            self.exit()
+        await real_setup(self)
+        setup_returned.set()
+        self.exit()
+
+    monkeypatch.setattr(type(app), "_post_mount_setup", exit_before_setup)
+    expected_error = (
+        pytest.raises(RuntimeError, match="injected pre-ready setup failure")
+        if stop_reason == "setup_failure"
+        else nullcontext()
+    )
+    with expected_error:
+        async with app.run_test(size=(120, 40)):
+            await asyncio.wait_for(setup_returned.wait(), timeout=20.0)
+
+    assert not app._ui_ready
+    assert getattr(app, "scheduler_worker", None) is None
+    assert not app.scheduler_loop.running

--- a/Tests/Canvas/test_hidden_run_scope.py
+++ b/Tests/Canvas/test_hidden_run_scope.py
@@ -1,0 +1,69 @@
+"""A hidden run keeps its Canvas owner without gaining browser authority."""
+
+import asyncio
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Canvas.models import CanvasScope
+from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
+
+
+@pytest.mark.parametrize(
+    "invalid_owner", (None, "session", "conversation", "branch", "closed")
+)
+def test_hidden_run_scope_preserves_exact_owner_and_browser_guard(invalid_owner):
+    runtime = ConsoleRuntime(SimpleNamespace(chachanotes_db=None))
+    store = runtime.ensure_chat_store()
+    session = store.create_session(ephemeral=True)
+    store.append_message(session.id, role="user", content="Make a Canvas")
+    scope = CanvasScope(
+        session_id=session.id,
+        conversation_id=session.id,
+        active_message_ids=store.canvas_active_path_message_ids(session.id),
+        selected_canvas_id=None,
+        selected_revision_id=None,
+        run_id="owned-run",
+    )
+
+    def visible_scope(session_id):
+        if session_id != store.active_session_id:
+            raise RuntimeError("Canvas session is no longer active")
+        return scope
+
+    authority = runtime.ensure_canvas_native_authority(scope_resolver=visible_scope)
+    try:
+        created = authority.import_html(session_id=session.id, source="<p>owned</p>")
+        authority.gateway_scope(
+            session_id=session.id,
+            browser_session_id="owned-browser",
+            canvas_id=created.canvas_id,
+            revision_id=created.revision_id,
+            follow_latest=False,
+        )
+        other = store.create_session(ephemeral=True)
+        if invalid_owner == "session":
+            scope = replace(scope, session_id=other.id)
+        elif invalid_owner == "conversation":
+            scope = replace(scope, conversation_id=other.id)
+        elif invalid_owner == "branch":
+            scope = replace(scope, active_message_ids=("not-this-branch",))
+        elif invalid_owner == "closed":
+            store.close_session(session.id)
+
+        if invalid_owner is None:
+            captured = runtime.canvas_controller.capture_selected_scope(scope)
+            # Switching session invalidates the old browser pin. Run capture
+            # preserves the exact branch and never substitutes the new view.
+            assert captured == scope
+            assert store.active_session_id == other.id
+        else:
+            with pytest.raises((RuntimeError, ValueError, KeyError)):
+                runtime.canvas_controller.capture_selected_scope(scope)
+
+        # A queued turn's scope must never relax browser interaction authority.
+        with pytest.raises(RuntimeError, match="no longer active"):
+            authority.import_html(session_id=session.id, source="<p>stale browser</p>")
+    finally:
+        asyncio.run(runtime.dispose())

--- a/Tests/Chat/test_buddy_hidden_results.py
+++ b/Tests/Chat/test_buddy_hidden_results.py
@@ -1,0 +1,46 @@
+"""A suspended Console cannot count its selected conversation's results as seen."""
+
+import pytest
+
+from Tests.Chat.test_console_chat_controller import StreamingGateway
+from tldw_chatbook.Chat.console_activity_receipts import ConsoleActivityReceiptService
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+
+@pytest.mark.parametrize("visible", [True, False])
+@pytest.mark.parametrize("queued", [False, True])
+def test_selected_conversation_results_are_unseen_only_when_console_hidden(
+    tmp_path, visible, queued
+):
+    store = ConsoleChatStore()
+    session = store.ensure_session()
+    db = AgentRunsDB(tmp_path / "activity.db")
+    receipts = ConsoleActivityReceiptService(db, None)
+    controller = ConsoleChatController(
+        store=store, provider_gateway=StreamingGateway(), activity_receipts=receipts
+    )
+    controller._interrupt_host.set_view_visible(visible)
+    if queued:
+        # Chain publication occurs after its final run has settled and relinquished
+        # its queue slot; idle is not a terminal outcome.
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id=session.id
+        )
+    controller._ordinary_outcome_ids[session.id] = "accepted-turn"
+    controller._ordinary_outcome_assistant_ids[session.id] = "assistant"
+    if queued:
+        controller._publish_queue_chain_terminal(
+            session.id, ConsoleRunStatus.COMPLETED, "queue-chain:accepted"
+        )
+    else:
+        controller._set_run_state(
+            ConsoleRunState(ConsoleRunStatus.COMPLETED), session_id=session.id
+        )
+    result = receipts.unseen_snapshot()
+    assert len(result) == (0 if visible else 1)
+    if result:
+        assert result[0].session_id == session.id
+        assert result[0].assistant_message_id == "assistant"

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -1755,8 +1755,8 @@ def test_persona_buddy_tool_step_uses_real_on_step_and_releases_result(tmp_path)
             self.observed: list[tuple[str, int]] = []
             self.released_runs: list[str] = []
 
-        def tool_step(self, run_id, sequence, kind):
-            result = super().tool_step(run_id, sequence, kind)
+        def tool_step(self, run_id, sequence, kind, *, session_id=None):
+            result = super().tool_step(run_id, sequence, kind, session_id=session_id)
             if kind in {"tool_call", "tool_result", "error"}:
                 self.observed.append((kind, self.active_owner_count("tool")))
             return result

--- a/Tests/Chat/test_console_context_policy_lifecycle.py
+++ b/Tests/Chat/test_console_context_policy_lifecycle.py
@@ -382,17 +382,14 @@ async def test_new_conversation_uses_store_default_without_post_create_write() -
         model="model-a",
     )
     controller._console_new_chat_default_generation = lambda: 0
-    controller._workspace_default_for_new_session = lambda: None
-
-    def _new_session(**kwargs):
-        generation = kwargs.pop("new_chat_default_generation")
-        session = store.create_session(**kwargs)
-        session.new_chat_default_generation = generation
-        return session
-
-    controller._ensure_console_chat_controller_fn = lambda: SimpleNamespace(
-        new_session=_new_session
+    controller._chat_store_accessor = lambda: store
+    controller.app_instance = SimpleNamespace()
+    chat_controller = ConsoleChatController(
+        store=store,
+        provider_gateway=SimpleNamespace(),
+        agent_runtime_enabled=False,
     )
+    controller._ensure_console_chat_controller_fn = lambda: chat_controller
     controller._invalidate_persisted_rows_cache_fn = lambda: None
 
     async def _sync() -> None:

--- a/Tests/Chat/test_console_conversation_hydration.py
+++ b/Tests/Chat/test_console_conversation_hydration.py
@@ -35,27 +35,30 @@ from Tests.UI.test_console_native_chat_flow import (
     StaticConversationTreeService,
     _configure_native_ready_console,
 )
-from tldw_chatbook.Chat.console_conversation_hydration import (
-    apply_resume_settings_overrides,
-    console_messages_from_conversation_tree,
-    hydrate_console_session,
-    load_console_conversation_tree,
-)
 from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
 from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_conversation_hydration import (
+    apply_resume_settings_overrides,
+    console_messages_from_conversation_tree,
+    hydrate_console_generation_settings,
+    hydrate_console_session,
+    load_console_conversation_tree,
+    prepare_console_session_data,
+)
 from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
     default_console_session_settings,
 )
 from tldw_chatbook.UI.Screens.chat_screen import ChatScreen
 
-
 CONVERSATION_ID = "conv-fixture"
 
 
-def test_resume_restores_the_complete_versioned_console_settings_snapshot() -> None:
+def test_legacy_resume_wrapper_preserves_base_settings_and_restores_row_owners() -> (
+    None
+):
     base = ConsoleSessionSettings(provider="base", model="base-model")
     persisted = ConsoleSessionSettings(
         provider="openai",
@@ -96,12 +99,12 @@ def test_resume_restores_the_complete_versioned_console_settings_snapshot() -> N
         },
     )
 
-    assert restored == ConsoleSessionSettings(
-        **{
-            **persisted.__dict__,
-            "system_prompt": "Canonical row prompt",
-            "pinned_prefill": "Canonical prefill",
-        }
+    # ADR-095: legacy complete snapshots are not the canonical generation owner.
+    # This compatibility helper only applies the row-owned prompt and prefill.
+    assert restored == replace(
+        base,
+        system_prompt="Canonical row prompt",
+        pinned_prefill="Canonical prefill",
     )
 
 
@@ -342,7 +345,10 @@ def _message_shape(store, session_id):
 
 
 @pytest.mark.asyncio
-async def test_production_hydration_restores_before_first_cursor(tmp_path) -> None:
+@pytest.mark.parametrize("preload", [False, True])
+async def test_production_hydration_restores_before_first_cursor(
+    tmp_path, preload
+) -> None:
     app = _fixture_app(tmp_path)
     assert (
         app.chachanotes_db.set_conversation_active_cursor(
@@ -354,12 +360,20 @@ async def test_production_hydration_restores_before_first_cursor(tmp_path) -> No
     )
     store = app.console_runtime.ensure_chat_store()
 
+    prepared = (
+        await prepare_console_session_data(
+            app=app, store=store, conversation_id=CONVERSATION_ID, tree=FIXTURE_TREE
+        )
+        if preload
+        else None
+    )
     session = await hydrate_console_session(
         app=app,
         store=store,
         conversation_id=CONVERSATION_ID,
         tree=FIXTURE_TREE,
         settings=default_console_session_settings(app.app_config),
+        prepared_data=prepared,
     )
 
     assert store.active_path_message_ids(session.id) == []
@@ -839,8 +853,9 @@ async def test_canonical_hydration_makes_persisted_generic_console_forkable(tmp_
         settings=default_console_session_settings(app.app_config),
     )
 
-    assert resumed.assistant_kind is None
-    assert resumed.assistant_id is None
+    # Explicit None is the current plain Console identity (ADR-139).
+    assert resumed.assistant_kind == "generic"
+    assert resumed.assistant_id == "console"
     assert resumed.assistant_authority_id is None
     assert resumed.persona_memory_mode is None
     resumed_message = next(
@@ -853,7 +868,7 @@ async def test_canonical_hydration_makes_persisted_generic_console_forkable(tmp_
 
 
 @pytest.mark.asyncio
-async def test_settings_replacement_refreshes_the_durable_resume_snapshot(tmp_path):
+async def test_canonical_settings_apply_refreshes_the_durable_resume_snapshot(tmp_path):
     app = _fixture_app(tmp_path)
     service = ChatPersistenceService(app.chachanotes_db)
     source_store = ConsoleChatStore(persistence=service)
@@ -894,13 +909,21 @@ async def test_settings_replacement_refreshes_the_durable_resume_snapshot(tmp_pa
         pinned_prefill="Stale snapshot prefill",
         source="user",
     )
-    source_store.replace_session_settings(source.id, latest)
+    from Tests.Chat.test_console_settings_apply_store import _submission
+
+    submission = _submission(
+        source_store, source.id, submission_id="resume-settings", model="gpt-test"
+    )
+    submission = replace(submission, draft=replace(submission.draft, settings=latest))
+    commit = source_store.commit_console_settings_live(submission)
+    outcome = await source_store.persist_console_settings_commit_serialized(commit)
+    assert not outcome.failed_components
 
     persisted = app.chachanotes_db.get_conversation_by_id(conversation_id)
     persisted_metadata = json.loads(persisted["metadata"])
     assert persisted_metadata["unrelated_owner"] == {"keep": True}
-    assert persisted_metadata["console_session_settings"]["provider"] == "openai"
-    assert persisted_metadata["console_session_settings"]["temperature"] == 0.22
+    assert persisted_metadata["console_generation_settings"]["provider"] == "openai"
+    assert persisted_metadata["console_generation_settings"]["temperature"] == 0.22
 
     tree = ChatConversationService(app.chachanotes_db).get_conversation_tree(
         conversation_id
@@ -911,10 +934,9 @@ async def test_settings_replacement_refreshes_the_durable_resume_snapshot(tmp_pa
         store=resumed_store,
         conversation_id=conversation_id,
         tree=tree,
-        settings=apply_resume_settings_overrides(
-            default_console_session_settings(app.app_config),
-            tree["conversation"],
-        ),
+        settings=hydrate_console_generation_settings(
+            app.app_config, tree["conversation"]
+        ).settings,
     )
 
     assert resumed.settings is not None
@@ -986,3 +1008,41 @@ async def test_first_persist_and_canonical_hydration_round_trip_persona_memory_m
     assert resumed.assistant_id == "persona-1"
     assert resumed.assistant_authority_id is None
     assert resumed.persona_memory_mode == "read_write"
+
+
+@pytest.mark.asyncio
+async def test_memory_database_preload_keeps_its_own_connection():
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    db = CharactersRAGDB(":memory:", "memory-hydration")
+    try:
+        service = ChatConversationService(db)
+        target = service.create_conversation(
+            title="Memory", runtime_backend="local", scope_type="global"
+        )
+        db.add_message(
+            {
+                "conversation_id": target,
+                "sender": "user",
+                "role": "user",
+                "content": "Memory input",
+            }
+        )
+        tree = service.get_conversation_tree(target)
+        store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+        app = SimpleNamespace(chachanotes_db=db)
+        prepared = await prepare_console_session_data(
+            app=app, store=store, conversation_id=target, tree=tree
+        )
+        session = await hydrate_console_session(
+            app=app,
+            store=store,
+            conversation_id=target,
+            tree=tree,
+            settings=None,
+            prepared_data=prepared,
+        )
+        assert store.messages_for_session(session.id)[0].content == "Memory input"
+        assert db.get_conversation_by_id(target)["title"] == "Memory"
+    finally:
+        db.close_connection()

--- a/Tests/Chat/test_console_decision_clock.py
+++ b/Tests/Chat/test_console_decision_clock.py
@@ -1,0 +1,190 @@
+"""Decision budgets count time during which their owning card is answerable."""
+
+from __future__ import annotations
+
+import pytest
+
+from Tests.Chat.test_console_interrupt_rounds import FakeSeamsFull
+from tldw_chatbook.Chat.console_interrupt_rounds import (
+    KIND_SETTER_ATTRS,
+    InterruptRoundHost,
+)
+
+
+@pytest.mark.parametrize("kind", tuple(KIND_SETTER_ATTRS))
+@pytest.mark.parametrize("away", ("navigation", "session"))
+def test_decision_budget_pauses_while_its_card_cannot_be_answered(
+    monkeypatch, kind, away
+):
+    """Wall-clock deadlines would expire at 102; ten visible seconds end at 110."""
+    import tldw_chatbook.Chat.console_interrupt_rounds as rounds
+
+    now = [0.0]
+    monkeypatch.setattr(rounds.time, "monotonic", lambda: now[0])
+    seams = FakeSeamsFull()
+    host = InterruptRoundHost(seams)
+    waits = iter((2.0, 102.0, 102.0, 109.0, 110.0))
+    observed = []
+
+    class Event:
+        def wait(self, seconds):
+            now[0] = next(waits)
+            observed.append(now[0])
+            if len(observed) == 1:
+                if away == "navigation":
+                    host.set_view_visible(False)
+                else:
+                    seams.store.active_session_id = "sess-B"
+                    host.refresh_decision_clocks()
+            elif len(observed) == 3:
+                if away == "navigation":
+                    host.set_view_visible(True)
+                else:
+                    seams.store.active_session_id = "sess-A"
+                    host.refresh_decision_clocks()
+            return False
+
+    outcome = host.run_round(
+        kind,
+        "r1",
+        {"round_id": "r1", "session_id": "sess-A", "timeout_seconds": 10.0},
+        {"event": Event(), "session_id": "sess-A"},
+        session_id="sess-A",
+        owning_session_id="sess-A",
+        deadline=10.0,
+        is_parked=False,
+    )
+    assert outcome == "timeout"
+    assert observed == [2.0, 102.0, 102.0, 109.0, 110.0]
+
+
+@pytest.mark.parametrize("kind", tuple(KIND_SETTER_ATTRS))
+def test_hidden_decision_still_observes_explicit_cancellation(kind):
+    """Pausing a deadline must never pause Stop or application shutdown."""
+    seams = FakeSeamsFull()
+    host = InterruptRoundHost(seams)
+    host.set_view_visible(False)
+    seams.cancelled = True
+
+    class Event:
+        def wait(self, seconds):
+            return False
+
+    assert (
+        host.run_round(
+            kind,
+            "r1",
+            {"round_id": "r1", "session_id": "sess-A", "timeout_seconds": 10.0},
+            {"event": Event(), "session_id": "sess-A"},
+            session_id="sess-A",
+            owning_session_id="sess-A",
+            deadline=10.0,
+            is_parked=False,
+        )
+        == "cancelled"
+    )
+
+
+@pytest.mark.parametrize("kind", tuple(KIND_SETTER_ATTRS))
+def test_queued_decision_only_spends_budget_after_becoming_fifo_head(monkeypatch, kind):
+    import tldw_chatbook.Chat.console_interrupt_rounds as rounds
+
+    now = [0.0]
+    monkeypatch.setattr(rounds.time, "monotonic", lambda: now[0])
+    host = InterruptRoundHost(FakeSeamsFull())
+    host.park_round_payload(kind, "first", {"session_id": "sess-A"})
+    waits = iter((100.0, 109.0, 110.0))
+    observed = []
+
+    class Event:
+        def wait(self, seconds):
+            now[0] = next(waits)
+            observed.append(now[0])
+            if len(observed) == 1:
+                host.unpark_round_payload(kind, "first")
+                host.remount_head(kind, "sess-A")
+            return False
+
+    assert (
+        host.run_round(
+            kind,
+            "second",
+            {"round_id": "second", "session_id": "sess-A", "timeout_seconds": 10.0},
+            {"event": Event(), "session_id": "sess-A"},
+            session_id="sess-A",
+            owning_session_id="sess-A",
+            deadline=10.0,
+            is_parked=False,
+        )
+        == "timeout"
+    )
+    assert observed == [100.0, 109.0, 110.0]
+
+
+@pytest.mark.parametrize("kind", tuple(KIND_SETTER_ATTRS))
+def test_legacy_unparked_decision_expires_while_its_card_is_visible(monkeypatch, kind):
+    import tldw_chatbook.Chat.console_interrupt_rounds as rounds
+
+    now = [0.0]
+    monkeypatch.setattr(rounds.time, "monotonic", lambda: now[0])
+    host = InterruptRoundHost(FakeSeamsFull())
+
+    class Event:
+        def wait(self, seconds):
+            now[0] += 1
+            assert now[0] <= 1, "Unparked legacy card never consumed its budget"
+            return False
+
+    assert (
+        host.run_round(
+            kind,
+            "legacy",
+            {"timeout_seconds": 1.0},
+            {"event": Event(), "session_id": "sess-A"},
+            session_id=None,
+            owning_session_id="sess-A",
+            deadline=1.0,
+            is_parked=False,
+        )
+        == "timeout"
+    )
+
+
+@pytest.mark.parametrize("kind", tuple(KIND_SETTER_ATTRS))
+def test_external_decision_projection_only_charges_supported_visible_kinds(
+    monkeypatch, kind
+):
+    import tldw_chatbook.Chat.console_interrupt_rounds as rounds
+
+    now = [0.0]
+    monkeypatch.setattr(rounds.time, "monotonic", lambda: now[0])
+    host = InterruptRoundHost(FakeSeamsFull())
+    host.set_view_visible(False)
+    host.set_decision_view("buddy", "sess-A", kinds=())
+    observed = []
+
+    class Event:
+        def wait(self, _seconds):
+            now[0] += 100 if not observed else 1
+            observed.append(now[0])
+            assert len(observed) <= 2
+            if len(observed) == 1:
+                host.set_decision_view("buddy", "sess-A", kinds=(kind,))
+            return False
+
+    assert (
+        host.run_round(
+            kind,
+            "r",
+            {"session_id": "sess-A"},
+            {"event": Event(), "session_id": "sess-A"},
+            session_id="sess-A",
+            owning_session_id="sess-A",
+            deadline=1.0,
+            is_parked=False,
+        )
+        == "timeout"
+    )
+    host.set_decision_view("buddy", None)
+    assert not host._decision_views
+    assert observed == [100, 101]

--- a/Tests/Chat/test_console_interrupt_attention.py
+++ b/Tests/Chat/test_console_interrupt_attention.py
@@ -60,6 +60,15 @@ def test_a_round_raised_while_console_is_visible_badges_but_does_not_ring():
     assert app.bells == 0 and getattr(app, CONSOLE_ATTENTION_ATTR) == 2
 
 
+def test_retained_hidden_console_rings_without_detaching_its_view():
+    app = _App()
+    controller = _controller(app, attached=True, pending=1)
+    controller.on_console_view_visibility_changed(False)
+    controller.on_pending_rounds_changed(1, "question", True)
+    assert app.bells == 1 and getattr(app, CONSOLE_ATTENTION_ATTR) == 1
+    assert controller.set_pending_approval is not None
+
+
 def _config_bell(monkeypatch, value):
     import tldw_chatbook.Chat.console_chat_controller as ccc
 

--- a/Tests/Chat/test_console_persona_assignment.py
+++ b/Tests/Chat/test_console_persona_assignment.py
@@ -1,0 +1,491 @@
+"""Exact-target Persona assignment commits before publishing live identity."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import replace
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Character_Chat.local_character_persona_service import (
+    LocalCharacterPersonaService,
+)
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleMessageRole,
+    ConsoleRunState,
+    ConsoleRunStatus,
+)
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
+from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.Workspaces.models import WorkspaceAssistantDefaults
+from tldw_chatbook.Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+)
+
+
+@pytest.fixture
+def context(tmp_path):
+    db = CharactersRAGDB(tmp_path / "chat.sqlite", "assignment-test")
+    workspace_db = WorkspaceDB(tmp_path / "workspace.sqlite", "assignment-test")
+    registry = LocalWorkspaceRegistryService(workspace_db)
+    personas = LocalCharacterPersonaService(
+        db, persona_store_path=tmp_path / "personas.json"
+    )
+    for persona_id in ("guide", "other"):
+        personas.create_persona_profile(
+            {
+                "id": persona_id,
+                "name": persona_id.title(),
+                "system_prompt": f"Be {persona_id}.",
+            }
+        )
+    store = ConsoleChatStore(persistence=ChatPersistenceService(db))
+    controller = ConsoleChatController(store=store, provider_gateway=SimpleNamespace())
+    app = SimpleNamespace(
+        console_runtime=SimpleNamespace(chat_store=store, chat_controller=controller),
+        local_character_persona_service=personas,
+        workspace_registry_service=registry,
+    )
+    session = store.create_session(
+        settings=ConsoleSessionSettings(
+            provider="llama_cpp", model="test-model", temperature=0.42
+        ),
+        assistant_kind="generic",
+    )
+    store.persist_session_if_needed(session.id)
+    yield SimpleNamespace(
+        app=app,
+        db=db,
+        store=store,
+        controller=controller,
+        session=session,
+        personas=personas,
+        registry=registry,
+    )
+    db.close_connection()
+    workspace_db.close()
+
+
+def prepare(ctx, choice="guide", *, target=None, binding=None):
+    from tldw_chatbook.Chat.console_persona_assignment import (
+        prepare_buddy_persona_assignment,
+    )
+
+    target = target or ctx.session
+    return prepare_buddy_persona_assignment(
+        ctx.app, binding or BuddyBinding.for_session(target), target, choice
+    )
+
+
+@pytest.mark.asyncio
+async def test_prepare_is_read_only_and_apply_round_trips_exact_identity(context):
+    ctx = context
+    original = replace(ctx.session)
+    before = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    epoch = ctx.store.conversation_context_epoch(ctx.session.id)
+    speech = ctx.store.speech_preference_epoch(ctx.session.id)
+    assignment = prepare(ctx)
+    assert ctx.session == original
+    assert not ctx.store._fork_source_transitions
+    assert ctx.db.get_conversation_by_id(original.persisted_conversation_id) == before
+    sibling = ctx.store.create_session(
+        settings=original.settings, assistant_kind="generic"
+    )
+    await assignment.apply()
+    assert ctx.store.active_session_id == sibling.id
+    assert sibling.assistant_kind == "generic"
+    row = ctx.db.get_conversation_by_id(original.persisted_conversation_id)
+    assert row["assistant_kind"] == ctx.session.assistant_kind == "persona"
+    assert row["assistant_id"] == ctx.session.assistant_id == "guide"
+    assert (
+        row["persona_memory_mode"]
+        == ctx.session.settings.persona_memory_mode
+        == "read_only"
+    )
+    assert row["system_prompt"] == ctx.session.settings.system_prompt
+    assert "Be guide." in row["system_prompt"]
+    metadata = json.loads(row["metadata"])
+    assert metadata["console_session_settings"]["character_label"] == "Guide"
+    assert metadata["console_session_settings"]["temperature"] == 0.42
+    assert row["version"] == before["version"] + 1
+    assert ctx.session.identity_revision == original.identity_revision + 1
+    assert (
+        ctx.session.generation_settings_revision
+        == original.generation_settings_revision + 1
+    )
+    assert ctx.store.conversation_context_epoch(ctx.session.id) > epoch
+    assert ctx.store.speech_preference_epoch(ctx.session.id) > speech
+    assert ctx.store.messages_for_session(ctx.session.id) == []
+
+
+@pytest.mark.asyncio
+async def test_sqlite_failure_leaves_prompt_settings_identity_and_live_memory_unchanged(
+    context,
+):
+    ctx = context
+    assignment = prepare(ctx)
+    before = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    original = replace(ctx.session)
+    with ctx.db.transaction() as conn:
+        conn.execute(
+            "CREATE TRIGGER reject_persona BEFORE UPDATE OF assistant_id ON conversations BEGIN SELECT RAISE(ABORT, 'assignment blocked'); END"
+        )
+    with pytest.raises(CharactersRAGDBError, match="assignment blocked"):
+        await assignment.apply()
+    assert (
+        ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id) == before
+    )
+    assert ctx.session == original
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change",
+    [
+        "revised",
+        "deleted",
+        "inactive",
+        "settings",
+        "identity",
+        "repurposed",
+        "busy",
+        "pending",
+        "durable",
+    ],
+)
+async def test_apply_rejects_stale_persona_or_target_without_overwriting(
+    context, change
+):
+    ctx = context
+    assignment = prepare(ctx)
+    if change == "revised":
+        ctx.personas.update_persona_profile(
+            "guide", {"system_prompt": "New instructions."}
+        )
+    elif change == "deleted":
+        ctx.personas.delete_persona_profile("guide")
+    elif change == "inactive":
+        ctx.personas.update_persona_profile("guide", {"is_active": False})
+    elif change == "settings":
+        ctx.store.replace_session_settings(
+            ctx.session.id, replace(ctx.session.settings, temperature=0.8)
+        )
+    elif change == "identity":
+        ctx.session.identity_revision += 1
+    elif change == "repurposed":
+        ctx.session.conversation_binding_revision += 1
+    elif change == "busy":
+        ctx.controller._run_states[ctx.session.id] = ConsoleRunState(
+            ConsoleRunStatus.STREAMING
+        )
+    elif change == "pending":
+        ctx.controller.add_pending_round(ctx.session.id, "decision")
+    elif change == "durable":
+        row = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+        ctx.db.update_conversation(row["id"], {"title": "New title"}, row["version"])
+    before = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    original = replace(ctx.session)
+    with pytest.raises(ValueError):
+        await assignment.apply()
+    assert ctx.session == original
+    assert (
+        ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id) == before
+    )
+
+
+@pytest.mark.asyncio
+async def test_explicit_none_clears_persona_without_changing_generation_choices(
+    context,
+):
+    ctx = context
+    await prepare(ctx).apply()
+    await prepare(ctx, "#none").apply()
+    assert ctx.session.assistant_kind == "generic"
+    assert ctx.session.assistant_id == "console"
+    assert ctx.session.settings.system_prompt is None
+    assert ctx.session.settings.character_label is None
+    assert ctx.session.settings.persona_memory_mode is None
+    assert ctx.session.settings.temperature == 0.42
+    row = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    assert row["assistant_kind"] is None
+    assert row["system_prompt"] is None
+    assert row["persona_memory_mode"] is None
+
+
+@pytest.mark.asyncio
+async def test_workspace_default_preserves_policy_and_explicit_none(context):
+    ctx = context
+    workspace = ctx.registry.create_workspace(
+        workspace_id="workspace",
+        name="Workspace",
+        assistant_defaults=WorkspaceAssistantDefaults(
+            assistant_id="other", tool_policy_profile_id="existing-profile"
+        ),
+    )
+    binding = BuddyBinding(kind="workspace", target_id=workspace.workspace_id)
+    assignment = prepare(ctx, target=workspace, binding=binding)
+    assert ctx.registry.get_workspace(workspace.workspace_id) == workspace
+    await assignment.apply()
+    changed = ctx.registry.get_workspace(workspace.workspace_id)
+    assert changed.assistant_defaults == replace(
+        workspace.assistant_defaults, assistant_id="guide"
+    )
+    await prepare(ctx, "#none", target=changed, binding=binding).apply()
+    cleared = ctx.registry.get_workspace(workspace.workspace_id)
+    assert cleared.assistant_defaults is None
+    assert cleared.assistant_defaults_explicit_none
+    assert ctx.session.assistant_kind == "generic"
+
+
+@pytest.mark.asyncio
+async def test_unchanged_and_same_persona_do_not_write(context):
+    ctx = context
+    await prepare(ctx).apply()
+    before = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    original = replace(ctx.session)
+    await prepare(ctx, "#unchanged").apply()
+    await prepare(ctx).apply()
+    assert ctx.session == original
+    assert (
+        ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id) == before
+    )
+
+
+@pytest.mark.parametrize("operation", ["set", "clear"])
+def test_workspace_registry_compare_and_set_rejects_stale_default(context, operation):
+    ctx = context
+    original = ctx.registry.create_workspace(
+        workspace_id="workspace", name="Workspace", assistant_defaults=None
+    )
+    newer = WorkspaceAssistantDefaults(assistant_id="other")
+    ctx.registry.set_assistant_defaults(original.workspace_id, newer)
+    with pytest.raises(WorkspaceRegistryServiceError, match="changed"):
+        if operation == "set":
+            ctx.registry.set_assistant_defaults(
+                original.workspace_id,
+                WorkspaceAssistantDefaults(assistant_id="guide"),
+                expected_record=original,
+            )
+        else:
+            ctx.registry.clear_assistant_defaults(
+                original.workspace_id, expected_record=original
+            )
+    assert ctx.registry.get_workspace(original.workspace_id).assistant_defaults == newer
+
+
+@pytest.mark.asyncio
+async def test_queued_prompt_refuses_assignment(context):
+    ctx = context
+    queue = ctx.controller.prompt_queue_registry
+    chain = queue.begin_chain(
+        ctx.session.id,
+        context_epoch=ctx.store.conversation_context_epoch(ctx.session.id),
+        expected_revision=0,
+    )
+    added = queue.admit(
+        ctx.session.id, text="Queued work", expected_revision=chain.snapshot.revision
+    )
+    assert added.applied
+    with pytest.raises(ValueError, match="queued"):
+        prepare(ctx)
+    assert queue.snapshot(ctx.session.id).total_count == 1
+
+
+@pytest.mark.parametrize(
+    "kind", ["approval", "skill_install", "skill_script", "question", "worktree_merge"]
+)
+def test_parked_decision_without_run_badge_refuses_assignment(context, kind):
+    ctx = context
+    ctx.controller._interrupt_host.park_round_payload(
+        kind, "decision", {"request_id": "decision", "session_id": ctx.session.id}
+    )
+    with pytest.raises(ValueError, match="decision"):
+        prepare(ctx)
+
+
+@pytest.mark.parametrize("ownership", ["character", "server"])
+def test_character_and_remote_ownership_cannot_be_reassigned(context, ownership):
+    ctx = context
+    binding = BuddyBinding.for_session(ctx.session)
+    if ownership == "character":
+        ctx.session.assistant_kind = "character"
+        ctx.session.character_id = 1
+    else:
+        ctx.session.runtime_backend = "server"
+    with pytest.raises(ValueError):
+        prepare(ctx, binding=binding)
+
+
+@pytest.mark.asyncio
+async def test_unsaved_temporary_assignment_never_creates_durable_conversation(context):
+    ctx = context
+    session = ctx.store.create_session(
+        settings=ctx.session.settings, ephemeral=True, assistant_kind="generic"
+    )
+    before = (
+        ctx.db.get_connection()
+        .execute("SELECT COUNT(*) FROM conversations")
+        .fetchone()[0]
+    )
+    await prepare(ctx, target=session).apply()
+    assert session.assistant_id == "guide"
+    assert session.persisted_conversation_id is None
+    assert (
+        ctx.db.get_connection()
+        .execute("SELECT COUNT(*) FROM conversations")
+        .fetchone()[0]
+        == before
+    )
+
+
+@pytest.mark.asyncio
+async def test_different_persona_never_inherits_unconfirmed_memory_writes(context):
+    ctx = context
+    await prepare(ctx).apply()
+    ctx.session.persona_memory_mode = "read_write"
+    ctx.session.settings = replace(
+        ctx.session.settings, persona_memory_mode="read_write"
+    )
+    with pytest.raises(ValueError, match="memory"):
+        prepare(ctx, "other")
+    workspace = ctx.registry.create_workspace(
+        workspace_id="rw",
+        name="RW",
+        assistant_defaults=WorkspaceAssistantDefaults(
+            assistant_id="guide", persona_memory_mode="read_write"
+        ),
+        confirm_read_write=True,
+    )
+    with pytest.raises(ValueError, match="memory"):
+        prepare(
+            ctx,
+            "other",
+            target=workspace,
+            binding=BuddyBinding(kind="workspace", target_id="rw"),
+        )
+
+
+@pytest.mark.asyncio
+async def test_persona_change_does_not_persist_a_live_only_endpoint(context):
+    from tldw_chatbook.Chat.console_session_endpoint_policy import (
+        ConsoleEphemeralEndpointPolicy,
+    )
+
+    ctx = context
+    endpoint = "http://ephemeral-only.example:12345"
+    ctx.session.settings = replace(ctx.session.settings, base_url=endpoint)
+    policy = ConsoleEphemeralEndpointPolicy(
+        provider="llama_cpp", model="test-model", base_url=endpoint
+    )
+    ctx.session.ephemeral_endpoint_policy = policy
+    await prepare(ctx).apply()
+    assert ctx.session.settings.base_url == endpoint
+    assert ctx.session.ephemeral_endpoint_policy is policy
+    row = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    assert endpoint not in row["metadata"]
+
+
+def test_already_stale_durable_identity_refuses_preparation(context):
+    ctx = context
+    row = ctx.db.get_conversation_by_id(ctx.session.persisted_conversation_id)
+    ctx.db.update_conversation(
+        row["id"],
+        {
+            "assistant_kind": "persona",
+            "assistant_id": "other",
+            "persona_memory_mode": "read_only",
+        },
+        row["version"],
+    )
+    with pytest.raises(ValueError, match="saved|Saved"):
+        prepare(ctx)
+    assert ctx.session.assistant_kind == "generic"
+
+
+def test_live_preparation_refuses_assignment_even_before_run_badge(context):
+    from Tests.Chat.test_console_turn_preparation import _preparation_values
+    from tldw_chatbook.Chat.console_turn_preparation import ConsoleTurnPreparation
+
+    ctx = context
+    values = _preparation_values(session_id=ctx.session.id)
+    ctx.store.begin_preparation(ConsoleTurnPreparation(**values))
+    with pytest.raises(ValueError, match="run"):
+        prepare(ctx)
+
+
+@pytest.mark.asyncio
+async def test_pending_settings_writer_refuses_assignment(context):
+    ctx = context
+    lifecycle = ctx.store._settings_persistence_lifecycles[ctx.session.id]
+    async with lifecycle.lock:
+        with pytest.raises(ValueError, match="saving"):
+            prepare(ctx)
+
+
+@pytest.mark.asyncio
+async def test_fork_snapshot_is_fenced_until_atomic_persona_publication(
+    context, monkeypatch
+):
+    ctx = context
+    message = ctx.store.append_message(
+        ctx.session.id, role=ConsoleMessageRole.USER, content="Keep this transcript"
+    )
+    ctx.store.persist_message_if_needed(message.id)
+    assert ctx.store.fork_eligibility(message.id).eligible
+    writer = ctx.db.update_conversation
+
+    def write_with_boundary_observation(*args, **kwargs):
+        assert ctx.session.assistant_kind == "generic"
+        assert ctx.session.settings.system_prompt is None
+        assert not ctx.store.fork_eligibility(message.id).eligible
+        return writer(*args, **kwargs)
+
+    monkeypatch.setattr(ctx.db, "update_conversation", write_with_boundary_observation)
+    await prepare(ctx).apply()
+    assert ctx.store.fork_eligibility(message.id).eligible
+    assert (
+        ctx.store.messages_for_session(ctx.session.id)[0].content
+        == "Keep this transcript"
+    )
+    assert ctx.store._fork_configuration_snapshot(ctx.session).assistant_id == "guide"
+
+
+@pytest.mark.asyncio
+async def test_workspace_stale_or_deleted_persona_cannot_change_defaults(context):
+    ctx = context
+    workspace = ctx.registry.create_workspace(
+        workspace_id="workspace", name="Workspace", assistant_defaults=None
+    )
+    assignment = prepare(
+        ctx,
+        target=workspace,
+        binding=BuddyBinding(kind="workspace", target_id="workspace"),
+    )
+    ctx.personas.delete_persona_profile("guide")
+    with pytest.raises(ValueError, match="unavailable"):
+        await assignment.apply()
+    assert ctx.registry.get_workspace("workspace") == workspace
+
+
+@pytest.mark.asyncio
+async def test_prepared_workspace_assignment_rejects_replaced_profile_service(context):
+    ctx = context
+    workspace = ctx.registry.create_workspace(
+        workspace_id="workspace", name="Workspace", assistant_defaults=None
+    )
+    assignment = prepare(
+        ctx,
+        target=workspace,
+        binding=BuddyBinding(kind="workspace", target_id="workspace"),
+    )
+    ctx.app.workspace_registry_service = object()
+    with pytest.raises(ValueError, match="Workspace"):
+        await assignment.apply()
+    assert ctx.registry.get_workspace("workspace") == workspace

--- a/Tests/Chat/test_console_receipt_bootstrap.py
+++ b/Tests/Chat/test_console_receipt_bootstrap.py
@@ -1,0 +1,299 @@
+"""Saved inbox results work before Console construction and retain one owner."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_activity_receipts import ConsoleActivityReceiptService
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
+from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.UI.Navigation.buddy_workspace import BuddyWorkspaceCoordinator
+
+
+def _seed_result(path, conversation_id="saved"):
+    database = AgentRunsDB(path)
+    try:
+        activity_id = ConsoleActivityReceiptService(database, None).publish_ordinary(
+            logical_outcome_id="previous-run",
+            status="done",
+            session_id="previous-session",
+            conversation_id=conversation_id,
+        )
+        assert activity_id is not None
+        return activity_id
+    finally:
+        database.close()
+
+
+def _runtime(tmp_path):
+    app = SimpleNamespace(
+        chachanotes_db=SimpleNamespace(db_path=tmp_path / "chat.db"),
+        conversation_local_marks_service=None,
+    )
+    runtime = ConsoleRuntime(app, canvas_enabled_reader=lambda: False)
+    app.console_runtime = runtime
+    return app, runtime
+
+
+@pytest.mark.asyncio
+async def test_receipt_bootstrap_reuses_hydrated_owner_when_bridge_is_built(tmp_path):
+    activity_id = _seed_result(tmp_path / "agent_runs.db")
+    _, runtime = _runtime(tmp_path)
+    try:
+        assert hasattr(runtime, "ensure_activity_receipt_service")
+        service = await asyncio.to_thread(runtime.ensure_activity_receipt_service)
+        await runtime.ensure_activity_hydration()
+        assert [row.activity_id for row in service.unseen_snapshot()] == [activity_id]
+        assert runtime.chat_store is None
+        assert runtime.provider_gateway is None
+        assert runtime.agent_bridge is None
+        database = runtime._agent_runs_db
+
+        bridge = runtime.ensure_agent_bridge(
+            store_factory=ConsoleChatStore, provider_gateway_factory=object
+        )
+        assert bridge.runs_db is database
+        assert runtime.activity_receipts is service
+        assert [row.activity_id for row in service.unseen_snapshot()] == [activity_id]
+    finally:
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_receipt_bootstrap_closes_constructor_and_hydration_worker_connections(
+    tmp_path, monkeypatch
+):
+    _seed_result(tmp_path / "agent_runs.db")
+    _, runtime = _runtime(tmp_path)
+    try:
+        assert hasattr(runtime, "ensure_activity_receipt_service")
+
+        def initialize():
+            service = runtime.ensure_activity_receipt_service()
+            return service, getattr(runtime._agent_runs_db._thread_local, "conn", None)
+
+        service, held = await asyncio.to_thread(initialize)
+        assert held is None
+        closed = threading.Event()
+        original_close = runtime._agent_runs_db.close
+
+        def observe_close():
+            original_close()
+            closed.set()
+
+        monkeypatch.setattr(runtime._agent_runs_db, "close", observe_close)
+        await runtime.ensure_activity_hydration()
+        assert service.hydration_state() == "ready"
+        assert closed.is_set()
+    finally:
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_dispose_fences_inflight_receipt_creation_and_closes_its_connection(
+    tmp_path, monkeypatch
+):
+    import tldw_chatbook.DB.AgentRuns_DB as database_module
+
+    _, runtime = _runtime(tmp_path)
+    assert hasattr(runtime, "ensure_activity_receipt_service")
+    entered, release, closed = threading.Event(), threading.Event(), threading.Event()
+    real_database = database_module.AgentRunsDB
+
+    class DelayedDatabase(real_database):
+        def __init__(self, *args, **kwargs):
+            super().__init__(*args, **kwargs)
+            entered.set()
+            assert release.wait(5)
+
+        def close(self):
+            super().close()
+            closed.set()
+
+    monkeypatch.setattr(database_module, "AgentRunsDB", DelayedDatabase)
+    initialize = asyncio.create_task(
+        asyncio.to_thread(runtime.ensure_activity_receipt_service)
+    )
+    try:
+        assert await asyncio.to_thread(entered.wait, 5)
+        dispose = asyncio.create_task(runtime.dispose())
+        await asyncio.sleep(0)
+        assert runtime._disposed
+        release.set()
+        assert await initialize is None
+        await dispose
+        assert closed.is_set()
+        assert runtime.activity_receipts is None
+        assert runtime._agent_runs_db is None
+        assert runtime.ensure_activity_receipt_service() is None
+    finally:
+        release.set()
+        await initialize
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_receipt_initializers_share_one_database(
+    tmp_path, monkeypatch
+):
+    import tldw_chatbook.DB.AgentRuns_DB as database_module
+
+    _, runtime = _runtime(tmp_path)
+    databases = []
+    real_database = database_module.AgentRunsDB
+
+    def record_database(*args, **kwargs):
+        database = real_database(*args, **kwargs)
+        databases.append(database)
+        return database
+
+    monkeypatch.setattr(database_module, "AgentRunsDB", record_database)
+    try:
+        services = await asyncio.gather(
+            *(
+                asyncio.to_thread(runtime.ensure_activity_receipt_service)
+                for _ in range(3)
+            )
+        )
+        assert len(databases) == 1
+        assert all(service is services[0] for service in services)
+        assert runtime._agent_runs_db is databases[0]
+    finally:
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("database", [None, SimpleNamespace(db_path=":memory:")])
+async def test_receipt_bootstrap_preserves_no_durable_database_harness(database):
+    runtime = ConsoleRuntime(
+        SimpleNamespace(chachanotes_db=database), canvas_enabled_reader=lambda: False
+    )
+    try:
+        assert hasattr(runtime, "ensure_activity_receipt_service")
+        assert await asyncio.to_thread(runtime.ensure_activity_receipt_service) is None
+        assert runtime.agent_bridge is None
+        assert runtime.chat_store is None
+        assert runtime.provider_gateway is None
+    finally:
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_inbox_reports_degraded_receipts_instead_of_empty_results(tmp_path):
+    app, runtime = _runtime(tmp_path)
+    app.workspace_registry_service = SimpleNamespace(
+        get_workspace=lambda _: SimpleNamespace(
+            name="Workspace", archived=False, authority="local-only"
+        )
+    )
+    service = SimpleNamespace(
+        hydration_state=lambda: "degraded", unseen_snapshot=lambda: ()
+    )
+    runtime._activity_receipts = service
+    runtime.ensure_activity_hydration = lambda: None
+    coordinator = BuddyWorkspaceCoordinator(
+        app, BuddyBinding(kind="workspace", target_id="workspace")
+    )
+    try:
+        with pytest.raises(ValueError, match="[Rr]esult storage"):
+            await coordinator.snapshot()
+    finally:
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_inbox_reports_loading_until_saved_receipts_have_been_read(
+    tmp_path, monkeypatch
+):
+    app, runtime = _runtime(tmp_path)
+    app.workspace_registry_service = SimpleNamespace()
+    service = await asyncio.to_thread(runtime.ensure_activity_receipt_service)
+    entered, release = threading.Event(), threading.Event()
+    original_read = service.hydrate_from_storage
+
+    def delayed_read():
+        entered.set()
+        assert release.wait(5)
+        return original_read()
+
+    monkeypatch.setattr(service, "hydrate_from_storage", delayed_read)
+    coordinator = BuddyWorkspaceCoordinator(
+        app, BuddyBinding(kind="workspace", target_id="workspace")
+    )
+    try:
+        with pytest.raises(ValueError, match="Loading saved results"):
+            await coordinator.snapshot()
+        assert await asyncio.to_thread(entered.wait, 5)
+    finally:
+        release.set()
+        task = runtime.ensure_activity_hydration()
+        if task is not None:
+            await task
+        await runtime.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.ui
+async def test_fresh_home_inbox_reads_saved_ordinary_result_without_console(
+    tmp_path, monkeypatch
+):
+    import os
+    from pathlib import Path
+
+    from Tests.UI.test_console_screen_reuse import _boot_settled, _scratch_env
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.UI.Navigation.buddy_workspace import open_buddy_workspace
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_workspace_modal import (
+        BuddyWorkspaceModal,
+    )
+
+    _scratch_env(monkeypatch, tmp_path)
+    config_path = Path(os.environ["TLDW_CONFIG_PATH"])
+    config_path.write_text(
+        config_path.read_text() + '\n[general]\ndefault_tab = "home"\n'
+    )
+    app = TldwCli()
+    async with app.run_test(size=(120, 35)) as pilot:
+        await _boot_settled(app, pilot)
+        home = app.screen
+        assert type(home).__name__ == "HomeScreen"
+        runtime = app.console_runtime
+        assert runtime.agent_bridge is None
+        assert runtime.chat_store is None
+        conversation_id = app.chachanotes_db.add_conversation({"title": "Saved reply"})
+        registry = app.workspace_registry_service
+        registry.create_workspace(workspace_id="ws-inbox", name="Inbox workspace")
+        registry.link_membership(
+            workspace_id="ws-inbox", item_type="conversation", item_id=conversation_id
+        )
+        activity_id = _seed_result(
+            Path(app.chachanotes_db.db_path).parent / "agent_runs.db", conversation_id
+        )
+        open_buddy_workspace(app, BuddyBinding(kind="workspace", target_id="ws-inbox"))
+        await pilot.pause()
+        modal = app.screen
+        assert isinstance(modal, BuddyWorkspaceModal)
+        deadline = asyncio.get_running_loop().time() + 10
+        while not modal._entries:
+            assert asyncio.get_running_loop().time() < deadline, str(
+                modal.query_one("#buddy-inbox-error").render()
+            )
+            await asyncio.sleep(0.05)
+            await modal.refresh_inbox()
+        assert [(row.title, row.receipt_ids) for row in modal._entries] == [
+            ("Saved reply", (activity_id,))
+        ]
+        assert runtime.agent_bridge is None
+        assert runtime.provider_gateway is None
+        assert runtime.chat_store is None
+        assert [
+            row.activity_id for row in runtime.activity_receipts.unseen_snapshot()
+        ] == [activity_id]
+        await pilot.press("escape")
+        assert app.screen is home

--- a/Tests/Chat/test_console_runtime_lifetime.py
+++ b/Tests/Chat/test_console_runtime_lifetime.py
@@ -1,22 +1,10 @@
-"""The teardown split: leaving a Console visit vs destroying the runtime.
+"""Final Console unmount and application disposal retain their cancellation fences.
 
-task-15860 (headless wake), the lifetime landing. `ConsoleChatController.
-shutdown()` used to mean both "cancel the user's work" and "this instance
-is finished forever", and one flag -- `_shutdown_requested` -- carried
-both meanings. With the runtime app-owned and surviving every navigation,
-those are different events:
-
-* `ConsoleRuntime.leave_console()` -> `controller.leave_console()` ends ONE
-  visit. AC#2's two documented screen-scoped semantics still happen here.
-* `ConsoleRuntime.dispose()` -> `controller.shutdown()` is the permanent,
-  app-exit form and keeps its old behaviour exactly.
-
-The two AC#2 tests below (`test_leaving_console_still_cancels_a_streaming_
-user_turn`, `test_leaving_console_still_denies_a_parked_approval_round`)
-are genuine reds for the intermediate state this landing passes through:
-with the runtime surviving and no `leave_console()` on the unmount path,
-BOTH fail. They were run in that state and observed failing before the
-split was wired -- see the lifetime report.
+TASK-15860 split visit cleanup from permanent runtime shutdown. TASK-31520
+subsequently made ordinary navigation reuse and suspend the mounted Console;
+that route does not call ``leave_console``. These direct runtime tests cover
+actual final-unmount cleanup and permanent app disposal. Real navigation with
+streams, queues and pending decisions is covered by test_console_navigation_decisions.
 """
 
 from __future__ import annotations
@@ -239,11 +227,7 @@ def _pending_call() -> MCPPendingCall:
 
 @pytest.mark.asyncio
 async def test_leaving_console_still_cancels_a_streaming_user_turn():
-    """AC#2 RED: nav-away must still kill the user's in-flight turn.
-
-    Goes red the moment the runtime survives unmount without a per-visit
-    teardown: the turn simply keeps streaming into a screen that is gone.
-    """
+    """An actual final unmount still cancels this visit's in-flight user turn."""
     gateway = _StalledGateway()
     store = ConsoleChatStore()
     controller = ConsoleChatController(store=store, provider_gateway=gateway)
@@ -271,7 +255,7 @@ async def test_leaving_console_still_cancels_a_streaming_user_turn():
 
 @pytest.mark.asyncio
 async def test_leaving_console_still_denies_a_parked_approval_round():
-    """AC#2 RED: an undecided round at nav-away resolves to `deny`.
+    """An undecided round at final visit teardown resolves to `deny`.
 
     The round polls on a worker thread exactly as production does; nothing
     ever answers it, so only the visit's cancellation signal can end it

--- a/Tests/Chat/test_console_speech_snapshots.py
+++ b/Tests/Chat/test_console_speech_snapshots.py
@@ -80,6 +80,25 @@ def test_snapshot_rejects_invalid_structural_values():
         )
 
 
+def test_explicit_speech_owner_does_not_change_default_visible_guard():
+    store = ConsoleChatStore()
+    owner = store.create_session(ephemeral=True)
+    message = store.append_message(owner.id, role=ConsoleMessageRole.ASSISTANT, content="Owned reply")
+    other = store.create_session(ephemeral=True)
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        store.issue_tts_message_speech_snapshot(message.id)
+    snapshot = store.issue_tts_message_speech_snapshot(message.id, owner_session_id=owner.id)
+    assert store.validate_tts_message_speech_snapshot(snapshot, owner_session_id=owner.id) == "Owned reply"
+    assert store.active_session_id == other.id
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        store.validate_tts_message_speech_snapshot(snapshot)
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        store.validate_tts_message_speech_snapshot(snapshot, owner_session_id=other.id)
+    store.close_session(owner.id)
+    with pytest.raises(ConsoleSpeechSnapshotRejected):
+        store.validate_tts_message_speech_snapshot(snapshot, owner_session_id=owner.id)
+
+
 def test_snapshot_rejection_exposes_only_bounded_code_and_safe_retry_copy():
     error = ConsoleSpeechSnapshotRejected(
         ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED

--- a/Tests/Chat/test_workspace_default_session.py
+++ b/Tests/Chat/test_workspace_default_session.py
@@ -1,33 +1,31 @@
-"""Workspace default persona applies to NEW sessions only (Task 9).
+"""Workspace Persona defaults apply at creation and preserve durable identity.
 
-Tested at the two isolable layers (a full ChatScreen harness is
-impractical here -- `_create_native_console_session_from_active_context`
-needs a live Textual screen):
-1. ``ConsoleSessionController._workspace_default_for_new_session`` -- the
-   workspace -> ``(assistant_id, label, prompt, memory_mode)`` resolver,
-   invoked unbound against a stub host.
-2. The controller/store seam -- ``new_session`` assistant kwargs forwarded
-   into ``store.create_session`` plus the settings replace the session.py
-   injection performs.
+These tests cover shared resolution, controller/store creation, SQLite
+persistence, and provider setup recovery. Native mounted creation and workspace
+details controls are covered in Tests/UI/test_workspace_persona_creation.py.
 """
 
 from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
+from tldw_chatbook.Chat.console_assistant_defaults import (
+    build_persona_agent_system_prompt,
+)
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
     ConsoleWorkspaceContext,
 )
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_session_settings import (
     ConsoleSessionSettings,
     default_console_session_settings,
 )
-from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.UI.Console_Modules.session import (
     ConsoleSessionController,
-    build_persona_agent_system_prompt,
 )
 from tldw_chatbook.Workspaces.models import (
     DEFAULT_WORKSPACE_ID,
@@ -141,6 +139,178 @@ def _host(workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID, *, workspace=None, persona=P
 
 def _resolve_workspace_default(host):
     return ConsoleSessionController._workspace_default_for_new_session(host)
+
+
+def _creation_store():
+    from tldw_chatbook.Chat.console_assistant_defaults import (
+        resolve_new_console_assistant,
+    )
+
+    target = _workspace(
+        "target",
+        defaults=WorkspaceAssistantDefaults(
+            assistant_id=PERSONA["id"], persona_memory_mode="read_write"
+        ),
+    )
+    app = StubApp(
+        StubRegistry({"target": target}), StubPersonas({PERSONA["id"]: PERSONA})
+    )
+    app.app_config = {}
+    return ConsoleChatStore(
+        workspace_context=ConsoleWorkspaceContext(active_workspace_id="elsewhere"),
+        assistant_defaults_provider=lambda workspace_id, settings: (
+            resolve_new_console_assistant(app, workspace_id, settings)
+        ),
+    ), app
+
+
+@pytest.mark.parametrize("surface", ["create", "ensure", "controller", "temporary"])
+def test_creation_seams_resolve_target_workspace_once_and_preserve_memory(surface):
+    """Bootstrap/new/temporary creation must not miss or borrow workspace identity."""
+    store, app = _creation_store()
+    settings = default_console_session_settings({}, "llama_cpp")
+    if surface == "create":
+        session = store.create_session(workspace_id="target", settings=settings)
+    elif surface == "ensure":
+        session = store.ensure_session(workspace_id="target", settings=settings)
+    else:
+        store.workspace_context = ConsoleWorkspaceContext(active_workspace_id="target")
+        session = _controller(store).new_session(
+            settings=settings, ephemeral=surface == "temporary"
+        )
+    assert session.workspace_id == "target"
+    assert session.assistant_kind == "persona"
+    assert session.assistant_id == PERSONA["id"]
+    assert (
+        session.persona_memory_mode
+        == session.settings.persona_memory_mode
+        == "read_write"
+    )
+    assert "literary companion" in session.settings.system_prompt
+    app.workspace_registry_service = StubRegistry({})
+    assert store.ensure_session().assistant_id == PERSONA["id"]
+
+
+@pytest.mark.parametrize(
+    "kind,assistant_id",
+    [(None, None), ("generic", "console"), ("persona", "chosen"), ("character", "12")],
+)
+def test_explicit_identity_bypasses_workspace_inheritance(kind, assistant_id):
+    """An explicit plain, copied/restored, Persona or Character choice wins."""
+    store, _app = _creation_store()
+    session = store.create_session(
+        workspace_id="target",
+        settings=default_console_session_settings({}, "llama_cpp"),
+        assistant_kind=kind,
+        assistant_id=assistant_id,
+    )
+    assert session.assistant_kind == (kind or "generic")
+    assert session.assistant_id == (assistant_id or "console")
+    assert session.settings.system_prompt is None
+
+
+def test_unavailable_default_keeps_plain_identity_and_exposes_reason():
+    store, app = _creation_store()
+    app.local_character_persona_service = StubPersonas({})
+    session = store.create_session(workspace_id="target")
+    assert session.assistant_kind == "generic"
+    assert session.assistant_id == "console"
+    assert "unavailable" in session.assistant_default_notice.lower()
+    assert "persona_deleted" in session.assistant_default_notice
+
+
+def test_created_persona_identity_persists_reopens_and_survives_workspace_move(
+    tmp_path,
+):
+    """The durable identity and fork source keep memory mode after a workspace change."""
+    from Tests.Workspaces.test_agent_provisioning import build
+    from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+    from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+
+    db = CharactersRAGDB(tmp_path / "chat.db", "creation-test")
+    try:
+        registry, _permissions = build(tmp_path)
+        registry.create_workspace(workspace_id="target", name="Target")
+        registry.create_workspace(workspace_id="moved", name="Moved")
+        persistence = ChatPersistenceService(db, workspace_registry=registry)
+        store, _app = _creation_store()
+        store.persistence = persistence
+        session = store.create_session(workspace_id="target")
+        conversation_id = store.persist_session_if_needed(session.id)
+        record = db.get_conversation_by_id(conversation_id)
+        assert record["assistant_kind"] == "persona"
+        assert record["assistant_id"] == PERSONA["id"]
+        assert record["persona_memory_mode"] == "read_write"
+        service = ChatConversationService(db)
+        assert service.update_conversation_metadata(
+            conversation_id,
+            {"scope_type": "workspace", "workspace_id": "moved"},
+            record["version"],
+        )
+        moved = db.get_conversation_by_id(conversation_id)
+        restored = store.restore_persisted_session(
+            title="Moved",
+            workspace_id=moved["workspace_id"],
+            persisted_conversation_id=conversation_id,
+            all_nodes=[],
+            settings=session.settings,
+            assistant_kind=moved["assistant_kind"],
+            assistant_id=moved["assistant_id"],
+            persona_memory_mode=moved["persona_memory_mode"],
+        )
+        assert restored.workspace_id == "moved"
+        assert restored.assistant_id == PERSONA["id"]
+        assert (
+            restored.persona_memory_mode
+            == restored.settings.persona_memory_mode
+            == "read_write"
+        )
+        fork = store._fork_configuration_snapshot(restored)
+        assert fork.assistant_id == PERSONA["id"]
+        assert fork.persona_memory_mode == "read_write"
+    finally:
+        db.close_connection()
+
+
+def test_provider_setup_recovery_keeps_created_persona_prompt(monkeypatch):
+    """Refreshing unused provider defaults must not erase the assigned Persona."""
+    from types import SimpleNamespace
+
+    import tldw_chatbook.UI.Console_Modules.session as session_module
+
+    store, _app = _creation_store()
+    session = store.create_session(
+        workspace_id="target",
+        settings=ConsoleSessionSettings(provider="openai"),
+        canonical_settings_baseline=ConsoleSessionSettings(provider="openai"),
+    )
+    before = session.settings
+    host = SimpleNamespace(
+        _console_new_chat_default_generation=lambda: 0,
+        _provider_readiness_app_config=dict,
+        _CONSOLE_REFRESHABLE_BLOCKED_LABELS={"missing-key"},
+        _notify_stale_default_provider_swap=lambda *_args: None,
+    )
+    monkeypatch.setattr(
+        session_module,
+        "build_console_settings_readiness",
+        lambda value, **_kwargs: SimpleNamespace(
+            native_send_supported=value.provider == "llama_cpp", label="missing-key"
+        ),
+    )
+    monkeypatch.setattr(
+        session_module,
+        "blank_console_session_settings",
+        lambda _config: ConsoleSessionSettings(provider="llama_cpp"),
+    )
+    after = ConsoleSessionController._maybe_refresh_stale_default_console_settings(
+        host, store, session
+    )
+    assert after.provider == "llama_cpp"
+    assert after.system_prompt == before.system_prompt
+    assert after.character_label == "Lit Agent"
+    assert after.persona_memory_mode == session.persona_memory_mode == "read_write"
 
 
 # -- Layer 1: the workspace-default resolver --------------------------------
@@ -402,6 +572,8 @@ def test_new_tab_re_resolves_workspace_persona_on_published_defaults():
         "assistant_kind": "persona",
         "assistant_id": "local-persona-1",
         "assistant_label": "Lit Agent",
+        "persona_memory_mode": "read_only",
+        "assistant_default_notice": "",
     }
 
 

--- a/Tests/DB/test_workspace_db.py
+++ b/Tests/DB/test_workspace_db.py
@@ -7,6 +7,48 @@ from tldw_chatbook.DB.Workspace_DB import WorkspaceDB
 from tldw_chatbook.Workspaces import LocalWorkspaceRegistryService
 
 
+def test_v8_explicit_none_migration_rolls_back_when_version_write_fails(tmp_path):
+    """A failed migration must leave the previous workspace schema and rows intact."""
+    path = tmp_path / "v7.sqlite"
+    db = WorkspaceDB(path)
+    registry = LocalWorkspaceRegistryService(db)
+    registry.create_workspace(workspace_id="prior", name="Prior")
+    with db.transaction() as connection:
+        connection.execute(
+            "ALTER TABLE workspace_records DROP COLUMN assistant_defaults_explicit_none"
+        )
+        connection.execute("DELETE FROM schema_version WHERE version = 8")
+        connection.execute("""CREATE TRIGGER refuse_v8 BEFORE INSERT ON schema_version
+            WHEN NEW.version = 8 BEGIN SELECT RAISE(ABORT, 'version failure'); END""")
+    db.close()
+    with pytest.raises(sqlite3.IntegrityError, match="version failure"):
+        WorkspaceDB(path)
+    with sqlite3.connect(path) as connection:
+        assert (
+            connection.execute("SELECT MAX(version) FROM schema_version").fetchone()[0]
+            == 7
+        )
+        assert "assistant_defaults_explicit_none" not in {
+            row[1] for row in connection.execute("PRAGMA table_info(workspace_records)")
+        }
+        assert (
+            connection.execute(
+                "SELECT name FROM workspace_records WHERE workspace_id='prior'"
+            ).fetchone()[0]
+            == "Prior"
+        )
+        connection.execute("DROP TRIGGER refuse_v8")
+    upgraded = WorkspaceDB(path)
+    assert upgraded.get_schema_version() == 8
+    assert (
+        LocalWorkspaceRegistryService(upgraded)
+        .get_workspace("prior")
+        .assistant_defaults_explicit_none
+        is False
+    )
+    upgraded.close()
+
+
 _WORKSPACE_V2_SCHEMA = """
 PRAGMA foreign_keys = ON;
 
@@ -346,7 +388,7 @@ def test_genuine_v2_upgrade_preserves_unrelated_rows_and_accepts_server_target(
         versions = connection.execute(
             "SELECT version FROM schema_version ORDER BY version"
         ).fetchall()
-        assert [row[0] for row in versions] == [1, 2, 3, 4, 5, 6]
+        assert [row[0] for row in versions] == list(range(1, WorkspaceDB._CURRENT_SCHEMA_VERSION + 1))
         kept = connection.execute(
             "SELECT name, description FROM workspace_records WHERE workspace_id = ?",
             ("local-kept",),
@@ -425,7 +467,7 @@ def test_genuine_v3_upgrade_adds_payload_free_receipts_and_drops_unverifiable_le
 
     db = WorkspaceDB(path)
 
-    assert db.get_schema_version() == 6
+    assert db.get_schema_version() == WorkspaceDB._CURRENT_SCHEMA_VERSION
     with db.connection() as connection:
         columns = {
             row[1]
@@ -495,7 +537,7 @@ def test_early_branch_v4_upgrade_quarantines_only_unsafe_receipts(
 
     db = WorkspaceDB(path)
 
-    assert db.get_schema_version() == 6
+    assert db.get_schema_version() == WorkspaceDB._CURRENT_SCHEMA_VERSION
     migration_path = (
         Path(__file__).parents[2]
         / "tldw_chatbook/DB/migrations/workspaces_v4_to_v5_quick_note_receipts.sql"

--- a/Tests/Persona_Buddy/test_buddy_inbox.py
+++ b/Tests/Persona_Buddy/test_buddy_inbox.py
@@ -1,0 +1,100 @@
+"""Workspace inbox rows derive from current authority, never ambient selection."""
+
+from types import SimpleNamespace
+
+from tldw_chatbook.Chat.console_activity_receipts import ConsoleActivityReceipt
+from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
+
+
+def receipt(key, session=None, conversation=None):
+    return ConsoleActivityReceipt(
+        key, "ordinary", key, 1, session, conversation, None, None, "done", "now"
+    )
+
+
+def project(sessions=(), receipts=(), statuses=None, activities=None, members=None):
+    from tldw_chatbook.Persona_Buddy.inbox import project_workspace_inbox
+
+    return project_workspace_inbox(
+        "workspace-a",
+        sessions=sessions,
+        receipts=receipts,
+        run_states=statuses or {},
+        activities=activities or {},
+        member_titles=members or {},
+    )
+
+
+def test_inbox_filters_history_and_other_workspaces_and_orders_attention_first():
+    waiting = ConsoleChatSession(id="waiting", workspace_id="workspace-a")
+    running = ConsoleChatSession(id="running", workspace_id="workspace-a")
+    history = ConsoleChatSession(id="history", workspace_id="workspace-a")
+    outside = ConsoleChatSession(id="outside", workspace_id="workspace-b")
+    entries = project(
+        (running, history, outside, waiting),
+        statuses={
+            key: ConsoleRunState(ConsoleRunStatus.STREAMING)
+            for key in ("running", "outside", "waiting")
+        },
+        activities={"waiting": SimpleNamespace(needs_approval=True)},
+    )
+    assert [(row.binding.target_id, row.group) for row in entries] == [
+        ("waiting", "needs_you"),
+        ("running", "running"),
+    ]
+
+
+def test_two_results_in_one_conversation_keep_separate_acknowledgement_ids():
+    session = ConsoleChatSession(
+        id="live", workspace_id="workspace-a", persisted_conversation_id="saved"
+    )
+    entries = project(
+        (session,), (receipt("old", "live", "saved"), receipt("new", "live", "saved"))
+    )
+    assert [row.receipt_ids for row in entries] == [("old",), ("new",)]
+    assert entries[0].key != entries[1].key
+
+
+def test_repurposed_live_slot_cannot_claim_old_result():
+    session = ConsoleChatSession(
+        id="live", workspace_id="workspace-a", persisted_conversation_id="different"
+    )
+    assert project((session,), (receipt("old", "live", "former"),)) == ()
+
+
+def test_unloaded_result_requires_current_membership_and_keeps_durable_target():
+    entries = project(
+        receipts=(
+            receipt("result", "old-runtime", "saved"),
+            receipt("outside", None, "other"),
+        ),
+        members={"saved": "Research"},
+    )
+    assert len(entries) == 1
+    assert entries[0].title == "Research"
+    assert entries[0].binding.conversation_id == "saved"
+
+
+def test_current_session_workspace_wins_over_stale_membership():
+    session = ConsoleChatSession(
+        id="live", workspace_id="workspace-b", persisted_conversation_id="saved"
+    )
+    assert (
+        project(
+            (session,),
+            (receipt("result", "live", "saved"),),
+            members={"saved": "Stale"},
+        )
+        == ()
+    )
+
+
+def test_paused_queue_needs_attention_without_pretending_to_be_a_question():
+    session = ConsoleChatSession(id="live", workspace_id="workspace-a")
+    entries = project(
+        (session,),
+        activities={"live": SimpleNamespace(queue_paused=True, queued_count=2)},
+    )
+    assert entries[0].group == "needs_you"
+    assert "paused" in entries[0].summary.lower()

--- a/Tests/Persona_Buddy/test_buddy_interaction.py
+++ b/Tests/Persona_Buddy/test_buddy_interaction.py
@@ -1,0 +1,94 @@
+"""Exact Buddy scope and private preference admission."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def interaction_module():
+    import importlib.util
+
+    assert (
+        importlib.util.find_spec("tldw_chatbook.Persona_Buddy.interaction") is not None
+    ), "Buddy scope contract is missing"
+    from tldw_chatbook.Persona_Buddy import interaction
+
+    return interaction
+
+
+def session(
+    id="live-a",
+    persisted="conversation-a",
+    revision=0,
+    backend="local",
+    ephemeral=False,
+):
+    return SimpleNamespace(
+        id=id,
+        persisted_conversation_id=persisted,
+        conversation_binding_revision=revision,
+        runtime_backend=backend,
+        ephemeral=ephemeral,
+        workspace_id="workspace-a",
+    )
+
+
+def test_binding_resolves_its_conversation_without_using_active_selection():
+    m = interaction_module()
+    a, b = session(), session("live-b", "conversation-b")
+    target = m.BuddyBinding.for_session(a)
+    assert target.resolve_session([b, a]) is a
+    assert target.resolve_session([b]) is None
+
+
+def test_repurposed_live_slot_never_receives_a_bound_reply():
+    m = interaction_module()
+    target = m.BuddyBinding.for_session(session())
+    assert (
+        target.resolve_session([session(persisted="conversation-b", revision=1)])
+        is None
+    )
+    assert target.resolve_session([session(revision=1)]) is None
+
+
+def test_durable_binding_can_reconnect_after_restart_but_never_across_sources():
+    m = interaction_module()
+    target = m.BuddyBinding.for_session(session())
+    restored = session("new-live-id")
+    assert target.resolve_session([restored]) is restored
+    assert target.resolve_session([session("server-live", backend="server")]) is None
+
+
+def test_temporary_binding_does_not_enter_profile_config():
+    m = interaction_module()
+    target = m.BuddyBinding.for_session(session(persisted=None, ephemeral=True))
+    prefs = m.BuddyInteractionPreferences(binding=target, animated=False)
+    encoded = m.serialize_preferences(prefs)
+    assert "live-a" not in str(encoded)
+    assert m.parse_preferences(encoded).binding is None
+    assert m.parse_preferences(encoded).animated is False
+
+
+def test_workspace_binding_matches_only_its_own_local_sessions():
+    m = interaction_module()
+    target = m.BuddyBinding(kind="workspace", target_id="workspace-a")
+    assert target.includes(session())
+    assert not target.includes(session(backend="server"))
+    different = session()
+    different.workspace_id = "workspace-b"
+    assert not target.includes(different)
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        {"kind": "other", "target_id": "ok"},
+        {"kind": "conversation", "target_id": ""},
+        {"kind": "workspace", "target_id": "../../private"},
+        {"kind": "conversation", "target_id": "a", "binding_revision": True},
+    ],
+)
+def test_invalid_scope_is_rejected(raw):
+    m = interaction_module()
+    with pytest.raises(ValueError):
+        m.BuddyBinding(**raw)

--- a/Tests/Persona_Buddy/test_buddy_library.py
+++ b/Tests/Persona_Buddy/test_buddy_library.py
@@ -457,3 +457,132 @@ def test_active_buddy_lookup_uses_partial_index_without_statistics(environment):
     assert any("idx_buddy_visual_bindings_active" in str(row[3]) for row in plan)
     binding = repository._active_binding_record(None, buddy_id=buddy.id)
     assert binding is not None and binding.buddy_id == buddy.id
+
+
+def test_archive_path_uses_shared_validation_before_opening(tmp_path, monkeypatch):
+    from tldw_chatbook.Persona_Visual import snapshot
+    from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportError
+
+    opened = []
+    monkeypatch.setattr(
+        snapshot.importer, "_pin_source", lambda path: opened.append(path)
+    )
+    with pytest.raises(PersonaVisualImportError):
+        snapshot.read_buddy_archive(str(tmp_path / "../../forbidden.zip"))
+    assert opened == []
+
+
+def test_archive_path_keeps_no_follow_symlink_boundary(tmp_path):
+    from Tests.Persona_Visual.test_persona_visual_importer import _write_archive
+    from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportError
+    from tldw_chatbook.Persona_Visual.snapshot import read_buddy_archive
+
+    target = _write_archive(tmp_path / "target.zip")
+    link = tmp_path / "link.zip"
+    link.symlink_to(target)
+    with pytest.raises(PersonaVisualImportError):
+        read_buddy_archive(link)
+
+
+def test_listing_pages_are_bounded_and_lookup_does_not_scan_collection(
+    environment, monkeypatch
+):
+    library, repo, *_ = environment
+    original = library.copy_persona("persona-local-1")
+    graph = library.get_graph(original.id)
+    with repo.db.transaction() as cursor:
+        for index in range(205):
+            buddy_id = f"page-{index:03d}"
+            cursor.execute(
+                "INSERT INTO buddy_profiles(id,name) VALUES (?,?)",
+                (buddy_id, "Same name"),
+            )
+            cursor.execute(
+                "INSERT INTO buddy_visual_bindings(buddy_id,buddy_revision,pack_id,active_version_id) VALUES (?,1,?,?)",
+                (buddy_id, graph.identity.pack_id, graph.identity.pack_version_id),
+            )
+    page1 = library.list_buddies(limit=100, offset=0)
+    page2 = library.list_buddies(limit=100, offset=100)
+    page3 = library.list_buddies(limit=100, offset=200)
+    assert [len(page) for page in (page1, page2, page3)] == [100, 100, 6]
+    assert len({row.id for page in (page1, page2, page3) for row in page}) == 206
+    assert len(library.list_buddies()) == 100
+    monkeypatch.setattr(
+        library,
+        "list_buddies",
+        lambda **_: pytest.fail("single lookup scanned library"),
+    )
+    assert library.get_buddy("page-204").id == "page-204"
+    assert library.get_buddy("missing") is None
+
+
+def test_library_reads_hold_transaction(environment):
+    library, repo, *_ = environment
+    buddy = library.copy_persona("persona-local-1", source_key="read-guard")
+    connection = repo.db.get_connection()
+    reads = []
+    connection.set_trace_callback(
+        lambda statement: (
+            reads.append(connection.in_transaction)
+            if statement.lstrip().upper().startswith("SELECT")
+            and "buddy_profiles" in statement
+            else None
+        )
+    )
+    try:
+        assert library.list_buddies()
+        assert library._source_record("read-guard") == buddy
+    finally:
+        connection.set_trace_callback(None)
+    assert reads and all(reads)
+
+
+def test_buddy_migration_verification_failure_rolls_back_schema(tmp_path, monkeypatch):
+    from tldw_chatbook.DB.ChaChaNotes_DB import SchemaError
+
+    monkeypatch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 69)
+    db = CharactersRAGDB(tmp_path / "rollback.db", "rollback")
+    original = db._get_db_version
+    monkeypatch.setattr(
+        db,
+        "_get_db_version",
+        lambda connection: 71 if original(connection) == 70 else original(connection),
+    )
+    try:
+        with pytest.raises(SchemaError, match="version check"):
+            db._migrate_from_v69_to_v70(db.get_connection())
+        assert original(db.get_connection()) == 69
+        assert (
+            db.execute_query(
+                "SELECT name FROM sqlite_master WHERE name='buddy_profiles'"
+            ).fetchone()
+            is None
+        )
+    finally:
+        db.close_connection()
+
+
+def test_buddy_archive_publication_cannot_spoof_import_provenance(
+    environment, tmp_path
+):
+    import json
+
+    from Tests.Persona_Visual.test_persona_visual_importer import (
+        _archive_payloads,
+        _canonical,
+        _replace_declared_payload,
+        _write_archive,
+    )
+
+    library, repo, *_ = environment
+    payloads = _archive_payloads()
+    pack = json.loads(payloads["metadata/pack.json"])
+    pack["pack"]["source_context"] = {
+        "provenance": "trusted-builtin",
+        "license": "Keep notice",
+    }
+    _replace_declared_payload(payloads, "metadata/pack.json", _canonical(pack))
+    buddy = library.import_archive(_write_archive(tmp_path / "forged.zip", payloads))
+    context = dict(repo.get_active_buddy_pack_for_export(buddy.id).source_context)
+    assert context["provenance"] == "untrusted-import"
+    assert context["license"] == "Keep notice"

--- a/Tests/Persona_Buddy/test_buddy_library.py
+++ b/Tests/Persona_Buddy/test_buddy_library.py
@@ -1,0 +1,438 @@
+"""Independent Buddy publication uses real SQLite and decoded image bytes."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+from Tests.Persona_Visual.test_persona_visual_publication import _snapshot
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Visual.publication import publish_persona_visual
+from tldw_chatbook.Persona_Visual.repository import PersonaVisualRepository
+
+
+@pytest.fixture
+def environment(tmp_path: Path):
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+    profile = tmp_path / "profile"
+    source = tmp_path / "source"
+    profile.mkdir(mode=0o700)
+    source.mkdir(mode=0o700)
+    db = CharactersRAGDB(tmp_path / "buddy.db", "independent-buddy")
+    repository = PersonaVisualRepository(db)
+    snapshot = _snapshot(source)
+    publish_persona_visual(
+        repository,
+        snapshot,
+        source_root=source,
+        profile_root=profile,
+        authority_guard=lambda: True,
+    )
+    library = BuddyLibrary(
+        db,
+        profile,
+        persona_reader=lambda _: {
+            "id": "persona-local-1",
+            "version": 7,
+            "is_active": True,
+            "deleted": False,
+        },
+    )
+    try:
+        yield library, repository, source, profile, snapshot
+    finally:
+        db.close_connection()
+
+
+def test_copy_has_real_buddy_owner_and_survives_persona_changes(environment):
+    from tldw_chatbook.Persona_Visual.runtime import resolve_active_buddy_visual
+
+    library, repo, source, profile, _ = environment
+    original = repo.get_active_persona_pack("persona-local-1")
+    buddy = library.copy_persona("persona-local-1", source_key="legacy:one")
+    graph = library.get_graph(buddy.id)
+    assert graph.identity.persona_id is None
+    assert graph.identity.buddy_id == buddy.id
+    assert graph.pack.id != original.pack.id
+    assert (
+        library.copy_persona("persona-local-1", source_key="legacy:one").id == buddy.id
+    )
+    updated = _snapshot(source, expected_identity=original.identity, color=(250, 0, 0))
+    publish_persona_visual(
+        repo,
+        updated,
+        source_root=source,
+        profile_root=profile,
+        authority_guard=lambda: True,
+    )
+    repo.archive_binding(
+        persona_id="persona-local-1",
+        expected_identity=repo.get_active_persona_pack("persona-local-1").identity,
+    )
+    assert library.get_graph(buddy.id) == graph
+    visual = resolve_active_buddy_visual(repo, buddy.id, profile, "idle")
+    assert visual.cache_identity.graph == graph.identity
+    assert visual.reason is None
+    assert len(library.list_buddies()) == 1
+
+
+@pytest.mark.asyncio
+async def test_independent_controller_needs_no_persona_service(environment):
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        BuddySelection,
+        PersonaBuddyPreferences,
+    )
+
+    library, repo, _, profile, _ = environment
+    buddy = library.copy_persona("persona-local-1")
+    controller = PersonaBuddyController(
+        preferences=PersonaBuddyPreferences(
+            enabled=True, selection=BuddySelection(buddy.id)
+        ),
+        profile_db=repo.db,
+        profile_root=profile,
+    )
+    try:
+        visual = await controller.resolve_current_visual(cols=12, lines=6)
+        assert visual.available
+        assert visual.graph_identity.buddy_id == buddy.id
+        assert visual.persona_id is None
+    finally:
+        await controller.shutdown()
+
+
+def test_builtin_is_independent_and_idempotent(environment):
+    library, repo, _, _, _ = environment
+    first = library.ensure_builtin()
+    second = library.ensure_builtin()
+    assert first.id == second.id
+    assert library.get_graph(first.id).identity.persona_id is None
+    assert repo.get_active_persona_pack("local-persona-builtin-pixel-migu") is None
+
+
+def test_native_archive_review_is_read_only_and_preserves_notices(
+    environment, tmp_path
+):
+    import json
+
+    from Tests.Persona_Visual.test_persona_visual_importer import (
+        _archive_payloads,
+        _canonical,
+        _replace_declared_payload,
+        _write_archive,
+    )
+    from tldw_chatbook.Persona_Visual.artwork import decode_native_artwork
+
+    library, repo, _, _, _ = environment
+    payloads = _archive_payloads()
+    pack = json.loads(payloads["metadata/pack.json"])
+    pack["pack"].update(
+        creator="Original Artist",
+        license=None,
+        source_url="https://example.com/pet",
+        notices="Original notice\nSecond line",
+    )
+    _replace_declared_payload(payloads, "metadata/pack.json", _canonical(pack))
+    path = _write_archive(tmp_path / "native.tldw-persona-vpack", payloads)
+    review = library.review_archive(path)
+    assert library.list_buddies() == ()
+    assert review.artwork["license"] is None
+    buddy = library.publish_review(review)
+    saved = repo.get_active_buddy_pack_for_export(buddy.id)
+    assert decode_native_artwork(dict(saved.source_context)["artwork"]) == dict(
+        review.artwork
+    )
+    assert saved.graph.identity.persona_id is None
+    assert library.resolve_preview(buddy.id).reason is None
+
+
+def test_migration_keeps_geometry_and_reuses_committed_copy_after_write_failure(
+    environment,
+):
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        BuddySelection,
+        PersonaBuddyGeometry,
+        PersonaBuddyPreferences,
+        PersonaBuddySelection,
+        parse_persona_buddy_preferences,
+        serialize_persona_buddy_preferences,
+    )
+
+    library, repo, _, profile, _ = environment
+    old = PersonaBuddyPreferences(
+        enabled=False,
+        open=False,
+        collapsed=True,
+        geometry=PersonaBuddyGeometry(2, 3, 19, 8),
+        selection=PersonaBuddySelection("local", "persona-local-1"),
+    )
+    assert library.migrate_legacy_selection(old, writer=lambda _: False) == old
+    first = library.list_buddies()
+    assert len(first) == 1
+    # Restart with no source service; the committed migration copy is sufficient.
+    reopened = BuddyLibrary(repo.db, profile)
+    writes = []
+    new = reopened.migrate_legacy_selection(
+        old, writer=lambda value: writes.append(value) is None
+    )
+    assert new == replace(old, selection=BuddySelection(first[0].id))
+    assert (
+        parse_persona_buddy_preferences(serialize_persona_buddy_preferences(new)) == new
+    )
+    assert len(reopened.list_buddies()) == 1
+    assert writes == [new]
+
+
+def test_failed_copy_and_stale_review_do_not_change_library_or_selection(
+    environment, tmp_path
+):
+    from Tests.Persona_Visual.test_persona_visual_importer import _write_archive
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        PersonaBuddyPreferences,
+        PersonaBuddySelection,
+    )
+
+    library, repo, _, _, _ = environment
+    old = PersonaBuddyPreferences(
+        enabled=True, selection=PersonaBuddySelection("local", "missing")
+    )
+    assert library.migrate_legacy_selection(old, writer=lambda _: True) == old
+    path = _write_archive(tmp_path / "native.tldw-persona-vpack")
+    review = library.review_archive(path)
+    path.unlink()
+    with pytest.raises(ValueError, match="buddy_source_changed"):
+        library.publish_review(review)
+    assert library.list_buddies() == ()
+    assert (
+        repo.db.execute_query("SELECT COUNT(*) FROM buddy_profiles").fetchone()[0] == 0
+    )
+
+
+def test_publication_rejection_leaves_no_owned_graph(environment, tmp_path):
+    from Tests.Persona_Visual.test_persona_visual_importer import _write_archive
+
+    library, repo, _, _, _ = environment
+    review = library.review_archive(
+        _write_archive(tmp_path / "native.tldw-persona-vpack")
+    )
+    corrupt = replace(review, assets=(replace(review.assets[0], data=b"invalid"),))
+    with pytest.raises(ValueError):
+        library.publish_review(corrupt)
+    assert library.list_buddies() == ()
+    assert (
+        repo.db.execute_query("SELECT COUNT(*) FROM buddy_profiles").fetchone()[0] == 0
+    )
+
+
+def test_schema69_upgrade_and_restart_preserve_legacy_binding(tmp_path, monkeypatch):
+    from Tests.Persona_Visual.test_persona_visual_repository import _activate
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+    path = tmp_path / "upgrade.db"
+    monkeypatch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 69)
+    old = CharactersRAGDB(path, "upgrade")
+    legacy = _activate(PersonaVisualRepository(old))
+    old.close_connection()
+    monkeypatch.setattr(CharactersRAGDB, "_CURRENT_SCHEMA_VERSION", 70)
+    upgraded = CharactersRAGDB(path, "upgrade")
+    try:
+        assert (
+            upgraded.execute_query(
+                "SELECT version FROM db_schema_version WHERE schema_name='rag_char_chat_schema'"
+            ).fetchone()[0]
+            == 70
+        )
+        assert upgraded.execute_query("PRAGMA foreign_key_check").fetchall() == []
+        assert BuddyLibrary(upgraded, tmp_path).list_buddies() == ()
+        assert (
+            PersonaVisualRepository(upgraded).get_active_persona_pack(
+                legacy.identity.persona_id
+            )
+            == legacy
+        )
+    finally:
+        upgraded.close_connection()
+
+
+@pytest.mark.asyncio
+async def test_management_batch_save_and_revision_guard(monkeypatch):
+    import tldw_chatbook.Persona_Buddy.preferences as preference_module
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+
+    writes = []
+    monkeypatch.setattr(
+        preference_module,
+        "save_settings_to_cli_config",
+        lambda sections: writes.append(sections) is None,
+    )
+    controller = PersonaBuddyController()
+    try:
+        old = controller.current_preferences()
+        revision = controller.apply_preferences_patch(
+            enabled=True, selection=BuddySelection("buddy-one")
+        )
+        assert await controller.persist_preferences_revision(
+            revision,
+            extra_sections={
+                "buddy_interaction": {
+                    "scope_kind": "conversation",
+                    "scope_id": "exact-conversation",
+                },
+            },
+        )
+        assert len(writes) == 1
+        assert writes[0]["persona_buddy"]["buddy_id"] == "buddy-one"
+        assert writes[0]["buddy_interaction"]["scope_id"] == "exact-conversation"
+        newer = controller.apply_preferences_patch(open=False)
+        assert not controller.rollback_preferences_revision(revision, old)
+        assert controller.current_preferences().open is False
+        assert controller.rollback_preferences_revision(newer, old)
+        assert controller.current_preferences() == old
+        assert not await controller.persist_preferences_revision(
+            revision, extra_sections={"buddy_interaction": {}}
+        )
+        assert len(writes) == 1
+    finally:
+        await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_controller_migrates_only_after_persisted_copy(environment):
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        BuddySelection,
+        PersonaBuddyPreferences,
+        PersonaBuddySelection,
+    )
+
+    library, repo, _, profile, _ = environment
+    old = PersonaBuddyPreferences(
+        enabled=True, selection=PersonaBuddySelection("local", "persona-local-1")
+    )
+    controller = PersonaBuddyController(
+        preferences=old,
+        profile_db=repo.db,
+        profile_root=profile,
+        preference_writer=lambda _: False,
+    )
+    try:
+        assert not await controller.migrate_legacy_selection(library)
+        assert controller.current_preferences() == old
+        controller._preference_writer = lambda _: True
+        assert await controller.migrate_legacy_selection(library)
+        assert type(controller.current_preferences().selection) is BuddySelection
+        assert len(library.list_buddies()) == 1
+    finally:
+        await controller.shutdown()
+
+
+def test_buddy_version_publication_uses_exact_owner_and_preserves_notices(environment):
+    import json
+
+    from tldw_chatbook.Persona_Visual.artwork import encode_native_artwork
+
+    library, repo, source, profile, _ = environment
+    buddy = library.copy_persona("persona-local-1")
+    graph = library.get_graph(buddy.id)
+    artwork = {
+        "version": 1,
+        "creator": "Artist",
+        "license": None,
+        "source_url": None,
+        "notices": "Keep this notice",
+    }
+    updated = replace(
+        _snapshot(source),
+        persona_id=None,
+        persona_revision=0,
+        buddy_id=buddy.id,
+        buddy_revision=buddy.revision,
+        expected_identity=graph.identity,
+        source_context=(("artwork", encode_native_artwork(artwork)),),
+    )
+    result = publish_persona_visual(
+        repo,
+        updated,
+        source_root=source,
+        profile_root=profile,
+        authority_guard=lambda: True,
+    )
+    assert result.new_identity.version_number == 2
+    assert result.new_identity.buddy_id == buddy.id
+    stored = repo.get_active_buddy_pack_for_export(buddy.id)
+    assert json.loads(dict(stored.source_context)["artwork"]) == artwork
+    assert library.resolve_preview(buddy.id).cache_identity.graph == result.new_identity
+    with pytest.raises(ValueError, match="identity_changed"):
+        publish_persona_visual(
+            repo,
+            updated,
+            source_root=source,
+            profile_root=profile,
+            authority_guard=lambda: True,
+        )
+
+
+def test_builtin_retains_legacy_and_independent_tombstones(environment):
+    library, repo, _, _, _ = environment
+    assert library.ensure_builtin(legacy_retired=True) is None
+    assert library.list_buddies() == ()
+    buddy = library.ensure_builtin()
+    assert library.ensure_builtin(legacy_retired=True) == buddy
+    with repo.db.transaction():
+        repo.db.execute_query(
+            "UPDATE buddy_profiles SET status='deleted' WHERE id=?", (buddy.id,)
+        )
+    assert library.ensure_builtin() is None
+    assert library.get_graph(buddy.id) is None
+
+
+def test_published_buddy_reopens_without_source_service(environment):
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+    library, repo, _, profile, _ = environment
+    buddy = library.copy_persona("persona-local-1")
+    expected = library.get_graph(buddy.id)
+    reopened_db = CharactersRAGDB(repo.db.db_path, "reopened-independent-buddy")
+    try:
+        reopened = BuddyLibrary(reopened_db, profile)
+        assert reopened.get_buddy(buddy.id) == buddy
+        assert reopened.get_graph(buddy.id) == expected
+        assert (
+            reopened.resolve_preview(buddy.id).cache_identity.graph == expected.identity
+        )
+    finally:
+        reopened_db.close_connection()
+
+
+def test_changed_persona_authority_rejects_the_copy(environment, monkeypatch):
+    import tldw_chatbook.Persona_Buddy.library as library_module
+
+    library, repo, _, _, _ = environment
+    record = {
+        "id": "persona-local-1",
+        "version": 7,
+        "is_active": True,
+        "deleted": False,
+    }
+    library.persona_reader = lambda _: dict(record)
+    original_publish = library_module.publish_persona_visual
+
+    def publish_after_persona_change(*args, **kwargs):
+        record["version"] = 8
+        return original_publish(*args, **kwargs)
+
+    monkeypatch.setattr(
+        library_module, "publish_persona_visual", publish_after_persona_change
+    )
+    with pytest.raises(ValueError, match="authority_changed"):
+        library.copy_persona("persona-local-1")
+    assert library.list_buddies() == ()
+    assert (
+        repo.db.execute_query("SELECT COUNT(*) FROM buddy_profiles").fetchone()[0] == 0
+    )

--- a/Tests/Persona_Buddy/test_buddy_library.py
+++ b/Tests/Persona_Buddy/test_buddy_library.py
@@ -436,3 +436,24 @@ def test_changed_persona_authority_rejects_the_copy(environment, monkeypatch):
     assert (
         repo.db.execute_query("SELECT COUNT(*) FROM buddy_profiles").fetchone()[0] == 0
     )
+
+
+def test_active_buddy_lookup_uses_partial_index_without_statistics(environment):
+    library, repository, *_ = environment
+    buddy = library.copy_persona("persona-local-1")
+    connection = library.db.get_connection()
+    # Pin the actual union-view lookup, without ANALYZE influencing the planner.
+    assert (
+        connection.execute(
+            "SELECT name FROM sqlite_master WHERE name = 'sqlite_stat1'"
+        ).fetchone()
+        is None
+    )
+    plan = connection.execute(
+        "EXPLAIN QUERY PLAN SELECT * FROM visual_owner_bindings "
+        "WHERE persona_id IS ? AND buddy_id IS ? AND status = 'active'",
+        (None, buddy.id),
+    ).fetchall()
+    assert any("idx_buddy_visual_bindings_active" in str(row[3]) for row in plan)
+    binding = repository._active_binding_record(None, buddy_id=buddy.id)
+    assert binding is not None and binding.buddy_id == buddy.id

--- a/Tests/Persona_Buddy/test_buddy_management_coordinator.py
+++ b/Tests/Persona_Buddy/test_buddy_management_coordinator.py
@@ -218,3 +218,190 @@ async def test_first_save_promotion_preserves_stale_or_unsavable_preferences(
         assert writes == []
     assert manager.preferences == previous
     assert app.app_config == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "action,enabled,opened",
+    [("show", True, True), ("close", True, False), ("disable", False, True)],
+)
+async def test_independent_visibility_does_not_read_or_change_persona(
+    action, enabled, opened
+):
+    from unittest.mock import AsyncMock
+
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        BuddySelection,
+        PersonaBuddyPreferences,
+    )
+
+    initial = PersonaBuddyPreferences(
+        enabled=True, open=action != "show", selection=BuddySelection("independent")
+    )
+    writes = []
+    controller = PersonaBuddyController(
+        preferences=initial, preference_writer=lambda p: writes.append(p) or True
+    )
+    app = SimpleNamespace(
+        app_config={}, console_runtime=None, reconcile_persona_buddy_view=AsyncMock()
+    )
+    manager = coordinator_module().BuddyManagementCoordinator(
+        app, controller=controller
+    )
+    await manager._set_visibility(action)
+    result = controller.current_preferences()
+    assert result.selection == initial.selection
+    assert result.enabled is enabled
+    assert result.open is opened
+    assert writes[-1] == result
+    app.reconcile_persona_buddy_view.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_import_retry_after_save_failure_reuses_publication_and_keeps_revision_guard(
+    monkeypatch,
+):
+    from tldw_chatbook import config
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementChoice,
+    )
+
+    published = []
+    record = SimpleNamespace(id="imported")
+    library = SimpleNamespace(
+        review_archive=lambda p: p,
+        publish_review=lambda review: published.append(review) or record,
+        get_buddy=lambda _: record,
+    )
+    controller = PersonaBuddyController()
+    manager = coordinator_module().BuddyManagementCoordinator(
+        SimpleNamespace(app_config={}, console_runtime=None),
+        controller=controller,
+        library=library,
+    )
+    choice = BuddyManagementChoice(enabled=True, import_path="pack.zip")
+    imports = {}
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: False)
+    with pytest.raises(ValueError) as failed:
+        await manager.apply_choice(choice, expected_revision=0, imports=imports)
+    revision = failed.value.buddy_retry_revision
+    assert imports == {"pack.zip": "imported"}
+    assert controller.current_preferences().selection is None
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: True)
+    await manager.apply_choice(choice, expected_revision=revision, imports=imports)
+    assert published == ["pack.zip"]
+    assert controller.current_preferences().selection == BuddySelection("imported")
+    controller.apply_preferences_patch(selection=BuddySelection("newer"))
+    with pytest.raises(ValueError, match="changed elsewhere"):
+        await manager.apply_choice(choice, expected_revision=revision, imports=imports)
+    assert controller.current_preferences().selection == BuddySelection("newer")
+
+
+@pytest.mark.asyncio
+async def test_invalid_import_error_is_actionable_and_does_not_expose_internal_code():
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementChoice,
+    )
+
+    def invalid(_):
+        raise ValueError("persona_visual_import_invalid")
+
+    manager = coordinator_module().BuddyManagementCoordinator(
+        SimpleNamespace(app_config={}, console_runtime=None),
+        controller=PersonaBuddyController(),
+        library=SimpleNamespace(review_archive=invalid),
+    )
+    with pytest.raises(ValueError) as failed:
+        await manager.apply_choice(BuddyManagementChoice(import_path="missing.zip"))
+    assert "Check the path" in str(failed.value)
+    assert "persona_visual_import_invalid" not in str(failed.value)
+
+
+def test_current_persona_labels_use_names_none_and_existing_workspace_resolution():
+    from tldw_chatbook.Workspaces.models import WorkspaceAssistantDefaults
+
+    manager = coordinator_module().BuddyManagementCoordinator(
+        SimpleNamespace(
+            app_config={},
+            local_character_persona_service=SimpleNamespace(
+                get_persona_profile=lambda key: (
+                    {"id": key, "name": "Archivist"} if key == "known" else None
+                )
+            ),
+        )
+    )
+    assert manager._persona_label("known") == "Archivist"
+    assert manager._persona_label(None) == "None"
+    assert manager._persona_label("secret-id") == "Unavailable"
+    assert (
+        manager._workspace_persona_label(
+            SimpleNamespace(
+                assistant_defaults=WorkspaceAssistantDefaults(assistant_id="known")
+            )
+        )
+        == "Archivist"
+    )
+    assert (
+        manager._workspace_persona_label(
+            SimpleNamespace(
+                assistant_defaults=WorkspaceAssistantDefaults(assistant_id="missing")
+            )
+        )
+        == "Unavailable (new conversations use None)"
+    )
+    assert (
+        manager._workspace_persona_label(SimpleNamespace(assistant_defaults=None))
+        == "None"
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_persona_failure_reports_saved_buddy_and_safe_retry_revision(
+    monkeypatch,
+):
+    from unittest.mock import AsyncMock
+
+    from tldw_chatbook import config
+    from tldw_chatbook.Chat import console_persona_assignment
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementChoice,
+    )
+
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: True)
+    assignment = SimpleNamespace(
+        apply=AsyncMock(side_effect=ValueError("Persona changed"))
+    )
+    monkeypatch.setattr(
+        console_persona_assignment,
+        "prepare_buddy_persona_assignment",
+        lambda *_: assignment,
+    )
+    controller = PersonaBuddyController()
+    manager = coordinator_module().BuddyManagementCoordinator(
+        SimpleNamespace(app_config={}, console_runtime=None),
+        controller=controller,
+        library=SimpleNamespace(get_buddy=lambda _: SimpleNamespace(id="migu")),
+    )
+    with pytest.raises(ValueError, match="Buddy settings were saved") as failed:
+        await manager.apply_choice(
+            BuddyManagementChoice(
+                enabled=True, buddy_id="migu", persona_choice="selected-persona"
+            ),
+            expected_revision=0,
+        )
+    assert controller.current_preferences().selection == BuddySelection("migu")
+    assert (
+        failed.value.buddy_retry_revision
+        == controller.snapshot().preferences_generation
+    )
+    await manager.apply_choice(
+        BuddyManagementChoice(enabled=True, buddy_id="migu"),
+        expected_revision=failed.value.buddy_retry_revision,
+    )
+    assert assignment.apply.await_count == 1

--- a/Tests/Persona_Buddy/test_buddy_management_coordinator.py
+++ b/Tests/Persona_Buddy/test_buddy_management_coordinator.py
@@ -1,0 +1,220 @@
+"""Apply's preference transaction preserves the last usable selection on failure."""
+
+import importlib.util
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
+from tldw_chatbook.Persona_Buddy.interaction import (
+    BuddyBinding,
+    BuddyInteractionPreferences,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+    BuddyTargetChoice,
+)
+
+
+def coordinator_module():
+    assert (
+        importlib.util.find_spec("tldw_chatbook.UI.Navigation.buddy_management")
+        is not None
+    ), "Shared Buddy management coordinator is missing"
+    from tldw_chatbook.UI.Navigation import buddy_management
+
+    return buddy_management
+
+
+@pytest.mark.asyncio
+async def test_failed_batch_persistence_restores_selection_and_scope(monkeypatch):
+    m = coordinator_module()
+    from tldw_chatbook import config
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.preferences import (
+        BuddySelection,
+        PersonaBuddyPreferences,
+    )
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementChoice,
+    )
+
+    old = PersonaBuddyPreferences(enabled=True, selection=BuddySelection("old"))
+    controller = PersonaBuddyController(preferences=old)
+    app = SimpleNamespace(
+        app_config={"buddy_interaction": {"animated": True}}, console_runtime=None
+    )
+    manager = m.BuddyManagementCoordinator(
+        app,
+        controller=controller,
+        library=SimpleNamespace(get_buddy=lambda id: SimpleNamespace(id=id)),
+    )
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda sections: False)
+    with pytest.raises(ValueError, match="save"):
+        await manager.apply_choice(
+            BuddyManagementChoice(enabled=True, buddy_id="new", animated=False)
+        )
+    assert controller.current_preferences() == old
+    assert app.app_config["buddy_interaction"] == {"animated": True}
+
+
+@pytest.mark.asyncio
+async def test_apply_batches_artwork_and_scope_without_creating_persona(monkeypatch):
+    m = coordinator_module()
+    from tldw_chatbook import config
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementChoice,
+    )
+
+    controller = PersonaBuddyController()
+    app = SimpleNamespace(app_config={}, console_runtime=None)
+    manager = m.BuddyManagementCoordinator(
+        app,
+        controller=controller,
+        library=SimpleNamespace(get_buddy=lambda id: SimpleNamespace(id=id)),
+    )
+    writes = []
+    monkeypatch.setattr(
+        config,
+        "save_settings_to_cli_config",
+        lambda sections: writes.append(sections) or True,
+    )
+    await manager.apply_choice(
+        BuddyManagementChoice(enabled=True, buddy_id="migu", animated=False)
+    )
+    assert len(writes) == 1
+    assert writes[0]["persona_buddy"]["buddy_id"] == "migu"
+    assert writes[0]["buddy_interaction"]["animated"] is False
+    assert controller.current_preferences().selection.buddy_id == "migu"
+    assert app.app_config["buddy_interaction"]["animated"] is False
+
+
+@pytest.mark.parametrize("restored", [False, True])
+def test_form_canonicalizes_same_conversation_after_first_save_or_restore(restored):
+    m = coordinator_module()
+    saved = BuddyBinding(
+        kind="conversation",
+        target_id="old" if restored else "live",
+        conversation_id="saved" if restored else None,
+    )
+    live = ConsoleChatSession(id="live", persisted_conversation_id="saved")
+    target = BuddyTargetChoice(
+        "conversation:live", "Saved conversation", BuddyBinding.for_session(live)
+    )
+    app = SimpleNamespace(
+        app_config={},
+        console_runtime=SimpleNamespace(
+            chat_store=SimpleNamespace(sessions=lambda: (live,))
+        ),
+    )
+    manager = m.BuddyManagementCoordinator(app)
+    manager.preferences = BuddyInteractionPreferences(binding=saved)
+    assert manager._binding_for_form((target,)) == target.binding
+    assert manager.preferences.binding == saved  # Opening remains read-only.
+
+
+def test_form_never_canonicalizes_a_repurposed_live_slot():
+    m = coordinator_module()
+    saved = BuddyBinding(
+        kind="conversation", target_id="live", conversation_id="former"
+    )
+    live = ConsoleChatSession(
+        id="live",
+        persisted_conversation_id="different",
+        conversation_binding_revision=1,
+    )
+    target = BuddyTargetChoice(
+        "conversation:live", "Different", BuddyBinding.for_session(live)
+    )
+    app = SimpleNamespace(
+        app_config={},
+        console_runtime=SimpleNamespace(
+            chat_store=SimpleNamespace(sessions=lambda: (live,))
+        ),
+    )
+    manager = m.BuddyManagementCoordinator(app)
+    manager.preferences = BuddyInteractionPreferences(binding=saved)
+    assert manager._binding_for_form((target,)) == saved
+
+
+@pytest.mark.asyncio
+async def test_first_save_promotes_pin_for_restart_without_creating_a_conversation(
+    monkeypatch,
+):
+    from tldw_chatbook import config
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+    from tldw_chatbook.Persona_Buddy.interaction import parse_preferences
+
+    original = BuddyBinding(kind="conversation", target_id="live")
+    live = ConsoleChatSession(id="live", persisted_conversation_id="saved")
+    app = SimpleNamespace(
+        app_config={},
+        console_runtime=SimpleNamespace(
+            chat_store=SimpleNamespace(sessions=lambda: (live,))
+        ),
+    )
+    manager = coordinator_module().BuddyManagementCoordinator(
+        app, controller=PersonaBuddyController()
+    )
+    manager.preferences = BuddyInteractionPreferences(binding=original, animated=False)
+    writes = []
+    monkeypatch.setattr(
+        config,
+        "save_settings_to_cli_config",
+        lambda value: writes.append(value) or True,
+    )
+    assert await manager._promote_saved_binding(original)
+    restored = parse_preferences(writes[0]["buddy_interaction"])
+    next_runtime = ConsoleChatSession(id="new-live", persisted_conversation_id="saved")
+    assert restored.binding.resolve_session((next_runtime,)) is next_runtime
+    assert not restored.animated
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reason", ["repurposed", "temporary", "rebound", "write_failed"]
+)
+async def test_first_save_promotion_preserves_stale_or_unsavable_preferences(
+    monkeypatch, reason
+):
+    from tldw_chatbook import config
+    from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+
+    original = BuddyBinding(
+        kind="conversation", target_id="live", ephemeral=reason == "temporary"
+    )
+    live = ConsoleChatSession(
+        id="live",
+        persisted_conversation_id=None if reason == "temporary" else "saved",
+        ephemeral=reason == "temporary",
+        conversation_binding_revision=int(reason == "repurposed"),
+    )
+    app = SimpleNamespace(
+        app_config={},
+        console_runtime=SimpleNamespace(
+            chat_store=SimpleNamespace(sessions=lambda: (live,))
+        ),
+    )
+    manager = coordinator_module().BuddyManagementCoordinator(
+        app, controller=PersonaBuddyController()
+    )
+    manager.preferences = BuddyInteractionPreferences(
+        binding=BuddyBinding(kind="workspace", target_id="another")
+        if reason == "rebound"
+        else original
+    )
+    previous = manager.preferences
+    writes = []
+    monkeypatch.setattr(
+        config,
+        "save_settings_to_cli_config",
+        lambda value: writes.append(value) or False,
+    )
+    if reason == "write_failed":
+        with pytest.raises(ValueError, match="save"):
+            await manager._promote_saved_binding(original)
+    else:
+        assert not await manager._promote_saved_binding(original)
+        assert writes == []
+    assert manager.preferences == previous
+    assert app.app_config == {}

--- a/Tests/Persona_Buddy/test_buddy_scoped_events.py
+++ b/Tests/Persona_Buddy/test_buddy_scoped_events.py
@@ -1,0 +1,106 @@
+"""Only bound conversation/workspace activity animates the selected Buddy."""
+
+import pytest
+
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+
+
+def scoped_adapter():
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    assert hasattr(adapter, "set_scope"), "Buddy lifecycle scope is missing"
+    adapter.set_scope(
+        session_ids=frozenset({"chat-a"}), conversation_ids=frozenset({"durable-a"})
+    )
+    return controller, adapter
+
+
+def test_unrelated_running_or_approval_events_do_not_animate_buddy():
+    controller, adapter = scoped_adapter()
+    adapter.run_state("chat-b", "streaming")
+    adapter.approval_round("chat-b", "question-b", pending=True)
+    assert controller.snapshot().state == "idle"
+    adapter.run_state("chat-a", "streaming")
+    assert controller.snapshot().state == "speaking"
+    adapter.approval_round("chat-a", "question-a", pending=True)
+    assert controller.snapshot().state == "approval_needed"
+
+
+def test_scope_change_releases_previous_leases_and_allows_new_scope():
+    controller, adapter = scoped_adapter()
+    adapter.run_state("chat-a", "streaming")
+    adapter.set_scope(session_ids=frozenset({"chat-b"}), conversation_ids=frozenset())
+    assert controller.snapshot().state == "idle"
+    adapter.approval_round("chat-a", "old-question", pending=True)
+    assert controller.snapshot().state == "idle"
+    adapter.run_state("chat-b", "validating")
+    assert controller.snapshot().state == "thinking"
+
+
+def test_scoped_tool_events_require_their_explicit_session_and_wakes_match_durable_id():
+    controller, adapter = scoped_adapter()
+    adapter.tool_step("run-b", 1, "tool_call", session_id="chat-b")
+    adapter.tool_step("unknown-run", 1, "tool_call")
+    adapter.wake("durable-b", "wake-b", active=True)
+    assert controller.snapshot().state == "idle"
+    adapter.tool_step("run-a", 1, "tool_call", session_id="chat-a")
+    assert controller.snapshot().state == "tool_running"
+    adapter.release_run("run-a")
+    adapter.wake("durable-a", "wake-a", active=True)
+    assert controller.snapshot().state == "wake_armed"
+
+
+def test_unscoped_legacy_adapter_retains_existing_behavior():
+    controller = PersonaBuddyController()
+    adapter = PersonaBuddyConsoleAdapter(controller)
+    adapter.tool_step("legacy", 1, "tool_call")
+    assert controller.snapshot().state == "tool_running"
+
+
+@pytest.mark.parametrize("status", ["validating", "streaming"])
+def test_rebinding_away_and_back_keeps_the_accepted_run_owner_until_completion(status):
+    controller, adapter = scoped_adapter()
+    accepted = adapter.run_state("chat-a", "validating")
+    if status == "streaming":
+        adapter.run_state("chat-a", status, run_owner=accepted)
+    adapter.set_scope(session_ids=frozenset({"chat-b"}), conversation_ids=frozenset())
+    adapter.set_scope(session_ids=frozenset({"chat-a"}), conversation_ids=frozenset())
+    assert adapter.run_state("chat-a", status, replay=True) == accepted
+    adapter.run_state("chat-a", "completed", run_owner=accepted)
+    assert controller.snapshot().state == "idle"
+
+
+def test_new_run_started_outside_scope_rejects_late_prior_completion_after_rebind():
+    controller, adapter = scoped_adapter()
+    old = adapter.run_state("chat-a", "validating")
+    adapter.set_scope(session_ids=frozenset({"chat-b"}), conversation_ids=frozenset())
+    current = adapter.run_state("chat-a", "validating")
+    assert current is not None and current != old
+    assert controller.snapshot().state == "idle"
+    adapter.set_scope(session_ids=frozenset({"chat-a"}), conversation_ids=frozenset())
+    adapter.run_state("chat-a", "streaming")
+    adapter.run_state("chat-a", "completed", run_owner=old)
+    assert controller.snapshot().state == "speaking"
+    adapter.run_state("chat-a", "completed", run_owner=current)
+    assert controller.snapshot().state == "idle"
+
+
+def test_adding_workspace_member_keeps_retained_tool_voice_and_wake_leases():
+    for source, expected in (
+        ("tool", "tool_running"),
+        ("voice", "listening"),
+        ("wake", "wake_armed"),
+    ):
+        controller, adapter = scoped_adapter()
+        if source == "tool":
+            adapter.tool_step("tool-a", 1, "tool_call", session_id="chat-a")
+        elif source == "voice":
+            adapter.voice_state("chat-a", 1, "listening")
+        else:
+            adapter.wake("durable-a", "wake-a", active=True)
+        adapter.set_scope(
+            session_ids=frozenset({"chat-a", "chat-b"}),
+            conversation_ids=frozenset({"durable-a"}),
+        )
+        assert controller.snapshot().state == expected

--- a/Tests/Persona_Buddy/test_buddy_speech.py
+++ b/Tests/Persona_Buddy/test_buddy_speech.py
@@ -151,3 +151,22 @@ async def test_microphone_hold_waits_for_output_cleanup_and_preserves_manual_pau
     await queue.wait_idle()
     assert spoken == ["response", "response"]
     await queue.aclose()
+
+
+@pytest.mark.asyncio
+async def test_skip_while_paused_removes_next_question_before_earlier_response():
+    spoken = []
+
+    async def play(entry, current):
+        spoken.append(entry.key)
+        return current()
+
+    queue = BuddySpeechQueue(play)
+    queue.pause()
+    queue.enqueue(item("response"))
+    queue.enqueue(item("question", question=True))
+    queue.skip()
+    queue.resume()
+    await queue.wait_idle()
+    assert spoken == ["response"]
+    await queue.aclose()

--- a/Tests/Persona_Buddy/test_buddy_speech.py
+++ b/Tests/Persona_Buddy/test_buddy_speech.py
@@ -1,0 +1,153 @@
+"""Speech presentation never owns work or acknowledgement."""
+
+import asyncio
+
+import pytest
+
+from tldw_chatbook.Persona_Buddy.speech import BuddySpeechItem, BuddySpeechQueue
+
+
+def item(key, *, question=False, current=lambda: True):
+    return BuddySpeechItem(key, "Research chat", key, question, current)
+
+
+@pytest.mark.asyncio
+async def test_named_serial_questions_first_and_duplicates_coalesce():
+    spoken = []
+
+    async def play(entry, current):
+        assert current()
+        spoken.append(entry.named_text)
+        await asyncio.sleep(0)
+        return True
+
+    queue = BuddySpeechQueue(play)
+    queue.pause()
+    assert queue.enqueue(item("response"))
+    assert not queue.enqueue(item("response"))
+    queue.enqueue(item("question", question=True))
+    queue.resume()
+    await queue.wait_idle()
+    assert spoken == ["Research chat. question", "Research chat. response"]
+    await queue.aclose()
+
+
+@pytest.mark.asyncio
+async def test_pause_replays_current_skip_drops_only_current_mute_clears():
+    entered = asyncio.Queue()
+    release = asyncio.Event()
+    stopped = []
+
+    async def play(entry, current):
+        await entered.put(entry.key)
+        try:
+            await release.wait()
+            return current()
+        finally:
+            stopped.append(entry.key)
+
+    queue = BuddySpeechQueue(play)
+    queue.enqueue(item("one"))
+    queue.enqueue(item("two"))
+    assert await entered.get() == "one"
+    queue.pause()
+    await queue.wait_idle()
+    assert stopped == ["one"]
+    assert queue.state.paused and queue.state.queued == 2
+    queue.resume()
+    assert await entered.get() == "one"
+    queue.skip()
+    assert await entered.get() == "two"
+    queue.mute()
+    await queue.wait_idle()
+    assert queue.state.muted and queue.state.queued == 0
+    assert stopped == ["one", "one", "two"]
+    await queue.aclose()
+
+
+@pytest.mark.asyncio
+async def test_stale_items_and_playback_failures_do_not_stall_queue():
+    spoken = []
+
+    async def play(entry, current):
+        spoken.append(entry.key)
+        if entry.key == "failure":
+            raise ValueError("private provider detail")
+        return True
+
+    queue = BuddySpeechQueue(play)
+    queue.pause()
+    valid = [True]
+    queue.enqueue(item("stale", current=lambda: valid[0]))
+    valid[0] = False
+    queue.enqueue(item("failure"))
+    queue.enqueue(item("next"))
+    queue.resume()
+    await queue.wait_idle()
+    assert spoken == ["failure", "next"]
+    assert queue.state.error == "Speech could not finish."
+    await queue.aclose()
+
+
+@pytest.mark.asyncio
+async def test_rebind_waits_for_old_playback_cleanup_before_new_item():
+    events = []
+    entered, cleanup = asyncio.Event(), asyncio.Event()
+
+    async def play(entry, current):
+        events.append(entry.key)
+        if entry.key == "old":
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await cleanup.wait()
+                events.append("old stopped")
+        return True
+
+    queue = BuddySpeechQueue(play)
+    queue.enqueue(item("old"))
+    await entered.wait()
+    queue.reset()
+    queue.enqueue(item("new"))
+    await asyncio.sleep(0)
+    assert events == ["old"]
+    cleanup.set()
+    await queue.wait_idle()
+    assert events == ["old", "old stopped", "new"]
+    await queue.aclose()
+
+
+@pytest.mark.asyncio
+async def test_microphone_hold_waits_for_output_cleanup_and_preserves_manual_pause():
+    entered, cleanup = asyncio.Event(), asyncio.Event()
+    spoken = []
+
+    async def play(entry, current):
+        spoken.append(entry.key)
+        if len(spoken) == 1:
+            entered.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                await cleanup.wait()
+        return current()
+
+    queue = BuddySpeechQueue(play)
+    queue.enqueue(item("response"))
+    await entered.wait()
+    queue.set_input_active("mic", True)
+    silent = asyncio.create_task(queue.wait_idle())
+    await asyncio.sleep(0)
+    assert not silent.done()
+    cleanup.set()
+    await silent
+    assert queue.state.input_active and queue.state.queued == 1
+    queue.pause()
+    queue.set_input_active("mic", False)
+    await asyncio.sleep(0)
+    assert spoken == ["response"] and queue.state.paused
+    queue.resume()
+    await queue.wait_idle()
+    assert spoken == ["response", "response"]
+    await queue.aclose()

--- a/Tests/Persona_Buddy/test_buddy_startup.py
+++ b/Tests/Persona_Buddy/test_buddy_startup.py
@@ -1,0 +1,155 @@
+"""Deferred legacy migration shares first-controller preference ownership."""
+
+import threading
+from dataclasses import replace
+from types import SimpleNamespace
+
+from loguru import logger
+
+from tldw_chatbook.Persona_Buddy.preferences import (
+    BuddySelection,
+    PersonaBuddyPreferences,
+    PersonaBuddySelection,
+    parse_persona_buddy_preferences,
+    serialize_persona_buddy_preferences,
+)
+
+
+def test_unclaimed_migration_commits_before_first_controller_can_read(monkeypatch):
+    import tldw_chatbook.app as app_module
+    from tldw_chatbook.Persona_Buddy import controller, library, preferences
+
+    previous = PersonaBuddyPreferences(
+        enabled=True, selection=PersonaBuddySelection("local", "legacy")
+    )
+    candidate = replace(previous, selection=BuddySelection("copied"))
+    host = SimpleNamespace(
+        app_config={"persona_buddy": serialize_persona_buddy_preferences(previous)},
+        chachanotes_db=object(),
+        local_character_persona_service=None,
+        persona_actor_pack_coordinator=SimpleNamespace(
+            recovery_attempted=True,
+            recovery_error=None,
+            ensure_recovered=lambda: None,
+        ),
+        actor_pack_recovery_error=None,
+        loguru_logger=logger,
+        _persona_buddy_controller=None,
+        _persona_buddy_controller_lock=threading.Lock(),
+        call_after_refresh=lambda *_args: None,
+        _notify_persona_buddy_changed=lambda: None,
+        call_from_thread=lambda callback: callback(),
+        run_worker=lambda coroutine, **_kwargs: coroutine.close(),
+    )
+    entered, release = threading.Event(), threading.Event()
+    lock_was_held = []
+
+    def persist(_candidate):
+        acquired = host._persona_buddy_controller_lock.acquire(blocking=False)
+        lock_was_held.append(not acquired)
+        if acquired:
+            host._persona_buddy_controller_lock.release()
+        entered.set()
+        assert release.wait(5)
+        return True
+
+    class Library:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def ensure_builtin(self, **_kwargs):
+            pass
+
+        def migrate_legacy_selection(self, old, *, writer):
+            return candidate if writer(candidate) else old
+
+    class Controller:
+        def __init__(self, **kwargs):
+            self.preferences = kwargs["preferences"]
+
+        async def migrate_legacy_selection(self, _library):
+            pass
+
+    monkeypatch.setattr(library, "BuddyLibrary", Library)
+    monkeypatch.setattr(controller, "PersonaBuddyController", Controller)
+    monkeypatch.setattr(preferences, "persist_persona_buddy_preferences", persist)
+    worker = threading.Thread(
+        target=app_module.TldwCli.ensure_actor_pack_recovery, args=(host,)
+    )
+    worker.start()
+    try:
+        assert entered.wait(5)
+        builder = threading.Thread(
+            target=app_module.TldwCli._build_persona_buddy_controller, args=(host,)
+        )
+        builder.start()
+    finally:
+        release.set()
+        worker.join(5)
+    builder.join(5)
+    assert not worker.is_alive() and not builder.is_alive()
+    assert lock_was_held == [True]
+    assert host._persona_buddy_controller.preferences == candidate
+    assert (
+        parse_persona_buddy_preferences(host.app_config["persona_buddy"]) == candidate
+    )
+
+
+def test_controller_claim_during_copy_hands_off_without_overwriting(monkeypatch):
+    import tldw_chatbook.app as app_module
+    from tldw_chatbook.Persona_Buddy import library, preferences
+
+    previous = PersonaBuddyPreferences(
+        selection=PersonaBuddySelection("local", "legacy")
+    )
+    selected = replace(previous, selection=BuddySelection("user-choice"))
+    delegated = []
+
+    class Controller:
+        def migrate_legacy_selection(self, value):
+            delegated.append(value)
+            return "delegated"
+
+    host = SimpleNamespace(
+        app_config={"persona_buddy": serialize_persona_buddy_preferences(previous)},
+        chachanotes_db=object(),
+        local_character_persona_service=None,
+        persona_actor_pack_coordinator=SimpleNamespace(
+            recovery_attempted=True,
+            recovery_error=None,
+            ensure_recovered=lambda: None,
+        ),
+        actor_pack_recovery_error=None,
+        loguru_logger=logger,
+        _persona_buddy_controller=None,
+        _persona_buddy_controller_lock=threading.Lock(),
+        call_from_thread=lambda callback: callback(),
+        run_worker=lambda value, **_kwargs: None,
+    )
+
+    class Library:
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def ensure_builtin(self, **_kwargs):
+            pass
+
+        def migrate_legacy_selection(self, old, *, writer):
+            # First feature use wins while the heavy visual copy is in flight.
+            with host._persona_buddy_controller_lock:
+                host._persona_buddy_controller = Controller()
+                host.app_config["persona_buddy"] = serialize_persona_buddy_preferences(
+                    selected
+                )
+            assert not writer(replace(old, selection=BuddySelection("copied")))
+            return old
+
+    monkeypatch.setattr(library, "BuddyLibrary", Library)
+    monkeypatch.setattr(
+        preferences,
+        "persist_persona_buddy_preferences",
+        lambda _value: (_ for _ in ()).throw(AssertionError("stale migration wrote")),
+    )
+    app_module.TldwCli.ensure_actor_pack_recovery(host)
+    assert parse_persona_buddy_preferences(host.app_config["persona_buddy"]) == selected
+    assert len(delegated) == 1

--- a/Tests/Persona_Buddy/test_buddy_workspace_coordinator.py
+++ b/Tests/Persona_Buddy/test_buddy_workspace_coordinator.py
@@ -1,0 +1,99 @@
+"""Exact result acknowledgement uses existing receipt authority."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Persona_Buddy.test_buddy_inbox import receipt
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatSession
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+
+def make_app():
+    rows = [receipt("one", "live", "saved")]
+    acked = []
+
+    def acknowledge(ids):
+        acked.extend(ids)
+        rows[:] = [r for r in rows if r.activity_id not in ids]
+        return len(ids)
+
+    session = ConsoleChatSession(
+        id="live", workspace_id="ws", persisted_conversation_id="saved"
+    )
+    receipts = SimpleNamespace(
+        unseen_snapshot=lambda: tuple(rows), acknowledge=acknowledge
+    )
+    from tldw_chatbook.Chat.console_chat_models import ConsoleRunState
+
+    controller = SimpleNamespace(
+        run_state_for=lambda _: ConsoleRunState(),
+        activity_for=lambda _: SimpleNamespace(),
+    )
+    app = SimpleNamespace(
+        console_runtime=SimpleNamespace(
+            chat_store=SimpleNamespace(sessions=lambda: (session,)),
+            chat_controller=controller,
+            activity_receipts=receipts,
+        ),
+        workspace_registry_service=SimpleNamespace(
+            get_workspace=lambda _: SimpleNamespace(
+                name="Workspace", archived=False, authority="local-only"
+            ),
+            list_workspace_conversations=lambda _: (),
+        ),
+    )
+    return app, rows, acked, session
+
+
+@pytest.mark.asyncio
+async def test_acknowledge_one_frozen_result_leaves_newer_result_unseen():
+    from tldw_chatbook.UI.Navigation.buddy_workspace import BuddyWorkspaceCoordinator
+
+    app, rows, acked, _ = make_app()
+    coordinator = BuddyWorkspaceCoordinator(
+        app, BuddyBinding(kind="workspace", target_id="ws")
+    )
+    _, entries = await coordinator.snapshot()
+    rows.append(receipt("two", "live", "saved"))
+    assert await coordinator.acknowledge(entries[0]) == 1
+    assert acked == ["one"]
+    assert [r.activity_id for r in rows] == ["two"]
+
+
+@pytest.mark.asyncio
+async def test_moved_conversation_cannot_acknowledge_old_workspace_row():
+    from tldw_chatbook.UI.Navigation.buddy_workspace import BuddyWorkspaceCoordinator
+
+    app, _, acked, session = make_app()
+    coordinator = BuddyWorkspaceCoordinator(
+        app, BuddyBinding(kind="workspace", target_id="ws")
+    )
+    _, entries = await coordinator.snapshot()
+    session.workspace_id = "elsewhere"
+    with pytest.raises(ValueError, match="no longer"):
+        await coordinator.acknowledge(entries[0])
+    assert acked == []
+
+
+@pytest.mark.asyncio
+async def test_storage_error_opening_result_does_not_escape_or_acknowledge():
+    from tldw_chatbook.UI.Navigation.buddy_workspace import BuddyWorkspaceCoordinator
+
+    app, _, acked, _ = make_app()
+    notices = []
+    app.notify = lambda message, **kwargs: notices.append((message, kwargs))
+    coordinator = BuddyWorkspaceCoordinator(
+        app, BuddyBinding(kind="workspace", target_id="ws")
+    )
+    _, entries = await coordinator.snapshot()
+
+    def unavailable(_):
+        raise OSError("private storage path")
+
+    app.workspace_registry_service.get_workspace = unavailable
+    await coordinator._open_entry(entries[0])
+    assert acked == []
+    assert len(notices) == 1
+    assert notices[0][1]["severity"] == "error"
+    assert "private storage path" not in notices[0][0]

--- a/Tests/Persona_Buddy/test_persona_buddy_config_projection.py
+++ b/Tests/Persona_Buddy/test_persona_buddy_config_projection.py
@@ -18,7 +18,6 @@ from tldw_chatbook.Persona_Buddy import (
     parse_persona_buddy_preferences,
 )
 
-
 _BUDDY_TOML = """\
 [persona_buddy]
 enabled = true
@@ -158,3 +157,19 @@ def test_projection_adds_only_the_buddy_top_level_table(
         "width": 31,
         "height": 14,
     }
+
+
+def test_real_toml_independent_selection_survives_restart(tmp_path, monkeypatch):
+    from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+
+    independent = _BUDDY_TOML.replace('source = "local"', 'source = "buddy"').replace(
+        'local_persona_id = "persona-uat"', 'buddy_id = "independent-one"'
+    )
+    with _scratch_config(tmp_path, monkeypatch, independent):
+        controller = PersonaBuddyController(preferences=_load_preferences())
+        assert controller.current_preferences().selection == BuddySelection(
+            "independent-one"
+        )
+        assert controller.current_preferences().geometry == PersonaBuddyGeometry(
+            7, 5, 31, 14
+        )

--- a/Tests/Persona_Visual/test_builtin_pixel_migu_buddy.py
+++ b/Tests/Persona_Visual/test_builtin_pixel_migu_buddy.py
@@ -173,11 +173,50 @@ def test_app_readiness_installs_after_recovery_and_before_return(
     )
     app_module.TldwCli.ensure_actor_pack_recovery(app)
     assert coordinator.recovery_attempted
-    assert service.get_persona_profile(PIXEL_MIGU_PERSONA_ID)["name"] == "pixel-migu"
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+    assert BuddyLibrary(db, root).list_buddies()[0].name == "pixel-migu"
     assert (
         PersonaVisualRepository(db).get_active_persona_pack(PIXEL_MIGU_PERSONA_ID)
-        is not None
+        is None
     )
+    with pytest.raises(ValueError):
+        service.get_persona_profile(PIXEL_MIGU_PERSONA_ID)
+
+
+@pytest.mark.parametrize("retirement", ["inactive", "deleted", "archived"])
+def test_app_readiness_preserves_retired_legacy_builtin(
+    components, monkeypatch, retirement
+):
+    from types import SimpleNamespace
+
+    from loguru import logger
+
+    import tldw_chatbook.app as app_module
+    from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+    db, service, coordinator, root = components
+    install(components)
+    if retirement == "inactive":
+        service.update_persona_profile(PIXEL_MIGU_PERSONA_ID, {"is_active": False})
+    elif retirement == "deleted":
+        service.delete_persona_profile(PIXEL_MIGU_PERSONA_ID)
+    else:
+        repository = PersonaVisualRepository(db)
+        graph = repository.get_active_persona_pack(PIXEL_MIGU_PERSONA_ID)
+        repository.archive_binding(
+            persona_id=PIXEL_MIGU_PERSONA_ID, expected_identity=graph.identity
+        )
+    monkeypatch.setattr(app_module, "get_user_data_dir", lambda: root)
+    app = SimpleNamespace(
+        chachanotes_db=db,
+        persona_actor_pack_coordinator=coordinator,
+        local_character_persona_service=service,
+        actor_pack_recovery_error=None,
+        loguru_logger=logger,
+    )
+    app_module.TldwCli.ensure_actor_pack_recovery(app)
+    assert BuddyLibrary(db, root).list_buddies() == ()
 
 
 def test_racing_service_loser_cleanup_preserves_winners_frames(components, monkeypatch):

--- a/Tests/Persona_Visual/test_persona_visual_importer.py
+++ b/Tests/Persona_Visual/test_persona_visual_importer.py
@@ -598,3 +598,28 @@ def test_import_errors_and_repr_do_not_expose_private_paths(tmp_path: Path) -> N
 
     assert private_marker not in str(caught.value)
     assert private_marker not in repr(caught.value)
+
+
+def test_archive_cannot_override_reserved_import_provenance(tmp_path):
+    payloads = _archive_payloads()
+    pack = json.loads(payloads["metadata/pack.json"])
+    pack["pack"]["source_context"] = {
+        "provenance": "trusted-builtin",
+        "license": "Keep notice",
+    }
+    _replace_declared_payload(payloads, "metadata/pack.json", _canonical(pack))
+    archive = _write_archive(tmp_path / "forged.zip", payloads)
+    staging = tmp_path / "staging"
+    staging.mkdir(mode=0o700)
+    review = import_persona_visual_pack(
+        archive,
+        staging_root=staging,
+        persona_id="persona-local-1",
+        persona_revision=1,
+        expected_identity=None,
+    )
+    try:
+        assert dict(review.draft.source_context)["provenance"] == "untrusted-import"
+        assert dict(review.draft.source_context)["license"] == "Keep notice"
+    finally:
+        cleanup_persona_visual_import_review(review, staging_root=staging)

--- a/Tests/Persona_Visual/test_persona_visual_repository.py
+++ b/Tests/Persona_Visual/test_persona_visual_repository.py
@@ -227,6 +227,8 @@ def test_activate_new_pack_returns_immutable_path_safe_graph(
         "pack_version_id",
         "version_number",
         "manifest_sha256",
+        "buddy_id",
+        "buddy_revision",
     )
     assert not any("path" in field.name for field in fields(PersonaVisualIdentity))
     assert not any(

--- a/Tests/TTS/test_buddy_guarded_speech.py
+++ b/Tests/TTS/test_buddy_guarded_speech.py
@@ -1,0 +1,195 @@
+"""Buddy speech reuses TTS identity, destination admission and exact playback owner."""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import TTSEventHandler
+
+DESTINATION = "sha256:" + "a" * 64
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("invalidate", [None, "resolution", "preparation"])
+async def test_guarded_utterance_revalidates_before_admission_and_waits_playback(
+    invalidate,
+):
+    handler = TTSEventHandler()
+    valid, admitted, stopped = [True], [], []
+
+    async def resolve(**kwargs):
+        if invalidate == "resolution":
+            valid[0] = False
+        return SimpleNamespace(source="global")
+
+    async def prepare(text, *_args, **_kwargs):
+        if invalidate == "preparation":
+            valid[0] = False
+        return text
+
+    async def admit(**kwargs):
+        admitted.append(kwargs)
+        kwargs["outcome_callback"](
+            True
+        )  # Generation success is not playback completion.
+
+    async def stop(event):
+        stopped.append(event)
+
+    handler._resolve_speech_request_identity = resolve
+    handler._prepare_tts_text = prepare
+    handler._admit_tts_generation = admit
+    handler.handle_tts_playback = stop
+    task = asyncio.create_task(
+        handler.speak_guarded_utterance(
+            "Research. Result",
+            assistant_kind="generic",
+            character_ref=None,
+            expected_destination_fingerprint=DESTINATION,
+            validator=lambda: valid[0],
+        )
+    )
+    await asyncio.sleep(0)
+    if invalidate:
+        assert await task is False
+        assert admitted == []
+    else:
+        assert not task.done()
+        assert admitted[0]["expected_destination_fingerprint"] == DESTINATION
+        owner = admitted[0]["playback_lifecycle"]
+        owner.report("playing")
+        owner.report_terminal("stopped")
+        assert await task is True
+        assert stopped[-1].playback_lifecycle is owner
+
+
+@pytest.mark.asyncio
+async def test_guarded_utterance_cancel_stops_only_its_exact_owner():
+    handler = TTSEventHandler()
+    admitted, stops = [], []
+
+    async def resolve(**kwargs):
+        return SimpleNamespace(source="global")
+
+    async def prepare(text, *_args, **_kwargs):
+        return text
+
+    async def admit(**kwargs):
+        admitted.append(kwargs)
+
+    async def stop(event):
+        stops.append(event)
+
+    handler._resolve_speech_request_identity = resolve
+    handler._prepare_tts_text = prepare
+    handler._admit_tts_generation = admit
+    handler.handle_tts_playback = stop
+    task = asyncio.create_task(
+        handler.speak_guarded_utterance(
+            "Named question",
+            assistant_kind="generic",
+            character_ref=None,
+            expected_destination_fingerprint=DESTINATION,
+            validator=lambda: True,
+        )
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert len(stops) == 1 and stops[0].message_id.startswith("buddy-")
+    assert stops[0].playback_lifecycle is admitted[0]["playback_lifecycle"]
+
+
+@pytest.mark.asyncio
+async def test_provider_admission_rejects_lifecycle_revoked_after_progress_await():
+    from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+        TTSPlaybackLifecycle,
+        TTSProgressEvent,
+    )
+
+    handler = TTSEventHandler()
+    valid, denied = [True], []
+
+    async def post(event):
+        if isinstance(event, TTSProgressEvent):
+            valid[0] = False
+
+    async def synthesize(**kwargs):
+        denied.append(
+            not kwargs["admission_authorizer"]("openai", "https://api.openai.com/v1")
+        )
+        raise ValueError("Test ends at provider admission")
+
+    handler._post_tts_message = post
+    handler._tts_service = SimpleNamespace(
+        synthesize_default=synthesize,
+        preferences_snapshot=lambda: SimpleNamespace(provider_id="openai"),
+    )
+    owner = TTSPlaybackLifecycle(
+        message_id="buddy-test",
+        request_id=1,
+        validator=lambda: valid[0],
+        callback=lambda _state: None,
+    )
+    await handler._generate_tts(
+        "Named response", "buddy-test", None, playback_lifecycle=owner
+    )
+    assert denied == [True]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cancel_closing", [False, True])
+async def test_app_shutdown_joins_buddy_before_shared_tts_owners(cancel_closing):
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Persona_Buddy.speech import BuddySpeechItem, BuddySpeechQueue
+
+    entered, cleanup_entered, release = (
+        asyncio.Event(),
+        asyncio.Event(),
+        asyncio.Event(),
+    )
+    events = []
+
+    async def play(_item, _current):
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cleanup_entered.set()
+            await release.wait()
+            events.append("buddy-stopped")
+
+    async def profiles():
+        events.append("profiles")
+
+    async def service():
+        events.append("service")
+
+    queue = BuddySpeechQueue(play)
+    queue.enqueue(BuddySpeechItem("reply", "Name", "Response"))
+    await entered.wait()
+    owner = SimpleNamespace(
+        buddy_speech_coordinator=queue,
+        _close_tts_profile_repository=profiles,
+        _close_tts_service=service,
+    )
+    closing = asyncio.create_task(TldwCli._close_owned_tts_resources(owner))
+    try:
+        await cleanup_entered.wait()
+        if cancel_closing:
+            closing.cancel("shutdown cancelled")
+            await asyncio.sleep(0)
+        assert not closing.done() and events == []
+        release.set()
+        if cancel_closing:
+            with pytest.raises(asyncio.CancelledError, match="shutdown cancelled"):
+                await closing
+        else:
+            await closing
+    finally:
+        release.set()
+        await asyncio.gather(closing, return_exceptions=True)
+        await queue.wait_idle()
+    assert events == ["buddy-stopped", "profiles", "service"]

--- a/Tests/UI/test_buddy_conversation_layout.py
+++ b/Tests/UI/test_buddy_conversation_layout.py
@@ -29,3 +29,121 @@ async def test_compact_conversation_keeps_reply_and_recovery_actions_visible(ava
         modal.query_one("#buddy-close", Button).press()
         await pilot.pause()
         assert app.screen is underlying
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (80, 24), (120, 40)])
+async def test_transcript_opens_latest_follows_only_at_end_and_off_speech_is_compact(
+    size,
+):
+    from textual.containers import VerticalScroll
+
+    from tldw_chatbook.Chat.console_chat_store import ConsoleMessageRole
+
+    app = Harness()
+    for n in range(40):
+        app.store.append_message(
+            app.target.id,
+            role=ConsoleMessageRole.USER,
+            content=f"Message {n}\nReading line {n}",
+        )
+    async with app.run_test(size=size) as pilot:
+        modal = open_buddy_conversation(
+            app, BuddyBinding.for_session(app.target), allow_voice=False
+        )
+        await pilot.pause()
+        body = modal.query_one("#buddy-conversation-body", VerticalScroll)
+        assert body.max_scroll_y > 0
+        assert body.scroll_y == body.max_scroll_y
+        assert not modal.query_one("#buddy-speech-actions").display
+        assert modal.query_one("#buddy-speech-status").region.height == 1
+        assert body.region.height >= 3
+        body.scroll_home(animate=False)
+        await pilot.pause()
+        app.store.append_message(
+            app.target.id,
+            role=ConsoleMessageRole.ASSISTANT,
+            content="New reply\nSecond line",
+        )
+        modal.refresh_projection()
+        await pilot.pause()
+        assert body.scroll_y == 0
+        assert "new updates" in str(modal.query_one("#buddy-latest", Button).label)
+        assert await pilot.click("#buddy-latest")
+        await pilot.pause()
+        assert body.scroll_y == body.max_scroll_y
+        app.store.append_message(
+            app.target.id, role=ConsoleMessageRole.ASSISTANT, content="Next reply"
+        )
+        modal.refresh_projection()
+        await pilot.pause()
+        assert body.scroll_y == body.max_scroll_y
+        assert not modal.query("#buddy-mic")
+        for button in modal.query("#buddy-actions Button"):
+            assert button.region.bottom <= size[1]
+
+
+@pytest.mark.asyncio
+async def test_empty_transcript_displays_no_messages_yet():
+    app = Harness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        modal = open_buddy_conversation(app, BuddyBinding.for_session(app.target))
+        await pilot.pause()
+        assert "No messages yet" in str(modal.query_one("#buddy-transcript").render())
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (80, 24), (120, 40)])
+async def test_pending_decision_is_reachable_while_reading_history(size):
+    import asyncio
+
+    from textual.containers import VerticalScroll
+
+    from Tests.UI.test_buddy_conversation_modal import _pending_call, until
+    from tldw_chatbook.Chat.console_chat_store import ConsoleMessageRole
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
+
+    app = Harness()
+    for n in range(40):
+        app.store.append_message(
+            app.target.id, role=ConsoleMessageRole.USER, content=f"Message {n}"
+        )
+    async with app.run_test(size=size) as pilot:
+        modal = open_buddy_conversation(
+            app, BuddyBinding.for_session(app.target), allow_voice=False
+        )
+        await pilot.pause()
+        body = modal.query_one("#buddy-conversation-body", VerticalScroll)
+        body.scroll_home(animate=False)
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                app.controller.request_mcp_approvals,
+                [_pending_call()],
+                session_id=app.target.id,
+            )
+        )
+        try:
+            await until(lambda: app.controller._interrupt_host.pending_total() == 1)
+            modal.refresh_projection()
+            await pilot.pause()
+            assert body.scroll_y == 0
+            assert modal.query_one("#buddy-pending", Button).display
+            assert await pilot.click("#buddy-pending")
+            await pilot.pause()
+            card = modal.query_one(ChatApprovalCard)
+            assert card.region.y < body.region.bottom
+            assert card.region.bottom > body.region.y
+            assert isinstance(app.focused, Button)
+            assert app.focused.region.bottom <= body.region.bottom
+            assert app.focused.region.y >= body.region.y
+            # Coordinates alone can pass while a 1fr ancestor clips the action.
+            for ancestor in app.focused.ancestors:
+                if ancestor is body:
+                    break
+                assert ancestor.content_region.contains_region(app.focused.region)
+            deny = card.query_one(".approval-row-fast-deny", Button)
+            assert deny.region.right <= body.content_region.right
+        finally:
+            if not pending.done():
+                app.controller.begin_shutdown()
+                await pending

--- a/Tests/UI/test_buddy_conversation_layout.py
+++ b/Tests/UI/test_buddy_conversation_layout.py
@@ -1,0 +1,31 @@
+"""Compact Buddy replies retain visible recovery and close controls."""
+
+import pytest
+from textual.widgets import Button, TextArea
+
+from Tests.UI.test_buddy_conversation_modal import Harness
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("available", [True, False])
+async def test_compact_conversation_keeps_reply_and_recovery_actions_visible(available):
+    app = Harness()
+    async with app.run_test(size=(60, 20)) as pilot:
+        binding = (
+            BuddyBinding.for_session(app.target)
+            if available
+            else BuddyBinding(kind="conversation", target_id="missing")
+        )
+        underlying = app.screen
+        modal = open_buddy_conversation(app, binding)
+        await pilot.pause()
+        for button in modal.query("#buddy-actions Button"):
+            assert button.region.bottom <= 20
+            assert button.region.right <= 60
+            assert button.region.y >= 0
+        assert modal.query_one("#buddy-reply", TextArea).region.height >= 3
+        modal.query_one("#buddy-close", Button).press()
+        await pilot.pause()
+        assert app.screen is underlying

--- a/Tests/UI/test_buddy_conversation_modal.py
+++ b/Tests/UI/test_buddy_conversation_modal.py
@@ -1,0 +1,882 @@
+"""Mounted exact-owner Buddy commands over the real Console controller/store."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App, ComposeResult
+from textual.widgets import Button, Input, TextArea
+
+from Tests.Chat.test_console_runtime_lifetime import (
+    ConsoleChatStore,
+    _pending_call,
+    _StalledGateway,
+)
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+
+def pending_image():
+    from tldw_chatbook.Chat.attachment_core import PendingAttachment
+
+    return PendingAttachment(
+        file_path="/tmp/buddy-private.png",
+        display_name="private.png",
+        file_type="image",
+        insert_mode="attachment",
+        data=b"private-image",
+        mime_type="image/png",
+        original_size=13,
+        processed_size=13,
+    )
+
+
+async def until(predicate):
+    deadline = asyncio.get_running_loop().time() + 5
+    while not predicate():
+        assert asyncio.get_running_loop().time() < deadline
+        await asyncio.sleep(0.01)
+
+
+class Harness(App):
+    def __init__(self):
+        super().__init__()
+        self.gateway = _StalledGateway()
+        self.store = ConsoleChatStore()
+        self.target = self.store.create_session()
+        self.target.title = "Bound conversation"
+        self.other = self.store.create_session()
+        self.other.draft = "Unrelated Console draft"
+        self.controller = ConsoleChatController(
+            store=self.store, provider_gateway=self.gateway
+        )
+        self.controller.app = self
+        self.controller.on_submission_accepted = lambda: setattr(
+            self.other, "draft", ""
+        )
+        self.controller.set_pending_approval = lambda payload: None
+        self.controller._interrupt_host.POLL_SECONDS = 0.01
+        self.console_runtime = ConsoleRuntime(self)
+        self.console_runtime.set_chat_store(self.store)
+        self.console_runtime.set_chat_controller(self.controller)
+
+    def compose(self) -> ComposeResult:
+        yield Input(id="underlying-input")
+
+    async def on_unmount(self):
+        await self.console_runtime.dispose()
+
+
+@pytest.mark.asyncio
+async def test_buddy_send_targets_bound_session_and_survives_modal_close():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    async with app.run_test(size=(100, 36)) as pilot:
+        opener = app.query_one(Input)
+        opener.focus()
+        base = app.screen
+        binding = BuddyBinding.for_session(app.target)
+        other_attachment = pending_image()
+        app.store.add_pending_attachment(app.other.id, other_attachment)
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        modal.query_one("#buddy-reply", TextArea).load_text("Directed reply")
+        modal.query_one("#buddy-send", Button).press()
+        await until(app.gateway.started.is_set)
+        assert app.store.active_session_id == app.other.id
+        assert app.other.draft == "Unrelated Console draft"
+        assert app.store.pending_attachments(app.other.id) == [other_attachment]
+        assert (
+            app.store.messages_for_session(app.target.id)[0].content == "Directed reply"
+        )
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is base)
+        assert app.controller.in_flight_run_count() == 1
+        assert app.focused is opener
+        app.gateway.never_release.set()
+        await until(lambda: app.controller.in_flight_run_count() == 0)
+        assert (
+            app.store.messages_for_session(app.target.id)[-1].content == "partialnever"
+        )
+        assert not app.store.messages_for_session(app.other.id)
+
+
+@pytest.mark.asyncio
+async def test_buddy_drafts_and_approval_use_exact_binding():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    async with app.run_test(size=(100, 36)) as pilot:
+        binding = BuddyBinding.for_session(app.target)
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        modal.query_one("#buddy-reply", TextArea).load_text("Keep this draft")
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        assert modal.query_one("#buddy-reply", TextArea).text == "Keep this draft"
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                app.controller.request_mcp_approvals,
+                [_pending_call()],
+                session_id=app.target.id,
+            )
+        )
+        try:
+            await until(lambda: app.controller._interrupt_host.pending_total() == 1)
+            await pilot.pause(0.3)
+            from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import (
+                ChatApprovalCard,
+            )
+
+            card = modal.query_one(ChatApprovalCard)
+            assert card.display
+            round_id = app.controller._interrupt_host.head_round_payload(
+                "approval", app.target.id
+            )["round_id"]
+            # A forged round belonging to the other conversation never resolves.
+            assert (
+                modal.coordinator.resolve_decision(
+                    binding, "approval", "wrong-round", {}
+                )
+                is False
+            )
+            card.post_message(
+                ChatApprovalCard.ApprovalDecided({"c1": "deny"}, round_id=round_id)
+            )
+            await asyncio.wait_for(pending, 3)
+            assert app.store.active_session_id == app.other.id
+        finally:
+            if not pending.done():
+                app.controller.begin_shutdown()
+                await pending
+
+
+@pytest.mark.asyncio
+async def test_closed_owner_does_not_fall_back_or_start_microphone():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding.for_session(app.target)
+        app.store.close_session(app.target.id)
+        modal = open_buddy_conversation(app, binding)
+        await pilot.pause()
+        assert modal.query_one("#buddy-send", Button).disabled
+        assert modal.query_one("#buddy-mic", Button).disabled
+        assert app.store.active_session_id == app.other.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ("question", "skill_install", "skill_script"))
+async def test_buddy_existing_decision_cards_resolve_only_the_bound_round(kind):
+    from Tests.Chat.test_console_ask_user_round import _questions
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_question_card import ChatQuestionCard
+    from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+    from tldw_chatbook.Widgets.Chat_Widgets.skill_install_confirm_card import (
+        SkillInstallConfirmCard,
+    )
+    from tldw_chatbook.Widgets.Chat_Widgets.skill_script_confirm_card import (
+        SkillScriptConfirmCard,
+    )
+
+    app = Harness()
+    async with app.run_test(size=(100, 36)) as pilot:
+        setattr(app.controller, "set_pending_" + kind, lambda payload: None)
+        requests = {
+            "question": lambda: app.controller.request_user_questions(
+                _questions(), session_id=app.target.id
+            ),
+            "skill_install": lambda: app.controller.request_skill_install_confirm(
+                "https://example.com/skill", session_id=app.target.id
+            ),
+            "skill_script": lambda: app.controller.request_skill_script_confirm(
+                {"skill_name": "Demo", "script_path": "demo.py"},
+                session_id=app.target.id,
+            ),
+        }
+        pending = asyncio.create_task(asyncio.to_thread(requests[kind]))
+        try:
+            await until(lambda: app.controller._interrupt_host.pending_total() == 1)
+            binding = BuddyBinding.for_session(app.target)
+            modal = open_buddy_conversation(app, binding, allow_voice=False)
+            await pilot.pause()
+            modal.refresh_projection()
+            payload = app.controller._interrupt_host.head_round_payload(
+                kind, app.target.id
+            )
+            request_id = payload["request_id"]
+            assert not modal.coordinator.resolve_decision(
+                BuddyBinding.for_session(app.other), kind, request_id, False
+            )
+            if kind == "question":
+                card = modal.query_one(ChatQuestionCard)
+                event = ChatTaskCards.QuestionAnswered([], request_id)
+            elif kind == "skill_install":
+                card = modal.query_one(SkillInstallConfirmCard)
+                event = SkillInstallConfirmCard.InstallDecided(False, request_id)
+            else:
+                card = modal.query_one(SkillScriptConfirmCard)
+                event = SkillScriptConfirmCard.ScriptDecided(False, False, request_id)
+            assert card.display
+            card.post_message(event)
+            await asyncio.wait_for(pending, 3)
+            assert app.store.active_session_id == app.other.id
+        finally:
+            if not pending.done():
+                app.controller.begin_shutdown()
+                await pending
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ("question", "skill_install", "skill_script"))
+async def test_explicit_buddy_retains_headless_decisions_after_close(kind):
+    from Tests.Chat.test_console_ask_user_round import _questions
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    async with app.run_test(size=(100, 36)) as pilot:
+        assert getattr(app.controller, "set_pending_" + kind) is None
+        binding = BuddyBinding.for_session(app.target)
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+
+        def request(session_id):
+            if kind == "question":
+                return app.controller.request_user_questions(
+                    _questions(), session_id=session_id
+                )
+            if kind == "skill_install":
+                return app.controller.request_skill_install_confirm(
+                    "https://example.com/skill", session_id=session_id
+                )
+            return app.controller.request_skill_script_confirm(
+                {"skill_name": "Demo", "script_path": "demo.py"}, session_id=session_id
+            )
+
+        # A wake-only sibling with no explicit interaction still fails closed.
+        result = request(app.other.id)
+        assert result in (
+            False,
+            {"answered": False, "reason": "cancelled"},
+            {"allow": False, "remember": False},
+        )
+        pending = asyncio.create_task(asyncio.to_thread(request, app.target.id))
+        try:
+            await until(
+                lambda: (
+                    app.controller._interrupt_host.pending_total() == 1
+                    or pending.done()
+                )
+            )
+            assert not pending.done()
+            reopened = open_buddy_conversation(app, binding, allow_voice=False)
+            await pilot.pause()
+            payload = reopened.coordinator.decision_payloads(binding)[kind]
+            decision = (
+                []
+                if kind == "question"
+                else (False, False)
+                if kind == "skill_script"
+                else False
+            )
+            assert reopened.coordinator.resolve_decision(
+                binding, kind, payload["request_id"], decision
+            )
+            await asyncio.wait_for(pending, 3)
+            assert app.store.active_session_id == app.other.id
+            app.target.conversation_binding_revision += 1
+            assert not app.controller._interrupt_host.has_retained_decision_target(
+                app.target.id
+            )
+        finally:
+            if not pending.done():
+                app.controller.begin_shutdown()
+                await pending
+
+
+@pytest.mark.asyncio
+async def test_draft_follows_same_conversation_canonical_binding():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    app.target.ephemeral = False
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding.for_session(app.target)
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        modal.query_one("#buddy-reply", TextArea).load_text("Keep this private draft")
+        await pilot.pause()
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+        app.target.persisted_conversation_id = "now-saved"
+        canonical = BuddyBinding.for_session(app.target)
+        reopened = open_buddy_conversation(app, canonical, allow_voice=False)
+        await pilot.pause()
+        assert (
+            reopened.query_one("#buddy-reply", TextArea).text
+            == "Keep this private draft"
+        )
+        assert app.store.active_session_id == app.other.id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ("deleted", "profile"))
+async def test_saved_load_revalidates_after_io_without_selecting(monkeypatch, change):
+    import tldw_chatbook.Chat.console_conversation_hydration as hydration
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    record = {"id": "saved-conversation", "runtime_backend": "local", "title": "Saved"}
+    app.local_chat_conversation_service = SimpleNamespace(
+        get_conversation_metadata=lambda _: record
+    )
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def load(_app, target):
+        assert target == "saved-conversation"
+        started.set()
+        await release.wait()
+        return {"conversation": record, "roots": []}
+
+    monkeypatch.setattr(hydration, "load_console_conversation_tree", load)
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding(
+            "conversation",
+            "saved:saved-conversation",
+            conversation_id="saved-conversation",
+        )
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await started.wait()
+        if change == "deleted":
+            record["deleted"] = True
+        else:
+            app.chachanotes_db = object()
+        release.set()
+        await until(lambda: not modal.coordinator.restoring)
+        await pilot.pause()
+        assert modal.coordinator.resolve(binding) is None
+        assert app.store.active_session_id == app.other.id
+        assert len(app.store.sessions()) == 2
+        assert not app.gateway.started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_failed_cold_bootstrap_keeps_explicit_console_recovery(monkeypatch):
+    import tldw_chatbook.Chat.console_launch_wake as wake
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    app.console_runtime.set_chat_store(None)
+    app.console_runtime.set_chat_controller(None)
+    app.local_chat_conversation_service = SimpleNamespace(
+        get_conversation_metadata=lambda _: {"runtime_backend": "local"}
+    )
+    monkeypatch.setattr(wake, "_ensure_launch_runtime", lambda _app: None)
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding(
+            "conversation", "saved:available", conversation_id="available"
+        )
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await until(lambda: not modal.coordinator.restoring)
+        await pilot.pause()
+        assert modal.query_one("#buddy-send", Button).disabled
+        assert not modal.query_one("#buddy-open-console", Button).disabled
+        assert "Open Console" in modal.coordinator.notices[binding]
+        assert not app.gateway.started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_saved_loader_retains_the_exact_buddy_decision_owner(
+    monkeypatch,
+):
+    import tldw_chatbook.Chat.console_conversation_hydration as hydration
+    from Tests.Chat.test_console_ask_user_round import _questions
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    conversation_id = "concurrent-saved"
+    record = {"id": conversation_id, "runtime_backend": "local", "title": "Saved"}
+    app.local_chat_conversation_service = SimpleNamespace(
+        get_conversation_metadata=lambda _: record
+    )
+    started, release = asyncio.Event(), asyncio.Event()
+
+    async def load(_app, target):
+        assert target == conversation_id
+        started.set()
+        await release.wait()
+        return {"conversation": record, "roots": []}
+
+    monkeypatch.setattr(hydration, "load_console_conversation_tree", load)
+    async with app.run_test(size=(100, 36)) as pilot:
+        binding = BuddyBinding(
+            "conversation", "saved:" + conversation_id, conversation_id=conversation_id
+        )
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await started.wait()
+        restored = app.store.create_session(ephemeral=False, activate=False)
+        app.store.rebind_persisted_conversation(restored.id, conversation_id)
+        release.set()
+        await until(lambda: not modal.coordinator.restoring)
+        await pilot.pause()
+        assert modal.coordinator.resolve(binding) is restored
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+        pending = asyncio.create_task(
+            asyncio.to_thread(
+                app.controller.request_user_questions,
+                _questions(),
+                session_id=restored.id,
+            )
+        )
+        try:
+            await until(
+                lambda: (
+                    app.controller._interrupt_host.pending_total() == 1
+                    or pending.done()
+                )
+            )
+            assert not pending.done()
+            reopened = open_buddy_conversation(app, binding, allow_voice=False)
+            await pilot.pause()
+            payload = reopened.coordinator.decision_payloads(binding)["question"]
+            assert reopened.coordinator.resolve_decision(
+                binding, "question", payload["request_id"], []
+            )
+            await asyncio.wait_for(pending, 3)
+            assert app.store.active_session_id == app.other.id
+        finally:
+            if not pending.done():
+                app.controller.begin_shutdown()
+                await pending
+
+
+@pytest.mark.asyncio
+async def test_dictation_finishes_into_reviewable_draft_without_sending():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+
+    class Voice:
+        discarded = False
+
+        def start(self, **kwargs):
+            assert app.buddy_speech_coordinator.queue.state.input_active
+
+        def stop_and_transcribe(self):
+            return "Dictated words"
+
+        def discard(self):
+            self.discarded = True
+
+    voice = Voice()
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding.for_session(app.target)
+        modal = open_buddy_conversation(app, binding)
+        modal.coordinator.voice_factory = lambda **kwargs: voice
+        modal.coordinator.voice_availability = lambda: SimpleNamespace(ok=True)
+        await pilot.pause()
+        modal.query_one("#buddy-mic", Button).press()
+        await until(lambda: modal.coordinator.voice_status(modal) == "recording")
+        await until(lambda: not modal.query_one("#buddy-mic", Button).disabled)
+        modal.query_one("#buddy-mic", Button).press()
+        await until(lambda: modal.coordinator.drafts.get(binding) == "Dictated words")
+        await until(
+            lambda: modal.query_one("#buddy-reply", TextArea).text == "Dictated words"
+        )
+        assert voice.discarded
+        assert not app.buddy_speech_coordinator.queue.state.input_active
+        assert not app.gateway.started.is_set()
+
+
+@pytest.mark.asyncio
+async def test_closing_buddy_discards_microphone_and_ignores_late_result():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+
+    class Voice:
+        discarded = False
+
+        def start(self, **kwargs):
+            pass
+
+        def discard(self):
+            self.discarded = True
+
+    voice = Voice()
+    async with app.run_test(size=(90, 28)) as pilot:
+        modal = open_buddy_conversation(app, BuddyBinding.for_session(app.target))
+        modal.coordinator.voice_factory = lambda **kwargs: voice
+        modal.coordinator.voice_availability = lambda: SimpleNamespace(ok=True)
+        await pilot.pause()
+        modal.query_one("#buddy-mic", Button).press()
+        await until(lambda: modal.coordinator.voice_status(modal) == "recording")
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+        await until(lambda: voice.discarded)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "refusal", ("attachment", "repurposed", "deleted", "busy", "command")
+)
+async def test_buddy_refuses_unseen_input_and_unavailable_owners(refusal):
+    from tldw_chatbook.Chat.console_chat_models import ConsoleRunState, ConsoleRunStatus
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    app = Harness()
+    async with app.run_test(size=(80, 24)) as pilot:
+        if refusal == "deleted":
+            app.target.ephemeral = False
+            app.target.persisted_conversation_id = "deleted-conversation"
+            app.local_chat_conversation_service = SimpleNamespace(
+                get_conversation_metadata=lambda _: None
+            )
+        binding = BuddyBinding.for_session(app.target)
+        if refusal == "attachment":
+            app.store.add_pending_attachment(app.target.id, pending_image())
+        elif refusal == "repurposed":
+            app.target.conversation_binding_revision += 1
+        elif refusal == "busy":
+            app.controller._set_run_state(
+                ConsoleRunState(ConsoleRunStatus.STREAMING), session_id=app.target.id
+            )
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        reply = "/new" if refusal == "command" else "Do not redirect me"
+        modal.coordinator.request_send(binding, reply)
+        await until(lambda: binding not in modal.coordinator.submitting)
+        assert modal.coordinator.notices[binding]
+        assert modal.coordinator.drafts[binding] == reply
+        assert not app.gateway.started.is_set()
+        assert not app.store.messages_for_session(app.other.id)
+        if refusal == "attachment":
+            assert (
+                app.store.pending_attachments(app.target.id)[0].data == b"private-image"
+            )
+        assert not modal.query("#buddy-mic")
+        assert modal.query_one("#buddy-close").region.bottom <= app.size.height
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("late_phase", ("starting", "transcribing"))
+async def test_late_voice_completion_after_close_cannot_change_the_draft(late_phase):
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    gate = threading.Event()
+    started = threading.Event()
+
+    class Voice:
+        discards = 0
+
+        def start(self, **kwargs):
+            if late_phase == "starting":
+                started.set()
+                gate.wait(5)
+
+        def stop_and_transcribe(self):
+            started.set()
+            gate.wait(5)
+            return "late private speech"
+
+        def discard(self):
+            self.discards += 1
+
+    voice = Voice()
+    app = Harness()
+    async with app.run_test(size=(90, 28)) as pilot:
+        binding = BuddyBinding.for_session(app.target)
+        modal = open_buddy_conversation(app, binding)
+        modal.coordinator.voice_factory = lambda **kwargs: voice
+        modal.coordinator.voice_availability = lambda: SimpleNamespace(ok=True)
+        await pilot.pause()
+        modal.query_one("#buddy-reply", TextArea).load_text("Keep typed words")
+        await pilot.pause()
+        modal.coordinator.request_voice(modal, binding, allowed=True)
+        if late_phase == "transcribing":
+            await until(lambda: modal.coordinator.voice_status(modal) == "recording")
+            modal.coordinator.request_voice(modal, binding, allowed=True)
+        await until(started.is_set)
+        modal.query_one("#buddy-close", Button).press()
+        await until(lambda: app.screen is not modal)
+        assert voice.discards
+        gate.set()
+        await pilot.pause(0.1)
+        assert modal.coordinator.drafts[binding] == "Keep typed words"
+        assert not app.gateway.started.is_set()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("saved", (False, True))
+async def test_real_console_buddy_send_preserves_both_durable_console_drafts(
+    monkeypatch, tmp_path, saved
+):
+    from Tests.UI.test_console_native_chat_flow import (
+        _configure_native_ready_console,
+        _ReadyResolutionGateway,
+        _select_llamacpp_console,
+    )
+    from Tests.UI.test_console_screen_reuse import (
+        _boot_settled,
+        _press_until_screen,
+        _scratch_env,
+    )
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+    from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+    _scratch_env(monkeypatch, tmp_path)
+
+    class Gateway(_ReadyResolutionGateway):
+        started = threading.Event()
+        release = threading.Event()
+
+        async def stream_chat(self, resolution, messages, **kwargs):
+            self.started.set()
+            yield "reply"
+            while not self.release.is_set():
+                await asyncio.sleep(0.01)
+
+        async def aclose(self):
+            pass
+
+    gateway = Gateway()
+    app = TldwCli()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app, pilot)
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        console = app.screen
+        _select_llamacpp_console(console)
+        controller = console._ensure_console_chat_controller()
+        target = controller.store.ensure_session()
+        binding = BuddyBinding.for_session(target)
+        reply = "Same durable Console draft"
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft(reply)
+        target.draft = reply
+        other = controller.new_session()
+        await console._sync_native_console_chat_ui()
+        composer.load_draft("Unrelated visible composer")
+        other.draft = "Unrelated visible composer"
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        prior_workspace = controller.store.workspace_context.active_workspace_id
+        if saved:
+            conversation_id = app.local_chat_conversation_service.create_conversation(
+                title="Unloaded saved conversation",
+                runtime_backend="local",
+                scope_type="global",
+            )
+            # A saved Console turn carries its durable Library policy; a raw
+            # legacy Chat row is deliberately refused by the commit guard.
+            controller.store.persistence.console_library_policy_repository.insert(
+                conversation_id,
+                controller.store.session_library_policy_candidate(target.id),
+            )
+            app.chachanotes_db.add_message(
+                {
+                    "conversation_id": conversation_id,
+                    "sender": "user",
+                    "role": "user",
+                    "content": "Earlier saved message",
+                }
+            )
+            binding = BuddyBinding(
+                "conversation",
+                "saved:" + conversation_id,
+                conversation_id=conversation_id,
+            )
+            assert binding.resolve_session(controller.store.sessions()) is None
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        await pilot.pause()
+        try:
+            if saved:
+                await until(lambda: modal.coordinator.resolve(binding) is not None)
+                target = modal.coordinator.resolve(binding)
+                target.draft = reply
+                assert target.persisted_conversation_id == conversation_id
+                assert (
+                    controller.store.messages_for_session(target.id)[0].content
+                    == "Earlier saved message"
+                )
+                assert (
+                    controller.store.workspace_context.active_workspace_id
+                    == prior_workspace
+                )
+            modal.query_one("#buddy-reply", TextArea).load_text(reply)
+            modal.query_one("#buddy-send", Button).press()
+            await until(gateway.started.is_set)
+            assert target.persisted_conversation_id
+            assert modal.coordinator.resolve(binding) is target
+            assert target.draft == reply
+            assert other.draft == "Unrelated visible composer"
+            assert composer.draft_text() == "Unrelated visible composer"
+            assert controller.store.active_session_id == other.id
+            modal.query_one("#buddy-close", Button).press()
+            await until(lambda: type(app.screen).__name__ == "HomeScreen")
+            assert controller.in_flight_run_count() == 1
+            gateway.release.set()
+            await until(lambda: controller.in_flight_run_count() == 0)
+            assert target.draft == reply
+            assert not controller.store.messages_for_session(other.id)
+            reopened = open_buddy_conversation(
+                app, BuddyBinding.for_session(target), allow_voice=False
+            )
+            await pilot.pause()
+            reopened.query_one("#buddy-open-console", Button).press()
+            await until(lambda: app.screen.__class__.__name__ == "ChatScreen")
+            await until(
+                lambda: (
+                    controller.store.active_session_id == target.id
+                    and composer.draft_text() == reply
+                )
+            )
+        finally:
+            gateway.release.set()
+            await controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cold_home_saved_buddy_bootstraps_only_after_explicit_open(
+    monkeypatch, tmp_path
+):
+    from Tests.UI.test_console_native_chat_flow import (
+        _configure_native_ready_console,
+        _ReadyResolutionGateway,
+    )
+    from Tests.UI.test_console_screen_reuse import _boot_settled, _scratch_env
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+    from tldw_chatbook.Chat.console_library_policy import (
+        ConsoleAssistantLibraryAccess,
+        ConsoleAutoRetrieve,
+        ConsoleLibraryPolicyCandidate,
+    )
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    _scratch_env(monkeypatch, tmp_path)
+    config_path = tmp_path / "config" / "tldw_cli" / "config.toml"
+    config_path.write_text(
+        config_path.read_text() + '\n[general]\ndefault_tab = "home"\n'
+    )
+
+    class Gateway(_ReadyResolutionGateway):
+        started = threading.Event()
+
+        async def stream_chat(self, resolution, messages, **kwargs):
+            self.started.set()
+            yield "Cold reply"
+
+        async def aclose(self):
+            pass
+
+    gateway = Gateway()
+    app = TldwCli()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    async with app.run_test(size=(150, 45)) as pilot:
+        await _boot_settled(app, pilot)
+        assert app.screen.__class__.__name__ == "HomeScreen"
+        runtime = app.console_runtime
+        assert runtime.chat_store is None and runtime.chat_controller is None
+        conversation_id = app.local_chat_conversation_service.create_conversation(
+            title="Cold saved Console", runtime_backend="local", scope_type="global"
+        )
+        ChatPersistenceService(
+            app.chachanotes_db
+        ).console_library_policy_repository.insert(
+            conversation_id,
+            ConsoleLibraryPolicyCandidate(
+                ConsoleAutoRetrieve.NEVER, ConsoleAssistantLibraryAccess.BLOCKED
+            ),
+        )
+        app.chachanotes_db.add_message(
+            {
+                "conversation_id": conversation_id,
+                "sender": "assistant",
+                "role": "assistant",
+                "content": "Saved result to review",
+            }
+        )
+        binding = BuddyBinding(
+            "conversation", "saved:" + conversation_id, conversation_id=conversation_id
+        )
+        modal = open_buddy_conversation(app, binding, allow_voice=False)
+        try:
+            await until(lambda: modal.coordinator.resolve(binding) is not None)
+            await until(lambda: not modal.query_one("#buddy-send", Button).disabled)
+            store = runtime.chat_store
+            target = modal.coordinator.resolve(binding)
+            assert store.active_session_id is None
+            assert (
+                store.messages_for_session(target.id)[0].content
+                == "Saved result to review"
+            )
+            modal.query_one("#buddy-reply", TextArea).load_text("Follow up from Home")
+            modal.query_one("#buddy-send", Button).press()
+            await until(gateway.started.is_set)
+            modal.query_one("#buddy-close", Button).press()
+            await until(lambda: app.screen.__class__.__name__ == "HomeScreen")
+            assert store.active_session_id is None
+            assert runtime.view is None
+            await until(lambda: runtime.chat_controller.in_flight_run_count() == 0)
+            from Tests.Chat.test_console_ask_user_round import _questions
+
+            for kind in ("question", "approval"):
+                controller = runtime.chat_controller
+                assert controller.set_pending_question is None
+                assert controller._ask_user_wiring(target.id)
+                if kind == "question":
+                    pending = asyncio.create_task(
+                        asyncio.to_thread(
+                            controller.request_user_questions,
+                            _questions(),
+                            session_id=target.id,
+                        )
+                    )
+                else:
+                    pending = asyncio.create_task(
+                        asyncio.to_thread(
+                            controller.request_mcp_approvals,
+                            [_pending_call()],
+                            session_id=target.id,
+                        )
+                    )
+                try:
+                    await until(
+                        lambda controller=controller, pending=pending: (
+                            controller._interrupt_host.pending_total() == 1
+                            or pending.done()
+                        )
+                    )
+                    assert not pending.done()
+                    reopened = open_buddy_conversation(app, binding, allow_voice=False)
+                    await pilot.pause()
+                    payload = reopened.coordinator.decision_payloads(binding)[kind]
+                    assert reopened.coordinator.resolve_decision(
+                        binding,
+                        kind,
+                        payload.get("request_id") or payload.get("round_id"),
+                        [] if kind == "question" else {"c1": "deny"},
+                    )
+                    await asyncio.wait_for(pending, 3)
+                    reopened.query_one("#buddy-close", Button).press()
+                    await until(lambda: app.screen.__class__.__name__ == "HomeScreen")
+                    assert store.active_session_id is None
+                finally:
+                    if not pending.done():
+                        controller.begin_shutdown()
+                        await pending
+        finally:
+            if runtime.chat_controller is not None:
+                await runtime.chat_controller.shutdown()

--- a/Tests/UI/test_buddy_conversation_modal.py
+++ b/Tests/UI/test_buddy_conversation_modal.py
@@ -886,3 +886,153 @@ async def test_cold_home_saved_buddy_bootstraps_only_after_explicit_open(
         finally:
             if runtime.chat_controller is not None:
                 await runtime.chat_controller.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_recorder_buffer_callback_runs_on_textual_app_thread():
+    from tldw_chatbook.UI.Navigation.buddy_conversation import (
+        BuddyConversationCoordinator,
+        _VoiceCapture,
+    )
+
+    app = Harness()
+    callback = []
+    threads = []
+    finished = asyncio.Event()
+
+    class Recorder:
+        def start(self, *, on_buffer_limit):
+            callback.append(on_buffer_limit)
+
+        def discard(self):
+            pass
+
+    class Speech:
+        async def wait_silent(self):
+            pass
+
+    async with app.run_test():
+        coordinator = BuddyConversationCoordinator(app)
+        binding = BuddyBinding.for_session(app.target)
+        owner = object()
+        capture = _VoiceCapture(binding, Recorder(), "", Speech())
+        coordinator._voices[owner] = capture
+
+        def voice(*args, **kwargs):
+            threads.append(threading.get_ident())
+            finished.set()
+
+        coordinator.request_voice = voice
+        await coordinator._start_voice(owner, capture)
+        await asyncio.to_thread(callback[0])
+        await asyncio.wait_for(finished.wait(), 2)
+        assert threads == [threading.get_ident()]
+        assert capture.status == "recording"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "phase", ["tree", "attachments", "cursor", "continuations", "generation"]
+)
+@pytest.mark.parametrize("change", [False, True])
+async def test_saved_buddy_bulk_reads_allow_loop_progress_and_recheck_owner(
+    tmp_path, monkeypatch, phase, change
+):
+    from tldw_chatbook.Chat.chat_conversation_scope_service import (
+        ChatConversationScopeService,
+    )
+    from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+    from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+    from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+    from tldw_chatbook.UI.Navigation.buddy_conversation import open_buddy_conversation
+
+    db = CharactersRAGDB(tmp_path / "restore.db", "buddy-restore")
+    local = ChatConversationService(db)
+    target = local.create_conversation(
+        title="Saved", runtime_backend="local", scope_type="global"
+    )
+    db.add_message(
+        {
+            "conversation_id": target,
+            "sender": "user",
+            "role": "user",
+            "content": "Saved input",
+        }
+    )
+    app = Harness()
+    app.chachanotes_db = db
+    app.local_chat_conversation_service = local
+    app.chat_conversation_scope_service = ChatConversationScopeService(
+        local_service=local, server_service=None
+    )
+    persistence = ChatPersistenceService(db)
+    app.store.persistence = persistence
+    service, name = {
+        "tree": (local, "get_conversation_tree"),
+        "attachments": (db, "get_attachments_for_messages"),
+        "cursor": (db, "get_conversation_active_cursor"),
+        "continuations": (db, "get_messages_for_conversation"),
+        "generation": (persistence, "get_generation_metadata_for_messages"),
+    }[phase]
+    original = getattr(service, name)
+    entered, release = threading.Event(), threading.Event()
+    reads = []
+    main_thread = threading.get_ident()
+
+    def delayed(*args, **kwargs):
+        reads.append(threading.get_ident())
+        entered.set()
+        assert release.wait(3), "bulk read blocked the event loop"
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(service, name, delayed)
+    closed = []
+    close = db.close_connection
+
+    def close_worker():
+        close()
+        closed.append((threading.get_ident(), getattr(db._local, "conn", None)))
+
+    monkeypatch.setattr(db, "close_connection", close_worker)
+    published = []
+    restore = app.store.restore_persisted_session
+
+    def restore_on_app(**kwargs):
+        published.append(threading.get_ident())
+        return restore(**kwargs)
+
+    monkeypatch.setattr(app.store, "restore_persisted_session", restore_on_app)
+    try:
+        async with app.run_test():
+            binding = BuddyBinding(
+                "conversation", "saved:" + target, conversation_id=target
+            )
+            modal = open_buddy_conversation(app, binding, allow_voice=False)
+            await until(entered.is_set)
+            assert reads == [reads[0]] and reads[0] != main_thread
+            assert not published
+            if change:
+                app.chachanotes_db = object()
+            release.set()
+            await until(lambda: not modal.coordinator.restoring)
+            if change:
+                assert modal.coordinator.resolve(binding) is None
+                assert not published
+            else:
+                restored = modal.coordinator.resolve(binding)
+                assert restored is not None
+                assert published == [main_thread]
+                assert (
+                    app.store.messages_for_session(restored.id)[0].content
+                    == "Saved input"
+                )
+            assert app.store.active_session_id == app.other.id
+            assert any(
+                thread != main_thread and connection is None
+                for thread, connection in closed
+            )
+            assert db.get_conversation_by_id(target)["id"] == target
+            assert len(reads) == 1 and reads[0] != main_thread
+    finally:
+        release.set()
+        db.close_connection()

--- a/Tests/UI/test_buddy_conversation_modal.py
+++ b/Tests/UI/test_buddy_conversation_modal.py
@@ -2,10 +2,11 @@
 
 import asyncio
 import threading
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
-from textual.app import App, ComposeResult
+from textual.app import ComposeResult
 from textual.widgets import Button, Input, TextArea
 
 from Tests.Chat.test_console_runtime_lifetime import (
@@ -13,6 +14,7 @@ from Tests.Chat.test_console_runtime_lifetime import (
     _pending_call,
     _StalledGateway,
 )
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
 from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
@@ -40,7 +42,11 @@ async def until(predicate):
         await asyncio.sleep(0.01)
 
 
-class Harness(App):
+class Harness(ConsolidatedCSSApp):
+    CSS_PATH = str(
+        Path(__file__).resolve().parents[2] / "tldw_chatbook/css/tldw_cli_modular.tcss"
+    )
+
     def __init__(self):
         super().__init__()
         self.gateway = _StalledGateway()

--- a/Tests/UI/test_buddy_entry_points.py
+++ b/Tests/UI/test_buddy_entry_points.py
@@ -1,0 +1,73 @@
+"""Both Buddy management controls use the same app-owned opener."""
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_persona_buddy_widget import (
+    _BuddyApp,
+    _compositor_text,
+    _FakeController,
+    _wait_until,
+)
+from tldw_chatbook.Widgets.Console.console_composer_menu_modal import (
+    build_composer_menu_entries,
+)
+from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
+    PersonaBuddyWidget,
+)
+
+
+def test_composer_menu_has_a_named_buddy_action():
+    choices = [
+        entry for entry in build_composer_menu_entries() if entry.action_id == "buddy"
+    ]
+    assert len(choices) == 1
+    assert choices[0].label == "Buddy…"
+    assert choices[0].enabled
+
+
+@pytest.mark.asyncio
+async def test_floating_settings_opens_the_shared_management_flow(monkeypatch):
+    from tldw_chatbook.UI.Navigation import buddy_management
+
+    opened = []
+    monkeypatch.setattr(buddy_management, "open_buddy_management", opened.append)
+    app = _BuddyApp(_FakeController())
+    async with app.run_test(size=(80, 24)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: "BUDDY-A" in _compositor_text(app.screen))
+        assert buddy.query("#persona-buddy-settings"), (
+            "Floating Buddy settings control is missing"
+        )
+        button = buddy.query_one("#persona-buddy-settings", Button)
+        assert button.tooltip == "Buddy & Persona Management"
+        await pilot.pause()
+        assert button.display and button.region.width >= 3
+        assert await pilot.click(button, offset=(1, 0)), (
+            button.region,
+            _compositor_text(app.screen),
+        )
+        assert opened == [app]
+
+
+@pytest.mark.asyncio
+async def test_body_click_and_enter_open_interaction_without_geometry_write(
+    monkeypatch,
+):
+    from tldw_chatbook.UI.Navigation import buddy_management
+
+    opened = []
+    monkeypatch.setattr(buddy_management, "open_buddy_interaction", opened.append)
+    controller = _FakeController()
+    app = _BuddyApp(controller)
+    async with app.run_test(size=(80, 24)) as pilot:
+        buddy = app.screen.query_one(PersonaBuddyWidget)
+        await _wait_until(lambda: "BUDDY-A" in _compositor_text(app.screen))
+        await pilot.pause()
+        writes = []
+        monkeypatch.setattr(buddy, "_schedule_geometry_persist", writes.append)
+        await pilot.click(buddy.query_one("#persona-buddy-frame"), offset=(6, 3))
+        assert opened == [app]
+        await pilot.press("enter")
+        assert opened == [app, app]
+        assert writes == []

--- a/Tests/UI/test_buddy_management_journey.py
+++ b/Tests/UI/test_buddy_management_journey.py
@@ -1,0 +1,94 @@
+"""Fresh-profile Console menu, independent artwork, and off-screen Buddy journey."""
+
+import asyncio
+
+import pytest
+from textual.widgets import Button, Select, Switch
+
+from Tests.UI.test_console_navigation_decisions import _until
+from Tests.UI.test_console_screen_reuse import (
+    _boot_settled,
+    _press_until_screen,
+    _scratch_env,
+)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ui
+async def test_fresh_install_selects_independent_buddy_and_opens_pinned_chat_from_home(
+    monkeypatch, tmp_path
+):
+    _scratch_env(monkeypatch, tmp_path)
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.UI.Navigation.buddy_management import (
+        get_buddy_management,
+        open_buddy_interaction,
+    )
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementModal,
+    )
+
+    app = TldwCli()
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app, pilot)
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        console = app.screen
+        controller = console._ensure_console_chat_controller()
+        target = controller.store.ensure_session()
+        persona_before = await asyncio.to_thread(
+            app.local_character_persona_service.list_persona_profiles
+        )
+
+        console.query_one("#console-composer-menu", Button).press()
+        await _until(lambda: type(app.screen).__name__ == "ConsoleComposerMenuModal")
+        app.screen.query_one("#console-composer-menu-buddy", Button).press()
+        await _until(lambda: isinstance(app.screen, BuddyManagementModal))
+        # Screen-stack publication precedes nested Select label composition.
+        await pilot.pause()
+        manager = get_buddy_management(app)
+        buddies = await asyncio.to_thread(manager.library.list_buddies)
+        assert buddies, (
+            "Fresh installation must offer built-in independent Buddy artwork"
+        )
+        modal = app.screen
+        modal.query_one("#buddy-artwork", Select).value = buddies[0].id
+        modal.query_one("#buddy-follow", Select).value = f"conversation:{target.id}"
+        modal.query_one("#buddy-motion", Select).value = "static"
+        modal.query_one("#buddy-enabled", Switch).value = True
+        modal.query_one("#buddy-apply", Button).press()
+        await _until(
+            lambda: (
+                app.app_config.get("buddy_interaction", {}).get("target_id")
+                == target.id
+            )
+        )
+        assert (
+            manager.controller.current_preferences().selection.buddy_id == buddies[0].id
+        )
+        assert manager.preferences.animated is False
+        assert (
+            await asyncio.to_thread(
+                app.local_character_persona_service.list_persona_profiles
+            )
+            == persona_before
+        )
+        assert manager.library.get_graph(buddies[0].id).identity.persona_id is None
+
+        await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+        home = app.screen
+        open_buddy_interaction(app)
+        await _until(lambda: type(app.screen).__name__ == "BuddyConversationModal")
+        await pilot.pause()
+        assert app.screen.binding.target_id == target.id
+        assert controller.store.active_session_id == target.id
+        app.screen.query_one("#buddy-close", Button).press()
+        await _until(lambda: app.screen is home)
+
+        manager.request_open()
+        await _until(lambda: isinstance(app.screen, BuddyManagementModal))
+        await pilot.pause()
+        before_cancel = manager.controller.current_preferences()
+        app.screen.query_one("#buddy-enabled", Switch).value = False
+        await pilot.press("escape")
+        assert app.screen is home
+        assert manager.controller.current_preferences() == before_cancel

--- a/Tests/UI/test_buddy_management_modal.py
+++ b/Tests/UI/test_buddy_management_modal.py
@@ -202,3 +202,57 @@ async def test_current_persona_name_is_literal_text(kind):
         app.push_screen(modal)
         await pilot.pause()
         assert "Archivist [/]" in str(modal.query_one("#buddy-persona-help").render())
+
+
+@pytest.mark.asyncio
+async def test_buddy_form_rejects_overlong_archive_at_shared_input_boundary():
+    m = modal_module()
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal()
+        app.push_screen(modal)
+        await pilot.pause()
+        modal.query_one("#buddy-import", Input).value = "x" * 4097
+        with pytest.raises(ValueError):
+            modal._choice()
+
+
+@pytest.mark.asyncio
+async def test_artwork_paging_retains_selected_label_and_staged_choice():
+    m = modal_module()
+    all_rows = tuple((f"[bold]Buddy {index}[/bold]", str(index)) for index in range(5))
+
+    async def page(offset):
+        return all_rows[offset : offset + 2]
+
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal(
+            buddies=all_rows[:2],
+            artwork_page=page,
+            artwork_page_size=2,
+            selected_buddy=all_rows[-1],
+            initial=m.BuddyManagementChoice(enabled=True, buddy_id="4"),
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        assert modal._choice().buddy_id == "4"
+        modal.query_one("#buddy-artwork-next", Button).press()
+        await pilot.pause()
+        assert {key for _, key in modal._buddies} == {"2", "3"}
+        assert modal._choice().buddy_id == "4"
+        modal.query_one("#buddy-artwork", Select).value = "3"
+        await pilot.pause()
+        modal.query_one("#buddy-artwork-next", Button).press()
+        await pilot.pause()
+        assert {key for _, key in modal._buddies} == {"4"}
+        assert modal._choice().buddy_id == "3"
+        assert modal.query_one("#buddy-artwork-next", Button).disabled
+        modal.query_one("#buddy-artwork-previous", Button).press()
+        await pilot.pause()
+        assert modal._choice().buddy_id == "3"
+        labels = [
+            str(label)
+            for label, _ in modal.query_one("#buddy-artwork", Select)._options
+        ]
+        assert "[bold]Buddy 3[/bold]" in labels

--- a/Tests/UI/test_buddy_management_modal.py
+++ b/Tests/UI/test_buddy_management_modal.py
@@ -1,0 +1,98 @@
+"""The Buddy management form stages intent and stays usable on compact terminals."""
+
+import importlib.util
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Input, Select, Switch
+
+
+def modal_module():
+    assert (
+        importlib.util.find_spec(
+            "tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal"
+        )
+        is not None
+    ), "Buddy management surface is missing"
+    from tldw_chatbook.Widgets.Persona_Widgets import buddy_management_modal
+
+    return buddy_management_modal
+
+
+@pytest.mark.asyncio
+async def test_cancel_returns_no_mutation_after_staged_changes():
+    m = modal_module()
+    result = []
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal(buddies=(("Pixel Migu", "migu"),))
+        app.push_screen(modal, result.append)
+        await pilot.pause()
+        modal.query_one("#buddy-enabled", Switch).value = True
+        modal.query_one("#buddy-artwork", Select).value = "migu"
+        await pilot.press("escape")
+        assert result == [None]
+
+
+@pytest.mark.asyncio
+async def test_apply_captures_explicit_binding_and_static_preference():
+    m = modal_module()
+    from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+    binding = BuddyBinding(kind="workspace", target_id="research")
+    target = m.BuddyTargetChoice("workspace-research", "Workspace: Research", binding)
+    result = []
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal(
+            buddies=(("Pixel Migu", "migu"),), targets=(target,)
+        )
+        app.push_screen(modal, result.append)
+        await pilot.pause()
+        modal.query_one("#buddy-enabled", Switch).value = True
+        modal.query_one("#buddy-artwork", Select).value = "migu"
+        modal.query_one("#buddy-follow", Select).value = "workspace-research"
+        modal.query_one("#buddy-motion", Select).value = "static"
+        modal.query_one("#buddy-width", Input).value = "32"
+        modal.query_one("#buddy-apply", Button).press()
+        await pilot.pause()
+        assert result[0].binding == binding
+        assert result[0].animated is False
+        assert result[0].width == 32
+        assert result[0].persona_choice == m.PERSONA_UNCHANGED
+
+
+@pytest.mark.asyncio
+async def test_invalid_artwork_keeps_form_open_with_recovery_copy():
+    m = modal_module()
+    result = []
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal()
+        app.push_screen(modal, result.append)
+        await pilot.pause()
+        modal.query_one("#buddy-enabled", Switch).value = True
+        modal.query_one("#buddy-apply", Button).press()
+        await pilot.pause()
+        assert app.screen is modal
+        assert "Choose artwork" in str(modal.query_one("#buddy-form-error").render())
+        assert result == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(100, 40), (60, 20)])
+async def test_actions_remain_visible_and_fields_keyboard_accessible(size):
+    m = modal_module()
+    app = App()
+    async with app.run_test(size=size) as pilot:
+        modal = m.BuddyManagementModal(buddies=(("Pixel Migu", "migu"),))
+        app.push_screen(modal)
+        await pilot.pause()
+        apply = modal.query_one("#buddy-apply", Button)
+        assert apply.region.bottom <= size[1]
+        assert apply.region.right <= size[0]
+        modal.query_one("#buddy-height", Input).focus()
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        assert modal.query_one("#buddy-height").region.bottom <= apply.region.y
+        assert modal.query_one("#buddy-height").has_focus

--- a/Tests/UI/test_buddy_management_modal.py
+++ b/Tests/UI/test_buddy_management_modal.py
@@ -91,8 +91,114 @@ async def test_actions_remain_visible_and_fields_keyboard_accessible(size):
         apply = modal.query_one("#buddy-apply", Button)
         assert apply.region.bottom <= size[1]
         assert apply.region.right <= size[0]
+        from textual.widgets import Collapsible
+
+        modal.query_one(Collapsible).collapsed = False
+        await pilot.pause()
         modal.query_one("#buddy-height", Input).focus()
         await pilot.pause()
         await pilot.wait_for_scheduled_animations()
         assert modal.query_one("#buddy-height").region.bottom <= apply.region.y
         assert modal.query_one("#buddy-height").has_focus
+
+
+@pytest.mark.asyncio
+async def test_apply_failure_preserves_form_and_blocks_dismissal_while_saving():
+    import asyncio
+
+    m = modal_module()
+    started, finish = asyncio.Event(), asyncio.Event()
+    calls = []
+
+    async def apply(choice):
+        calls.append(choice)
+        started.set()
+        await finish.wait()
+        raise ValueError("Cannot import this pack. Check its path and retry.")
+
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal(apply=apply)
+        app.push_screen(modal)
+        await pilot.pause()
+        modal.query_one("#buddy-import", Input).value = "/missing.zip"
+        modal.query_one("#buddy-apply", Button).press()
+        await started.wait()
+        await pilot.press("escape")
+        assert app.screen is modal
+        assert modal.query_one("#buddy-apply", Button).disabled
+        finish.set()
+        await pilot.pause()
+        assert app.screen is modal
+        assert modal.query_one("#buddy-import", Input).value == "/missing.zip"
+        assert "Check its path" in str(modal.query_one("#buddy-form-error").render())
+        assert not modal.query_one("#buddy-apply", Button).disabled
+        assert len(calls) == 1
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(60, 20), (80, 24), (120, 40)])
+async def test_preview_pointer_focus_and_disclosed_geometry_fit(size):
+    from textual.widgets import Collapsible
+
+    m = modal_module()
+    previews = []
+    app = App()
+    async with app.run_test(size=size) as pilot:
+        modal = m.BuddyManagementModal(
+            buddies=(("Migu", "migu"),),
+            initial=m.BuddyManagementChoice(buddy_id="migu"),
+            preview=lambda *args: previews.append(args) or "Migu preview",
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        preview = modal.query_one("#buddy-preview-button", Button)
+        preview.focus()
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        assert preview.has_focus
+        assert (
+            preview.region.right
+            <= modal.query_one("#buddy-management-body").region.right
+        )
+        assert await pilot.click("#buddy-preview-button")
+        await pilot.pause()
+        assert previews == [("migu", "idle")]
+        advanced = modal.query_one(Collapsible)
+        assert advanced.collapsed
+        advanced.query_one("CollapsibleTitle").focus()
+        await pilot.press("enter")
+        await pilot.pause()
+        assert not advanced.collapsed
+        height = modal.query_one("#buddy-height", Input)
+        height.focus()
+        await pilot.pause()
+        await pilot.wait_for_scheduled_animations()
+        assert height.has_focus
+        assert (
+            height.region.right
+            <= modal.query_one("#buddy-management-body").region.right
+        )
+        assert height.region.bottom <= modal.query_one("#buddy-apply").region.y
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("kind", ["conversation", "workspace"])
+async def test_current_persona_name_is_literal_text(kind):
+    from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+    m = modal_module()
+    binding = BuddyBinding(kind=kind, target_id="target")
+    app = App()
+    async with app.run_test() as pilot:
+        modal = m.BuddyManagementModal(
+            targets=(
+                m.BuddyTargetChoice(
+                    "target", "Named target", binding, current_persona="Archivist [/]"
+                ),
+            ),
+            initial=m.BuddyManagementChoice(binding=binding),
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        assert "Archivist [/]" in str(modal.query_one("#buddy-persona-help").render())

--- a/Tests/UI/test_buddy_speech.py
+++ b/Tests/UI/test_buddy_speech.py
@@ -1,0 +1,298 @@
+"""App-owned named speech follows trusted sources without activating Console."""
+
+import asyncio
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_interrupt_rounds import InterruptRoundHost
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.UI.Navigation.buddy_speech import BuddySpeechCoordinator
+
+DESTINATION = "sha256:" + "b" * 64
+
+
+class Handler:
+    def __init__(self):
+        self.spoken = []
+        self.destination = SimpleNamespace(
+            fingerprint=DESTINATION,
+            provider_label="Configured TTS",
+            sanitized_destination="https://speech.example",
+            charges_may_apply=True,
+        )
+        self.resolving = None
+
+    async def resolve_console_speech_destination(self, *_args):
+        if self.resolving is not None:
+            await self.resolving.wait()
+        return self.destination
+
+    async def speak_guarded_utterance(self, text, **kwargs):
+        assert kwargs["validator"]()
+        assert kwargs["expected_destination_fingerprint"] == DESTINATION
+        self.spoken.append(text)
+        return True
+
+
+def setup():
+    store = ConsoleChatStore()
+    session = store.create_session(title="Research", ephemeral=True)
+    message = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="Owned response"
+    )
+    other = store.create_session(ephemeral=True)
+    handler = Handler()
+    host = InterruptRoundHost(SimpleNamespace(store=store))
+    app = SimpleNamespace(
+        app_config={},
+        console_runtime=SimpleNamespace(
+            chat_store=store,
+            chat_controller=SimpleNamespace(_interrupt_host=host),
+            alive=True,
+        ),
+    )
+
+    async def ensure():
+        return handler
+
+    app._ensure_tts_handler = ensure
+    return app, store, session, other, message, handler
+
+
+@pytest.mark.asyncio
+async def test_hidden_named_reply_uses_consent_and_does_not_select_or_acknowledge():
+    app, store, owner, other, _, handler = setup()
+    store.confirm_auto_speak_destination(owner.id, DESTINATION)
+    speech = BuddySpeechCoordinator(app)
+    speech.configure(BuddyBinding.for_session(owner), True)
+    try:
+        await speech.refresh()
+        await speech.queue.wait_idle()
+        await speech.refresh()
+        await speech.queue.wait_idle()
+        assert handler.spoken == ["Research. Owned response"]
+        assert store.active_session_id == other.id
+        assert not owner.speech_preferences.auto_speak
+    finally:
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+async def test_no_destination_consent_means_no_synthesis_or_background_modal():
+    app, _store, owner, _, _, handler = setup()
+    app.push_screen = lambda *_args: pytest.fail(
+        "Background speech must not steal focus"
+    )
+    speech = BuddySpeechCoordinator(app)
+    speech.configure(BuddyBinding.for_session(owner), True)
+    try:
+        await speech.refresh()
+        await speech.queue.wait_idle()
+        assert handler.spoken == []
+        assert speech.needs_consent
+        assert owner.speech_preferences.consent_destination is None
+    finally:
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+async def test_explicit_consent_revalidates_changed_destination_before_speech():
+    app, _, owner, _, _, handler = setup()
+    callbacks = []
+    app.push_screen = lambda screen, callback: callbacks.append(callback)
+    speech = BuddySpeechCoordinator(app)
+    speech.configure(BuddyBinding.for_session(owner), True)
+    try:
+        await speech.refresh()
+        await speech.queue.wait_idle()
+        speech.request_consent()
+        await asyncio.sleep(0)
+        handler.destination = SimpleNamespace(fingerprint="sha256:" + "c" * 64)
+        callbacks[0](True)
+        await speech._consent_task
+        assert handler.spoken == []
+        assert "changed" in speech.notice
+    finally:
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "change", ["assistant", "close", "profile", "binding", "content"]
+)
+async def test_owner_revalidated_after_destination_await(change):
+    app, store, owner, other, message, handler = setup()
+    store.confirm_auto_speak_destination(owner.id, DESTINATION)
+    handler.resolving = asyncio.Event()
+    speech = BuddySpeechCoordinator(app)
+    speech.configure(BuddyBinding.for_session(owner), True)
+    try:
+        await speech.refresh()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        if change == "assistant":
+            owner.assistant_id = "different"
+        elif change == "close":
+            store.close_session(owner.id)
+        elif change == "profile":
+            app.console_runtime = None
+        elif change == "content":
+            store.update_message_content(message.id, "Edited while preparing speech")
+        else:
+            speech.configure(BuddyBinding.for_session(other), True)
+        handler.resolving.set()
+        await speech.queue.wait_idle()
+        assert handler.spoken == []
+    finally:
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["version", "is_active", "deleted"])
+async def test_persona_revision_and_retirement_revoke_queued_speech(change):
+    app, store, owner, _, _, handler = setup()
+    record = {"id": "persona", "version": 1, "is_active": True}
+    owner.assistant_kind, owner.assistant_id = "persona", "persona"
+    app.local_character_persona_service = SimpleNamespace(
+        get_persona_profile=lambda _id: dict(record)
+    )
+    store.confirm_auto_speak_destination(owner.id, DESTINATION)
+    handler.resolving = asyncio.Event()
+    speech = BuddySpeechCoordinator(app)
+    speech.configure(BuddyBinding.for_session(owner), True)
+    try:
+        await speech.refresh()
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        record[change] = {"version": 2, "is_active": False, "deleted": True}[change]
+        handler.resolving.set()
+        await speech.queue.wait_idle()
+        assert handler.spoken == []
+    finally:
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+async def test_speech_controls_only_change_presentation():
+    from textual.app import App
+    from textual.widgets import Button
+
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_speech_controls import (
+        BuddySpeechControls,
+    )
+
+    app, _, owner, _, _, _ = setup()
+    speech = BuddySpeechCoordinator(app)
+    speech.enabled = True
+    ui = App()
+    async with ui.run_test(size=(80, 24)) as pilot:
+        await ui.screen.mount(BuddySpeechControls(speech))
+        ui.query_one("#buddy-speech-pause", Button).press()
+        await pilot.pause()
+        assert speech.queue.state.paused
+        ui.query_one("#buddy-speech-mute", Button).press()
+        await pilot.pause()
+        assert speech.queue.state.muted
+        assert not owner.speech_preferences.auto_speak
+    await speech.aclose()
+
+
+@pytest.mark.asyncio
+async def test_rebind_dismisses_owned_destination_confirmation_without_consent():
+    from textual.app import App
+
+    from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
+        AutoSpeakConsentModal,
+    )
+
+    app, _, owner, other, _, handler = setup()
+    ui = App()
+    ui.app_config = app.app_config
+    ui.console_runtime = app.console_runtime
+    ui._ensure_tts_handler = app._ensure_tts_handler
+    speech = BuddySpeechCoordinator(ui)
+    async with ui.run_test() as pilot:
+        speech.configure(BuddyBinding.for_session(owner), True)
+        await speech.refresh()
+        await speech.queue.wait_idle()
+        speech.request_consent()
+        await pilot.pause()
+        assert isinstance(ui.screen, AutoSpeakConsentModal)
+        speech.configure(BuddyBinding.for_session(other), True)
+        await pilot.pause()
+        assert not isinstance(ui.screen, AutoSpeakConsentModal)
+        assert speech._consents == set() and handler.spoken == []
+        await speech.aclose()
+
+
+@pytest.mark.asyncio
+async def test_workspace_questions_precede_named_results_and_never_acknowledge(
+    monkeypatch,
+):
+    from tldw_chatbook.Persona_Buddy.inbox import BuddyInboxEntry
+    from tldw_chatbook.UI.Navigation.buddy_workspace import BuddyWorkspaceCoordinator
+
+    app, store, owner, other, message, handler = setup()
+    owner.workspace_id = other.workspace_id = "workspace"
+    other.title = "Questions"
+    for session in (owner, other):
+        store.confirm_auto_speak_destination(session.id, DESTINATION)
+    receipt = SimpleNamespace(activity_id="receipt", assistant_message_id=message.id)
+    receipts = [receipt]
+    app.console_runtime.activity_receipts = SimpleNamespace(
+        unseen_snapshot=lambda: tuple(receipts)
+    )
+    host = app.console_runtime.chat_controller._interrupt_host
+    event = threading.Event()
+    host.registries["question"]["round"] = {"event": event}
+    host.park_round_payload(
+        "question",
+        "round",
+        {
+            "round_id": "round",
+            "session_id": other.id,
+            "questions": [{"question": "Which source should I use?"}],
+        },
+    )
+    rows = (
+        BuddyInboxEntry(
+            "result",
+            owner.title,
+            "results",
+            "Done",
+            BuddyBinding.for_session(owner),
+            ("receipt",),
+        ),
+        BuddyInboxEntry(
+            "question",
+            other.title,
+            "needs_you",
+            "Question",
+            BuddyBinding.for_session(other),
+        ),
+    )
+
+    async def snapshot(_self):
+        await asyncio.sleep(0)
+        return "Workspace", rows
+
+    monkeypatch.setattr(BuddyWorkspaceCoordinator, "snapshot", snapshot)
+    speech = BuddySpeechCoordinator(app)
+    speech.queue.pause()
+    speech.configure(BuddyBinding("workspace", "workspace"), True)
+    try:
+        await speech.refresh()
+        speech.queue.resume()
+        await speech.queue.wait_idle()
+        assert handler.spoken == [
+            "Questions. Your response is needed. Which source should I use?",
+            "Research. Owned response",
+        ]
+        assert receipts == [receipt] and not event.is_set()
+        assert store.active_session_id == other.id
+    finally:
+        await speech.aclose()

--- a/Tests/UI/test_buddy_workspace_modal.py
+++ b/Tests/UI/test_buddy_workspace_modal.py
@@ -104,3 +104,41 @@ async def test_refresh_preserves_selected_result_and_focus_without_acknowledging
         assert modal.query_one("#buddy-inbox-close").has_focus
         assert modal.selected_entry() == entry()
         assert seen == []
+
+
+@pytest.mark.asyncio
+async def test_failed_refresh_blocks_enter_highlight_and_acknowledgement_until_recovery():
+    from textual.widgets import OptionList
+
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_workspace_modal import (
+        BuddyWorkspaceModal,
+    )
+
+    failed = False
+    opened, seen = [], []
+
+    async def snapshot():
+        if failed:
+            raise ValueError("Workspace unavailable; retrying.")
+        return "Research", (entry(),)
+
+    app = App()
+    async with app.run_test() as pilot:
+        modal = BuddyWorkspaceModal(
+            snapshot=snapshot, open_entry=opened.append, acknowledge=seen.append
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        failed = True
+        await modal.refresh_inbox()
+        listing = modal.query_one(OptionList)
+        listing.focus()
+        await pilot.press("enter")
+        modal._sync_actions()
+        assert modal.query_one("#buddy-inbox-open", Button).disabled
+        await modal._mark_seen(entry())
+        assert opened == seen == []
+        failed = False
+        await modal.refresh_inbox()
+        await pilot.press("enter")
+        assert opened == [entry()]

--- a/Tests/UI/test_buddy_workspace_modal.py
+++ b/Tests/UI/test_buddy_workspace_modal.py
@@ -1,0 +1,106 @@
+"""Workspace Buddy interaction leaves the underlying destination in place."""
+
+from types import SimpleNamespace
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Input
+
+from tldw_chatbook.Persona_Buddy.inbox import BuddyInboxEntry
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.Persona_Buddy.speech import BuddySpeechQueue
+
+
+def entry(key="first"):
+    return BuddyInboxEntry(
+        key,
+        "Research",
+        "results",
+        "Response ready",
+        BuddyBinding(kind="conversation", target_id="live"),
+        (key,),
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(100, 40), (60, 20)])
+async def test_workspace_open_is_read_only_and_actions_fit(size):
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_workspace_modal import (
+        BuddyWorkspaceModal,
+    )
+
+    opened, seen = [], []
+
+    async def snapshot():
+        return "Research workspace", (entry(),)
+
+    app = App()
+
+    async def play(*_):
+        pytest.fail("Opening the inbox must not start speech")
+
+    queue = BuddySpeechQueue(play)
+    speech = SimpleNamespace(queue=queue, notice="", enabled=True, needs_consent=True)
+    async with app.run_test(size=size) as pilot:
+        underlying = app.screen
+        modal = BuddyWorkspaceModal(
+            snapshot=snapshot,
+            open_entry=opened.append,
+            acknowledge=seen.append,
+            speech=speech,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        assert seen == []
+        assert not list(modal.query(Input))
+        assert "voice" not in " ".join(
+            str(b.label).lower() for b in modal.query(Button)
+        )
+        actions = modal.query_one("#buddy-inbox-actions")
+        assert actions.region.bottom <= size[1]
+        assert modal.query_one("#buddy-inbox-list").region.height >= 1
+        speech_confirm = modal.query_one("#buddy-speech-confirm", Button)
+        assert speech_confirm.region.right <= size[0]
+        assert speech_confirm.region.bottom <= size[1]
+        modal.query_one("#buddy-speech-pause", Button).press()
+        await pilot.pause()
+        assert queue.state.paused
+        assert seen == []
+        modal.query_one("#buddy-inbox-open", Button).press()
+        await pilot.pause()
+        assert opened == [entry()]
+        assert seen == []
+        modal.query_one("#buddy-inbox-seen", Button).press()
+        await pilot.pause()
+        assert seen == [entry()]
+        modal.query_one("#buddy-inbox-close", Button).press()
+        await pilot.pause()
+        assert app.screen is underlying
+
+
+@pytest.mark.asyncio
+async def test_refresh_preserves_selected_result_and_focus_without_acknowledging():
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_workspace_modal import (
+        BuddyWorkspaceModal,
+    )
+
+    rows = [entry()]
+
+    async def snapshot():
+        return "Research", tuple(rows)
+
+    seen = []
+    app = App()
+    async with app.run_test() as pilot:
+        modal = BuddyWorkspaceModal(
+            snapshot=snapshot, open_entry=lambda _: None, acknowledge=seen.append
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        modal.query_one("#buddy-inbox-close", Button).focus()
+        await pilot.pause()
+        rows.insert(0, entry("new"))
+        await modal.refresh_inbox()
+        assert modal.query_one("#buddy-inbox-close").has_focus
+        assert modal.selected_entry() == entry()
+        assert seen == []

--- a/Tests/UI/test_console_composer_menu.py
+++ b/Tests/UI/test_console_composer_menu.py
@@ -44,6 +44,7 @@ def test_menu_lists_the_requested_actions_in_order():
         ACTION_GENERATE_IMAGE,
         ACTION_GENERATE_CAPTION,
         ACTION_IMPERSONATE,
+        "buddy",
     ]
 
 

--- a/Tests/UI/test_console_headless_approval.py
+++ b/Tests/UI/test_console_headless_approval.py
@@ -24,7 +24,8 @@ made for `_attempt`: the visit Event means "the visit that armed this
 round ended". A round armed while NO view is attached was not armed
 during any visit -- reading that Event for it is the same category error,
 one layer down. `_disposed` (app exit), the run's own cancel event and a
-CONFIGURED deadline all still deny, unchanged.
+configured answerable-time budget still deny. TASK-32078 pauses that budget
+while a retained Console is hidden or the round has no answerable view.
 """
 
 from __future__ import annotations
@@ -32,9 +33,9 @@ from __future__ import annotations
 import asyncio
 import functools
 import threading
-import time
 
 import pytest
+from textual.widgets import Button
 
 from Tests.Chat.test_console_fleet_wake import (
     _controller_rig,
@@ -44,25 +45,22 @@ from Tests.Chat.test_console_fleet_wake import (
     _survivor,
     _terminal_subagent_run,
 )
-from Tests.Chat.test_console_runtime_lifetime import _View, _pending_call
+from Tests.Chat.test_console_runtime_lifetime import _pending_call, _View
 from Tests.UI.app_factory import _build_test_app
 from Tests.UI.test_console_fleet_wake_wiring import _attach_real_dbs
 from Tests.UI.test_console_mcp_approval import _pending
 from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
 from Tests.UI.test_console_store_continuity import (
-    _StallingWakeGateway,
     _drain_from_child_thread,
     _navigate,
     _seed_console,
+    _StallingWakeGateway,
     _terminal_survivor_run,
 )
-from textual.widgets import Button
-
 from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_runtime import ConsoleRuntime
 from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
-
 
 # ---------------------------------------------------------------------------
 # rig
@@ -813,25 +811,21 @@ async def test_app_exit_denies_a_round_armed_while_detached():
 
 
 @pytest.mark.asyncio
-async def test_a_configured_deadline_still_expires_a_headless_round():
-    """Plan Task 5 bullet 2: the clock is NOT paused or extended while detached.
-
-    A positive `[mcp] approval_timeout_seconds` is a fail-closed ceiling
-    the user opted into; detachment does not buy the round more time.
-    """
-    runtime, controller, _store, session, _app = _detached_rig(timeout_seconds=2.0)
+async def test_a_configured_deadline_waits_for_an_answerable_view():
+    """ADR-094: an unseen round retains its configured decision-active budget."""
+    runtime, controller, _store, session, _app = _detached_rig(timeout_seconds=0.1)
     await _leave(runtime)
-    started = time.monotonic()
     thread, box = _arm(controller, session.id)
-    assert await _settle(lambda: "decisions" in box, seconds=10.0), (
-        "a configured deadline never expired the headless round"
-    )
-    elapsed = time.monotonic() - started
-    thread.join(timeout=5)
-    assert box["decisions"] == {"write_file": "timeout"}, box["decisions"]
-    assert elapsed < 6.0, (
-        f"the 2s deadline took {elapsed:.2f}s -- detachment must not extend it"
-    )
+    try:
+        assert await _wait_for_round(controller, session.id)
+        await asyncio.sleep(1.2)
+        assert "decisions" not in box
+        runtime.attach_view(_View({"set_pending_approval": lambda payload: None}))
+        assert await _settle(lambda: "decisions" in box, seconds=4.0)
+        assert box["decisions"] == {"write_file": "timeout"}
+    finally:
+        await runtime.dispose()
+        thread.join(timeout=5)
 
 
 @pytest.mark.asyncio
@@ -844,10 +838,12 @@ async def test_no_headless_path_returns_an_approval_without_a_human():
     """
     verdicts: list[str] = []
 
-    # deadline
+    # A finite decision budget starts once a view can show the round.
     runtime, controller, _store, session, _app = _detached_rig(timeout_seconds=1.0)
     await _leave(runtime)
     thread, box = _arm(controller, session.id)
+    assert await _wait_for_round(controller, session.id)
+    runtime.attach_view(_View({"set_pending_approval": lambda payload: None}))
     assert await _settle(lambda: "decisions" in box, seconds=10.0)
     thread.join(timeout=5)
     verdicts.extend(box["decisions"].values())
@@ -951,10 +947,10 @@ async def test_the_risk_floor_still_raises_a_card_in_a_headless_turn(
         def get_kill_switch(self) -> bool:
             return False
 
-        def approve_for_session(self, server_key, tool_name) -> None:
+        def approve_for_session(self, server_key, tool_name, **kwargs) -> None:
             return None
 
-        def is_session_approved(self, server_key, tool_name) -> bool:
+        def is_session_approved(self, server_key, tool_name, **kwargs) -> bool:
             return False
 
     class _RealToolProvider:
@@ -997,14 +993,14 @@ async def test_the_risk_floor_still_raises_a_card_in_a_headless_turn(
     round_id = _armed_round_ids(controller, session.id)[0]
     with controller._approval_state_lock:
         state = controller._pending_approval_rounds[round_id]
-    assert state["names"] == ("read_file",), state["names"]
+    assert state["names"] == ("c1",), state["names"]
     payload = controller._head_round_payload(
         controller._parked_approval_payloads, session.id
     )
     assert payload["calls"][0]["server_key"] == BUILTIN_TOOL_SERVER_KEY
     assert payload["calls"][0]["reason"] == "risk_floored"
 
-    controller.resolve_pending_approval({"read_file": "deny"}, round_id=round_id)
+    controller.resolve_pending_approval({"c1": "deny"}, round_id=round_id)
     thread.join(timeout=10)
     assert verdicts.get("c1") not in (None, "proceed"), (
         f"the refusal did not reach the runtime: {verdicts}"

--- a/Tests/UI/test_console_navigation_decisions.py
+++ b/Tests/UI/test_console_navigation_decisions.py
@@ -1,0 +1,239 @@
+"""Real Console navigation with accepted provider work and retained decisions."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from Tests.UI.test_console_screen_reuse import (
+    _boot_settled,
+    _press_until_screen,
+    _scratch_env,
+)
+
+
+async def _until(
+    predicate, *, seconds=15.0, detail=lambda: "Console transition stalled"
+):
+    deadline = asyncio.get_running_loop().time() + seconds
+    while not predicate():
+        assert asyncio.get_running_loop().time() < deadline, detail()
+        await asyncio.sleep(0.01)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ui
+@pytest.mark.parametrize("kind", ("approval", "skill_install", "skill_script"))
+async def test_hidden_finite_decisions_notify_once_and_remain_answerable(
+    monkeypatch, tmp_path, kind
+):
+    """A retained screen cannot spend the user's decision time or hide its notice."""
+    _scratch_env(monkeypatch, tmp_path)
+    from textual.screen import ModalScreen
+
+    from Tests.Chat.test_console_runtime_lifetime import _pending_call
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+
+    app = TldwCli()
+    notices = []
+    app.notify = lambda message, **kwargs: notices.append(str(message))
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app, pilot)
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        console = app.screen
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.ensure_session().id
+        controller.mcp_approval_timeout_seconds = lambda: 1.0
+        controller.skill_install_confirm_timeout_seconds = lambda: 1.0
+        controller.skill_script_confirm_timeout_seconds = lambda: 1.0
+        controller._interrupt_host.POLL_SECONDS = 0.01
+
+        def request():
+            if kind == "approval":
+                return controller.request_mcp_approvals(
+                    [_pending_call()], session_id=session_id
+                )
+            if kind == "skill_install":
+                return controller.request_skill_install_confirm(
+                    "https://example.com/test-skill", session_id=session_id
+                )
+            return controller.request_skill_script_confirm(
+                {"skill_name": "demo", "script_path": "scripts/demo.py"},
+                session_id=session_id,
+            )
+
+        for away in ("navigation", "modal", "armed_navigation"):
+            if away == "navigation":
+                await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+            elif away == "modal":
+                await app.push_screen(ModalScreen())
+            notices.clear()
+            decision = asyncio.create_task(asyncio.to_thread(request))
+            try:
+                await _until(lambda: controller._interrupt_host.pending_total() == 1)
+                if away == "armed_navigation":
+                    await _until(
+                        lambda: (
+                            controller._interrupt_host.head_round_payload(
+                                kind, session_id
+                            )
+                            is not None
+                        )
+                    )
+                    app.post_message(NavigateToScreen("home"))
+                    await _until(lambda: type(app.screen).__name__ == "HomeScreen")
+                await asyncio.sleep(1.2)
+                assert not decision.done(), (
+                    "A hidden decision consumed its finite budget"
+                )
+                attention = [
+                    message for message in notices if "Open Console" in message
+                ]
+                assert len(attention) == 1
+                # Repeated visibility notifications must not repeat a round's notice.
+                console.on_screen_suspend()
+                assert (
+                    len([message for message in notices if "Open Console" in message])
+                    == 1
+                )
+                if away != "modal":
+                    app.post_message(NavigateToScreen("chat"))
+                    await _until(lambda: app.screen is console)
+                else:
+                    await app.pop_screen()
+                payload = controller._interrupt_host.head_round_payload(
+                    kind, session_id
+                )
+                assert payload is not None
+                if kind == "approval":
+                    controller.resolve_pending_approval(
+                        [], round_id=payload["round_id"]
+                    )
+                elif kind == "skill_install":
+                    controller.resolve_pending_skill_install(
+                        True, request_id=payload["request_id"]
+                    )
+                else:
+                    controller.resolve_pending_skill_script(
+                        True, False, request_id=payload["request_id"]
+                    )
+                result = await asyncio.wait_for(decision, 3.0)
+                if kind == "skill_install":
+                    assert result is True
+                elif kind == "skill_script":
+                    assert result == {"allow": True, "remember": False}
+                assert controller._interrupt_host.pending_total() == 0
+            finally:
+                if not decision.done():
+                    controller.begin_shutdown()
+                    await asyncio.wait_for(decision, 3.0)
+
+
+@pytest.mark.asyncio
+@pytest.mark.ui
+@pytest.mark.parametrize("settlement", ("complete", "stop", "shutdown"))
+async def test_navigation_preserves_real_stream_and_queue_without_retargeting(
+    monkeypatch, tmp_path, settlement
+):
+    """Screen-worker cancellation or ambient session routing loses a real response."""
+    _scratch_env(monkeypatch, tmp_path)
+    from textual.widgets import Button
+
+    from Tests.UI.test_console_native_chat_flow import (
+        _configure_native_ready_console,
+        _ReadyResolutionGateway,
+        _select_llamacpp_console,
+    )
+    from tldw_chatbook.app import TldwCli
+    from tldw_chatbook.Chat.console_chat_models import ConsoleRunStatus
+    from tldw_chatbook.Widgets.Console import ConsoleComposerBar
+
+    class Gateway(_ReadyResolutionGateway):
+        def __init__(self):
+            self.started = threading.Event()
+            self.release = threading.Event()
+
+        async def stream_chat(self, resolution, messages, **kwargs):
+            yield "partial"
+            self.started.set()
+            while not self.release.is_set():
+                await asyncio.sleep(0.01)
+            yield " done"
+
+        async def aclose(self):
+            pass
+
+    gateway = Gateway()
+    app = TldwCli()
+    _configure_native_ready_console(app)
+    app.console_provider_gateway_factory = lambda: gateway
+    async with app.run_test(size=(170, 48)) as pilot:
+        await _boot_settled(app, pilot)
+        await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+        console = app.screen
+        _select_llamacpp_console(console)
+        controller = console._ensure_console_chat_controller()
+        session_id = controller.store.active_session_id
+        composer = console.query_one("#console-native-composer", ConsoleComposerBar)
+        composer.load_draft("First navigation message")
+        console.query_one("#console-send-message", Button).press()
+        try:
+            await _until(gateway.started.is_set)
+            queued = await console._prompt_queue.dispatch("Second navigation message")
+            assert queued.status.value == "queued"
+            await _press_until_screen(pilot, "ctrl+1", "HomeScreen")
+            assert controller.in_flight_run_count() == 1
+            if settlement != "complete":
+                if settlement == "stop":
+                    assert controller.stop_active_run() is True
+                else:
+                    await controller.shutdown()
+                await _until(lambda: controller.in_flight_run_count() == 0)
+                messages = controller.store.messages_for_session(session_id)
+                assert messages[1].status == "stopped"
+                assert not any(
+                    m.content == "Second navigation message" for m in messages
+                )
+                return
+            other_session = controller.new_session().id
+            gateway.release.set()
+            await _until(
+                lambda: (
+                    sum(
+                        message.content == "partial done"
+                        for message in controller.store.messages_for_session(session_id)
+                    )
+                    == 2
+                    and controller.in_flight_run_count() == 0
+                ),
+                detail=lambda: (
+                    controller.run_state_for(session_id),
+                    controller.prompt_queue_registry.snapshot(session_id),
+                    [
+                        (m.role, m.content)
+                        for m in controller.store.messages_for_session(session_id)
+                    ],
+                ),
+            )
+            assert type(app.screen).__name__ == "HomeScreen"
+            messages = controller.store.messages_for_session(session_id)
+            assert [message.content for message in messages] == [
+                "First navigation message",
+                "partial done",
+                "Second navigation message",
+                "partial done",
+            ]
+            assert not controller.store.messages_for_session(other_session)
+            await _press_until_screen(pilot, "ctrl+2", "ChatScreen")
+            assert app.screen is console
+            assert controller.store.active_session_id == other_session
+            assert (
+                controller.run_state_for(session_id).status
+                is ConsoleRunStatus.COMPLETED
+            )
+        finally:
+            gateway.release.set()
+            await controller.shutdown()

--- a/Tests/UI/test_persona_buddy_widget.py
+++ b/Tests/UI/test_persona_buddy_widget.py
@@ -390,6 +390,7 @@ async def test_resting_buddy_contains_pet_and_icons_without_default_words():
             "persona-buddy-frame",
             "persona-buddy-collapse",
             "persona-buddy-close",
+            "persona-buddy-settings",
         ]
         for removed_id in (
             "persona-buddy-header",
@@ -1197,7 +1198,7 @@ async def test_keyboard_move_resize_reset_collapse_close_exact_bindings():
         await _wait_until(lambda: not controller.preferences.open)
 
         keys = {binding.key for binding in PersonaBuddyWidget.BINDINGS}
-        assert keys == {"h", "j", "k", "l", "H", "J", "K", "L", "0", "c", "x"}
+        assert keys == {"h", "j", "k", "l", "H", "J", "K", "L", "0", "c", "x", "m", "enter"}
         assert not any(key.startswith("ctrl+") for key in keys)
 
 

--- a/Tests/UI/test_personas_inspector_pane.py
+++ b/Tests/UI/test_personas_inspector_pane.py
@@ -260,7 +260,7 @@ async def test_persona_buddy_action_message_uses_normal_textual_delivery():
 @pytest.mark.parametrize(
     ("button_id", "label", "action"),
     (
-        ("#personas-buddy-use", "Use for Buddy", "use"),
+        ("#personas-buddy-use", "Manage Buddy", "manage"),
         ("#personas-buddy-show", "Show Buddy", "show"),
         ("#personas-buddy-close", "Close Buddy", "close"),
         ("#personas-buddy-disable", "Disable Buddy", "disable"),
@@ -270,7 +270,18 @@ async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
     button_id: str,
     label: str,
     action: str,
+    monkeypatch,
 ):
+    from types import SimpleNamespace
+
+    from tldw_chatbook.UI.Navigation import buddy_management
+
+    calls = []
+    monkeypatch.setattr(
+        buddy_management,
+        "get_buddy_management",
+        lambda _: SimpleNamespace(request_visibility=calls.append),
+    )
     app = InspectorApp()
     async with app.run_test(size=(170, 50)) as pilot:
         pane = pilot.app.query_one(PersonasInspectorPane)
@@ -297,76 +308,36 @@ async def test_active_local_persona_buddy_actions_are_explicit_and_typed(
         await pilot.click(button_id)
         await pilot.pause()
 
-        message = app.buddy_messages[-1]
-        assert (
-            message.action,
-            message.source,
-            message.persona_id,
-            message.revision,
-        ) == (
-            action,
-            "local",
-            "persona-7",
-            4,
-        )
+        assert calls == [action]
+        assert app.buddy_messages == []
 
 
-async def test_server_persona_buddy_actions_are_disabled_with_exact_recovery_copy():
+@pytest.mark.parametrize("source", ["local", "server", None])
+async def test_independent_buddy_controls_do_not_require_persona_owner(source):
     app = InspectorApp()
-    async with app.run_test(size=(170, 50)) as pilot:
-        pane = pilot.app.query_one(PersonasInspectorPane)
-        pane.show_selection(
-            name="Remote Archivist",
-            kind="persona",
-            source="server",
-            entity_id="persona-7",
-            revision=4,
-            active=True,
-            profile_current=True,
-        )
+    async with app.run_test(size=(80, 24)) as pilot:
+        pane = app.query_one(PersonasInspectorPane)
+        if source:
+            pane.show_selection(
+                name="Unrelated",
+                kind="persona",
+                source=source,
+                entity_id="other",
+                revision=1,
+                active=False,
+                profile_current=False,
+            )
+        pane.set_buddy_status(source=None, persona_id=None, enabled=True, open=True)
         await pilot.pause()
-
-        for button_id in (
+        for selector in (
             "#personas-buddy-use",
-            "#personas-buddy-show",
             "#personas-buddy-close",
             "#personas-buddy-disable",
         ):
-            button = pilot.app.query_one(button_id, Button)
-            assert button.disabled is True
-            assert button.tooltip == "Save a local copy first"
-
-
-async def test_non_owner_highlight_only_enables_use_with_truthful_tooltip():
-    app = InspectorApp()
-    async with app.run_test(size=(170, 50)) as pilot:
-        pane = pilot.app.query_one(PersonasInspectorPane)
-        pane.show_selection(
-            name="Navigator",
-            kind="persona",
-            source="local",
-            entity_id="persona-2",
-            revision=5,
-            active=True,
-            profile_current=True,
-        )
-        pane.set_buddy_status(
-            source="local",
-            persona_id="persona-1",
-            enabled=True,
-            open=True,
-        )
-        await pilot.pause()
-
-        assert pane.query_one("#personas-buddy-use", Button).disabled is False
-        for button_id in (
-            "#personas-buddy-show",
-            "#personas-buddy-close",
-            "#personas-buddy-disable",
-        ):
-            button = pane.query_one(button_id, Button)
-            assert button.disabled is True
-            assert button.tooltip == "Select the Persona currently used by Buddy"
+            button = pane.query_one(selector, Button)
+            assert not button.disabled
+            assert all(node.display for node in button.ancestors_with_self)
+        assert pane.query_one("#personas-buddy-show", Button).disabled
 
 
 async def test_persona_highlight_alone_emits_no_buddy_action():
@@ -404,7 +375,7 @@ async def test_buddy_actions_keep_exact_labels_and_focus_without_keybindings(siz
         await pilot.pause()
 
         expected = (
-            ("#personas-buddy-use", "Use for Buddy"),
+            ("#personas-buddy-use", "Manage Buddy"),
             ("#personas-buddy-show", "Show Buddy"),
             ("#personas-buddy-close", "Close Buddy"),
             ("#personas-buddy-disable", "Disable Buddy"),
@@ -425,54 +396,6 @@ async def test_buddy_actions_keep_exact_labels_and_focus_without_keybindings(siz
 
         await pilot.press("u", "s", "c", "d")
         assert app.buddy_messages == []
-
-
-@pytest.mark.parametrize(
-    ("entity_id", "revision", "active"),
-    ((None, 4, True), ("persona-7", None, True), ("persona-7", 4, False)),
-)
-async def test_buddy_rejects_incomplete_or_inactive_local_persona(
-    entity_id, revision, active
-):
-    app = InspectorApp()
-    async with app.run_test(size=(170, 50)) as pilot:
-        pane = pilot.app.query_one(PersonasInspectorPane)
-        pane.show_selection(
-            name="Archivist",
-            kind="persona",
-            source="local",
-            entity_id=entity_id,
-            revision=revision,
-            active=active,
-            profile_current=True,
-        )
-        await pilot.pause()
-
-        for button in pilot.app.query(".persona-buddy-action").results(Button):
-            assert button.disabled is True
-
-
-async def test_buddy_requires_current_complete_profile_not_cached_eligibility():
-    app = InspectorApp()
-    async with app.run_test(size=(170, 50)) as pilot:
-        pane = pilot.app.query_one(PersonasInspectorPane)
-        pane.show_selection(
-            name="Cached Persona",
-            kind="persona",
-            source="local",
-            entity_id="persona-7",
-            revision=4,
-            active=True,
-            profile_current=False,
-        )
-        await pilot.pause()
-
-        for button in pilot.app.query(".persona-buddy-action").results(Button):
-            assert button.disabled is True
-            assert (
-                button.tooltip
-                == "Persona details are unavailable. Refresh and try again."
-            )
 
 
 async def test_default_state_shows_no_selection_and_disabled_actions():

--- a/Tests/UI/test_personas_workbench.py
+++ b/Tests/UI/test_personas_workbench.py
@@ -103,7 +103,6 @@ from tldw_chatbook.Widgets.Persona_Widgets.persona_buddy_widget import (
 from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
 from tldw_chatbook.Widgets.Persona_Widgets.personas_messages import (
     PersonaActionRequested,
-    PersonaBuddyActionRequested,
 )
 from tldw_chatbook.Widgets.Persona_Widgets.personas_inspector_pane import (
     PersonasInspectorPane,
@@ -15172,7 +15171,7 @@ async def test_floating_buddy_close_refreshes_active_personas_inspector(
         close = screen.query_one("#personas-buddy-close", Button)
         assert show.disabled is False
         assert close.disabled is True
-        assert close.tooltip == "Buddy is already closed."
+        assert close.tooltip == "Controls the current independent Buddy."
 
 
 async def test_stale_personas_screen_reconcile_skips_screen_local_buddy_hook(
@@ -15197,282 +15196,14 @@ async def test_stale_personas_screen_reconcile_skips_screen_local_buddy_hook(
         hook.assert_not_called()
 
 
-@pytest.mark.parametrize("compact", (False, True), ids=("normal", "compact"))
-async def test_real_80x24_workbench_scrolls_each_buddy_action_into_view_and_runs_it(
-    mock_app_instance,
-    stub_characters,
-    compact: bool,
-) -> None:
-    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        records,
-        preferences=PersonaBuddyPreferences(
-            enabled=True,
-            open=True,
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test(size=(80, 24)) as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        workbench = screen.query_one("#personas-workbench")
-        workbench.set_class(compact, "personas-workbench-compact")
-        for pane_id in (
-            "#personas-library-pane",
-            "#personas-work-area",
-            "#personas-inspector-pane",
-        ):
-            screen.query_one(pane_id).set_class(
-                compact, "personas-workbench-compact-pane"
-            )
-        await pilot.pause()
-
-        inspector = screen.query_one("#personas-inspector-pane")
-        expectations = (
-            ("#personas-buddy-close", "Close Buddy", True, False),
-            ("#personas-buddy-show", "Show Buddy", True, True),
-            ("#personas-buddy-disable", "Disable Buddy", False, True),
-            ("#personas-buddy-use", "Use for Buddy", True, True),
-        )
-        for button_id, label, enabled, opened in expectations:
-            button = screen.query_one(button_id, Button)
-            assert str(button.label) == label
-            assert button.disabled is False
-            button.focus(scroll_visible=True)
-            await pilot.pause(0.5)
-
-            assert pilot.app.focused is button
-            assert button.region.y >= max(0, inspector.content_region.y)
-            assert button.region.bottom <= min(24, inspector.content_region.bottom)
-
-            await pilot.press("enter")
-            await pilot.app.workers.wait_for_complete()
-            await pilot.pause()
-            preferences = controller.current_preferences()
-            assert preferences.enabled is enabled
-            assert preferences.open is opened
 
 
-async def test_explicit_replacement_is_required(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    records = {
-        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
-        "p-2": {
-            **PROFILE,
-            "id": "p-2",
-            "name": "Navigator",
-            "version": 5,
-            "is_active": True,
-            "deleted": False,
-        },
-    }
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        records,
-        preferences=PersonaBuddyPreferences(
-            enabled=True,
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-2", "Navigator")
-        await pilot.pause()
-        assert not screen.query_one("#personas-buddy-use", Button).disabled
-        for button_id in (
-            "#personas-buddy-show",
-            "#personas-buddy-close",
-            "#personas-buddy-disable",
-        ):
-            button = screen.query_one(button_id, Button)
-            assert button.disabled is True
-            assert button.tooltip == "Select the Persona currently used by Buddy"
-
-        await screen._select_profile("p-1", "Archivist")
-        assert screen.query_one("#personas-buddy-use", Button).disabled is False
-        assert screen.query_one("#personas-buddy-close", Button).disabled is False
-        assert screen.query_one("#personas-buddy-disable", Button).disabled is False
-        show = screen.query_one("#personas-buddy-show", Button)
-        assert show.disabled is True
-        assert show.tooltip == "Buddy is already open."
-
-        await screen._select_profile("p-2", "Navigator")
-
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="show", source="local", persona_id="p-2", revision=5
-            )
-        )
-        await pilot.pause()
-        assert controller.snapshot().selection == PersonaBuddySelection("local", "p-1")
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
-
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="use", source="local", persona_id="p-2", revision=5
-            )
-        )
-        await pilot.pause()
-
-        snapshot = controller.snapshot()
-        assert snapshot.selection == PersonaBuddySelection("local", "p-2")
-        assert snapshot.enabled is True
-        assert snapshot.open is True
-        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
 
 
-@pytest.mark.parametrize(
-    ("action", "expected_enabled", "expected_open"),
-    (
-        ("show", True, True),
-        ("close", True, False),
-        ("disable", False, True),
-    ),
-)
-async def test_buddy_visibility_actions_preserve_explicit_selection(
-    mock_app_instance,
-    stub_characters,
-    action: str,
-    expected_enabled: bool,
-    expected_open: bool,
-) -> None:
-    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        {"p-1": record},
-        preferences=PersonaBuddyPreferences(
-            enabled=action != "show",
-            open=action != "show",
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action=action, source="local", persona_id="p-1", revision=2
-            )
-        )
-        await pilot.pause()
-
-        preferences = controller.current_preferences()
-        assert preferences.selection == PersonaBuddySelection("local", "p-1")
-        assert preferences.enabled is expected_enabled
-        assert preferences.open is expected_open
 
 
-@pytest.mark.parametrize("failure", ("false", "raise", "cancel"))
-async def test_buddy_action_writer_failure_leaves_memory_and_durable_state_unchanged(
-    mock_app_instance,
-    stub_characters,
-    failure: str,
-) -> None:
-    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
-    initial = PersonaBuddyPreferences(
-        enabled=True,
-        open=True,
-        selection=PersonaBuddySelection("local", "p-1"),
-    )
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        {"p-1": record},
-        preferences=initial,
-    )
-    durable = initial
-
-    def writer(preferences: PersonaBuddyPreferences) -> bool:
-        nonlocal durable
-        if failure == "false":
-            return False
-        if failure == "raise":
-            raise RuntimeError("writer failed")
-        raise asyncio.CancelledError
-
-    controller._preference_writer = writer
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="close", source="local", persona_id="p-1", revision=2
-            )
-        )
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        assert durable == initial
-        assert controller.current_preferences() == initial
-        assert screen.state.has_unsaved_changes is False
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
-async def test_buddy_action_persists_before_applying_memory_or_reconciling(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    record = {**PROFILE, "version": 2, "is_active": True, "deleted": False}
-    initial = PersonaBuddyPreferences(
-        enabled=True,
-        open=True,
-        selection=PersonaBuddySelection("local", "p-1"),
-    )
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        {"p-1": record},
-        preferences=initial,
-    )
-    entered = threading.Event()
-    release = threading.Event()
-    durable = initial
-
-    def writer(preferences: PersonaBuddyPreferences) -> bool:
-        nonlocal durable
-        entered.set()
-        release.wait(timeout=5)
-        durable = preferences
-        return True
-
-    controller._preference_writer = writer
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="close", source="local", persona_id="p-1", revision=2
-            )
-        )
-        assert await asyncio.to_thread(entered.wait, 2)
-
-        assert durable == initial
-        assert controller.current_preferences() == initial
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
-
-        release.set()
-        await pilot.app.workers.wait_for_complete()
-        await pilot.pause()
-
-        assert durable.open is False
-        assert controller.current_preferences() == durable
-        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
 
 
 async def test_disabled_deleted_missing_persona_hides_but_preserves_enabled_selection(
@@ -15573,85 +15304,8 @@ async def test_restore_reresolves_same_selection(
         ]
 
 
-async def test_buddy_action_fetch_aba_cannot_apply_or_reconcile(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    records = {
-        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
-        "p-2": {
-            **PROFILE,
-            "id": "p-2",
-            "name": "Navigator",
-            "version": 5,
-            "is_active": True,
-            "deleted": False,
-        },
-    }
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        records,
-        preferences=PersonaBuddyPreferences(
-            enabled=True,
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        started = asyncio.Event()
-        release = asyncio.Event()
-        calls = 0
-
-        async def fetch(persona_id: str, *, mode: str):
-            nonlocal calls
-            calls += 1
-            if calls == 1:
-                started.set()
-                await release.wait()
-            return dict(records[persona_id])
-
-        mock_app_instance.character_persona_scope_service.get_persona_profile = fetch
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="close", source="local", persona_id="p-1", revision=2
-            )
-        )
-        await wait_for_signal(started, what="Buddy action fetch start")
-        await screen._select_profile("p-2", "Navigator")
-        await screen._select_profile("p-1", "Archivist")
-        release.set()
-        await pilot.pause()
-
-        assert controller.current_preferences().open is True
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
-async def test_incomplete_profile_fetch_disables_cached_buddy_actions(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
-    _configure_persona_buddy(mock_app_instance, records)
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        mock_app_instance.character_persona_scope_service.get_persona_profile = (
-            AsyncMock(side_effect=RuntimeError("service unavailable"))
-        )
-        await screen._select_profile("p-1", "Archivist")
-
-        for button in screen.query(".persona-buddy-action").results(Button):
-            assert button.disabled is True
-            assert (
-                button.tooltip
-                == "Persona details are unavailable. Refresh and try again."
-            )
 
 
 async def test_local_save_and_delete_refresh_only_the_same_buddy_selection(
@@ -15715,111 +15369,8 @@ async def test_server_profile_durable_changes_never_refresh_local_buddy(
         refresh.assert_not_awaited()
 
 
-async def test_stale_buddy_action_does_not_refresh_replaced_workbench_selection(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    records = {
-        "p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False},
-        "p-2": {
-            **PROFILE,
-            "id": "p-2",
-            "name": "Navigator",
-            "version": 5,
-            "is_active": True,
-            "deleted": False,
-        },
-    }
-    started = threading.Event()
-    release = threading.Event()
-
-    def blocked_writer(_preferences):
-        started.set()
-        release.wait(timeout=5)
-        return True
-
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        records,
-        preferences=PersonaBuddyPreferences(
-            enabled=True,
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    controller._preference_writer = blocked_writer
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="close", source="local", persona_id="p-1", revision=2
-            )
-        )
-        while not started.is_set():
-            await asyncio.sleep(0)
-        assert controller.current_preferences().open is True
-        await screen._select_profile("p-2", "Navigator")
-        await screen._select_profile("p-1", "Archivist")
-        release.set()
-        await pilot.pause()
-
-        assert controller.current_preferences().open is True
-        mock_app_instance.reconcile_persona_buddy_view.assert_not_awaited()
 
 
-async def test_newer_buddy_action_wins_serialized_persistence_and_reconcile(
-    mock_app_instance,
-    stub_characters,
-) -> None:
-    records = {"p-1": {**PROFILE, "version": 2, "is_active": True, "deleted": False}}
-    started = threading.Event()
-    release = threading.Event()
-    writes = []
-
-    def blocked_first_writer(preferences):
-        writes.append(preferences)
-        if len(writes) == 1:
-            started.set()
-            release.wait(timeout=5)
-        return True
-
-    controller = _configure_persona_buddy(
-        mock_app_instance,
-        records,
-        preferences=PersonaBuddyPreferences(
-            enabled=True,
-            selection=PersonaBuddySelection("local", "p-1"),
-        ),
-    )
-    controller._preference_writer = blocked_first_writer
-    app = PersonasTestApp(mock_app_instance)
-
-    async with app.run_test() as pilot:
-        screen = await _mounted(pilot)
-        await screen._apply_mode("personas")
-        await screen._select_profile("p-1", "Archivist")
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="close", source="local", persona_id="p-1", revision=2
-            )
-        )
-        while not started.is_set():
-            await asyncio.sleep(0)
-        screen.post_message(
-            PersonaBuddyActionRequested(
-                action="show", source="local", persona_id="p-1", revision=2
-            )
-        )
-        await pilot.pause()
-        release.set()
-        await pilot.pause()
-
-        assert [preferences.open for preferences in writes] == [False, True]
-        assert controller.current_preferences().open is True
-        mock_app_instance.reconcile_persona_buddy_view.assert_awaited_once()
 
 
 async def test_persona_json_export_excludes_buddy_preferences(
@@ -15854,3 +15405,51 @@ async def test_persona_json_export_excludes_buddy_preferences(
     exported = json.loads(target.read_text(encoding="utf-8"))
     assert exported == record
     assert "persona_buddy" not in exported
+
+
+@pytest.mark.parametrize("size", [(80, 24), (120, 40)])
+async def test_independent_buddy_actions_use_shared_coordinator_without_persona_selection(
+    mock_app_instance, stub_characters, size
+):
+    from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+    from tldw_chatbook.UI.Navigation.buddy_management import BuddyManagementCoordinator
+
+    controller = _configure_persona_buddy(
+        mock_app_instance,
+        {},
+        preferences=PersonaBuddyPreferences(
+            enabled=True, open=True, selection=BuddySelection("independent")
+        ),
+    )
+    mock_app_instance.app_config = {}
+    mock_app_instance.console_runtime = None
+    app = PersonasTestApp(mock_app_instance)
+    app._buddy_management = BuddyManagementCoordinator(app, controller=controller)
+    async with app.run_test(size=size) as pilot:
+        screen = await _mounted(pilot)
+        await screen._apply_mode("personas")
+        inspector = screen.query_one("#personas-inspector-pane")
+        screen._sync_inspector_buddy_status()
+        for selector, enabled, opened in (
+            ("#personas-buddy-close", True, False),
+            ("#personas-buddy-show", True, True),
+            ("#personas-buddy-disable", False, True),
+        ):
+            button = screen.query_one(selector, Button)
+            assert not button.disabled
+            button.focus(scroll_visible=True)
+            await pilot.pause(0.2)
+            await pilot.wait_for_scheduled_animations()
+            assert button.has_focus
+            assert button.region.bottom <= min(size[1], inspector.content_region.bottom)
+            await pilot.press("enter")
+            await app.workers.wait_for_complete()
+            screen._sync_inspector_buddy_status()
+            assert controller.current_preferences().selection == BuddySelection(
+                "independent"
+            )
+            assert controller.current_preferences().enabled is enabled
+            assert controller.current_preferences().open is opened
+        assert (
+            str(screen.query_one("#personas-buddy-use", Button).label) == "Manage Buddy"
+        )

--- a/Tests/UI/test_workspace_persona_creation.py
+++ b/Tests/UI/test_workspace_persona_creation.py
@@ -1,0 +1,167 @@
+"""Native workspace creation/default controls retain explicit Persona choices."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App
+from textual.widgets import Button, Checkbox, Input, Select, Static
+
+from Tests.Workspaces.test_agent_provisioning import StubPersonaService, build
+from tldw_chatbook.Widgets.workspace_create_modal import WorkspaceCreateModal
+
+
+class Personas(StubPersonaService):
+    def list_persona_profiles(self):
+        return [{"id": "author", "name": "Author", "system_prompt": "Write clearly."}]
+
+    def get_persona_profile(self, persona_id):
+        return next(
+            (item for item in self.list_persona_profiles() if item["id"] == persona_id),
+            None,
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("choice", ["none", "author"])
+async def test_create_choice_survives_folder_recompose_and_saves(tmp_path, choice):
+    personas = Personas()
+    registry, _permissions = build(tmp_path, personas)
+    app = App()
+    async with app.run_test(size=(90, 36)) as pilot:
+        await app.push_screen(
+            WorkspaceCreateModal(registry_service=registry, persona_service=personas)
+        )
+        modal = app.screen
+        modal.query_one("#workspace-create-name", Input).value = "Chosen"
+        modal.query_one("#workspace-default-persona", Select).value = choice
+        modal.query_one("#workspace-create-folder-path", Input).value = str(tmp_path)
+        modal.query_one("#workspace-create-folder-add", Button).press()
+        await pilot.pause()
+        assert modal.query_one("#workspace-default-persona", Select).value == choice
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
+        saved = next(
+            item for item in registry.list_workspaces() if item.name == "Chosen"
+        )
+        if choice == "none":
+            assert saved.assistant_defaults is None
+            assert saved.assistant_defaults_explicit_none
+        else:
+            assert saved.assistant_defaults.assistant_id == "author"
+        assert personas.created == []
+
+
+@pytest.mark.asyncio
+async def test_read_write_create_requires_visible_confirmation(tmp_path):
+    personas = Personas()
+    registry, _permissions = build(tmp_path, personas)
+    app = App()
+    async with app.run_test(size=(90, 36)) as pilot:
+        await app.push_screen(
+            WorkspaceCreateModal(registry_service=registry, persona_service=personas)
+        )
+        modal = app.screen
+        modal.query_one("#workspace-default-persona", Select).value = "author"
+        modal.query_one("#workspace-default-memory", Select).value = "read_write"
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
+        assert registry.list_workspaces() == ()
+        assert "Confirm" in str(
+            modal.query_one("#workspace-create-error", Static).render()
+        )
+        modal.query_one("#workspace-default-memory-confirm", Checkbox).value = True
+        modal.query_one("#workspace-create-confirm", Button).press()
+        await pilot.pause()
+        assert (
+            registry.list_workspaces()[0].assistant_defaults.persona_memory_mode
+            == "read_write"
+        )
+
+
+@pytest.mark.asyncio
+async def test_default_modal_cancel_preserves_and_apply_clears(tmp_path):
+    from tldw_chatbook.Widgets.workspace_persona_default import (
+        WorkspacePersonaDefaultModal,
+    )
+
+    personas = Personas()
+    registry, _permissions = build(tmp_path, personas)
+    before = registry.create_workspace(workspace_id="chosen", name="Chosen")
+    app = App()
+    async with app.run_test(size=(80, 24)) as pilot:
+        await app.push_screen(
+            WorkspacePersonaDefaultModal(registry, personas, "chosen")
+        )
+        app.screen.query_one("#workspace-default-persona", Select).value = "none"
+        app.screen.query_one("#workspace-default-cancel", Button).press()
+        await pilot.pause()
+        assert (
+            registry.get_workspace("chosen").assistant_defaults
+            == before.assistant_defaults
+        )
+        await app.push_screen(
+            WorkspacePersonaDefaultModal(registry, personas, "chosen")
+        )
+        app.screen.query_one("#workspace-default-persona", Select).value = "none"
+        app.screen.query_one("#workspace-default-apply", Button).press()
+        await pilot.pause()
+        assert registry.get_workspace("chosen").assistant_defaults is None
+        assert registry.get_workspace("chosen").assistant_defaults_explicit_none
+
+
+@pytest.mark.asyncio
+async def test_console_bootstrap_workspace_activation_and_details_use_target_default():
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_console_workspace_action_row_geometry import StyledConsoleHarness
+    from tldw_chatbook.Widgets.workspace_persona_default import (
+        WorkspacePersonaDefaultModal,
+    )
+    from tldw_chatbook.Workspaces.models import WorkspaceAssistantDefaults
+
+    app = _build_test_app()
+    app.local_character_persona_service = Personas()
+    registry = app.workspace_registry_service
+    defaults = WorkspaceAssistantDefaults(assistant_id="author")
+    registry.create_workspace(
+        workspace_id="first", name="First", assistant_defaults=defaults
+    )
+    registry.create_workspace(
+        workspace_id="second", name="Second", assistant_defaults=defaults
+    )
+    registry.set_active_workspace("first")
+    host = StyledConsoleHarness(app)
+    async with host.run_test(size=(120, 36)) as pilot:
+        await pilot.pause()
+        screen = host.screen
+        store = screen._ensure_console_chat_store()
+        first = screen._session._active_native_console_session()
+        assert first.workspace_id == "first"
+        assert first.assistant_id == "author"
+        screen._workspace._activate_console_session_for_workspace("second")
+        second = screen._session._active_native_console_session()
+        assert second.workspace_id == "second"
+        assert second.assistant_id == "author"
+        assert (
+            second.persona_memory_mode
+            == second.settings.persona_memory_mode
+            == "read_only"
+        )
+        registry.set_active_workspace("second")
+        await screen._sync_native_console_chat_ui()
+        screen._set_console_rail_preference(left_open=True)
+        if not screen._current_console_rail_state().details_open:
+            screen._toggle_console_rail_section("details")
+        await pilot.pause()
+        button = screen.query_one("#console-workspace-default-persona", Button)
+        button.scroll_visible(animate=False, immediate=True)
+        await pilot.pause()
+        button.press()
+        await pilot.pause()
+        assert isinstance(host.screen, WorkspacePersonaDefaultModal)
+        host.screen.query_one("#workspace-default-persona", Select).value = "none"
+        host.screen.query_one("#workspace-default-apply", Button).press()
+        await pilot.pause()
+        assert registry.get_workspace("second").assistant_defaults is None
+        assert store.ensure_session().assistant_id == "author"
+        future = store.create_session(workspace_id="second")
+        assert future.assistant_kind == "generic"

--- a/Tests/Workspaces/test_agent_provisioning.py
+++ b/Tests/Workspaces/test_agent_provisioning.py
@@ -58,6 +58,37 @@ def test_provision_failure_is_non_fatal(tmp_path):
     assert record.assistant_defaults is None
 
 
+def test_explicit_none_survives_creation_and_pending_backfill_restart(tmp_path):
+    """A user opting out must never acquire an automatically created Persona."""
+    personas = StubPersonaService()
+    registry, store = build(tmp_path, personas)
+    record = registry.create_workspace(
+        workspace_id="plain", name="Plain", assistant_defaults=None
+    )
+    assert record.assistant_defaults is None
+    assert personas.created == []
+    registry.db.close()
+    registry, store = build(tmp_path, personas)
+    provisioner = WorkspaceAgentProvisioner(personas, store)
+    assert run_workspace_agent_backfill(registry=registry, provisioner=provisioner) == 0
+    assert registry.get_workspace("plain").assistant_defaults is None
+    assert personas.created == []
+
+
+def test_clear_survives_pending_backfill_restart(tmp_path):
+    """Clearing a default is durable even before the global backfill completes."""
+    personas = StubPersonaService()
+    registry, store = build(tmp_path, personas)
+    registry.create_workspace(workspace_id="clear", name="Clear")
+    registry.clear_assistant_defaults("clear")
+    registry.db.close()
+    registry, store = build(tmp_path, personas)
+    provisioner = WorkspaceAgentProvisioner(personas, store)
+    assert run_workspace_agent_backfill(registry=registry, provisioner=provisioner) == 0
+    assert registry.get_workspace("clear").assistant_defaults is None
+    assert len(personas.created) == 1
+
+
 def test_backfill_skips_archived_and_default_and_is_idempotent(tmp_path):
     registry, store = build(tmp_path)
     personas = StubPersonaService()

--- a/Tests/Workspaces/test_workspace_assistant_defaults.py
+++ b/Tests/Workspaces/test_workspace_assistant_defaults.py
@@ -46,7 +46,7 @@ def test_v2_database_migrates_preserving_rows(tmp_path):
     conn.commit()
     conn.close()
     db = WorkspaceDB(legacy, client_id="client-1")
-    assert db.get_schema_version() == 7
+    assert db.get_schema_version() == WorkspaceDB._CURRENT_SCHEMA_VERSION
     with db.connection() as read_conn:
         cols = {
             row[1] for row in read_conn.execute("PRAGMA table_info(workspace_records)")

--- a/backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+++ b/backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
@@ -1,0 +1,100 @@
+# ADR-139: Independent Buddy ownership and explicit conversation/workspace bindings
+
+Status: Accepted
+Date: 2026-09-08
+Amends: the Persona-required Buddy selection/seeding in ADR-074 and ADR-122,
+and ADR-079 §5 automatic provisioning when the user explicitly selects None.
+
+## Decision
+
+Keep one visible Buddy in v1. It owns a local visual binding independent of Persona
+records and explicitly follows one conversation or one workspace. Reuse existing
+immutable visual pack versions/assets and import validation. Introduce a genuine
+Buddy owner/binding instead of a hidden Persona or a fabricated Persona identifier.
+Copy a legacy selection's binding into that owner so subsequent Persona changes or
+deletion cannot invalidate the Buddy. Preserve notices and original pack metadata.
+Keep private placement/settings out of portable exports.
+
+The existing app Buddy overlay hosts presentation. ConsoleRuntime, its controller and
+store continue to own execution. The management and interaction modals submit commands
+with explicit target identities and project existing run/approval/transcript state.
+Switching the active Console tab, workspace, modal or screen does not retarget a Buddy
+or terminate a run. Normal navigation uses the existing reusable Console route from
+TASK-31520; this feature does not replace application navigation or add a job service.
+
+Workspace Persona defaults use the existing ADR-079 reference-backed setting. Resolve
+it only for newly created conversations. Explicit None is distinct from unspecified;
+existing/copy/move flows retain assignments. An explicitly absent workspace default
+must remain absent through provisioning/backfill; omission can retain the existing
+auto-create convenience. Artwork never grants Persona or tool
+authority and never modifies accepted request settings.
+
+Conversation mode allows directed text and supported voice input. Workspace mode
+allows directed text and optional named spoken output, with no voice input. One
+application-owned speech queue serializes Buddy announcements, retaining pause/skip/
+mute independently of run state. Only explicit user responses resolve questions or
+approvals; hearing speech or opening the inbox does not acknowledge everything.
+
+An explicit conversation opener may initialize the existing headless launch runtime
+and restore that exact local saved conversation with `activate=False`. Passive inbox
+inspection must not construct provider gateways or agent bridges. A failed bootstrap
+keeps an explicit Open Console recovery action; it never selects another conversation.
+
+Opening a Buddy interaction also retains decision availability for that exact live
+session object and binding revision. This amends the existing no-view question posture
+only for explicitly opened Buddy targets: their questions, approvals and confirmations
+remain parked and recoverable after the modal closes. Wake-only sessions with no
+Console view or retained Buddy interaction keep their existing fail-closed posture.
+This capability neither supplies fake UI setters nor approves actions. Existing
+per-round owner checks, permissions, Stop and shutdown cancellation remain authoritative.
+Finite decision clocks count only visible, answerable cards; the worktree review link
+alone does not spend that budget. Open Console uses the existing handoff to synchronize
+the selected conversation's transcript and composer.
+
+The same user-facing behavior is the target for the later tldw_server port. Local
+profile paths, DB keys, UI geometry and Textual lifecycle are not server contracts.
+Multiple visible Buddies remain v2; explicit bindings avoid an implicit active-session
+contract that would prevent that extension.
+
+## Alternatives
+
+- Keep requiring a Persona: prevents the requested artwork-only experience and makes
+  deleting a prompt identity accidentally delete its UI companion.
+- Fabricate a Persona identifier: obscures data ownership and leaks dummy assistant
+  identities into selectors and exports.
+- Follow whatever Console currently selects: makes off-screen replies ambiguous and
+  can direct a private reply to the wrong conversation.
+- Build a second execution system for Buddy replies: duplicates approvals, tools,
+  persistence and cancellation, risking divergent behavior.
+- Automatically change older conversations when workspace defaults change: violates
+  explicit conversation choices and would change established assistant behavior.
+
+## Consequences
+
+Storage changes require versioned migration and real SQLite coverage. Selection and
+migration failures must leave the previous usable selection intact. Tests must cover
+source Persona deletion, notices, restart, exact-target reply routing, navigation,
+explicit-None precedence, and directed speech. Server implementation follows Chatbook
+validation; no cross-product storage coupling is introduced.
+
+## Links
+
+- [Approved design](../../Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md)
+- [ADR-074](074-portable-actor-packs-and-local-persona-visual-runtime.md)
+- [ADR-079](079-workspace-assistant-defaults.md)
+- [ADR-094 lifecycle objective](094-console-turn-lifetime-and-navigation-boundary.md)
+
+## Chatbook artwork implementation (TASK-32079)
+
+ChaChaNotes schema 70 adds `buddy_profiles` and `buddy_visual_bindings`. The existing
+immutable pack/version/asset tables remain shared storage. A read-only
+`visual_owner_bindings` projection retains explicit, mutually exclusive Persona and
+Buddy identifiers; Buddy graph identities have no Persona identifier. Publication
+and rendering use the same validation and exact-identity checks for both owner kinds.
+
+`Persona_Buddy/library.py` supplies read-only archive review, list/read/preview, native
+publication, guarded Persona artwork copying, and built-in installation. Independent
+copies own new pack/version rows and private file copies. Legacy selection migration
+uses a unique source key, publishes first, and writes preferences before changing the
+selected owner; failed attempts keep the old selection. Built-in and import records
+preserve public artwork notices, and unknown license statements remain null.

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -104,6 +104,7 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-118](118-chunking-lab-local-execution-and-recovery.md) | Accepted | Keep Chunking Lab local-first, with faithful full-recipe previews, immutable A/B results, conflict-safe catalog saves, and private recoverable session checkpoints. |
 | [ADR-122](122-bundled-pixel-migu-character-and-buddy.md) | Accepted | Include pixel-migu as optional fresh-profile character and Buddy content using existing ownership and runtime boundaries. |
 | [ADR-127](127-fresh-install-private-data-root-recovery.md) | Accepted | Select durable home-level private storage for fresh installs blocked by shared default ancestors. |
+| [ADR-139](139-independent-buddy-conversation-and-workspace-bindings.md) | Accepted | Give one Buddy independent artwork ownership, explicit conversation/workspace binding, and directed interaction while retaining Console execution authority. |
 
 ## Historical Decision Material
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -6286,6 +6286,16 @@ Three mechanics worth keeping:
    harness with `CSS_PATH = BUNDLED_STYLESHEET` — and treat a red mounted
    test in a bare harness as unattributed until reproduced under the bundle.
 
+**Buddy follow-up (TASK-32082, 2026-09-08).** A 60x20 pending-decision test
+reported the focused action inside the transcript, but the final render still
+hid Approve once and Deny. With the full production CSS loaded, the nested
+`approval-batch-body` remained a default `1fr` Container inside an auto-sized
+card and clipped its children to one row. Coordinates inside the outer scroll
+viewport were insufficient. Buddy-scoped auto-height/flexible Select rules,
+after regenerating the app bundle, made both actions visible. The regression
+now checks each relevant ancestor's content bounds and horizontal containment;
+the final 60x20 and 80x24 compositor renders confirm the controls are painted.
+
 ## A `0.000` from a seam the harness never wired reads exactly like a real negative (TASK-17855/18255, 2026-08-18)
 
 TASK-17855 censused the RAG eval harness's residual zero-row queries and

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -9,6 +9,22 @@ decays into folklore, and folklore is ignored. If you add one, bring the inciden
 
 ---
 
+## Retained screen identity does not prove queued work survives navigation
+
+**TASK-32078, 2026-09-08.** TASK-31520 reuse checks passed, but an actual
+stalled provider turn with a queued follow-up failed after navigating Home
+and selecting another conversation: Canvas admission consulted the browser's
+active-view guard for the original run. A separate exact-owner run resolver
+fixed it without relaxing browser authority. The mounted test also had to
+wait for both settled assistant responses: an empty queue and zero active
+runs briefly occur between reservation release and the next admission.
+
+**What to do.** Verify accepted work and its final owner through real mounted
+navigation. Wait for the requested outcome, not a transient idle snapshot;
+use thread-safe gates when fake provider execution crosses event loops.
+
+---
+
 ## Index-plan guards must accept the names the DDL actually uses
 
 **TASK-31242 isolated PR preparation, 2026-09-05.** Five real-SQLite,
@@ -12568,3 +12584,38 @@ Chatterbox version in that extra.
 unseeded environment. Probe the capability and required resources, not just the
 top-level import or declared dependency consistency. Preserve the original
 extra-only evidence before adding test instrumentation.
+
+## Keep source stable while source-inspection tests execute
+
+**TASK-32079, independent Buddy ownership, 2026-09-08.** Formatting `app.py` during a
+long targeted run caused several shutdown/deferred-startup `inspect.getsource` checks
+to read neighboring methods: a shutdown assertion received
+`get_chunking_lab_coordinator`. Imported functions retained line numbers from the old
+file while inspection read the newly formatted source. A fresh, stable-file rerun of
+the six affected startup/shutdown checks passed.
+
+**What to do.** Do not change a module while tests inspect its source, including from
+a parallel worker. Finish edits first or rerun those checks in a fresh process. A
+failure whose quoted function has the wrong name is not evidence of a runtime change.
+
+## Exercise a cold opener and verify the destination composer
+
+**TASK-32082, Buddy interaction, 2026-09-08.** The first saved-row test visited
+Console before returning Home, so it could not expose the missing lazy runtime on
+a true Home startup. Configure Home as the startup destination and assert that
+the store/controller are absent before invoking the opener. The mounted cold test
+now loads the exact saved transcript, sends, closes and answers later questions
+without ever mounting Console or choosing an active session.
+
+A separate Open Console check found that changing the controller selection and
+navigating to the reused screen left its old composer visible. Assert the destination
+transcript/composer as well as its selected ID; use the existing navigation handoff
+that synchronizes both. When setting up multiple drafts directly in a mounted test,
+settle the real session-switch UI before typing the sibling draft, or the fixture
+itself will save that text against the previous visible owner.
+
+The combined management journey also reached the new modal on the screen stack
+before its Select child labels were composed. Assigning Select.value at that point
+raised NoMatches for the internal label. Settle the pilot after detecting the modal,
+then interact with its controls; the normal journey and compact controls passed
+together after that fixture correction.

--- a/backlog/tasks/task-32078 - Verify-Console-navigation-continuity-for-Buddy-interaction.md
+++ b/backlog/tasks/task-32078 - Verify-Console-navigation-continuity-for-Buddy-interaction.md
@@ -1,0 +1,62 @@
+---
+id: TASK-32078
+title: Verify Console navigation continuity for Buddy interaction
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:27'
+updated_date: '2026-09-08 21:03'
+labels:
+  - console
+  - buddy
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+priority: high
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Verify actual reusable Console navigation before adding cross-screen Buddy interaction; preserve accepted work and explicit cancellation boundaries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Mounted navigation preserves streaming, queues and pending decisions; explicit shutdown still cancels.
+- [x] #2 Document current reuse semantics and correct obsolete user-facing cancellation claims using targeted tests.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR paths: backlog/decisions/094-console-turn-lifetime-and-navigation-boundary.md; backlog/decisions/121-local-versioned-canvas-artifacts-and-browser-sandbox.md; backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: implement approved answerable-time and exact-owner boundaries while preserving TASK-31520 reusable Console navigation.
+1. Read reusable-route implementation and relevant lifetime tests.
+2. Exercise actual streaming, queued continuation and all three approval bridges through mounted navigation and covering modals; cover all five human decision kinds at the shared clock boundary.
+3. Fix hidden attachment-as-visibility notices and finite answerable-time clocks; preserve explicit Stop, final unmount and shutdown.
+4. Resolve Canvas selection for an accepted turn from its exact live runtime session and branch, separately from browser active-view authorization; reject mismatched and closed owners. This narrow correction follows the mounted queue failure and the approved ADR-121/139 execution-owner boundary.
+5. Correct obsolete user guide copy and run targeted mounted, interrupt, Canvas and runtime lifetime checks; record evidence and limitations.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Preserved TASK-31520 retained Console navigation. Suspend/resume now informs the interrupt host of actual visibility (including covering modals), so hidden requests surface one app-wide notice and finite budgets count only time when their owning session and FIFO head are answerable. All five interrupt kinds share the clock; explicit Stop, final-unmount and shutdown fences remain intact.
+
+The mounted queued-turn test exposed Canvas run admission depending on the browser active-view guard after another conversation was selected. Added an exact live runtime session/conversation/branch resolver used only by run selection capture; browser interaction guards remain unchanged and wrong/closed owners fail closed. Implements existing ADR-094 answerable-time and ADR-121/139 exact execution ownership, with the current screen reuse ruling recorded in the foundations plan.
+
+Changed controller visibility/notification methods, interrupt host, runtime Canvas resolver, native Canvas authority and screen suspend/resume hooks. Added mounted navigation/decision and exact-owner Canvas tests, plus deterministic decision-clock coverage; updated existing headless tests and the stale risk-floor fixture to the current call-id/profile API. Corrected Console, index, tools/runs and Watchlists guide copy and recorded the accepted-work verification lesson.
+
+Validation used the shared main .venv Python with cwd and PYTHONPATH explicitly set to .worktrees/buddy-console-management and isolated Tests fixtures:
+- Tests/UI/test_console_navigation_decisions.py: 6 passed in 87.63s, covering actual stalled gateway work, queued continuation without retargeting, explicit Stop/shutdown, and all three approval bridges through Home and a modal. The added already-armed-before-navigation scenarios were then verified with -k hidden_finite: 3 passed, 3 deselected in 39.55s.
+- Tests/Chat/test_console_decision_clock.py, test_console_interrupt_rounds.py, test_console_interrupt_attention.py; Tests/Canvas/test_hidden_run_scope.py, test_native_authority.py, test_canvas_kill_switch.py, test_startup_deferral.py: 110 passed in 18.31s.
+- Tests/UI/test_console_headless_approval.py, Tests/Chat/test_console_runtime_lifetime.py, Tests/UI/test_console_screen_reuse.py: 44 passed in 75.33s.
+- Final small clock/visibility changes: decision_clock, interrupt_rounds, interrupt_attention and hidden_run_scope files: 59 passed in 5.16s.
+- New test files pass Ruff lint/format; changed definitions pass Ruff range-format checks; comparison to HEAD finds zero introduced lint diagnostics; git diff --check passes. Full-file lint on the large existing files retains unrelated legacy findings.
+
+Self-reviewed exact-owner guards, cancellation ordering, lazy Canvas construction and shared-file edits. No schema, dependency or license changes in this task. Evidence is mounted Textual with a deterministic fake provider plus real controller/store/SQLite paths; no real-provider or audible-terminal run, full suite, restart-resumption, or fresh-screen redesign is claimed.
+
+Review follow-up: legacy run_round(session_id=None) deliberately mounts without FIFO parking. Added a requires_head flag so its visible card still consumes the configured budget; explicit session rounds retain FIFO eligibility. All five legacy round kinds reproduced the regression before the fix. Targeted clock/authority gate: 59 passed in 5.23s (/private/tmp/console-legacy-clock-green.log). Buddy interaction extends the same host with per-kind Buddy visibility claims; unsupported worktree review links do not consume answerable time.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32079 - Give-Buddy-artwork-independent-local-ownership.md
+++ b/backlog/tasks/task-32079 - Give-Buddy-artwork-independent-local-ownership.md
@@ -1,0 +1,56 @@
+---
+id: TASK-32079
+title: Give Buddy artwork independent local ownership
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:29'
+updated_date: '2026-09-08 20:53'
+labels:
+  - buddy
+  - console
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let users select an installed visual companion without creating or retaining a Persona; preserve existing appearances and source attribution.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh and migrated profiles can own and select Buddy artwork without a Persona; source Persona edits/deletion do not affect the copy.
+- [x] #2 Existing private visual validation/publication/rendering are reused with explicit Buddy authority and versioned schema migration; no dummy Persona is created.
+- [x] #3 Legacy selection migration is idempotent, preserves geometry, enabled state and artwork notices, and leaves the old selection usable on failure.
+- [x] #4 Built-in and native imported artwork can be published to Buddy ownership with preserved supplied attribution and unknown licensing kept unspecified.
+- [x] #5 Targeted SQLite, publication and controller tests verify restart, migration, failure and ownership isolation.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: independent ownership and explicit default-selection semantics.
+Follow Task 2 in Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md.
+Read the approved spec and existing relevant ADRs; add failing targeted regression coverage, implement shared authority/creation seams, validate targeted integration, then document evidence and review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented independent local Buddy artwork ownership under ADR-139. Schema 70 adds real Buddy owners/bindings and a read-only explicit-owner projection over shared immutable visual storage. Existing Persona APIs remain compatible; Buddy snapshots have persona_id=None and real buddy_id/revision authority. Shared publication supports first and subsequent versions under CAS.
+
+BuddyLibrary exposes list/get/graph/preview, bounded read-only native archive review, publication, guarded Persona copying, independent built-in seeding, and idempotent legacy selection migration. Copies own separate packs/files. Source notices and unspecified licenses survive native imports and copies. Startup no longer creates a built-in Persona; legacy and independent tombstones are retained. Independent controller selection needs no Persona service. Migration preserves geometry/visibility and prior selection on copy or config-write failure. The management batch writer and revision-guarded rollback support atomic persona_buddy plus buddy_interaction config writes.
+
+Verification: broad targeted ownership/repository/publication/runtime/import/authoring/preferences/schema/startup/packaging run reported 485 passing; six startup/source-inspection failures were rerun with files stable and all six passed. Final focused library/config/startup/lazy-controller check: 21 passed. Existing Persona compatibility subset previously passed 195. One architecture AST guard fails identically on pristine HEAD because the untouched legacy builtin_pixel_migu module imports Character_Chat; reproduced in an isolated HEAD source tree, not introduced here. New library/artwork/snapshot/test modules pass the configured Ruff rules; modified existing runtime modules introduce no new Ruff findings compared with HEAD. Thirteen scoped files pass formatter check, and scoped git diff --check passes. No full-suite run.
+
+Core changed files: Persona_Buddy/library.py, controller.py, preferences.py and facade; Persona_Visual artwork/snapshot/importer/repository/publication/runtime/authoring; ChaChaNotes schema migration and app composition. ADR-139 records the concrete ownership projection. Added a testing-evidence lesson for editing source during inspect.getsource-based test execution. Parent integration review remains pending; task status stays In Progress until that review and overall integration finish.
+
+Parent review reproduced and resolved two startup regressions: inactive or archived legacy builtins no longer seed a replacement independent Buddy, and unclaimed migration now holds the first-controller construction lock across preference admission, disk write and app_config publication. If controller construction wins during the visual copy, migration hands off without overwriting its current selection. Deterministic concurrency/handoff tests and real inactive/deleted/archived legacy seed tests pass; included in the final 183-test speech/startup regression run. No full-suite run or shared-file formatting.
+
+Final integration gate: 813 passed in Tests/Persona_Buddy, Tests/Persona_Visual, WorkspaceDB/default/provisioning and Persona assignment suites (162.62s); 7 lazy packaging/architecture checks passed, with the previously reproduced untouched legacy builtin boundary failure excluded. Independent review startup retirement and constructor/migration ownership races are fixed and covered. Final user guide: Docs/User_Guide/buddies.md. ADR-139 governs genuine Buddy ownership. No new lint findings in task-owned files; only targeted tests were run.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32079 - Give-Buddy-artwork-independent-local-ownership.md
+++ b/backlog/tasks/task-32079 - Give-Buddy-artwork-independent-local-ownership.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:29'
-updated_date: '2026-09-08 20:53'
+updated_date: '2026-09-09 01:13'
 labels:
   - buddy
   - console
@@ -27,16 +27,13 @@ Let users select an installed visual companion without creating or retaining a P
 - [x] #3 Legacy selection migration is idempotent, preserves geometry, enabled state and artwork notices, and leaves the old selection usable on failure.
 - [x] #4 Built-in and native imported artwork can be published to Buddy ownership with preserved supplied attribution and unknown licensing kept unspecified.
 - [x] #5 Targeted SQLite, publication and controller tests verify restart, migration, failure and ownership isolation.
+- [x] #6 New Buddy index has meaningful query-plan evidence without SQLite statistics and appears in the required index census.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes
-ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
-Reason: independent ownership and explicit default-selection semantics.
-Follow Task 2 in Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md.
-Read the approved spec and existing relevant ADRs; add failing targeted regression coverage, implement shared authority/creation seams, validate targeted integration, then document evidence and review.
+Retain the existing ADR-139 implementation. PR CI follow-up: reproduce the index census and UI-ready failures on merged dev, defer unnecessary imports and capture active Buddy lookup query plans without sqlite_stat1, run guards and focused regression tests. ADR required: no new ADR. ADR paths: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md and backlog/decisions/097-boot-budget-ratchets.md. Reason: validation and lazy-import correction within existing contracts.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -53,4 +50,6 @@ Core changed files: Persona_Buddy/library.py, controller.py, preferences.py and 
 Parent review reproduced and resolved two startup regressions: inactive or archived legacy builtins no longer seed a replacement independent Buddy, and unclaimed migration now holds the first-controller construction lock across preference admission, disk write and app_config publication. If controller construction wins during the visual copy, migration hands off without overwriting its current selection. Deterministic concurrency/handoff tests and real inactive/deleted/archived legacy seed tests pass; included in the final 183-test speech/startup regression run. No full-suite run or shared-file formatting.
 
 Final integration gate: 813 passed in Tests/Persona_Buddy, Tests/Persona_Visual, WorkspaceDB/default/provisioning and Persona assignment suites (162.62s); 7 lazy packaging/architecture checks passed, with the previously reproduced untouched legacy builtin boundary failure excluded. Independent review startup retirement and constructor/migration ownership races are fixed and covered. Final user guide: Docs/User_Guide/buddies.md. ADR-139 governs genuine Buddy ownership. No new lint findings in task-owned files; only targeted tests were run.
+
+PR UX follow-up complete: real SQLite active Buddy lookup now asserts idx_buddy_visual_bindings_active through the production union-view shape with no sqlite_stat1. Index census passes282 entries/67 pins; affected Buddy library/controller/UI/default verification384passed. Independent review confirmed the query evidence. ADR-139 and ADR-097 remain authoritative; no index or budget waiver. Final evidence: Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32080 - Apply-workspace-Persona-defaults-consistently-at-conversation-creation.md
+++ b/backlog/tasks/task-32080 - Apply-workspace-Persona-defaults-consistently-at-conversation-creation.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:29'
-updated_date: '2026-09-08 20:53'
+updated_date: '2026-09-09 01:13'
 labels:
   - buddy
   - console
@@ -27,16 +27,13 @@ Make optional workspace Persona defaults consistent for every new-conversation s
 - [x] #3 Workspace creation and settings permit explicit None without provisioning or backfill recreating a default.
 - [x] #4 Persona memory-mode identity persists with the new session and matches its settings.
 - [x] #5 Targeted creation, persistence and native UI tests verify precedence and failure behavior.
+- [x] #6 Assistant-default and artwork additions preserve the existing UI-ready module budget without increasing its limit.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes
-ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
-Reason: independent ownership and explicit default-selection semantics.
-Follow Task 3 in Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md.
-Read the approved spec and existing relevant ADRs; add failing targeted regression coverage, implement shared authority/creation seams, validate targeted integration, then document evidence and review.
+Retain the existing ADR-139 implementation. PR CI follow-up: reproduce the index census and UI-ready failures on merged dev, defer unnecessary imports and capture active Buddy lookup query plans without sqlite_stat1, run guards and focused regression tests. ADR required: no new ADR. ADR paths: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md and backlog/decisions/097-boot-budget-ratchets.md. Reason: validation and lazy-import correction within existing contracts.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -61,4 +58,6 @@ Baseline limits: clean c0a42150 source extracted to /private/tmp/task-32080-base
 No staging or commits. Task remains In Progress for parent integration review; acceptance checks reflect verified task behavior, not a claim that all pre-existing UI/static checks pass. Existing-session Persona reassignment is explicitly outside this task and awaits the separate management task.
 
 Final integration gate: 813 targeted tests passed across Buddy/Persona_Visual, WorkspaceDB, creation defaults/provisioning and atomic Persona assignment (162.62s). Independent implementation review was clean; existing baseline UI failures above remain outside this change. User guide includes future-only defaults and explicit None precedence. ADR-139 remains the applicable amendment to ADR-079. No new diagnostics after removing the now-unused DEFAULT_WORKSPACE_ID session import.
+
+PR follow-up complete: deferred artwork publication imports and kept Default/global startup on already-loaded session value types with the compatibility re-export and malformed-config fallback preserved. Actual UI-ready census973/973 and default-creation group30passed; no budget increase. Independent review confirmed resolution behavior. ADR-079/139/097 apply; no new runtime boundary. Evidence: Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32080 - Apply-workspace-Persona-defaults-consistently-at-conversation-creation.md
+++ b/backlog/tasks/task-32080 - Apply-workspace-Persona-defaults-consistently-at-conversation-creation.md
@@ -1,0 +1,64 @@
+---
+id: TASK-32080
+title: Apply workspace Persona defaults consistently at conversation creation
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:29'
+updated_date: '2026-09-08 20:53'
+labels:
+  - buddy
+  - console
+dependencies: []
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make optional workspace Persona defaults consistent for every new-conversation surface while retaining explicit and existing assignments.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 New conversations resolve workspace defaults across creation surfaces; explicit Persona and explicit None take precedence.
+- [x] #2 Existing, copied and moved conversations retain assignment; future-default edits never rewrite them.
+- [x] #3 Workspace creation and settings permit explicit None without provisioning or backfill recreating a default.
+- [x] #4 Persona memory-mode identity persists with the new session and matches its settings.
+- [x] #5 Targeted creation, persistence and native UI tests verify precedence and failure behavior.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: independent ownership and explicit default-selection semantics.
+Follow Task 3 in Docs/superpowers/plans/2026-09-08-console-buddy-foundations.md.
+Read the approved spec and existing relevant ADRs; add failing targeted regression coverage, implement shared authority/creation seams, validate targeted integration, then document evidence and review.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented creation-only workspace Persona defaults under ADR-139 (amending ADR-079): Console bootstrap, direct/store/controller, ordinary/temporary new chat and workspace activation resolve the explicit target once. Explicit None/generic/Persona/Character identities and restore/fork snapshots bypass inheritance. Provider setup recovery retains the already-assigned Persona prompt, label and memory mode.
+
+WorkspaceDB v8 records deliberate None separately from omitted defaults, so legacy omission still auto-provisions a workspace Agent while user-selected None survives restart and pending backfill. Set/clear update the flag atomically; migration rollback/retry is covered with real SQLite. Session memory mode now matches its settings and durable conversation identity.
+
+Shared WorkspacePersonaPicker and WorkspacePersonaDefaultModal add native creation/details choices with unavailable-Persona validation, stale-default rejection, preserved tool profile, inline failures and explicit read/write-memory confirmation. Console, Settings and Library creation pass the local Persona service. User guide documents future-only defaults and preserved existing conversations.
+
+Verification (shared main .venv with explicit worktree/package PYTHONPATH and isolated fixtures; no full suite):
+- Tests/Chat/test_workspace_default_session.py + test_console_chat_store.py: 429 passed.
+- Final core group (workspace_default_session, workspace_persona_creation, agent_provisioning, workspace_assistant_defaults, workspace_db): 81 passed.
+- Existing new-workspace/settings-default/lifecycle native group: 29 passed.
+- Context-policy lifecycle + session-controller + switch-draft group: 64 passed, 1 baseline failure. The formerly partial lifecycle fake now uses the real controller/store seam.
+- Provider default-actions persistence/publication flow: 1 passed (33 deselected).
+- New/owned module and test Ruff/formatter checks pass; 22 touched Python files parse; diff-scoped Ruff reports zero diagnostics on added lines; git diff --check passes. Whole pre-existing touched files retain unrelated lint debt.
+
+Baseline limits: clean c0a42150 source extracted to /private/tmp/task-32080-baseline-G7MHRn (not the dirty main checkout) reproduces the compact Settings recovery-layout failure, two Library handoff-copy failures, and fork-validation DuplicateIds recompose failure. The broader Settings/Library chunk had 51 passes and 4 failures; its folder-binding failure passes in isolation and on baseline, so no root cause claimed for that transient result. The session fork failure reproduces independently on both baseline and implementation. Existing shared-venv RequestsDependencyWarning also remains.
+
+No staging or commits. Task remains In Progress for parent integration review; acceptance checks reflect verified task behavior, not a claim that all pre-existing UI/static checks pass. Existing-session Persona reassignment is explicitly outside this task and awaits the separate management task.
+
+Final integration gate: 813 targeted tests passed across Buddy/Persona_Visual, WorkspaceDB, creation defaults/provisioning and atomic Persona assignment (162.62s). Independent implementation review was clean; existing baseline UI failures above remain outside this change. User guide includes future-only defaults and explicit None precedence. ADR-139 remains the applicable amendment to ADR-079. No new diagnostics after removing the now-unused DEFAULT_WORKSPACE_ID session import.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32081 - Add-Console-Buddy-and-Persona-management.md
+++ b/backlog/tasks/task-32081 - Add-Console-Buddy-and-Persona-management.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:30'
-updated_date: '2026-09-08 21:02'
+updated_date: '2026-09-09 01:13'
 labels:
   - buddy
   - console
@@ -31,20 +31,15 @@ Manage the current Buddy and conversation Persona without leaving Console using 
 - [x] #4 Preview, keyboard access, narrow-terminal scrolling and focus restoration work; missing targets show an actionable unavailable state.
 - [x] #5 Buddy animation reflects only its selected scope; changing Console selection does not retarget it.
 - [x] #6 Existing-session Persona assignment commits identity, prompt and settings atomically before live publication; stale, busy, inactive or repurposed targets retain their old assignment, and workspace changes preserve memory/tool policy.
+- [x] #7 Preview, geometry, Apply and Cancel are visible and usable at normal and compact sizes, with optional import and geometry progressively disclosed.
+- [x] #8 Apply failures preserve all staged values with actionable errors and truthful partial-save status; duplicate Apply and ambiguous dismissal while saving are prevented.
+- [x] #9 Current conversation Persona and workspace default names, None and unavailable states are visible; Personas controls manage the independent Buddy through the shared coordinator.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes
-ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
-Reason: management and explicit scope are the new application Buddy interaction boundary.
-1. Define strict local conversation/workspace bindings and private interaction preferences; verify no implicit retarget or ephemeral persistence.
-2. Build a native staged management modal with injected read-only library/target/Persona choices, fixed Apply/Cancel footer and keyboard/compact layout coverage.
-3. Integrate the completed independent library, controller preferences and shared app opener into composer menu and floating settings.
-4. Scope trusted lifecycle leases, preserve static/reduce-motion expressions, and wire existing Persona assignment with explicit target and safe future-turn behavior.
-5. Verify Apply/Cancel, missing targets, rendering/focus and scoped state with targeted tests; review integrations and document.
-6. Add a read-only prepared Persona assignment service for exact local sessions/workspaces. Revalidate target and active Persona, reject busy/stale owners, atomically CAS identity/prompt/settings before publishing fenced live memory, and preserve workspace policy. Verify SQLite rollback/round-trip, explicit None and concurrent target/Persona changes.
+Preserve the completed implementation under ADR-139 and ADR-079; follow Docs/superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md for the reviewed UX corrections, focused regressions and mounted verification. ADR required: no new ADR. Reason: direct correction within existing ownership, persistence and runtime boundaries.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -61,4 +56,6 @@ Verification: 50 passed in Tests/Chat/test_console_persona_assignment.py, Tests/
 Root integration: added one native staged Buddy/Follow/Persona/Notifications form shared by Console Menu and floating settings, independent library preview/import, fixed Apply/Cancel footer, exact conversation/workspace binding persistence, and scoped trusted lifecycle projection. Apply batches private artwork/presentation/scope preferences with rollback; existing Persona assignment uses the prepared atomic seam above. First-save binding promotion is serialized with Apply and preserves temporary/stale-owner fences; restored bindings resolve to their exact current form choice. Body click/Enter opens interaction without writing geometry. Static and global reduced motion suppress animation. Scope replay preserves accepted run identity, including VALIDATING, and retained workspace-member tool/voice/wake leases survive scope additions. Targeted evidence: 31 adapter/scope/coordinator checks, 5 management modal checks, entry-point/body-click checks and fresh-profile actual Menu -> Apply -> Home -> pinned chat -> Close -> Cancel journey pass. Independent UI review issues fixed with regressions. Docs/User_Guide/buddies.md and ADR-139 describe behavior; final combined feature gate pending.
 
 Final joint verification: 813 foundational tests passed and the 288-test runtime/UI gate passed all management behavior except a test-only premature Select assignment before child composition. Settling the pilot after modal publication fixes that fixture; the focused management modal, fresh-install journey, entry points and normal/compact speech-enabled inbox group now passes all 12 tests (18.11s). Root and independent UI reviews are complete; validating-state replay, saved binding promotion/restoration and stale-owner fixes are covered. All modified Python files parse, no introduced Ruff diagnostics, new files formatted, diff whitespace clean. Known unrelated baseline tests are recorded under final TASK-32084 evidence.
+
+Native UX corrections complete: visible preview/focus and scoped geometry, progressively disclosed import/size, named current/default Persona with literal brackets, retained staged Apply errors and guarded imports/retry, and independent Personas inspector Manage/Show/Close/Disable controls.384affected tests passed; later management/layout20 and coordinator17 passed including partial-save recovery. Normal/compact native renders inspected; independent review clear. Existing ADR-139/079 boundaries, guide, plan and review evidence updated. No full suite or real provider/audio checks.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32081 - Add-Console-Buddy-and-Persona-management.md
+++ b/backlog/tasks/task-32081 - Add-Console-Buddy-and-Persona-management.md
@@ -1,0 +1,64 @@
+---
+id: TASK-32081
+title: Add Console Buddy and Persona management
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:30'
+updated_date: '2026-09-08 21:02'
+labels:
+  - buddy
+  - console
+dependencies:
+  - TASK-32078
+  - TASK-32079
+  - TASK-32080
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Manage the current Buddy and conversation Persona without leaving Console using one shared modal.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Composer Menu has a Buddy action opening the same management modal as floating Buddy settings.
+- [x] #2 Apply can enable/select/import an independent Buddy, set animation/size, and choose an explicit named conversation or workspace binding; Cancel has no mutations.
+- [x] #3 Persona changes including None use existing assignment boundaries and do not alter running request context.
+- [x] #4 Preview, keyboard access, narrow-terminal scrolling and focus restoration work; missing targets show an actionable unavailable state.
+- [x] #5 Buddy animation reflects only its selected scope; changing Console selection does not retarget it.
+- [x] #6 Existing-session Persona assignment commits identity, prompt and settings atomically before live publication; stale, busy, inactive or repurposed targets retain their old assignment, and workspace changes preserve memory/tool policy.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: management and explicit scope are the new application Buddy interaction boundary.
+1. Define strict local conversation/workspace bindings and private interaction preferences; verify no implicit retarget or ephemeral persistence.
+2. Build a native staged management modal with injected read-only library/target/Persona choices, fixed Apply/Cancel footer and keyboard/compact layout coverage.
+3. Integrate the completed independent library, controller preferences and shared app opener into composer menu and floating settings.
+4. Scope trusted lifecycle leases, preserve static/reduce-motion expressions, and wire existing Persona assignment with explicit target and safe future-turn behavior.
+5. Verify Apply/Cancel, missing targets, rendering/focus and scoped state with targeted tests; review integrations and document.
+6. Add a read-only prepared Persona assignment service for exact local sessions/workspaces. Revalidate target and active Persona, reject busy/stale owners, atomically CAS identity/prompt/settings before publishing fenced live memory, and preserve workspace policy. Verify SQLite rollback/round-trip, explicit None and concurrent target/Persona changes.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+TASK-32081 Persona assignment seam (workspace_persona_audit): Added Chat/console_persona_assignment.py. prepare_buddy_persona_assignment(app, binding, target, persona_choice) performs read-only admission and returns PreparedPersonaAssignment; await assignment.apply() revalidates the exact local target and active Persona record. #unchanged is skipped, same Persona is a no-op, #none removes the Persona explicitly. Character/server ownership, active/early-preparation runs, queued work, parked decisions, recovery and settings writes in flight are rejected. No conversation reset, greeting, recreation or active-tab lookup occurs.
+
+Existing saved conversation identity, prompt, full Console settings and safe generation metadata use one optimistic SQLite update/transaction before live publication. Target/settings/identity/binding revisions and saved identity/version are checked, unrelated settings and metadata are preserved, live-only endpoint URLs remain out of durable settings, and source-fork, identity/generation/settings, provider-context and speech epochs fence subsequent work. This bounded synchronous local write has no await between final admission and publication; unsaved/temporary assignments remain staged without creating a durable row.
+
+Workspace assignments preserve existing tool profile and memory policy, use read_only when starting from no Persona, and reject assigning a different Persona under existing read_write permission because this picker has no new write-memory confirmation. None revokes the default and records the provisioning optout. Added optional expected_record guards to registry set/clear, checked inside BEGIN IMMEDIATE; the native workspace default modal also uses them. WorkspaceDB intentionally rejects nested transactions, so the optimistic guard lives inside its existing registry mutation instead of an outer transaction.
+
+Verification: 50 passed in Tests/Chat/test_console_persona_assignment.py, Tests/Workspaces/test_workspace_assistant_defaults.py, Tests/UI/test_workspace_persona_creation.py, and Tests/Persona_Buddy/test_buddy_management_coordinator.py (24.19s), using shared main .venv with explicit worktree/package PYTHONPATH and isolated fixtures. Covers real SQLite identity/prompt/settings round-trip, trigger-induced rollback, optimistic DB conflict, stale/deleted/inactive Persona, busy/queued/parked/early-preparation targets, repurposed sessions, workspace default CAS/profile replacement, None, no-op, temporary staging, exact-tab targeting and fork barrier. New files and picker pass Ruff/formatter; four changed Python files parse; zero Ruff diagnostics on changed lines (12 existing registry diagnostics outside changes); git diff --check passes. Shared-venv RequestsDependencyWarning remains. No commits/staging; parent owns remaining management ACs and final task status. ADR-139 is the applicable ownership/service boundary.
+
+Root integration: added one native staged Buddy/Follow/Persona/Notifications form shared by Console Menu and floating settings, independent library preview/import, fixed Apply/Cancel footer, exact conversation/workspace binding persistence, and scoped trusted lifecycle projection. Apply batches private artwork/presentation/scope preferences with rollback; existing Persona assignment uses the prepared atomic seam above. First-save binding promotion is serialized with Apply and preserves temporary/stale-owner fences; restored bindings resolve to their exact current form choice. Body click/Enter opens interaction without writing geometry. Static and global reduced motion suppress animation. Scope replay preserves accepted run identity, including VALIDATING, and retained workspace-member tool/voice/wake leases survive scope additions. Targeted evidence: 31 adapter/scope/coordinator checks, 5 management modal checks, entry-point/body-click checks and fresh-profile actual Menu -> Apply -> Home -> pinned chat -> Close -> Cancel journey pass. Independent UI review issues fixed with regressions. Docs/User_Guide/buddies.md and ADR-139 describe behavior; final combined feature gate pending.
+
+Final joint verification: 813 foundational tests passed and the 288-test runtime/UI gate passed all management behavior except a test-only premature Select assignment before child composition. Settling the pilot after modal publication fixes that fixture; the focused management modal, fresh-install journey, entry points and normal/compact speech-enabled inbox group now passes all 12 tests (18.11s). Root and independent UI reviews are complete; validating-state replay, saved binding promotion/restoration and stale-owner fixes are covered. All modified Python files parse, no introduced Ruff diagnostics, new files formatted, diff whitespace clean. Known unrelated baseline tests are recorded under final TASK-32084 evidence.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32082 - Reply-to-a-conversation-through-its-Buddy.md
+++ b/backlog/tasks/task-32082 - Reply-to-a-conversation-through-its-Buddy.md
@@ -1,0 +1,61 @@
+---
+id: TASK-32082
+title: Reply to a conversation through its Buddy
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:31'
+updated_date: '2026-09-08 21:03'
+labels:
+  - buddy
+  - console
+dependencies:
+  - TASK-32081
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Allow context and replies to a pinned conversation from another application destination.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Click opens the named conversation transcript/activity/decisions and a text composer without navigating the underlying screen.
+- [x] #2 Replies and approvals target the explicit bound conversation even when Console has another active conversation.
+- [x] #3 Per-conversation drafts survive closing; Open in Console is available and close restores focus.
+- [x] #4 Supported conversation voice uses existing guarded voice facilities; microphone capture stops when interaction closes.
+- [x] #5 Closing, hiding or rebinding never stops accepted work; deleted/inaccessible targets never fall back.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: directly implement approved explicit conversation interaction using retained Console execution and existing guarded decisions/voice.
+1. Add an app-owned exact-binding coordinator and mounted projection modal; preserve per-binding drafts and opener focus.
+2. Add a narrow composer-preserving manual send option with visible refusal of unseen staged inputs, retaining all normal admission/permission and durable recovery checks.
+3. Project existing approval/question cards and resolve only exact current owner rounds. Extend answerable-time claims for the visible Buddy projection.
+4. Reuse guarded Console streaming dictation with explicit start/finish, review-before-send, owner/generation fencing, and microphone discard on close/suspend.
+5. Add targeted two-session mounted text/approval, stale/deleted owner, draft/focus and microphone-close coverage; record exact results and limitations.
+Detailed plan: Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented app-owned conversation Buddy interaction over retained Console execution: named transcript/activity, existing question/tool/skill cards, a private composer, Close/focus restoration and exact Open Console handoff. Replies preserve both Console drafts and refuse unseen staged attachments, evidence, one-shot prefill, slash commands and @ routing. The preserve_composer intent survives prepared/durable recovery; ordinary admission, permission and provider rules remain authoritative.
+
+Explicit saved-row interaction uses shared full-tree hydration with activate=False and repeated durable/profile/owner checks. Cold Home opening may initialize the established launch runtime; passive inbox reads do not. Bootstrap failure keeps Open Console recovery. Both newly hydrated and concurrently restored exact sessions retain a weak session/revision decision capability after modal close; wake-only siblings retain their existing no-view refusal. Per-kind visible claims spend finite decision time only on answerable cards; worktree decisions retain their existing Console review.
+
+Dictation reuses ConsoleStreamingDictationSession guards, explicit start/finish, editable text and separate Send. Closing or suspending releases the microphone; late results cannot alter a closed/replaced owner. Shared speech controls hold playback during microphone capture. Drafts transfer when the same durable conversation gains a canonical binding. Accepted runs remain app-owned through close/navigation; explicit Stop and shutdown still cancel.
+
+Validation: final race/cold/retained-decision/bootstrap-failure subset 6 passed in 14.37s (/private/tmp/buddy-loader-race-green.log); clock tests 30 passed in 1.84s; runtime lifetime/interrupt/ask_user/durable/clock gate 105 passed in 30.73s; controller submission selection 22 passed in 4.76s. Parent combined stable-source gate passed every conversation and clock case; its three unrelated failures remained with root. Earlier mounted conversation/clock gate:50 passed in 56.40s. All five owned host/new module/test files pass Ruff lint and full-file formatting; shared controller introduces no Ruff diagnostics versus HEAD (178 preexisting). git diff --check clean.
+
+Files: UI/Navigation/buddy_conversation.py; Widgets/Persona_Widgets/buddy_conversation_modal.py; narrow Chat/console_chat_controller.py and console_interrupt_rounds.py changes; Tests/UI/test_buddy_conversation_modal.py; Tests/Chat/test_console_decision_clock.py; Docs/User_Guide/console/buddy-conversation.md; Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md; testing-evidence lesson. Existing ADR139 amended for explicit cold bootstrap and retained decision availability.
+
+Evidence uses mounted Textual and real SQLite with injected provider/recorder boundaries. No full sweep, live provider, physical microphone, audible playback or realtime-voice claim. No commits made.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32082 - Reply-to-a-conversation-through-its-Buddy.md
+++ b/backlog/tasks/task-32082 - Reply-to-a-conversation-through-its-Buddy.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:31'
-updated_date: '2026-09-08 21:03'
+updated_date: '2026-09-09 01:13'
 labels:
   - buddy
   - console
@@ -28,20 +28,14 @@ Allow context and replies to a pinned conversation from another application dest
 - [x] #3 Per-conversation drafts survive closing; Open in Console is available and close restores focus.
 - [x] #4 Supported conversation voice uses existing guarded voice facilities; microphone capture stops when interaction closes.
 - [x] #5 Closing, hiding or rebinding never stops accepted work; deleted/inaccessible targets never fall back.
+- [x] #6 The modal initially shows current content, follows new replies when at end, preserves deliberate reading and offers a Latest or new-updates action with readily reachable pending decisions.
+- [x] #7 Fresh conversations show an empty state and speech-off presentation leaves useful reading space at compact sizes.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: no
-ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
-Reason: directly implement approved explicit conversation interaction using retained Console execution and existing guarded decisions/voice.
-1. Add an app-owned exact-binding coordinator and mounted projection modal; preserve per-binding drafts and opener focus.
-2. Add a narrow composer-preserving manual send option with visible refusal of unseen staged inputs, retaining all normal admission/permission and durable recovery checks.
-3. Project existing approval/question cards and resolve only exact current owner rounds. Extend answerable-time claims for the visible Buddy projection.
-4. Reuse guarded Console streaming dictation with explicit start/finish, review-before-send, owner/generation fencing, and microphone discard on close/suspend.
-5. Add targeted two-session mounted text/approval, stale/deleted owner, draft/focus and microphone-close coverage; record exact results and limitations.
-Detailed plan: Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md
+Preserve the completed implementation under ADR-139 and ADR-079; follow Docs/superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md for the reviewed UX corrections, focused regressions and mounted verification. ADR required: no new ADR. Reason: direct correction within existing ownership, persistence and runtime boundaries.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -58,4 +52,6 @@ Validation: final race/cold/retained-decision/bootstrap-failure subset 6 passed 
 Files: UI/Navigation/buddy_conversation.py; Widgets/Persona_Widgets/buddy_conversation_modal.py; narrow Chat/console_chat_controller.py and console_interrupt_rounds.py changes; Tests/UI/test_buddy_conversation_modal.py; Tests/Chat/test_console_decision_clock.py; Docs/User_Guide/console/buddy-conversation.md; Docs/superpowers/plans/2026-09-08-buddy-conversation-interaction.md; testing-evidence lesson. Existing ADR139 amended for explicit cold bootstrap and retained decision availability.
 
 Evidence uses mounted Textual and real SQLite with injected provider/recorder boundaries. No full sweep, live provider, physical microphone, audible playback or realtime-voice claim. No commits made.
+
+Native conversation UX follow-up complete: initial empty state, current-content opening, follow-at-end with retained reading position, Latest/new updates, direct exact-decision access and compact speech-off controls. Final production-CSS confirmation exposed nested approval-body clipping at60x20; Buddy-scoped auto-height/flexible Select and ancestor-aware regression now show Approve once and Deny at60x20/80x24.384affected cases before final fixes; final transcript/layout/CSS37passed. Independent source/render review clear; lesson, guides and evidence updated under ADR-139. No real microphone/audio or provider claim.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32083 - Track-workspace-conversations-in-the-Buddy-inbox.md
+++ b/backlog/tasks/task-32083 - Track-workspace-conversations-in-the-Buddy-inbox.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:32'
-updated_date: '2026-09-08 21:06'
+updated_date: '2026-09-09 01:13'
 labels:
   - buddy
   - console
@@ -28,17 +28,13 @@ Present active workspace conversations and directed replies through a nonintrusi
 - [x] #3 Workspace mode has no voice input, including inside a selected conversation.
 - [x] #4 Opening inbox does not mark all results read or resolve questions; acknowledgement is result-specific.
 - [x] #5 Updates are scoped to the bound workspace and never steal focus.
+- [x] #6 Refresh failures consistently gate mouse and keyboard activation and acknowledgement until a successful fresh snapshot recovers the inbox.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes; existing ADR applies. ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md. Reason: independent Buddy scope and existing app-owned Console activity authority.
-1. Project active local sessions and existing durable unseen receipts into exact workspace inbox entries.
-2. Add a native keyboard/compact-safe inbox with Needs you, Running and Results and explicit result-specific acknowledgement.
-3. Route row interaction to the shared conversation modal with voice disabled and preserve focus on refresh.
-4. Verify workspace filtering, stale targets, frozen acknowledgement, no mutation on open and mounted directed row interaction; document behavior.
-5. Fix cold-start receipt access through a narrow app-owned ConsoleRuntime.ensure_activity_receipt_service seam: reuse one AgentRunsDB/lazy service across inbox and later bridge creation, fence creation against disposal, close worker-owned connections, and report loading/degraded storage without false empty results. Verify persisted ordinary receipts from a fresh runtime on Home with no bridge/provider/selection and targeted resource-lifetime races.
+Preserve the completed implementation under ADR-139 and ADR-079; follow Docs/superpowers/plans/2026-09-08-chatbook-buddy-ux-review-remediation.md for the reviewed UX corrections, focused regressions and mounted verification. ADR required: no new ADR. Reason: direct correction within existing ownership, persistence and runtime boundaries.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -55,4 +51,6 @@ Verification: 16 targeted tests passed in 7.32s: new Tests/Chat/test_console_rec
 Root implementation: added read-only workspace projection over current local session/queue/decision snapshots and immutable existing unread result receipts, native Needs you/Running/Results inbox, exact frozen-ID acknowledgement and directed row opening with voice disabled. Refresh preserves selected row and focus; opening or speaking never acknowledges. Hidden selected-session ordinary and queued completions now publish unread receipts using existing authority. Fixed Close awaiting safe dismissal and bounded row-open storage errors. Six workspace coordinator/normal and compact modal checks with speech controls, 6 projection checks and 4 hidden/visible direct/queue receipt cases pass. Agent cold receipt initialization evidence is recorded above. Saved-row cold interaction is being completed under TASK-32082; final combined gate pending. ADR-139 and Docs/User_Guide/buddies.md document scope and limitations.
 
 Final integration complete: cold Home result opening now lazily boots the existing headless runtime only on explicit interaction, hydrates exact saved rows without selecting Console, and retains their later questions/confirmations. Concurrent loader admission is verified by the TASK-32082 regression. Root receipt, projection, exact acknowledgement, no-microphone, normal/compact speech controls and focus checks pass; combined runtime/UI gate includes the actual cold saved transcript -> Send -> Close -> late question/tool approval journey. Independent final review is clear after fixing the cold opener and retained target race. No new run owner, automatic acknowledgement or voice input was added. ADR-139 and user guide capture shipped limits.
+
+Native inbox refresh recovery complete: freshness now gates Enter, pointer Open and result acknowledgement consistently, retaining rows for context and restoring actions on a successful identical snapshot. Scoped tests and combined384affected group passed, preserving exact result identity and workspace no-microphone behavior. Independent review clear; guides and evidence updated. ADR-139 applies; no new ownership or runtime boundary.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32083 - Track-workspace-conversations-in-the-Buddy-inbox.md
+++ b/backlog/tasks/task-32083 - Track-workspace-conversations-in-the-Buddy-inbox.md
@@ -1,0 +1,58 @@
+---
+id: TASK-32083
+title: Track workspace conversations in the Buddy inbox
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:32'
+updated_date: '2026-09-08 21:06'
+labels:
+  - buddy
+  - console
+dependencies:
+  - TASK-32082
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Present active workspace conversations and directed replies through a nonintrusive Buddy inbox.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Inbox separates Needs you, Running and unseen Results from historical inactive chats.
+- [x] #2 Selecting a conversation permits directed text reply and review without leaving the current screen.
+- [x] #3 Workspace mode has no voice input, including inside a selected conversation.
+- [x] #4 Opening inbox does not mark all results read or resolve questions; acknowledgement is result-specific.
+- [x] #5 Updates are scoped to the bound workspace and never steal focus.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes; existing ADR applies. ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md. Reason: independent Buddy scope and existing app-owned Console activity authority.
+1. Project active local sessions and existing durable unseen receipts into exact workspace inbox entries.
+2. Add a native keyboard/compact-safe inbox with Needs you, Running and Results and explicit result-specific acknowledgement.
+3. Route row interaction to the shared conversation modal with voice disabled and preserve focus on refresh.
+4. Verify workspace filtering, stale targets, frozen acknowledgement, no mutation on open and mounted directed row interaction; document behavior.
+5. Fix cold-start receipt access through a narrow app-owned ConsoleRuntime.ensure_activity_receipt_service seam: reuse one AgentRunsDB/lazy service across inbox and later bridge creation, fence creation against disposal, close worker-owned connections, and report loading/degraded storage without false empty results. Verify persisted ordinary receipts from a fresh runtime on Home with no bridge/provider/selection and targeted resource-lifetime races.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Review follow-up (buddy_ui_review): cold workspace inbox currently treats an uninitialized receipt owner as no unread results. Approved bounded change will initialize existing local receipt authority without creating an agent bridge/provider or selecting Console. ADR-139 applies; no new storage schema or provider boundary. Implementation and targeted evidence to follow.
+
+Cold-start receipt fix (buddy_ui_review): ConsoleRuntime.ensure_activity_receipt_service() now initializes and retains one app-owned AgentRunsDB/lazy receipt service without constructing a Console store, controller, provider or agent bridge. Later bridge initialization reuses the same hydrated receipt identity. A serialized constructor and the existing disposal publication latch fence creation against shutdown; background initialization and hydration close their own thread-local SQLite connections, and disposal waits away from the UI loop for any in-flight construction.
+
+BuddyWorkspaceCoordinator.snapshot initializes storage off-loop and projects a frozen receipt snapshot only after hydration is ready. Cold/degraded/unavailable storage reports actionable loading/retry copy rather than an empty inbox; runtime disposal/profile replacement still rejects stale snapshots. Opening remains read-only and does not acknowledge receipts or change selection. ADR-139 applies; no schema or provider boundary change.
+
+Verification: 16 targeted tests passed in 7.32s: new Tests/Chat/test_console_receipt_bootstrap.py (real SQLite persisted ordinary result from mounted fresh Home with no Console/provider/bridge, later bridge reuse, concurrent construction, first-creation/dispose race, per-thread cleanup, absent/in-memory DB, loading/degraded states), existing Buddy workspace coordinator cases, receipt ownership/hydration cases from test_console_runtime_ownership, and three selected runtime disposal/resource guards. New tests were red before implementation (missing API, absent degraded error, Home inbox missing persisted result). Ruff and formatter pass for new test file; zero Ruff diagnostics in owned implementation methods, with 9 existing diagnostics elsewhere in the two production files. All three Python files parse and scoped git diff --check passes. Existing RequestsDependencyWarning remains. No commits; parent owns remaining task acceptance and final status.
+
+Root implementation: added read-only workspace projection over current local session/queue/decision snapshots and immutable existing unread result receipts, native Needs you/Running/Results inbox, exact frozen-ID acknowledgement and directed row opening with voice disabled. Refresh preserves selected row and focus; opening or speaking never acknowledges. Hidden selected-session ordinary and queued completions now publish unread receipts using existing authority. Fixed Close awaiting safe dismissal and bounded row-open storage errors. Six workspace coordinator/normal and compact modal checks with speech controls, 6 projection checks and 4 hidden/visible direct/queue receipt cases pass. Agent cold receipt initialization evidence is recorded above. Saved-row cold interaction is being completed under TASK-32082; final combined gate pending. ADR-139 and Docs/User_Guide/buddies.md document scope and limitations.
+
+Final integration complete: cold Home result opening now lazily boots the existing headless runtime only on explicit interaction, hydrates exact saved rows without selecting Console, and retains their later questions/confirmations. Concurrent loader admission is verified by the TASK-32082 regression. Root receipt, projection, exact acknowledgement, no-microphone, normal/compact speech controls and focus checks pass; combined runtime/UI gate includes the actual cold saved transcript -> Send -> Close -> late question/tool approval journey. Independent final review is clear after fixing the cold opener and retained target race. No new run owner, automatic acknowledgement or voice input was added. ADR-139 and user guide capture shipped limits.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
+++ b/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:33'
-updated_date: '2026-09-08 21:06'
+updated_date: '2026-09-09 02:49'
 labels:
   - buddy
   - console
@@ -28,22 +28,13 @@ Speak scoped responses serially and verify the complete Chatbook Buddy journey b
 - [x] #3 Existing TTS configuration and authority are reused; background listening is never enabled.
 - [x] #4 Targeted integration and compact/normal terminal journeys verify management, conversation and workspace behavior.
 - [x] #5 User documentation and a server port contract capture shipped behavior and limitations; no server implementation is claimed.
+- [x] #6 All Qodo findings have verified fixes or evidence-backed dispositions and targeted regressions on rebased dev; derived artifact and schema allowlist checks pass.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: yes
-ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
-Reason: reuses existing TTS privacy and playback authority with one app-owned, explicit-binding Buddy speech queue.
-
-1. Read existing trusted message speech, destination confirmation, playback lifecycle and Buddy scope contracts.
-2. Add one serial speech queue with named prefixes, question priority, terminal-response deduplication and pause/skip/mute controls that never alter execution or acknowledgement.
-3. Reuse existing configured TTS destination and snapshot admission for explicit bound owners; validate content, profile and owner after asynchronous boundaries and cancel only owned playback.
-4. Integrate app-owned lifecycle and optional UI controls with root; verify targeted ordering, privacy, stale-owner/content and failure behavior.
-5. Root completes compact/normal integrated journeys, user documentation and server-port contract.
-
-Detailed speech plan: Docs/superpowers/plans/2026-09-08-buddy-named-speech.md
+ADR required: no new ADR. ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md. Reason: review corrections within the approved Buddy ownership and runtime contracts. Follow Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md; root owns integration, PR checks and merge.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -62,4 +53,6 @@ Final Chatbook integration and review complete. Root gate: 813 passed across Bud
 Final review fixes: exact saved-binding promotion/restoration, immutable run-owner replay during validating, cold result receipt bootstrap and conversation loading, concurrent-loader retained decisions, and shielded Buddy speech shutdown before shared TTS teardown. Final focused concurrent/cold/retained/bootstrap gate6 and clocks30 pass; cancelled playback teardown13 pass. Additional compact60x20 conversation layout verifies live/unavailable reply and recovery controls (2 pass). All changed Python files parse, zero introduced Ruff diagnostics compared with HEAD, new files pass lint/formatter, and diff whitespace is clean. No full test suite, live paid provider, device microphone or audible playback was claimed.
 
 Docs/User_Guide/buddies.md and console/buddy-conversation.md explain management, exact follow, workspace defaults, dictation, consent, pause/skip/mute and restart limits. Docs/superpowers/specs/2026-09-08-buddy-server-port-contract.md records the later authenticated server contract; no server implementation is part of this change. ADR-139 is the ownership/lifecycle contract and its headless interaction amendment. Testing lessons record source stability, genuine cold startup and modal composition timing. All approved Chatbook tasks are complete; changes remain on the isolated codex/buddy-console-management branch for review.
+
+September 9 rebase/Qodo follow-up complete under ADR-139 and canonical settings contract ADR-095. All 11 Qodo comments have verified fixes or source-backed dispositions. Fixed central archive/form validation, bounded paged Buddy reads, transaction and migration guards, question-first Skip and reserved import provenance; collection-sized hydration reads now precede UI-thread publication with late authority checks. 362 affected tests and20 post-format/census tests pass, actual UI-ready imports973/973;19 changed files add no Ruff/formatter findings. Independent review found no Important/Critical issues. Root repaired the2 Buddy SQL allowlist entries and reviewed diagnostic statements before regenerating the inventory; all6 derived checks pass. User guide documents pagination. Full evidence: Docs/Development/Reviews/2026-09-09-buddy-pr-review.md. Publication and remote CI/merge are the remaining integration steps; no full local suite or real provider/audio claimed.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
+++ b/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 19:33'
-updated_date: '2026-09-09 02:49'
+updated_date: '2026-09-09 03:20'
 labels:
   - buddy
   - console
@@ -29,12 +29,13 @@ Speak scoped responses serially and verify the complete Chatbook Buddy journey b
 - [x] #4 Targeted integration and compact/normal terminal journeys verify management, conversation and workspace behavior.
 - [x] #5 User documentation and a server port contract capture shipped behavior and limitations; no server implementation is claimed.
 - [x] #6 All Qodo findings have verified fixes or evidence-backed dispositions and targeted regressions on rebased dev; derived artifact and schema allowlist checks pass.
+- [x] #7 The published Linux boot-budget failure is reproduced or explained with evidence and corrected without raising the startup budget; focused startup checks and independent review pass.
 <!-- AC:END -->
 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-ADR required: no new ADR. ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md. Reason: review corrections within the approved Buddy ownership and runtime contracts. Follow Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md; root owns integration, PR checks and merge.
+ADR required: no new ADR. ADR paths: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md and backlog/decisions/097-boot-budget-ratchets.md. Reason: maintain the approved Buddy boundary and existing startup budget. Complete Task2 in Docs/superpowers/plans/2026-09-09-buddy-pr-review-and-merge.md before final publication/merge.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -55,4 +56,6 @@ Final review fixes: exact saved-binding promotion/restoration, immutable run-own
 Docs/User_Guide/buddies.md and console/buddy-conversation.md explain management, exact follow, workspace defaults, dictation, consent, pause/skip/mute and restart limits. Docs/superpowers/specs/2026-09-08-buddy-server-port-contract.md records the later authenticated server contract; no server implementation is part of this change. ADR-139 is the ownership/lifecycle contract and its headless interaction amendment. Testing lessons record source stability, genuine cold startup and modal composition timing. All approved Chatbook tasks are complete; changes remain on the isolated codex/buddy-console-management branch for review.
 
 September 9 rebase/Qodo follow-up complete under ADR-139 and canonical settings contract ADR-095. All 11 Qodo comments have verified fixes or source-backed dispositions. Fixed central archive/form validation, bounded paged Buddy reads, transaction and migration guards, question-first Skip and reserved import provenance; collection-sized hydration reads now precede UI-thread publication with late authority checks. 362 affected tests and20 post-format/census tests pass, actual UI-ready imports973/973;19 changed files add no Ruff/formatter findings. Independent review found no Important/Critical issues. Root repaired the2 Buddy SQL allowlist entries and reviewed diagnostic statements before regenerating the inventory; all6 derived checks pass. User guide documents pagination. Full evidence: Docs/Development/Reviews/2026-09-09-buddy-pr-review.md. Publication and remote CI/merge are the remaining integration steps; no full local suite or real provider/audio claimed.
+
+Published Linux startup race reproduced with actual scheduler import traces. Deferred the existing coroutine scheduler worker until UI-ready, preserving its loop/group/exclusivity and ordering before startup reconciliation, with early-quit/shutdown/failure guards. All4new lifecycle regressions and18boot guards pass (973/973 UIready; no budget/snapshot changes). Broader154pass/4fail; all4failures reproduce with HEAD app and unchanged tests/other production modules, documented precisely. New-test lint/format and app differential static checks pass; diagnostic inventory verifies unchanged. Independent review approved with no Important/Critical findings. Existing ADR097 applies; Docs/Development/Reviews/2026-09-09-buddy-pr-review.md records evidence and residual unrelated slow-mount character-search sensitivity.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
+++ b/backlog/tasks/task-32084 - Queue-named-Buddy-speech-and-validate-Chatbook-interaction.md
@@ -1,0 +1,65 @@
+---
+id: TASK-32084
+title: Queue named Buddy speech and validate Chatbook interaction
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-08 19:33'
+updated_date: '2026-09-08 21:06'
+labels:
+  - buddy
+  - console
+dependencies:
+  - TASK-32083
+references:
+  - Docs/superpowers/specs/2026-09-08-console-buddy-management-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Speak scoped responses serially and verify the complete Chatbook Buddy journey before a later server port.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Optional spoken responses use one shared queue and start with the conversation name; questions have priority and repetitive progress is consolidated.
+- [x] #2 Pause, skip and mute change presentation without cancelling work or answering questions.
+- [x] #3 Existing TTS configuration and authority are reused; background listening is never enabled.
+- [x] #4 Targeted integration and compact/normal terminal journeys verify management, conversation and workspace behavior.
+- [x] #5 User documentation and a server port contract capture shipped behavior and limitations; no server implementation is claimed.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md
+Reason: reuses existing TTS privacy and playback authority with one app-owned, explicit-binding Buddy speech queue.
+
+1. Read existing trusted message speech, destination confirmation, playback lifecycle and Buddy scope contracts.
+2. Add one serial speech queue with named prefixes, question priority, terminal-response deduplication and pause/skip/mute controls that never alter execution or acknowledgement.
+3. Reuse existing configured TTS destination and snapshot admission for explicit bound owners; validate content, profile and owner after asynchronous boundaries and cancel only owned playback.
+4. Integrate app-owned lifecycle and optional UI controls with root; verify targeted ordering, privacy, stale-owner/content and failure behavior.
+5. Root completes compact/normal integrated journeys, user documentation and server-port contract.
+
+Detailed speech plan: Docs/superpowers/plans/2026-09-08-buddy-named-speech.md
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented the speech portion under ADR-139. One app-owned serial BuddySpeechQueue speaks named terminal responses and current questions for the committed conversation/workspace binding. Questions precede responses; duplicate receipt/message/round keys coalesce and streaming progress is not spoken. Pause restarts the current utterance on Resume, Skip drops speech only, and Mute clears speech without changing run state, decisions or receipt acknowledgement. Explicit microphone capture can hold output and await owned playback cleanup before recording; the queue never starts input.
+
+The coordinator polls only while enabled and survives navigation. It uses existing configured TTS identity/profile resolution, trusted store-issued snapshots with a narrow explicit local owner opt-in, exact destination consent, provider-admission guards and exact playback lifecycle cleanup. Default snapshot callers retain the visible-session requirement. Binding/profile, message edits, Persona revision/retirement and receipt validity are rechecked after asynchronous work. Consent opens only from the reusable speech controls, is scoped to the current binding/profile, and a stale owned prompt closes after rebinding. Root integrated configure, modal controls and app shutdown before shared TTS resources.
+
+Verification: 183 tests passed across existing TTS destination/playback/snapshot admission, trusted store snapshots, queue, native UI controls, workspace ordering and legacy startup tests. A final shutdown-specific run passed 7 tests, including actual app cleanup waiting for Buddy output to stop before closing shared TTS owners. Seven new source/test modules pass Ruff and formatter checks; changed lines in the existing TTS/store/consent modules have no Ruff findings. Scoped diff whitespace checks pass. Tests use the main venv, worktree PYTHONPATH and isolated test profiles; no live paid TTS, microphone device recording or full-suite run. AC4-5 integrated journeys/documentation remain root-owned.
+
+Core files: Persona_Buddy/speech.py, UI/Navigation/buddy_speech.py, Widgets/Persona_Widgets/buddy_speech_controls.py, existing Chat/console_chat_store.py, Event_Handlers/TTS_Events/tts_events.py and Console consent modal. Limitations: unloaded saved result bodies remain in the inbox for explicit review; speech does not restore or activate conversations, and restarting the app resets volatile speech deduplication and Buddy-specific consent.
+
+Final Chatbook integration and review complete. Root gate: 813 passed across Buddy/Persona_Visual, WorkspaceDB/default/provisioning and atomic Persona assignment (162.62s); 285 passed in the 288-case runtime/UI/TTS gate (281.97s). Its new management journey failure was premature Select mutation before nested composition: corrected pilot settling, then all 12 management/entry/workspace journey checks passed. Two other gate failures reproduce identically on pristine c0a42150d1785c9ef7394def669a0aeb62578ff4: test_impersonate_payload_obeys_the_provider_contract returns empty text; test_app_lifecycle_shutdown_drains_all_owners_in_authority_order uses a stale test double lacking _shutdown_collections_capture_runtime. Verified 5,652 baseline source files and all 808 imported production modules; tested methods and test functions are unchanged. Existing legacy builtin architecture boundary failure also reproduced on pristine HEAD; other 7 packaging/architecture checks pass. These unrelated failures were not modified.
+
+Final review fixes: exact saved-binding promotion/restoration, immutable run-owner replay during validating, cold result receipt bootstrap and conversation loading, concurrent-loader retained decisions, and shielded Buddy speech shutdown before shared TTS teardown. Final focused concurrent/cold/retained/bootstrap gate6 and clocks30 pass; cancelled playback teardown13 pass. Additional compact60x20 conversation layout verifies live/unavailable reply and recovery controls (2 pass). All changed Python files parse, zero introduced Ruff diagnostics compared with HEAD, new files pass lint/formatter, and diff whitespace is clean. No full test suite, live paid provider, device microphone or audible playback was claimed.
+
+Docs/User_Guide/buddies.md and console/buddy-conversation.md explain management, exact follow, workspace defaults, dictation, consent, pause/skip/mute and restart limits. Docs/superpowers/specs/2026-09-08-buddy-server-port-contract.md records the later authenticated server contract; no server implementation is part of this change. ADR-139 is the ownership/lifecycle contract and its headless interaction amendment. Testing lessons record source stability, genuine cold startup and modal composition timing. All approved Chatbook tasks are complete; changes remain on the isolated codex/buddy-console-management branch for review.
+<!-- SECTION:NOTES:END -->

--- a/scripts/index_plan_pin_census.tsv
+++ b/scripts/index_plan_pin_census.tsv
@@ -29,6 +29,7 @@ idx_briefing_audio_script	pre-convention	plan never captured without stats
 idx_briefing_items_item	pre-convention	plan never captured without stats
 idx_briefing_scripts_briefing	pre-convention	plan never captured without stats
 idx_briefings_watchlist_status	pre-convention	plan never captured without stats
+idx_buddy_visual_bindings_active	plan-pinned	Tests/Persona_Buddy/test_buddy_library.py
 idx_canvas_documents_conversation	plan-pinned	Tests/Canvas/test_repository.py
 idx_canvas_revisions_canvas_sequence	plan-pinned	Tests/Canvas/test_repository.py
 idx_canvas_revisions_origin_message	plan-pinned	Tests/Canvas/test_repository.py

--- a/tldw_chatbook/Canvas/native_authority.py
+++ b/tldw_chatbook/Canvas/native_authority.py
@@ -174,6 +174,7 @@ class NativeConsoleCanvasAuthority:
         *,
         scope_resolver: Callable[[str], CanvasScope],
         canvas_controller: Any,
+        run_scope_resolver: Callable[[str], CanvasScope] | None = None,
         bridge_sink: Callable[[CanvasBridgeTarget, str], None] | None = None,
         bridge_prepare: Callable[[CanvasBridgeTarget], Callable[[str], None]] | None = None,
         auto_open: Callable[[str, CanvasRevisionInfo], None] | None = None,
@@ -181,6 +182,7 @@ class NativeConsoleCanvasAuthority:
         enabled_reader: Callable[[], bool] | None = None,
     ) -> None:
         self._scope_resolver = scope_resolver
+        self._run_scope_resolver = run_scope_resolver
         self._canvas_controller = canvas_controller
         self._compilation = canvas_controller.compilation
         self._bridge_sink = bridge_sink
@@ -225,7 +227,8 @@ class NativeConsoleCanvasAuthority:
         with self._lock:
             if self._disposed or self._enabled_reader() is not True:
                 raise RuntimeError("canvas_scope_unavailable")
-            current = self._scope_resolver(scope.session_id)
+            resolver = self._run_scope_resolver or self._scope_resolver
+            current = resolver(scope.session_id)
             if (
                 current.session_id != scope.session_id
                 or current.conversation_id != scope.conversation_id

--- a/tldw_chatbook/Chat/chat_conversation_scope_service.py
+++ b/tldw_chatbook/Chat/chat_conversation_scope_service.py
@@ -308,11 +308,28 @@ class ChatConversationScopeService:
                 service_kwargs["root_offset"] = service_kwargs.pop("offset")
             if "max_depth" in service_kwargs and "depth_cap" not in service_kwargs:
                 service_kwargs["depth_cap"] = service_kwargs.pop("max_depth")
-        return await self._maybe_await(
-            self._service_for_mode(normalized_mode).get_conversation_tree(
-                conversation_id, **service_kwargs
-            )
-        )
+        service = self._service_for_mode(normalized_mode)
+        reader = service.get_conversation_tree
+        if (
+            normalized_mode == "local"
+            and not inspect.iscoroutinefunction(reader)
+            and not self._is_memory_backed(service)
+        ):
+
+            def read_local_tree():
+                try:
+                    return reader(conversation_id, **service_kwargs)
+                finally:
+                    close = getattr(
+                        getattr(service, "db", None), "close_connection", None
+                    )
+                    if callable(close):
+                        close()
+
+            result = await asyncio.to_thread(read_local_tree)
+            self._enforce_policy(self._action_id("detail", normalized_mode))
+            return await self._maybe_await(result)
+        return await self._maybe_await(reader(conversation_id, **service_kwargs))
 
     async def get_messages_with_context(
         self,

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -5627,11 +5627,11 @@ class ConsoleAgentBridge:
                     buddy_tool_sequences.setdefault(buddy_run_id, deque()).append(
                         step.index
                     )
-                    buddy_sink.tool_step(buddy_run_id, step.index, step.kind)
+                    buddy_sink.tool_step(buddy_run_id, step.index, step.kind, session_id=session_id)
                 elif step.kind == STEP_TOOL_RESULT:
                     sequences = buddy_tool_sequences.get(buddy_run_id)
                     sequence = sequences.popleft() if sequences else step.index
-                    buddy_sink.tool_step(buddy_run_id, sequence, step.kind)
+                    buddy_sink.tool_step(buddy_run_id, sequence, step.kind, session_id=session_id)
                     if sequences is not None and not sequences:
                         buddy_tool_sequences.pop(buddy_run_id, None)
                 elif step.kind == STEP_ERROR:

--- a/tldw_chatbook/Chat/console_assistant_defaults.py
+++ b/tldw_chatbook/Chat/console_assistant_defaults.py
@@ -3,26 +3,16 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from dataclasses import dataclass, replace
+from dataclasses import replace
 from typing import Any
 
 from ..Workspaces.models import DEFAULT_WORKSPACE_ID
 from .console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
 from .console_session_settings import (
+    ConsoleAssistantStartup,
     ConsoleSessionSettings,
     blank_console_session_settings,
 )
-
-
-@dataclass(frozen=True)
-class ConsoleAssistantStartup:
-    """Resolved settings and identity for one new conversation."""
-
-    settings: ConsoleSessionSettings
-    assistant_kind: str = "generic"
-    assistant_id: str = "console"
-    persona_memory_mode: str | None = None
-    notice: str = ""
 
 
 def build_persona_agent_system_prompt(record: Mapping[str, Any]) -> str:

--- a/tldw_chatbook/Chat/console_assistant_defaults.py
+++ b/tldw_chatbook/Chat/console_assistant_defaults.py
@@ -1,0 +1,111 @@
+"""Creation-only workspace Persona resolution (ADR-079 and ADR-139)."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, replace
+from typing import Any
+
+from ..Workspaces.models import DEFAULT_WORKSPACE_ID
+from .console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
+from .console_session_settings import (
+    ConsoleSessionSettings,
+    blank_console_session_settings,
+)
+
+
+@dataclass(frozen=True)
+class ConsoleAssistantStartup:
+    """Resolved settings and identity for one new conversation."""
+
+    settings: ConsoleSessionSettings
+    assistant_kind: str = "generic"
+    assistant_id: str = "console"
+    persona_memory_mode: str | None = None
+    notice: str = ""
+
+
+def build_persona_agent_system_prompt(record: Mapping[str, Any]) -> str:
+    """Compose a Persona into the same prompt used by the Console preview."""
+    from ..Character_Chat.Character_Chat_Lib import compose_character_card_text
+
+    return (
+        compose_character_card_text(
+            name=str(record.get("name") or "Workspace Agent"),
+            system_prompt=str(record.get("system_prompt") or ""),
+            personality=str(record.get("personality") or ""),
+            description=str(record.get("description") or ""),
+            user_name="User",
+        )
+        or "Stay in character."
+    )
+
+
+def resolve_new_console_assistant(
+    app: Any, workspace_id: str, settings: ConsoleSessionSettings | None
+) -> ConsoleAssistantStartup:
+    """Resolve the explicit target workspace once; absence never blocks a chat.
+
+    Explicit assistant identities bypass this helper at the store's creation
+    boundary. Supplied custom prompts retain their existing precedence.
+    """
+    config = getattr(app, "app_config", {})
+    settings = settings or blank_console_session_settings(
+        config if isinstance(config, Mapping) else {}
+    )
+    plain = ConsoleAssistantStartup(settings)
+    if (
+        workspace_id in (CONSOLE_GLOBAL_WORKSPACE_ID, DEFAULT_WORKSPACE_ID, "")
+        or settings.system_prompt is not None
+        or settings.character_label
+        or settings.persona_memory_mode is not None
+    ):
+        return plain
+    try:
+        registry = getattr(app, "workspace_registry_service", None)
+        workspace = registry.get_workspace(workspace_id) if registry else None
+        if (
+            workspace is None
+            or workspace.archived
+            or workspace.assistant_defaults is None
+        ):
+            return plain
+        personas = getattr(app, "local_character_persona_service", None)
+        record = None
+
+        def lookup(persona_id: str) -> Mapping | None:
+            nonlocal record
+            try:
+                record = personas.get_persona_profile(persona_id) if personas else None
+            except (KeyError, ValueError):
+                record = None
+            return record
+
+        from ..Workspaces.assistant_defaults import resolve_effective_assistant_default
+
+        effective = resolve_effective_assistant_default(
+            workspace.assistant_defaults, lookup
+        )
+        if effective.status != "available" or not isinstance(record, Mapping):
+            return replace(
+                plain,
+                notice="Workspace default Persona unavailable "
+                f"({effective.degraded_reason or 'persona_unavailable'}). Started with None.",
+            )
+        mode = effective.persona_memory_mode or "read_only"
+        return ConsoleAssistantStartup(
+            settings=replace(
+                settings,
+                system_prompt=build_persona_agent_system_prompt(record),
+                character_label=effective.label or "Workspace Agent",
+                persona_memory_mode=mode,
+            ),
+            assistant_kind="persona",
+            assistant_id=effective.assistant_id,
+            persona_memory_mode=mode,
+        )
+    except Exception:  # noqa: BLE001 - a unavailable default must not block creation
+        return replace(
+            plain,
+            notice="Workspace default Persona unavailable (persona_unavailable). Started with None.",
+        )

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -106,6 +106,7 @@ from tldw_chatbook.Chat.console_chat_store import (
     CapturePolicyStaleError,
     ConsoleChatSession,
     ConsoleChatStore,
+    UNSPECIFIED_ASSISTANT,
     ConsoleDispatchSettlementError,
     ConsoleDurableAcceptanceRetired,
     ConsoleDurableAcceptanceFingerprint,
@@ -2523,6 +2524,7 @@ class _PreparedSendContinuation:
     one_shot_prefill_revision: int | None
     staged_evidence_frozen: bool
     staged_evidence: _PreparedEvidenceLease | None
+    preserve_composer: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -7090,6 +7092,7 @@ class ConsoleChatController:
         queue_entry_id: str | None = None,
         queue_authorization: QueueGenerationAuthorization | None = None,
         wake_authorization: AgentWakeAuthorization | None = None,
+        preserve_composer: bool = False,
         _resume_preparation_id: str | None = None,
         _resume_resolution: Any | None = None,
     ) -> ConsoleSubmitResult:
@@ -7104,6 +7107,7 @@ class ConsoleChatController:
                 queue_entry_id=queue_entry_id,
                 queue_authorization=queue_authorization,
                 wake_authorization=wake_authorization,
+                preserve_composer=preserve_composer,
                 _resume_preparation_id=_resume_preparation_id,
                 _resume_resolution=_resume_resolution,
             )
@@ -7125,6 +7129,7 @@ class ConsoleChatController:
         queue_entry_id: str | None = None,
         queue_authorization: QueueGenerationAuthorization | None = None,
         wake_authorization: AgentWakeAuthorization | None = None,
+        preserve_composer: bool = False,
         _resume_preparation_id: str | None = None,
         _resume_resolution: Any | None = None,
     ) -> ConsoleSubmitResult:
@@ -7157,6 +7162,7 @@ class ConsoleChatController:
                 queue_entry_id=queue_entry_id,
                 queue_authorization=queue_authorization,
                 wake_authorization=wake_authorization,
+                preserve_composer=preserve_composer,
                 _resume_preparation_id=_resume_preparation_id,
                 _resume_resolution=_resume_resolution,
             )
@@ -7168,6 +7174,7 @@ class ConsoleChatController:
                 queue_entry_id=queue_entry_id,
                 queue_authorization=queue_authorization,
                 wake_authorization=wake_authorization,
+                preserve_composer=preserve_composer,
                 _resume_preparation_id=_resume_preparation_id,
                 _resume_resolution=_resume_resolution,
             )
@@ -7207,6 +7214,7 @@ class ConsoleChatController:
         queue_entry_id: str | None = None,
         queue_authorization: QueueGenerationAuthorization | None = None,
         wake_authorization: AgentWakeAuthorization | None = None,
+        preserve_composer: bool = False,
         _resume_preparation_id: str | None = None,
         _resume_resolution: Any | None = None,
     ) -> ConsoleSubmitResult:
@@ -7271,6 +7279,15 @@ class ConsoleChatController:
             if _resume_preparation_id is not None
             else None
         )
+        if prepared_continuation is not None:
+            preserve_composer = prepared_continuation.preserve_composer
+        if preserve_composer and not session_id:
+            return ConsoleSubmitResult(False, False, "Choose an explicit conversation.")
+        if preserve_composer and str(draft).lstrip().startswith((COMMAND_PREFIX, MENTION_SIGIL)):
+            return ConsoleSubmitResult(
+                False, False, "Use Console for slash commands and @ references.",
+                session_id=session_id,
+            )
         if _resume_preparation_id is not None and resumed_preparation is None:
             return ConsoleSubmitResult(
                 False, False, "Prepared turn is no longer available."
@@ -7378,6 +7395,17 @@ class ConsoleChatController:
                 self._bind_submit_preparation(
                     active_task, resumed_preparation.preparation_id
                 )
+        if preserve_composer and (
+            self.store.pending_attachments(session.id)
+            or self.store.session_one_shot_prefill(session.id)
+            or self._has_explicit_staged_evidence(session.id) is not False
+        ):
+            return ConsoleSubmitResult(
+                False, False,
+                "This conversation has staged Console attachments, evidence or prefill. "
+                "Review them in Console before sending from Buddy.",
+                session_id=session.id,
+            )
         # PR3a-2 Task 5: a wake never touches the user's staged state --
         # pending attachments belong to the USER's next send and must be
         # neither embedded nor cleared by a machine turn.
@@ -7385,7 +7413,7 @@ class ConsoleChatController:
             list(prepared_continuation.attachments)
             if prepared_continuation is not None
             else self.store.pending_attachments(session.id)
-            if origin is not ConsoleSubmissionOrigin.AGENT_WAKE
+            if origin is not ConsoleSubmissionOrigin.AGENT_WAKE and not preserve_composer
             else []
         )
         attachment_mode_pendings = [
@@ -7851,16 +7879,18 @@ class ConsoleChatController:
                     session.id
                 ).revision
             one_shot_prefill, captured_prefill_revision = (
-                self.store.session_one_shot_prefill_snapshot(session.id)
+                (None, None) if preserve_composer
+                else self.store.session_one_shot_prefill_snapshot(session.id)
             )
-            frozen_prefill, frozen_prefill_from_one_shot = self._resolve_submit_prefill(
-                session.id
+            frozen_prefill, frozen_prefill_from_one_shot = (
+                (self._pinned_prefill_for_session(session.id), False)
+                if preserve_composer else self._resolve_submit_prefill(session.id)
             )
             (
                 staged_evidence_frozen,
                 staged_evidence,
                 staged_evidence_release,
-            ) = self._snapshot_staged_evidence()
+            ) = (True, None, None) if preserve_composer else self._snapshot_staged_evidence()
             preparation = ConsoleTurnPreparation(
                 preparation_id=str(uuid4()),
                 attempt_id=library_authority.attempt_id,
@@ -7925,6 +7955,7 @@ class ConsoleChatController:
             self._prepared_send_continuations[preparation.preparation_id] = (
                 _PreparedSendContinuation(
                     preparation_id=preparation.preparation_id,
+                    preserve_composer=preserve_composer,
                     attachments=tuple(pendings),
                     prefill=frozen_prefill,
                     prefill_from_one_shot=frozen_prefill_from_one_shot,
@@ -8382,6 +8413,7 @@ class ConsoleChatController:
                 self.store.consume_pending_attachment(session.id, pending.attachment_id)
             self._notify_submission_accepted(
                 session_id=session.id,
+                preserve_composer=preserve_composer,
                 origin=origin,
                 entry_id=queue_entry_id,
                 context_epoch=committed_context_epoch,
@@ -9538,6 +9570,7 @@ class ConsoleChatController:
             )
             if (
                 live_session is not None
+                and not (continuation.prepared and continuation.prepared.preserve_composer)
                 and live_session.draft == continuation.clean_draft
             ):
                 live_session.draft = ""
@@ -9578,7 +9611,11 @@ class ConsoleChatController:
                 raise RuntimeError("Workspace projection remains pending.")
 
         def accepted_hook() -> None:
-            if continuation.origin is ConsoleSubmissionOrigin.MANUAL:
+            if (
+                continuation.origin is ConsoleSubmissionOrigin.MANUAL
+                and not (continuation.prepared and continuation.prepared.preserve_composer)
+                and self.store.active_session_id == session_id
+            ):
                 callback = self.on_submission_accepted
                 if callback is not None:
                     callback()
@@ -10594,13 +10631,16 @@ class ConsoleChatController:
         self,
         *,
         title: str | None = None,
+        workspace_id: str | None = None,
         settings: ConsoleSessionSettings | None = None,
         canonical_settings_baseline: ConsoleSessionSettings | None = None,
         new_chat_default_generation: int = 0,
         ephemeral: bool = False,
-        assistant_kind: str | None = None,
+        assistant_kind: str | None | object = UNSPECIFIED_ASSISTANT,
         assistant_id: str | None = None,
         assistant_label: str | None = None,
+        persona_memory_mode: str | None = None,
+        assistant_default_notice: str = "",
     ) -> ConsoleChatSession:
         """Create and activate a new native Console session.
 
@@ -10611,10 +10651,8 @@ class ConsoleChatController:
                 captured when the blank chat is created.
             ephemeral: Create the session temporary -- never written to local
                 storage until explicitly saved.
-            assistant_kind: Optional durable assistant identity forwarded to
-                ``store.create_session`` (Task 9: the workspace-default
-                persona path passes ``"persona"``). ``None`` keeps the
-                store's default identity.
+            assistant_kind: Omission inherits the target workspace default;
+                None explicitly starts plain. Other values retain the supplied identity.
             assistant_id: Optional assistant id forwarded alongside
                 ``assistant_kind``.
             assistant_label: Optional human label; stamped into the supplied
@@ -10632,17 +10670,16 @@ class ConsoleChatController:
         next_number = len(self.store.sessions()) + 1
         if assistant_label and settings is not None:
             settings = replace(settings, character_label=assistant_label)
-        assistant_kwargs = (
-            {"assistant_kind": assistant_kind, "assistant_id": assistant_id}
-            if assistant_kind is not None
-            else {}
-        )
         session = self.store.create_session(
             title=title or f"Chat {next_number}",
+            workspace_id=workspace_id,
             settings=settings,
             canonical_settings_baseline=canonical_settings_baseline,
             ephemeral=ephemeral,
-            **assistant_kwargs,
+            assistant_kind=assistant_kind,
+            assistant_id=assistant_id,
+            persona_memory_mode=persona_memory_mode,
+            assistant_default_notice=assistant_default_notice,
         )
         session.new_chat_default_generation = new_chat_default_generation
         # `create_session` above already activated the new session, so the
@@ -11572,34 +11609,11 @@ class ConsoleChatController:
         instance's teardown is supposed to reach every live round with,
         unconditionally.
 
-        Correction (review, TASK-1052): an earlier revision of this
-        docstring justified ORing in ``_shutdown_requested`` here by
-        calling it "real process teardown" and treating that as
-        inherently global/safe. That premise was FALSE: ``shutdown()`` is
-        also called from ordinary Console-screen unmount
-        (``ChatScreen.on_unmount``), which fires on every navigation AWAY
-        from the Console tab, not only on app exit -- so
-        ``_shutdown_requested`` can be set on a controller instance the
-        user is still actively using the app around. The actual safety
-        argument does not rest on "global by definition"; it rests on
-        this controller's OWN lifecycle: ``ChatScreen`` only ever
-        constructs a fresh ``ConsoleChatController`` lazily
-        (``_ensure_console_chat_controller``) after ``on_unmount`` has
-        both run this instance's ``shutdown()`` and dropped the screen's
-        reference to it, so a torn-down instance -- flag permanently set
-        or not -- is never reused for a later Console visit, and no round
-        still parked on it could ever be resolved through a UI that no
-        longer exists anyway. ``_shutdown_requested`` is set exactly once,
-        only by ``shutdown()``, and never reset for THIS instance's
-        lifetime (see ``shutdown()``'s own docstring and its ``self.
-        _shutdown_requested.set()`` call), so ORing it in here for a real
-        ``session_id`` can never wrongly deny a live round while this
-        controller instance is still the one actually in use -- it can
-        only ever fire once this instance itself is being (or has been)
-        torn down. This does NOT widen scoping for everyday per-session
-        Stop/Close: ``_signal_stop`` still only touches the ONE session's
-        own cancel event; an unrelated session's Stop still leaves both
-        this branch's checks unset.
+        The captured visit Event fences an earlier final-unmount boundary even
+        after ``begin_visit`` installs a fresh Event. App disposal is separately
+        permanent. TASK-31520 ordinary navigation suspends the retained Console
+        and sets neither signal. Per-session Stop/Close only sets that owner's
+        cancel Event, leaving unrelated sessions untouched.
         """
         if session_id is not None:
             # task-15860: `visit_event`, NOT a fresh read of
@@ -11790,7 +11804,7 @@ class ConsoleChatController:
             # did, so an attach landing meanwhile mounts the card instead.
             if not self._approval_view_is_detached():
                 return False
-            self._announce_detached_approval(owning_session_id)
+            self._interrupt_host.announce_hidden_decisions()
             return True
 
         def _on_teardown() -> bool:
@@ -12150,7 +12164,19 @@ class ConsoleChatController:
         """
         from tldw_chatbook.Chat.console_interrupt_rounds import SESSION_REMOUNT_KINDS
 
+        self._interrupt_host.refresh_decision_clocks()
         self._interrupt_host.remount_for_session(session_id, kinds=SESSION_REMOUNT_KINDS)
+
+    def on_console_view_visibility_changed(self, visible: bool) -> None:
+        """Project screen visibility without changing execution or cancellation."""
+        if self._disposed:
+            return
+        self._interrupt_host.set_view_visible(visible)
+        if visible:
+            self.remount_pending_approval_for_active_session()
+            session_id = self.store.active_session_id
+            if session_id:
+                self._remount_session_kinds(session_id)
 
     def remount_pending_approval_for_active_session(self) -> bool:
         """Mount the ACTIVE session's still-armed approval round, if any.
@@ -12195,17 +12221,14 @@ class ConsoleChatController:
         return True
 
     def _approval_view_is_detached(self) -> bool:
-        """True when NO Console view can surface an approval round.
+        """True when Console is hidden or its approval view hooks are absent.
 
-        task-15860 Task 5. Deliberately a property of the SEAMS, not of
-        ``ConsoleRuntime.view``: these two slots are what an announcement
-        would travel through, and ``detach_view`` clears them together
-        (``CONSOLE_VIEW_HOOK_SLOTS``). Asking the runtime instead would
-        make this method wrong in exactly the case it exists for -- a
-        controller whose seams are unwired for any other reason would
-        still surface nothing while claiming a view.
+        TASK-31520 retains hooks during navigation. Attachment alone therefore
+        cannot tell whether the user can see a card; modals also suspend it.
         """
-        return self.set_pending_approval is None and self.park_pending_approval is None
+        return self._interrupt_host.view_visible is False or (
+            self.set_pending_approval is None and self.park_pending_approval is None
+        )
 
     def on_pending_rounds_changed(self, total: int, kind: str, raised: bool) -> None:
         """task-31385: attention when a round blocks on the user off-screen.
@@ -12214,14 +12237,13 @@ class ConsoleChatController:
         or parked) and after every teardown. Two effects, both on the UI
         thread: the Console entry in the app navigation carries a
         pending-interrupt badge while ``total`` is non-zero, and a round
-        that ARMS while no Console view is attached -- the user is on
-        another screen, or Console has not been opened this launch --
+        that ARMS while Console is hidden or detached -- another screen or
+        modal is visible, or Console has not been opened this launch --
         rings the terminal bell once. The bell is governed by
         ``[console] interrupt_bell`` (default on) and never fires in a
         headless app, so tests and embedded runs emit no control bytes.
-        Visibility is read from the view seams (``_approval_view_is_
-        detached``): ``detach_view`` clears every slot together, so the
-        approval pair stands for all five kinds.
+        ``_approval_view_is_detached`` combines suspend/resume visibility
+        with the absent-hook fallback for a truly detached view.
 
         Args:
             total: Rounds of every kind registered after this change.
@@ -12274,8 +12296,14 @@ class ConsoleChatController:
         config_value = _bool_or_none(get_cli_setting("console", "interrupt_bell", None))
         return True if config_value is None else config_value
 
-    def _announce_detached_approval(self, session_id: str) -> None:
-        """Raise the app-wide toast for a round armed with no Console view.
+    def announce_hidden_decision(self, session_id: str, kind: str) -> None:
+        """Use the app-wide notice for all retained human-decision kinds."""
+        self._announce_detached_approval(session_id, kind=kind)
+
+    def _announce_detached_approval(
+        self, session_id: str, *, kind: str = "approval"
+    ) -> None:
+        """Raise the app-wide toast for a round with no visible Console view.
 
         WORKER THREAD. ``App.notify`` is documented thread-safe (it posts
         a message), so this needs no ``call_from_thread`` marshal -- and
@@ -12306,8 +12334,13 @@ class ConsoleChatController:
         except Exception:  # noqa: BLE001 -- a missing title never blocks the notice
             title = ""
         where = f" in {escape_markup(title)}" if title else ""
+        reason = (
+            "needs your answer to a question"
+            if kind == "question"
+            else "needs approval to use a tool"
+        )
         message = (
-            f"Agent{where} needs approval to use a tool. "
+            f"Agent{where} {reason}. "
             "Open Console to review -- nothing runs until you answer."
         )
         try:
@@ -13115,7 +13148,10 @@ class ConsoleChatController:
         Returns:
             ``{"ask_user": callback}`` or ``{}``.
         """
-        if session_id is None or self.app is None or self.set_pending_question is None:
+        if session_id is None or self.app is None or (
+            self.set_pending_question is None
+            and not self._interrupt_host.has_retained_decision_target(session_id)
+        ):
             return {}
 
         def _ask(questions: list[dict[str, Any]]) -> dict[str, Any]:
@@ -13589,7 +13625,10 @@ class ConsoleChatController:
             True only on an explicit Allow; every other path (deny, cancel,
             stop, timeout, or no wired UI) returns False.
         """
-        if self.app is None or self.set_pending_skill_install is None:
+        if self.app is None or (
+            self.set_pending_skill_install is None
+            and not self._interrupt_host.has_retained_decision_target(session_id)
+        ):
             return False
         event = threading.Event()
         decision: dict[str, bool] = {}
@@ -13761,7 +13800,10 @@ class ConsoleChatController:
             ``{"allow": bool, "remember": bool}``. Every non-Allow path (deny,
             cancel, stop, timeout, no wired UI) returns ``allow=False``.
         """
-        if self.app is None or self.set_pending_skill_script is None:
+        if self.app is None or (
+            self.set_pending_skill_script is None
+            and not self._interrupt_host.has_retained_decision_target(session_id)
+        ):
             return {"allow": False, "remember": False}
         event = threading.Event()
         decision: dict[str, bool] = {}
@@ -14013,7 +14055,10 @@ class ConsoleChatController:
         )
         from tldw_chatbook.Chat.console_agent_bridge import format_question_marker
 
-        if self.app is None or self.set_pending_question is None:
+        if self.app is None or (
+            self.set_pending_question is None
+            and not self._interrupt_host.has_retained_decision_target(session_id)
+        ):
             return unanswered_result("cancelled")
         owning_session_id = (
             session_id if session_id is not None else (self.store.active_session_id or "")
@@ -14240,7 +14285,10 @@ class ConsoleChatController:
             non-Allow path (deny, cancel, stop, timeout, no wired UI)
             returns ``allow=False``.
         """
-        if self.app is None or self.set_pending_worktree_merge is None:
+        if self.app is None or (
+            self.set_pending_worktree_merge is None
+            and not self._interrupt_host.has_retained_decision_target(session_id)
+        ):
             return {"allow": False}
         event = threading.Event()
         decision: dict[str, bool] = {}
@@ -14542,9 +14590,8 @@ class ConsoleChatController:
         only ever resolves the active session.
 
         Production caller: app-owned :class:`ConsoleRuntime` disposal at
-        application exit. Ordinary Console navigation calls
-        ``ConsoleRuntime.leave_console`` instead; that runtime and this
-        controller survive unmount/remount and are reused by the next view.
+        application exit. Ordinary navigation suspends and reuses Console;
+        only final unmount calls ``ConsoleRuntime.leave_console``.
 
         F5 fix (Qodo wave): sets ``_shutdown_requested`` unconditionally
         and FIRST -- before the no-tasks early return below -- so a
@@ -14785,8 +14832,9 @@ class ConsoleChatController:
     async def leave_console(self) -> None:
         """End ONE Console visit. This controller SURVIVES it.
 
-        The nav-away half of the teardown split (task-15860). Everything
-        AC#2 names as screen-scoped still happens:
+        The final-unmount half of the teardown split (task-15860). Ordinary
+        navigation now suspends the retained Console and does not call this.
+        An actual unmount still performs the original visit cleanup:
 
         - this visit's queue chains are tombstoned, before any
           cancellation, exactly as `begin_shutdown` did it;
@@ -14823,10 +14871,8 @@ class ConsoleChatController:
         self.prompt_queue_coordinator.shutdown()
         self._visit_open = False
         self._shutdown_requested.set()
-        # task-15860 Task 5: a round armed while DETACHED deferred to this
-        # moment. The user has now had a Console visit in which to answer
-        # it and has navigated away instead, so AC#2's rule applies to it
-        # exactly as it does to a round armed during the visit.
+        # Final unmount also cancels rounds born detached; ordinary screen
+        # suspension does not enter this teardown boundary.
         self._cancel_headless_rounds()
         for message_id in tuple(self._original_attempts):
             self.clear_original_attempt(message_id)
@@ -18640,6 +18686,7 @@ class ConsoleChatController:
         self,
         *,
         session_id: str,
+        preserve_composer: bool = False,
         origin: ConsoleSubmissionOrigin,
         entry_id: str | None,
         context_epoch: int,
@@ -18660,7 +18707,11 @@ class ConsoleChatController:
         if preparation_id:
             self._ordinary_outcome_ids[session_id] = f"turn:{preparation_id}"
             self._ordinary_outcome_assistant_ids[session_id] = assistant_message_id
-        if origin is not ConsoleSubmissionOrigin.MANUAL:
+        if (
+            origin is not ConsoleSubmissionOrigin.MANUAL
+            or preserve_composer
+            or self.store.active_session_id != session_id
+        ):
             return
         callback = self.on_submission_accepted
         if callback is None:
@@ -22852,6 +22903,7 @@ class ConsoleChatController:
                         self.request_skill_script_confirm, session_id=session_id
                     )
                     if self.set_pending_skill_script is not None
+                    or self._interrupt_host.has_retained_decision_target(session_id)
                     else None
                 ),
                 # TASK-28238 phase 2 Task 6/Task 7: same "advertised must
@@ -22875,6 +22927,7 @@ class ConsoleChatController:
                         self.request_worktree_merge_confirm, session_id=session_id
                     )
                     if self.set_pending_worktree_merge is not None
+                    or self._interrupt_host.has_retained_decision_target(session_id)
                     else None
                 ),
                 # PR2a Task 7: the fleet cancels/abandons children on the
@@ -24368,7 +24421,10 @@ class ConsoleChatController:
         logical_outcome_id = self._ordinary_outcome_ids.get(target)
         if (
             logical_outcome_id
-            and target != (self.store.active_session_id or "")
+            and (
+                target != (self.store.active_session_id or "")
+                or self._interrupt_host.view_visible is False
+            )
             and terminal_notification_eligible
             and run_state.status
             in {
@@ -24537,7 +24593,9 @@ class ConsoleChatController:
         if not self.activity_for(session_id).terminal_notification_eligible:
             return
         active_id = self.store.active_session_id or ""
-        if session_id != active_id and logical_outcome_id:
+        if (
+            session_id != active_id or self._interrupt_host.view_visible is False
+        ) and logical_outcome_id:
             self._publish_inactive_outcome(
                 session_id=session_id,
                 status=status,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -34,6 +34,7 @@ from loguru import logger
 
 # None is an explicit plain choice; omission alone permits workspace inheritance.
 UNSPECIFIED_ASSISTANT = object()
+_HYDRATION_NOT_PREPARED = object()
 
 if TYPE_CHECKING:
     from tldw_chatbook.Canvas.staging import (
@@ -41,6 +42,7 @@ if TYPE_CHECKING:
         CanvasStagingOwner,
     )
 
+    from .console_conversation_hydration import ConsoleConversationHydrationData
     from .console_session_settings import ConsoleAssistantStartup
 
 from tldw_chatbook.Agents.agent_models import (
@@ -2653,6 +2655,7 @@ class ConsoleChatStore:
         ephemeral: bool = False,
         remote_active: bool = False,
         activate: bool = True,
+        prepared_data: ConsoleConversationHydrationData | None = None,
     ) -> ConsoleChatSession:
         """Create and activate a native session from persisted conversation data.
 
@@ -2692,6 +2695,8 @@ class ConsoleChatStore:
                 prompt immediately after an explicitly empty active path, or
                 ``None`` for ordinary selected/unset cursor state.
             settings: Optional provider/model settings snapshot for the session.
+            prepared_data: Optional unpublished bulk reads for this conversation.
+                Policy reconciliation and all store publication remain on the caller.
 
         Returns:
             The newly created and activated Console session.
@@ -2700,6 +2705,11 @@ class ConsoleChatStore:
         # definition not temporary. Refuse rather than silently produce a
         # session that is both temporary and persisted -- the one state the
         # gate's invariant does not allow.
+        if (
+            prepared_data is not None
+            and prepared_data.conversation_id != persisted_conversation_id
+        ):
+            raise ValueError("Conversation hydration identity changed")
         if ephemeral:
             raise ValueError(
                 "Cannot restore a persisted session as temporary: a temporary "
@@ -2775,14 +2785,15 @@ class ConsoleChatStore:
                 persisted_conversation_id,
                 list(all_nodes),
                 remote_active=remote_active,
+                prepared_rows=prepared_data.continuation_rows
+                if prepared_data is not None
+                else _HYDRATION_NOT_PREPARED,
             )
             self._ingest_full_tree(
                 session.id,
                 restored_nodes,
                 active_leaf_persisted_id=active_leaf_persisted_id,
-                active_leaf_before_persisted_id=(
-                    active_leaf_before_persisted_id
-                ),
+                active_leaf_before_persisted_id=(active_leaf_before_persisted_id),
             )
             self._normalize_restored_provider_continuation(
                 session.id, str(persisted_conversation_id)
@@ -2790,7 +2801,12 @@ class ConsoleChatStore:
             self._reconcile_restored_chat_sync_intents(
                 session.id, str(persisted_conversation_id)
             )
-            self._hydrate_generation_metadata_from_persistence(session.id)
+            if prepared_data is None:
+                self._hydrate_generation_metadata_from_persistence(session.id)
+            elif isinstance(prepared_data.generation_rows, dict):
+                self.hydrate_generation_metadata(
+                    session.id, prepared_data.generation_rows
+                )
             self._seed_console_settings_owned_bases(session)
             self._bump_payload_revision(session.id)
             return session
@@ -3627,19 +3643,28 @@ class ConsoleChatStore:
         nodes: list[ConsoleChatMessage],
         *,
         remote_active: bool = False,
+        prepared_rows: object = _HYDRATION_NOT_PREPARED,
     ) -> list[ConsoleChatMessage]:
         """Tolerantly attach private checkpoints without exposing their data."""
-        database = getattr(self.persistence, "db", None) if self.persistence else None
-        getter = getattr(database, "get_messages_for_conversation", None)
-        if not callable(getter):
-            self._quarantine_continuation_hydration(session_id, conversation_id)
-            return nodes
-        try:
-            rows = getter(conversation_id, limit=100_000)
-        except Exception:
-            logger.warning("Console continuation restore was unavailable.")
-            self._quarantine_continuation_hydration(session_id, conversation_id)
-            return nodes
+        if prepared_rows is not _HYDRATION_NOT_PREPARED:
+            if prepared_rows is None:
+                self._quarantine_continuation_hydration(session_id, conversation_id)
+                return nodes
+            rows = prepared_rows
+        else:
+            database = (
+                getattr(self.persistence, "db", None) if self.persistence else None
+            )
+            getter = getattr(database, "get_messages_for_conversation", None)
+            if not callable(getter):
+                self._quarantine_continuation_hydration(session_id, conversation_id)
+                return nodes
+            try:
+                rows = getter(conversation_id, limit=100_000)
+            except Exception:
+                logger.warning("Console continuation restore was unavailable.")
+                self._quarantine_continuation_hydration(session_id, conversation_id)
+                return nodes
         by_persisted_id = {
             node.persisted_message_id: node
             for node in nodes

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -32,6 +32,11 @@ from uuid import uuid4
 
 from loguru import logger
 
+from .console_assistant_defaults import ConsoleAssistantStartup
+
+# None is an explicit plain choice; omission alone permits workspace inheritance.
+UNSPECIFIED_ASSISTANT = object()
+
 if TYPE_CHECKING:
     from tldw_chatbook.Canvas.staging import (
         CanvasPromotionContribution,
@@ -1435,6 +1440,7 @@ class ConsoleChatSession:
     assistant_authority_id: str | None = None
     #: Persona-owned memory behavior persisted with persona conversations.
     persona_memory_mode: str | None = None
+    assistant_default_notice: str = ""
     #: Local-only numeric compatibility/display projection. Server character
     #: IDs remain opaque in ``assistant_id`` and never populate this field.
     character_id: int | None = None
@@ -1606,6 +1612,10 @@ class ConsoleChatStore:
         canvas_promotion_participant: ConsoleCanvasPromotionParticipant | None = None,
         canvas_turn_controller: Any | None = None,
         on_canvas_context_changed: Callable[[str | None], None] | None = None,
+        assistant_defaults_provider: Callable[
+            [str, ConsoleSessionSettings | None], ConsoleAssistantStartup
+        ] | None = None,
+        on_assistant_default_notice: Callable[[str], None] | None = None,
     ) -> None:
         """Initialize the Console chat store.
 
@@ -1649,6 +1659,8 @@ class ConsoleChatStore:
                 a native session activation or active-branch transition.
         """
         self.persistence = persistence
+        self._assistant_defaults_provider = assistant_defaults_provider
+        self._on_assistant_default_notice = on_assistant_default_notice
         self.canvas_promotion_participant = canvas_promotion_participant
         self.canvas_turn_controller = canvas_turn_controller
         self._on_canvas_context_changed = on_canvas_context_changed
@@ -2051,10 +2063,11 @@ class ConsoleChatStore:
         canonical_settings_baseline: ConsoleSessionSettings | None = None,
         thinking_history_policy: object = _OMITTED_THINKING_HISTORY_POLICY,
         runtime_backend: str = "local",
-        assistant_kind: str | None = "generic",
+        assistant_kind: str | None | object = UNSPECIFIED_ASSISTANT,
         assistant_id: str | None = "console",
         assistant_authority_id: str | None = None,
         persona_memory_mode: str | None = None,
+        assistant_default_notice: str = "",
         character_id: int | None = None,
         character_name: str | None = None,
         ephemeral: bool = False,
@@ -2090,6 +2103,27 @@ class ConsoleChatStore:
             or canonical_settings_baseline != settings
         ):
             raise ValueError("canonical baseline must equal the session settings.")
+        target_workspace_id = workspace_id or self.workspace_context.active_workspace_id
+        if assistant_kind is UNSPECIFIED_ASSISTANT:
+            assistant_kind, assistant_id = "generic", "console"
+            if self._assistant_defaults_provider is not None:
+                startup = self._assistant_defaults_provider(target_workspace_id, settings)
+                if canonical_settings_baseline is not None:
+                    canonical_settings_baseline = startup.settings
+                settings = startup.settings
+                assistant_kind = startup.assistant_kind
+                assistant_id = startup.assistant_id
+                persona_memory_mode = startup.persona_memory_mode
+                assistant_default_notice = startup.notice
+        elif assistant_kind is None:
+            assistant_kind, assistant_id = "generic", "console"
+        if assistant_kind == "persona" and settings is not None:
+            persona_memory_mode = persona_memory_mode or settings.persona_memory_mode
+            if settings.persona_memory_mode != persona_memory_mode:
+                was_canonical = canonical_settings_baseline == settings
+                settings = replace(settings, persona_memory_mode=persona_memory_mode)
+                if was_canonical:
+                    canonical_settings_baseline = settings
         defaults = (
             self._library_policy_defaults_provider()
             if self._library_policy_defaults_provider is not None
@@ -2110,7 +2144,7 @@ class ConsoleChatStore:
         session = ConsoleChatSession(
             id=resolved_session_id,
             title=title,
-            workspace_id=workspace_id or self.workspace_context.active_workspace_id,
+            workspace_id=target_workspace_id,
             settings=settings,
             canonical_settings_baseline=canonical_settings_baseline,
             thinking_history_policy=normalize_thinking_history_policy(
@@ -2121,6 +2155,7 @@ class ConsoleChatStore:
             assistant_id=assistant_id,
             assistant_authority_id=assistant_authority_id,
             persona_memory_mode=persona_memory_mode,
+            assistant_default_notice=assistant_default_notice,
             character_id=character_id,
             character_name=character_name,
             ephemeral=ephemeral,
@@ -2172,6 +2207,11 @@ class ConsoleChatStore:
             )
         if activate:
             self._activate_session(session.id)
+        if assistant_default_notice and self._on_assistant_default_notice is not None:
+            try:
+                self._on_assistant_default_notice(assistant_default_notice)
+            except Exception:  # noqa: BLE001 - presentation cannot undo a new chat
+                logger.warning("Workspace default Persona notice could not be shown")
         return session
 
     def _activate_session(self, session_id: str | None) -> None:
@@ -11180,6 +11220,7 @@ class ConsoleChatStore:
         message_id: str,
         *,
         presentation_context: ConsolePresentationContext | None = None,
+        owner_session_id: str | None = None,
     ) -> TTSMessageSpeechSnapshot:
         """Issue a trusted snapshot for one speakable active-path message.
 
@@ -11187,6 +11228,8 @@ class ConsoleChatStore:
             message_id: Native Console message selected by the user.
             presentation_context: Optional live identity used to resolve trusted
                 character-template content. ``None`` preserves neutral callers.
+            owner_session_id: Explicit local owner for app-owned Buddy speech.
+                Omission retains the visible-session requirement.
 
         Returns:
             An immutable snapshot bound to the exact selected text and
@@ -11202,7 +11245,7 @@ class ConsoleChatStore:
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
             )
-        if session_id != self.active_session_id:
+        if session_id != (self.active_session_id if owner_session_id is None else owner_session_id):
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
             )
@@ -11212,6 +11255,8 @@ class ConsoleChatStore:
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.MISSING_MESSAGE
             )
+        if owner_session_id is not None and session.runtime_backend != "local":
+            raise ConsoleSpeechSnapshotRejected(ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED)
         if message.generation_projection_quarantined:
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
@@ -11277,6 +11322,7 @@ class ConsoleChatStore:
         snapshot: TTSMessageSpeechSnapshot,
         *,
         presentation_context: ConsolePresentationContext | None = None,
+        owner_session_id: str | None = None,
     ) -> str:
         """Revalidate an issued Console speech snapshot against live state.
 
@@ -11284,6 +11330,8 @@ class ConsoleChatStore:
             snapshot: Immutable snapshot previously issued by this store.
             presentation_context: Optional fresh identity used to re-resolve
                 trusted character-template content before comparison.
+            owner_session_id: Exact local owner, matching the issue-time opt-in.
+                The caller also validates its captured Buddy binding.
 
         Returns:
             The captured exact raw content after every identity, state,
@@ -11297,7 +11345,7 @@ class ConsoleChatStore:
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.MESSAGE_CHANGED
             )
-        if snapshot.session_id != self.active_session_id:
+        if snapshot.session_id != (self.active_session_id if owner_session_id is None else owner_session_id):
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
             )
@@ -11306,6 +11354,8 @@ class ConsoleChatStore:
             raise ConsoleSpeechSnapshotRejected(
                 ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED
             )
+        if owner_session_id is not None and session.runtime_backend != "local":
+            raise ConsoleSpeechSnapshotRejected(ConsoleSpeechSnapshotRejectionCode.SESSION_CHANGED)
         owner_session_id = self._message_session_index.get(snapshot.message_id)
         if owner_session_id is None:
             raise ConsoleSpeechSnapshotRejected(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -32,8 +32,6 @@ from uuid import uuid4
 
 from loguru import logger
 
-from .console_assistant_defaults import ConsoleAssistantStartup
-
 # None is an explicit plain choice; omission alone permits workspace inheritance.
 UNSPECIFIED_ASSISTANT = object()
 
@@ -42,6 +40,8 @@ if TYPE_CHECKING:
         CanvasPromotionContribution,
         CanvasStagingOwner,
     )
+
+    from .console_session_settings import ConsoleAssistantStartup
 
 from tldw_chatbook.Agents.agent_models import (
     FinalContinuation,

--- a/tldw_chatbook/Chat/console_conversation_hydration.py
+++ b/tldw_chatbook/Chat/console_conversation_hydration.py
@@ -33,8 +33,9 @@ only app members read are `chat_conversation_scope_service` and
 
 from __future__ import annotations
 
+import asyncio
 import inspect
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, field, replace
 from typing import Any, Mapping, Sequence
 
 from loguru import logger
@@ -445,6 +446,99 @@ def hydrate_console_generation_settings(
     )
 
 
+@dataclass(frozen=True, slots=True)
+class ConsoleConversationHydrationData:
+    """Unpublished bulk read results for one exact persisted conversation."""
+
+    conversation_id: str
+    nodes: tuple[ConsoleChatMessage, ...] = field(repr=False)
+    active_leaf_id: str | None
+    active_leaf_before_id: str | None
+    continuation_rows: list[dict[str, Any]] | None = field(repr=False)
+    generation_rows: dict[str, Any] | None = field(repr=False)
+
+
+async def prepare_console_session_data(
+    *, app: Any, store: Any, conversation_id: str, tree: Mapping[str, Any]
+) -> ConsoleConversationHydrationData:
+    """Read size-dependent hydration data off-loop without publishing a session.
+
+    Args:
+        app: Profile owner supplying the message/attachment database.
+        store: Store supplying the persistence reader, never mutated here.
+        conversation_id: Exact durable conversation being restored.
+        tree: Previously loaded full conversation tree.
+
+    Returns:
+        Detached nodes, cursor and optional bulk persistence metadata. The caller
+        must revalidate authority after awaiting this read and before publication.
+    """
+    db = getattr(app, "chachanotes_db", None)
+    persistence = store.persistence
+    persistence_db = getattr(persistence, "db", None)
+    databases = tuple(
+        {
+            id(value): value for value in (db, persistence_db) if value is not None
+        }.values()
+    )
+    # A :memory: DB is connection-local; retain its existing inline behavior.
+    threaded = not any(
+        getattr(database, "is_memory_db", False) for database in databases
+    )
+
+    def read() -> ConsoleConversationHydrationData:
+        try:
+            nodes = console_messages_from_conversation_tree(tree, db=db)
+            cursor_reader = getattr(db, "get_conversation_active_cursor", None)
+            if callable(cursor_reader):
+                leaf, before = cursor_reader(conversation_id)
+            else:
+                leaf = getattr(db, "get_conversation_active_leaf", lambda _: None)(
+                    conversation_id
+                )
+                before = None
+            continuation_rows = None
+            getter = getattr(persistence_db, "get_messages_for_conversation", None)
+            if callable(getter):
+                try:
+                    continuation_rows = getter(conversation_id, limit=100_000)
+                except Exception:  # noqa: BLE001 - publication retains continuation quarantine
+                    logger.warning("Console continuation restore was unavailable.")
+            ids = {
+                node.persisted_message_id for node in nodes if node.persisted_message_id
+            }
+            ids.update(
+                str(row["id"])
+                for row in continuation_rows or ()
+                if row.get("id") is not None
+            )
+            generation_rows = None
+            getter = getattr(persistence, "get_generation_metadata_for_messages", None)
+            if ids and callable(getter):
+                try:
+                    generation_rows = getter(sorted(ids))
+                except Exception:  # noqa: BLE001 - optional sidecars retain existing fallback
+                    logger.warning(
+                        "Console resume generation-metadata batch fetch failed."
+                    )
+            return ConsoleConversationHydrationData(
+                conversation_id,
+                tuple(nodes),
+                leaf,
+                before,
+                continuation_rows,
+                generation_rows,
+            )
+        finally:
+            if threaded:
+                for database in databases:
+                    close = getattr(database, "close_connection", None)
+                    if callable(close):
+                        close()
+
+    return await asyncio.to_thread(read) if threaded else read()
+
+
 async def hydrate_console_session(
     *,
     app: Any,
@@ -459,6 +553,7 @@ async def hydrate_console_session(
     target_scope_type: str | None = None,
     target_workspace_id: str | None = None,
     activate: bool = True,
+    prepared_data: ConsoleConversationHydrationData | None = None,
 ) -> Any:
     """Create a Console session from a persisted tree.
 
@@ -484,6 +579,8 @@ async def hydrate_console_session(
             conversation carries none.
         activate: Whether to activate the hydrated session after its policy
             state has been restored.
+        prepared_data: Optional off-loop bulk reads for this exact conversation;
+            callers must revalidate their binding before supplying them.
 
     Returns:
         The newly created `ConsoleChatSession`, activated when ``activate``
@@ -521,15 +618,24 @@ async def hydrate_console_session(
     # branches (not just the latest) is what makes off-path siblings
     # navigable (swipe) right after resume.
     db = getattr(app, "chachanotes_db", None)
-    all_nodes = console_messages_from_conversation_tree(tree, db=db)
-    cursor_reader = getattr(db, "get_conversation_active_cursor", None)
-    if callable(cursor_reader):
-        active_leaf_id, active_leaf_before_id = cursor_reader(target)
+    if prepared_data is not None:
+        if prepared_data.conversation_id != target:
+            raise ValueError("Conversation hydration identity changed")
+        all_nodes = list(prepared_data.nodes)
+        active_leaf_id, active_leaf_before_id = (
+            prepared_data.active_leaf_id,
+            prepared_data.active_leaf_before_id,
+        )
     else:
-        active_leaf_id = getattr(
-            db, "get_conversation_active_leaf", lambda _target: None
-        )(target)
-        active_leaf_before_id = None
+        all_nodes = console_messages_from_conversation_tree(tree, db=db)
+        cursor_reader = getattr(db, "get_conversation_active_cursor", None)
+        if callable(cursor_reader):
+            active_leaf_id, active_leaf_before_id = cursor_reader(target)
+        else:
+            active_leaf_id = getattr(
+                db, "get_conversation_active_leaf", lambda _target: None
+            )(target)
+            active_leaf_before_id = None
     raw_runtime_backend = conversation.get("runtime_backend")
     if type(raw_runtime_backend) is str:
         runtime_backend = raw_runtime_backend
@@ -593,6 +699,7 @@ async def hydrate_console_session(
         character_name=character_name,
         user_display_name_override=roleplay_context.user_name_override,
         character_system_template=roleplay_context.character_system_template,
+        **({"prepared_data": prepared_data} if prepared_data is not None else {}),
         activate=False,
     )
     try:

--- a/tldw_chatbook/Chat/console_interrupt_rounds.py
+++ b/tldw_chatbook/Chat/console_interrupt_rounds.py
@@ -36,8 +36,10 @@ from __future__ import annotations
 
 import threading
 import time
+import weakref
 from collections.abc import Callable
 from contextlib import nullcontext
+from dataclasses import dataclass
 from typing import Any
 
 from loguru import logger
@@ -174,6 +176,27 @@ def unpark_round_payload(
         store.pop(round_id, None)
 
 
+@dataclass
+class _DecisionClock:
+    """Volatile answerable-time budget; never included in a card payload."""
+
+    remaining: float
+    updated_at: float
+    payload: dict[str, Any]
+    answerable: bool = False
+    requires_head: bool = True
+
+    def update(self, now: float, answerable: bool) -> None:
+        if self.answerable:
+            self.remaining = max(0.0, self.remaining - (now - self.updated_at))
+        self.updated_at = now
+        self.answerable = answerable
+        self.payload["timeout_seconds"] = self.remaining
+        self.payload["deadline_monotonic"] = (
+            now + self.remaining if answerable else None
+        )
+
+
 class InterruptRoundHost:
     """Own the registries, payload maps, and FIFO-head render contract."""
 
@@ -193,6 +216,105 @@ class InterruptRoundHost:
         self.payloads: dict[str, dict[str, dict[str, Any]]] = {
             kind: {} for kind in KIND_SETTER_ATTRS
         }
+        # None preserves the setter-based contract for non-Textual callers.
+        # A reused screen explicitly reports suspend/resume, including modals.
+        self.view_visible: bool | None = None
+        self._decision_views: dict[object, tuple[str, frozenset[str]]] = {}
+        self._retained_decision_targets: dict[
+            str, tuple[weakref.ReferenceType[Any], int, bool]
+        ] = {}
+
+    def retain_decision_target(self, session_id: str) -> None:
+        """An explicit Buddy opener makes this exact session's cards recoverable."""
+        session = next(
+            (row for row in self._seams.store.sessions() if row.id == session_id), None
+        )
+        if session is not None:
+            with self.lock:
+                self._retained_decision_targets[session_id] = (
+                    weakref.ref(session),
+                    session.conversation_binding_revision,
+                    session.ephemeral,
+                )
+
+    def has_retained_decision_target(self, session_id: str | None) -> bool:
+        """Wake-only, closed, replaced or repurposed slots gain no Buddy capability."""
+        with self.lock:
+            retained = self._retained_decision_targets.get(session_id)
+        if retained is None:
+            return False
+        reference, revision, ephemeral = retained
+        session = reference()
+        return bool(
+            session is not None
+            and session.runtime_backend == "local"
+            and session.conversation_binding_revision == revision
+            and session.ephemeral == ephemeral
+            and any(row is session for row in self._seams.store.sessions())
+        )
+
+    def set_decision_view(
+        self,
+        owner: object,
+        session_id: str | None,
+        *,
+        kinds: tuple[str, ...] = tuple(KIND_SETTER_ATTRS),
+    ) -> None:
+        """Claim/release a visible exact-session decision projection, such as Buddy."""
+        with self.lock:
+            if session_id is None:
+                self._decision_views.pop(owner, None)
+            else:
+                self._decision_views[owner] = (session_id, frozenset(kinds))
+        self.refresh_decision_clocks()
+
+    def set_view_visible(self, visible: bool) -> None:
+        """Account for the old visibility interval before changing clock activity."""
+        self.view_visible = visible
+        self.refresh_decision_clocks()
+        if not visible:
+            self.announce_hidden_decisions()
+
+    def refresh_decision_clocks(self) -> None:
+        """Charge only a visible session's FIFO head, across every decision kind."""
+        with self.lock:
+            active_session_id = self._active_session_id()
+            now = time.monotonic()
+            for kind, states in self.registries.items():
+                for state in states.values():
+                    clock = state.get("decision_clock")
+                    if not isinstance(clock, _DecisionClock):
+                        continue
+                    session_id = state.get("session_id")
+                    head = head_payload_locked(self.payloads[kind], session_id)
+                    answerable = (
+                        (
+                            self.view_visible is not False
+                            and self._setter(kind) is not None
+                            and (not session_id or session_id == active_session_id)
+                        )
+                        or any(
+                            session_id == target and kind in kinds
+                            for target, kinds in self._decision_views.values()
+                        )
+                    ) and (not clock.requires_head or head is clock.payload)
+                    clock.update(now, answerable)
+
+    def announce_hidden_decisions(self) -> None:
+        """Notify once per live round, including one hidden after it was mounted."""
+        announce = getattr(self._seams, "announce_hidden_decision", None)
+        if not callable(announce):
+            return
+        with self.lock:
+            pending = []
+            for kind, states in self.registries.items():
+                for state in states.values():
+                    if state.get("attention_announced") or state.get("revoked"):
+                        continue
+                    state["attention_announced"] = True
+                    pending.append((state.get("session_id", ""), kind))
+        for session_id, kind in pending:
+            announce(session_id, kind)
 
     # -- setter / app access (always late-bound) -----------------------
 
@@ -211,9 +333,7 @@ class InterruptRoundHost:
         """Retain ``payload``; return whether it is now its session's head."""
         return park_round_payload(self.lock, self.payloads[kind], round_id, payload)
 
-    def head_round_payload(
-        self, kind: str, session_id: str
-    ) -> dict[str, Any] | None:
+    def head_round_payload(self, kind: str, session_id: str) -> dict[str, Any] | None:
         """The payload whose card ``session_id`` should show (remaining-time snapshot)."""
         return head_round_payload(self.lock, self.payloads[kind], session_id)
 
@@ -266,6 +386,7 @@ class InterruptRoundHost:
                 target = self._active_session_id()
             elif target != self._active_session_id():
                 return
+            self.refresh_decision_clocks()
             payload = self.head_round_payload(kind, target)
             setter(payload)
             hook = after if after is not None else self.after_remount.get(kind)
@@ -430,14 +551,15 @@ class InterruptRoundHost:
                 or None for the legacy no-session shape.
             owning_session_id: The session whose head is re-derived at
                 teardown.
-            deadline: ``time.monotonic()`` deadline, or None to wait
-                indefinitely.
+            deadline: Initial ``time.monotonic()`` deadline, or None to wait
+                indefinitely. Finite budgets advance only while the owning
+                session's FIFO head can be answered on the visible Console.
             is_parked: True when the round belongs to a non-viewed session.
             announce_detached: Detached-view announcer; returns True when
                 it announced instead of mounting.
             human_wait_run_id: Run id for ``use_human_input_wait``, or None.
             on_cancelled: Runs once when the session cancel fires mid-wait.
-            on_timeout: Runs once when ``deadline`` passes.
+            on_timeout: Runs once when the answerable-time budget is exhausted.
             check_revoked: Whether a ``revoked`` stamp wins over "decided".
             on_teardown: Returns True to keep the payload parked.
             before_wait: Runs once inside the wait mark before polling.
@@ -458,6 +580,17 @@ class InterruptRoundHost:
             if on_outcome is not None:
                 on_outcome("revoked")
             return "revoked"
+        clock = None
+        if deadline is not None:
+            now = time.monotonic()
+            clock = _DecisionClock(
+                max(0.0, float(payload.get("timeout_seconds", deadline - now))),
+                now,
+                payload,
+                requires_head=session_id is not None,
+            )
+            with self.lock:
+                state["decision_clock"] = clock
         is_head = True
         if session_id is not None:
             add = getattr(self._seams, "add_pending_round", None)
@@ -468,7 +601,10 @@ class InterruptRoundHost:
             app = getattr(self._seams, "app", None)
             park_toast = getattr(self._seams, "park_pending_approval", None)
             if announce_detached is not None and announce_detached():
-                pass  # announced app-wide instead of mounting: no view can show it
+                with self.lock:
+                    state["attention_announced"] = True
+            elif self.view_visible is False:
+                self.announce_hidden_decisions()
             elif is_parked:
                 if app is not None and park_toast is not None:
                     app.call_from_thread(park_toast, session_id)
@@ -476,13 +612,13 @@ class InterruptRoundHost:
                 setter = self._setter(kind)
                 if app is not None and setter is not None:
                     app.call_from_thread(setter, payload)
+            self.refresh_decision_clocks()
             # A sweep can revoke and pop the round between registration and
             # here; a round that is no longer registered never announces
             # itself (no bell for a dead round, no zero-total "raised").
             with self.lock:
-                still_live = (
-                    self.registries[kind].get(round_id) is state
-                    and not bool(state.get("revoked"))
+                still_live = self.registries[kind].get(round_id) is state and not bool(
+                    state.get("revoked")
                 )
             if still_live:
                 self._note_pending(kind, raised=True)
@@ -509,7 +645,8 @@ class InterruptRoundHost:
                             on_cancelled()
                         outcome = "cancelled"
                         break
-                    if deadline is not None and time.monotonic() >= deadline:
+                    self.refresh_decision_clocks()
+                    if clock is not None and clock.remaining <= 0:
                         if on_timeout is not None:
                             on_timeout()
                         outcome = "timeout"

--- a/tldw_chatbook/Chat/console_persona_assignment.py
+++ b/tldw_chatbook/Chat/console_persona_assignment.py
@@ -1,0 +1,377 @@
+"""Prepared, exact-target Persona changes for Buddy management (ADR-139)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from copy import deepcopy
+from dataclasses import asdict, dataclass, replace
+from datetime import UTC, datetime
+from typing import Any
+
+from ..Persona_Buddy.interaction import BuddyBinding
+from ..Workspaces.models import DEFAULT_WORKSPACE_ID, WorkspaceAssistantDefaults
+from .console_assistant_defaults import build_persona_agent_system_prompt
+from .console_chat_store import ConsoleSettingsComponent
+from .console_generation_settings_metadata import (
+    ConsoleGenerationSettingsReadStatus,
+    merge_console_generation_settings,
+    snapshot_from_session_settings,
+    strict_json_metadata_object,
+)
+from .console_turn_preparation import ConsoleTurnPreparationState
+
+
+@dataclass(frozen=True)
+class PreparedPersonaAssignment:
+    """Read-only admission result; Apply owns the later domain mutation."""
+
+    _apply: Callable[[], None]
+
+    async def apply(self) -> None:
+        """Commit without yielding between the final check and live publication.
+
+        This bounded local SQLite update follows the existing synchronous store
+        persistence seam. No provider, artwork, filesystem or network work occurs
+        between admission and publication.
+        """
+        self._apply()
+
+
+def _persona(app: Any, persona_id: str) -> dict[str, Any]:
+    try:
+        row = app.local_character_persona_service.get_persona_profile(persona_id)
+    except (AttributeError, KeyError, ValueError) as exc:
+        raise ValueError(
+            "Selected Persona is unavailable. Reopen Buddy settings."
+        ) from exc
+    if (
+        not isinstance(row, Mapping)
+        or row.get("id") != persona_id
+        or row.get("deleted")
+        or not row.get("is_active", True)
+        or row.get("backend", "local") != "local"
+    ):
+        raise ValueError(
+            "Selected Persona is unavailable or inactive. Choose another Persona."
+        )
+    return deepcopy(dict(row))
+
+
+def _session_identity(session: Any) -> tuple[Any, ...]:
+    return (
+        session.id,
+        session.persisted_conversation_id,
+        session.conversation_binding_revision,
+        session.workspace_id,
+        session.runtime_backend,
+        session.ephemeral,
+        session.assistant_kind,
+        session.assistant_id,
+        session.assistant_authority_id,
+        session.character_id,
+        session.character_name,
+        session.persona_memory_mode,
+        session.identity_revision,
+        session.generation_settings_revision,
+        session.settings_revision,
+        session.settings,
+        session.ephemeral_endpoint_policy,
+    )
+
+
+def _require_idle(store: Any, controller: Any, session: Any) -> None:
+    # The direct queue projection is read-only; controller.activity_for can hydrate
+    # recovery state and is deliberately avoided by preparation.
+    activity = controller.prompt_queue_coordinator.activity(session.id)
+    preparation = store.preparation_for_session(session.id)
+    if (
+        not controller.run_state_for(session.id).is_send_allowed
+        or activity.occupies_slot
+        or activity.preparing_before_acceptance
+        or activity.accepted_live_turn
+        or activity.has_queued_work
+        or activity.needs_approval
+        or controller.has_pending_approval_round(session.id)
+        or store.dispatch_recovery_blocks_submission(session.id)
+        or (
+            preparation is not None
+            and preparation.state
+            not in {
+                ConsoleTurnPreparationState.CANCELLED,
+                ConsoleTurnPreparationState.SETTLED,
+            }
+        )
+        or any(
+            controller._interrupt_host.session_round_payloads(kind, session.id)
+            for kind in (
+                "approval",
+                "skill_install",
+                "skill_script",
+                "question",
+                "worktree_merge",
+            )
+        )
+    ):
+        raise ValueError(
+            "Finish this conversation’s run, queued work or pending decision before changing its Persona."
+        )
+    lifecycle = store._settings_persistence_lifecycles.get(session.id)
+    if lifecycle is not None and (
+        lifecycle.lock.locked()
+        or lifecycle.drain is not None
+        or any(not task.done() for task in lifecycle.tasks)
+    ):
+        raise ValueError(
+            "Conversation settings are still saving. Retry the Persona change afterwards."
+        )
+
+
+def _require_memory_confirmation(
+    old_id: str | None, mode: str | None, choice: str | None
+) -> None:
+    if choice is not None and choice != old_id and mode == "read_write":
+        raise ValueError(
+            "This target permits memory writes. Review its Persona memory setting before assigning a different Persona."
+        )
+
+
+def prepare_buddy_persona_assignment(
+    app: Any, binding: BuddyBinding | None, target: Any, persona_choice: str
+) -> PreparedPersonaAssignment:
+    """Validate and capture an assignment without changing the target or Persona.
+
+    Args:
+        app: Application owning local Persona and Console/workspace services.
+        binding: Explicit conversation or workspace chosen by the user.
+        target: Exact record resolved by the management coordinator.
+        persona_choice: A local Persona id, ``#none``, or ``#unchanged``.
+
+    Returns:
+        An awaitable Apply command with its own stale-target guards.
+
+    Raises:
+        ValueError: The target/Persona is unavailable or changing it is unsafe.
+    """
+    if persona_choice == "#unchanged":
+        return PreparedPersonaAssignment(lambda: None)
+    if not isinstance(binding, BuddyBinding) or target is None:
+        raise ValueError(
+            "Choose a conversation or workspace before changing its Persona."
+        )
+    if not isinstance(persona_choice, str) or not persona_choice:
+        raise ValueError("Choose a saved Persona or None.")
+    choice = None if persona_choice == "#none" else persona_choice
+    persona = _persona(app, choice) if choice is not None else None
+
+    def validate_persona() -> None:
+        if choice is not None and _persona(app, choice) != persona:
+            raise ValueError(
+                "Selected Persona changed. Reopen Buddy settings to review it."
+            )
+
+    if binding.kind == "workspace":
+        registry = getattr(app, "workspace_registry_service", None)
+        if registry is None:
+            raise ValueError("Workspace storage is unavailable.")
+        original = registry.get_workspace(binding.target_id)
+        if original != target:
+            raise ValueError("Workspace changed. Reopen Buddy settings.")
+
+        def validate_workspace() -> Any:
+            if getattr(app, "workspace_registry_service", None) is not registry:
+                raise ValueError("Workspace profile changed. Reopen Buddy settings.")
+            current = registry.get_workspace(binding.target_id)
+            if (
+                current is None
+                or current.archived
+                or current.workspace_id == DEFAULT_WORKSPACE_ID
+                or str(getattr(current.authority, "value", current.authority))
+                != "local-only"
+                or current.created_at != original.created_at
+                or current.assistant_defaults != original.assistant_defaults
+                or current.assistant_defaults_explicit_none
+                != original.assistant_defaults_explicit_none
+            ):
+                raise ValueError(
+                    "Workspace default changed or is unavailable. Reopen Buddy settings."
+                )
+            return current
+
+        validate_workspace()
+        old = original.assistant_defaults
+        _require_memory_confirmation(
+            old.assistant_id if old else None,
+            old.persona_memory_mode if old else None,
+            choice,
+        )
+        defaults = (
+            (
+                replace(old, assistant_id=choice)
+                if old is not None
+                else WorkspaceAssistantDefaults(assistant_id=choice)
+            )
+            if choice is not None
+            else None
+        )
+
+        def apply_workspace() -> None:
+            validate_workspace()
+            validate_persona()
+            if defaults is None:
+                if old is not None or not original.assistant_defaults_explicit_none:
+                    registry.clear_assistant_defaults(
+                        binding.target_id, expected_record=original
+                    )
+            elif defaults != old:
+                registry.set_assistant_defaults(
+                    binding.target_id, defaults, expected_record=original
+                )
+
+        return PreparedPersonaAssignment(apply_workspace)
+
+    runtime = getattr(app, "console_runtime", None)
+    store, controller = (
+        getattr(runtime, "chat_store", None),
+        getattr(runtime, "chat_controller", None),
+    )
+    if store is None or controller is None or controller.store is not store:
+        raise ValueError(
+            "Open the bound conversation in Console before changing its Persona."
+        )
+
+    def validate_session() -> None:
+        if (
+            getattr(app, "console_runtime", None) is not runtime
+            or runtime.chat_store is not store
+            or runtime.chat_controller is not controller
+            or binding.resolve_session(store.sessions()) is not target
+            or target.runtime_backend != "local"
+            or target.assistant_kind not in (None, "generic", "persona")
+            or target.character_id is not None
+            or target.assistant_authority_id is not None
+            or target.settings is None
+        ):
+            raise ValueError(
+                "The bound local conversation is unavailable or uses a Character. Reopen Buddy settings."
+            )
+        _require_idle(store, controller, target)
+
+    validate_session()
+    original_identity = _session_identity(target)
+    old_id = target.assistant_id if target.assistant_kind == "persona" else None
+    _require_memory_confirmation(old_id, target.persona_memory_mode, choice)
+    unchanged = choice == old_id
+    settings = replace(
+        target.settings,
+        system_prompt=build_persona_agent_system_prompt(persona) if persona else None,
+        character_label=str(persona.get("name") or choice) if persona else None,
+        persona_memory_mode=(target.persona_memory_mode or "read_only")
+        if persona
+        else None,
+    )
+    snapshot = snapshot_from_session_settings(settings)
+    persistence = store.persistence
+    db = getattr(persistence, "db", None)
+    conversation_id = target.persisted_conversation_id
+    expected_row = (
+        db.get_conversation_by_id(conversation_id)
+        if db is not None and conversation_id
+        else None
+    )
+    if conversation_id and expected_row is None:
+        raise ValueError(
+            "The saved conversation is unavailable. Reopen it before changing its Persona."
+        )
+    if expected_row is not None and (
+        (expected_row.get("assistant_kind") or "generic")
+        != (target.assistant_kind or "generic")
+        or (expected_row.get("assistant_id") or "console")
+        != (target.assistant_id or "console")
+        or expected_row.get("assistant_authority_id") != target.assistant_authority_id
+        or expected_row.get("character_id") != target.character_id
+        or expected_row.get("persona_memory_mode") != target.persona_memory_mode
+        or expected_row.get("runtime_backend", "local") != target.runtime_backend
+        or (expected_row.get("system_prompt") or None)
+        != (target.settings.system_prompt or None)
+    ):
+        raise ValueError(
+            "Saved Persona identity changed. Reopen the conversation before changing its Persona."
+        )
+
+    def apply_session() -> None:
+        with store.durable_preparation_lock, store.fork_source_transition(target.id):
+            validate_session()
+            validate_persona()
+            if (
+                _session_identity(target) != original_identity
+                or store.persistence is not persistence
+            ):
+                raise ValueError(
+                    "Conversation changed. Reopen Buddy settings to review it."
+                )
+            if unchanged:
+                return
+            if conversation_id is not None:
+                with db.transaction():
+                    row = db.get_conversation_by_id(conversation_id)
+                    if row is None or row["version"] != expected_row["version"]:
+                        raise ValueError(
+                            "Saved conversation changed. Reopen it before changing its Persona."
+                        )
+                    metadata = strict_json_metadata_object(row.get("metadata") or {})
+                    stored_settings = settings
+                    if target.ephemeral_endpoint_policy is not None:
+                        prior = metadata.get("console_session_settings", {})
+                        stored_settings = replace(
+                            settings,
+                            base_url=prior.get("base_url")
+                            if isinstance(prior, dict)
+                            else None,
+                        )
+                    metadata = merge_console_generation_settings(metadata, snapshot)
+                    metadata["console_session_settings"] = {
+                        "version": 1,
+                        **asdict(stored_settings),
+                    }
+                    if not db.update_conversation(
+                        conversation_id,
+                        {
+                            "assistant_kind": "persona" if choice else None,
+                            "assistant_id": choice,
+                            "assistant_authority_id": None,
+                            "character_id": None,
+                            "persona_memory_mode": settings.persona_memory_mode,
+                            "system_prompt": settings.system_prompt,
+                            "metadata": json.dumps(metadata),
+                        },
+                        expected_version=expected_row["version"],
+                    ):
+                        raise ValueError("Could not save the Persona change.")
+            # No await separates the committed local row and these plain dataclass
+            # assignments. Existing settings writers use this same owner thread.
+            target.settings = settings
+            target.assistant_kind = "persona" if choice else "generic"
+            target.assistant_id = choice or "console"
+            target.persona_memory_mode = settings.persona_memory_mode
+            target.assistant_default_notice = ""
+            target.character_name = None
+            target.canonical_settings_baseline = None
+            target.has_user_work = True
+            target.updated_at = datetime.now(UTC).isoformat()
+            target.generation_settings_revision += 1
+            target.settings_persistence_failures.pop(
+                ConsoleSettingsComponent.GENERATION_SETTINGS, None
+            )
+            if conversation_id is not None:
+                target.generation_durable_snapshot = snapshot
+                target.generation_metadata_status = (
+                    ConsoleGenerationSettingsReadStatus.VALID
+                )
+                store._seed_console_settings_owned_bases(target)
+            store._bump_identity_revision(target.id)
+            store._bump_settings_revision(target.id)
+            store._bump_conversation_context_epoch(target.id)
+            store._bump_speech_preference_epoch(target.id)
+
+    return PreparedPersonaAssignment(apply_session)

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -1318,6 +1318,25 @@ class ConsoleRuntime:
 
     def _resolve_new_console_assistant(self, workspace_id: str, settings: Any) -> Any:
         """Resolve new-chat identity without requiring a mounted Console view."""
+        from collections.abc import Mapping
+
+        from ..Workspaces.models import DEFAULT_WORKSPACE_ID
+        from .console_chat_models import CONSOLE_GLOBAL_WORKSPACE_ID
+        from .console_session_settings import (
+            ConsoleAssistantStartup,
+            blank_console_session_settings,
+        )
+
+        # Default/global scopes never inherit a Persona (ADR-079). Keep their
+        # ordinary boot path free of workspace Persona resolution.
+        if workspace_id in (CONSOLE_GLOBAL_WORKSPACE_ID, DEFAULT_WORKSPACE_ID, ""):
+            config = getattr(self._app, "app_config", {})
+            return ConsoleAssistantStartup(
+                settings
+                or blank_console_session_settings(
+                    config if isinstance(config, Mapping) else {}
+                )
+            )
         from .console_assistant_defaults import resolve_new_console_assistant
 
         return resolve_new_console_assistant(self._app, workspace_id, settings)

--- a/tldw_chatbook/Chat/console_runtime.py
+++ b/tldw_chatbook/Chat/console_runtime.py
@@ -35,8 +35,13 @@ in two:
 
 | Call | When | What it does |
 |---|---|---|
-| `leave_console_runtime` | every navigation AWAY from Console | ends ONE visit: clears the view's hook slots, cancels+awaits this visit's USER stream tasks, denies its parked approval rounds, tombstones its queue chains |
+| `leave_console_runtime` | final Console unmount | ends ONE visit: clears the view's hook slots, cancels+awaits this visit's USER stream tasks, denies its parked approval rounds, tombstones its queue chains |
 | `dispose_console_runtime` | app exit (`_shutdown_app_owned_lifecycles`) | the permanent form — `controller.shutdown()` then `gateway.aclose()`, exactly the order `on_unmount` used to run |
+
+TASK-31520 reuses and suspends Console during ordinary navigation instead of
+unmounting it. Streams, queues and decisions continue with their original owners.
+TASK-32078 accounts for actual visibility when notifying and timing decisions;
+a covering modal also makes a retained card temporarily unanswerable.
 
 An `AGENT_WAKE` turn is deliberately NOT cancelled by `leave_console`
 (owner ruling): cancelling it would re-create the "only completes if you
@@ -120,12 +125,12 @@ it left behind — tree, active leaf, drafts, pending attachments and all.
 from __future__ import annotations
 
 import asyncio
-from datetime import datetime, timezone
 import inspect
-from dataclasses import dataclass
-from pathlib import Path
-from threading import Lock
 import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from threading import Lock, get_ident
 from typing import TYPE_CHECKING, Any, Callable, Mapping
 from uuid import uuid4
 
@@ -138,8 +143,8 @@ from tldw_chatbook.Chat.console_library_policy import (
 )
 from tldw_chatbook.Chat.console_scratch_space import ConsoleScratchSpaceManager
 from tldw_chatbook.Chat.thinking_blocks import normalize_thinking_history_policy
-from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
 from tldw_chatbook.config import coerce_bool_setting, runtime_capture_policy
+from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
 
 if TYPE_CHECKING:  # pragma: no cover - typing only
     from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
@@ -738,6 +743,8 @@ class ConsoleRuntime:
         self._agent_bridge: Any | None = None
         self._agent_runs_db: Any | None = None
         self._activity_receipts: Any | None = None
+        self._activity_receipts_lock = Lock()
+        self._receipt_owner_thread_id = get_ident()
         self._activity_hydration_task: asyncio.Task[int] | None = None
         self._change_review_coordinator: Any | None = None
         self._chat_controller: Any | None = None
@@ -957,6 +964,35 @@ class ConsoleRuntime:
                 )
             return authority
 
+    def _canvas_scope_for_run(self, session_id: str) -> Any:
+        """Resolve a live run's exact owner independently of the selected view.
+
+        Browser operations retain the view's active-session resolver. Queued
+        turns may start while another session or screen is selected, but must
+        still match their captured conversation and transcript branch.
+        """
+        from tldw_chatbook.Canvas.models import CanvasScope
+
+        store = self._chat_store
+        if self._disposed or store is None:
+            raise RuntimeError("Canvas session is unavailable")
+        session = next(
+            (item for item in store.sessions() if item.id == session_id), None
+        )
+        if session is None:
+            raise RuntimeError("Canvas session is unavailable")
+        active_ids = store.canvas_active_path_message_ids(session_id)
+        if not active_ids:
+            raise RuntimeError("Canvas requires an active transcript message")
+        return CanvasScope(
+            session_id=session_id,
+            conversation_id=session.persisted_conversation_id or session_id,
+            active_message_ids=active_ids,
+            selected_canvas_id=None,
+            selected_revision_id=None,
+            run_id=str(uuid4()),
+        )
+
     def _materialize_canvas_native_authority(self) -> Any:
         """Construct the single authority for an actual publication/open."""
 
@@ -976,6 +1012,7 @@ class ConsoleRuntime:
             self._canvas_native_authority = NativeConsoleCanvasAuthority(
                 scope_resolver=binding.scope_resolver,
                 canvas_controller=controller,
+                run_scope_resolver=self._canvas_scope_for_run,
                 bridge_sink=binding.bridge_sink,
                 bridge_prepare=binding.bridge_prepare,
                 auto_open=binding.auto_open,
@@ -1233,6 +1270,10 @@ class ConsoleRuntime:
         )
         self._chat_store = ConsoleChatStore(
             persistence=persistence,
+            assistant_defaults_provider=self._resolve_new_console_assistant,
+            on_assistant_default_notice=lambda notice: self._app.notify(
+                notice, severity="warning"
+            ),
             settle_provider_traces_off_thread=True,
             trace_projection=(
                 ConsoleTraceProjection(
@@ -1274,6 +1315,12 @@ class ConsoleRuntime:
             self._schedule_legacy_trace_maintenance(db, get_legacy_normalizer)
         self._bind_view_hooks()
         return self._chat_store
+
+    def _resolve_new_console_assistant(self, workspace_id: str, settings: Any) -> Any:
+        """Resolve new-chat identity without requiring a mounted Console view."""
+        from .console_assistant_defaults import resolve_new_console_assistant
+
+        return resolve_new_console_assistant(self._app, workspace_id, settings)
 
     def _schedule_legacy_trace_maintenance(
         self,
@@ -1495,6 +1542,48 @@ class ConsoleRuntime:
             )
         return self._provider_gateway
 
+    def ensure_activity_receipt_service(self) -> Any | None:
+        """Create local result storage without constructing Console or a provider.
+
+        Call via ``asyncio.to_thread`` from async presentation code. Construction
+        is serialized with other readers and disposal, and background callers
+        close their initialization connection before handing ownership back.
+
+        Returns:
+            The app-owned lazy receipt service, or None without a durable local
+            profile database or after shutdown admission has closed.
+        """
+        with self._activity_receipts_lock:
+            if self._disposed:
+                return None
+            if self._activity_receipts is not None:
+                return self._activity_receipts
+            db = getattr(self._app, "chachanotes_db", None)
+            db_path = getattr(db, "db_path", None) if db is not None else None
+            if not db_path or str(db_path) == ":memory:":
+                return None
+            from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+            runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
+            try:
+                service = _LazyConsoleActivityReceiptService(
+                    runs_db,
+                    getattr(self._app, "conversation_local_marks_service", None),
+                )
+                # Dispose writes its lifetime latch under this same lock. Never
+                # publish an owner between that latch and its resource snapshot.
+                with self._canvas_native_lock:
+                    if self._disposed:
+                        return None
+                    self._agent_runs_db = runs_db
+                    self._activity_receipts = service
+                    return service
+            finally:
+                # AgentRunsDB.close affects only the calling thread. A worker's
+                # held initialization connection cannot be closed by app exit.
+                if self._disposed or get_ident() != self._receipt_owner_thread_id:
+                    runs_db.close()
+
     def ensure_agent_bridge(
         self,
         *,
@@ -1533,20 +1622,11 @@ class ConsoleRuntime:
         """
         if self._agent_bridge is not None or self._disposed:
             return self._agent_bridge
-        db = getattr(self._app, "chachanotes_db", None)
-        db_path = getattr(db, "db_path", None) if db is not None else None
-        if not db_path or str(db_path) == ":memory:":
-            self._agent_bridge = None
+        if self.ensure_activity_receipt_service() is None or self._disposed:
             return None
         from tldw_chatbook.Chat.console_agent_bridge import ConsoleAgentBridge
-        from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
-        runs_db = AgentRunsDB(Path(db_path).parent / "agent_runs.db")
-        self._agent_runs_db = runs_db
-        self._activity_receipts = _LazyConsoleActivityReceiptService(
-            runs_db,
-            getattr(self._app, "conversation_local_marks_service", None),
-        )
+        runs_db = self._agent_runs_db
         # TASK-1971 (Agent Change Review): the tracker is None when git is
         # absent -- the bridge then skips tracking entirely, and runs behave
         # exactly as before the feature existed (spec gating decision).
@@ -1608,19 +1688,27 @@ class ConsoleRuntime:
         service = self._activity_receipts
         if service is None or self._disposed:
             return None
-        if service.hydration_state() == "ready":
-            return self._activity_hydration_task
         task = self._activity_hydration_task
         if task is not None and not task.done():
             return task
+        if service.hydration_state() == "ready":
+            return self._activity_hydration_task
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return None
         token = self.authority_token
+        runs_db = self._agent_runs_db
+
+        def read_receipts() -> int:
+            try:
+                return service.hydrate_from_storage()
+            finally:
+                if runs_db is not None:
+                    runs_db.close()
 
         async def hydrate() -> int:
-            result = await asyncio.to_thread(service.hydrate_from_storage)
+            result = await asyncio.to_thread(read_receipts)
             if self._disposed or self.authority_token != token:
                 return 0
             return result
@@ -1956,10 +2044,15 @@ class ConsoleRuntime:
         controller, gateway = self._chat_controller, self._provider_gateway
         canvas_gateway = self._canvas_gateway
         canvas_authority = self._canvas_native_authority
-        coordinator, runs_db = (
-            self._change_review_coordinator,
-            self._agent_runs_db,
-        )
+        coordinator = self._change_review_coordinator
+
+        def receipt_database_after_creation() -> Any:
+            # An inbox may still be initializing storage on a worker. Wait away
+            # from the UI loop; the disposed latch prevents late publication.
+            with self._activity_receipts_lock:
+                return self._agent_runs_db
+
+        runs_db = await asyncio.to_thread(receipt_database_after_creation)
         self.generation += 1
         hydration_task = self._activity_hydration_task
         self._activity_hydration_task = None

--- a/tldw_chatbook/Chat/console_session_settings.py
+++ b/tldw_chatbook/Chat/console_session_settings.py
@@ -2368,3 +2368,14 @@ def _format_credential_summary_row(readiness: ConsoleSettingsReadiness) -> str:
         "draft": "unsaved draft",
     }.get(readiness.credential_source, "present")
     return f"Credential: {source} (not verified)"
+
+
+@dataclass(frozen=True)
+class ConsoleAssistantStartup:
+    """Resolved settings and identity for one new conversation."""
+
+    settings: ConsoleSessionSettings
+    assistant_kind: str = "generic"
+    assistant_id: str = "console"
+    persona_memory_mode: str | None = None
+    notice: str = ""

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -8013,13 +8013,13 @@ UPDATE db_schema_version
 
     def _migrate_from_v69_to_v70(self, conn: sqlite3.Connection) -> None:
         """Add independent local Buddy owners and versioned visual bindings."""
-        self._require_migration_entry_version(conn, 69, "V69→V70")
         path = (
             Path(__file__).parent
             / "migrations"
             / "chachanotes_v69_to_v70_independent_buddy.sql"
         )
         with self.transaction() as cursor:
+            self._require_migration_entry_version(cursor.connection, 69, "V69→V70")
             self._execute_migration_statements(
                 cursor, path.read_text(encoding="utf-8"), "V69→V70"
             )
@@ -8031,8 +8031,8 @@ UPDATE db_schema_version
             )
             if updated.rowcount != 1:
                 raise SchemaError("Buddy migration version update failed")
-        if self._get_db_version(conn) != 70:
-            raise SchemaError("Buddy migration version check failed")
+            if self._get_db_version(cursor.connection) != 70:
+                raise SchemaError("Buddy migration version check failed")
 
     def _migrate_from_v68_to_v69(self, conn: sqlite3.Connection) -> None:
         """Permit the existing event FK to pin a call's exact saved source."""

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -660,7 +660,7 @@ class CharactersRAGDB:
         db_path_str (str): String representation of the database path for SQLite connection.
     """
 
-    _CURRENT_SCHEMA_VERSION = 69  # Pin the exact saved source of Console calls.
+    _CURRENT_SCHEMA_VERSION = 70  # Independent local Buddy visual ownership.
     _SCHEMA_NAME = "rag_char_chat_schema"  # Used for the db_schema_version table
     _ALLOWED_CONVERSATION_STATES = ("in-progress", "resolved", "backlog", "non-viable")
     _DEFAULT_CONVERSATION_STATE = "in-progress"
@@ -8011,6 +8011,29 @@ UPDATE db_schema_version
                 f"{type(exc).__name__}"
             ) from exc
 
+    def _migrate_from_v69_to_v70(self, conn: sqlite3.Connection) -> None:
+        """Add independent local Buddy owners and versioned visual bindings."""
+        self._require_migration_entry_version(conn, 69, "V69→V70")
+        path = (
+            Path(__file__).parent
+            / "migrations"
+            / "chachanotes_v69_to_v70_independent_buddy.sql"
+        )
+        with self.transaction() as cursor:
+            self._execute_migration_statements(
+                cursor, path.read_text(encoding="utf-8"), "V69→V70"
+            )
+            if cursor.execute("PRAGMA foreign_key_check").fetchall():
+                raise SchemaError("Buddy migration foreign key audit failed")
+            updated = cursor.execute(
+                "UPDATE db_schema_version SET version=70 WHERE schema_name=? AND version=69",
+                (self._SCHEMA_NAME,),
+            )
+            if updated.rowcount != 1:
+                raise SchemaError("Buddy migration version update failed")
+        if self._get_db_version(conn) != 70:
+            raise SchemaError("Buddy migration version check failed")
+
     def _migrate_from_v68_to_v69(self, conn: sqlite3.Connection) -> None:
         """Permit the existing event FK to pin a call's exact saved source."""
 
@@ -8281,6 +8304,7 @@ UPDATE db_schema_version
                     66: self._migrate_from_v66_to_v67,
                     67: self._migrate_from_v67_to_v68,
                     68: self._migrate_from_v68_to_v69,
+                    69: self._migrate_from_v69_to_v70,
                 }
 
                 if current_db_version == 0:

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
-from datetime import datetime, timezone
-from pathlib import Path
 import sqlite3
 import threading
 import time
+from contextlib import contextmanager
+from datetime import datetime, timezone
+from pathlib import Path
 from typing import Iterator, Union
 
 from .base_db import BaseDB
@@ -23,7 +23,7 @@ class WorkspaceDB(BaseDB):
     paint, cProfile in task-2902's notes).
     """
 
-    _CURRENT_SCHEMA_VERSION = 7
+    _CURRENT_SCHEMA_VERSION = 8
     _MIGRATE_V2_TO_V3_SQL = """BEGIN IMMEDIATE;
 
 CREATE TABLE research_source_operations (
@@ -602,6 +602,9 @@ COMMIT;
                 is not None
             )
             needs_v7 = version < 7 or not v7_backfill_exists
+            needs_v8 = version < 8 or "assistant_defaults_explicit_none" not in {
+                row[1] for row in conn.execute("PRAGMA table_info(workspace_records)")
+            }
             rows: list[tuple[str, str]] = []
             if needs_v2:
                 # Reads only here; all v2 writes happen below inside self.transaction().
@@ -625,6 +628,8 @@ COMMIT;
                 self._migrate_v5_to_v6()
             if needs_v7:
                 self._migrate_v6_to_v7()
+            if needs_v8:
+                self._migrate_v7_to_v8()
             return
 
         # Reserve every existing non-archived name up front (stripped, casefolded)
@@ -684,6 +689,8 @@ COMMIT;
             self._migrate_v5_to_v6()
         if needs_v7:
             self._migrate_v6_to_v7()
+        if needs_v8:
+            self._migrate_v7_to_v8()
 
     def _migrate_v2_to_v3(self) -> None:
         """Add durable Research source-operation intent and stage receipts."""
@@ -753,6 +760,20 @@ COMMIT;
             write_conn.execute(
                 "INSERT OR IGNORE INTO schema_version (version) VALUES (7)"
             )
+
+    def _migrate_v7_to_v8(self) -> None:
+        """Retain deliberate None defaults across provisioning and restart (ADR-139)."""
+        with self.transaction() as conn:
+            columns = {
+                row[1] for row in conn.execute("PRAGMA table_info(workspace_records)")
+            }
+            if "assistant_defaults_explicit_none" not in columns:
+                conn.execute(
+                    "ALTER TABLE workspace_records ADD COLUMN "
+                    "assistant_defaults_explicit_none INTEGER NOT NULL DEFAULT 0 "
+                    "CHECK (assistant_defaults_explicit_none IN (0, 1))"
+                )
+            conn.execute("INSERT OR IGNORE INTO schema_version (version) VALUES (8)")
 
     def get_schema_version(self) -> int:
         """Return the initialized schema version."""

--- a/tldw_chatbook/DB/Workspace_DB.py
+++ b/tldw_chatbook/DB/Workspace_DB.py
@@ -602,9 +602,11 @@ COMMIT;
                 is not None
             )
             needs_v7 = version < 7 or not v7_backfill_exists
-            needs_v8 = version < 8 or "assistant_defaults_explicit_none" not in {
-                row[1] for row in conn.execute("PRAGMA table_info(workspace_records)")
-            }
+            with self.transaction() as read_conn:
+                needs_v8 = version < 8 or "assistant_defaults_explicit_none" not in {
+                    row[1]
+                    for row in read_conn.execute("PRAGMA table_info(workspace_records)")
+                }
             rows: list[tuple[str, str]] = []
             if needs_v2:
                 # Reads only here; all v2 writes happen below inside self.transaction().

--- a/tldw_chatbook/DB/migrations/chachanotes_v69_to_v70_independent_buddy.sql
+++ b/tldw_chatbook/DB/migrations/chachanotes_v69_to_v70_independent_buddy.sql
@@ -1,0 +1,33 @@
+-- Independent Buddy authority; no Persona row or JSON mutation.
+CREATE TABLE buddy_profiles (
+    id TEXT PRIMARY KEY CHECK(length(id) BETWEEN 1 AND 128),
+    name TEXT NOT NULL CHECK(length(name) BETWEEN 1 AND 256),
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','archived','deleted')),
+    source_key TEXT UNIQUE,
+    version INTEGER NOT NULL DEFAULT 1 CHECK(version > 0),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+CREATE TABLE buddy_visual_bindings (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    buddy_id TEXT NOT NULL REFERENCES buddy_profiles(id),
+    buddy_revision INTEGER NOT NULL CHECK(buddy_revision > 0),
+    pack_id INTEGER NOT NULL REFERENCES persona_visual_packs(id),
+    active_version_id INTEGER NOT NULL,
+    status TEXT NOT NULL DEFAULT 'active' CHECK(status IN ('active','archived','deleted')),
+    created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    version INTEGER NOT NULL DEFAULT 1 CHECK(version > 0),
+    FOREIGN KEY(pack_id,active_version_id) REFERENCES persona_visual_pack_versions(pack_id,id)
+);
+CREATE UNIQUE INDEX idx_buddy_visual_bindings_active ON buddy_visual_bindings(buddy_id) WHERE status='active';
+CREATE VIEW visual_owner_bindings AS
+    SELECT id,persona_id,persona_revision,NULL AS buddy_id,NULL AS buddy_revision,
+           pack_id,active_version_id,status,created_at,updated_at,version
+      FROM persona_visual_bindings
+    UNION ALL
+    SELECT binding.id,NULL,0,binding.buddy_id,binding.buddy_revision,
+           binding.pack_id,binding.active_version_id,binding.status,
+           binding.created_at,binding.updated_at,binding.version
+      FROM buddy_visual_bindings AS binding JOIN buddy_profiles AS buddy ON buddy.id=binding.buddy_id
+     WHERE buddy.status='active' AND buddy.version=binding.buddy_revision;

--- a/tldw_chatbook/DB/migrations/workspaces_v7_to_v8_explicit_none.sql
+++ b/tldw_chatbook/DB/migrations/workspaces_v7_to_v8_explicit_none.sql
@@ -1,0 +1,6 @@
+-- ADR-139: omitted defaults may be provisioned; an explicit None must remain absent.
+BEGIN IMMEDIATE;
+ALTER TABLE workspace_records ADD COLUMN assistant_defaults_explicit_none
+    INTEGER NOT NULL DEFAULT 0 CHECK (assistant_defaults_explicit_none IN (0, 1));
+INSERT OR IGNORE INTO schema_version (version) VALUES (8);
+COMMIT;

--- a/tldw_chatbook/DB/sql_validation.py
+++ b/tldw_chatbook/DB/sql_validation.py
@@ -58,6 +58,8 @@ VALID_TABLES = {
         "actor_pack_persona_intents",
         "actor_portable_identities",
         "agent_lessons_seed_state",
+        "buddy_profiles",
+        "buddy_visual_bindings",
         "canvas_conversation_hints",
         "canvas_documents",
         "canvas_revisions",

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -876,6 +876,70 @@ class TTSEventHandler:
             playback_lifecycle=event.playback_lifecycle,
         )
 
+    async def speak_guarded_utterance(
+        self,
+        text: str,
+        *,
+        assistant_kind: str | None,
+        character_ref: CharacterRef | None,
+        expected_destination_fingerprint: str,
+        validator: Callable[[], bool],
+    ) -> bool:
+        """Speak app-owned, named Buddy text through existing TTS authority.
+
+        The caller validates the exact source/binding and supplies previously
+        confirmed destination authority. Completion means playback terminated,
+        not merely that synthesis produced an artifact. Cancellation stops only
+        this request's generation/stream/file owner; it never sends a bare Stop.
+        """
+        if not is_console_speech_destination(expected_destination_fingerprint):
+            raise ValueError("A confirmed speech destination is required.")
+        finished: asyncio.Future[bool] = asyncio.get_running_loop().create_future()
+        played = False
+
+        def report(state: str) -> None:
+            nonlocal played
+            if state == "playing":
+                played = True
+            elif state in {"stopped", "failed"} and not finished.done():
+                finished.set_result(played and state == "stopped")
+
+        owner = TTSPlaybackLifecycle(
+            message_id=f"buddy-{uuid4().hex}", request_id=1,
+            validator=validator, callback=report,
+        )
+        try:
+            if not owner.is_current():
+                return False
+            resolution = await self._resolve_speech_request_identity(
+                text=text, assistant_kind=assistant_kind, character_ref=character_ref,
+            )
+            if not owner.is_current():
+                return False
+            prepared = await self._prepare_tts_text(
+                text, owner.message_id, playback_lifecycle=owner,
+            )
+            if prepared is None or not owner.is_current():
+                return False
+
+            def generation_finished(ok: bool) -> None:
+                if ok is not True:
+                    owner.report_terminal("failed")
+
+            await self._admit_tts_generation(
+                text=prepared, message_id=owner.message_id, voice=None,
+                resolution=resolution, outcome_callback=generation_finished,
+                expected_destination_fingerprint=expected_destination_fingerprint,
+                playback_lifecycle=owner,
+            )
+            if not owner.is_current() and not finished.done():
+                return False
+            return await finished
+        finally:
+            await self.handle_tts_playback(TTSPlaybackEvent(
+                action="stop", message_id=owner.message_id, playback_lifecycle=owner,
+            ))
+
     async def speak_utterance(
         self,
         text: str,
@@ -1703,6 +1767,8 @@ class TTSEventHandler:
             admitted_provider_id: str,
             admitted_endpoint: str,
         ) -> bool:
+            if playback_lifecycle is not None and not playback_lifecycle.is_current():
+                return False
             if expected_destination_fingerprint is None:
                 return True
             try:
@@ -1717,7 +1783,7 @@ class TTSEventHandler:
 
         admission_authorizer = (
             authorize_destination
-            if expected_destination_fingerprint is not None
+            if expected_destination_fingerprint is not None or playback_lifecycle is not None
             else None
         )
 

--- a/tldw_chatbook/Persona_Buddy/__init__.py
+++ b/tldw_chatbook/Persona_Buddy/__init__.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     )
     from .preferences import (
         PERSONA_BUDDY_UNPOSITIONED_COORDINATE,
+        BuddySelection,
         PersonaBuddyGeometry,
         PersonaBuddyPreferences,
         PersonaBuddySelection,
@@ -51,6 +52,7 @@ _EXPORTS = {
     "PersonaBuddyGeometry": "preferences",
     "PersonaBuddyPreferences": "preferences",
     "PersonaBuddySelection": "preferences",
+    "BuddySelection": "preferences",
     "parse_persona_buddy_preferences": "preferences",
     "persist_persona_buddy_preferences": "preferences",
     "serialize_persona_buddy_preferences": "preferences",
@@ -71,6 +73,7 @@ __all__ = (
     "PersonaBuddyPreferences",
     "PersonaBuddyPreparedFrame",
     "PersonaBuddySelection",
+    "BuddySelection",
     "PersonaBuddySnapshot",
     "PersonaBuddyVisualSnapshot",
     "load_local_persona_portrait",

--- a/tldw_chatbook/Persona_Buddy/console_adapter.py
+++ b/tldw_chatbook/Persona_Buddy/console_adapter.py
@@ -119,11 +119,14 @@ class PersonaBuddyConsoleAdapter:
         self._lock = RLock()
         self._clock = time.monotonic
         self._disposed = False
+        self._scope_sessions: frozenset[str] | None = None
+        self._scope_conversations: frozenset[str] | None = None
         self._tokens: dict[tuple[str, str], PersonaBuddyLeaseToken] = {}
         self._run_generation: dict[str, int] = {}
         self._run_owners: dict[str, str] = {}
         self._approval_owners: dict[tuple[str, str], str] = {}
         self._tool_owners: dict[tuple[str, int], str] = {}
+        self._tool_sessions: dict[tuple[str, int], str | None] = {}
         self._wake_owners: dict[tuple[str, str], str] = {}
         self._voice_owners: dict[tuple[str, int], str] = {}
         self._voice_generation: dict[str, int] = {}
@@ -138,6 +141,101 @@ class PersonaBuddyConsoleAdapter:
                 self._controller = controller
             elif self._controller is not controller:
                 raise RuntimeError("persona_buddy_console_controller_replacement")
+
+    def set_scope(
+        self, *, session_ids: frozenset[str], conversation_ids: frozenset[str]
+    ) -> bool:
+        """Replace permitted owners, retiring leases from the previous scope.
+
+        Returns whether scope changed. Callers replay current trusted state only
+        after a change; repeated reconciliation does not restart animations.
+        """
+        if not isinstance(session_ids, frozenset) or not isinstance(
+            conversation_ids, frozenset
+        ):
+            raise TypeError("buddy_scope_invalid")
+        if any(
+            type(value) is not str or not value
+            for value in session_ids | conversation_ids
+        ):
+            raise ValueError("buddy_scope_invalid")
+        with self._lock:
+            if self._disposed:
+                return False
+            if (session_ids, conversation_ids) == (
+                self._scope_sessions,
+                self._scope_conversations,
+            ):
+                return False
+            # Scope affects presentation, not accepted run identity. Keep leases
+            # for retained members, and keep the run ledger so a reattached
+            # projection accepts that run's original terminal callback.
+            retained = {
+                ("console-run", owner)
+                for session, owner in self._run_owners.items()
+                if session in session_ids
+            }
+            retained.update(
+                ("approval", owner)
+                for (session, _), owner in self._approval_owners.items()
+                if session in session_ids
+            )
+            retained.update(
+                ("tool", owner)
+                for key, owner in self._tool_owners.items()
+                if self._tool_sessions.get(key) in session_ids
+            )
+            retained.update(
+                ("wake", owner)
+                for (conversation, _), owner in self._wake_owners.items()
+                if conversation in conversation_ids
+            )
+            retained.update(
+                ("voice", owner)
+                for (session, _), owner in self._voice_owners.items()
+                if session in session_ids
+            )
+            for key, token in tuple(self._tokens.items()):
+                if key not in retained:
+                    if self._controller is not None:
+                        self._controller.release_state(token=token)
+                    self._tokens.pop(key, None)
+            self._approval_owners = {
+                key: owner
+                for key, owner in self._approval_owners.items()
+                if key[0] in session_ids
+            }
+            self._tool_owners = {
+                key: owner
+                for key, owner in self._tool_owners.items()
+                if ("tool", owner) in retained
+            }
+            self._tool_sessions = {
+                key: session
+                for key, session in self._tool_sessions.items()
+                if key in self._tool_owners
+            }
+            self._wake_owners = {
+                key: owner
+                for key, owner in self._wake_owners.items()
+                if key[0] in conversation_ids
+            }
+            self._voice_owners = {
+                key: owner
+                for key, owner in self._voice_owners.items()
+                if key[0] in session_ids
+            }
+            self._voice_generation = {
+                session: generation
+                for session, generation in self._voice_generation.items()
+                if session in session_ids
+            }
+            self._scope_sessions = session_ids
+            self._scope_conversations = conversation_ids
+            return True
+
+    def _session_allowed(self, session_id: str | None) -> bool:
+        return self._scope_sessions is None or session_id in self._scope_sessions
 
     @staticmethod
     def _owner(kind: str, *parts: object) -> str:
@@ -189,16 +287,21 @@ class PersonaBuddyConsoleAdapter:
         )
 
     def run_state(
-        self, session_id: str, status: object, *, run_owner: str | None = None
+        self,
+        session_id: str,
+        status: object,
+        *,
+        run_owner: str | None = None,
+        replay: bool = False,
     ) -> str | None:
-        """Map one per-session run state, replacing on a new validation."""
+        """Map run state; scope replay preserves an already accepted owner."""
 
         normalized = str(getattr(status, "value", status)).strip().lower()
         with self._lock:
             if self._disposed or self._controller is None:
                 return None
             owner = self._run_owners.get(session_id)
-            if normalized == "validating":
+            if normalized == "validating" and not (replay and owner is not None):
                 if owner is not None:
                     self._release("console-run", owner)
                 generation = self._run_generation.get(session_id, 0) + 1
@@ -220,7 +323,7 @@ class PersonaBuddyConsoleAdapter:
                     self._run_owners.pop(session_id, None)
                 return None
             state = _RUN_STATES.get(normalized)
-            if state is None or owner is None:
+            if state is None or owner is None or not self._session_allowed(session_id):
                 return owner
             self.publish(
                 BuddyLifecycleEvent(
@@ -238,7 +341,11 @@ class PersonaBuddyConsoleAdapter:
 
         key = (session_id, round_id)
         with self._lock:
-            if self._disposed or self._controller is None:
+            if (
+                self._disposed
+                or self._controller is None
+                or not self._session_allowed(session_id)
+            ):
                 return None
             owner = self._approval_owners.get(key)
             if not pending:
@@ -258,14 +365,21 @@ class PersonaBuddyConsoleAdapter:
             )
             return owner
 
-    def tool_step(self, run_id: str, sequence: int, kind: str) -> str | None:
+    def tool_step(
+        self, run_id: str, sequence: int, kind: str, *, session_id: str | None = None
+    ) -> str | None:
         """Pair a tool-call start with its exact result or run cleanup."""
 
         key = (run_id, sequence)
         with self._lock:
-            if self._disposed or self._controller is None:
+            if (
+                self._disposed
+                or self._controller is None
+                or not self._session_allowed(session_id)
+            ):
                 return None
             if kind == _TOOL_START:
+                self._tool_sessions[key] = session_id
                 owner = self._tool_owners.get(key)
                 if owner is None:
                     owner = self._owner("tool", run_id, sequence)
@@ -280,6 +394,7 @@ class PersonaBuddyConsoleAdapter:
                 return owner
             if kind in _TOOL_RELEASE:
                 owner = self._tool_owners.pop(key, None)
+                self._tool_sessions.pop(key, None)
                 if owner is not None:
                     self._release("tool", owner)
                 return None
@@ -295,13 +410,21 @@ class PersonaBuddyConsoleAdapter:
                 if key[0] == run_id:
                     self._release("tool", owner)
                     self._tool_owners.pop(key, None)
+                    self._tool_sessions.pop(key, None)
 
     def wake(self, conversation_id: str, run_id: str, *, active: bool) -> str | None:
         """Mirror one pending or delivering fleet-wake membership."""
 
         key = (conversation_id, run_id)
         with self._lock:
-            if self._disposed or self._controller is None:
+            if (
+                self._disposed
+                or self._controller is None
+                or (
+                    self._scope_conversations is not None
+                    and conversation_id not in self._scope_conversations
+                )
+            ):
                 return None
             owner = self._wake_owners.get(key)
             if not active:
@@ -337,7 +460,11 @@ class PersonaBuddyConsoleAdapter:
 
         key = (session_id, generation)
         with self._lock:
-            if self._disposed or self._controller is None:
+            if (
+                self._disposed
+                or self._controller is None
+                or not self._session_allowed(session_id)
+            ):
                 return None
             current_generation = self._voice_generation.get(session_id)
             if current_generation is not None and generation < current_generation:
@@ -435,6 +562,7 @@ class PersonaBuddyConsoleAdapter:
         self._run_owners.clear()
         self._approval_owners.clear()
         self._tool_owners.clear()
+        self._tool_sessions.clear()
         self._wake_owners.clear()
         self._voice_owners.clear()
         self._voice_generation.clear()

--- a/tldw_chatbook/Persona_Buddy/controller.py
+++ b/tldw_chatbook/Persona_Buddy/controller.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field, replace
 from numbers import Real
 from pathlib import Path
 from threading import RLock
-from typing import Generic, Literal, TypeVar
+from typing import TYPE_CHECKING, Generic, Literal, TypeVar
 
 from tldw_chatbook.Persona_Visual.repository import (
     PersonaVisualGraph,
@@ -24,10 +24,12 @@ from tldw_chatbook.Persona_Visual.runtime import (
     PersonaVisualCacheIdentity,
     PersonaVisualPortrait,
     PersonaVisualResolution,
+    resolve_active_buddy_visual,
     resolve_active_persona_visual,
 )
 
 from .preferences import (
+    BuddySelection,
     PersonaBuddyPreferences,
     PersonaBuddySelection,
     persist_persona_buddy_preferences,
@@ -42,6 +44,8 @@ from .rendering import (
     prepare_persona_buddy_portrait,
 )
 
+if TYPE_CHECKING:
+    from .library import BuddyLibrary
 
 _BUILTIN_STATES = frozenset(
     {
@@ -138,7 +142,7 @@ class PersonaBuddySnapshot:
     """Immutable controller state safe for app-owned consumers."""
 
     generation: int
-    selection: PersonaBuddySelection | None
+    selection: PersonaBuddySelection | BuddySelection | None
     state: str
     state_source: str | None = None
     state_owner: str | None = None
@@ -169,11 +173,12 @@ class PersonaBuddyVisualSnapshot:
     frame_rate: float | None = None
     loop: bool = False
     animate: bool = False
+    buddy_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
 class _ResolutionTicket:
-    selection: PersonaBuddySelection
+    selection: PersonaBuddySelection | BuddySelection
     requested_state: str
     controller_generation: int
     preferences_generation: int
@@ -187,9 +192,10 @@ class _ResolutionTicket:
 
 @dataclass(frozen=True, slots=True)
 class _LocalPersona:
-    persona_id: str
+    persona_id: str | None
     revision: int
     portrait: PersonaVisualPortrait | None = field(default=None, repr=False)
+    buddy_id: str | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -317,7 +323,7 @@ class PersonaBuddyController:
     def __init__(
         self,
         *,
-        selection: PersonaBuddySelection | None = None,
+        selection: PersonaBuddySelection | BuddySelection | None = None,
         preferences: PersonaBuddyPreferences | None = None,
         clock: Callable[[], float] = time.monotonic,
         local_persona_service: object | None = None,
@@ -337,7 +343,10 @@ class PersonaBuddyController:
         on_change: Callable[[], None] | None = None,
         phase_barrier: Callable[[str], Awaitable[None] | None] | None = None,
     ) -> None:
-        if selection is not None and type(selection) is not PersonaBuddySelection:
+        if selection is not None and type(selection) not in (
+            PersonaBuddySelection,
+            BuddySelection,
+        ):
             raise PersonaBuddyStateError()
         if preferences is not None and type(preferences) is not PersonaBuddyPreferences:
             raise PersonaBuddyStateError()
@@ -434,7 +443,12 @@ class PersonaBuddyController:
             self._apply_preferences_locked(candidate)
             return self._preferences_generation
 
-    async def persist_preferences_revision(self, revision: int) -> bool:
+    async def persist_preferences_revision(
+        self,
+        revision: int,
+        *,
+        extra_sections: Mapping[str, Mapping[str, object]] | None = None,
+    ) -> bool:
         """Persist current merged preferences once for one applied revision.
 
         A failed write leaves the immediate in-memory intent authoritative; it is
@@ -452,9 +466,35 @@ class PersonaBuddyController:
                 with self._lock:
                     if revision > self._preferences_generation:
                         raise PersonaBuddyStateError()
+                    if (
+                        extra_sections is not None
+                        and revision != self._preferences_generation
+                    ):
+                        return False
                     candidate = self._preferences
+                writer = self._preference_writer
+                if extra_sections is not None:
+                    from .preferences import (
+                        save_settings_to_cli_config,
+                        serialize_persona_buddy_preferences,
+                    )
+
+                    if not isinstance(extra_sections, Mapping) or set(
+                        extra_sections
+                    ) != {"buddy_interaction"}:
+                        raise PersonaBuddyStateError()
+                    sections = {
+                        name: dict(values) for name, values in extra_sections.items()
+                    }
+                    sections["persona_buddy"] = serialize_persona_buddy_preferences(
+                        candidate
+                    )
+
+                    def writer(_candidate):
+                        return save_settings_to_cli_config(sections)
+
                 write = await self._drain_owned(
-                    asyncio.to_thread(self._preference_writer, candidate),
+                    asyncio.to_thread(writer, candidate),
                     name="preferences:patch-write",
                 )
                 return write.completed and write.value is True
@@ -465,6 +505,63 @@ class PersonaBuddyController:
         if outcome.cancellation is not None:
             raise outcome.cancellation
         return outcome.completed and outcome.value is True
+
+    async def migrate_legacy_selection(self, library: BuddyLibrary) -> bool:
+        """Publish a retryable independent copy before changing durable selection."""
+
+        async def serialized() -> bool:
+            async with self._operation_lock:
+                previous = self.current_preferences()
+                if type(previous.selection) is not PersonaBuddySelection:
+                    return False
+                outcome = await self._drain_owned(
+                    asyncio.to_thread(
+                        library.migrate_legacy_selection,
+                        previous,
+                        writer=lambda _: True,
+                    ),
+                    name="legacy:copy",
+                )
+                candidate = outcome.value
+                if (
+                    not outcome.completed
+                    or candidate == previous
+                    or self.current_preferences() != previous
+                ):
+                    return False
+                written = await self._drain_owned(
+                    asyncio.to_thread(self._preference_writer, candidate),
+                    name="legacy:preferences",
+                )
+                if not written.completed or written.value is not True:
+                    return False
+                with self._lock:
+                    if self._preferences == previous:
+                        self._apply_preferences_locked(candidate)
+                        return True
+                    current = self._preferences
+                # A newer UI preference won during the write; restore that durable
+                # snapshot under the same serialized writer before returning.
+                await self._drain_owned(
+                    asyncio.to_thread(self._preference_writer, current),
+                    name="legacy:newer-preferences",
+                )
+                return False
+
+        result = await self._drain_owned(serialized(), name="legacy:migration")
+        return result.completed and result.value is True
+
+    def rollback_preferences_revision(
+        self, revision: int, previous: PersonaBuddyPreferences
+    ) -> bool:
+        """Restore a failed staged Apply only while its exact revision still owns state."""
+        if type(previous) is not PersonaBuddyPreferences:
+            raise PersonaBuddyStateError()
+        with self._lock:
+            if revision != self._preferences_generation:
+                return False
+            self._apply_preferences_locked(previous)
+            return True
 
     def select_local_persona(self, persona_id: str) -> int:
         """Explicitly replace the selected local Persona and return generation."""
@@ -477,6 +574,10 @@ class PersonaBuddyController:
                 self._preferences_generation += 1
                 self._advance_generation_locked()
             return self._generation
+
+    def select_buddy(self, buddy_id: str) -> int:
+        """Select independent artwork; persist the returned preference revision."""
+        return self.apply_preferences_patch(selection=BuddySelection(buddy_id))
 
     def invalidate_profile(self) -> int:
         """Advance local Persona/graph authority without clearing preferences."""
@@ -759,7 +860,12 @@ class PersonaBuddyController:
                     )
 
                 persona_outcome = await self._drain_owned(
-                    asyncio.to_thread(self._read_local_persona, ticket.selection),
+                    asyncio.to_thread(
+                        self._read_local_buddy
+                        if type(ticket.selection) is BuddySelection
+                        else self._read_local_persona,
+                        ticket.selection,
+                    ),
                     name="resolve:persona-read",
                 )
                 if not self._is_current(ticket):
@@ -775,7 +881,15 @@ class PersonaBuddyController:
                     return self._stale_snapshot(ticket)
 
                 graph_outcome = await self._drain_owned(
-                    asyncio.to_thread(self._read_graph, persona.persona_id),
+                    asyncio.to_thread(
+                        self._read_graph,
+                        persona.persona_id,
+                        **(
+                            {"buddy_id": persona.buddy_id}
+                            if persona.buddy_id is not None
+                            else {}
+                        ),
+                    ),
                     name="resolve:graph-read",
                 )
                 if not self._is_current(ticket):
@@ -784,7 +898,8 @@ class PersonaBuddyController:
                 if (
                     type(graph) is not PersonaVisualGraph
                     or graph.identity.persona_id != persona.persona_id
-                    or graph.identity.persona_revision != persona.revision
+                    or graph.identity.buddy_id != persona.buddy_id
+                    or graph.identity.owner_revision != persona.revision
                 ):
                     return self._apply_unavailable(
                         "persona_buddy_binding_unavailable",
@@ -859,7 +974,10 @@ class PersonaBuddyController:
                     reason=resolution.reason,
                     source=resolution.source,
                     persona_id=persona.persona_id,
-                    persona_revision=persona.revision,
+                    persona_revision=persona.revision
+                    if persona.persona_id is not None
+                    else None,
+                    buddy_id=persona.buddy_id,
                     requested_state=resolution.requested_state,
                     resolved_state=resolution.resolved_state,
                     animation_id=resolution.animation_id,
@@ -1013,8 +1131,23 @@ class PersonaBuddyController:
                 return False
         return self._is_current(ticket)
 
+    def _read_local_buddy(self, selection: BuddySelection) -> _LocalPersona | None:
+        from .library import BuddyLibrary
+
+        try:
+            buddy = BuddyLibrary(self._profile_db, self._profile_root).get_buddy(
+                selection.buddy_id
+            )
+            return (
+                None
+                if buddy is None
+                else _LocalPersona(None, buddy.revision, buddy_id=buddy.id)
+            )
+        except Exception:  # noqa: BLE001 - reject invalid private library authority without paths
+            return None
+
     def _read_local_persona(
-        self, selection: PersonaBuddySelection
+        self, selection: PersonaBuddySelection | BuddySelection
     ) -> _LocalPersona | None:
         service = self._local_persona_service
         getter = getattr(service, "get_persona_profile", None)
@@ -1042,12 +1175,17 @@ class PersonaBuddyController:
         except Exception:
             return None
 
-    def _read_graph(self, persona_id: str) -> PersonaVisualGraph | None:
+    def _read_graph(
+        self, persona_id: str | None, *, buddy_id: str | None = None
+    ) -> PersonaVisualGraph | None:
         if self._profile_db is None:
             return None
         try:
-            return self._repository_factory(self._profile_db).get_active_persona_pack(
-                persona_id
+            repository = self._repository_factory(self._profile_db)
+            return (
+                repository.get_active_buddy_pack(buddy_id)
+                if buddy_id is not None
+                else repository.get_active_persona_pack(persona_id)
             )
         except Exception:
             return None
@@ -1061,6 +1199,14 @@ class PersonaBuddyController:
         if self._profile_db is None or self._profile_root is None:
             return None
         try:
+            if persona.buddy_id is not None:
+                return resolve_active_buddy_visual(
+                    self._repository_factory(self._profile_db),
+                    persona.buddy_id,
+                    self._profile_root,
+                    requested_state,
+                    reduced_motion=reduced_motion,
+                )
             return resolve_active_persona_visual(
                 self._repository_factory(self._profile_db),
                 persona.persona_id,
@@ -1169,6 +1315,7 @@ class PersonaBuddyController:
                 previous is not None
                 and previous.available
                 and previous.persona_id == persona.persona_id
+                and previous.buddy_id == persona.buddy_id
                 and previous.frames
             ):
                 retained = replace(previous, reason=reason)
@@ -1214,7 +1361,10 @@ class PersonaBuddyController:
             reason=reason,
             source="unavailable",
             persona_id=persona.persona_id if persona else None,
-            persona_revision=persona.revision if persona else None,
+            persona_revision=persona.revision
+            if persona and persona.persona_id is not None
+            else None,
+            buddy_id=persona.buddy_id if persona else None,
             requested_state=requested_state,
             resolved_state=None,
             animation_id=None,
@@ -1229,7 +1379,12 @@ class PersonaBuddyController:
             available=False,
             reason="persona_buddy_resolution_stale",
             source="unavailable",
-            persona_id=ticket.selection.local_persona_id,
+            persona_id=ticket.selection.local_persona_id
+            if type(ticket.selection) is PersonaBuddySelection
+            else None,
+            buddy_id=ticket.selection.buddy_id
+            if type(ticket.selection) is BuddySelection
+            else None,
             persona_revision=None,
             requested_state=ticket.requested_state,
             resolved_state=None,

--- a/tldw_chatbook/Persona_Buddy/inbox.py
+++ b/tldw_chatbook/Persona_Buddy/inbox.py
@@ -1,0 +1,123 @@
+"""Read-only workspace activity projection over existing Console owners."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from .interaction import BuddyBinding
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyInboxEntry:
+    """One live conversation or one independently acknowledgeable result."""
+
+    key: str
+    title: str
+    group: Literal["needs_you", "running", "results"]
+    summary: str
+    binding: BuddyBinding
+    receipt_ids: tuple[str, ...] = ()
+
+
+def project_workspace_inbox(
+    workspace_id: str,
+    *,
+    sessions: Iterable[Any],
+    receipts: Iterable[Any],
+    run_states: Mapping[str, Any],
+    activities: Mapping[str, Any],
+    member_titles: Mapping[str, str],
+) -> tuple[BuddyInboxEntry, ...]:
+    """Project current local scope without marking viewed results or decisions.
+
+    Args:
+        workspace_id: Explicit workspace owner.
+        sessions: Current runtime sessions, including other workspaces.
+        receipts: Existing immutable unseen outcome records.
+        run_states: Per-session run snapshots.
+        activities: Queue-aware per-session activity snapshots.
+        member_titles: Verified current durable workspace members and their titles.
+    """
+    live = tuple(sessions)
+    scoped = {
+        session.id: session
+        for session in live
+        if session.runtime_backend == "local" and session.workspace_id == workspace_id
+    }
+    rows: list[BuddyInboxEntry] = []
+    for session in scoped.values():
+        activity = activities.get(session.id)
+        state = run_states.get(session.id)
+        if getattr(activity, "needs_approval", False):
+            group, summary = "needs_you", "A question or approval needs your response"
+        elif getattr(activity, "queue_paused", False):
+            group, summary = (
+                "needs_you",
+                "Queued follow-ups are paused; review in Console",
+            )
+        elif state is not None and not state.is_send_allowed:
+            group, summary = "running", state.visible_copy or "Working"
+        elif getattr(activity, "queued_count", 0):
+            group, summary = "running", "Follow-ups queued"
+        else:
+            continue
+        rows.append(
+            BuddyInboxEntry(
+                f"live:{session.id}",
+                session.title,
+                group,
+                summary,
+                BuddyBinding.for_session(session),
+            )
+        )
+
+    for receipt in receipts:
+        conversation_id = receipt.conversation_id
+        if conversation_id:
+            matches = [
+                s for s in live if s.persisted_conversation_id == conversation_id
+            ]
+        else:
+            matches = [
+                s
+                for s in live
+                if s.id == receipt.session_id and not s.persisted_conversation_id
+            ]
+        if len(matches) > 1:
+            continue  # No ambiguous live conversation authority.
+        if matches:
+            session = matches[0]
+            if session.id not in scoped:
+                continue  # Current live placement wins over stale membership.
+            binding = BuddyBinding.for_session(session)
+            title = session.title
+        elif conversation_id and conversation_id in member_titles:
+            binding = BuddyBinding(
+                kind="conversation",
+                target_id=f"saved:{conversation_id}",
+                conversation_id=conversation_id,
+            )
+            title = member_titles[conversation_id]
+        else:
+            continue
+        summary = {
+            "done": "Response ready",
+            "completed": "Response ready",
+            "failed": "Run failed; review the result",
+            "cancelled": "Run stopped",
+            "stuck": "Run needs review",
+        }.get(receipt.status, "New run result")
+        rows.append(
+            BuddyInboxEntry(
+                f"result:{receipt.activity_id}",
+                title,
+                "results",
+                summary,
+                binding,
+                (receipt.activity_id,),
+            )
+        )
+    order = {"needs_you": 0, "running": 1, "results": 2}
+    return tuple(sorted(rows, key=lambda row: order[row.group]))

--- a/tldw_chatbook/Persona_Buddy/interaction.py
+++ b/tldw_chatbook/Persona_Buddy/interaction.py
@@ -1,0 +1,173 @@
+"""Private Buddy presentation preferences and exact local conversation bindings.
+
+A binding never consults Console selection. It can reconnect a durable conversation
+in a new runtime, but cannot follow a repurposed live slot or a remote identifier.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from typing import Any, Literal
+
+_ID = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,255}\Z")
+
+
+def _valid_id(value: object) -> bool:
+    return type(value) is str and _ID.fullmatch(value) is not None
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyBinding:
+    """An explicit local target, independent of the selected Console session."""
+
+    kind: Literal["conversation", "workspace"]
+    target_id: str
+    conversation_id: str | None = None
+    binding_revision: int = 0
+    ephemeral: bool = False
+
+    def __post_init__(self) -> None:
+        if self.kind not in {"conversation", "workspace"} or not _valid_id(
+            self.target_id
+        ):
+            raise ValueError("Choose a valid conversation or workspace for the Buddy.")
+        if self.conversation_id is not None and not _valid_id(self.conversation_id):
+            raise ValueError("Invalid Buddy conversation reference.")
+        if type(self.binding_revision) is not int or self.binding_revision < 0:
+            raise ValueError("Invalid Buddy conversation binding revision.")
+        if type(self.ephemeral) is not bool:
+            raise ValueError("Invalid temporary conversation binding.")
+        if self.kind == "workspace" and (
+            self.conversation_id is not None or self.ephemeral or self.binding_revision
+        ):
+            raise ValueError("A workspace binding cannot carry conversation identity.")
+        if self.ephemeral and self.conversation_id is not None:
+            raise ValueError("A temporary conversation cannot carry durable identity.")
+
+    @classmethod
+    def for_session(cls, session: Any) -> BuddyBinding:
+        """Capture an existing local session without changing or persisting it."""
+        if session.runtime_backend != "local":
+            raise ValueError(
+                "Buddy interaction currently supports local conversations."
+            )
+        return cls(
+            kind="conversation",
+            target_id=session.id,
+            conversation_id=session.persisted_conversation_id,
+            binding_revision=session.conversation_binding_revision,
+            ephemeral=session.ephemeral,
+        )
+
+    def resolve_session(self, sessions: Iterable[Any]) -> Any | None:
+        """Find exactly the bound live session or its uniquely restored local record."""
+        if self.kind != "conversation":
+            return None
+        candidates = list(sessions)
+        # A present but repurposed live slot invalidates this binding. Never recover
+        # by falling through to another copy of a durable conversation in that case.
+        live = [row for row in candidates if row.id == self.target_id]
+        if live:
+            if len(live) != 1:
+                return None
+            row = live[0]
+            return (
+                row
+                if (
+                    row.runtime_backend == "local"
+                    and row.conversation_binding_revision == self.binding_revision
+                    and row.ephemeral == self.ephemeral
+                    and (
+                        self.conversation_id is None
+                        or row.persisted_conversation_id == self.conversation_id
+                    )
+                )
+                else None
+            )
+        if self.conversation_id is None or self.ephemeral:
+            return None
+        restored = [
+            row
+            for row in candidates
+            if row.runtime_backend == "local"
+            and not row.ephemeral
+            and row.persisted_conversation_id == self.conversation_id
+        ]
+        return restored[0] if len(restored) == 1 else None
+
+    def includes(self, session: Any) -> bool:
+        """Test scope for a trusted runtime event without reading any transcript."""
+        if self.kind == "workspace":
+            return (
+                session.runtime_backend == "local"
+                and session.workspace_id == self.target_id
+            )
+        return self.resolve_session((session,)) is session
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyInteractionPreferences:
+    """Presentation-only settings; artwork and run authority have other owners."""
+
+    binding: BuddyBinding | None = None
+    animated: bool = True
+    speak_responses: bool = False
+
+    def __post_init__(self) -> None:
+        if self.binding is not None and not isinstance(self.binding, BuddyBinding):
+            raise ValueError("Invalid Buddy target.")
+        if type(self.animated) is not bool or type(self.speak_responses) is not bool:
+            raise ValueError("Invalid Buddy animation or speech preference.")
+
+
+def serialize_preferences(
+    preferences: BuddyInteractionPreferences,
+) -> dict[str, object]:
+    """Encode profile-safe values, excluding temporary conversation references."""
+    binding = preferences.binding
+    values: dict[str, object] = {
+        "animated": preferences.animated,
+        "speak_responses": preferences.speak_responses,
+        # Explicit empty keys clear a previous target with the merge-based writer.
+        "kind": "",
+        "target_id": "",
+        "conversation_id": "",
+        "binding_revision": 0,
+    }
+    if binding is not None and not binding.ephemeral:
+        values.update(
+            kind=binding.kind,
+            target_id=binding.target_id,
+            conversation_id=binding.conversation_id or "",
+            binding_revision=binding.binding_revision,
+        )
+    return values
+
+
+def parse_preferences(
+    raw: Mapping[str, object] | object,
+) -> BuddyInteractionPreferences:
+    """Parse untrusted profile settings with independent safe field fallbacks."""
+    if not isinstance(raw, Mapping):
+        return BuddyInteractionPreferences()
+    binding = None
+    try:
+        binding = BuddyBinding(
+            kind=raw.get("kind", ""),  # type: ignore[arg-type]
+            target_id=raw.get("target_id", ""),  # type: ignore[arg-type]
+            conversation_id=raw.get("conversation_id") or None,  # type: ignore[arg-type]
+            binding_revision=raw.get("binding_revision", 0),  # type: ignore[arg-type]
+        )
+    except (TypeError, ValueError):
+        pass
+    return BuddyInteractionPreferences(
+        binding=binding,
+        animated=raw.get("animated") if type(raw.get("animated")) is bool else True,
+        speak_responses=(
+            raw.get("speak_responses")
+            if type(raw.get("speak_responses")) is bool
+            else False
+        ),
+    )

--- a/tldw_chatbook/Persona_Buddy/library.py
+++ b/tldw_chatbook/Persona_Buddy/library.py
@@ -66,29 +66,94 @@ class BuddyLibrary:
         *,
         persona_reader: Callable[[str], Mapping[str, object]] | None = None,
     ) -> None:
+        """Bind operations to one local profile.
+
+        Args:
+            db: Profile database owning Buddy and visual records.
+            profile_root: Confined root for private visual files.
+            persona_reader: Current local Persona authority used for guarded copying.
+        """
         self.db = db
         self.profile_root = Path(profile_root)
         self.repository = PersonaVisualRepository(db)
         self.persona_reader = persona_reader
 
-    def list_buddies(self) -> tuple[BuddyRecord, ...]:
-        rows = self.db.execute_query(
-            "SELECT buddy.id,buddy.name,buddy.version,buddy.source_key FROM buddy_profiles buddy "
-            "JOIN buddy_visual_bindings binding ON binding.buddy_id=buddy.id "
-            "WHERE buddy.status='active' AND binding.status='active' "
-            "AND binding.buddy_revision=buddy.version ORDER BY buddy.name COLLATE NOCASE,buddy.id"
-        ).fetchall()
+    def list_buddies(
+        self, *, limit: int = 100, offset: int = 0
+    ) -> tuple[BuddyRecord, ...]:
+        """Read one bounded, consistently ordered page of installed artwork.
+
+        Args:
+            limit: Maximum records in this page, from 1 through 100.
+            offset: Number of ordered records to skip, starting at zero.
+
+        Returns:
+            Active owners with a current active visual binding, ordered by name/id.
+
+        Raises:
+            ValueError: The requested page bounds are invalid.
+        """
+        if (
+            type(limit) is not int
+            or not 1 <= limit <= 100
+            or type(offset) is not int
+            or offset < 0
+        ):
+            raise ValueError("buddy_page_invalid")
+        with self.db.transaction() as cursor:
+            rows = cursor.execute(
+                "SELECT buddy.id,buddy.name,buddy.version,buddy.source_key FROM buddy_profiles buddy "
+                "JOIN buddy_visual_bindings binding ON binding.buddy_id=buddy.id "
+                "WHERE buddy.status='active' AND binding.status='active' "
+                "AND binding.buddy_revision=buddy.version ORDER BY buddy.name COLLATE NOCASE,buddy.id "
+                "LIMIT ? OFFSET ?",
+                (limit, offset),
+            ).fetchall()
         return tuple(BuddyRecord(*row) for row in rows)
 
     def get_buddy(self, buddy_id: str) -> BuddyRecord | None:
-        return next((row for row in self.list_buddies() if row.id == buddy_id), None)
+        """Read one installed Buddy without enumerating the library.
+
+        Args:
+            buddy_id: Exact profile-local Buddy identity.
+
+        Returns:
+            Its active record, or None if the owner/binding is unavailable.
+        """
+        with self.db.transaction() as cursor:
+            row = cursor.execute(
+                "SELECT buddy.id,buddy.name,buddy.version,buddy.source_key FROM buddy_profiles buddy "
+                "JOIN buddy_visual_bindings binding ON binding.buddy_id=buddy.id "
+                "WHERE buddy.id=? AND buddy.status='active' AND binding.status='active' "
+                "AND binding.buddy_revision=buddy.version",
+                (buddy_id,),
+            ).fetchone()
+        return BuddyRecord(*row) if row is not None else None
 
     def get_graph(self, buddy_id: str) -> PersonaVisualGraph | None:
+        """Read the current visual identity for one Buddy.
+
+        Args:
+            buddy_id: Exact profile-local Buddy identity.
+
+        Returns:
+            Active visual graph, or None for an unavailable owner/binding.
+        """
         return self.repository.get_active_buddy_pack(buddy_id)
 
     def resolve_preview(
         self, buddy_id: str, *, state: str = "idle", reduced_motion: bool = False
     ) -> PersonaVisualResolution:
+        """Resolve a validated preview through the native renderer.
+
+        Args:
+            buddy_id: Exact profile-local Buddy identity.
+            state: Requested expression state.
+            reduced_motion: Whether animation must be suppressed.
+
+        Returns:
+            Render resolution with either validated artwork or an unavailable reason.
+        """
         return resolve_active_buddy_visual(
             self.repository,
             buddy_id,
@@ -99,19 +164,42 @@ class BuddyLibrary:
 
     @staticmethod
     def review_archive(path: Path | str) -> BuddySnapshot:
-        """Validate archive bytes and notices without staging or changing selection."""
+        """Validate archive bytes and notices without changing selection.
+
+        Args:
+            path: Absolute native archive path; links are rejected.
+
+        Returns:
+            Reviewed content with its private source-revalidation guard.
+
+        Raises:
+            PersonaVisualImportError: Invalid archive/path or changed source.
+        """
         return read_buddy_archive(path)
 
     def import_archive(
         self, path: Path | str, *, name: str | None = None
     ) -> BuddyRecord:
+        """Review and publish a native pack as independent artwork.
+
+        Args:
+            path: Absolute native archive path.
+            name: Optional display-name override.
+
+        Returns:
+            Published Buddy record, without changing selection.
+
+        Raises:
+            ValueError: Review, publication, or name validation fails.
+        """
         return self.publish_review(self.review_archive(path), name=name)
 
     def _source_record(self, source_key: str) -> BuddyRecord | None:
-        row = self.db.execute_query(
-            "SELECT id,name,version,source_key,status FROM buddy_profiles WHERE source_key=?",
-            (source_key,),
-        ).fetchone()
+        with self.db.transaction() as cursor:
+            row = cursor.execute(
+                "SELECT id,name,version,source_key,status FROM buddy_profiles WHERE source_key=?",
+                (source_key,),
+            ).fetchone()
         if row is None:
             return None
         if row[4] != "active":
@@ -125,7 +213,19 @@ class BuddyLibrary:
         name: str | None = None,
         source_key: str | None = None,
     ) -> BuddyRecord:
-        """Publish one reviewed immutable copy; only a complete binding is listed."""
+        """Publish one reviewed immutable copy; only a complete binding is listed.
+
+        Args:
+            review: Validated content with a still-current source guard.
+            name: Optional display-name override.
+            source_key: Optional private idempotency key for builtins/legacy copies.
+
+        Returns:
+            New Buddy record, or the existing active record for source_key.
+
+        Raises:
+            ValueError: Invalid/stale content, retired source, or failed publication.
+        """
         from tldw_chatbook.Persona_Visual.artwork import encode_native_artwork
 
         if type(review) is not BuddySnapshot or not review.is_current():
@@ -223,7 +323,19 @@ class BuddyLibrary:
     def copy_persona(
         self, persona_id: str, *, name: str | None = None, source_key: str | None = None
     ) -> BuddyRecord:
-        """Copy a current local Persona graph; its subsequent lifecycle is irrelevant."""
+        """Copy current local Persona artwork into an independent owner.
+
+        Args:
+            persona_id: Exact local Persona identity to validate and copy.
+            name: Optional display-name override.
+            source_key: Optional private idempotency key.
+
+        Returns:
+            Independent Buddy record that survives source Persona changes.
+
+        Raises:
+            ValueError: Persona authority/artwork is unavailable or changes during copying.
+        """
         from tldw_chatbook.Persona_Visual.artwork import artwork_from_pack
 
         if source_key is not None:
@@ -286,7 +398,17 @@ class BuddyLibrary:
         return self.publish_review(review, name=name, source_key=source_key)
 
     def ensure_builtin(self, *, legacy_retired: bool = False) -> BuddyRecord | None:
-        """Install bundled pixels once without Persona creation or selection changes."""
+        """Install bundled pixels once without Persona creation or selection changes.
+
+        Args:
+            legacy_retired: Whether a legacy tombstone forbids new installation.
+
+        Returns:
+            Existing/new builtin Buddy, or None when a retained tombstone forbids it.
+
+        Raises:
+            ValueError: Bundled content cannot be published safely.
+        """
         key = "builtin:pixel-migu"
         try:
             existing = self._source_record(key)
@@ -342,7 +464,15 @@ class BuddyLibrary:
         *,
         writer: Callable[[PersonaBuddyPreferences], bool],
     ) -> PersonaBuddyPreferences:
-        """Copy once, then persist; a failed copy/write leaves legacy choices intact."""
+        """Copy once, then persist; a failed copy/write leaves legacy choices intact.
+
+        Args:
+            preferences: Current immutable Buddy preferences.
+            writer: Persists a candidate and returns True only on success.
+
+        Returns:
+            Migrated preferences after successful persistence, otherwise the original.
+        """
         from .preferences import BuddySelection, PersonaBuddySelection
 
         selection = preferences.selection

--- a/tldw_chatbook/Persona_Buddy/library.py
+++ b/tldw_chatbook/Persona_Buddy/library.py
@@ -1,0 +1,359 @@
+"""Profile-local Buddy library; artwork ownership never creates a Persona."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, replace
+from importlib.resources import files
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import TYPE_CHECKING
+from uuid import uuid4
+
+from loguru import logger
+
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Visual.artwork import (
+    artwork_from_pack,
+    encode_native_artwork,
+)
+from tldw_chatbook.Persona_Visual.assets import (
+    PersonaVisualAssetMetadata,
+    load_persona_visual_asset,
+)
+from tldw_chatbook.Persona_Visual.publication import (
+    PersonaVisualPublicationAssetSource,
+    PersonaVisualPublicationSnapshot,
+    cleanup_persona_visual_publication_candidate,
+    publish_persona_visual,
+)
+from tldw_chatbook.Persona_Visual.repository import (
+    PersonaVisualGraph,
+    PersonaVisualRepository,
+)
+from tldw_chatbook.Persona_Visual.runtime import (
+    PersonaVisualResolution,
+    resolve_active_buddy_visual,
+)
+from tldw_chatbook.Persona_Visual.snapshot import (
+    BuddyAssetSnapshot,
+    BuddySnapshot,
+    read_buddy_archive,
+)
+
+if TYPE_CHECKING:
+    from .preferences import PersonaBuddyPreferences
+
+_PUBLICATION_LOCK = threading.RLock()
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyRecord:
+    """Path-free library identity, independent of prompts and Persona lifecycle."""
+
+    id: str
+    name: str
+    revision: int
+    source_key: str | None = None
+
+
+class BuddyLibrary:
+    """Blocking library operations; callers run I/O on their retained app worker."""
+
+    def __init__(
+        self,
+        db: CharactersRAGDB,
+        profile_root: Path,
+        *,
+        persona_reader: Callable[[str], Mapping[str, object]] | None = None,
+    ) -> None:
+        self.db = db
+        self.profile_root = Path(profile_root)
+        self.repository = PersonaVisualRepository(db)
+        self.persona_reader = persona_reader
+
+    def list_buddies(self) -> tuple[BuddyRecord, ...]:
+        rows = self.db.execute_query(
+            "SELECT buddy.id,buddy.name,buddy.version,buddy.source_key FROM buddy_profiles buddy "
+            "JOIN buddy_visual_bindings binding ON binding.buddy_id=buddy.id "
+            "WHERE buddy.status='active' AND binding.status='active' "
+            "AND binding.buddy_revision=buddy.version ORDER BY buddy.name COLLATE NOCASE,buddy.id"
+        ).fetchall()
+        return tuple(BuddyRecord(*row) for row in rows)
+
+    def get_buddy(self, buddy_id: str) -> BuddyRecord | None:
+        return next((row for row in self.list_buddies() if row.id == buddy_id), None)
+
+    def get_graph(self, buddy_id: str) -> PersonaVisualGraph | None:
+        return self.repository.get_active_buddy_pack(buddy_id)
+
+    def resolve_preview(
+        self, buddy_id: str, *, state: str = "idle", reduced_motion: bool = False
+    ) -> PersonaVisualResolution:
+        return resolve_active_buddy_visual(
+            self.repository,
+            buddy_id,
+            self.profile_root,
+            state,
+            reduced_motion=reduced_motion,
+        )
+
+    @staticmethod
+    def review_archive(path: Path | str) -> BuddySnapshot:
+        """Validate archive bytes and notices without staging or changing selection."""
+        return read_buddy_archive(path)
+
+    def import_archive(
+        self, path: Path | str, *, name: str | None = None
+    ) -> BuddyRecord:
+        return self.publish_review(self.review_archive(path), name=name)
+
+    def _source_record(self, source_key: str) -> BuddyRecord | None:
+        row = self.db.execute_query(
+            "SELECT id,name,version,source_key,status FROM buddy_profiles WHERE source_key=?",
+            (source_key,),
+        ).fetchone()
+        if row is None:
+            return None
+        if row[4] != "active":
+            raise ValueError("buddy_source_retired")
+        return self.get_buddy(row[0])
+
+    def publish_review(
+        self,
+        review: BuddySnapshot,
+        *,
+        name: str | None = None,
+        source_key: str | None = None,
+    ) -> BuddyRecord:
+        """Publish one reviewed immutable copy; only a complete binding is listed."""
+        if type(review) is not BuddySnapshot or not review.is_current():
+            raise ValueError("buddy_source_changed")
+        title = review.title if name is None else name
+        if type(title) is not str or not title.strip() or len(title) > 256:
+            raise ValueError("buddy_name_invalid")
+        if source_key is not None and (
+            type(source_key) is not str or not 1 <= len(source_key) <= 256
+        ):
+            raise ValueError("buddy_source_key_invalid")
+        with _PUBLICATION_LOCK:
+            if source_key is not None:
+                existing = self._source_record(source_key)
+                if existing is not None:
+                    return existing
+            buddy_id = str(uuid4())
+            # A prior interrupted attempt may have only its unlisted owner row.
+            with self.db.transaction(immediate=True):
+                pending = (
+                    None
+                    if source_key is None
+                    else self.db.execute_query(
+                        "SELECT id FROM buddy_profiles WHERE source_key=?",
+                        (source_key,),
+                    ).fetchone()
+                )
+                if pending is not None:
+                    buddy_id = pending[0]
+                else:
+                    self.db.execute_query(
+                        "INSERT INTO buddy_profiles(id,name,source_key) VALUES (?,?,?)",
+                        (buddy_id, title, source_key),
+                    )
+            try:
+                with TemporaryDirectory(prefix="buddy-publication-") as folder:
+                    source = Path(folder).resolve()
+                    sources = []
+                    for index, asset in enumerate(review.assets):
+                        suffix = {
+                            "image/png": ".png",
+                            "image/jpeg": ".jpg",
+                            "image/gif": ".gif",
+                            "image/webp": ".webp",
+                        }[asset.metadata.mime_type]
+                        key = f"{index:03d}{suffix}"
+                        (source / key).write_bytes(asset.data)
+                        sources.append(
+                            PersonaVisualPublicationAssetSource(key, asset.metadata)
+                        )
+                    context = dict(review.source_context)
+                    context["artwork"] = encode_native_artwork(dict(review.artwork))
+                    snapshot = PersonaVisualPublicationSnapshot(
+                        persona_id=None,
+                        persona_revision=0,
+                        buddy_id=buddy_id,
+                        buddy_revision=1,
+                        title=title,
+                        description=review.description,
+                        source_kind=review.source_kind,
+                        source_context=tuple(sorted(context.items())),
+                        manifest_json=review.manifest_json,
+                        assets=tuple(sources),
+                    )
+                    publish_persona_visual(
+                        self.repository,
+                        snapshot,
+                        source_root=source,
+                        profile_root=self.profile_root,
+                        authority_guard=review.is_current,
+                    )
+            except Exception as exc:
+                # Never remove an owner/files after a possibly committed write.
+                if self.get_graph(buddy_id) is None:
+                    with self.db.transaction(immediate=True):
+                        self.db.execute_query(
+                            "DELETE FROM buddy_profiles WHERE id=?", (buddy_id,)
+                        )
+                    candidate = getattr(exc, "cleanup_candidate", None)
+                    if candidate:
+                        try:
+                            cleanup_persona_visual_publication_candidate(
+                                self.repository,
+                                profile_root=self.profile_root,
+                                cleanup_candidate=candidate,
+                            )
+                        except Exception:  # noqa: BLE001 - stable path-free cleanup boundary
+                            logger.warning("buddy_publication_cleanup_deferred")
+                raise
+            result = self.get_buddy(buddy_id)
+            if result is None:
+                raise ValueError("buddy_publication_failed")
+            return result
+
+    def copy_persona(
+        self, persona_id: str, *, name: str | None = None, source_key: str | None = None
+    ) -> BuddyRecord:
+        """Copy a current local Persona graph; its subsequent lifecycle is irrelevant."""
+        if source_key is not None:
+            existing = self._source_record(source_key)
+            if existing is not None:
+                return existing
+        if self.persona_reader is None:
+            raise ValueError("buddy_persona_authority_unavailable")
+        record = dict(self.persona_reader(persona_id))
+        graph = self.repository.get_active_persona_pack_for_export(persona_id)
+        if graph is None:
+            raise ValueError("buddy_persona_visual_unavailable")
+
+        def current() -> bool:
+            fresh = self.persona_reader(persona_id)
+            saved = self.repository.get_active_persona_pack(persona_id)
+            return bool(
+                fresh.get("id") == persona_id
+                and fresh.get("version") == record.get("version")
+                and type(record.get("version")) is int
+                and fresh.get("deleted", False) is False
+                and fresh.get("is_active", True) is True
+                and saved is not None
+                and saved.identity == graph.graph.identity
+                and saved.identity.persona_revision == record["version"]
+            )
+
+        if not current():
+            raise ValueError("buddy_persona_authority_changed")
+        assets = []
+        for item in graph.assets:
+            row = item.record
+            metadata = PersonaVisualAssetMetadata(
+                asset_key=row.asset_key,
+                role=row.role,
+                mime_type=row.mime_type,
+                byte_count=row.byte_count,
+                sha256=row.sha256,
+                width=row.width,
+                height=row.height,
+                frame_count=row.frame_count,
+                duration_ms=row.duration_ms,
+            )
+            loaded = load_persona_visual_asset(
+                self.profile_root, storage_key=item.storage_key, metadata=metadata
+            )
+            assets.append(BuddyAssetSnapshot(metadata, loaded.data))
+        context = dict(graph.source_context)
+        review = BuddySnapshot(
+            graph.graph.pack.title,
+            graph.manifest_bytes.decode("utf-8"),
+            tuple(assets),
+            artwork_from_pack({"source_context": context}),
+            graph.graph.identity.manifest_sha256,
+            current,
+            graph.source_context,
+            graph.graph.pack.description,
+            source_kind=graph.graph.pack.source_kind,
+        )
+        return self.publish_review(review, name=name, source_key=source_key)
+
+    def ensure_builtin(self, *, legacy_retired: bool = False) -> BuddyRecord | None:
+        """Install bundled pixels once without Persona creation or selection changes."""
+        key = "builtin:pixel-migu"
+        try:
+            existing = self._source_record(key)
+        except ValueError:
+            return None  # A retained user tombstone is terminal.
+        if existing is not None:
+            return existing
+        if legacy_retired:
+            return None
+        source = files("tldw_chatbook").joinpath(
+            "assets", "persona_visual", "pixel_migu"
+        )
+        manifest = json.dumps(
+            json.loads(source.joinpath("manifest.json").read_bytes()),
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        assets = []
+        for declaration in json.loads(source.joinpath("assets.json").read_bytes()):
+            fields = dict(declaration)
+            filename = fields.pop("filename")
+            assets.append(
+                BuddyAssetSnapshot(
+                    PersonaVisualAssetMetadata(**fields),
+                    source.joinpath(filename).read_bytes(),
+                )
+            )
+        review = BuddySnapshot(
+            "pixel-migu",
+            manifest,
+            tuple(assets),
+            {
+                "version": 1,
+                "creator": None,
+                "license": "LicenseRef-User-Supplied",
+                "source_url": None,
+                "notices": "",
+            },
+            hashlib.sha256(manifest.encode()).hexdigest(),
+            lambda: True,
+            (
+                ("provenance", "bundled-pixel-migu"),
+                ("license", "LicenseRef-User-Supplied"),
+            ),
+            source_kind="manual",
+        )
+        return self.publish_review(review, source_key=key)
+
+    def migrate_legacy_selection(
+        self,
+        preferences: PersonaBuddyPreferences,
+        *,
+        writer: Callable[[PersonaBuddyPreferences], bool],
+    ) -> PersonaBuddyPreferences:
+        """Copy once, then persist; a failed copy/write leaves legacy choices intact."""
+        from .preferences import BuddySelection, PersonaBuddySelection
+
+        selection = preferences.selection
+        if type(selection) is not PersonaBuddySelection:
+            return preferences
+        key = (
+            "legacy:" + hashlib.sha256(selection.local_persona_id.encode()).hexdigest()
+        )
+        try:
+            buddy = self.copy_persona(selection.local_persona_id, source_key=key)
+            candidate = replace(preferences, selection=BuddySelection(buddy.id))
+            return candidate if writer(candidate) is True else preferences
+        except Exception:  # noqa: BLE001 - failed migration preserves the usable legacy selection
+            return preferences

--- a/tldw_chatbook/Persona_Buddy/library.py
+++ b/tldw_chatbook/Persona_Buddy/library.py
@@ -16,10 +16,6 @@ from uuid import uuid4
 from loguru import logger
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
-from tldw_chatbook.Persona_Visual.artwork import (
-    artwork_from_pack,
-    encode_native_artwork,
-)
 from tldw_chatbook.Persona_Visual.assets import (
     PersonaVisualAssetMetadata,
     load_persona_visual_asset,
@@ -130,6 +126,8 @@ class BuddyLibrary:
         source_key: str | None = None,
     ) -> BuddyRecord:
         """Publish one reviewed immutable copy; only a complete binding is listed."""
+        from tldw_chatbook.Persona_Visual.artwork import encode_native_artwork
+
         if type(review) is not BuddySnapshot or not review.is_current():
             raise ValueError("buddy_source_changed")
         title = review.title if name is None else name
@@ -226,6 +224,8 @@ class BuddyLibrary:
         self, persona_id: str, *, name: str | None = None, source_key: str | None = None
     ) -> BuddyRecord:
         """Copy a current local Persona graph; its subsequent lifecycle is irrelevant."""
+        from tldw_chatbook.Persona_Visual.artwork import artwork_from_pack
+
         if source_key is not None:
             existing = self._source_record(source_key)
             if existing is not None:

--- a/tldw_chatbook/Persona_Buddy/preferences.py
+++ b/tldw_chatbook/Persona_Buddy/preferences.py
@@ -53,6 +53,18 @@ class PersonaBuddySelection:
 
 
 @dataclass(frozen=True, slots=True)
+class BuddySelection:
+    """One exact independent profile-local Buddy owner."""
+
+    buddy_id: str
+    source: Literal["buddy"] = field(default="buddy", init=False)
+
+    def __post_init__(self) -> None:
+        if not _valid_persona_id(self.buddy_id):
+            raise PersonaBuddyPreferenceError()
+
+
+@dataclass(frozen=True, slots=True)
 class PersonaBuddyGeometry:
     """Persisted floating-window geometry before viewport clamping.
 
@@ -78,7 +90,7 @@ class PersonaBuddyPreferences:
     """One immutable snapshot of Buddy UI and selection preferences."""
 
     enabled: bool = False
-    selection: PersonaBuddySelection | None = None
+    selection: PersonaBuddySelection | BuddySelection | None = None
     open: bool = True
     collapsed: bool = False
     geometry: PersonaBuddyGeometry = field(default_factory=PersonaBuddyGeometry)
@@ -86,9 +98,9 @@ class PersonaBuddyPreferences:
     def __post_init__(self) -> None:
         if type(self.enabled) is not bool:
             raise PersonaBuddyPreferenceError()
-        if (
-            self.selection is not None
-            and type(self.selection) is not PersonaBuddySelection
+        if self.selection is not None and type(self.selection) not in (
+            PersonaBuddySelection,
+            BuddySelection,
         ):
             raise PersonaBuddyPreferenceError()
         if type(self.open) is not bool or type(self.collapsed) is not bool:
@@ -142,6 +154,8 @@ def parse_persona_buddy_preferences(
     selection = None
     if type(source) is str and source == "local" and _valid_persona_id(persona_id):
         selection = PersonaBuddySelection("local", persona_id)
+    elif source == "buddy" and _valid_persona_id(section.get("buddy_id")):
+        selection = BuddySelection(section["buddy_id"])
 
     default_geometry = defaults.geometry
     geometry = PersonaBuddyGeometry(
@@ -171,7 +185,14 @@ def serialize_persona_buddy_preferences(
         "enabled": preferences.enabled,
         "source": selection.source if selection is not None else "",
         "local_persona_id": (
-            selection.local_persona_id if selection is not None else ""
+            selection.local_persona_id
+            if type(selection) is PersonaBuddySelection
+            else ""
+        ),
+        **(
+            {"buddy_id": selection.buddy_id}
+            if type(selection) is BuddySelection
+            else {}
         ),
         "open": preferences.open,
         "collapsed": preferences.collapsed,

--- a/tldw_chatbook/Persona_Buddy/speech.py
+++ b/tldw_chatbook/Persona_Buddy/speech.py
@@ -1,0 +1,215 @@
+"""One bounded Buddy speech queue, independent of execution and acknowledgement."""
+
+from __future__ import annotations
+
+import asyncio
+from collections import OrderedDict
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass, field
+
+
+@dataclass(frozen=True, slots=True)
+class BuddySpeechItem:
+    """A named immutable utterance with its source's live authority probe."""
+
+    key: str
+    title: str
+    text: str = field(repr=False)
+    question: bool = False
+    is_current: Callable[[], bool] = field(
+        default=lambda: True, repr=False, compare=False
+    )
+    context: object = field(default=None, repr=False, compare=False)
+
+    @property
+    def named_text(self) -> str:
+        """Prefix the spoken content with a bounded, plain conversation name."""
+        title = " ".join(self.title.split())[:180] or "Conversation"
+        return f"{title}. {self.text}"[:5000]
+
+
+@dataclass(frozen=True, slots=True)
+class BuddySpeechState:
+    paused: bool
+    muted: bool
+    queued: int
+    current_title: str
+    error: str
+    input_active: bool = False
+
+
+class BuddySpeechQueue:
+    """Serialize playback and cleanup; controls touch no agent or receipt service.
+
+    Pause stops current playback and restarts that utterance from its beginning
+    on Resume. Question priority applies between utterances, without interrupting
+    a response already being heard. All methods run on the app event loop.
+    """
+
+    def __init__(
+        self,
+        play: Callable[[BuddySpeechItem, Callable[[], bool]], Awaitable[bool]],
+    ) -> None:
+        self._play = play
+        self._pending: list[BuddySpeechItem] = []
+        self._seen: OrderedDict[str, None] = OrderedDict()
+        self._runner: asyncio.Task | None = None
+        self._playback: asyncio.Task | None = None
+        self._active: BuddySpeechItem | None = None
+        self._replay = False
+        self._epoch = 0
+        self._paused = False
+        self._muted = False
+        self._closed = False
+        self._error = ""
+        self._input_owners: set[object] = set()
+
+    @property
+    def state(self) -> BuddySpeechState:
+        return BuddySpeechState(
+            self._paused,
+            self._muted,
+            len(self._pending),
+            self._active.title if self._active else "",
+            self._error,
+            bool(self._input_owners),
+        )
+
+    @staticmethod
+    def _valid(item: BuddySpeechItem) -> bool:
+        try:
+            return item.is_current() is True
+        except Exception:  # noqa: BLE001 - stale authority fails closed
+            return False
+
+    def enqueue(self, item: BuddySpeechItem) -> bool:
+        """Queue one new terminal item; duplicate/progress events never accumulate."""
+        if (
+            self._closed
+            or self._muted
+            or item.key in self._seen
+            or not self._valid(item)
+        ):
+            return False
+        if len(self._pending) >= 64:
+            return False
+        self._seen[item.key] = None
+        while len(self._seen) > 512:
+            self._seen.popitem(last=False)
+        self._pending.append(item)
+        self._start()
+        return True
+
+    def _start(self) -> None:
+        if (
+            not self._closed
+            and not self._paused
+            and not self._muted
+            and self._pending
+            and self._runner is None
+            and not self._input_owners
+        ):
+            self._runner = asyncio.create_task(self._drain())
+
+    async def _drain(self) -> None:
+        try:
+            while self._pending and not (
+                self._closed or self._paused or self._muted or self._input_owners
+            ):
+                index = next(
+                    (i for i, item in enumerate(self._pending) if item.question), 0
+                )
+                item = self._pending.pop(index)
+                if not self._valid(item):
+                    continue
+                epoch = self._epoch
+                self._active, self._replay = item, False
+
+                def current(epoch=epoch, item=item) -> bool:
+                    return (
+                        epoch == self._epoch
+                        and not self._closed
+                        and not self._muted
+                        and not self._paused
+                        and not self._input_owners
+                        and self._active is item
+                        and self._valid(item)
+                    )
+
+                self._playback = asyncio.create_task(self._play(item, current))
+                try:
+                    if not await self._playback:
+                        self._error = "Speech could not finish."
+                except asyncio.CancelledError:
+                    pass  # Exact playback cancellation; the app's work is untouched.
+                except Exception:  # noqa: BLE001 - never retain provider/private error text
+                    self._error = "Speech could not finish."
+                finally:
+                    if self._replay and epoch == self._epoch and self._valid(item):
+                        self._pending.insert(0, item)
+                    self._active, self._playback, self._replay = None, None, False
+        finally:
+            self._runner = None
+            self._start()
+
+    def pause(self) -> None:
+        self._paused = True
+        self._replay = self._active is not None
+        if self._playback is not None and not self._playback.cancelling():
+            self._playback.cancel()
+
+    def resume(self) -> None:
+        self._paused = False
+        self._start()
+
+    def skip(self) -> None:
+        self._replay = False
+        if self._playback is not None:
+            if not self._playback.cancelling():
+                self._playback.cancel()
+        elif self._pending:
+            self._pending.pop(0)
+
+    def mute(self) -> None:
+        self._muted = True
+        self._pending.clear()
+        self.skip()
+
+    def unmute(self) -> None:
+        self._muted = False
+        self._start()
+
+    def reset(self) -> None:
+        """Invalidate all old binding/profile work before new items can play."""
+        self._epoch += 1
+        self._pending.clear()
+        self._seen.clear()
+        self._error = ""
+        self.skip()
+
+    def revalidate(self) -> None:
+        """Discard revoked sources and interrupt only their owned playback."""
+        self._pending[:] = [item for item in self._pending if self._valid(item)]
+        if self._active is not None and not self._valid(self._active):
+            self.skip()
+
+    def set_input_active(self, owner: object, active: bool) -> None:
+        """Hold output while an explicit microphone owner is active."""
+        if active:
+            self._input_owners.add(owner)
+            self._replay = self._active is not None
+            if self._playback is not None and not self._playback.cancelling():
+                self._playback.cancel()
+        else:
+            self._input_owners.discard(owner)
+            self._start()
+
+    async def wait_idle(self) -> None:
+        """Wait for the current drain, including cancelled playback cleanup."""
+        while self._runner is not None:
+            await asyncio.shield(self._runner)
+
+    async def aclose(self) -> None:
+        self._closed = True
+        self.reset()
+        await self.wait_idle()

--- a/tldw_chatbook/Persona_Buddy/speech.py
+++ b/tldw_chatbook/Persona_Buddy/speech.py
@@ -111,15 +111,15 @@ class BuddySpeechQueue:
         ):
             self._runner = asyncio.create_task(self._drain())
 
+    def _next_index(self) -> int:
+        return next((i for i, item in enumerate(self._pending) if item.question), 0)
+
     async def _drain(self) -> None:
         try:
             while self._pending and not (
                 self._closed or self._paused or self._muted or self._input_owners
             ):
-                index = next(
-                    (i for i, item in enumerate(self._pending) if item.question), 0
-                )
-                item = self._pending.pop(index)
+                item = self._pending.pop(self._next_index())
                 if not self._valid(item):
                     continue
                 epoch = self._epoch
@@ -168,7 +168,7 @@ class BuddySpeechQueue:
             if not self._playback.cancelling():
                 self._playback.cancel()
         elif self._pending:
-            self._pending.pop(0)
+            self._pending.pop(self._next_index())
 
     def mute(self) -> None:
         self._muted = True

--- a/tldw_chatbook/Persona_Visual/artwork.py
+++ b/tldw_chatbook/Persona_Visual/artwork.py
@@ -1,0 +1,148 @@
+"""Bounded public artwork metadata, adapted from the reviewed Buddy import work."""
+
+from __future__ import annotations
+
+import ipaddress
+import json
+import re
+from typing import Any
+from urllib.parse import urlsplit
+
+MAX_ARTWORK_BYTES = 512 * 1024
+MAX_NOTICE_BYTES = 64 * 1024
+_FIELDS = {"version", "creator", "license", "source_url", "notices"}
+_DIGEST = re.compile(r"[0-9a-f]{64}\Z")
+
+
+def _invalid() -> ValueError:
+    return ValueError("artwork_attribution_invalid")
+
+
+def _text(value: object, limit: int, *, nullable: bool = False) -> str | None:
+    if value is None and nullable:
+        return None
+    if type(value) is not str or len(value) > limit:
+        raise _invalid()
+    if any(
+        (ord(char) < 32 and char not in "\n\r\t") or 127 <= ord(char) <= 159
+        for char in value
+    ):
+        raise _invalid()
+    try:
+        if len(value.encode("utf-8")) > limit:
+            raise _invalid()
+    except UnicodeError:
+        raise _invalid() from None
+    return value
+
+
+def _url(value: object) -> str | None:
+    text = _text(value, 2048, nullable=True)
+    if text is None:
+        return None
+    if "\\" in text or any(char.isspace() for char in text):
+        raise _invalid()
+    try:
+        parsed = urlsplit(text)
+        host = parsed.hostname
+        if (
+            parsed.scheme != "https"
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.port is not None
+            or ":" in parsed.netloc
+            or parsed.query
+            or parsed.fragment
+            or "?" in text
+            or "#" in text
+            or not host
+            or "." not in host
+            or host.endswith(
+                (".", ".local", ".localhost", ".internal", ".lan", ".home")
+            )
+            or not re.fullmatch(r"[a-z0-9.-]+", host)
+            or not re.fullmatch(r"[a-z][a-z0-9-]*", host.rsplit(".", 1)[-1])
+            or any(
+                not label or label.startswith("-") or label.endswith("-")
+                for label in host.split(".")
+            )
+        ):
+            raise _invalid()
+        try:
+            ipaddress.ip_address(host)
+        except ValueError:
+            pass
+        else:
+            raise _invalid()
+    except (UnicodeError, ValueError):
+        raise _invalid() from None
+    return text
+
+
+def _record(value: object, expected_sha256: str | None) -> dict[str, Any]:
+    fields = _FIELDS | ({"output_sha256"} if expected_sha256 is not None else set())
+    if type(value) is not dict or set(value) != fields:
+        raise _invalid()
+    if type(value["version"]) is not int or value["version"] != 1:
+        raise _invalid()
+    result = {
+        "version": 1,
+        "creator": _text(value["creator"], 512, nullable=True),
+        "license": _text(value["license"], 4096, nullable=True),
+        "source_url": _url(value["source_url"]),
+        "notices": _text(value["notices"], MAX_NOTICE_BYTES),
+    }
+    if expected_sha256 is not None:
+        if type(expected_sha256) is not str or not _DIGEST.fullmatch(expected_sha256):
+            raise _invalid()
+        if value["output_sha256"] != expected_sha256:
+            raise _invalid()
+        result["output_sha256"] = expected_sha256
+    return result
+
+
+def encode_native_artwork(record: object) -> str:
+    return json.dumps(
+        _record(record, None),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+def decode_native_artwork(value: object) -> dict[str, Any]:
+    if type(value) is not str or len(value.encode("utf-8")) > MAX_ARTWORK_BYTES:
+        raise _invalid()
+    record = json.loads(value)
+    if encode_native_artwork(record) != value:
+        raise _invalid()
+    return record
+
+
+def artwork_from_pack(pack: dict) -> dict[str, Any]:
+    context = pack.get("source_context", {})
+    if not isinstance(context, dict):
+        raise _invalid()
+    if "artwork" in context:
+        return decode_native_artwork(context["artwork"])
+    for source in (context, pack):
+        if "tldw/artwork" in source:
+            return _record(source["tldw/artwork"], None)
+        if "artwork" in source:
+            value = source["artwork"]
+            return (
+                decode_native_artwork(value)
+                if isinstance(value, str)
+                else _record(value, None)
+            )
+    return _record(
+        {
+            "version": 1,
+            "creator": pack.get("creator"),
+            "license": pack.get("license", context.get("license")),
+            "source_url": pack.get("source_url"),
+            "notices": pack.get("notices", ""),
+        },
+        None,
+    )

--- a/tldw_chatbook/Persona_Visual/authoring.py
+++ b/tldw_chatbook/Persona_Visual/authoring.py
@@ -15,9 +15,9 @@ from .assets import (
 )
 from .contracts import (
     ALLOWED_STATE_CATALOG_KINDS,
+    RESERVED_STATES,
     PersonaVisualManifest,
     PersonaVisualManifestError,
-    RESERVED_STATES,
 )
 from .publication import (
     PersonaVisualPublicationAssetSource,
@@ -29,7 +29,6 @@ from .repository import (
     PersonaVisualIdentity,
 )
 from .validation import validate_persona_visual_manifest
-
 
 _INVALID = "persona_visual_draft_invalid"
 _INCOMPLETE = "persona_visual_draft_incomplete"
@@ -137,6 +136,7 @@ def create_persona_visual_import_draft(
     description: str,
     manifest_json: str,
     assets: tuple[PersonaVisualDraftAsset, ...],
+    source_context: Mapping[str, str] | None = None,
 ) -> PersonaVisualAuthoringDraft:
     """Create a validated review draft from already-confined imported sources."""
 
@@ -148,7 +148,11 @@ def create_persona_visual_import_draft(
             title=title,
             description=description,
             source_kind="imported",
-            source_context=(("provenance", "untrusted-import"),),
+            source_context=tuple(
+                sorted(
+                    {"provenance": "untrusted-import", **(source_context or {})}.items()
+                )
+            ),
             manifest_json=manifest_json,
             assets=assets,
         )

--- a/tldw_chatbook/Persona_Visual/authoring.py
+++ b/tldw_chatbook/Persona_Visual/authoring.py
@@ -150,7 +150,7 @@ def create_persona_visual_import_draft(
             source_kind="imported",
             source_context=tuple(
                 sorted(
-                    {"provenance": "untrusted-import", **(source_context or {})}.items()
+                    {**(source_context or {}), "provenance": "untrusted-import"}.items()
                 )
             ),
             manifest_json=manifest_json,

--- a/tldw_chatbook/Persona_Visual/importer.py
+++ b/tldw_chatbook/Persona_Visual/importer.py
@@ -41,7 +41,6 @@ from .contracts import (
 )
 from .repository import PersonaVisualIdentity
 
-
 PERSONA_VISUAL_PACK_SCHEMA = "tldw.persona_visual_pack.v1"
 _REQUIRED_MEMBERS = frozenset(
     {
@@ -165,23 +164,7 @@ def import_persona_visual_pack(
         root = _private_staging_root(staging_root)
         _raise_if_cancelled(cancelled)
         with zipfile.ZipFile(BytesIO(source.data), "r") as archive:
-            members = _validated_members(archive)
-            outer = _json_member(archive, members, "manifest.json")
-            checksums = _checksums(
-                _json_member(archive, members, "checksums/sha256.json")
-            )
-            pack = _pack(_json_member(archive, members, "metadata/pack.json"))
-            asset_records = _assets(
-                _json_member(archive, members, "metadata/assets.json")
-            )
-            _validate_declarations(
-                archive,
-                members,
-                outer,
-                checksums,
-                asset_records,
-                cancelled,
-            )
+            members, pack, asset_records = _validated_archive(archive, cancelled)
             _preflight_space(root, members)
             candidate = _create_candidate(root)
             draft_assets = _extract_assets(
@@ -203,6 +186,7 @@ def import_persona_visual_pack(
                 description="Imported Persona Visual pack",
                 manifest_json=manifest_json,
                 assets=draft_assets,
+                source_context=pack["source_context"],
             )
         _raise_if_cancelled(cancelled)
         if not _source_identity_current(
@@ -238,6 +222,23 @@ def import_persona_visual_pack(
             "persona_visual_import_invalid",
             cleanup_candidate=cleanup_candidate,
         ) from None
+
+
+def _validated_archive(archive: zipfile.ZipFile, cancelled: Any):
+    members = _validated_members(archive)
+    outer = _json_member(archive, members, "manifest.json")
+    checksums = _checksums(_json_member(archive, members, "checksums/sha256.json"))
+    pack = _pack(_json_member(archive, members, "metadata/pack.json"))
+    asset_records = _assets(_json_member(archive, members, "metadata/assets.json"))
+    _validate_declarations(
+        archive,
+        members,
+        outer,
+        checksums,
+        asset_records,
+        cancelled,
+    )
+    return members, pack, asset_records
 
 
 def persona_visual_import_source_root(
@@ -447,7 +448,22 @@ def _pack(value: object) -> dict[str, Any]:
     if type(persona) is dict:
         policy_rules = persona.get("policy_rules")
     rule_count = len(policy_rules) if type(policy_rules) is list else 0
-    return {"title": title, "visual_manifest": manifest, "policy_rule_count": rule_count}
+    from .artwork import artwork_from_pack, encode_native_artwork
+    from .repository import _source_context_json
+
+    context = pack.get("source_context", {})
+    if type(context) is not dict:
+        raise ValueError
+    context = dict(context)
+    context.pop("tldw/artwork", None)
+    context["artwork"] = encode_native_artwork(artwork_from_pack(pack))
+    _source_context_json(context)
+    return {
+        "title": title,
+        "visual_manifest": manifest,
+        "policy_rule_count": rule_count,
+        "source_context": context,
+    }
 
 
 def _assets(value: object) -> tuple[dict[str, Any], ...]:

--- a/tldw_chatbook/Persona_Visual/publication.py
+++ b/tldw_chatbook/Persona_Visual/publication.py
@@ -27,9 +27,10 @@ from .assets import (
 from .repository import (
     PersonaVisualIdentity,
     PersonaVisualRepository,
+    _source_context_json,
+    _visual_owner_id,
 )
 from .validation import validate_persona_visual_manifest
-
 
 _ERROR_PREFIX = "persona_visual_"
 _READ_CHUNK_BYTES = 64 * 1024
@@ -80,7 +81,7 @@ class PersonaVisualPublicationAssetSource:
 class PersonaVisualPublicationSnapshot:
     """One complete immutable publication request; it is not an editable model."""
 
-    persona_id: str
+    persona_id: str | None
     persona_revision: int
     title: str
     manifest_json: str
@@ -89,6 +90,8 @@ class PersonaVisualPublicationSnapshot:
     description: str = ""
     source_kind: str = "manual"
     source_context: tuple[tuple[str, str], ...] = ()
+    buddy_id: str | None = None
+    buddy_revision: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -342,6 +345,8 @@ def publish_persona_visual(
             if snapshot.expected_identity is None:
                 graph = repository.activate_new_pack(
                     persona_id=snapshot.persona_id,
+                    buddy_id=snapshot.buddy_id,
+                    buddy_revision=snapshot.buddy_revision,
                     title=snapshot.title,
                     description=snapshot.description,
                     source_kind=snapshot.source_kind,
@@ -355,6 +360,9 @@ def publish_persona_visual(
             else:
                 graph = repository.publish_version(
                     persona_id=snapshot.persona_id,
+                    buddy_id=snapshot.buddy_id,
+                    buddy_revision=snapshot.buddy_revision,
+                    source_context=context or None,
                     manifest=manifest,
                     manifest_storage_relpath=manifest_storage,
                     assets=asset_rows,
@@ -525,11 +533,15 @@ def _validate_snapshot(
     try:
         if type(snapshot) is not PersonaVisualPublicationSnapshot:
             raise ValueError
+        _visual_owner_id(snapshot.persona_id, snapshot.buddy_id)
+        if snapshot.buddy_id is not None and (
+            type(snapshot.buddy_revision) is not int
+            or snapshot.buddy_revision < 1
+            or snapshot.persona_revision != 0
+        ):
+            raise ValueError
         if (
-            type(snapshot.persona_id) is not str
-            or not snapshot.persona_id
-            or len(snapshot.persona_id) > 200
-            or type(snapshot.persona_revision) is not int
+            type(snapshot.persona_revision) is not int
             or snapshot.persona_revision < 0
             or type(snapshot.title) is not str
             or not snapshot.title
@@ -548,7 +560,7 @@ def _validate_snapshot(
         ):
             raise ValueError
         for value in (
-            snapshot.persona_id,
+            _visual_owner_id(snapshot.persona_id, snapshot.buddy_id),
             snapshot.title,
             snapshot.description,
             snapshot.manifest_json,
@@ -575,26 +587,10 @@ def _validate_snapshot(
             if type(item) is not tuple or len(item) != 2:
                 raise ValueError
             key, value = item
-            if (
-                type(key) is not str
-                or key not in _SOURCE_CONTEXT_KEYS
-                or key in context
-                or type(value) is not str
-                or not value
-                or len(value) > 256
-            ):
-                raise ValueError
-            value.encode("utf-8")
-            stripped = value.strip()
-            if (
-                "/" in value
-                or "\\" in value
-                or any(ord(character) < 32 for character in value)
-                or stripped in {".", ".."}
-                or stripped.startswith(("{", "[", "~"))
-            ):
+            if type(key) is not str or key in context or type(value) is not str:
                 raise ValueError
             context[key] = value
+        _source_context_json(context)
         sources: list[tuple[str, PersonaVisualAssetMetadata]] = []
         metadata_items: list[PersonaVisualAssetMetadata] = []
         source_keys: set[str] = set()
@@ -636,7 +632,11 @@ def _preflight_identity(
 ):
     expected = snapshot.expected_identity
     try:
-        current = repository.get_active_persona_pack(snapshot.persona_id)
+        current = (
+            repository.get_active_buddy_pack(snapshot.buddy_id)
+            if snapshot.buddy_id is not None
+            else repository.get_active_persona_pack(snapshot.persona_id)
+        )
     except ValueError:
         raise PersonaVisualPublicationError(
             "persona_visual_identity_changed"
@@ -660,6 +660,8 @@ def _preflight_identity(
         or current.identity != expected
         or expected.persona_id != snapshot.persona_id
         or expected.persona_revision != snapshot.persona_revision
+        or expected.buddy_id != snapshot.buddy_id
+        or expected.buddy_revision != snapshot.buddy_revision
     ):
         raise PersonaVisualPublicationError("persona_visual_identity_changed")
     return current

--- a/tldw_chatbook/Persona_Visual/repository.py
+++ b/tldw_chatbook/Persona_Visual/repository.py
@@ -14,7 +14,6 @@ from typing import Any
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 
-from .artwork import decode_native_artwork
 from .contracts import (
     ALLOWED_ASSET_MIME_TYPES,
     ALLOWED_ASSET_ROLES,
@@ -1361,6 +1360,8 @@ def _validate_source_context_content(value: object) -> None:
         raise ValueError
     for key, item in value.items():
         if key == "artwork":
+            from .artwork import decode_native_artwork
+
             decode_native_artwork(item)
             continue
         if not isinstance(item, str) or not item:

--- a/tldw_chatbook/Persona_Visual/repository.py
+++ b/tldw_chatbook/Persona_Visual/repository.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB, CharactersRAGDBError
 
+from .artwork import decode_native_artwork
 from .contracts import (
     ALLOWED_ASSET_MIME_TYPES,
     ALLOWED_ASSET_ROLES,
@@ -25,9 +26,15 @@ from .contracts import (
 )
 from .validation import validate_persona_visual_manifest
 
-
 _SOURCE_CONTEXT_KEYS = frozenset(
-    {"source_id", "provenance", "license", "source_server_commit"}
+    {
+        "source_id",
+        "provenance",
+        "license",
+        "source_server_commit",
+        "artwork",
+        "mapping_source",
+    }
 )
 _MAX_SOURCE_CONTEXT_VALUE_LENGTH = 256
 _ASSET_KEY_PATTERN = re.compile(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}\Z")
@@ -44,7 +51,7 @@ _SQLITE_UTF8_DECODE_PREFIX = "Could not decode to UTF-8 column "
 class PersonaVisualIdentity:
     """Complete optimistic identity for one active Persona Visual graph."""
 
-    persona_id: str
+    persona_id: str | None
     persona_revision: int
     binding_id: int
     binding_version: int
@@ -53,6 +60,18 @@ class PersonaVisualIdentity:
     pack_version_id: int
     version_number: int
     manifest_sha256: str
+    buddy_id: str | None = None
+    buddy_revision: int | None = None
+
+    @property
+    def owner_id(self) -> str:
+        return _visual_owner_id(self.persona_id, self.buddy_id)
+
+    @property
+    def owner_revision(self) -> int:
+        return (
+            self.buddy_revision if self.buddy_id is not None else self.persona_revision
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,7 +126,7 @@ class PersonaVisualBindingRecord:
     """One active local-Persona binding snapshot."""
 
     id: int
-    persona_id: str
+    persona_id: str | None
     persona_revision: int
     pack_id: int
     active_version_id: int
@@ -115,6 +134,9 @@ class PersonaVisualBindingRecord:
     created_at: str
     updated_at: str
     revision: int
+
+    buddy_id: str | None = None
+    buddy_revision: int | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -166,27 +188,29 @@ class PersonaVisualRepository:
     def __init__(self, db: CharactersRAGDB) -> None:
         self.db = db
 
-    def get_active_persona_pack(self, persona_id: str) -> PersonaVisualGraph | None:
+    def get_active_persona_pack(
+        self, persona_id: str | None, *, buddy_id: str | None = None
+    ) -> PersonaVisualGraph | None:
         """Return the Persona's active graph, ignoring inactive bindings/packs."""
 
-        _validate_persona_id(persona_id)
+        _visual_owner_id(persona_id, buddy_id)
         try:
             with self.db.transaction():
-                return self._get_active_persona_pack(persona_id)
+                return self._get_active_persona_pack(persona_id, buddy_id=buddy_id)
         except (UnicodeError, RecursionError, TypeError, OverflowError):
             raise ValueError("persona_visual_graph_invalid") from None
         except (sqlite3.Error, CharactersRAGDBError):
             raise ValueError("persona_visual_repository_read_failed") from None
 
     def get_active_persona_pack_for_export(
-        self, persona_id: str
+        self, persona_id: str | None, *, buddy_id: str | None = None
     ) -> PersonaVisualExportGraph | None:
         """Return one exact active graph with bounded private export metadata."""
 
-        _validate_persona_id(persona_id)
+        _visual_owner_id(persona_id, buddy_id)
         try:
             with self.db.transaction():
-                graph = self._get_active_persona_pack(persona_id)
+                graph = self._get_active_persona_pack(persona_id, buddy_id=buddy_id)
                 if graph is None:
                     return None
                 pack_row = _fetchone(
@@ -243,6 +267,15 @@ class PersonaVisualRepository:
         except (sqlite3.Error, CharactersRAGDBError):
             raise ValueError("persona_visual_repository_read_failed") from None
 
+    def get_active_buddy_pack(self, buddy_id: str) -> PersonaVisualGraph | None:
+        """Read an independent Buddy graph without consulting Persona authority."""
+        return self.get_active_persona_pack(None, buddy_id=buddy_id)
+
+    def get_active_buddy_pack_for_export(
+        self, buddy_id: str
+    ) -> PersonaVisualExportGraph | None:
+        return self.get_active_persona_pack_for_export(None, buddy_id=buddy_id)
+
     def _get_active_asset_storage_key(
         self,
         identity: PersonaVisualIdentity,
@@ -261,7 +294,7 @@ class PersonaVisualRepository:
                     self.db.execute_query(
                         """
                         SELECT asset.storage_relpath
-                          FROM persona_visual_bindings AS binding
+                          FROM visual_owner_bindings AS binding
                           JOIN persona_visual_packs AS pack
                             ON pack.id = binding.pack_id
                           JOIN persona_visual_pack_versions AS version_row
@@ -270,8 +303,8 @@ class PersonaVisualRepository:
                           JOIN persona_visual_assets AS asset
                             ON asset.pack_version_id = version_row.id
                            AND asset.pack_id = pack.id
-                         WHERE binding.id = ? AND binding.persona_id = ?
-                           AND binding.persona_revision = ?
+                         WHERE binding.id = ? AND binding.persona_id IS ? AND binding.buddy_id IS ?
+                           AND binding.persona_revision = ? AND binding.buddy_revision IS ?
                            AND binding.version = ? AND binding.status = 'active'
                            AND binding.pack_id = ?
                            AND binding.active_version_id = ?
@@ -292,7 +325,9 @@ class PersonaVisualRepository:
                         (
                             identity.binding_id,
                             identity.persona_id,
+                            identity.buddy_id,
                             identity.persona_revision,
+                            identity.buddy_revision,
                             identity.binding_version,
                             identity.pack_id,
                             identity.pack_version_id,
@@ -330,20 +365,22 @@ class PersonaVisualRepository:
     def activate_new_pack(
         self,
         *,
-        persona_id: str,
+        persona_id: str | None,
         title: str,
         manifest: object,
         manifest_storage_relpath: str,
         assets: Sequence[Mapping[str, Any]],
         expected_persona_revision: int,
         authority_guard: Callable[[], bool],
+        buddy_id: str | None = None,
+        buddy_revision: int | None = None,
         description: str = "",
         source_kind: str = "manual",
         source_context: object | None = None,
     ) -> PersonaVisualGraph:
         """Create and activate a first immutable graph for a local Persona."""
 
-        _validate_persona_id(persona_id)
+        _visual_owner_id(persona_id, buddy_id)
         _validate_revision(expected_persona_revision)
         try:
             _input_text(title, 256)
@@ -367,8 +404,22 @@ class PersonaVisualRepository:
         try:
             with self.db.transaction(immediate=True):
                 transaction_connection = self.db.get_connection()
-                if self._active_binding_record(persona_id) is not None:
+                if (
+                    self._active_binding_record(persona_id, buddy_id=buddy_id)
+                    is not None
+                ):
                     raise ValueError("persona_visual_binding_changed")
+                if buddy_id is not None:
+                    row = self.db.execute_query(
+                        "SELECT version FROM buddy_profiles WHERE id=? AND status='active'",
+                        (buddy_id,),
+                    ).fetchone()
+                    if (
+                        row is None
+                        or type(buddy_revision) is not int
+                        or row[0] != buddy_revision
+                    ):
+                        raise ValueError("persona_visual_identity_changed")
                 _run_authority_guard(authority_guard, self.db, transaction_connection)
                 pack_id = int(
                     self.db.execute_query(
@@ -401,15 +452,17 @@ class PersonaVisualRepository:
                 )
                 if activated.rowcount != 1:
                     raise ValueError("persona_visual_identity_changed")
-                self.db.execute_query(
-                    """
-                    INSERT INTO persona_visual_bindings(
-                        persona_id, persona_revision, pack_id, active_version_id
-                    ) VALUES (?, ?, ?, ?)
-                    """,
-                    (persona_id, expected_persona_revision, pack_id, version_id),
-                )
-                graph = self._get_active_persona_pack(persona_id)
+                if buddy_id is None:
+                    self.db.execute_query(
+                        "INSERT INTO persona_visual_bindings(persona_id,persona_revision,pack_id,active_version_id) VALUES (?,?,?,?)",
+                        (persona_id, expected_persona_revision, pack_id, version_id),
+                    )
+                else:
+                    self.db.execute_query(
+                        "INSERT INTO buddy_visual_bindings(buddy_id,buddy_revision,pack_id,active_version_id) VALUES (?,?,?,?)",
+                        (buddy_id, buddy_revision, pack_id, version_id),
+                    )
+                graph = self._get_active_persona_pack(persona_id, buddy_id=buddy_id)
                 if graph is None:
                     raise ValueError("persona_visual_activation_failed")
                 return graph
@@ -421,17 +474,20 @@ class PersonaVisualRepository:
     def publish_version(
         self,
         *,
-        persona_id: str,
+        persona_id: str | None,
         manifest: object,
         manifest_storage_relpath: str,
         assets: Sequence[Mapping[str, Any]],
         expected_identity: PersonaVisualIdentity,
         expected_persona_revision: int,
         authority_guard: Callable[[], bool],
+        buddy_id: str | None = None,
+        buddy_revision: int | None = None,
+        source_context: object | None = None,
     ) -> PersonaVisualGraph:
         """Publish and activate the next immutable version under full-graph CAS."""
 
-        _validate_persona_id(persona_id)
+        _visual_owner_id(persona_id, buddy_id)
         _validate_revision(expected_persona_revision)
         if not isinstance(expected_identity, PersonaVisualIdentity):
             raise ValueError("persona_visual_identity_changed")
@@ -446,14 +502,24 @@ class PersonaVisualRepository:
         try:
             with self.db.transaction(immediate=True):
                 transaction_connection = self.db.get_connection()
-                current = self._get_active_persona_pack(persona_id)
+                current = self._get_active_persona_pack(persona_id, buddy_id=buddy_id)
                 if current is None:
+                    raise ValueError("persona_visual_identity_changed")
+                if current.identity.buddy_revision != buddy_revision:
                     raise ValueError("persona_visual_identity_changed")
                 if current.identity.persona_revision != expected_persona_revision:
                     raise ValueError("persona_visual_persona_revision_changed")
                 if current.identity != expected_identity:
                     raise ValueError("persona_visual_identity_changed")
 
+                context_json = None
+                if source_context is not None:
+                    existing = self.get_active_persona_pack_for_export(
+                        persona_id, buddy_id=buddy_id
+                    )
+                    context_json = _source_context_json(
+                        {**dict(existing.source_context), **dict(source_context)}
+                    )
                 source_manifest_json = self._read_identity_snapshot(current.identity)
                 next_number = _db_positive_int(
                     _fetchone(
@@ -482,6 +548,7 @@ class PersonaVisualRepository:
                     """
                     UPDATE persona_visual_packs
                        SET active_version_id = ?,
+                           source_context_json = COALESCE(?, source_context_json),
                            updated_at = CURRENT_TIMESTAMP,
                            version = version + 1
                      WHERE id = ? AND status = 'active'
@@ -500,6 +567,7 @@ class PersonaVisualRepository:
                     """,
                     (
                         version_id,
+                        context_json,
                         current.pack.id,
                         current.version.id,
                         current.pack.revision,
@@ -513,29 +581,45 @@ class PersonaVisualRepository:
                     ),
                     redact_params=True,
                 )
-                binding_update = self.db.execute_query(
-                    """
-                    UPDATE persona_visual_bindings
-                       SET active_version_id = ?,
-                           updated_at = CURRENT_TIMESTAMP,
-                           version = version + 1
-                     WHERE id = ? AND persona_id = ? AND persona_revision = ?
-                       AND pack_id = ? AND active_version_id = ?
-                       AND status = 'active' AND version = ?
-                    """,
-                    (
-                        version_id,
-                        current.binding.id,
-                        persona_id,
-                        expected_persona_revision,
-                        current.pack.id,
-                        current.version.id,
-                        current.binding.revision,
-                    ),
-                )
+                if buddy_id is not None:
+                    binding_update = self.db.execute_query(
+                        "UPDATE buddy_visual_bindings SET active_version_id=?, updated_at=CURRENT_TIMESTAMP, version=version+1 "
+                        "WHERE id=? AND buddy_id=? AND buddy_revision=? AND pack_id=? AND active_version_id=? "
+                        "AND status='active' AND version=?",
+                        (
+                            version_id,
+                            current.binding.id,
+                            buddy_id,
+                            buddy_revision,
+                            current.pack.id,
+                            current.version.id,
+                            current.binding.revision,
+                        ),
+                    )
+                else:
+                    binding_update = self.db.execute_query(
+                        """
+                        UPDATE persona_visual_bindings
+                           SET active_version_id = ?,
+                               updated_at = CURRENT_TIMESTAMP,
+                               version = version + 1
+                         WHERE id = ? AND persona_id = ? AND persona_revision = ?
+                           AND pack_id = ? AND active_version_id = ?
+                           AND status = 'active' AND version = ?
+                        """,
+                        (
+                            version_id,
+                            current.binding.id,
+                            persona_id,
+                            expected_persona_revision,
+                            current.pack.id,
+                            current.version.id,
+                            current.binding.revision,
+                        ),
+                    )
                 if pack_update.rowcount != 1 or binding_update.rowcount != 1:
                     raise ValueError("persona_visual_identity_changed")
-                graph = self._get_active_persona_pack(persona_id)
+                graph = self._get_active_persona_pack(persona_id, buddy_id=buddy_id)
                 if graph is None:
                     raise ValueError("persona_visual_activation_failed")
                 return graph
@@ -670,8 +754,10 @@ class PersonaVisualRepository:
         except (sqlite3.Error, CharactersRAGDBError):
             raise ValueError("persona_visual_repository_write_failed") from None
 
-    def _get_active_persona_pack(self, persona_id: str) -> PersonaVisualGraph | None:
-        binding = self._active_binding_record(persona_id)
+    def _get_active_persona_pack(
+        self, persona_id: str | None, *, buddy_id: str | None = None
+    ) -> PersonaVisualGraph | None:
+        binding = self._active_binding_record(persona_id, buddy_id=buddy_id)
         if binding is None:
             return None
         pack_row = _fetchone(
@@ -721,6 +807,8 @@ class PersonaVisualRepository:
         identity = PersonaVisualIdentity(
             persona_id=binding.persona_id,
             persona_revision=binding.persona_revision,
+            buddy_id=binding.buddy_id,
+            buddy_revision=binding.buddy_revision,
             binding_id=binding.id,
             binding_version=binding.revision,
             pack_id=pack.id,
@@ -738,15 +826,23 @@ class PersonaVisualRepository:
         )
 
     def _active_binding_record(
-        self, persona_id: str
+        self, persona_id: str | None, *, buddy_id: str | None = None
     ) -> PersonaVisualBindingRecord | None:
+        if buddy_id is None:
+            row = _fetchone(
+                self.db.execute_query(
+                    "SELECT * FROM persona_visual_bindings WHERE persona_id = ? AND status = 'active'",
+                    (persona_id,),
+                )
+            )
+            return None if row is None else _decode_binding(row)
         row = _fetchone(
             self.db.execute_query(
                 """
-                SELECT * FROM persona_visual_bindings
-                 WHERE persona_id = ? AND status = 'active'
+                SELECT * FROM visual_owner_bindings
+                 WHERE persona_id IS ? AND buddy_id IS ? AND status = 'active'
                 """,
-                (persona_id,),
+                (persona_id, buddy_id),
             )
         )
         return None if row is None else _decode_binding(row)
@@ -824,13 +920,13 @@ class PersonaVisualRepository:
             self.db.execute_query(
                 """
             SELECT version_row.manifest_json
-              FROM persona_visual_bindings AS binding
+              FROM visual_owner_bindings AS binding
               JOIN persona_visual_packs AS pack ON pack.id = binding.pack_id
               JOIN persona_visual_pack_versions AS version_row
                 ON version_row.id = binding.active_version_id
                AND version_row.pack_id = binding.pack_id
-             WHERE binding.id = ? AND binding.persona_id = ?
-               AND binding.persona_revision = ? AND binding.pack_id = ?
+             WHERE binding.id = ? AND binding.persona_id IS ? AND binding.buddy_id IS ?
+               AND binding.persona_revision = ? AND binding.buddy_revision IS ? AND binding.pack_id = ?
                AND binding.active_version_id = ?
                AND binding.status = 'active' AND binding.version = ?
                AND pack.status = 'active' AND pack.active_version_id = ?
@@ -840,7 +936,9 @@ class PersonaVisualRepository:
                 (
                     identity.binding_id,
                     identity.persona_id,
+                    identity.buddy_id,
                     identity.persona_revision,
+                    identity.buddy_revision,
                     identity.pack_id,
                     identity.pack_version_id,
                     identity.binding_version,
@@ -1070,11 +1168,17 @@ def _decode_binding(row: Mapping[str, Any]) -> PersonaVisualBindingRecord:
     """Decode one binding before selecting its active graph."""
 
     try:
-        persona_id = _db_text(row["persona_id"], 200)
+        buddy_id = row["buddy_id"] if "buddy_id" in row.keys() else None  # noqa: SIM118 - sqlite.Row membership checks values
+        persona_id = row["persona_id"]
+        _visual_owner_id(persona_id, buddy_id)
         return PersonaVisualBindingRecord(
             id=_db_positive_int(row["id"]),
             persona_id=persona_id,
             persona_revision=_db_nonnegative_int(row["persona_revision"]),
+            buddy_id=buddy_id,
+            buddy_revision=_db_positive_int(row["buddy_revision"])
+            if buddy_id is not None
+            else None,
             pack_id=_db_positive_int(row["pack_id"]),
             active_version_id=_db_positive_int(row["active_version_id"]),
             status=_db_enum(row["status"], _GRAPH_STATUSES),
@@ -1255,7 +1359,10 @@ def _reject_json_constant(_value: str) -> None:
 def _validate_source_context_content(value: object) -> None:
     if type(value) is not dict or not set(value) <= _SOURCE_CONTEXT_KEYS:
         raise ValueError
-    for item in value.values():
+    for key, item in value.items():
+        if key == "artwork":
+            decode_native_artwork(item)
+            continue
         if not isinstance(item, str) or not item:
             raise ValueError
         item.encode("utf-8")
@@ -1382,3 +1489,17 @@ def _is_sha256(value: object) -> bool:
         and len(value) == 64
         and all(character in "0123456789abcdef" for character in value)
     )
+
+
+def _visual_owner_id(persona_id: object, buddy_id: object) -> str:
+    """Exactly one concrete local owner; Buddy identifiers are never Persona IDs."""
+    if buddy_id is None:
+        _validate_persona_id(persona_id)
+        return persona_id
+    if (
+        persona_id is not None
+        or type(buddy_id) is not str
+        or not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_.:-]{0,127}", buddy_id)
+    ):
+        raise ValueError("persona_visual_owner_invalid")
+    return buddy_id

--- a/tldw_chatbook/Persona_Visual/runtime.py
+++ b/tldw_chatbook/Persona_Visual/runtime.py
@@ -40,9 +40,9 @@ from .repository import (
     PersonaVisualPackRecord,
     PersonaVisualRepository,
     PersonaVisualVersionRecord,
+    _visual_owner_id,
 )
 from .validation import revalidate_persona_visual_manifest
-
 
 STATE_FALLBACK_REASON = "persona_visual_state_fallback"
 IDLE_UNAVAILABLE_REASON = "persona_visual_idle_unavailable"
@@ -160,17 +160,22 @@ class PersonaVisualResolution:
 
 def resolve_active_persona_visual(
     repository: PersonaVisualRepository,
-    persona_id: str,
+    persona_id: str | None,
     profile_root: PathLike[str] | str,
     requested_state: str,
     *,
     portrait: PersonaVisualPortrait | None = None,
     reduced_motion: bool = False,
+    buddy_id: str | None = None,
 ) -> PersonaVisualResolution:
     """Resolve one persisted active graph through its private storage bridge."""
 
     try:
-        graph = repository.get_active_persona_pack(persona_id)
+        graph = (
+            repository.get_active_buddy_pack(buddy_id)
+            if buddy_id is not None
+            else repository.get_active_persona_pack(persona_id)
+        )
     except Exception:
         public_state, _ = _public_state(requested_state)
         return _fallback_result(
@@ -200,6 +205,25 @@ def resolve_active_persona_visual(
         requested_state,
         asset_loader=load,
         portrait=portrait,
+        reduced_motion=reduced_motion,
+    )
+
+
+def resolve_active_buddy_visual(
+    repository: PersonaVisualRepository,
+    buddy_id: str,
+    profile_root: PathLike[str] | str,
+    requested_state: str,
+    *,
+    reduced_motion: bool = False,
+) -> PersonaVisualResolution:
+    """Resolve a real Buddy binding through the shared validated sprite runtime."""
+    return resolve_active_persona_visual(
+        repository,
+        None,
+        profile_root,
+        requested_state,
+        buddy_id=buddy_id,
         reduced_motion=reduced_motion,
     )
 
@@ -342,6 +366,8 @@ def _validated_graph(
         or binding.revision != identity.binding_version
         or binding.persona_id != identity.persona_id
         or binding.persona_revision != identity.persona_revision
+        or binding.buddy_id != identity.buddy_id
+        or binding.buddy_revision != identity.buddy_revision
         or binding.pack_id != identity.pack_id
         or binding.active_version_id != identity.pack_version_id
     ):
@@ -384,7 +410,13 @@ def _validated_identity(value: object) -> PersonaVisualIdentity:
         "binding_id binding_version pack_id pack_revision pack_version_id version_number",
         "persona_revision",
     )
-    _runtime_text(value.persona_id, 200)
+    _visual_owner_id(value.persona_id, value.buddy_id)
+    if value.buddy_id is not None:
+        _runtime_int(value.buddy_revision)
+        if value.persona_revision != 0:
+            raise ValueError
+    elif value.buddy_revision is not None:
+        raise ValueError
     _runtime_digest(value.manifest_sha256)
     return replace(value)
 
@@ -430,7 +462,13 @@ def _validated_binding(value: object) -> PersonaVisualBindingRecord:
         "persona_revision",
         "created_at updated_at",
     )
-    _runtime_text(value.persona_id, 200)
+    _visual_owner_id(value.persona_id, value.buddy_id)
+    if value.buddy_id is not None:
+        _runtime_int(value.buddy_revision)
+        if value.persona_revision != 0:
+            raise ValueError
+    elif value.buddy_revision is not None:
+        raise ValueError
     if _runtime_text(value.status, 64) != "active":
         raise ValueError
     return value

--- a/tldw_chatbook/Persona_Visual/snapshot.py
+++ b/tldw_chatbook/Persona_Visual/snapshot.py
@@ -74,8 +74,12 @@ def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
     Raises:
         PersonaVisualImportError: Native validation fails or the source changes.
     """
+    from tldw_chatbook.Utils.path_validation import validate_path_simple
+
     try:
-        source = importer._pin_source(path)
+        # The importer owns no-follow identity checks; do not resolve links here.
+        validated_path = validate_path_simple(path, probe_existing=False)
+        source = importer._pin_source(validated_path)
         with zipfile.ZipFile(BytesIO(source.data)) as archive:
             members, pack, records = importer._validated_archive(archive, lambda: False)
             assets = []
@@ -146,7 +150,11 @@ def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
             lambda: importer._source_identity_current(
                 source_path, source_identity, source_digest
             ),
-            tuple(sorted(pack["source_context"].items())),
+            tuple(
+                sorted(
+                    {**pack["source_context"], "provenance": "untrusted-import"}.items()
+                )
+            ),
         )
         if not snapshot.is_current():
             raise importer.PersonaVisualImportError("persona_visual_import_stale")

--- a/tldw_chatbook/Persona_Visual/snapshot.py
+++ b/tldw_chatbook/Persona_Visual/snapshot.py
@@ -1,0 +1,158 @@
+"""Read-only, bounded native Buddy archive snapshots for explicit publication."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import zipfile
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass, field
+from io import BytesIO
+from types import MappingProxyType
+from typing import Any
+
+from . import importer
+from .artwork import artwork_from_pack
+from .assets import (
+    PersonaVisualAssetMetadata,
+    _decode_selected_frame,
+    validate_persona_visual_asset_set,
+)
+from .validation import validate_persona_visual_manifest
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyAssetSnapshot:
+    """Immutable validated source bytes and their native raster metadata."""
+
+    metadata: PersonaVisualAssetMetadata
+    data: bytes = field(repr=False)
+
+
+@dataclass(frozen=True, slots=True)
+class BuddySnapshot:
+    """Path-free reviewed content with private source-revalidation authority."""
+
+    title: str
+    manifest_json: str
+    assets: tuple[BuddyAssetSnapshot, ...]
+    artwork: Mapping[str, Any]
+    source_sha256: str
+    _guard: Callable[[], bool] = field(repr=False, compare=False)
+
+    source_context: tuple[tuple[str, str], ...] = ()
+    description: str = ""
+    source_kind: str = "imported"
+
+    def __post_init__(self) -> None:
+        """Detach inert scalar artwork fields from mutable review inputs."""
+        object.__setattr__(self, "artwork", MappingProxyType(dict(self.artwork)))
+
+    def is_current(self) -> bool:
+        """Fail closed if the reviewed source changed or cannot be revalidated."""
+        try:
+            return self._guard() is True
+        except Exception:  # noqa: BLE001 - public boundary must fail closed without paths
+            return False
+
+
+def _validate_manifest(
+    manifest_json: str, assets: tuple[BuddyAssetSnapshot, ...]
+) -> None:
+    validate_persona_visual_asset_set(tuple(asset.metadata for asset in assets))
+    validate_persona_visual_manifest(
+        manifest_json,
+        {
+            asset.metadata.asset_key: (asset.metadata.width, asset.metadata.height)
+            for asset in assets
+        },
+    )
+
+
+def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
+    """Read a pinned native archive without staging files or creating a Persona.
+
+    Raises:
+        PersonaVisualImportError: Native validation fails or the source changes.
+    """
+    try:
+        source = importer._pin_source(path)
+        with zipfile.ZipFile(BytesIO(source.data)) as archive:
+            members, pack, records = importer._validated_archive(archive, lambda: False)
+            assets = []
+            for record in records:
+                data = archive.read(members[record["asset_path"]])
+                if (
+                    len(data) != record["byte_count"]
+                    or hashlib.sha256(data).hexdigest() != record["sha256"]
+                ):
+                    raise ValueError
+                metadata = PersonaVisualAssetMetadata(
+                    **{
+                        key: record[key]
+                        for key in (
+                            "asset_key",
+                            "role",
+                            "mime_type",
+                            "byte_count",
+                            "sha256",
+                            "width",
+                            "height",
+                        )
+                    }
+                )
+                metadata = validate_persona_visual_asset_set((metadata,))[0]
+                # Enforce the native decoded-pixel budget before decoding all frames.
+                _decode_selected_frame(data, metadata, 0)
+                frame_count, duration_ms = importer._inspect_image(
+                    BytesIO(data), record
+                )
+                metadata = PersonaVisualAssetMetadata(
+                    **{
+                        key: getattr(metadata, key)
+                        for key in (
+                            "asset_key",
+                            "role",
+                            "mime_type",
+                            "byte_count",
+                            "sha256",
+                            "width",
+                            "height",
+                        )
+                    },
+                    frame_count=frame_count,
+                    duration_ms=duration_ms,
+                )
+                assets.append(BuddyAssetSnapshot(metadata, data))
+            manifest_json = importer._canonical_text(pack["visual_manifest"])
+            frozen_assets = tuple(assets)
+            _validate_manifest(manifest_json, frozen_assets)
+            raw_pack = importer._json_member(archive, members, "metadata/pack.json")[
+                "pack"
+            ]
+            artwork = artwork_from_pack(raw_pack)
+        source_path, source_identity, source_digest = (
+            source.path,
+            source.identity,
+            source.sha256,
+        )
+        snapshot = BuddySnapshot(
+            pack["title"],
+            manifest_json,
+            frozen_assets,
+            artwork,
+            source.sha256,
+            lambda: importer._source_identity_current(
+                source_path, source_identity, source_digest
+            ),
+            tuple(sorted(pack["source_context"].items())),
+        )
+        if not snapshot.is_current():
+            raise importer.PersonaVisualImportError("persona_visual_import_stale")
+        return snapshot
+    except importer.PersonaVisualImportError:
+        raise
+    except Exception:  # noqa: BLE001 - public boundary must fail closed without paths
+        raise importer.PersonaVisualImportError(
+            "persona_visual_import_invalid"
+        ) from None

--- a/tldw_chatbook/Persona_Visual/snapshot.py
+++ b/tldw_chatbook/Persona_Visual/snapshot.py
@@ -12,7 +12,6 @@ from types import MappingProxyType
 from typing import Any
 
 from . import importer
-from .artwork import artwork_from_pack
 from .assets import (
     PersonaVisualAssetMetadata,
     _decode_selected_frame,
@@ -130,6 +129,8 @@ def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
             raw_pack = importer._json_member(archive, members, "metadata/pack.json")[
                 "pack"
             ]
+            from .artwork import artwork_from_pack
+
             artwork = artwork_from_pack(raw_pack)
         source_path, source_identity, source_digest = (
             source.path,

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -252,7 +252,7 @@ from ...Widgets.Console.console_activity_outcome_notice import (
     ConsoleActivityOutcomeNotice,
     ConsoleActivityOutcomePresentation,
 )
-from ...Workspaces import ConsoleConversationBrowserRow, DEFAULT_WORKSPACE_ID
+from ...Workspaces import ConsoleConversationBrowserRow
 from ...Workspaces.display_state import (
     ConsoleWorkspaceContextState,
     ConsoleWorkspaceConversationRow,
@@ -267,31 +267,6 @@ if TYPE_CHECKING:
 # helpers) so it stays out of the UI-ready module census.
 
 logger = logger.bind(module="ChatScreen")
-
-
-def _safe_persona_lookup(service: Any, persona_id: str) -> Mapping[str, Any] | None:
-    """Look a persona up through the app service; any failure means ``None``."""
-    try:
-        record = service.get_persona_profile(persona_id)
-    except Exception:  # noqa: BLE001 -- workspace defaults degrade, never block
-        return None
-    return record if isinstance(record, Mapping) else None
-
-
-def build_persona_agent_system_prompt(record: Mapping[str, Any]) -> str:
-    """Compose a persona record into a Console system prompt (preview seam parity)."""
-    from ...Character_Chat.Character_Chat_Lib import compose_character_card_text
-
-    return (
-        compose_character_card_text(
-            name=str(record.get("name") or "Workspace Agent"),
-            system_prompt=str(record.get("system_prompt") or ""),
-            personality=str(record.get("personality") or ""),
-            description=str(record.get("description") or ""),
-            user_name="User",
-        )
-        or "Stay in character."
-    )
 
 
 _DEFAULT_PROJECT_INSTRUCTION_NOTICE_TIMEOUT_SECONDS = 120.0
@@ -3057,8 +3032,10 @@ class ConsoleSessionController:
         # session. Settings/default-persona selection lives in the helper
         # below so published-default provenance is testable without a live
         # screen.
-        settings, assistant_kwargs = self._new_session_startup_settings()
+        target_workspace_id = self._ensure_console_chat_store().workspace_context.active_workspace_id
+        settings, assistant_kwargs = self._new_session_startup_settings(target_workspace_id)
         self._ensure_console_chat_controller().new_session(
+            workspace_id=target_workspace_id,
             settings=settings,
             canonical_settings_baseline=settings,
             new_chat_default_generation=(self._console_new_chat_default_generation()),
@@ -3184,132 +3161,53 @@ class ConsoleSessionController:
         return ()
 
     def _workspace_default_for_new_session(
-        self,
+        self, workspace_id: str | None = None
     ) -> tuple[str, str, str, str] | None:
-        """Resolve the active workspace's default persona for a NEW session.
+        """Resolve the explicitly targeted workspace for a new conversation."""
+        from ...Chat.console_assistant_defaults import resolve_new_console_assistant
 
-        Workspace assistant defaults (Task 9): explicit workspaces may pin a
-        default persona; a plain new Console tab in such a workspace starts
-        as that persona's session. Returns
-        ``(assistant_id, label, system_prompt, memory_mode)`` only when the
-        active workspace is explicit (never the global console workspace or
-        the built-in Default workspace), not archived, and its effective
-        default resolves ``available``. Every absence or failure degrades to
-        ``None`` (plain session) -- never raises. Handoff/character paths do
-        not consult this helper; their explicit choices outrank the default.
-        """
-        try:
-            registry = getattr(self.app_instance, "workspace_registry_service", None)
-            personas = getattr(
-                self.app_instance, "local_character_persona_service", None
-            )
-            if registry is None or personas is None:
-                return None
-            store = self._ensure_console_chat_store()
-            workspace_id = getattr(
-                getattr(store, "workspace_context", None),
-                "active_workspace_id",
-                None,
-            )
-            if not workspace_id or workspace_id in (
-                CONSOLE_GLOBAL_WORKSPACE_ID,
-                DEFAULT_WORKSPACE_ID,
-            ):
-                return None
-            workspace = registry.get_workspace(workspace_id)
-            if workspace is None or getattr(workspace, "archived", False):
-                return None
-            # Lazy import (boot budget, ADR-097): per-turn resolution only.
-            from ...Workspaces.assistant_defaults import (
-                resolve_effective_assistant_default,
-            )
-
-            effective = resolve_effective_assistant_default(
-                getattr(workspace, "assistant_defaults", None),
-                lambda pid: _safe_persona_lookup(personas, pid),
-            )
-            if effective.status != "available" or not effective.assistant_id:
-                return None
-            record = _safe_persona_lookup(personas, effective.assistant_id)
-            if record is None:
-                return None
-            prompt = build_persona_agent_system_prompt(record)
-            return (
-                effective.assistant_id,
-                effective.label or "Workspace Agent",
-                prompt,
-                effective.persona_memory_mode or "read_only",
-            )
-        except Exception as exc:  # noqa: BLE001 -- workspace defaults degrade, never block
-            logger.warning(
-                "Console session startup: workspace default persona "
-                "resolution failed; starting a plain session; error_type={}",
-                type(exc).__name__,
-            )
+        target = workspace_id
+        if target is None:
+            target = self._ensure_console_chat_store().workspace_context.active_workspace_id
+        startup = resolve_new_console_assistant(
+            self.app_instance, target, ConsoleSessionSettings(provider="")
+        )
+        if startup.assistant_kind != "persona":
             return None
+        return (
+            startup.assistant_id, startup.settings.character_label,
+            startup.settings.system_prompt, startup.persona_memory_mode,
+        )
 
     def _new_session_startup_settings(
-        self,
-    ) -> "tuple[ConsoleSessionSettings | None, dict[str, str]]":
-        """Pick the settings + assistant identity a plain new tab starts with.
+        self, workspace_id: str | None = None
+    ) -> tuple[ConsoleSessionSettings, dict[str, Any]]:
+        """Capture one creation-time Persona choice; existing sessions are never read."""
+        from ...Chat.console_assistant_defaults import resolve_new_console_assistant
 
-        Per ADR-095, Ctrl+T and temporary chats are eligible blank-chat
-        creation paths: they start from the app-published new-chat defaults
-        and never clone the active session. An explicit workspace's available
-        default persona is then stamped onto that snapshot per ADR-079.
-        Duplicate, branch, continue, character, and handoff paths carry their
-        own source settings without routing through this helper. Never raises.
-        """
-        try:
-            settings = self._blank_console_session_settings()
-            if (
-                settings is not None
-                and settings.system_prompt is None
-                and not settings.character_label
-                and settings.persona_memory_mode is None
-            ):
-                workspace_default = self._workspace_default_for_new_session()
-                if workspace_default is not None:
-                    (
-                        default_assistant_id,
-                        default_label,
-                        default_prompt,
-                        default_memory_mode,
-                    ) = workspace_default
-                    return (
-                        replace(
-                            settings,
-                            system_prompt=default_prompt,
-                            character_label=default_label,
-                            persona_memory_mode=default_memory_mode,
-                        ),
-                        {
-                            "assistant_kind": "persona",
-                            "assistant_id": default_assistant_id,
-                            "assistant_label": default_label,
-                        },
-                    )
-            return settings, {}
-        except Exception as exc:  # noqa: BLE001 -- startup degrades, never blocks
-            logger.warning(
-                "Console session startup: new-session settings selection "
-                "failed; falling back to plain defaults; error_type={}",
-                type(exc).__name__,
-            )
-            try:
-                return self._blank_console_session_settings(), {}
-            except Exception:  # noqa: BLE001 -- last-resort plain session
-                return None, {}
+        target = workspace_id
+        if target is None:
+            target = self._ensure_console_chat_store().workspace_context.active_workspace_id
+        startup = resolve_new_console_assistant(
+            self.app_instance, target, self._blank_console_session_settings()
+        )
+        return startup.settings, {
+            "assistant_kind": startup.assistant_kind,
+            "assistant_id": startup.assistant_id,
+            "assistant_label": startup.settings.character_label,
+            "persona_memory_mode": startup.persona_memory_mode,
+            "assistant_default_notice": startup.notice,
+        }
 
     def _build_console_turn_execution_context(
         self, session_id: str
     ) -> ConsoleTurnConfigurationSnapshot:
         """Capture one detached configuration snapshot for an owning session."""
         from ...Chat.attachment_core import max_history_images
+        from ...model_capabilities import is_vision_capable
         from ..Screens.settings_library_rag_defaults import (
             load_direct_library_tools,
         )
-        from ...model_capabilities import is_vision_capable
 
         app_config = self._provider_readiness_app_config()
         selection = self._build_provider_selection_fn(session_id)
@@ -3533,6 +3431,15 @@ class ConsoleSessionController:
         # readiness mapping already resolved above so an eligible, unused,
         # blocked chat still converges without an app restart (task-177).
         fresh_defaults = blank_console_session_settings(app_config)
+        if session.assistant_kind == "persona":
+            # Provider setup recovery changes provider defaults, never the
+            # Persona already assigned at this conversation's creation.
+            fresh_defaults = replace(
+                fresh_defaults,
+                system_prompt=settings.system_prompt,
+                character_label=settings.character_label,
+                persona_memory_mode=session.persona_memory_mode,
+            )
         if fresh_defaults == settings:
             return settings
         fresh_readiness = build_console_settings_readiness(

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -4205,10 +4205,27 @@ class ConsoleWorkspaceController:
         self.push_screen(
             WorkspaceCreateModal(
                 registry_service=registry_service,
+                persona_service=getattr(self.app_instance, "local_character_persona_service", None),
                 description="Local workspace created from Console.",
             ),
             self._handle_workspace_create_result,
         )
+
+    def _open_workspace_persona_default(self, workspace_id: str) -> None:
+        """Edit future defaults for the requested workspace without changing sessions."""
+        from ...Widgets.workspace_persona_default import WorkspacePersonaDefaultModal
+
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        if registry is None or not workspace_id or workspace_id == DEFAULT_WORKSPACE_ID:
+            return
+        record = registry.get_workspace(workspace_id)
+        if record is None or record.archived:
+            self.app_instance.notify("This workspace is unavailable.", severity="warning")
+            return
+        self.push_screen(WorkspacePersonaDefaultModal(
+            registry, getattr(self.app_instance, "local_character_persona_service", None),
+            workspace_id,
+        ))
 
     def _handle_workspace_create_result(
         self, result: WorkspaceCreateResult | None

--- a/tldw_chatbook/UI/Navigation/buddy_conversation.py
+++ b/tldw_chatbook/UI/Navigation/buddy_conversation.py
@@ -75,8 +75,11 @@ class BuddyConversationCoordinator:
             return None
         return session
 
-    def _saved_record_available(self, conversation_id: str) -> bool:
-        service = getattr(self.app, "local_chat_conversation_service", None)
+    def _saved_record_available(
+        self, conversation_id: str, *, service: Any = None
+    ) -> bool:
+        if service is None:
+            service = getattr(self.app, "local_chat_conversation_service", None)
         if service is None:
             return False
         try:
@@ -88,6 +91,24 @@ class BuddyConversationCoordinator:
             )
         except Exception:  # noqa: BLE001 - unavailable identity never becomes another target
             return False
+
+    async def _read_saved_availability(self, conversation_id: str) -> bool:
+        service = getattr(self.app, "local_chat_conversation_service", None)
+        if service is None:
+            return False
+        db = getattr(service, "db", None)
+        if getattr(db, "is_memory_db", False):
+            return self._saved_record_available(conversation_id, service=service)
+
+        def read() -> bool:
+            try:
+                return self._saved_record_available(conversation_id, service=service)
+            finally:
+                close = getattr(db, "close_connection", None)
+                if callable(close):
+                    close()
+
+        return await asyncio.to_thread(read)
 
     def can_open_console(self, binding: BuddyBinding) -> bool:
         if self.resolve(binding) is not None:
@@ -147,6 +168,7 @@ class BuddyConversationCoordinator:
             hydrate_console_generation_settings,
             hydrate_console_session,
             load_console_conversation_tree,
+            prepare_console_session_data,
         )
 
         target = binding.conversation_id
@@ -154,7 +176,7 @@ class BuddyConversationCoordinator:
         store = None
         restored = None
         try:
-            if not await asyncio.to_thread(self._saved_record_available, target):
+            if not await self._read_saved_availability(target):
                 raise ValueError("This saved conversation is missing or unavailable.")
             if self._profile_identity() != self._profile or runtime._disposed:
                 return
@@ -169,9 +191,7 @@ class BuddyConversationCoordinator:
                     raise ValueError("Console interaction could not start.")
             store = runtime.chat_store
             tree = await load_console_conversation_tree(self.app, target)
-            if not tree or not await asyncio.to_thread(
-                self._saved_record_available, target
-            ):
+            if not tree or not await self._read_saved_availability(target):
                 raise ValueError("This saved conversation is missing or unavailable.")
             if self.controller is None or runtime._disposed:
                 return
@@ -183,6 +203,15 @@ class BuddyConversationCoordinator:
                 raise ValueError(
                     "This saved conversation is not available for local interaction."
                 )
+            prepared_data = await prepare_console_session_data(
+                app=self.app,
+                store=store,
+                conversation_id=target,
+                tree=tree,
+            )
+            record_available = await self._read_saved_availability(target)
+            if self.controller is None or runtime._disposed or not record_available:
+                raise ValueError("This saved conversation is no longer available.")
             # Recheck after I/O. An existing or repurposed slot owns its own state.
             matches = [
                 row
@@ -215,10 +244,9 @@ class BuddyConversationCoordinator:
                 if not conversation.get("workspace_id")
                 else None,
                 activate=False,
+                prepared_data=prepared_data,
             )
-            record_available = await asyncio.to_thread(
-                self._saved_record_available, target
-            )
+            record_available = await self._read_saved_availability(target)
             if self.controller is None or runtime._disposed or not record_available:
                 raise ValueError("This saved conversation is no longer available.")
             if binding.resolve_session(store.sessions()) is not restored:

--- a/tldw_chatbook/UI/Navigation/buddy_conversation.py
+++ b/tldw_chatbook/UI/Navigation/buddy_conversation.py
@@ -1,0 +1,537 @@
+"""Exact-target Buddy commands; accepted work belongs to the application runtime."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+
+@dataclass
+class _VoiceCapture:
+    binding: BuddyBinding
+    session: Any
+    draft: str
+    speech: Any
+    status: str = "starting"
+
+
+class BuddyConversationCoordinator:
+    """Keep private drafts and submit commands without selecting Console sessions."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self._runtime = getattr(app, "console_runtime", None)
+        self._profile = self._profile_identity()
+        self.drafts: dict[BuddyBinding, str] = {}
+        self.notices: dict[BuddyBinding, str] = {}
+        self.submitting: set[BuddyBinding] = set()
+        self.restoring: set[str] = set()
+        self._voices: dict[object, _VoiceCapture] = {}
+        self.voice_factory: Any = None
+        self.voice_availability: Any = None
+
+    @property
+    def controller(self) -> Any:
+        if self._profile_identity() != self._profile:
+            return None
+        return getattr(
+            getattr(self.app, "console_runtime", None), "chat_controller", None
+        )
+
+    def _profile_identity(self) -> tuple[object, ...]:
+        return tuple(
+            getattr(self.app, name, None)
+            for name in (
+                "console_runtime",
+                "chachanotes_db",
+                "local_chat_conversation_service",
+                "chat_conversation_scope_service",
+            )
+        )
+
+    def resolve(
+        self, binding: BuddyBinding, *, verify_record: bool = False
+    ) -> Any | None:
+        runtime = getattr(self.app, "console_runtime", None)
+        store = getattr(runtime, "chat_store", None)
+        if (
+            self._profile_identity() != self._profile
+            or store is None
+            or runtime._disposed
+        ):
+            return None
+        session = binding.resolve_session(store.sessions())
+        if session is not None and session.persisted_conversation_id in self.restoring:
+            return None
+        if (
+            session is not None
+            and verify_record
+            and session.persisted_conversation_id
+            and not self._saved_record_available(session.persisted_conversation_id)
+        ):
+            return None
+        return session
+
+    def _saved_record_available(self, conversation_id: str) -> bool:
+        service = getattr(self.app, "local_chat_conversation_service", None)
+        if service is None:
+            return False
+        try:
+            record = service.get_conversation_metadata(conversation_id)
+            return bool(
+                record
+                and not record.get("deleted")
+                and record.get("runtime_backend", "local") == "local"
+            )
+        except Exception:  # noqa: BLE001 - unavailable identity never becomes another target
+            return False
+
+    def can_open_console(self, binding: BuddyBinding) -> bool:
+        if self.resolve(binding) is not None:
+            return True
+        runtime = getattr(self.app, "console_runtime", None)
+        store = getattr(runtime, "chat_store", None)
+        return bool(
+            self._profile_identity() == self._profile
+            and runtime is not None
+            and not runtime._disposed
+            and binding.conversation_id
+            and not binding.ephemeral
+            and (
+                store is None
+                or not any(row.id == binding.target_id for row in store.sessions())
+            )
+        )
+
+    def prepare(self, binding: BuddyBinding) -> None:
+        """Retain a conversation draft and load an explicitly requested saved row."""
+        session = self.resolve(binding)
+        if session is not None and self.controller is not None:
+            self.controller._interrupt_host.retain_decision_target(session.id)
+        for previous in tuple(self.drafts):
+            previous_session = self.resolve(previous)
+            same_conversation = (
+                binding.conversation_id is not None
+                and binding.conversation_id
+                == (
+                    previous_session.persisted_conversation_id
+                    if previous_session is not None
+                    else previous.conversation_id
+                )
+            )
+            if (
+                session is not None and previous_session is session
+            ) or same_conversation:
+                if binding not in self.drafts:
+                    self.drafts[binding] = self.drafts[previous]
+                if previous != binding:
+                    self.drafts.pop(previous, None)
+                break
+        if session is None and self.can_open_console(binding):
+            target = binding.conversation_id
+            if target not in self.restoring:
+                self.restoring.add(target)
+                self.notices[binding] = "Loading the saved conversation…"
+                self.app.run_worker(
+                    self._restore_saved(binding),
+                    group=f"buddy-restore:{target}",
+                    exclusive=False,
+                    exit_on_error=False,
+                )
+
+    async def _restore_saved(self, binding: BuddyBinding) -> None:
+        from tldw_chatbook.Chat.console_conversation_hydration import (
+            hydrate_console_generation_settings,
+            hydrate_console_session,
+            load_console_conversation_tree,
+        )
+
+        target = binding.conversation_id
+        runtime = self._runtime
+        store = None
+        restored = None
+        try:
+            if not await asyncio.to_thread(self._saved_record_available, target):
+                raise ValueError("This saved conversation is missing or unavailable.")
+            if self._profile_identity() != self._profile or runtime._disposed:
+                return
+            if self.controller is None:
+                # Explicit interaction may construct execution services. Passive
+                # inbox inspection never reaches the existing launch bootstrap.
+                from tldw_chatbook.Chat.console_launch_wake import (
+                    _ensure_launch_runtime,
+                )
+
+                if _ensure_launch_runtime(self.app) is None:
+                    raise ValueError("Console interaction could not start.")
+            store = runtime.chat_store
+            tree = await load_console_conversation_tree(self.app, target)
+            if not tree or not await asyncio.to_thread(
+                self._saved_record_available, target
+            ):
+                raise ValueError("This saved conversation is missing or unavailable.")
+            if self.controller is None or runtime._disposed:
+                return
+            conversation = tree.get("conversation", {})
+            if (
+                conversation.get("id") != target
+                or conversation.get("runtime_backend", "local") != "local"
+            ):
+                raise ValueError(
+                    "This saved conversation is not available for local interaction."
+                )
+            # Recheck after I/O. An existing or repurposed slot owns its own state.
+            matches = [
+                row
+                for row in store.sessions()
+                if row.id == binding.target_id
+                or row.persisted_conversation_id == target
+            ]
+            if matches:
+                matched = binding.resolve_session(matches)
+                if matched is None:
+                    raise ValueError(
+                        "This conversation binding changed. Choose it again."
+                    )
+                self.controller._interrupt_host.retain_decision_target(matched.id)
+                self.notices[binding] = ""
+                return
+            hydration = hydrate_console_generation_settings(
+                getattr(self.app, "app_config", {}) or {},
+                conversation,
+            )
+            restored = await hydrate_console_session(
+                app=self.app,
+                store=store,
+                conversation_id=target,
+                tree=tree,
+                settings=hydration.settings,
+                generation_durable_snapshot=hydration.durable_snapshot,
+                generation_metadata_status=hydration.metadata_status,
+                target_scope_type="global"
+                if not conversation.get("workspace_id")
+                else None,
+                activate=False,
+            )
+            record_available = await asyncio.to_thread(
+                self._saved_record_available, target
+            )
+            if self.controller is None or runtime._disposed or not record_available:
+                raise ValueError("This saved conversation is no longer available.")
+            if binding.resolve_session(store.sessions()) is not restored:
+                raise ValueError("This conversation binding changed. Choose it again.")
+            self.notices[binding] = ""
+            self.controller._interrupt_host.retain_decision_target(restored.id)
+        except Exception:  # noqa: BLE001 - retain a bounded unavailable state
+            if restored is not None:
+                store.rollback_restored_session(
+                    restored.id,
+                    expected_session=restored,
+                    prior_active_session_id=store.active_session_id,
+                )
+            self.notices[binding] = (
+                "This saved conversation could not be loaded. Open Console to retry."
+            )
+        finally:
+            self.restoring.discard(target)
+
+    def decision_payloads(self, binding: BuddyBinding) -> dict[str, dict[str, Any]]:
+        session = self.resolve(binding)
+        controller = self.controller
+        if session is None or controller is None:
+            return {}
+        host = controller._interrupt_host
+        return {
+            kind: dict(payload)
+            for kind in host.payloads
+            if (payload := host.head_round_payload(kind, session.id)) is not None
+        }
+
+    def show_decisions(self, owner: object, binding: BuddyBinding | None) -> None:
+        controller = self.controller
+        if controller is not None:
+            session = self.resolve(binding) if binding is not None else None
+            controller._interrupt_host.set_decision_view(
+                owner,
+                session.id if session else None,
+                kinds=("approval", "question", "skill_install", "skill_script"),
+            )
+
+    def request_send(self, binding: BuddyBinding, text: str) -> None:
+        """Capture a target/text and schedule on App, never on the modal DOM owner."""
+        if binding in self.submitting or not text.strip():
+            return
+        self.drafts[binding] = text
+        self.submitting.add(binding)
+        self.app.run_worker(
+            self._submit(binding, text),
+            group=f"buddy-reply:{binding.target_id}",
+            exclusive=False,
+            exit_on_error=False,
+        )
+
+    async def _submit(self, binding: BuddyBinding, text: str) -> None:
+        try:
+            session = await asyncio.to_thread(self.resolve, binding, verify_record=True)
+            controller = self.controller
+            if (
+                session is None
+                or controller is None
+                or self.resolve(binding) is not session
+            ):
+                raise ValueError(
+                    "This conversation is unavailable. Open Console to review it."
+                )
+            if not controller.run_state_for(session.id).is_send_allowed:
+                raise ValueError(
+                    "This conversation is busy. Wait for its current turn or answer its decision."
+                )
+            # The normal send path keeps all admission, capture and tool checks.
+            result = await controller.submit_draft(
+                text,
+                session_id=session.id,
+                preserve_composer=True,
+            )
+            self.notices[binding] = result.visible_copy or ""
+            if result.accepted and self.drafts.get(binding) == text:
+                self.drafts[binding] = ""
+        except ValueError as exc:
+            self.notices[binding] = str(exc)
+        except Exception:  # noqa: BLE001 - report a bounded UI failure without provider data
+            self.notices[binding] = (
+                "The reply could not finish. Open Console to review its state."
+            )
+        finally:
+            self.submitting.discard(binding)
+
+    def resolve_decision(
+        self, binding: BuddyBinding, kind: str, round_id: str | None, decision: Any
+    ) -> bool:
+        """Only the bound session's current FIFO card can reach its existing resolver."""
+        session = self.resolve(binding, verify_record=True)
+        controller = self.controller
+        if (
+            session is None
+            or controller is None
+            or round_id is None
+            or kind not in {"approval", "question", "skill_install", "skill_script"}
+        ):
+            return False
+        host = controller._interrupt_host
+        payload = host.head_round_payload(kind, session.id)
+        if (
+            payload is None
+            or (payload.get("round_id") or payload.get("request_id")) != round_id
+        ):
+            return False
+        with host.lock:
+            state = host.registries[kind].get(round_id)
+            if (
+                state is None
+                or state.get("session_id") != session.id
+                or state.get("revoked")
+            ):
+                return False
+        if kind == "approval":
+            controller.resolve_pending_approval(decision, round_id=round_id)
+        elif kind == "question":
+            controller.resolve_pending_question(decision, request_id=round_id)
+        elif kind == "skill_install":
+            controller.resolve_pending_skill_install(decision, request_id=round_id)
+        elif kind == "skill_script":
+            controller.resolve_pending_skill_script(*decision, request_id=round_id)
+        else:
+            return False
+        return True
+
+    def voice_status(self, owner: object) -> str:
+        capture = self._voices.get(owner)
+        return capture.status if capture is not None else "idle"
+
+    def request_voice(
+        self, owner: object, binding: BuddyBinding, *, allowed: bool
+    ) -> None:
+        target = self.resolve(binding, verify_record=True)
+        if not allowed or target is None or self.controller is None:
+            return
+        capture = self._voices.get(owner)
+        if capture is not None:
+            if capture.status == "recording":
+                capture.status = "transcribing"
+                self.app.run_worker(self._finish_voice(owner, capture), exclusive=False)
+            return
+        if not self.controller.run_state_for(target.id).is_send_allowed:
+            return
+        if self._voices:
+            self.notices[binding] = (
+                "Another Buddy microphone capture is active. Finish it first."
+            )
+            return
+        from tldw_chatbook.Chat.console_voice_input import probe
+        from tldw_chatbook.UI.Console_Modules.dictation import (
+            ConsoleStreamingDictationSession,
+        )
+
+        availability = (self.voice_availability or probe)()
+        if not availability.ok:
+            self.notices[binding] = (
+                f"{availability.reason} {availability.remedy}".strip()
+            )
+            return
+        session = (self.voice_factory or ConsoleStreamingDictationSession)(
+            on_event=lambda _session, _event: None,
+        )
+        from .buddy_speech import ensure_buddy_speech
+
+        speech = ensure_buddy_speech(self.app)
+        capture = _VoiceCapture(binding, session, self.drafts.get(binding, ""), speech)
+        self._voices[owner] = capture
+        speech.set_input_active(owner, True)
+        self.app.run_worker(self._start_voice(owner, capture), exclusive=False)
+
+    async def _start_voice(self, owner: object, capture: _VoiceCapture) -> None:
+        try:
+            await capture.speech.wait_silent()
+            if (
+                self._voices.get(owner) is not capture
+                or self.resolve(capture.binding) is None
+            ):
+                self.close_voice(owner)
+                return
+            await asyncio.to_thread(
+                capture.session.start,
+                on_buffer_limit=lambda: self.app.call_later(
+                    self.request_voice, owner, capture.binding, allowed=True
+                ),
+            )
+            if (
+                self._voices.get(owner) is not capture
+                or self.resolve(capture.binding) is None
+            ):
+                capture.session.discard()
+                return
+            capture.status = "recording"
+        except Exception:  # noqa: BLE001 - audio errors can contain device/profile details
+            if self._voices.get(owner) is capture:
+                self.notices[capture.binding] = (
+                    "Microphone capture could not start. Check Console voice settings."
+                )
+                self.close_voice(owner)
+
+    async def _finish_voice(self, owner: object, capture: _VoiceCapture) -> None:
+        try:
+            text = await asyncio.to_thread(capture.session.stop_and_transcribe)
+            target = await asyncio.to_thread(
+                self.resolve, capture.binding, verify_record=True
+            )
+            if (
+                self._voices.get(owner) is not capture
+                or target is None
+                or self.resolve(capture.binding) is not target
+            ):
+                return
+            if self.drafts.get(capture.binding, "") != capture.draft:
+                self.notices[capture.binding] = (
+                    "The draft changed during dictation. Recording discarded."
+                )
+            else:
+                self.drafts[capture.binding] = " ".join(
+                    part for part in (capture.draft, text) if part
+                )
+                self.notices[capture.binding] = "Review your dictated reply, then Send."
+        except Exception:  # noqa: BLE001 - local speech failures must not submit text
+            if self._voices.get(owner) is capture:
+                self.notices[capture.binding] = (
+                    "Dictation could not finish. Retry or type your reply."
+                )
+        finally:
+            if self._voices.get(owner) is capture:
+                self.close_voice(owner)
+
+    def close_voice(self, owner: object) -> None:
+        capture = self._voices.pop(owner, None)
+        if capture is not None:
+            try:
+                capture.session.discard()
+            finally:
+                capture.speech.set_input_active(owner, False)
+
+    def open_console(self, binding: BuddyBinding) -> bool:
+        if not self.can_open_console(binding):
+            return False
+        self.app.run_worker(
+            self._open_bound(binding),
+            group="buddy-open-console",
+            exclusive=False,
+        )
+        return True
+
+    async def _console_target(self, binding: BuddyBinding) -> str | None:
+        session = await asyncio.to_thread(self.resolve, binding, verify_record=True)
+        if session is not None and self.resolve(binding) is session:
+            return f"native:{session.id}"
+        if binding.conversation_id and self.can_open_console(binding):
+            available = await asyncio.to_thread(
+                self._saved_record_available, binding.conversation_id
+            )
+            if available and self.can_open_console(binding):
+                return binding.conversation_id
+        return None
+
+    async def _open_bound(self, binding: BuddyBinding) -> None:
+        if await self._console_target(binding) is None:
+            self.app.notify(
+                "The bound conversation is unavailable.", severity="warning"
+            )
+            return
+        from tldw_chatbook.UI.Navigation.main_navigation import NavigateToScreen
+
+        def navigated(success: bool) -> None:
+            if not success or self.controller is None:
+                return
+            screen = self.app.screen
+            workspace = getattr(screen, "_workspace", None)
+            if workspace is not None:
+                self.app.run_worker(
+                    self._activate_bound(binding, workspace),
+                    group="buddy-open-console",
+                    exclusive=False,
+                )
+
+        self.app.post_message(NavigateToScreen("chat", on_completion=navigated))
+
+    async def _activate_bound(self, binding: BuddyBinding, workspace: Any) -> None:
+        target = await self._console_target(binding)
+        if target is None:
+            self.app.notify(
+                "The bound conversation is unavailable.", severity="warning"
+            )
+            return
+        if (
+            self.controller is None
+            or getattr(self.app.screen, "_workspace", None) is not workspace
+        ):
+            return
+        # The existing handoff owns view/composer synchronization and failure rollback.
+        await workspace.open_console_workspace_conversation(target)
+
+
+def open_buddy_conversation(
+    app: Any, binding: BuddyBinding, *, allow_voice: bool = True
+) -> Any:
+    """Open exact local conversation interaction, preserving the underlying screen."""
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_conversation_modal import (
+        BuddyConversationModal,
+    )
+
+    coordinator = getattr(app, "buddy_conversation_coordinator", None)
+    if coordinator is None or coordinator._profile != coordinator._profile_identity():
+        coordinator = BuddyConversationCoordinator(app)
+        app.buddy_conversation_coordinator = coordinator
+    modal = BuddyConversationModal(coordinator, binding, allow_voice=allow_voice)
+    coordinator.prepare(binding)
+    app.push_screen(modal)
+    return modal

--- a/tldw_chatbook/UI/Navigation/buddy_management.py
+++ b/tldw_chatbook/UI/Navigation/buddy_management.py
@@ -71,6 +71,51 @@ class BuddyManagementCoordinator:
         self._opening = True
         self.app.run_worker(self._open(), group="buddy-management-open", exclusive=True)
 
+    def request_visibility(self, action: str) -> None:
+        """Control the independent Buddy without a Persona selection."""
+        if action == "manage":
+            self.request_open()
+        elif action in {"show", "close", "disable"}:
+            self.app.run_worker(
+                self._set_visibility(action), group="buddy-visibility", exclusive=False
+            )
+
+    async def _set_visibility(self, action: str) -> None:
+        async with self._apply_lock:
+            controller = self.controller
+            previous = controller.current_preferences()
+            if action == "show" and previous.selection is None:
+                self.request_open()
+                return
+            changes = (
+                {"enabled": True, "open": True}
+                if action == "show"
+                else {"open": False}
+                if action == "close"
+                else {"enabled": False}
+            )
+            revision = controller.apply_preferences_patch(**changes)
+            try:
+                if not await controller.persist_preferences_revision(revision):
+                    raise ValueError("Could not save Buddy visibility. Retry.")
+            except Exception:  # noqa: BLE001 - keep current settings on storage failure
+                controller.rollback_preferences_revision(revision, previous)
+                self.app.notify(
+                    "Could not save Buddy visibility. Retry.", severity="error"
+                )
+                return
+            from tldw_chatbook.Persona_Buddy.preferences import (
+                serialize_persona_buddy_preferences,
+            )
+
+            self.app.app_config["persona_buddy"] = serialize_persona_buddy_preferences(
+                controller.current_preferences()
+            )
+            self.reconcile_scope()
+            pending = self.app.reconcile_persona_buddy_view()
+            if asyncio.iscoroutine(pending):
+                await pending
+
     def request_interaction(self) -> None:
         """Open the explicitly followed target without selecting a Console tab."""
         binding = self.preferences.binding
@@ -109,12 +154,37 @@ class BuddyManagementCoordinator:
                 width=saved.geometry.width,
                 height=saved.geometry.height,
             )
+            revision = controller.snapshot().preferences_generation
+            imports: dict[str, str] = {}
+
+            async def commit(choice: Any) -> None:
+                nonlocal revision
+                try:
+                    await self.apply_choice(
+                        choice, expected_revision=revision, imports=imports
+                    )
+                except ValueError as exc:
+                    if getattr(exc, "buddy_retry_revision", None) is not None:
+                        revision = exc.buddy_retry_revision
+                    raise
+                self.app.notify("Buddy settings applied.")
+                try:
+                    pending = self.app.reconcile_persona_buddy_view()
+                    if asyncio.iscoroutine(pending):
+                        await pending
+                except Exception:  # noqa: BLE001 - settings already saved
+                    self.app.notify(
+                        "Buddy settings saved, but the view could not refresh. Try Show Buddy again.",
+                        severity="warning",
+                    )
+
             self._modal = BuddyManagementModal(
                 buddies=tuple((record.name, record.id) for record in buddies),
                 targets=targets,
                 personas=personas,
                 initial=initial,
                 preview=self._preview,
+                apply=commit,
             )
             self.app.push_screen(self._modal, self._closed)
         except Exception:  # noqa: BLE001 - app boundary keeps storage faults out of the message pump
@@ -136,7 +206,8 @@ class BuddyManagementCoordinator:
                 active_only=True, limit=100, offset=offset
             )
             rows.extend(
-                (str(row.get("name") or row["id"]), str(row["id"])) for row in page
+                (str(row.get("name") or "Unnamed Persona"), str(row["id"]))
+                for row in page
             )
             if len(page) < 100:
                 return tuple(rows)
@@ -199,6 +270,39 @@ class BuddyManagementCoordinator:
         finally:
             self._promotion_pending = False
 
+    def _persona_label(self, persona_id: str | None) -> str:
+        if not persona_id:
+            return "None"
+        service = getattr(self.app, "local_character_persona_service", None)
+        try:
+            row = service.get_persona_profile(persona_id) if service else None
+            if not row or row.get("deleted"):
+                return "Unavailable"
+            return str(row.get("name") or "Unnamed Persona")
+        except Exception:  # noqa: BLE001 - display-only lookup degrades independently
+            return "Unavailable"
+
+    def _workspace_persona_label(self, workspace: Any) -> str:
+        from tldw_chatbook.Workspaces.assistant_defaults import (
+            resolve_effective_assistant_default,
+        )
+
+        service = getattr(self.app, "local_character_persona_service", None)
+        try:
+            effective = resolve_effective_assistant_default(
+                workspace.assistant_defaults,
+                service.get_persona_profile if service else lambda _: None,
+            )
+            if effective.status == "available":
+                return effective.label or "Unnamed Persona"
+            return (
+                "Unavailable (new conversations use None)"
+                if effective.status == "unavailable"
+                else "None"
+            )
+        except Exception:  # noqa: BLE001 - display-only lookup cannot prevent management
+            return "Unavailable (new conversations use None)"
+
     async def _target_choices(self) -> tuple[Any, ...]:
         from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
             BuddyTargetChoice,
@@ -221,6 +325,12 @@ class BuddyManagementCoordinator:
                     f"conversation:{session.id}",
                     f"Conversation: {session.title} · {session.id[:8]}",
                     BuddyBinding.for_session(session),
+                    current_persona=await asyncio.to_thread(
+                        self._persona_label,
+                        session.assistant_id
+                        if session.assistant_kind == "persona"
+                        else None,
+                    ),
                     persona_editable=not busy and not is_character,
                     persona_unavailable_reason=(
                         "Wait for this conversation’s current run to finish before changing its Persona."
@@ -250,6 +360,9 @@ class BuddyManagementCoordinator:
                         f"Workspace: {workspace.name}",
                         BuddyBinding(
                             kind="workspace", target_id=workspace.workspace_id
+                        ),
+                        current_persona=await asyncio.to_thread(
+                            self._workspace_persona_label, workspace
                         ),
                     )
                 )
@@ -327,7 +440,13 @@ class BuddyManagementCoordinator:
             )
         return workspace
 
-    async def apply_choice(self, choice: Any) -> None:
+    async def apply_choice(
+        self,
+        choice: Any,
+        *,
+        expected_revision: int | None = None,
+        imports: dict[str, str] | None = None,
+    ) -> None:
         """Validate, publish requested artwork, then batch preference persistence.
 
         Import failure cannot change selection. A failed preference write rolls back
@@ -339,6 +458,18 @@ class BuddyManagementCoordinator:
         )
 
         async with self._apply_lock:
+
+            def require_current() -> None:
+                if (
+                    expected_revision is not None
+                    and self.controller.snapshot().preferences_generation
+                    != expected_revision
+                ):
+                    raise ValueError(
+                        "Buddy settings changed elsewhere. Cancel and reopen to review the current selection before applying."
+                    )
+
+            require_current()
             target = await self._validate_binding(choice.binding)
             if choice.persona_choice != PERSONA_UNCHANGED:
                 # Admission runs before artwork publication or preference mutation.
@@ -353,11 +484,31 @@ class BuddyManagementCoordinator:
                 assignment = None
             selected_id = choice.buddy_id
             if choice.import_path:
-                review = await asyncio.to_thread(
-                    self.library.review_archive, choice.import_path
+                selected_id = (
+                    imports.get(choice.import_path) if imports is not None else None
                 )
-                record = await asyncio.to_thread(self.library.publish_review, review)
-                selected_id = record.id
+                if selected_id is None:
+                    try:
+                        review = await asyncio.to_thread(
+                            self.library.review_archive, choice.import_path
+                        )
+                        require_current()
+                        record = await asyncio.to_thread(
+                            self.library.publish_review, review
+                        )
+                    except Exception as exc:
+                        raise ValueError(
+                            "Could not import this Buddy pack. Check the path, pack format and profile storage, then retry."
+                        ) from exc
+                    selected_id = record.id
+                    if imports is not None:
+                        imports[choice.import_path] = selected_id
+                elif (
+                    await asyncio.to_thread(self.library.get_buddy, selected_id) is None
+                ):
+                    raise ValueError(
+                        "The imported Buddy was removed. Cancel and reopen to import it again."
+                    )
             elif selected_id is not None:
                 record = await asyncio.to_thread(self.library.get_buddy, selected_id)
                 if record is None:
@@ -366,6 +517,7 @@ class BuddyManagementCoordinator:
                     )
             # I/O above can outlive a deleted or repurposed target.
             await self._validate_binding(choice.binding)
+            require_current()
             controller = self.controller
             previous = controller.current_preferences()
             selected = (
@@ -393,14 +545,28 @@ class BuddyManagementCoordinator:
                 saved = await controller.persist_preferences_revision(
                     revision, extra_sections={"buddy_interaction": encoded}
                 )
-            except Exception:
-                controller.rollback_preferences_revision(revision, previous)
-                raise
-            if not saved:
-                controller.rollback_preferences_revision(revision, previous)
-                raise ValueError(
-                    "Could not save Buddy settings. Your previous settings are retained; retry."
+            except Exception as exc:
+                restored = controller.rollback_preferences_revision(revision, previous)
+                error = ValueError(
+                    "Could not save Buddy settings. Check profile storage and retry."
                 )
+                if restored:
+                    error.buddy_retry_revision = (
+                        controller.snapshot().preferences_generation
+                    )
+                raise error from exc
+            if not saved:
+                restored = controller.rollback_preferences_revision(revision, previous)
+                error = ValueError(
+                    "Could not save Buddy settings. Your previous settings are retained; retry."
+                    if restored
+                    else "Buddy settings changed elsewhere while saving. Cancel and reopen to review the current selection."
+                )
+                if restored:
+                    error.buddy_retry_revision = (
+                        controller.snapshot().preferences_generation
+                    )
+                raise error
             self.preferences = interaction
             self._scope_configured = True
             self.app.app_config["buddy_interaction"] = dict(encoded)
@@ -412,6 +578,7 @@ class BuddyManagementCoordinator:
                 controller.current_preferences()
             )
             controller.invalidate_profile()
+            self.start_scope_tracking()
             if assignment is not None:
                 # This is a separate assistant-domain commit, never hidden inside
                 # artwork selection. Its own version guard retains the old Persona
@@ -419,10 +586,11 @@ class BuddyManagementCoordinator:
                 try:
                     await assignment.apply()
                 except Exception as exc:
-                    raise ValueError(
-                        "Buddy settings were saved, but the Persona changed or could not be saved. Reopen Buddy settings to retry the Persona change."
-                    ) from exc
-            self.start_scope_tracking()
+                    error = ValueError(
+                        "Buddy settings were saved, but the Persona changed or could not be saved. Your staged Persona choice is retained; review it and retry."
+                    )
+                    error.buddy_retry_revision = revision
+                    raise error from exc
 
     def start_scope_tracking(self) -> None:
         """Resume persisted scope when an enabled Buddy first becomes visible."""

--- a/tldw_chatbook/UI/Navigation/buddy_management.py
+++ b/tldw_chatbook/UI/Navigation/buddy_management.py
@@ -145,6 +145,18 @@ class BuddyManagementCoordinator:
             targets = await self._target_choices()
             saved = controller.current_preferences()
             buddy_id = getattr(saved.selection, "buddy_id", None)
+            selected_buddy = (
+                await asyncio.to_thread(self.library.get_buddy, buddy_id)
+                if buddy_id
+                else None
+            )
+
+            async def artwork_page(offset: int) -> tuple[tuple[str, str], ...]:
+                page = await asyncio.to_thread(
+                    self.library.list_buddies, limit=100, offset=offset
+                )
+                return tuple((record.name, record.id) for record in page)
+
             initial = BuddyManagementChoice(
                 enabled=saved.enabled and saved.open,
                 buddy_id=buddy_id,
@@ -185,6 +197,10 @@ class BuddyManagementCoordinator:
                 initial=initial,
                 preview=self._preview,
                 apply=commit,
+                artwork_page=artwork_page,
+                selected_buddy=(selected_buddy.name, selected_buddy.id)
+                if selected_buddy
+                else None,
             )
             self.app.push_screen(self._modal, self._closed)
         except Exception:  # noqa: BLE001 - app boundary keeps storage faults out of the message pump

--- a/tldw_chatbook/UI/Navigation/buddy_management.py
+++ b/tldw_chatbook/UI/Navigation/buddy_management.py
@@ -1,0 +1,529 @@
+"""One app-owned entry point for Buddy management from any primary destination."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from dataclasses import replace
+from typing import Any
+
+from tldw_chatbook.Persona_Buddy.interaction import (
+    BuddyBinding,
+    BuddyInteractionPreferences,
+    parse_preferences,
+    serialize_preferences,
+)
+
+
+class BuddyManagementCoordinator:
+    """Own staged-management application and scope; never own Console execution."""
+
+    def __init__(
+        self, app: Any, *, controller: Any = None, library: Any = None
+    ) -> None:
+        self.app = app
+        self._controller = controller
+        self._library = library
+        self.preferences = parse_preferences(
+            app.app_config.get("buddy_interaction", {})
+        )
+        self._apply_lock = asyncio.Lock()
+        self._opening = False
+        self._modal: Any = None
+        self._scope_timer: Any = None
+        self._scope_configured = "buddy_interaction" in app.app_config
+        self._promotion_pending = False
+        self._promotion_retry_after = 0.0
+
+    @property
+    def controller(self) -> Any:
+        if self._controller is None:
+            self._controller = self.app.ensure_persona_buddy_controller()
+        if self._controller is None:
+            raise ValueError("Buddy storage is unavailable. Check the active profile.")
+        return self._controller
+
+    @property
+    def library(self) -> Any:
+        if self._library is None:
+            from tldw_chatbook.config import get_user_data_dir
+            from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+
+            db = getattr(self.app, "chachanotes_db", None)
+            if db is None:
+                raise ValueError(
+                    "Buddy storage is unavailable. Check the active profile."
+                )
+            personas = getattr(self.app, "local_character_persona_service", None)
+            self._library = BuddyLibrary(
+                db,
+                get_user_data_dir(),
+                persona_reader=(
+                    personas.get_persona_profile if personas is not None else None
+                ),
+            )
+        return self._library
+
+    def request_open(self) -> None:
+        """Open at most one management surface through an app-owned worker."""
+        if self._opening or (self._modal is not None and self._modal.is_mounted):
+            return
+        self._opening = True
+        self.app.run_worker(self._open(), group="buddy-management-open", exclusive=True)
+
+    def request_interaction(self) -> None:
+        """Open the explicitly followed target without selecting a Console tab."""
+        binding = self.preferences.binding
+        if binding is None:
+            self.request_open()
+        elif binding.kind == "conversation":
+            from .buddy_conversation import open_buddy_conversation
+
+            open_buddy_conversation(self.app, binding)
+        else:
+            from .buddy_workspace import open_buddy_workspace
+
+            open_buddy_workspace(self.app, binding)
+
+    async def _open(self) -> None:
+        from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+            BuddyManagementChoice,
+            BuddyManagementModal,
+        )
+
+        try:
+            controller = self.controller
+            # Selection/startup publication has its own authority. Merely opening
+            # this form lists installed content and never imports or seeds it.
+            buddies = await asyncio.to_thread(self.library.list_buddies)
+            personas = await asyncio.to_thread(self._persona_choices)
+            targets = await self._target_choices()
+            saved = controller.current_preferences()
+            buddy_id = getattr(saved.selection, "buddy_id", None)
+            initial = BuddyManagementChoice(
+                enabled=saved.enabled and saved.open,
+                buddy_id=buddy_id,
+                binding=self._binding_for_form(targets),
+                animated=self.preferences.animated,
+                speak_responses=self.preferences.speak_responses,
+                width=saved.geometry.width,
+                height=saved.geometry.height,
+            )
+            self._modal = BuddyManagementModal(
+                buddies=tuple((record.name, record.id) for record in buddies),
+                targets=targets,
+                personas=personas,
+                initial=initial,
+                preview=self._preview,
+            )
+            self.app.push_screen(self._modal, self._closed)
+        except Exception:  # noqa: BLE001 - app boundary keeps storage faults out of the message pump
+            self.app.notify(
+                "Could not open the Buddy library. Check the active profile and retry.",
+                severity="error",
+            )
+        finally:
+            self._opening = False
+
+    def _persona_choices(self) -> tuple[tuple[str, str], ...]:
+        service = getattr(self.app, "local_character_persona_service", None)
+        if service is None:
+            return ()
+        rows = []
+        offset = 0
+        while True:
+            page = service.list_persona_profiles(
+                active_only=True, limit=100, offset=offset
+            )
+            rows.extend(
+                (str(row.get("name") or row["id"]), str(row["id"])) for row in page
+            )
+            if len(page) < 100:
+                return tuple(rows)
+            offset += len(page)
+
+    def _runtime_sessions(self) -> tuple[Any, ...]:
+        runtime = getattr(self.app, "console_runtime", None)
+        store = getattr(runtime, "chat_store", None)
+        return tuple(store.sessions()) if store is not None else ()
+
+    def _binding_for_form(self, targets: tuple[Any, ...]) -> BuddyBinding | None:
+        """Match a restored/first-saved conversation while preserving stale-slot guards."""
+        binding = self.preferences.binding
+        if binding is None or binding.kind != "conversation":
+            return binding
+        session = binding.resolve_session(self._runtime_sessions())
+        if session is not None:
+            for target in targets:
+                if target.binding.resolve_session((session,)) is session:
+                    return target.binding
+        return binding
+
+    async def _promote_saved_binding(self, expected: BuddyBinding) -> bool:
+        """Persist a first-save identity only while that exact pin still owns settings."""
+        async with self._apply_lock:
+            if (
+                self.preferences.binding != expected
+                or expected.ephemeral
+                or expected.conversation_id
+            ):
+                return False
+            session = expected.resolve_session(self._runtime_sessions())
+            if session is None or not session.persisted_conversation_id:
+                return False
+            promoted = replace(
+                self.preferences, binding=BuddyBinding.for_session(session)
+            )
+            encoded = serialize_preferences(promoted)
+            revision = self.controller.snapshot().preferences_generation
+            saved = await self.controller.persist_preferences_revision(
+                revision, extra_sections={"buddy_interaction": encoded}
+            )
+            if not saved:
+                raise ValueError(
+                    "Could not save the Buddy’s conversation link. It will retry while this app is open."
+                )
+            self.preferences = promoted
+            self.app.app_config["buddy_interaction"] = dict(encoded)
+            return True
+
+    async def _finish_binding_promotion(self, expected: BuddyBinding) -> None:
+        try:
+            await self._promote_saved_binding(expected)
+        except Exception:  # noqa: BLE001 - failed preference I/O must not affect a conversation
+            self._promotion_retry_after = time.monotonic() + 30.0
+            self.app.notify(
+                "Could not save the Buddy’s conversation link. It will retry while this app is open.",
+                severity="warning",
+            )
+        finally:
+            self._promotion_pending = False
+
+    async def _target_choices(self) -> tuple[Any, ...]:
+        from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+            BuddyTargetChoice,
+        )
+        from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
+
+        runtime = getattr(self.app, "console_runtime", None)
+        controller = getattr(runtime, "chat_controller", None)
+        targets = []
+        for session in self._runtime_sessions():
+            if session.runtime_backend != "local":
+                continue
+            busy = (
+                controller is not None
+                and not controller.run_state_for(session.id).is_send_allowed
+            )
+            is_character = session.assistant_kind == "character"
+            targets.append(
+                BuddyTargetChoice(
+                    f"conversation:{session.id}",
+                    f"Conversation: {session.title} · {session.id[:8]}",
+                    BuddyBinding.for_session(session),
+                    persona_editable=not busy and not is_character,
+                    persona_unavailable_reason=(
+                        "Wait for this conversation’s current run to finish before changing its Persona."
+                        if busy
+                        else "This conversation uses a character. Manage its character settings in Console."
+                        if is_character
+                        else ""
+                    ),
+                )
+            )
+        registry = getattr(self.app, "workspace_registry_service", None)
+        if registry is not None:
+            workspaces = await asyncio.to_thread(registry.list_workspaces)
+            for workspace in workspaces:
+                authority = str(
+                    getattr(workspace.authority, "value", workspace.authority)
+                )
+                if (
+                    workspace.archived
+                    or workspace.workspace_id == DEFAULT_WORKSPACE_ID
+                    or authority != "local-only"
+                ):
+                    continue
+                targets.append(
+                    BuddyTargetChoice(
+                        f"workspace:{workspace.workspace_id}",
+                        f"Workspace: {workspace.name}",
+                        BuddyBinding(
+                            kind="workspace", target_id=workspace.workspace_id
+                        ),
+                    )
+                )
+        return tuple(targets)
+
+    async def _preview(self, buddy_id: str, state: str) -> Any:
+        from rich.text import Text
+
+        from tldw_chatbook.Persona_Buddy.rendering import prepare_persona_buddy_frame
+
+        def render() -> Any:
+            resolution = self.library.resolve_preview(
+                buddy_id, state=state, reduced_motion=True
+            )
+            if not resolution.frames:
+                return Text("No preview is available for this expression.")
+            return prepare_persona_buddy_frame(
+                resolution.frames[0],
+                resolution_cache_identity=resolution.cache_identity,
+                cols=24,
+                lines=10,
+            ).renderable
+
+        return await asyncio.to_thread(render)
+
+    def _closed(self, choice: Any) -> None:
+        self._modal = None
+        if choice is not None:
+            self.app.run_worker(
+                self._apply_and_report(choice),
+                group="buddy-management-apply",
+                exclusive=False,
+            )
+
+    async def _apply_and_report(self, choice: Any) -> None:
+        try:
+            await self.apply_choice(choice)
+        except ValueError as exc:
+            self.app.notify(str(exc), severity="error")
+        except Exception:  # noqa: BLE001 - app boundary keeps storage faults out of the message pump
+            self.app.notify(
+                "Could not finish applying Buddy settings. Reopen Buddy settings to review the current selection and retry.",
+                severity="error",
+            )
+        else:
+            self.app.notify("Buddy settings applied.")
+            pending = self.app.reconcile_persona_buddy_view()
+            if asyncio.iscoroutine(pending):
+                await pending
+
+    async def _validate_binding(self, binding: BuddyBinding | None) -> Any:
+        if binding is None:
+            return None
+        if binding.kind == "conversation":
+            session = binding.resolve_session(self._runtime_sessions())
+            if session is None:
+                raise ValueError(
+                    "The bound conversation is unavailable. Open it in Console or choose another target."
+                )
+            return session
+        registry = getattr(self.app, "workspace_registry_service", None)
+        workspace = (
+            await asyncio.to_thread(registry.get_workspace, binding.target_id)
+            if registry
+            else None
+        )
+        if (
+            workspace is None
+            or workspace.archived
+            or str(getattr(workspace.authority, "value", workspace.authority))
+            != "local-only"
+        ):
+            raise ValueError(
+                "The bound workspace is unavailable. Choose another target."
+            )
+        return workspace
+
+    async def apply_choice(self, choice: Any) -> None:
+        """Validate, publish requested artwork, then batch preference persistence.
+
+        Import failure cannot change selection. A failed preference write rolls back
+        only this exact in-memory revision, preserving any newer user changes.
+        """
+        from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
+        from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+            PERSONA_UNCHANGED,
+        )
+
+        async with self._apply_lock:
+            target = await self._validate_binding(choice.binding)
+            if choice.persona_choice != PERSONA_UNCHANGED:
+                # Admission runs before artwork publication or preference mutation.
+                from tldw_chatbook.Chat.console_persona_assignment import (
+                    prepare_buddy_persona_assignment,
+                )
+
+                assignment = prepare_buddy_persona_assignment(
+                    self.app, choice.binding, target, choice.persona_choice
+                )
+            else:
+                assignment = None
+            selected_id = choice.buddy_id
+            if choice.import_path:
+                review = await asyncio.to_thread(
+                    self.library.review_archive, choice.import_path
+                )
+                record = await asyncio.to_thread(self.library.publish_review, review)
+                selected_id = record.id
+            elif selected_id is not None:
+                record = await asyncio.to_thread(self.library.get_buddy, selected_id)
+                if record is None:
+                    raise ValueError(
+                        "Selected artwork is unavailable. Choose another Buddy or import its pack."
+                    )
+            # I/O above can outlive a deleted or repurposed target.
+            await self._validate_binding(choice.binding)
+            controller = self.controller
+            previous = controller.current_preferences()
+            selected = (
+                BuddySelection(selected_id)
+                if selected_id is not None
+                else previous.selection
+            )
+            if choice.enabled and selected is None:
+                raise ValueError("Choose artwork before enabling the Buddy.")
+            interaction = BuddyInteractionPreferences(
+                binding=choice.binding,
+                animated=choice.animated,
+                speak_responses=choice.speak_responses,
+            )
+            encoded = serialize_preferences(interaction)
+            revision = controller.apply_preferences_patch(
+                enabled=choice.enabled,
+                open=choice.enabled or previous.open,
+                selection=selected,
+                geometry=replace(
+                    previous.geometry, width=choice.width, height=choice.height
+                ),
+            )
+            try:
+                saved = await controller.persist_preferences_revision(
+                    revision, extra_sections={"buddy_interaction": encoded}
+                )
+            except Exception:
+                controller.rollback_preferences_revision(revision, previous)
+                raise
+            if not saved:
+                controller.rollback_preferences_revision(revision, previous)
+                raise ValueError(
+                    "Could not save Buddy settings. Your previous settings are retained; retry."
+                )
+            self.preferences = interaction
+            self._scope_configured = True
+            self.app.app_config["buddy_interaction"] = dict(encoded)
+            from tldw_chatbook.Persona_Buddy.preferences import (
+                serialize_persona_buddy_preferences,
+            )
+
+            self.app.app_config["persona_buddy"] = serialize_persona_buddy_preferences(
+                controller.current_preferences()
+            )
+            controller.invalidate_profile()
+            if assignment is not None:
+                # This is a separate assistant-domain commit, never hidden inside
+                # artwork selection. Its own version guard retains the old Persona
+                # on failure and reports the exact partial Apply outcome.
+                try:
+                    await assignment.apply()
+                except Exception as exc:
+                    raise ValueError(
+                        "Buddy settings were saved, but the Persona changed or could not be saved. Reopen Buddy settings to retry the Persona change."
+                    ) from exc
+            self.start_scope_tracking()
+
+    def start_scope_tracking(self) -> None:
+        """Resume persisted scope when an enabled Buddy first becomes visible."""
+        self.reconcile_scope()
+        if self._scope_timer is None and hasattr(self.app, "set_interval"):
+            self._scope_timer = self.app.set_interval(0.5, self.reconcile_scope)
+
+    def reconcile_scope(self) -> None:
+        """Filter trusted lifecycle events and replay current state after a rebind."""
+        if not self._scope_configured:
+            return
+        speech = getattr(self.app, "buddy_speech_coordinator", None)
+        if speech is not None or self.preferences.speak_responses:
+            from .buddy_speech import ensure_buddy_speech
+
+            presentation = self.controller.current_preferences()
+            ensure_buddy_speech(self.app).configure(
+                self.preferences.binding,
+                self.preferences.speak_responses
+                and presentation.enabled
+                and presentation.open,
+            )
+        runtime = getattr(self.app, "console_runtime", None)
+        if runtime is None:
+            return
+        controller = getattr(runtime, "chat_controller", None)
+        if controller is None:
+            return
+        binding = self.preferences.binding
+        sessions = self._runtime_sessions()
+        if binding is None:
+            selected = ()
+        elif binding.kind == "conversation":
+            resolved = binding.resolve_session(sessions)
+            selected = (resolved,) if resolved is not None else ()
+            if (
+                resolved is not None
+                and resolved.persisted_conversation_id
+                and not binding.ephemeral
+                and binding.conversation_id is None
+                and not self._promotion_pending
+                and time.monotonic() >= self._promotion_retry_after
+            ):
+                self._promotion_pending = True
+                self.app.run_worker(
+                    self._finish_binding_promotion(binding),
+                    group="buddy-binding-promotion",
+                    exclusive=False,
+                    exit_on_error=False,
+                )
+        else:
+            selected = tuple(
+                session for session in sessions if binding.includes(session)
+            )
+        sink = runtime.persona_buddy_sink
+        changed = sink.set_scope(
+            session_ids=frozenset(session.id for session in selected),
+            conversation_ids=frozenset(
+                session.persisted_conversation_id
+                for session in selected
+                if session.persisted_conversation_id
+            ),
+        )
+        if changed:
+            for session in selected:
+                sink.run_state(
+                    session.id, controller.run_state_for(session.id).status, replay=True
+                )
+                for kind in (
+                    "approval",
+                    "skill_install",
+                    "skill_script",
+                    "question",
+                    "worktree_merge",
+                ):
+                    for payload in controller._interrupt_host.session_round_payloads(
+                        kind, session.id
+                    ):
+                        request_id = payload.get("request_id") or payload.get(
+                            "round_id"
+                        )
+                        if request_id:
+                            sink.approval_round(
+                                session.id, str(request_id), pending=True
+                            )
+
+
+def get_buddy_management(app: Any) -> BuddyManagementCoordinator:
+    """Lazily compose the one app-owned Buddy interaction/management coordinator."""
+    coordinator = getattr(app, "_buddy_management", None)
+    if coordinator is None:
+        coordinator = BuddyManagementCoordinator(app)
+        app._buddy_management = coordinator
+    return coordinator
+
+
+def open_buddy_management(app: Any) -> None:
+    """Shared composer-menu and floating-Buddy settings action."""
+    get_buddy_management(app).request_open()
+
+
+def open_buddy_interaction(app: Any) -> None:
+    """Shared click/keyboard action on the current floating Buddy."""
+    get_buddy_management(app).request_interaction()

--- a/tldw_chatbook/UI/Navigation/buddy_speech.py
+++ b/tldw_chatbook/UI/Navigation/buddy_speech.py
@@ -1,0 +1,440 @@
+"""App-owned Buddy speech using existing trusted TTS and destination consent."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.Persona_Buddy.speech import BuddySpeechItem, BuddySpeechQueue
+
+
+@dataclass(frozen=True, slots=True)
+class _SpeechIdentity:
+    session: Any
+    assistant_kind: str | None
+    character_ref: Any
+
+
+class BuddySpeechCoordinator:
+    """Read the selected scope without selecting, acknowledging or answering it."""
+
+    def __init__(self, app: Any) -> None:
+        self.app = app
+        self.binding: BuddyBinding | None = None
+        self.enabled = False
+        self.queue = BuddySpeechQueue(self._play)
+        self.notice = ""
+        self._epoch = 0
+        self._profile: tuple[object, ...] = ()
+        self._poller: asyncio.Task | None = None
+        self._consent_task: asyncio.Task | None = None
+        self._consents: set[str] = set()
+        self._pending_consent: tuple[BuddySpeechItem, Any] | None = None
+        self._closed = False
+
+    @property
+    def needs_consent(self) -> bool:
+        return self._pending_consent is not None
+
+    def _profile_identity(self) -> tuple[object, ...]:
+        return (
+            getattr(self.app, "console_runtime", None),
+            getattr(self.app, "chachanotes_db", None),
+            getattr(self.app, "local_character_persona_service", None),
+        )
+
+    def configure(self, binding: BuddyBinding | None, enabled: bool) -> None:
+        """Apply the committed selection synchronously; work remains app-owned."""
+        profile = self._profile_identity()
+        enabled = enabled is True and binding is not None and not self._closed
+        if (
+            binding != self.binding
+            or enabled != self.enabled
+            or profile != self._profile
+        ):
+            self._epoch += 1
+            if self._consent_task is not None:
+                self._consent_task.cancel()
+            self.queue.reset()
+            self._consents.clear()
+            self._pending_consent = None
+            self.notice = ""
+            self.binding, self.enabled, self._profile = binding, enabled, profile
+        if not enabled:
+            if self._poller is not None:
+                self._poller.cancel()
+            if self._consent_task is not None:
+                self._consent_task.cancel()
+        elif self._poller is None:
+            self._poller = asyncio.create_task(self._poll())
+
+    async def _poll(self) -> None:
+        try:
+            while self.enabled and not self._closed:
+                if self._profile_identity() != self._profile:
+                    self.configure(self.binding, False)
+                    self.notice = (
+                        "The active profile changed. Enable Buddy speech again."
+                    )
+                    break
+                try:
+                    await self.refresh()
+                except Exception:  # noqa: BLE001 - preserve execution, expose no private errors
+                    self.notice = "Buddy speech is unavailable. Review the conversation in Console."
+                await asyncio.sleep(1.0)
+        finally:
+            self._poller = None
+            # A quick disable/re-enable waits for the previous owner to unwind.
+            if self.enabled and not self._closed:
+                self._poller = asyncio.create_task(self._poll())
+
+    def _session_stamp(self, session: Any) -> tuple[object, ...]:
+        persona_version = None
+        if session.assistant_kind == "persona":
+            service = getattr(self.app, "local_character_persona_service", None)
+            record = (
+                service.get_persona_profile(session.assistant_id) if service else None
+            )
+            if (
+                not isinstance(record, Mapping)
+                or record.get("deleted")
+                or record.get("is_active", True) is not True
+            ):
+                raise ValueError("Persona unavailable")
+            persona_version = record.get("version")
+        return (
+            session.assistant_kind,
+            session.assistant_id,
+            session.assistant_authority_id,
+            session.identity_revision,
+            persona_version,
+        )
+
+    def _context(self, store: Any, session: Any) -> Any:
+        raw = getattr(self.app, "app_config", {})
+        defaults = raw.get("chat_defaults", {}) if isinstance(raw, Mapping) else {}
+        return store.presentation_context(session.id, defaults.get("user_display_name"))
+
+    async def refresh(self) -> None:
+        """Queue only completed responses/current questions; never streaming progress."""
+        self.queue.revalidate()
+        if not self.enabled or self.binding is None or self.queue.state.muted:
+            return
+        epoch, binding, profile = self._epoch, self.binding, self._profile
+        runtime = getattr(self.app, "console_runtime", None)
+        store = getattr(runtime, "chat_store", None)
+        controller = getattr(runtime, "chat_controller", None)
+        if store is None or controller is None or not runtime.alive:
+            return
+        candidates: list[tuple[Any, str | None, str | None]] = []
+        if binding.kind == "workspace":
+            from .buddy_workspace import BuddyWorkspaceCoordinator
+
+            _, entries = await BuddyWorkspaceCoordinator(self.app, binding).snapshot()
+            if epoch != self._epoch or profile != self._profile_identity():
+                return
+            receipt_service = getattr(runtime, "activity_receipts", None)
+            receipts = (
+                {r.activity_id: r for r in receipt_service.unseen_snapshot()}
+                if receipt_service
+                else {}
+            )
+            for entry in entries:
+                session = entry.binding.resolve_session(store.sessions())
+                if session is None or not binding.includes(session):
+                    continue  # Never restore/activate a saved conversation to speak it.
+                if entry.group == "needs_you":
+                    candidates.append((session, None, None))
+                elif entry.group == "results":
+                    for receipt_id in entry.receipt_ids:
+                        receipt = receipts.get(receipt_id)
+                        if receipt is not None and receipt.assistant_message_id:
+                            candidates.append(
+                                (session, receipt.assistant_message_id, receipt_id)
+                            )
+        else:
+            session = binding.resolve_session(store.sessions())
+            if session is not None:
+                candidates.append((session, None, None))
+                from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+                latest = next(
+                    (
+                        m
+                        for m in reversed(store.messages_for_session(session.id))
+                        if m.role is ConsoleMessageRole.ASSISTANT
+                        and m.status == "complete"
+                    ),
+                    None,
+                )
+                if latest is not None:
+                    candidates.append((session, latest.id, None))
+        for session, message_id, receipt_id in candidates:
+            try:
+                self._capture(
+                    store,
+                    controller,
+                    session,
+                    message_id,
+                    epoch,
+                    binding,
+                    profile,
+                    receipt_id,
+                )
+            except (ValueError, KeyError):
+                continue  # Missing, edited, incomplete or unverifiable sources stay silent.
+
+    def _capture(
+        self,
+        store,
+        controller,
+        session,
+        message_id,
+        epoch,
+        binding,
+        profile,
+        receipt_id=None,
+    ) -> None:
+        exact = BuddyBinding.for_session(session)
+        stamp = self._session_stamp(session)
+        title = session.title
+        identity = _SpeechIdentity(
+            session, session.assistant_kind, session.character_ref()
+        )
+
+        def owner_current() -> bool:
+            return (
+                self.enabled
+                and epoch == self._epoch
+                and profile == self._profile_identity()
+                and exact.resolve_session(store.sessions()) is session
+                and binding.includes(session)
+                and session.title == title
+                and self._session_stamp(session) == stamp
+                and (
+                    receipt_id is None
+                    or any(
+                        receipt.activity_id == receipt_id
+                        for receipt in profile[0].activity_receipts.unseen_snapshot()
+                    )
+                )
+            )
+
+        if message_id is not None:
+            snapshot = store.issue_tts_message_speech_snapshot(
+                message_id,
+                owner_session_id=session.id,
+                presentation_context=self._context(store, session),
+            )
+
+            def current() -> bool:
+                return (
+                    owner_current()
+                    and store.validate_tts_message_speech_snapshot(
+                        snapshot,
+                        owner_session_id=session.id,
+                        presentation_context=self._context(store, session),
+                    )
+                    == snapshot.raw_content
+                )
+
+            self.queue.enqueue(
+                BuddySpeechItem(
+                    f"message:{session.id}:{message_id}",
+                    title,
+                    snapshot.raw_content,
+                    False,
+                    current,
+                    identity,
+                )
+            )
+            return
+        host = controller._interrupt_host
+        for kind in host.payloads:
+            payload = host.head_round_payload(kind, session.id)
+            if not payload:
+                continue
+            round_id = payload.get("round_id") or payload.get("request_id")
+            if not round_id:
+                continue
+            text = self._decision_text(kind, payload)
+
+            def current(kind=kind, round_id=round_id, text=text) -> bool:
+                with host.lock:
+                    state = host.registries[kind].get(round_id)
+                    live = bool(
+                        state
+                        and not state.get("revoked")
+                        and not state["event"].is_set()
+                    )
+                head = host.head_round_payload(kind, session.id)
+                return bool(
+                    live
+                    and owner_current()
+                    and head
+                    and (head.get("round_id") or head.get("request_id")) == round_id
+                    and self._decision_text(kind, head) == text
+                )
+
+            self.queue.enqueue(
+                BuddySpeechItem(
+                    f"decision:{kind}:{round_id}",
+                    title,
+                    text,
+                    True,
+                    current,
+                    identity,
+                )
+            )
+
+    @staticmethod
+    def _decision_text(kind: str, payload: Mapping) -> str:
+        if kind == "question":
+            questions = payload.get("questions") or ()
+            return (
+                "Your response is needed. "
+                + " ".join(
+                    str(q.get("question") or "")
+                    for q in questions
+                    if isinstance(q, Mapping)
+                )[:2000]
+            )
+        return "Approval is needed. Open the Buddy or Console to review the request."
+
+    async def _play(self, item: BuddySpeechItem, current) -> bool:
+        identity = item.context
+        if not isinstance(identity, _SpeechIdentity) or not current():
+            return False
+        ensure = getattr(self.app, "_ensure_tts_handler", None)
+        if ensure is None:
+            self.notice = "Configure speech in Settings before enabling Buddy speech."
+            return False
+        handler = await ensure()
+        if handler is None or not current():
+            return False
+        destination = await handler.resolve_console_speech_destination(
+            identity.assistant_kind, identity.character_ref
+        )
+        if destination is None or not current():
+            return False
+        consent = getattr(identity.session, "speech_preferences", None)
+        if (
+            destination.fingerprint not in self._consents
+            and getattr(consent, "consent_destination", None) != destination.fingerprint
+        ):
+            self._pending_consent = (item, destination)
+            self.notice = "Confirm the speech destination in Buddy speech controls."
+            return False
+        self.notice = ""
+        return await handler.speak_guarded_utterance(
+            item.named_text,
+            assistant_kind=identity.assistant_kind,
+            character_ref=identity.character_ref,
+            expected_destination_fingerprint=destination.fingerprint,
+            validator=current,
+        )
+
+    def request_consent(self) -> None:
+        """Open consent only after an explicit user action, never from polling."""
+        if self._pending_consent is not None and self._consent_task is None:
+            self._consent_task = asyncio.create_task(self._confirm_destination())
+
+    def set_input_active(self, owner: object, active: bool) -> None:
+        """Accept an explicit microphone presentation hold without starting input."""
+        self.queue.set_input_active(owner, active)
+
+    async def wait_silent(self) -> None:
+        """Wait for owned output to stop before a caller starts its microphone."""
+        await self.queue.wait_idle()
+
+    async def _confirm_destination(self) -> None:
+        from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
+            AutoSpeakConsentModal,
+        )
+
+        pending = self._pending_consent
+        epoch = self._epoch
+        modal = None
+        try:
+            if pending is None:
+                return
+            item, destination = pending
+            if not BuddySpeechQueue._valid(item):
+                self._pending_consent = None
+                return
+            result = asyncio.get_running_loop().create_future()
+
+            def decided(value):
+                if not result.done():
+                    result.set_result(value is True)
+
+            modal = AutoSpeakConsentModal(
+                destination.provider_label,
+                destination.sanitized_destination,
+                destination.charges_may_apply,
+                scope_label="the selected Buddy conversation or workspace",
+            )
+            self.app.push_screen(modal, decided)
+            if (
+                not await result
+                or epoch != self._epoch
+                or not BuddySpeechQueue._valid(item)
+            ):
+                return
+            identity = item.context
+            handler = await self.app._ensure_tts_handler()
+            if (
+                handler is None
+                or epoch != self._epoch
+                or not BuddySpeechQueue._valid(item)
+            ):
+                return
+            current = await handler.resolve_console_speech_destination(
+                identity.assistant_kind, identity.character_ref
+            )
+            if (
+                epoch != self._epoch
+                or not BuddySpeechQueue._valid(item)
+                or current is None
+                or current.fingerprint != destination.fingerprint
+            ):
+                self.notice = (
+                    "The speech destination changed. Confirm its current settings."
+                )
+                return
+            self._consents.add(destination.fingerprint)
+            self._pending_consent = None
+            self.notice = ""
+            self.queue.reset()
+            await self.refresh()
+        except Exception:  # noqa: BLE001 - configuration failures expose no private detail
+            self.notice = "Buddy speech is unavailable. Review speech settings."
+        finally:
+            if modal is not None and getattr(self.app, "screen", None) is modal:
+                modal.dismiss(False)
+            self._consent_task = None
+
+    async def aclose(self) -> None:
+        """Actual app shutdown only; normal navigation never calls this."""
+        self._closed = True
+        self.configure(None, False)
+        tasks = [
+            task for task in (self._poller, self._consent_task) if task is not None
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        await self.queue.aclose()
+
+
+def ensure_buddy_speech(app: Any) -> BuddySpeechCoordinator:
+    """Return the single app-owned queue without starting synthesis or polling."""
+    coordinator = getattr(app, "buddy_speech_coordinator", None)
+    if coordinator is None:
+        coordinator = BuddySpeechCoordinator(app)
+        app.buddy_speech_coordinator = coordinator
+    return coordinator

--- a/tldw_chatbook/UI/Navigation/buddy_workspace.py
+++ b/tldw_chatbook/UI/Navigation/buddy_workspace.py
@@ -1,0 +1,182 @@
+"""App-owned workspace Buddy projection and exact-result commands."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from tldw_chatbook.Persona_Buddy.inbox import BuddyInboxEntry, project_workspace_inbox
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+
+
+class BuddyWorkspaceCoordinator:
+    """Project existing work; this object never accepts or owns an agent run."""
+
+    def __init__(self, app: Any, binding: BuddyBinding) -> None:
+        if binding.kind != "workspace":
+            raise ValueError("Choose a workspace for this inbox.")
+        self.app = app
+        self.binding = binding
+
+    async def snapshot(self) -> tuple[str, tuple[BuddyInboxEntry, ...]]:
+        """Read membership off-loop and then project current in-memory activity."""
+        registry = getattr(self.app, "workspace_registry_service", None)
+        if registry is None:
+            raise ValueError("Workspace storage is unavailable.")
+        runtime = getattr(self.app, "console_runtime", None)
+        initialize = getattr(runtime, "ensure_activity_receipt_service", None)
+        receipts_service = (
+            await asyncio.to_thread(initialize)
+            if initialize is not None
+            else getattr(runtime, "activity_receipts", None)
+        )
+        if receipts_service is None:
+            raise ValueError(
+                "Result storage is unavailable. Check the active local profile and reopen the inbox."
+            )
+        if runtime is not getattr(self.app, "console_runtime", None) or getattr(
+            runtime, "_disposed", False
+        ):
+            raise ValueError("The active profile changed. Reopen the Buddy inbox.")
+        state_reader = getattr(receipts_service, "hydration_state", None)
+        state = await asyncio.to_thread(state_reader) if state_reader else "ready"
+        hydrate = getattr(runtime, "ensure_activity_hydration", None)
+        if hydrate is not None and state != "ready":
+            hydrate()
+        if state == "degraded":
+            raise ValueError(
+                "Result storage could not be read. The inbox will retry; check the active profile if this continues."
+            )
+        if state != "ready":
+            raise ValueError(
+                "Loading saved results. The inbox will refresh automatically."
+            )
+        receipts = await asyncio.to_thread(receipts_service.unseen_snapshot)
+        wanted = {
+            receipt.conversation_id for receipt in receipts if receipt.conversation_id
+        }
+
+        def read_members() -> tuple[str, dict[str, str]]:
+            workspace = registry.get_workspace(self.binding.target_id)
+            if (
+                workspace is None
+                or workspace.archived
+                or str(getattr(workspace.authority, "value", workspace.authority))
+                != "local-only"
+            ):
+                raise ValueError(
+                    "The bound workspace is unavailable. Choose another in Buddy settings."
+                )
+            service = getattr(self.app, "local_chat_conversation_service", None)
+            members = {}
+            if wanted:
+                for membership in registry.list_workspace_conversations(
+                    self.binding.target_id
+                ):
+                    if membership.item_id not in wanted or service is None:
+                        continue
+                    row = service.get_conversation_metadata(membership.item_id)
+                    if row and not row.get("deleted", False):
+                        members[membership.item_id] = str(
+                            row.get("title") or membership.title or "Conversation"
+                        )
+            return workspace.name, members
+
+        title, members = await asyncio.to_thread(read_members)
+        # Refresh live owners after I/O: selection, move or deletion may have changed.
+        if runtime is not getattr(self.app, "console_runtime", None) or getattr(
+            runtime, "_disposed", False
+        ):
+            raise ValueError("The active profile changed. Reopen the Buddy inbox.")
+        store = getattr(runtime, "chat_store", None)
+        controller = getattr(runtime, "chat_controller", None)
+        sessions = tuple(store.sessions()) if store else ()
+        scoped = [s for s in sessions if self.binding.includes(s)]
+        states = (
+            {s.id: controller.run_state_for(s.id) for s in scoped} if controller else {}
+        )
+        activities = (
+            {s.id: controller.activity_for(s.id) for s in scoped} if controller else {}
+        )
+        # Use the frozen receipt set with matching membership; the next refresh
+        # picks up later outcomes. No result is acknowledged by this read.
+        return title, project_workspace_inbox(
+            self.binding.target_id,
+            sessions=sessions,
+            receipts=receipts,
+            run_states=states,
+            activities=activities,
+            member_titles=members,
+        )
+
+    async def _validate_entry(self, entry: BuddyInboxEntry) -> BuddyInboxEntry:
+        _, rows = await self.snapshot()
+        current = next((row for row in rows if row.key == entry.key), None)
+        if (
+            current is None
+            or current.binding != entry.binding
+            or current.receipt_ids != entry.receipt_ids
+        ):
+            raise ValueError(
+                "This item is no longer in the workspace inbox. Refresh and select its current entry."
+            )
+        return current
+
+    async def acknowledge(self, entry: BuddyInboxEntry) -> int:
+        """Acknowledge only the exact selected outcome, never an entire conversation."""
+        if entry.group != "results" or not entry.receipt_ids:
+            raise ValueError(
+                "Only a result can be marked seen; questions still need a response."
+            )
+        await self._validate_entry(entry)
+        runtime = getattr(self.app, "console_runtime", None)
+        receipts = getattr(runtime, "activity_receipts", None)
+        if receipts is None:
+            raise ValueError(
+                "Result storage is unavailable; the result remains unseen."
+            )
+        return await asyncio.to_thread(receipts.acknowledge, entry.receipt_ids)
+
+    def request_open_entry(self, entry: BuddyInboxEntry) -> None:
+        self.app.run_worker(
+            self._open_entry(entry),
+            group="buddy-inbox-open",
+            exclusive=True,
+            exit_on_error=False,
+        )
+
+    async def _open_entry(self, entry: BuddyInboxEntry) -> None:
+        try:
+            await self._validate_entry(entry)
+            from .buddy_conversation import open_buddy_conversation
+
+            open_buddy_conversation(self.app, entry.binding, allow_voice=False)
+        except ValueError as exc:
+            self.app.notify(str(exc), severity="warning")
+        except Exception:  # noqa: BLE001 - a failed inbox read must not terminate active work
+            self.app.notify(
+                "Could not open this workspace item. Reopen the inbox and retry.",
+                severity="error",
+            )
+
+
+def open_buddy_workspace(app: Any, binding: BuddyBinding) -> None:
+    """Open a workspace inbox without selecting a Console session or microphone."""
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_workspace_modal import (
+        BuddyWorkspaceModal,
+    )
+
+    from .buddy_speech import ensure_buddy_speech
+
+    current = getattr(app, "_buddy_workspace_modal", None)
+    if current is not None and current.is_mounted:
+        return
+    coordinator = BuddyWorkspaceCoordinator(app, binding)
+    modal = BuddyWorkspaceModal(
+        snapshot=coordinator.snapshot,
+        open_entry=coordinator.request_open_entry,
+        acknowledge=coordinator.acknowledge,
+        speech=ensure_buddy_speech(app),
+    )
+    app._buddy_workspace_modal = modal
+    app.push_screen(modal)

--- a/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
+++ b/tldw_chatbook/UI/Navigation/persona_buddy_overlay.py
@@ -118,6 +118,10 @@ class PersonaBuddyOverlay:
                     controller, snapshot
                 )
             )
+            if desired and getattr(self.app, "app_config", {}).get("buddy_interaction"):
+                from .buddy_management import get_buddy_management
+
+                get_buddy_management(self.app).start_scope_tracking()
             if not desired:
                 await self._retire()
                 self._sync_affordances(screen)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -638,6 +638,7 @@ from ...Widgets.Console.console_composer_menu_modal import (
     ACTION_GENERATE_IMAGE,
     ACTION_ATTACH_CONTEXT,
     ACTION_IMPERSONATE,
+    ACTION_BUDDY,
     ACTION_IMPROVE_CURRENT_DRAFT,
     ACTION_PROMPTS,
     ACTION_SAVE_CHATBOOK,
@@ -5316,6 +5317,11 @@ class ChatScreen(BaseAppScreen):
             ),
             callback=self._apply_console_model_popover_result,
         )
+
+    def on_console_workspace_details_tray_default_persona_requested(self, event) -> None:
+        """Route the workspace details action to its explicit workspace owner."""
+        event.stop()
+        self._workspace._open_workspace_persona_default(event.workspace_id)
 
     def _apply_console_model_popover_result(
         self,
@@ -10583,6 +10589,11 @@ class ChatScreen(BaseAppScreen):
     def _handle_console_composer_menu_choice(self, action_id: str | None) -> None:
         """Route the chosen menu action (task-1680)."""
         if not action_id:
+            return
+        if action_id == ACTION_BUDDY:
+            from ..Navigation.buddy_management import open_buddy_management
+
+            open_buddy_management(self.app)
             return
         if action_id == ACTION_SAVE_CHAT:
             self._session._dispatch_promote_console_temporary_session()
@@ -22614,6 +22625,9 @@ class ChatScreen(BaseAppScreen):
           install is idempotent), and the previews cache -- all correct to
           leave running/installed across a suspend.
         """
+        controller = self._console_chat_controller
+        if controller is not None:
+            controller.on_console_view_visibility_changed(False)
         self._release_claimed_conversation_settings_return()
         # The debounced sidebar write is async and its read-modify-write of
         # ui_state.toml is unlocked, so consecutive suspends must SERIALIZE
@@ -22653,6 +22667,9 @@ class ChatScreen(BaseAppScreen):
 
     def on_screen_resume(self) -> None:
         """Called when returning to this screen."""
+        controller = self._console_chat_controller
+        if controller is not None:
+            controller.on_console_view_visibility_changed(True)
         if self._pending_character_return_focus_id is not None:
             self.call_after_refresh(self._workspace.restore_character_navigation_focus)
         logger.debug("Chat screen resuming")

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -32920,6 +32920,7 @@ class LibraryScreen(BaseAppScreen):
         self.app.push_screen(
             WorkspaceCreateModal(
                 registry_service=registry_service,
+                persona_service=getattr(self.app_instance, "local_character_persona_service", None),
                 description="Local workspace created from Library.",
             ),
             _done,

--- a/tldw_chatbook/UI/Screens/personas_screen.py
+++ b/tldw_chatbook/UI/Screens/personas_screen.py
@@ -520,19 +520,6 @@ class _CharacterTTSControlSnapshot:
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class _PersonaBuddyActionAuthority:
-    """Immutable Workbench and app-owner authority for one explicit action."""
-
-    action: str
-    source: str
-    persona_id: str
-    revision: int
-    session_generation: int
-    scope_service: object = dataclasses.field(repr=False, compare=False)
-    controller: object = dataclasses.field(repr=False, compare=False)
-
-
-@dataclasses.dataclass(frozen=True, slots=True)
 class _ActorPackExportUIAuthority:
     """Exact screen and selection authority for one app-owned export."""
 
@@ -1263,7 +1250,6 @@ class PersonasScreen(BaseAppScreen):
         self._profile_save_operation_inflight: bool = False
         self._profile_save_completion: asyncio.Future[None] | None = None
         self._persona_buddy_session_generation: int = 0
-        self._persona_buddy_action_lock = asyncio.Lock()
         # Mirrors _profile_save_inflight for the character editor: guards
         # against a re-entrant Save (double-click/Ctrl+S) while an earlier
         # save for this session is still persisting.
@@ -7152,218 +7138,17 @@ class PersonasScreen(BaseAppScreen):
         event.stop()
         await self._attach_selection_to_console(intent="start_chat")
 
-    def _persona_buddy_action_context_is_current(
-        self,
-        authority: _PersonaBuddyActionAuthority,
-    ) -> bool:
-        """Revalidate every Workbench owner behind one explicit Buddy action."""
-
-        return bool(
-            self.is_mounted
-            and getattr(self.app_instance, "character_persona_scope_service", None)
-            is authority.scope_service
-            and getattr(self.app, "persona_buddy_controller", None)
-            is authority.controller
-            and self._persona_buddy_session_generation == authority.session_generation
-            and self.state.active_mode == "personas"
-            and self.state.runtime_source == authority.source
-            and self.persona_handler.current_mode() == authority.source
-            and self.state.selected_entity_kind == "persona"
-            and self.state.selected_entity_id == authority.persona_id
-            and not self.state.has_unsaved_changes
-        )
-
-    @staticmethod
-    def _persona_buddy_record_is_eligible(
-        record: Mapping[str, object], authority: _PersonaBuddyActionAuthority
-    ) -> bool:
-        """Return whether a complete record still matches local action authority."""
-
-        return bool(
-            authority.source == "local"
-            and str(record.get("id") or "") == authority.persona_id
-            and type(record.get("version")) is int
-            and record.get("version") == authority.revision
-            and record.get("is_active", True) is True
-            and record.get("deleted", False) is False
-        )
-
-    @staticmethod
-    async def _fetch_persona_buddy_action_record(
-        authority: _PersonaBuddyActionAuthority,
-    ) -> Mapping[str, object] | None:
-        """Fetch a full record only through the request's captured service."""
-
-        getter = getattr(authority.scope_service, "get_persona_profile", None)
-        if not callable(getter):
-            return None
-        try:
-            record = await getter(authority.persona_id, mode=authority.source)
-        except asyncio.CancelledError:
-            raise
-        except Exception:
-            logger.warning(
-                "Persona Buddy action profile refresh failed "
-                "(category=profile_unavailable)."
-            )
-            return None
-        if hasattr(record, "model_dump"):
-            record = record.model_dump(mode="json")
-        return record if isinstance(record, Mapping) else None
-
     @on(PersonaBuddyActionRequested)
     def _handle_persona_buddy_action(
         self, message: PersonaBuddyActionRequested
     ) -> None:
-        """Capture one action session and run it as a replaceable screen worker."""
-
+        """Route legacy inspector messages to independent Buddy management."""
         message.stop()
-        scope_service = getattr(
-            self.app_instance, "character_persona_scope_service", None
+        from ..Navigation.buddy_management import get_buddy_management
+
+        get_buddy_management(self.app).request_visibility(
+            "manage" if message.action == "use" else message.action
         )
-        # Explicit Buddy actions are the feature's entry point, so when the
-        # passive read yields None they must CONSTRUCT the lazy controller
-        # (TASK-21103): a profile whose preferences still say disabled reads
-        # None from the persona_buddy_controller property, and "Use for
-        # Buddy" from that state has to be able to enable it end to end.
-        controller = getattr(self.app, "persona_buddy_controller", None)
-        if controller is None:
-            ensure = getattr(self.app, "ensure_persona_buddy_controller", None)
-            if callable(ensure):
-                controller = ensure()
-        authority = _PersonaBuddyActionAuthority(
-            action=message.action,
-            source=message.source,
-            persona_id=message.persona_id,
-            revision=message.revision,
-            session_generation=self._advance_persona_buddy_session(),
-            scope_service=scope_service,
-            controller=controller,
-        )
-        self.run_worker(
-            self._run_persona_buddy_action(authority),
-            group="personas-buddy-action",
-            exclusive=True,
-            exit_on_error=False,
-        )
-
-    async def _run_persona_buddy_action(
-        self, authority: _PersonaBuddyActionAuthority
-    ) -> None:
-        """Persist one explicit action behind exact ABA-safe authority."""
-
-        scope_service = authority.scope_service
-        controller = authority.controller
-        if (
-            authority.source != "local"
-            or scope_service is None
-            or controller is None
-            or not self._persona_buddy_action_context_is_current(authority)
-        ):
-            self._notify(
-                "Persona Buddy is available for active local Personas.", "warning"
-            )
-            return
-
-        record = await self._fetch_persona_buddy_action_record(authority)
-        if (
-            record is None
-            or not self._persona_buddy_action_context_is_current(authority)
-            or not self._persona_buddy_record_is_eligible(record, authority)
-        ):
-            if self._persona_buddy_action_context_is_current(authority):
-                self._notify(
-                    "Persona Buddy is available for active local Personas.", "warning"
-                )
-            return
-
-        selection = PersonaBuddySelection("local", authority.persona_id)
-        async with self._persona_buddy_action_lock:
-            if not self._persona_buddy_action_context_is_current(authority):
-                return
-            current = controller.current_preferences()
-            if authority.action == "use":
-                changes: dict[str, object] = {
-                    "selection": selection,
-                    "enabled": True,
-                    "open": True,
-                }
-            elif current.selection != selection:
-                self._notify("Use this Persona for Buddy first.", "warning")
-                return
-            elif authority.action == "show":
-                changes = {"enabled": True, "open": True}
-            elif authority.action == "close":
-                changes = {"open": False}
-            else:
-                changes = {"enabled": False}
-
-            candidate = dataclasses.replace(current, **changes)
-            if candidate != current:
-
-                async def restore_previous_action_fields() -> None:
-                    latest_preferences = controller.current_preferences()
-                    rollback = dataclasses.replace(
-                        latest_preferences,
-                        **{field: getattr(current, field) for field in changes},
-                    )
-                    if rollback != latest_preferences:
-                        await controller.update_preferences(rollback)
-
-                try:
-                    await controller.update_preferences(candidate)
-                except asyncio.CancelledError:
-                    if not self._persona_buddy_action_context_is_current(authority):
-                        await restore_previous_action_fields()
-                    raise
-                except Exception:
-                    logger.warning(
-                        "Persona Buddy preference update failed "
-                        "(category=preference_update_failed)."
-                    )
-                    if self._persona_buddy_action_context_is_current(authority):
-                        self._notify(
-                            "Persona Buddy preference could not be saved.", "error"
-                        )
-                    return
-                if not self._persona_buddy_action_context_is_current(authority):
-                    await restore_previous_action_fields()
-                    return
-                preferences = controller.current_preferences()
-                if any(
-                    getattr(preferences, field) != value
-                    for field, value in changes.items()
-                ):
-                    self._notify(
-                        "Persona Buddy preference could not be saved.", "error"
-                    )
-                    return
-            self._sync_inspector_buddy_status()
-
-        record = await self._fetch_persona_buddy_action_record(authority)
-        if (
-            record is None
-            or not self._persona_buddy_action_context_is_current(authority)
-            or not self._persona_buddy_record_is_eligible(record, authority)
-        ):
-            return
-        reconcile = getattr(self.app, "reconcile_persona_buddy_view", None)
-        if callable(reconcile):
-            try:
-                await reconcile()
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                logger.warning(
-                    "Persona Buddy view refresh failed (category=view_refresh_failed)."
-                )
-                if self._persona_buddy_action_context_is_current(authority):
-                    self._notify(
-                        "Persona Buddy was updated, but its view could not refresh.",
-                        "warning",
-                    )
-            if not self._persona_buddy_action_context_is_current(authority):
-                return
 
     @on(CharacterMessage.Loaded)
     async def _handle_character_loaded(self, message: CharacterMessage.Loaded) -> None:

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -23085,6 +23085,7 @@ class SettingsScreen(BaseAppScreen):
         self.app.push_screen(
             WorkspaceCreateModal(
                 registry_service=registry,
+                persona_service=getattr(self.app_instance, "local_character_persona_service", None),
                 description="Local workspace created from Settings.",
             ),
             _done,

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -755,6 +755,28 @@ def validate_bounded_integer(value: object, *, minimum: int, maximum: int) -> in
     return number
 
 
+class BuddyManagementInput(BaseModel):
+    """Bound raw Buddy form values before resolving selected application identities."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    enabled: bool
+    artwork: str = Field(max_length=256)
+    archive: str = Field(max_length=4096)
+    target: str = Field(max_length=512)
+    persona: str = Field(max_length=256)
+    motion: Literal["dynamic", "static"]
+    speak_responses: bool
+    width: int
+    height: int
+
+    @field_validator("width", "height", mode="before")
+    @classmethod
+    def _dimensions(cls, value: object, info: ValidationInfo) -> int:
+        minimum, maximum = (8, 120) if info.field_name == "width" else (4, 60)
+        return validate_bounded_integer(value, minimum=minimum, maximum=maximum)
+
+
 def validate_port(port: Union[str, int]) -> bool:
     """Validate port number."""
     log_counter("input_validation_port_attempt")

--- a/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
+++ b/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
@@ -101,6 +101,8 @@ class AutoSpeakConsentModal(SafeModalDismissMixin, ModalScreen[bool]):
         provider_label: str,
         sanitized_destination: str,
         charges_may_apply: bool,
+        *,
+        scope_label: str | None = None,
     ) -> None:
         super().__init__()
         self.provider_label = _safe_label(provider_label, fallback="TTS provider")
@@ -108,6 +110,7 @@ class AutoSpeakConsentModal(SafeModalDismissMixin, ModalScreen[bool]):
             sanitized_destination
         )
         self.charges_may_apply = charges_may_apply is True
+        self.scope_label = _safe_label(scope_label, fallback="the selected Buddy scope") if scope_label is not None else None
 
     def __repr__(self) -> str:
         return (
@@ -137,7 +140,7 @@ class AutoSpeakConsentModal(SafeModalDismissMixin, ModalScreen[bool]):
                     markup=False,
                 )
             yield Static(
-                "Only new replies in this conversation will be spoken.",
+                (f"Buddy will speak queued updates for {self.scope_label}." if self.scope_label is not None else "Only new replies in this conversation will be spoken."),
                 markup=False,
             )
             with Horizontal(id="console-auto-speak-consent-actions"):

--- a/tldw_chatbook/Widgets/Console/console_composer_menu_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_composer_menu_modal.py
@@ -29,6 +29,7 @@ ACTION_GENERATE_CAPTION = "generate-caption"
 #: whose only behavior is a "not implemented yet" toast erodes trust in every
 #: other entry. Re-add the action id here when the feature lands.
 ACTION_IMPERSONATE = "impersonate"
+ACTION_BUDDY = "buddy"
 #: Moved here from the composer action row. These two strings are also the
 #: ids of the buttons they replaced, so the screen's existing
 #: `@on(Button.Pressed, "#console-<id>")` handlers stay the one
@@ -160,6 +161,11 @@ def build_composer_menu_entries(
             ACTION_IMPERSONATE,
             "Impersonate",
             "Draft your next reply with the current model",
+        ),
+        ComposerMenuEntry(
+            ACTION_BUDDY,
+            "Buddy…",
+            "Manage Buddy artwork, follow target, and Persona",
         ),
     )
     if not ephemeral:

--- a/tldw_chatbook/Widgets/Console/console_workspace_details.py
+++ b/tldw_chatbook/Widgets/Console/console_workspace_details.py
@@ -5,16 +5,18 @@ from __future__ import annotations
 import re
 from typing import Any
 
+from textual import on
 from textual.app import ComposeResult
 from textual.containers import Vertical
-from textual.widgets import Static
+from textual.message import Message
+from textual.widgets import Button, Static
 
 from tldw_chatbook.Widgets.Console.console_workspace_context import (
     ConsoleWorkspaceStatusPair,
 )
-from tldw_chatbook.Workspaces.display_state import ConsoleWorkspaceContextState
 from tldw_chatbook.Widgets.recompose_capture_guard import RecomposeCaptureGuard
-
+from tldw_chatbook.Workspaces.display_state import ConsoleWorkspaceContextState
+from tldw_chatbook.Workspaces.models import DEFAULT_WORKSPACE_ID
 
 _AUTHORITY_LABELS = {
     "local registry ready": "local",
@@ -31,6 +33,18 @@ _AUTHORITY_LABELS = {
 
 class ConsoleWorkspaceDetailsTray(RecomposeCaptureGuard, Vertical):
     """Render workspace plumbing status, readiness, and handoff rows."""
+
+    class DefaultPersonaRequested(Message):
+        """Open default controls for this explicit workspace, without activating it."""
+
+        def __init__(self, workspace_id: str) -> None:
+            super().__init__()
+            self.workspace_id = workspace_id
+
+    @on(Button.Pressed, "#console-workspace-default-persona")
+    def _edit_default_persona(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.post_message(self.DefaultPersonaRequested(self.state.workspace_id))
 
     def __init__(self, state: ConsoleWorkspaceContextState, **kwargs: Any) -> None:
         super().__init__(**kwargs)
@@ -145,6 +159,15 @@ class ConsoleWorkspaceDetailsTray(RecomposeCaptureGuard, Vertical):
         """Render workspace status, readiness, runtime, and handoff rows."""
 
         collapse_server_features = self._server_features_unconfigured()
+
+        if self.state.workspace_id and self.state.workspace_id != DEFAULT_WORKSPACE_ID:
+            yield Button(
+                "Default Persona…", id="console-workspace-default-persona", compact=True
+            )
+            yield self._static(
+                "Applies to future new conversations.",
+                id="console-workspace-default-persona-scope",
+            )
 
         yield from self._status_pair(
             self._friendly_status_label(self.state.authority_label),

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_conversation_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_conversation_modal.py
@@ -36,9 +36,13 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
         border: round $accent; background: $panel; padding: 0 1; }
     #buddy-conversation-title { height: 2; text-style: bold; }
     #buddy-activity, #buddy-reply-notice { height: auto; }
-    #buddy-conversation-body { height: 1fr; }
+    #buddy-conversation-body { height: 1fr; min-height: 2; }
+    #buddy-transcript-navigation { height: 1; }
+    #buddy-transcript-navigation Button { height: 1; min-width: 8; width: auto; }
     #buddy-transcript { height: auto; padding: 1 0; }
     #buddy-reply { height: 5; min-height: 3; }
+    BuddyConversationModal.compact #buddy-reply { height: 3; }
+    BuddyConversationModal.compact #buddy-conversation-title { height: 1; }
     #buddy-actions { height: 3; align-horizontal: right; }
     #buddy-actions Button { min-width: 8; width: auto; margin-left: 1; }
     #buddy-reply-notice { color: $text-muted; }
@@ -54,7 +58,9 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
         self._syncing_draft = False
         self._visible = True
         self._timer: Any = None
-        self._last_transcript = ""
+        self._last_transcript: str | None = None
+        self._last_decisions = ""
+        self._new_updates = False
         self._last_draft = coordinator.drafts.get(binding, "")
 
     def compose(self) -> ComposeResult:
@@ -67,6 +73,9 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
                 yield SkillInstallConfirmCard(id="buddy-install")
                 yield SkillScriptConfirmCard(id="buddy-script")
                 yield ChatQuestionCard(id="buddy-question")
+            with Horizontal(id="buddy-transcript-navigation"):
+                yield Button("Latest", id="buddy-latest", compact=True)
+                yield Button("Pending decision", id="buddy-pending", compact=True)
             yield Static("", id="buddy-reply-notice", markup=False)
             yield TextArea(
                 self.coordinator.drafts.get(self.binding, ""), id="buddy-reply"
@@ -84,8 +93,12 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
                 yield Button("Open Console", id="buddy-open-console")
                 yield Button("Close", id="buddy-close")
 
+    def on_resize(self) -> None:
+        self.set_class(self.size.height <= 24, "compact")
+
     def on_mount(self) -> None:
         super().on_mount()
+        self.query_one("#buddy-conversation-body", VerticalScroll).anchor()
         self._timer = self.set_interval(0.2, self.refresh_projection)
         self.call_after_refresh(self.refresh_projection)
         self.query_one("#buddy-reply", TextArea).focus()
@@ -93,6 +106,10 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
     def refresh_projection(self) -> None:
         if not self.is_mounted or not self._visible:
             return
+        body = self.query_one("#buddy-conversation-body", VerticalScroll)
+        first = self._last_transcript is None
+        follow = first or body.scroll_y >= body.max_scroll_y - 1
+        changed = False
         coordinator = self.coordinator
         session = coordinator.resolve(self.binding)
         controller = coordinator.controller
@@ -125,6 +142,7 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
                 for message in messages
             )[-64000:]
             if transcript != self._last_transcript:
+                changed = True
                 self.query_one("#buddy-transcript", Static).update(
                     transcript or "No messages yet."
                 )
@@ -132,6 +150,18 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
         else:
             self.query_one("#buddy-transcript", Static).update("")
         payloads = coordinator.decision_payloads(self.binding) if available else {}
+        decisions = repr(payloads)
+        changed = changed or decisions != self._last_decisions
+        self._last_decisions = decisions
+        self.query_one("#buddy-pending", Button).display = bool(payloads)
+        if changed:
+            if follow:
+                self.call_after_refresh(self._scroll_latest)
+            else:
+                self._new_updates = True
+        self.query_one("#buddy-latest", Button).label = (
+            "Latest · new updates" if self._new_updates else "Latest"
+        )
         approval = payloads.get("approval")
         card = self.query_one(ChatApprovalCard)
         if approval:
@@ -173,6 +203,47 @@ class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
                 if status != "idle"
                 else "Dictate"
             )
+
+    def _scroll_latest(self) -> None:
+        self.query_one("#buddy-conversation-body", VerticalScroll).anchor()
+        self._new_updates = False
+        self.query_one("#buddy-latest", Button).label = "Latest"
+
+    @on(Button.Pressed, "#buddy-latest")
+    def latest(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._scroll_latest()
+
+    @on(Button.Pressed, "#buddy-pending")
+    def pending(self, event: Button.Pressed) -> None:
+        event.stop()
+        for card_type in (
+            ChatApprovalCard,
+            SkillInstallConfirmCard,
+            SkillScriptConfirmCard,
+            ChatQuestionCard,
+        ):
+            card = self.query_one(card_type)
+            if card.display:
+                body = self.query_one("#buddy-conversation-body", VerticalScroll)
+                body.release_anchor()
+                controls = [widget for widget in card.query(Button) if widget.focusable]
+                if controls:
+                    controls[0].focus(scroll_visible=False)
+                    # Nested scroll_to_widget clips through the tall card's
+                    # ancestors at small sizes. Target the action's measured
+                    # position directly in the transcript viewport instead.
+                    body.scroll_to(
+                        y=body.scroll_y
+                        + controls[0].region.bottom
+                        - body.content_region.bottom,
+                        animate=False,
+                        immediate=True,
+                    )
+                else:
+                    body.scroll_to_widget(card, animate=False, top=True, immediate=True)
+                return
+        self.query_one("#buddy-open-console", Button).focus()
 
     @on(TextArea.Changed, "#buddy-reply")
     def draft_changed(self, event: TextArea.Changed) -> None:

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_conversation_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_conversation_modal.py
@@ -1,0 +1,261 @@
+"""A disposable transcript and decision projection for one explicit Buddy target."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Static, TextArea
+
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.Widgets.Chat_Widgets.chat_approval_card import ChatApprovalCard
+from tldw_chatbook.Widgets.Chat_Widgets.chat_question_card import ChatQuestionCard
+from tldw_chatbook.Widgets.Chat_Widgets.chat_task_cards import ChatTaskCards
+from tldw_chatbook.Widgets.Chat_Widgets.skill_install_confirm_card import (
+    SkillInstallConfirmCard,
+)
+from tldw_chatbook.Widgets.Chat_Widgets.skill_script_confirm_card import (
+    SkillScriptConfirmCard,
+)
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+
+class BuddyConversationModal(SafeModalDismissMixin, ModalScreen[None]):
+    """Close only the projection and microphone, leaving accepted runtime work intact."""
+
+    SAFE_MODAL_CONTENT = "#buddy-conversation"
+    BINDINGS: ClassVar[list[tuple[str, str, str]]] = [
+        ("escape", "request_safe_cancel", "Close")
+    ]
+    DEFAULT_CSS = """
+    BuddyConversationModal { align: center middle; }
+    #buddy-conversation { width: 90; max-width: 96%; height: 90%; max-height: 52;
+        border: round $accent; background: $panel; padding: 0 1; }
+    #buddy-conversation-title { height: 2; text-style: bold; }
+    #buddy-activity, #buddy-reply-notice { height: auto; }
+    #buddy-conversation-body { height: 1fr; }
+    #buddy-transcript { height: auto; padding: 1 0; }
+    #buddy-reply { height: 5; min-height: 3; }
+    #buddy-actions { height: 3; align-horizontal: right; }
+    #buddy-actions Button { min-width: 8; width: auto; margin-left: 1; }
+    #buddy-reply-notice { color: $text-muted; }
+    """
+
+    def __init__(
+        self, coordinator: Any, binding: BuddyBinding, *, allow_voice: bool = True
+    ) -> None:
+        super().__init__()
+        self.coordinator = coordinator
+        self.binding = binding
+        self.allow_voice = allow_voice
+        self._syncing_draft = False
+        self._visible = True
+        self._timer: Any = None
+        self._last_transcript = ""
+        self._last_draft = coordinator.drafts.get(binding, "")
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="buddy-conversation"):
+            yield Static("Conversation", id="buddy-conversation-title", markup=False)
+            yield Static("", id="buddy-activity", markup=False)
+            with VerticalScroll(id="buddy-conversation-body"):
+                yield Static("", id="buddy-transcript", markup=False)
+                yield ChatApprovalCard(id="buddy-approval")
+                yield SkillInstallConfirmCard(id="buddy-install")
+                yield SkillScriptConfirmCard(id="buddy-script")
+                yield ChatQuestionCard(id="buddy-question")
+            yield Static("", id="buddy-reply-notice", markup=False)
+            yield TextArea(
+                self.coordinator.drafts.get(self.binding, ""), id="buddy-reply"
+            )
+            from tldw_chatbook.UI.Navigation.buddy_speech import ensure_buddy_speech
+            from tldw_chatbook.Widgets.Persona_Widgets.buddy_speech_controls import (
+                BuddySpeechControls,
+            )
+
+            yield BuddySpeechControls(ensure_buddy_speech(self.coordinator.app))
+            with Horizontal(id="buddy-actions"):
+                if self.allow_voice:
+                    yield Button("Dictate", id="buddy-mic")
+                yield Button("Send", id="buddy-send", variant="primary")
+                yield Button("Open Console", id="buddy-open-console")
+                yield Button("Close", id="buddy-close")
+
+    def on_mount(self) -> None:
+        super().on_mount()
+        self._timer = self.set_interval(0.2, self.refresh_projection)
+        self.call_after_refresh(self.refresh_projection)
+        self.query_one("#buddy-reply", TextArea).focus()
+
+    def refresh_projection(self) -> None:
+        if not self.is_mounted or not self._visible:
+            return
+        coordinator = self.coordinator
+        session = coordinator.resolve(self.binding)
+        controller = coordinator.controller
+        available = session is not None and controller is not None
+        coordinator.show_decisions(self, self.binding if available else None)
+        if not available:
+            coordinator.close_voice(self)
+        title = session.title if session is not None else "Conversation unavailable"
+        self.query_one("#buddy-conversation-title", Static).update(str(title))
+        busy = not available or not controller.run_state_for(session.id).is_send_allowed
+        if busy:
+            coordinator.close_voice(self)
+        activity = (
+            controller.run_state_for(session.id).status.value.replace("_", " ")
+            if available
+            else "This target is missing or unavailable. No other conversation will be used."
+        )
+        self.query_one("#buddy-activity", Static).update(activity)
+        self.query_one("#buddy-send", Button).disabled = (
+            busy or self.binding in coordinator.submitting
+        )
+        self.query_one(
+            "#buddy-open-console", Button
+        ).disabled = not coordinator.can_open_console(self.binding)
+        self.query_one("#buddy-reply", TextArea).disabled = not available
+        if available:
+            messages = controller.store.messages_for_session(session.id)[-60:]
+            transcript = "\n\n".join(
+                f"{message.role.value.title()}: {message.content}"
+                for message in messages
+            )[-64000:]
+            if transcript != self._last_transcript:
+                self.query_one("#buddy-transcript", Static).update(
+                    transcript or "No messages yet."
+                )
+                self._last_transcript = transcript
+        else:
+            self.query_one("#buddy-transcript", Static).update("")
+        payloads = coordinator.decision_payloads(self.binding) if available else {}
+        approval = payloads.get("approval")
+        card = self.query_one(ChatApprovalCard)
+        if approval:
+            card.set_batch(
+                approval.get("calls", []),
+                timeout_seconds=approval.get("timeout_seconds", 0),
+                round_id=approval.get("round_id"),
+                phase=approval.get("phase", "approval"),
+                summary=approval.get("summary"),
+            )
+        else:
+            card.display = False
+        self.query_one(SkillInstallConfirmCard).set_install(
+            payloads.get("skill_install")
+        )
+        self.query_one(SkillScriptConfirmCard).set_script(payloads.get("skill_script"))
+        self.query_one(ChatQuestionCard).set_questions(payloads.get("question"))
+        notice = coordinator.notices.get(self.binding, "")
+        if "worktree_merge" in payloads:
+            notice = "A worktree decision needs review. Open Console to continue."
+        self.query_one("#buddy-reply-notice", Static).update(notice)
+        draft = coordinator.drafts.get(self.binding, "")
+        composer = self.query_one("#buddy-reply", TextArea)
+        if self._last_draft != draft:
+            self._syncing_draft = True
+            composer.load_text(draft)
+            self._last_draft = draft
+            self._syncing_draft = False
+        if self.allow_voice:
+            mic = self.query_one("#buddy-mic", Button)
+            status = coordinator.voice_status(self)
+            mic.disabled = (
+                not available or busy or status in {"starting", "transcribing"}
+            )
+            mic.label = (
+                "Finish dictation"
+                if status == "recording"
+                else status.title()
+                if status != "idle"
+                else "Dictate"
+            )
+
+    @on(TextArea.Changed, "#buddy-reply")
+    def draft_changed(self, event: TextArea.Changed) -> None:
+        if not self._syncing_draft:
+            self.coordinator.drafts[self.binding] = event.text_area.text
+            self._last_draft = event.text_area.text
+
+    @on(Button.Pressed, "#buddy-send")
+    def send_reply(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.coordinator.request_send(
+            self.binding, self.query_one("#buddy-reply", TextArea).text
+        )
+        self.refresh_projection()
+
+    @on(Button.Pressed, "#buddy-mic")
+    def dictate(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.coordinator.request_voice(self, self.binding, allowed=self.allow_voice)
+        self.refresh_projection()
+
+    @on(Button.Pressed, "#buddy-close")
+    def close(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss_safe_once(None)
+
+    @on(Button.Pressed, "#buddy-open-console")
+    def open_console(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self.coordinator.can_open_console(self.binding):
+            self.dismiss_safe_once(None)
+            self.coordinator.open_console(self.binding)
+
+    @on(ChatApprovalCard.ApprovalDecided)
+    def approval_decided(self, event: ChatApprovalCard.ApprovalDecided) -> None:
+        event.stop()
+        self.coordinator.resolve_decision(
+            self.binding, "approval", event.round_id, event.decisions
+        )
+
+    @on(SkillInstallConfirmCard.InstallDecided)
+    def install_decided(self, event: SkillInstallConfirmCard.InstallDecided) -> None:
+        event.stop()
+        self.coordinator.resolve_decision(
+            self.binding, "skill_install", event.request_id, event.allow
+        )
+
+    @on(SkillScriptConfirmCard.ScriptDecided)
+    def script_decided(self, event: SkillScriptConfirmCard.ScriptDecided) -> None:
+        event.stop()
+        self.coordinator.resolve_decision(
+            self.binding,
+            "skill_script",
+            event.request_id,
+            (event.allow, event.remember),
+        )
+
+    @on(ChatTaskCards.QuestionAnswered)
+    def question_answered(self, event: ChatTaskCards.QuestionAnswered) -> None:
+        event.stop()
+        self.coordinator.resolve_decision(
+            self.binding, "question", event.request_id, event.answers
+        )
+
+    def on_screen_suspend(self) -> None:
+        self._visible = False
+        self.coordinator.show_decisions(self, None)
+        self.coordinator.close_voice(self)
+
+    def on_screen_resume(self) -> None:
+        self._visible = True
+        self.call_after_refresh(self.refresh_projection)
+
+    def on_unmount(self) -> None:
+        self.coordinator.show_decisions(self, None)
+        self.coordinator.close_voice(self)
+        if self._timer is not None:
+            self._timer.stop()
+        super().on_unmount()
+
+    def dismiss_safe_once(self, result: object) -> bool:
+        if self.is_mounted:
+            text = self.query_one("#buddy-reply", TextArea).text
+            if text != self._last_draft:
+                self.coordinator.drafts[self.binding] = text
+        return super().dismiss_safe_once(result)

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
@@ -1,0 +1,340 @@
+"""Staged Buddy and Persona controls shared by Console and floating companions."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Input, Select, Static, Switch
+
+from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+PERSONA_UNCHANGED = "#unchanged"
+PERSONA_NONE = "#none"
+_NO_ARTWORK = "#none"
+_NO_TARGET = "#none"
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyTargetChoice:
+    """A named, explicitly resolved follow target with Persona edit availability."""
+
+    key: str
+    label: str
+    binding: BuddyBinding
+    persona_editable: bool = True
+    persona_unavailable_reason: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class BuddyManagementChoice:
+    """User intent returned by Apply; constructing this changes no application state."""
+
+    enabled: bool = False
+    buddy_id: str | None = None
+    import_path: str = ""
+    binding: BuddyBinding | None = None
+    persona_choice: str = PERSONA_UNCHANGED
+    animated: bool = True
+    speak_responses: bool = False
+    width: int = 28
+    height: int = 12
+
+
+class BuddyManagementModal(
+    SafeModalDismissMixin, ModalScreen[BuddyManagementChoice | None]
+):
+    """Edit a staged choice, returning None on Escape or Cancel.
+
+    Args:
+        buddies: Installed artwork (display label, stable Buddy ID) choices.
+        targets: Named local conversation and workspace choices.
+        personas: Available assistant Persona (display label, profile ID) choices.
+        initial: Current preference snapshot; never modified by this form.
+        preview: Read-only callback accepting Buddy ID and expression state.
+    """
+
+    SAFE_MODAL_CONTENT = "#buddy-management"
+    BINDINGS: ClassVar[list[tuple[str, str, str]]] = [
+        ("escape", "request_safe_cancel", "Cancel")
+    ]
+
+    DEFAULT_CSS = """
+    BuddyManagementModal { align: center middle; }
+    #buddy-management {
+        width: 78; max-width: 96%; height: 90%; max-height: 48;
+        border: round $accent; background: $panel; padding: 0 1;
+    }
+    #buddy-management-title { height: 2; text-style: bold; padding-top: 1; }
+    #buddy-management-body { height: 1fr; padding-right: 1; }
+    .buddy-section { height: auto; margin-top: 1; text-style: bold; }
+    .buddy-help { height: auto; color: $text-muted; }
+    #buddy-management-body Select, #buddy-management-body Input { width: 100%; }
+    .buddy-toggle-row { height: 3; align-vertical: middle; }
+    .buddy-toggle-row Static { width: 1fr; height: auto; }
+    .buddy-toggle-row Switch { width: auto; }
+    #buddy-size { height: 3; }
+    #buddy-size Input { width: 1fr; }
+    #buddy-size Static { width: 9; height: 3; content-align: left middle; }
+    #buddy-size #buddy-height-label { width: 10; padding-left: 1; }
+    #buddy-preview { height: auto; max-height: 12; content-align: center middle; }
+    #buddy-preview-actions { height: 3; }
+    #buddy-preview-state { width: 1fr; }
+    #buddy-preview-button { width: auto; min-width: 11; }
+    #buddy-form-error { height: auto; color: $error; }
+    #buddy-management-actions { height: 3; min-height: 3; align-horizontal: right; }
+    #buddy-management-actions Button { width: auto; min-width: 10; margin-left: 1; }
+    """
+
+    def __init__(
+        self,
+        *,
+        buddies: tuple[tuple[str, str], ...] = (),
+        targets: tuple[BuddyTargetChoice, ...] = (),
+        personas: tuple[tuple[str, str], ...] = (),
+        initial: BuddyManagementChoice | None = None,
+        preview: Callable[[str, str], Any] | None = None,
+    ) -> None:
+        super().__init__()
+        self._buddies = buddies
+        self._targets = targets
+        self._personas = personas
+        self._initial = initial or BuddyManagementChoice()
+        self._preview_callback = preview
+        self._preview_generation = 0
+
+    def compose(self) -> ComposeResult:
+        initial = self._initial
+        selected_artwork = initial.buddy_id or _NO_ARTWORK
+        artwork_choices = [(Text("Choose artwork"), _NO_ARTWORK)] + [
+            (Text(label), key) for label, key in self._buddies
+        ]
+        if initial.buddy_id and initial.buddy_id not in {
+            key for _, key in self._buddies
+        }:
+            artwork_choices.append(
+                (Text("Selected artwork is unavailable"), initial.buddy_id)
+            )
+        target_choices = [(Text("None — appearance only"), _NO_TARGET)] + [
+            (Text(target.label), target.key) for target in self._targets
+        ]
+        target_key = next(
+            (t.key for t in self._targets if t.binding == initial.binding), _NO_TARGET
+        )
+        if initial.binding is not None and target_key == _NO_TARGET:
+            # Preserve the missing choice so Apply cannot silently detach a stale binding.
+            target_key = "#missing"
+            target_choices.append(
+                (Text("Current target is unavailable — choose another"), target_key)
+            )
+        with Vertical(id="buddy-management"):
+            yield Static("Buddy & Persona Management", id="buddy-management-title")
+            with VerticalScroll(id="buddy-management-body"):
+                yield Static("Buddy", classes="buddy-section")
+                with Horizontal(classes="buddy-toggle-row"):
+                    yield Static("Show Buddy")
+                    yield Switch(initial.enabled, id="buddy-enabled")
+                yield Select(
+                    artwork_choices,
+                    value=selected_artwork,
+                    allow_blank=False,
+                    id="buddy-artwork",
+                )
+                yield Static(
+                    "Import a native Buddy pack (.tldw-persona-vpack or .zip)",
+                    classes="buddy-help",
+                )
+                yield Input(
+                    value=initial.import_path,
+                    placeholder="Path to pack; installed when you Apply",
+                    id="buddy-import",
+                )
+                if self._preview_callback is not None:
+                    with Horizontal(id="buddy-preview-actions"):
+                        yield Select(
+                            [
+                                (s.replace("_", " ").capitalize(), s)
+                                for s in (
+                                    "idle",
+                                    "thinking",
+                                    "speaking",
+                                    "approval_needed",
+                                    "error",
+                                )
+                            ],
+                            value="idle",
+                            allow_blank=False,
+                            id="buddy-preview-state",
+                        )
+                        yield Button("Preview", id="buddy-preview-button")
+                    yield Static("", id="buddy-preview")
+                yield Static("Expressions", classes="buddy-help")
+                yield Select(
+                    [("Dynamic", "dynamic"), ("Static", "static")],
+                    value="dynamic" if initial.animated else "static",
+                    allow_blank=False,
+                    id="buddy-motion",
+                )
+                with Horizontal(id="buddy-size"):
+                    yield Static("Width")
+                    yield Input(str(initial.width), type="integer", id="buddy-width")
+                    yield Static("Height", id="buddy-height-label")
+                    yield Input(str(initial.height), type="integer", id="buddy-height")
+                yield Static("Follow", classes="buddy-section")
+                yield Select(
+                    target_choices,
+                    value=target_key,
+                    allow_blank=False,
+                    id="buddy-follow",
+                )
+                yield Static(
+                    "This target stays fixed when you switch screens or conversations.",
+                    classes="buddy-help",
+                )
+                yield Static("Persona", classes="buddy-section")
+                yield Static("", id="buddy-persona-help", classes="buddy-help")
+                yield Select(
+                    [
+                        (Text("Keep current assignment"), PERSONA_UNCHANGED),
+                        (Text("None"), PERSONA_NONE),
+                    ]
+                    + [(Text(label), key) for label, key in self._personas],
+                    value=initial.persona_choice,
+                    allow_blank=False,
+                    id="buddy-persona",
+                )
+                yield Static("Notifications & voice", classes="buddy-section")
+                with Horizontal(classes="buddy-toggle-row"):
+                    yield Static("Speak responses with conversation names")
+                    yield Switch(initial.speak_responses, id="buddy-speech")
+                yield Static(
+                    "Workspace Buddies accept typed replies; voice input is available only for a conversation Buddy.",
+                    classes="buddy-help",
+                )
+            yield Static("", id="buddy-form-error", markup=False)
+            with Horizontal(id="buddy-management-actions"):
+                yield Button("Cancel", id="buddy-cancel")
+                yield Button("Apply", variant="primary", id="buddy-apply")
+
+    def on_mount(self) -> None:
+        self._sync_persona_controls()
+        self.query_one("#buddy-enabled").focus()
+
+    def _target(self) -> BuddyTargetChoice | None:
+        key = self.query_one("#buddy-follow", Select).value
+        return next((target for target in self._targets if target.key == key), None)
+
+    @on(Select.Changed, "#buddy-follow")
+    def _follow_changed(self) -> None:
+        if self.is_mounted:
+            self.query_one("#buddy-persona", Select).value = PERSONA_UNCHANGED
+            self._sync_persona_controls()
+
+    def _sync_persona_controls(self) -> None:
+        target = self._target()
+        control = self.query_one("#buddy-persona", Select)
+        control.disabled = target is None or not target.persona_editable
+        if target is None:
+            message = "Choose a conversation or workspace to manage its Persona."
+        elif not target.persona_editable:
+            message = (
+                target.persona_unavailable_reason
+                or "Persona changes are unavailable for this target."
+            )
+        elif target.binding.kind == "workspace":
+            message = "Default Persona for future new conversations in this workspace."
+        else:
+            message = "Assistant Persona for this conversation. Artwork is independent."
+        self.query_one("#buddy-persona-help", Static).update(message)
+
+    @on(Button.Pressed, "#buddy-preview-button")
+    async def _preview(self, event: Button.Pressed) -> None:
+        event.stop()
+        buddy_id = self.query_one("#buddy-artwork", Select).value
+        if buddy_id == _NO_ARTWORK or self._preview_callback is None:
+            self.query_one("#buddy-preview", Static).update(
+                "Choose installed artwork to preview."
+            )
+            return
+        self._preview_generation += 1
+        generation = self._preview_generation
+        try:
+            result = self._preview_callback(
+                str(buddy_id), str(self.query_one("#buddy-preview-state", Select).value)
+            )
+            if inspect.isawaitable(result):
+                result = await result
+            if self.is_mounted and generation == self._preview_generation:
+                self.query_one("#buddy-preview", Static).update(result)
+        except Exception:  # noqa: BLE001 - untrusted asset preview must not terminate the modal
+            if self.is_mounted and generation == self._preview_generation:
+                self.query_one("#buddy-preview", Static).update(
+                    "Preview unavailable. Choose another expression or check the pack."
+                )
+
+    @on(Button.Pressed, "#buddy-cancel")
+    def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#buddy-apply")
+    def _apply(self, event: Button.Pressed) -> None:
+        event.stop()
+        try:
+            choice = self._choice()
+        except ValueError as exc:
+            self.query_one("#buddy-form-error", Static).update(str(exc))
+            return
+        self.dismiss(choice)
+
+    def _choice(self) -> BuddyManagementChoice:
+        enabled = self.query_one("#buddy-enabled", Switch).value
+        artwork = str(self.query_one("#buddy-artwork", Select).value)
+        archive = self.query_one("#buddy-import", Input).value.strip()
+        if enabled and artwork not in {key for _, key in self._buddies} and not archive:
+            raise ValueError(
+                "Choose artwork or enter a Buddy pack path before enabling it."
+            )
+        target_key = self.query_one("#buddy-follow", Select).value
+        target = self._target()
+        if target_key != _NO_TARGET and target is None:
+            raise ValueError("Choose an available conversation or workspace.")
+        try:
+            width = int(self.query_one("#buddy-width", Input).value)
+            height = int(self.query_one("#buddy-height", Input).value)
+        except ValueError:
+            raise ValueError("Enter whole numbers for width and height.") from None
+        if not (8 <= width <= 120 and 4 <= height <= 60):
+            raise ValueError(
+                "Use a width of 8–120 and a height of 4–60 terminal cells."
+            )
+        persona = str(self.query_one("#buddy-persona", Select).value)
+        if persona not in {
+            PERSONA_UNCHANGED,
+            PERSONA_NONE,
+            *[key for _, key in self._personas],
+        }:
+            raise ValueError("Choose an available Persona or None.")
+        if persona != PERSONA_UNCHANGED and (
+            target is None or not target.persona_editable
+        ):
+            raise ValueError("Persona changes are unavailable for this target.")
+        return BuddyManagementChoice(
+            enabled=enabled,
+            buddy_id=None if artwork == _NO_ARTWORK else artwork,
+            import_path=archive,
+            binding=target.binding if target else None,
+            persona_choice=persona,
+            animated=self.query_one("#buddy-motion", Select).value == "dynamic",
+            speak_responses=self.query_one("#buddy-speech", Switch).value,
+            width=width,
+            height=height,
+        )

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
@@ -87,6 +87,9 @@ class BuddyManagementModal(
     #buddy-size Static { width: 9; height: 3; content-align: left middle; }
     #buddy-size #buddy-height-label { width: 10; padding-left: 1; }
     #buddy-preview { height: auto; max-height: 12; content-align: center middle; }
+    #buddy-artwork-pages { height: 3; }
+    #buddy-artwork-pages Button { width: auto; min-width: 10; }
+    #buddy-artwork-page { width: 1fr; content-align: center middle; }
     #buddy-preview-actions { height: 3; }
     #buddy-management-body #buddy-preview-state { width: 1fr; min-width: 10; }
     #buddy-preview-button { width: auto; min-width: 11; }
@@ -106,9 +109,17 @@ class BuddyManagementModal(
         initial: BuddyManagementChoice | None = None,
         preview: Callable[[str, str], Any] | None = None,
         apply: Callable[[BuddyManagementChoice], Any] | None = None,
+        artwork_page: Callable[[int], Any] | None = None,
+        artwork_page_size: int = 100,
+        selected_buddy: tuple[str, str] | None = None,
     ) -> None:
         super().__init__()
         self._buddies = buddies
+        self._artwork_page = artwork_page
+        self._artwork_page_size = artwork_page_size
+        self._artwork_offset = 0
+        self._paging = False
+        self._selected_buddy = selected_buddy
         self._targets = targets
         self._personas = personas
         self._initial = initial or BuddyManagementChoice()
@@ -123,9 +134,20 @@ class BuddyManagementModal(
         artwork_choices = [(Text("Choose artwork"), _NO_ARTWORK)] + [
             (Text(label), key) for label, key in self._buddies
         ]
-        if initial.buddy_id and initial.buddy_id not in {
+        if self._selected_buddy and self._selected_buddy[1] not in {
             key for _, key in self._buddies
         }:
+            artwork_choices.append(
+                (Text(self._selected_buddy[0]), self._selected_buddy[1])
+            )
+        if (
+            initial.buddy_id
+            and initial.buddy_id not in {key for _, key in self._buddies}
+            and (
+                self._selected_buddy is None
+                or self._selected_buddy[1] != initial.buddy_id
+            )
+        ):
             artwork_choices.append(
                 (Text("Selected artwork is unavailable"), initial.buddy_id)
             )
@@ -154,6 +176,17 @@ class BuddyManagementModal(
                     allow_blank=False,
                     id="buddy-artwork",
                 )
+                if self._artwork_page is not None:
+                    with Horizontal(id="buddy-artwork-pages"):
+                        yield Button(
+                            "Previous", id="buddy-artwork-previous", disabled=True
+                        )
+                        yield Static("Page 1", id="buddy-artwork-page")
+                        yield Button(
+                            "Next",
+                            id="buddy-artwork-next",
+                            disabled=len(self._buddies) < self._artwork_page_size,
+                        )
                 if self._preview_callback is not None:
                     with Horizontal(id="buddy-preview-actions"):
                         yield Select(
@@ -367,28 +400,98 @@ class BuddyManagementModal(
         if succeeded:
             self.dismiss_safe_once(None)
 
+    @on(Button.Pressed, "#buddy-artwork-previous")
+    @on(Button.Pressed, "#buddy-artwork-next")
+    async def _change_artwork_page(self, event: Button.Pressed) -> None:
+        event.stop()
+        if self._paging or self._applying or self._artwork_page is None:
+            return
+        delta = (
+            -self._artwork_page_size
+            if event.button.id == "buddy-artwork-previous"
+            else self._artwork_page_size
+        )
+        offset = max(0, self._artwork_offset + delta)
+        self._paging = True
+        previous = self.query_one("#buddy-artwork-previous", Button)
+        following = self.query_one("#buddy-artwork-next", Button)
+        previous.disabled = following.disabled = True
+        try:
+            page = self._artwork_page(offset)
+            if inspect.isawaitable(page):
+                page = await page
+            if not self.is_mounted:
+                return
+            control = self.query_one("#buddy-artwork", Select)
+            selected = control.value
+            known = {key: label for label, key in self._buddies}
+            if self._selected_buddy is not None:
+                known[self._selected_buddy[1]] = self._selected_buddy[0]
+            if selected in known:
+                self._selected_buddy = (known[selected], selected)
+            self._buddies = tuple(page)
+            self._artwork_offset = offset
+            options = [(Text("Choose artwork"), _NO_ARTWORK)] + [
+                (Text(label), key) for label, key in self._buddies
+            ]
+            if selected != _NO_ARTWORK and selected not in {
+                key for _, key in self._buddies
+            }:
+                options.append(
+                    (
+                        Text(known.get(selected, "Selected artwork is unavailable")),
+                        selected,
+                    )
+                )
+            control.set_options(options)
+            control.value = selected
+            self.query_one("#buddy-artwork-page", Static).update(
+                f"Page {offset // self._artwork_page_size + 1}"
+            )
+        except Exception:  # noqa: BLE001 - retain staged selection on failed page reads
+            if self.is_mounted:
+                self.query_one("#buddy-form-error", Static).update(
+                    "Could not load artwork. Retry this page."
+                )
+        finally:
+            self._paging = False
+            if self.is_mounted:
+                previous.disabled = self._artwork_offset == 0
+                following.disabled = len(self._buddies) < self._artwork_page_size
+
     def _choice(self) -> BuddyManagementChoice:
-        enabled = self.query_one("#buddy-enabled", Switch).value
-        artwork = str(self.query_one("#buddy-artwork", Select).value)
-        archive = self.query_one("#buddy-import", Input).value.strip()
-        if enabled and artwork not in {key for _, key in self._buddies} and not archive:
+        # Lazy loading keeps the boot import budget independent of this form.
+        from tldw_chatbook.Utils.input_validation import BuddyManagementInput
+
+        try:
+            values = BuddyManagementInput(
+                enabled=self.query_one("#buddy-enabled", Switch).value,
+                artwork=self.query_one("#buddy-artwork", Select).value,
+                archive=self.query_one("#buddy-import", Input).value.strip(),
+                target=self.query_one("#buddy-follow", Select).value,
+                persona=self.query_one("#buddy-persona", Select).value,
+                motion=self.query_one("#buddy-motion", Select).value,
+                speak_responses=self.query_one("#buddy-speech", Switch).value,
+                width=self.query_one("#buddy-width", Input).value,
+                height=self.query_one("#buddy-height", Input).value,
+            )
+        except ValueError:
+            raise ValueError(
+                "Check the pack path and selections. Use a width of 8–120 and a height of 4–60 whole terminal cells."
+            ) from None
+        enabled, artwork, archive = values.enabled, values.artwork, values.archive
+        available = {key for _, key in self._buddies}
+        if self._selected_buddy is not None:
+            available.add(self._selected_buddy[1])
+        if enabled and artwork not in available and not archive:
             raise ValueError(
                 "Choose artwork or enter a Buddy pack path before enabling it."
             )
-        target_key = self.query_one("#buddy-follow", Select).value
+        target_key = values.target
         target = self._target()
         if target_key != _NO_TARGET and target is None:
             raise ValueError("Choose an available conversation or workspace.")
-        try:
-            width = int(self.query_one("#buddy-width", Input).value)
-            height = int(self.query_one("#buddy-height", Input).value)
-        except ValueError:
-            raise ValueError("Enter whole numbers for width and height.") from None
-        if not (8 <= width <= 120 and 4 <= height <= 60):
-            raise ValueError(
-                "Use a width of 8–120 and a height of 4–60 terminal cells."
-            )
-        persona = str(self.query_one("#buddy-persona", Select).value)
+        persona = values.persona
         if persona not in {
             PERSONA_UNCHANGED,
             PERSONA_NONE,
@@ -405,8 +508,8 @@ class BuddyManagementModal(
             import_path=archive,
             binding=target.binding if target else None,
             persona_choice=persona,
-            animated=self.query_one("#buddy-motion", Select).value == "dynamic",
-            speak_responses=self.query_one("#buddy-speech", Switch).value,
-            width=width,
-            height=height,
+            animated=values.motion == "dynamic",
+            speak_responses=values.speak_responses,
+            width=values.width,
+            height=values.height,
         )

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
@@ -12,7 +12,7 @@ from textual import on
 from textual.app import ComposeResult
 from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
-from textual.widgets import Button, Input, Select, Static, Switch
+from textual.widgets import Button, Collapsible, Input, Select, Static, Switch
 
 from tldw_chatbook.Persona_Buddy.interaction import BuddyBinding
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
@@ -32,6 +32,7 @@ class BuddyTargetChoice:
     binding: BuddyBinding
     persona_editable: bool = True
     persona_unavailable_reason: str = ""
+    current_persona: str = "None"
 
 
 @dataclass(frozen=True, slots=True)
@@ -82,14 +83,16 @@ class BuddyManagementModal(
     .buddy-toggle-row Static { width: 1fr; height: auto; }
     .buddy-toggle-row Switch { width: auto; }
     #buddy-size { height: 3; }
-    #buddy-size Input { width: 1fr; }
+    #buddy-management-body #buddy-size Input { width: 1fr; min-width: 4; }
     #buddy-size Static { width: 9; height: 3; content-align: left middle; }
     #buddy-size #buddy-height-label { width: 10; padding-left: 1; }
     #buddy-preview { height: auto; max-height: 12; content-align: center middle; }
     #buddy-preview-actions { height: 3; }
-    #buddy-preview-state { width: 1fr; }
+    #buddy-management-body #buddy-preview-state { width: 1fr; min-width: 10; }
     #buddy-preview-button { width: auto; min-width: 11; }
-    #buddy-form-error { height: auto; color: $error; }
+    #buddy-form-error, #buddy-import-error { height: auto; color: $error; }
+    #buddy-advanced { height: auto; padding: 0; }
+    #buddy-preview-button:focus { text-style: bold reverse; }
     #buddy-management-actions { height: 3; min-height: 3; align-horizontal: right; }
     #buddy-management-actions Button { width: auto; min-width: 10; margin-left: 1; }
     """
@@ -102,6 +105,7 @@ class BuddyManagementModal(
         personas: tuple[tuple[str, str], ...] = (),
         initial: BuddyManagementChoice | None = None,
         preview: Callable[[str, str], Any] | None = None,
+        apply: Callable[[BuddyManagementChoice], Any] | None = None,
     ) -> None:
         super().__init__()
         self._buddies = buddies
@@ -110,6 +114,8 @@ class BuddyManagementModal(
         self._initial = initial or BuddyManagementChoice()
         self._preview_callback = preview
         self._preview_generation = 0
+        self._apply_callback = apply
+        self._applying = False
 
     def compose(self) -> ComposeResult:
         initial = self._initial
@@ -148,15 +154,6 @@ class BuddyManagementModal(
                     allow_blank=False,
                     id="buddy-artwork",
                 )
-                yield Static(
-                    "Import a native Buddy pack (.tldw-persona-vpack or .zip)",
-                    classes="buddy-help",
-                )
-                yield Input(
-                    value=initial.import_path,
-                    placeholder="Path to pack; installed when you Apply",
-                    id="buddy-import",
-                )
                 if self._preview_callback is not None:
                     with Horizontal(id="buddy-preview-actions"):
                         yield Select(
@@ -183,11 +180,6 @@ class BuddyManagementModal(
                     allow_blank=False,
                     id="buddy-motion",
                 )
-                with Horizontal(id="buddy-size"):
-                    yield Static("Width")
-                    yield Input(str(initial.width), type="integer", id="buddy-width")
-                    yield Static("Height", id="buddy-height-label")
-                    yield Input(str(initial.height), type="integer", id="buddy-height")
                 yield Static("Follow", classes="buddy-section")
                 yield Select(
                     target_choices,
@@ -200,7 +192,9 @@ class BuddyManagementModal(
                     classes="buddy-help",
                 )
                 yield Static("Persona", classes="buddy-section")
-                yield Static("", id="buddy-persona-help", classes="buddy-help")
+                yield Static(
+                    "", id="buddy-persona-help", classes="buddy-help", markup=False
+                )
                 yield Select(
                     [
                         (Text("Keep current assignment"), PERSONA_UNCHANGED),
@@ -211,6 +205,30 @@ class BuddyManagementModal(
                     allow_blank=False,
                     id="buddy-persona",
                 )
+                with Collapsible(
+                    title="Import pack & size",
+                    collapsed=not bool(initial.import_path),
+                    id="buddy-advanced",
+                ):
+                    yield Static(
+                        "Import a native Buddy pack (.tldw-persona-vpack or .zip)",
+                        classes="buddy-help",
+                    )
+                    yield Input(
+                        value=initial.import_path,
+                        placeholder="Path to pack; installed when you Apply",
+                        id="buddy-import",
+                    )
+                    yield Static("", id="buddy-import-error", markup=False)
+                    with Horizontal(id="buddy-size"):
+                        yield Static("Width")
+                        yield Input(
+                            str(initial.width), type="integer", id="buddy-width"
+                        )
+                        yield Static("Height", id="buddy-height-label")
+                        yield Input(
+                            str(initial.height), type="integer", id="buddy-height"
+                        )
                 yield Static("Notifications & voice", classes="buddy-section")
                 with Horizontal(classes="buddy-toggle-row"):
                     yield Static("Speak responses with conversation names")
@@ -225,6 +243,7 @@ class BuddyManagementModal(
                 yield Button("Apply", variant="primary", id="buddy-apply")
 
     def on_mount(self) -> None:
+        super().on_mount()
         self._sync_persona_controls()
         self.query_one("#buddy-enabled").focus()
 
@@ -253,6 +272,13 @@ class BuddyManagementModal(
             message = "Default Persona for future new conversations in this workspace."
         else:
             message = "Assistant Persona for this conversation. Artwork is independent."
+        if target is not None:
+            label = (
+                "Current default"
+                if target.binding.kind == "workspace"
+                else "Current Persona"
+            )
+            message = f"{label}: {target.current_persona}. {message}"
         self.query_one("#buddy-persona-help", Static).update(message)
 
     @on(Button.Pressed, "#buddy-preview-button")
@@ -283,17 +309,63 @@ class BuddyManagementModal(
     @on(Button.Pressed, "#buddy-cancel")
     def _cancel(self, event: Button.Pressed) -> None:
         event.stop()
-        self.dismiss(None)
+        self.dismiss_safe_once(None)
+
+    def dismiss_safe_once(self, result: object) -> bool:
+        if self._applying:
+            return False
+        return super().dismiss_safe_once(result)
 
     @on(Button.Pressed, "#buddy-apply")
     def _apply(self, event: Button.Pressed) -> None:
         event.stop()
+        if self._applying:
+            return
         try:
             choice = self._choice()
         except ValueError as exc:
             self.query_one("#buddy-form-error", Static).update(str(exc))
             return
-        self.dismiss(choice)
+        if self._apply_callback is None:
+            self.dismiss_safe_once(choice)
+            return
+        self._applying = True
+        self.query_one("#buddy-apply", Button).disabled = True
+        self.query_one("#buddy-apply", Button).label = "Applying…"
+        self.query_one("#buddy-cancel", Button).disabled = True
+        self.query_one("#buddy-management-body").disabled = True
+        self.query_one("#buddy-form-error", Static).update(
+            "Applying settings… Keep this dialog open."
+        )
+        self.run_worker(
+            self._commit(choice), group="buddy-management-commit", exclusive=True
+        )
+
+    async def _commit(self, choice: BuddyManagementChoice) -> None:
+        succeeded = False
+        try:
+            result = self._apply_callback(choice)
+            if inspect.isawaitable(result):
+                await result
+            succeeded = True
+        except Exception as exc:  # noqa: BLE001 - preserve staged input on storage failure
+            message = (
+                str(exc)
+                if isinstance(exc, ValueError)
+                else "Could not save Buddy settings. Check profile storage and retry."
+            )
+            self.query_one("#buddy-form-error", Static).update(message)
+            if choice.import_path:
+                self.query_one("#buddy-import-error", Static).update(message)
+                self.query_one("#buddy-advanced", Collapsible).collapsed = False
+        finally:
+            self._applying = False
+            self.query_one("#buddy-management-body").disabled = False
+            self.query_one("#buddy-apply", Button).disabled = False
+            self.query_one("#buddy-apply", Button).label = "Apply"
+            self.query_one("#buddy-cancel", Button).disabled = False
+        if succeeded:
+            self.dismiss_safe_once(None)
 
     def _choice(self) -> BuddyManagementChoice:
         enabled = self.query_one("#buddy-enabled", Switch).value

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_speech_controls.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_speech_controls.py
@@ -26,7 +26,7 @@ class BuddySpeechControls(Vertical):
 
     def compose(self) -> ComposeResult:
         yield Static("", id="buddy-speech-status", markup=False)
-        with Horizontal():
+        with Horizontal(id="buddy-speech-actions"):
             yield Button("Pause", id="buddy-speech-pause", compact=True)
             yield Button("Skip", id="buddy-speech-skip", compact=True)
             yield Button("Mute", id="buddy-speech-mute", compact=True)
@@ -54,6 +54,17 @@ class BuddySpeechControls(Vertical):
                 else "Buddy speech is off"
             )
         self.query_one("#buddy-speech-status", Static).update(status)
+        self.query_one("#buddy-speech-actions").display = bool(
+            self.coordinator.enabled
+            or self.coordinator.needs_consent
+            or state.current_title
+            or state.queued
+            or state.error
+            or self.coordinator.notice
+            or state.paused
+            or state.muted
+            or state.input_active
+        )
         pause = self.query_one("#buddy-speech-pause", Button)
         pause.label = "Resume" if state.paused else "Pause"
         pause.disabled = not self.coordinator.enabled or state.input_active

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_speech_controls.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_speech_controls.py
@@ -1,0 +1,85 @@
+"""Reusable speech-only controls for both Buddy conversation and workspace modals."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.widgets import Button, Static
+
+
+class BuddySpeechControls(Vertical):
+    """Project an app-owned queue; unmounting this widget never stops playback."""
+
+    DEFAULT_CSS = """
+    BuddySpeechControls { height: auto; }
+    BuddySpeechControls Static { height: auto; }
+    BuddySpeechControls Horizontal { height: auto; }
+    BuddySpeechControls Button { min-width: 8; }
+    """
+
+    def __init__(self, coordinator: Any, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.coordinator = coordinator
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="buddy-speech-status", markup=False)
+        with Horizontal():
+            yield Button("Pause", id="buddy-speech-pause", compact=True)
+            yield Button("Skip", id="buddy-speech-skip", compact=True)
+            yield Button("Mute", id="buddy-speech-mute", compact=True)
+            yield Button("Confirm speech", id="buddy-speech-confirm", compact=True)
+
+    def on_mount(self) -> None:
+        self.refresh_state()
+        self.set_interval(0.5, self.refresh_state)
+
+    def refresh_state(self) -> None:
+        state = self.coordinator.queue.state
+        status = self.coordinator.notice or state.error
+        if state.input_active:
+            status = "Microphone active; speech waits"
+        if not status:
+            status = (
+                "Speech muted"
+                if state.muted
+                else "Speech paused · Resume restarts this update"
+                if state.paused
+                else f"Speaking: {state.current_title}"
+                if state.current_title
+                else "Buddy speech enabled"
+                if self.coordinator.enabled
+                else "Buddy speech is off"
+            )
+        self.query_one("#buddy-speech-status", Static).update(status)
+        pause = self.query_one("#buddy-speech-pause", Button)
+        pause.label = "Resume" if state.paused else "Pause"
+        pause.disabled = not self.coordinator.enabled or state.input_active
+        self.query_one("#buddy-speech-mute", Button).label = (
+            "Unmute" if state.muted else "Mute"
+        )
+        self.query_one("#buddy-speech-skip", Button).disabled = not (
+            state.current_title or state.queued
+        )
+        self.query_one(
+            "#buddy-speech-confirm", Button
+        ).display = self.coordinator.needs_consent
+
+    @on(Button.Pressed)
+    def _control(self, event: Button.Pressed) -> None:
+        action = event.button.id
+        if not action or not action.startswith("buddy-speech-"):
+            return
+        event.stop()
+        queue = self.coordinator.queue
+        if action == "buddy-speech-pause":
+            (queue.resume if queue.state.paused else queue.pause)()
+        elif action == "buddy-speech-skip":
+            queue.skip()
+        elif action == "buddy-speech-mute":
+            (queue.unmute if queue.state.muted else queue.mute)()
+        elif action == "buddy-speech-confirm":
+            self.coordinator.request_consent()
+        self.refresh_state()

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_workspace_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_workspace_modal.py
@@ -1,0 +1,197 @@
+"""Native workspace activity inbox with explicit result acknowledgement."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Callable
+from typing import Any, ClassVar
+
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical
+from textual.screen import ModalScreen
+from textual.widgets import Button, OptionList, Static
+from textual.widgets.option_list import Option
+
+from tldw_chatbook.Persona_Buddy.inbox import BuddyInboxEntry
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+
+class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
+    """Display live rows while keeping keyboard focus and receipt ownership stable."""
+
+    SAFE_MODAL_CONTENT = "#buddy-inbox"
+    BINDINGS: ClassVar[list[tuple[str, str, str]]] = [
+        ("escape", "request_safe_cancel", "Close")
+    ]
+    DEFAULT_CSS = """
+    BuddyWorkspaceModal { align: center middle; }
+    #buddy-inbox {
+        width: 82; max-width: 96%; height: 85%; max-height: 42;
+        border: round $accent; background: $panel; padding: 0 1;
+    }
+    #buddy-inbox-title { height: 2; text-style: bold; padding-top: 1; }
+    #buddy-inbox-help { height: auto; color: $text-muted; }
+    #buddy-inbox-list { height: 1fr; margin-top: 1; }
+    #buddy-inbox-error { height: auto; color: $error; }
+    #buddy-inbox-actions { height: 3; min-height: 3; align-horizontal: right; }
+    #buddy-inbox-actions Button { width: auto; min-width: 8; margin-left: 1; }
+    """
+
+    def __init__(
+        self,
+        *,
+        snapshot: Callable[[], Any],
+        open_entry: Callable[[BuddyInboxEntry], Any],
+        acknowledge: Callable[[BuddyInboxEntry], Any],
+        speech: Any = None,
+    ) -> None:
+        super().__init__()
+        self._snapshot = snapshot
+        self._open_entry = open_entry
+        self._acknowledge = acknowledge
+        self._speech = speech
+        self._entries: tuple[BuddyInboxEntry, ...] = ()
+        self._refreshing = False
+        self._loaded = False
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="buddy-inbox"):
+            yield Static("Workspace Buddy", id="buddy-inbox-title", markup=False)
+            yield Static(
+                "Open a conversation to review or reply. Results stay unread until marked seen.",
+                id="buddy-inbox-help",
+            )
+            yield OptionList(id="buddy-inbox-list")
+            if self._speech is not None:
+                from .buddy_speech_controls import BuddySpeechControls
+
+                yield BuddySpeechControls(self._speech)
+            yield Static("", id="buddy-inbox-error", markup=False)
+            with Horizontal(id="buddy-inbox-actions"):
+                yield Button(
+                    "Open", id="buddy-inbox-open", variant="primary", disabled=True
+                )
+                yield Button("Mark seen", id="buddy-inbox-seen", disabled=True)
+                yield Button("Close", id="buddy-inbox-close")
+
+    async def on_mount(self) -> None:
+        self.call_after_refresh(self.refresh_inbox)
+        self.set_interval(1.0, self.refresh_inbox)
+
+    def selected_entry(self) -> BuddyInboxEntry | None:
+        listing = self.query_one("#buddy-inbox-list", OptionList)
+        if listing.highlighted is None:
+            return None
+        key = listing.get_option_at_index(listing.highlighted).id
+        return next((entry for entry in self._entries if entry.key == key), None)
+
+    async def refresh_inbox(self) -> None:
+        """Refresh the projection without acknowledging or moving focus."""
+        if self._refreshing or not self.is_mounted:
+            return
+        self._refreshing = True
+        try:
+            title, entries = await self._snapshot()
+            if not self.is_mounted:
+                return
+            self.query_one("#buddy-inbox-title", Static).update(f"Buddy · {title}")
+            self.query_one("#buddy-inbox-error", Static).update("")
+            if entries == self._entries and self._loaded:
+                self._sync_actions()
+                return
+            self._loaded = True
+            selected = self.selected_entry()
+            self._entries = entries
+            listing = self.query_one("#buddy-inbox-list", OptionList)
+            listing.clear_options()
+            if not entries:
+                listing.add_option(
+                    Option(
+                        Text("No active work or unread results in this workspace."),
+                        disabled=True,
+                    )
+                )
+            for group, label in (
+                ("needs_you", "Needs you"),
+                ("running", "Running"),
+                ("results", "Results"),
+            ):
+                rows = [entry for entry in entries if entry.group == group]
+                listing.add_option(
+                    Option(Text(f"{label} ({len(rows)})", style="bold"), disabled=True)
+                )
+                for entry in rows:
+                    listing.add_option(
+                        Option(Text(f"{entry.title}\n{entry.summary}"), id=entry.key)
+                    )
+            if selected and any(row.key == selected.key for row in entries):
+                listing.highlighted = listing.get_option_index(selected.key)
+            elif entries:
+                listing.highlighted = listing.get_option_index(entries[0].key)
+            self._sync_actions()
+        except Exception as exc:  # noqa: BLE001 - storage failure cannot break a live modal
+            if self.is_mounted:
+                message = (
+                    str(exc)
+                    if isinstance(exc, ValueError)
+                    else "Could not refresh the inbox. Retry by reopening it."
+                )
+                self.query_one("#buddy-inbox-error", Static).update(message)
+                self.query_one("#buddy-inbox-open", Button).disabled = True
+                self.query_one("#buddy-inbox-seen", Button).disabled = True
+        finally:
+            self._refreshing = False
+
+    def _sync_actions(self) -> None:
+        entry = self.selected_entry()
+        self.query_one("#buddy-inbox-open", Button).disabled = entry is None
+        self.query_one("#buddy-inbox-seen", Button).disabled = (
+            entry is None or not entry.receipt_ids
+        )
+
+    @on(OptionList.OptionHighlighted, "#buddy-inbox-list")
+    def _highlighted(self) -> None:
+        self._sync_actions()
+
+    @on(OptionList.OptionSelected, "#buddy-inbox-list")
+    def _selected(self) -> None:
+        self._request_open()
+
+    def _request_open(self) -> None:
+        entry = self.selected_entry()
+        if entry is not None:
+            self._open_entry(entry)
+
+    @on(Button.Pressed)
+    async def _button(self, event: Button.Pressed) -> None:
+        event.stop()
+        if event.button.id == "buddy-inbox-close":
+            await self.action_request_safe_cancel()
+        elif event.button.id == "buddy-inbox-open":
+            self._request_open()
+        elif event.button.id == "buddy-inbox-seen":
+            entry = self.selected_entry()
+            if entry is not None and entry.receipt_ids:
+                self.app.run_worker(
+                    self._mark_seen(entry),
+                    group="buddy-inbox-acknowledge",
+                    exclusive=False,
+                )
+
+    async def _mark_seen(self, entry: BuddyInboxEntry) -> None:
+        try:
+            pending = self._acknowledge(entry)
+            count = await pending if inspect.isawaitable(pending) else pending
+            if count == 0:
+                raise ValueError("Could not confirm the result was marked seen. Retry.")
+        except Exception as exc:  # noqa: BLE001 - retain receipt on failed storage
+            self.app.notify(
+                str(exc)
+                if isinstance(exc, ValueError)
+                else "Could not mark the result seen. Retry.",
+                severity="warning",
+            )
+        if self.is_mounted:
+            await self.refresh_inbox()

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_workspace_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_workspace_modal.py
@@ -55,6 +55,7 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
         self._entries: tuple[BuddyInboxEntry, ...] = ()
         self._refreshing = False
         self._loaded = False
+        self._fresh = False
 
     def compose(self) -> ComposeResult:
         with Vertical(id="buddy-inbox"):
@@ -96,6 +97,7 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
             title, entries = await self._snapshot()
             if not self.is_mounted:
                 return
+            self._fresh = True
             self.query_one("#buddy-inbox-title", Static).update(f"Buddy · {title}")
             self.query_one("#buddy-inbox-error", Static).update("")
             if entries == self._entries and self._loaded:
@@ -132,6 +134,7 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
                 listing.highlighted = listing.get_option_index(entries[0].key)
             self._sync_actions()
         except Exception as exc:  # noqa: BLE001 - storage failure cannot break a live modal
+            self._fresh = False
             if self.is_mounted:
                 message = (
                     str(exc)
@@ -146,9 +149,11 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
 
     def _sync_actions(self) -> None:
         entry = self.selected_entry()
-        self.query_one("#buddy-inbox-open", Button).disabled = entry is None
+        self.query_one("#buddy-inbox-open", Button).disabled = (
+            not self._fresh or entry is None
+        )
         self.query_one("#buddy-inbox-seen", Button).disabled = (
-            entry is None or not entry.receipt_ids
+            not self._fresh or entry is None or not entry.receipt_ids
         )
 
     @on(OptionList.OptionHighlighted, "#buddy-inbox-list")
@@ -161,7 +166,7 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
 
     def _request_open(self) -> None:
         entry = self.selected_entry()
-        if entry is not None:
+        if self._fresh and entry is not None:
             self._open_entry(entry)
 
     @on(Button.Pressed)
@@ -173,7 +178,7 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
             self._request_open()
         elif event.button.id == "buddy-inbox-seen":
             entry = self.selected_entry()
-            if entry is not None and entry.receipt_ids:
+            if self._fresh and entry is not None and entry.receipt_ids:
                 self.app.run_worker(
                     self._mark_seen(entry),
                     group="buddy-inbox-acknowledge",
@@ -181,6 +186,8 @@ class BuddyWorkspaceModal(SafeModalDismissMixin, ModalScreen[None]):
                 )
 
     async def _mark_seen(self, entry: BuddyInboxEntry) -> None:
+        if not self._fresh:
+            return
         try:
             pending = self._acknowledge(entry)
             count = await pending if inspect.isawaitable(pending) else pending

--- a/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/persona_buddy_widget.py
@@ -123,6 +123,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         Binding("0", "reset_geometry", "Reset", show=False),
         Binding("c", "toggle_collapse", "Collapse", show=False),
         Binding("x", "close", "Close", show=False),
+        Binding("m", "manage", "Manage Buddy", show=False),
+        Binding("enter", "interact", "Open Buddy conversation", show=False),
     ]
 
     BUNDLED_CSS = """
@@ -269,6 +271,9 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         close = Button("×", id="persona-buddy-close", classes="persona-buddy-control")
         close.tooltip = "Close"
         yield close
+        settings = Button("⚙", id="persona-buddy-settings", classes="persona-buddy-control")
+        settings.tooltip = "Buddy & Persona Management"
+        yield settings
 
     def on_mount(self) -> None:
         """Start bounded snapshot and frame polling without changing focus."""
@@ -931,6 +936,13 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         close.styles.offset = Offset(
             max(0, content_width - close_width - resize_grip_width), 0
         )
+        settings = self.query_one("#persona-buddy-settings", Button)
+        settings.display = (
+            not self.has_class("persona-buddy-compact")
+            and content_width >= collapse_width + close_width + 3
+        )
+        settings.styles.offset = Offset(collapse_width, 0)
+
 
     def on_mouse_down(self, event: events.MouseDown) -> None:
         """Arm pet-surface drag or lower-right resize for a terminal event."""
@@ -966,6 +978,7 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             y=self.absolute_offset.y,
         )
         self._interaction = (mode, screen_x, screen_y, geometry)
+        self._interaction_moved = False
         self.focus(scroll_visible=False)
         self.capture_mouse(True)
         event.stop()
@@ -990,6 +1003,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         screen_y = int(event.screen_y if event.screen_y is not None else event.y)
         dx = screen_x - origin_x
         dy = screen_y - origin_y
+        if dx or dy:
+            self._interaction_moved = True
         if mode == "drag":
             candidate = replace(
                 original, x=max(0, original.x + dx), y=max(0, original.y + dy)
@@ -1017,8 +1032,12 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             return
         # Terminals may coalesce moves or report the last position only on release.
         self._apply_interaction_position(event)
+        clicked = self._interaction[0] == "drag" and not self._interaction_moved
         self.release_interaction_capture()
-        self._schedule_geometry_persist(self._working_preferences.geometry)
+        if clicked:
+            self.action_interact()
+        else:
+            self._schedule_geometry_persist(self._working_preferences.geometry)
         event.stop()
 
     def release_interaction_capture(self) -> None:
@@ -1130,6 +1149,20 @@ class PersonaBuddyWidget(Widget, can_focus=True):
         if inspect.isawaitable(pending):
             await pending
 
+    def action_manage(self) -> None:
+        """Open shared management only from the current presentation generation."""
+        if self._is_current_view():
+            from ...UI.Navigation.buddy_management import open_buddy_management
+
+            open_buddy_management(self.app)
+
+    def action_interact(self) -> None:
+        """Open the captured conversation or workspace; dragging stays geometry-only."""
+        if self._is_current_view():
+            from ...UI.Navigation.buddy_management import open_buddy_interaction
+
+            open_buddy_interaction(self.app)
+
     def on_button_pressed(self, event: Button.Pressed) -> None:
         if not self._is_current_view():
             return
@@ -1137,6 +1170,8 @@ class PersonaBuddyWidget(Widget, can_focus=True):
             self.action_toggle_collapse()
         elif event.button.id == "persona-buddy-close":
             self.action_close()
+        elif event.button.id == "persona-buddy-settings":
+            self.action_manage()
         event.stop()
 
     def _apply_and_schedule_preferences(

--- a/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/personas_inspector_pane.py
@@ -14,7 +14,7 @@ from textual.widgets import Button, Checkbox, Input, ListItem, ListView, Static
 from ...Constants import PERSONAS_CONVERSATIONS_PAGE_SIZE
 from ..Console.console_image_viewer_modal import ClickableAvatarBox
 
-from .personas_messages import ActorPackExportRequested, PersonaBuddyActionRequested
+from .personas_messages import ActorPackExportRequested
 from .personas_pane_messages import (
     ConversationRowSelected,
     ConversationSearchChanged,
@@ -120,11 +120,11 @@ class PersonasInspectorPane(VerticalScroll):
         text-wrap: wrap;
     }
 
-    PersonasInspectorPane #personas-inspector-actions {
+    PersonasInspectorPane #personas-inspector-actions, PersonasInspectorPane #personas-independent-buddy-actions {
         height: auto;
     }
 
-    PersonasInspectorPane #personas-inspector-actions Button {
+    PersonasInspectorPane #personas-inspector-actions Button, PersonasInspectorPane #personas-independent-buddy-actions Button {
         width: 100%;
         min-width: 0;
         height: 1;
@@ -297,30 +297,6 @@ class PersonasInspectorPane(VerticalScroll):
                 classes="console-action-secondary",
                 tooltip=_NO_SELECTION_GUIDANCE,
             )
-            yield Button(
-                "Use for Buddy",
-                id="personas-buddy-use",
-                disabled=True,
-                classes="console-action-secondary persona-buddy-action",
-            )
-            yield Button(
-                "Show Buddy",
-                id="personas-buddy-show",
-                disabled=True,
-                classes="console-action-subdued persona-buddy-action",
-            )
-            yield Button(
-                "Close Buddy",
-                id="personas-buddy-close",
-                disabled=True,
-                classes="console-action-subdued persona-buddy-action",
-            )
-            yield Button(
-                "Disable Buddy",
-                id="personas-buddy-disable",
-                disabled=True,
-                classes="console-action-subdued persona-buddy-action",
-            )
             tts_checkbox = Checkbox(
                 "Include assigned voice profile",
                 id="personas-export-include-tts",
@@ -358,6 +334,32 @@ class PersonasInspectorPane(VerticalScroll):
                 disabled=True,
                 classes="console-action-subdued personas-destructive",
                 tooltip=_NO_SELECTION_DELETE_TOOLTIP,
+            )
+
+        with Vertical(id="personas-independent-buddy-actions"):
+            yield Button(
+                "Manage Buddy",
+                id="personas-buddy-use",
+                disabled=True,
+                classes="console-action-secondary persona-buddy-action",
+            )
+            yield Button(
+                "Show Buddy",
+                id="personas-buddy-show",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
+            )
+            yield Button(
+                "Close Buddy",
+                id="personas-buddy-close",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
+            )
+            yield Button(
+                "Disable Buddy",
+                id="personas-buddy-disable",
+                disabled=True,
+                classes="console-action-subdued persona-buddy-action",
             )
 
     def show_selection(
@@ -1141,99 +1143,33 @@ class PersonasInspectorPane(VerticalScroll):
             else (None if selected else _NO_SELECTION_DELETE_TOOLTIP)
         )
 
-        buddy_applies = selected and kind == "persona"
-        buddy_eligible = (
-            buddy_applies
-            and not unsaved
-            and self._buddy_profile_current
-            and self._buddy_source == "local"
-            and bool(self._buddy_persona_id)
-            and type(self._buddy_revision) is int
-            and self._buddy_revision >= 1
-            and self._buddy_active
-        )
-        if self._buddy_source == "server":
-            buddy_tooltip = "Save a local copy first"
-        elif unsaved:
-            buddy_tooltip = _UNSAVED_TOOLTIP
-        elif not self._buddy_profile_current:
-            buddy_tooltip = "Persona details are unavailable. Refresh and try again."
-        elif not self._buddy_active:
-            buddy_tooltip = "Activate this Persona first."
-        else:
-            buddy_tooltip = "Select a saved local Persona."
-        use_button = self.query_one("#personas-buddy-use", Button)
-        use_button.display = buddy_applies
-        use_button.disabled = not buddy_eligible
-        use_button.tooltip = None if buddy_eligible else buddy_tooltip
-        owner = bool(
-            buddy_eligible
-            and self._buddy_owner_source == "local"
-            and self._buddy_owner_persona_id == self._buddy_persona_id
-        )
-        owner_tooltip = "Select the Persona currently used by Buddy"
-        if not buddy_eligible:
-            state = {
-                "personas-buddy-show": (False, buddy_tooltip),
-                "personas-buddy-close": (False, buddy_tooltip),
-                "personas-buddy-disable": (False, buddy_tooltip),
-            }
-        elif not owner:
-            state = {
-                "personas-buddy-show": (False, owner_tooltip),
-                "personas-buddy-close": (False, owner_tooltip),
-                "personas-buddy-disable": (False, owner_tooltip),
-            }
-        elif not self._buddy_enabled:
-            disabled_tooltip = "Buddy is disabled. Use for Buddy to enable it."
-            state = {
-                "personas-buddy-show": (False, disabled_tooltip),
-                "personas-buddy-close": (False, disabled_tooltip),
-                "personas-buddy-disable": (False, "Buddy is already disabled."),
-            }
-        elif self._buddy_open:
-            state = {
-                "personas-buddy-show": (False, "Buddy is already open."),
-                "personas-buddy-close": (True, None),
-                "personas-buddy-disable": (True, None),
-            }
-        else:
-            state = {
-                "personas-buddy-show": (True, None),
-                "personas-buddy-close": (False, "Buddy is already closed."),
-                "personas-buddy-disable": (True, None),
-            }
-        for button_id, (enabled, tooltip) in state.items():
+        manage = self.query_one("#personas-buddy-use", Button)
+        manage.display = True
+        manage.disabled = False
+        manage.tooltip = "Manage independent Buddy artwork, Follow and Persona."
+        for button_id, enabled in (
+            ("personas-buddy-show", not self._buddy_enabled or not self._buddy_open),
+            ("personas-buddy-close", self._buddy_enabled and self._buddy_open),
+            ("personas-buddy-disable", self._buddy_enabled),
+        ):
             button = self.query_one(f"#{button_id}", Button)
-            button.display = buddy_applies
+            button.display = True
             button.disabled = not enabled
-            button.tooltip = tooltip
+            button.tooltip = "Controls the current independent Buddy."
 
     @on(Button.Pressed, ".persona-buddy-action")
     def _buddy_action_pressed(self, event: Button.Pressed) -> None:
         event.stop()
-        actions = {
-            "personas-buddy-use": "use",
+        from tldw_chatbook.UI.Navigation.buddy_management import get_buddy_management
+
+        action = {
+            "personas-buddy-use": "manage",
             "personas-buddy-show": "show",
             "personas-buddy-close": "close",
             "personas-buddy-disable": "disable",
-        }
-        action = actions.get(str(event.button.id or ""))
-        if (
-            action is None
-            or self._buddy_source not in {"local", "server"}
-            or not self._buddy_persona_id
-            or type(self._buddy_revision) is not int
-        ):
-            return
-        self.post_message(
-            PersonaBuddyActionRequested(
-                action=action,
-                source=self._buddy_source,
-                persona_id=self._buddy_persona_id,
-                revision=self._buddy_revision,
-            )
-        )
+        }.get(event.button.id)
+        if action and not event.button.disabled:
+            get_buddy_management(self.app).request_visibility(action)
 
     @on(Button.Pressed, "#personas-export-actor-pack")
     def _actor_pack_export_pressed(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/workspace_create_modal.py
+++ b/tldw_chatbook/Widgets/workspace_create_modal.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 from textual import on
 from textual.app import ComposeResult
-from textual.containers import Horizontal, Vertical
+from textual.containers import Horizontal, Vertical, VerticalScroll
 from textual.screen import ModalScreen
 from textual.widgets import Button, Checkbox, Input, Static
 
@@ -23,6 +24,10 @@ from tldw_chatbook.Skills_Interop.project_skills_discovery import (
 from tldw_chatbook.Third_Party.textual_fspicker import SelectDirectory
 from tldw_chatbook.Utils.input_validation import sanitize_string
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+from tldw_chatbook.Widgets.workspace_persona_default import (
+    WorkspacePersonaPicker,
+    WorkspacePersonaSelection,
+)
 from tldw_chatbook.Workspaces.registry_service import (
     LocalWorkspaceRegistryService,
     WorkspaceRegistryServiceError,
@@ -120,6 +125,7 @@ class WorkspaceCreateModal(
         self,
         *,
         registry_service: LocalWorkspaceRegistryService,
+        persona_service: Any = None,
         description: str = "Created from the workspace setup dialog.",
     ) -> None:
         """Build the dialog against a registry, with per-surface provenance.
@@ -133,6 +139,8 @@ class WorkspaceCreateModal(
         """
         super().__init__()
         self._registry = registry_service
+        self._personas = persona_service
+        self._persona_selection = WorkspacePersonaSelection()
         #: Provenance stored on the created ``WorkspaceRecord`` (TASK-17962):
         #: each surface (Console/Settings/Library) passes its own wording so
         #: a workspace's origin is still visible after creation -- restoring
@@ -197,7 +205,7 @@ class WorkspaceCreateModal(
             if workspace_created
             else self._offer_profile_interview_value
         )
-        with Vertical(id="workspace-create-modal"):
+        with VerticalScroll(id="workspace-create-modal"):
             yield Static("New Workspace", classes="console-modal-header")
             yield Static(
                 _WORKSPACE_EXPLAINER, id="workspace-create-explainer", markup=False
@@ -207,6 +215,12 @@ class WorkspaceCreateModal(
                 id="workspace-create-name",
                 placeholder="Workspace name",
                 compact=True,
+            )
+            yield WorkspacePersonaPicker(
+                self._personas,
+                selection=self._persona_selection,
+                allow_auto=True,
+                disabled=workspace_created,
             )
             with Horizontal(id="workspace-create-folder-row"):
                 yield Input(
@@ -330,6 +344,7 @@ class WorkspaceCreateModal(
         (and an unchecked "make active" box back to checked).
         """
         self._name_value = self.query_one("#workspace-create-name", Input).value
+        self._persona_selection = self.query_one(WorkspacePersonaPicker).selection()
         self._folder_path_value = self.query_one(
             "#workspace-create-folder-path", Input
         ).value
@@ -535,13 +550,15 @@ class WorkspaceCreateModal(
         # this try so a raise resets _committed instead of permanently
         # locking the Create button for the rest of the session.
         try:
+            assistant_kwargs = self.query_one(WorkspacePersonaPicker).creation_kwargs()
             workspace_id, generated_name = next_local_workspace_identity(self._registry)
             self._registry.create_workspace(
                 workspace_id=workspace_id,
                 name=name or generated_name,
                 description=self._description,
+                **assistant_kwargs,
             )
-        except WorkspaceRegistryServiceError as exc:
+        except (ValueError, WorkspaceRegistryServiceError) as exc:
             # Nothing was committed -- let the user fix the name/folder and
             # retry rather than permanently locking the dialog.
             self._committed = False

--- a/tldw_chatbook/Widgets/workspace_persona_default.py
+++ b/tldw_chatbook/Widgets/workspace_persona_default.py
@@ -1,0 +1,257 @@
+"""Shared native controls for future conversations' workspace Persona default."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, ClassVar
+
+from rich.text import Text
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, Vertical, VerticalScroll
+from textual.screen import ModalScreen
+from textual.widgets import Button, Checkbox, Select, Static
+
+from ..Workspaces.models import DEFAULT_WORKSPACE_ID, WorkspaceAssistantDefaults
+from ..Workspaces.registry_service import (
+    LocalWorkspaceRegistryService,
+    WorkspaceRegistryServiceError,
+)
+from .modal_dismissal import SafeModalDismissMixin
+
+
+@dataclass(frozen=True)
+class WorkspacePersonaSelection:
+    """Uncommitted form values retained through a parent recompose."""
+
+    persona: str = "auto"
+    memory_mode: str = "read_only"
+    confirm_read_write: bool = False
+
+
+class WorkspacePersonaPicker(Vertical):
+    """Select None or a saved Persona without changing the registry."""
+
+    DEFAULT_CSS = """
+    WorkspacePersonaPicker { height: auto; }
+    WorkspacePersonaPicker Static { height: auto; }
+    WorkspacePersonaPicker Select { height: 3; }
+    """
+
+    def __init__(
+        self,
+        persona_service: Any,
+        *,
+        selection: WorkspacePersonaSelection,
+        allow_auto: bool = False,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self._personas = persona_service
+        self._selection = selection
+        self._allow_auto = allow_auto
+
+    def compose(self) -> ComposeResult:
+        options = [("None", "none")]
+        if self._allow_auto:
+            options.insert(0, ("Create a workspace Agent", "auto"))
+        unavailable = False
+        try:
+            records = self._personas.list_persona_profiles() if self._personas else []
+        except Exception:  # noqa: BLE001 - None remains a usable choice
+            records, unavailable = [], True
+        for record in records or []:
+            if not isinstance(record, Mapping) or record.get("deleted"):
+                continue
+            persona_id = str(record.get("id") or "")
+            if persona_id and persona_id not in {"auto", "none"}:
+                options.append(
+                    (Text(str(record.get("name") or persona_id)), persona_id)
+                )
+        if self._selection.persona not in {value for _, value in options}:
+            options.append(("Saved Persona unavailable", self._selection.persona))
+        yield Static("Default Persona · future new conversations", markup=False)
+        yield Select(
+            options,
+            value=self._selection.persona,
+            allow_blank=False,
+            id="workspace-default-persona",
+            compact=True,
+        )
+        yield Static(
+            "Existing, copied and moved conversations keep their Persona.", markup=False
+        )
+        if unavailable:
+            yield Static(
+                "Persona list unavailable. None is still available.", markup=False
+            )
+        yield Static("Persona memory", markup=False)
+        yield Select(
+            [("Read only", "read_only"), ("Read and write", "read_write")],
+            value=self._selection.memory_mode,
+            allow_blank=False,
+            id="workspace-default-memory",
+            compact=True,
+        )
+        yield Checkbox(
+            "Confirm this Persona may write memory across sessions",
+            self._selection.confirm_read_write,
+            id="workspace-default-memory-confirm",
+            compact=True,
+        )
+
+    @on(Select.Changed)
+    def _choice_changed(self, event: Select.Changed) -> None:
+        event.stop()
+        current = self.selection()
+        if (current.persona, current.memory_mode) != (
+            self._selection.persona,
+            self._selection.memory_mode,
+        ):
+            self.query_one("#workspace-default-memory-confirm", Checkbox).value = False
+            self._selection = self.selection()
+        self._sync_memory_controls()
+
+    def on_mount(self) -> None:
+        self._sync_memory_controls()
+
+    def _sync_memory_controls(self) -> None:
+        selected = self.query_one("#workspace-default-persona", Select).value
+        self.query_one("#workspace-default-memory", Select).disabled = selected in {
+            "auto",
+            "none",
+        }
+        self.query_one("#workspace-default-memory-confirm", Checkbox).disabled = (
+            selected in {"auto", "none"}
+            or self.query_one("#workspace-default-memory", Select).value != "read_write"
+        )
+
+    def selection(self) -> WorkspacePersonaSelection:
+        """Capture uncommitted values before any parent recomposition."""
+        return WorkspacePersonaSelection(
+            str(self.query_one("#workspace-default-persona", Select).value),
+            str(self.query_one("#workspace-default-memory", Select).value),
+            self.query_one("#workspace-default-memory-confirm", Checkbox).value,
+        )
+
+    def creation_kwargs(self, *, profile_id: str | None = None) -> dict[str, Any]:
+        """Validate current identity and confirmation without changing any store."""
+        choice = self.selection()
+        if choice.persona == "auto" and self._allow_auto:
+            return {}
+        if choice.persona == "none":
+            return {"assistant_defaults": None}
+        try:
+            record = self._personas.get_persona_profile(choice.persona)
+        except Exception as exc:
+            raise ValueError(
+                "Selected Persona is unavailable. Choose another Persona or None."
+            ) from exc
+        if (
+            not isinstance(record, Mapping)
+            or record.get("deleted")
+            or str(record.get("id")) != choice.persona
+        ):
+            raise ValueError(
+                "Selected Persona is unavailable. Choose another Persona or None."
+            )
+        if choice.memory_mode == "read_write" and not choice.confirm_read_write:
+            raise ValueError(
+                "Confirm read and write memory before applying this default."
+            )
+        return {
+            "assistant_defaults": WorkspaceAssistantDefaults(
+                assistant_id=choice.persona,
+                persona_memory_mode=choice.memory_mode,
+                tool_policy_profile_id=profile_id,
+            ),
+            "confirm_read_write": choice.confirm_read_write,
+        }
+
+
+class WorkspacePersonaDefaultModal(SafeModalDismissMixin, ModalScreen[bool]):
+    """Edit one explicit workspace's default; Cancel never mutates it."""
+
+    DEFAULT_CSS = """
+    WorkspacePersonaDefaultModal { align: center middle; }
+    #workspace-default-dialog { width: 68; max-width: 95%; height: auto; max-height: 95%;
+        background: $surface; border: tall $primary; padding: 1 2; }
+    #workspace-default-form { height: auto; max-height: 17; }
+    #workspace-default-actions { height: 3; align-horizontal: right; }
+    #workspace-default-error { height: auto; color: $error; }
+    """
+    SAFE_MODAL_CONTENT = "#workspace-default-dialog"
+    BINDINGS: ClassVar = [("escape", "request_safe_cancel", "Cancel")]
+
+    def __init__(
+        self,
+        registry: LocalWorkspaceRegistryService,
+        persona_service: Any,
+        workspace_id: str,
+    ) -> None:
+        super().__init__()
+        self._registry, self._personas, self._workspace_id = (
+            registry,
+            persona_service,
+            workspace_id,
+        )
+        record = registry.get_workspace(workspace_id)
+        defaults = record.assistant_defaults if record else None
+        self._selection = WorkspacePersonaSelection(
+            defaults.assistant_id if defaults else "none",
+            defaults.persona_memory_mode if defaults else "read_only",
+        )
+        self._original_defaults = defaults
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="workspace-default-dialog"):
+            yield Static("Workspace default Persona", classes="console-modal-header")
+            with VerticalScroll(id="workspace-default-form"):
+                yield WorkspacePersonaPicker(self._personas, selection=self._selection)
+                yield Static("", id="workspace-default-error", markup=False)
+            with Horizontal(id="workspace-default-actions"):
+                yield Button("Cancel", id="workspace-default-cancel", compact=True)
+                yield Button("Apply", id="workspace-default-apply", compact=True)
+
+    @on(Button.Pressed, "#workspace-default-cancel")
+    async def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="button")
+
+    @on(Button.Pressed, "#workspace-default-apply")
+    def _apply(self, event: Button.Pressed) -> None:
+        event.stop()
+        try:
+            record = self._registry.get_workspace(self._workspace_id)
+            if (
+                record is None
+                or record.archived
+                or self._workspace_id == DEFAULT_WORKSPACE_ID
+            ):
+                raise ValueError("This workspace is unavailable for default changes.")
+            if record.assistant_defaults != self._original_defaults:
+                raise ValueError(
+                    "This workspace default changed. Reopen to review its current value."
+                )
+            values = self.query_one(WorkspacePersonaPicker).creation_kwargs(
+                profile_id=getattr(
+                    self._original_defaults, "tool_policy_profile_id", None
+                )
+            )
+            defaults = values["assistant_defaults"]
+            if defaults is None:
+                self._registry.clear_assistant_defaults(
+                    self._workspace_id, expected_record=record
+                )
+            else:
+                self._registry.set_assistant_defaults(
+                    self._workspace_id,
+                    defaults,
+                    confirm_read_write=values.get("confirm_read_write", False),
+                    expected_record=record,
+                )
+        except (ValueError, WorkspaceRegistryServiceError) as exc:
+            self.query_one("#workspace-default-error", Static).update(str(exc))
+            return
+        self.dismiss_safe_once(True)

--- a/tldw_chatbook/Workspaces/agent_provisioning.py
+++ b/tldw_chatbook/Workspaces/agent_provisioning.py
@@ -160,7 +160,7 @@ def run_workspace_agent_backfill(
     for record in registry.list_workspaces():
         if record.archived or record.workspace_id == DEFAULT_WORKSPACE_ID:
             continue
-        if record.assistant_defaults is not None:
+        if record.assistant_defaults is not None or record.assistant_defaults_explicit_none:
             continue
         defaults = provisioner.provision(record)
         if defaults is None:

--- a/tldw_chatbook/Workspaces/models.py
+++ b/tldw_chatbook/Workspaces/models.py
@@ -136,6 +136,7 @@ class WorkspaceRecord:
     active: bool = False
     archived: bool = False
     assistant_defaults: WorkspaceAssistantDefaults | None = None
+    assistant_defaults_explicit_none: bool = False
     created_at: str = field(default_factory=utc_now_iso)
     updated_at: str = field(default_factory=utc_now_iso)
 

--- a/tldw_chatbook/Workspaces/registry_service.py
+++ b/tldw_chatbook/Workspaces/registry_service.py
@@ -51,6 +51,7 @@ from .change_review_consent import (
 
 
 _STORAGE_FAILURE_MESSAGE = "Workspace registry storage failed."
+_OMITTED_ASSISTANT_DEFAULTS = object()
 _QUICK_NOTE_LEASE_SECONDS = 30
 _QUICK_NOTE_ABANDON_SECONDS = 7 * 24 * 60 * 60
 _QUICK_NOTE_MAX_FAILURES = 3
@@ -491,11 +492,19 @@ class LocalWorkspaceRegistryService:
         description: str = "",
         authority: WorkspaceAuthority | str = WorkspaceAuthority.LOCAL_ONLY,
         sync_status: WorkspaceSyncStatus | str = WorkspaceSyncStatus.NOT_CONFIGURED,
-        assistant_defaults: WorkspaceAssistantDefaults | None = None,
+        assistant_defaults: WorkspaceAssistantDefaults | None | object = _OMITTED_ASSISTANT_DEFAULTS,
         confirm_read_write: bool = False,
         tool_profile_confirmation_token: str | None = None,
     ) -> WorkspaceRecord:
-        """Create a local workspace record."""
+        """Create a workspace; omitted defaults allow provisioning, explicit None opts out."""
+
+        explicit_none = assistant_defaults is None
+        if assistant_defaults is _OMITTED_ASSISTANT_DEFAULTS:
+            assistant_defaults = None
+        if assistant_defaults is not None and not isinstance(
+            assistant_defaults, WorkspaceAssistantDefaults
+        ):
+            raise WorkspaceRegistryServiceError("Invalid assistant defaults.")
 
         if (
             assistant_defaults is not None
@@ -514,6 +523,7 @@ class LocalWorkspaceRegistryService:
             authority=authority,
             sync_status=sync_status,
             assistant_defaults=assistant_defaults,
+            assistant_defaults_explicit_none=explicit_none,
             created_at=now,
             updated_at=now,
         )
@@ -538,10 +548,11 @@ class LocalWorkspaceRegistryService:
                             active,
                             archived,
                             assistant_defaults,
+                            assistant_defaults_explicit_none,
                             created_at,
                             updated_at
                         )
-                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                         """,
                         (
                             record.workspace_id,
@@ -552,6 +563,7 @@ class LocalWorkspaceRegistryService:
                             int(record.active),
                             int(record.archived),
                             _assistant_defaults_to_json(record.assistant_defaults),
+                            int(record.assistant_defaults_explicit_none),
                             record.created_at,
                             record.updated_at,
                         ),
@@ -582,7 +594,11 @@ class LocalWorkspaceRegistryService:
         ``assistant_defaults`` NULL with a warning (task-8).
         """
         hook = self._agent_provisioner
-        if hook is None or created.assistant_defaults is not None:
+        if (
+            hook is None
+            or created.assistant_defaults is not None
+            or created.assistant_defaults_explicit_none
+        ):
             return created
         if created.workspace_id == DEFAULT_WORKSPACE_ID:
             # The built-in Default workspace never carries an agent (the
@@ -802,6 +818,7 @@ class LocalWorkspaceRegistryService:
         *,
         confirm_read_write: bool = False,
         tool_profile_confirmation_token: str | None = None,
+        expected_record: WorkspaceRecord | None = None,
     ) -> WorkspaceRecord:
         """Persist a workspace's reference-backed default assistant.
 
@@ -814,6 +831,8 @@ class LocalWorkspaceRegistryService:
             defaults: The default-assistant record to store.
             confirm_read_write: Explicit confirmation required when
                 ``defaults.persona_memory_mode`` is ``read_write``.
+            expected_record: Optional captured identity/defaults checked inside
+                the write transaction; stale choices never replace newer defaults.
 
         Returns:
             The updated workspace record.
@@ -843,11 +862,15 @@ class LocalWorkspaceRegistryService:
                 intended_defaults=defaults,
                 confirmation_token=tool_profile_confirmation_token,
             ):
-                with self.db.transaction() as conn:
+                with self.db.transaction(immediate=True) as conn:
+                    self._check_assistant_defaults_record(
+                        conn, safe_workspace_id, expected_record
+                    )
                     conn.execute(
                         """
                         UPDATE workspace_records
-                        SET assistant_defaults = ?, updated_at = ?
+                        SET assistant_defaults = ?, assistant_defaults_explicit_none = 0,
+                            updated_at = ?
                         WHERE workspace_id = ?
                         """,
                         (payload, now, safe_workspace_id),
@@ -859,11 +882,15 @@ class LocalWorkspaceRegistryService:
             raise WorkspaceRegistryServiceError("Assistant defaults update failed.")
         return updated
 
-    def clear_assistant_defaults(self, workspace_id: str) -> WorkspaceRecord:
+    def clear_assistant_defaults(
+        self, workspace_id: str, *, expected_record: WorkspaceRecord | None = None
+    ) -> WorkspaceRecord:
         """Remove a workspace's default assistant (falls back to none).
 
         Args:
             workspace_id: Workspace to update.
+            expected_record: Optional captured identity/defaults checked inside
+                the write transaction.
 
         Returns:
             The updated workspace record.
@@ -885,11 +912,15 @@ class LocalWorkspaceRegistryService:
                 intended_defaults=None,
                 confirmation_token=None,
             ):
-                with self.db.transaction() as conn:
+                with self.db.transaction(immediate=True) as conn:
+                    self._check_assistant_defaults_record(
+                        conn, safe_workspace_id, expected_record
+                    )
                     conn.execute(
                         """
                         UPDATE workspace_records
-                        SET assistant_defaults = NULL, updated_at = ?
+                        SET assistant_defaults = NULL, assistant_defaults_explicit_none = 1,
+                            updated_at = ?
                         WHERE workspace_id = ?
                         """,
                         (now, safe_workspace_id),
@@ -900,6 +931,33 @@ class LocalWorkspaceRegistryService:
         if updated is None:
             raise WorkspaceRegistryServiceError("Assistant defaults clear failed.")
         return updated
+
+    @staticmethod
+    def _check_assistant_defaults_record(
+        conn: sqlite3.Connection,
+        workspace_id: str,
+        expected: WorkspaceRecord | None,
+    ) -> None:
+        if expected is None:
+            return
+        row = conn.execute(
+            "SELECT * FROM workspace_records WHERE workspace_id = ?", (workspace_id,)
+        ).fetchone()
+        current = _workspace_from_row(row) if row is not None else None
+        fields = (
+            "workspace_id",
+            "created_at",
+            "authority",
+            "archived",
+            "assistant_defaults",
+            "assistant_defaults_explicit_none",
+        )
+        if current is None or any(
+            getattr(current, field) != getattr(expected, field) for field in fields
+        ):
+            raise WorkspaceRegistryServiceError(
+                "Workspace default changed. Reopen to review it."
+            )
 
     def _reject_duplicate_name(
         self, name: str, *, exclude_workspace_id: str | None = None
@@ -2991,6 +3049,7 @@ def _workspace_from_row(row: sqlite3.Row) -> WorkspaceRecord:
         active=bool(row["active"]),
         archived=bool(row["archived"]),
         assistant_defaults=_assistant_defaults_from_json(row["assistant_defaults"]),
+        assistant_defaults_explicit_none=bool(row["assistant_defaults_explicit_none"]),
         created_at=row["created_at"],
         updated_at=row["updated_at"],
     )

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -15320,18 +15320,6 @@ class TldwCli(
             name="recover_inflight_transfers",
         )
 
-        # Start the background scheduler loop for reminders and scheduled tasks.
-        # A COROUTINE worker, never thread=True: scheduled watchlist checks
-        # dispatch from this loop, and the watchlists in-flight guard
-        # (`local_watchlists_service._IN_FLIGHT_URL_CHECKS`) is lock-free on
-        # the invariant that every check entrant runs on the app's one event
-        # loop. Moving dispatch off-loop needs a lock there.
-        self.scheduler_worker = self.run_worker(
-            self.scheduler_loop.run(),
-            exclusive=True,
-            group="scheduling",
-        )
-
         # TASK-22215: the two FTS backfills (task-688 subscription_items,
         # task-21100 messages) used to start HERE, before first paint, next
         # to the scheduler. They are whole-table re-tokenizations that
@@ -16328,6 +16316,10 @@ class TldwCli(
 
     async def _post_mount_setup(self) -> None:
         """Operations to perform after the main UI is expected to be fully mounted."""
+        # A delayed setup callback must not admit startup work after quit.
+        # Textual exit() sets _exit before ShutdownRequest sets our flag.
+        if self._shutting_down or self._exit:
+            return
         post_mount_start = time.perf_counter()
         self.loguru_logger.info(
             "App _post_mount_setup: Binding Select widgets and populating dynamic content..."
@@ -16505,6 +16497,22 @@ class TldwCli(
 
             # Final memory usage
             log_resource_usage()
+
+        # The first scheduler tick loads emergency-stop and heartbeat support.
+        # Start only after `_ui_ready`: launching in on_mount let its queue
+        # reads finish during slow UI setup and spend first-frame budget
+        # nondeterministically (ADR-097).
+        # Start the background scheduler loop for reminders and scheduled tasks.
+        # A COROUTINE worker, never thread=True: scheduled watchlist checks
+        # dispatch from this loop, and the watchlists in-flight guard
+        # (`local_watchlists_service._IN_FLIGHT_URL_CHECKS`) is lock-free on
+        # the invariant that every check entrant runs on the app's one event
+        # loop. Moving dispatch off-loop needs a lock there.
+        self.scheduler_worker = self.run_worker(
+            self.scheduler_loop.run(),
+            exclusive=True,
+            group="scheduling",
+        )
 
         self._schedule_deferred_startup_work()
 
@@ -16934,7 +16942,7 @@ class TldwCli(
 
         Scoped by the boundary ``_wire_watchlists_and_notifications_services``
         captured when it opened the database, so this cannot fail a row the
-        scheduler -- started earlier, in ``on_mount`` -- launched moments ago
+        scheduler -- started earlier in post-mount setup -- launched moments ago
         (Qodo review of PR #1972). No boundary means no sweep: leaving a row
         wedged is recoverable on the next launch, failing a live one is not.
         """

--- a/tldw_chatbook/app.py
+++ b/tldw_chatbook/app.py
@@ -8457,16 +8457,12 @@ class TldwCli(
         with self._persona_buddy_controller_lock:
             if self._persona_buddy_controller is not None:
                 return self._persona_buddy_controller
-            # Only the persona service gates construction: the old eager
-            # wiring ran right after _wire_character_persona_services() and
-            # passed self.chachanotes_db through as-is (it is legitimately
-            # None on test-factory apps; the controller tolerates that).
-            local_persona_service = getattr(
-                self, "local_character_persona_service", None
-            )
-            if local_persona_service is None:
-                return None
+            # Independent Buddy artwork needs only the profile DB. The local
+            # Persona service remains optional compatibility for legacy choices.
+            local_persona_service = getattr(self, "local_character_persona_service", None)
             profile_db = getattr(self, "chachanotes_db", None)
+            if local_persona_service is None and profile_db is None:
+                return None
             from .Persona_Buddy.controller import (  # noqa: PLC0415 - imports Persona_Visual + PIL; first feature use only (TASK-21103)
                 PersonaBuddyController,
                 load_local_persona_portrait,
@@ -8486,8 +8482,11 @@ class TldwCli(
                 ),
                 profile_db=profile_db,
                 profile_root=get_user_data_dir(),
-                reduced_motion=bool(
-                    get_cli_setting("appearance", "reduce_motion", False)
+                reduced_motion=lambda: bool(
+                    self.app_config.get("appearance", {}).get("reduce_motion", False)
+                    or not self.app_config.get("buddy_interaction", {}).get(
+                        "animated", True
+                    )
                 ),
                 scheduler=self.call_after_refresh,
                 on_change=self._notify_persona_buddy_changed,
@@ -9355,20 +9354,87 @@ class TldwCli(
 
         if self.actor_pack_recovery_error is None:
             service = getattr(self, "local_character_persona_service", None)
-            if service is not None:
-                try:
-                    from .Persona_Visual.builtin_pixel_migu import (
-                        ensure_builtin_pixel_migu_buddy,
+            try:
+                from .Persona_Buddy.library import BuddyLibrary
+                from .Persona_Buddy.preferences import (
+                    parse_persona_buddy_preferences,
+                    persist_persona_buddy_preferences,
+                    serialize_persona_buddy_preferences,
+                )
+
+                library = BuddyLibrary(
+                    self.chachanotes_db,
+                    get_user_data_dir(),
+                    persona_reader=getattr(service, "get_persona_profile", None),
+                )
+                legacy_retired = False
+                if service is not None:
+                    try:
+                        legacy_builtin = service._find_persona_profile(
+                            "local-persona-builtin-pixel-migu", include_deleted=True
+                        )
+                    except ValueError:
+                        legacy_builtin = None
+                    legacy_retired = bool(
+                        legacy_builtin
+                        and (
+                            legacy_builtin.get("deleted")
+                            or legacy_builtin.get("is_active", True) is not True
+                            or library.repository.get_active_persona_pack(
+                                "local-persona-builtin-pixel-migu"
+                            )
+                            is None
+                        )
+                    )
+                library.ensure_builtin(legacy_retired=legacy_retired)
+                controller = getattr(self, "_persona_buddy_controller", None)
+                if controller is None:
+                    config = getattr(self, "app_config", {})
+                    previous = parse_persona_buddy_preferences(
+                        config.get("persona_buddy", {})
                     )
 
-                    ensure_builtin_pixel_migu_buddy(
-                        service, coordinator, profile_root=get_user_data_dir()
+                    def persist_unclaimed_migration(candidate):
+                        # First construction reads app_config under this same lock.
+                        # Keep disk admission and publication together so it sees
+                        # the committed owner, or takes over migration itself.
+                        with self._persona_buddy_controller_lock:
+                            if (
+                                self._persona_buddy_controller is not None
+                                or parse_persona_buddy_preferences(
+                                    config.get("persona_buddy", {})
+                                )
+                                != previous
+                                or not persist_persona_buddy_preferences(candidate)
+                            ):
+                                return False
+                            config["persona_buddy"] = serialize_persona_buddy_preferences(
+                                candidate
+                            )
+                            return True
+
+                    library.migrate_legacy_selection(
+                        previous,
+                        writer=persist_unclaimed_migration,
                     )
-                except Exception:
-                    self.loguru_logger.warning(
-                        "Built-in pixel-migu Buddy installation failed; "
-                        "will retry on next Personas read"
-                    )
+                    controller = getattr(self, "_persona_buddy_controller", None)
+                if controller is not None:
+
+                    def schedule_migration():
+                        self.run_worker(
+                            controller.migrate_legacy_selection(library),
+                            group="buddy-legacy-migration",
+                            exclusive=False,
+                        )
+
+                    if threading.get_ident() == getattr(self, "_thread_id", None):
+                        schedule_migration()
+                    else:
+                        self.call_from_thread(schedule_migration)
+            except Exception:
+                self.loguru_logger.warning(
+                    "Independent Buddy installation/migration deferred; existing choices retained"
+                )
 
     def ensure_actor_pack_staging_sweep(self) -> None:
         """Run the Actor Pack staging crash-sweep once per session (task-22216).
@@ -14796,6 +14862,18 @@ class TldwCli(
         """Close app-owned TTS resources without masking cancellation."""
 
         failures: list[tuple[str, BaseException]] = []
+        buddy_speech = getattr(self, "buddy_speech_coordinator", None)
+        if buddy_speech is not None:
+            try:
+                close_task = getattr(self, "_buddy_speech_close_task", None)
+                if close_task is None:
+                    close_task = asyncio.create_task(
+                        buddy_speech.aclose(), name="close_buddy_speech"
+                    )
+                    self._buddy_speech_close_task = close_task
+                await join_retained_task(close_task)
+            except BaseException as buddy_close_error:  # noqa: BLE001 - drain all owners before preserving cancellation
+                failures.append(("buddy_speech", buddy_close_error))
         if hasattr(self, "_close_tts_voice_bundle_service"):
             try:
                 await self._close_tts_voice_bundle_service()

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -11816,3 +11816,13 @@ ConsoleExchangeExportDialog {
 #exchange-export-path {
     height: 3;
 }
+
+/* Buddy transcripts scroll the complete decision card. A 1fr batch body
+   inside the auto-height card collapses and clips its controls at 60x20. */
+BuddyConversationModal #approval-batch-body {
+    height: auto;
+}
+BuddyConversationModal .approval-row-decision {
+    width: 1fr;
+    min-width: 10;
+}

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -5212,6 +5212,16 @@ ConsoleExchangeExportDialog {
     height: 3;
 }
 
+/* Buddy transcripts scroll the complete decision card. A 1fr batch body
+   inside the auto-height card collapses and clips its controls at 60x20. */
+BuddyConversationModal #approval-batch-body {
+    height: auto;
+}
+BuddyConversationModal .approval-row-decision {
+    width: 1fr;
+    min-width: 10;
+}
+
 /* ===== MODULE: components/_workbench.tcss ===== */
 /* ========================================
  * COMPONENTS: Workbench

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -3472,11 +3472,11 @@
         text-wrap: wrap;
     }
 
-    PersonasInspectorPane #personas-inspector-actions {
+    PersonasInspectorPane #personas-inspector-actions, PersonasInspectorPane #personas-independent-buddy-actions {
         height: auto;
     }
 
-    PersonasInspectorPane #personas-inspector-actions Button {
+    PersonasInspectorPane #personas-inspector-actions Button, PersonasInspectorPane #personas-independent-buddy-actions Button {
         width: 100%;
         min-width: 0;
         height: 1;


### PR DESCRIPTION
Buddy artwork can now be selected independently of a Persona from **Console → Menu → Buddy**. The same management form is available from the floating Buddy and Personas inspector. Users can follow one explicit conversation or workspace, review results and supported decisions, and reply over their current screen while accepted work continues.

## Behavior

- Fresh profiles offer Pixel Migu without creating a Persona. Local native-pack imports and legacy selection migration preserve attribution in the independent Buddy library.
- One visible Buddy supports Dynamic/Static expressions, geometry controls, scoped activity and private per-conversation drafts. Workspace mode groups Needs you, Running and Results, with exact-result acknowledgement and text replies; it has no microphone input.
- Workspace Persona defaults apply only to new conversations. Explicit Persona/None overrides remain distinct from keeping the current effective assignment. Existing-conversation assignment saves identity, prompt and settings atomically.
- Optional named speech uses consent, serial queueing, question priority, pause/skip/mute, microphone handoff and cancellation guards.
- Console runtime, queued work and pending decisions retain their original owner across navigation and closing interaction surfaces.

## UX review corrections

Preview is visible and keyboard/pointer usable at compact sizes. Import and size settings are disclosed after the common selection path. The form names the current Persona literally and retains staged values during failed imports or saves, with accurate partial-save recovery and guarded retry. Personas controls manage the independent Buddy.

Conversation dialogs open at current content, follow replies only when already at the end, preserve deliberate reading, and expose Latest/new updates and a pending-decision jump. Empty states and compact speech-off controls preserve reading space. At 60x20, approval controls are visible through all ancestor containers. Workspace refresh failure consistently disables both keyboard and pointer activation until recovery.

ChaChaNotes migrates 69→70 and WorkspaceDB 7→8. ADR-139 records ownership/lifecycle decisions; ADR-079 governs workspace defaults. The corresponding server/shared WebUI implementation is in [server PR #2933](https://github.com/rmusser01/tldw_server/pull/2933).

## Qodo follow-up and rebase

Rebased onto latest dev `c4a7b1911f14181faa471eb1ea209cfdeed98226`. The initial rebase preserved both additions in the only testing-lessons conflict; the later Library updates preserve all four Buddy commits, reconciling only the generated diagnostic inventory summary. All eleven Qodo findings have fixes or evidence-backed dispositions in `Docs/Development/Reviews/2026-09-09-buddy-pr-review.md`.

The follow-up adds central archive/form validation, bounded Buddy-library pagination and exact lookup, transaction-safe reads and migration verification, question-first Skip behavior, and protected import provenance in both import routes. File-backed saved-conversation bulk reads run before app-thread publication with late identity/authority checks and worker-connection cleanup. Small policy reads and authority-coupled reconciliation remain on the app thread. The recorder callback already uses Textual's thread-safe message queue; a mounted regression verifies that path.

## Startup CI correction

Linux exposed the scheduler's first tick importing heartbeat/emergency-stop support before UI readiness. A controlled slow boot reproduced it. The existing app-owned scheduler now starts after readiness, preserving its loop/group/exclusivity and ordering before deferred reconciliation; late startup after quit/shutdown or setup failure is rejected. No startup budgets or snapshots changed. Independent review approved with no Important/Critical findings.

## Validation

- Latest-base boot/lifecycle gate: **22 passed**, actual ready census **973/973**. Scheduler implementation/test hashes match independent review; diagnostic inventory verifies after the Library rebase.
- Broader startup/scheduler group: **154 passed, 4 failures reproduced with the original HEAD app and unchanged tests/other production modules**. Exact cases and controlled-baseline limits are documented. The artificial slow mount retains a separate preexisting character-search import sensitivity; no blanket timing-independence claim is made.

- Fresh affected Buddy, Persona import/authoring, workspace migration, hydration, settings and packaging checks: **362 passed**.
- Final-base Buddy navigation, conversation and startup checks: **45 passed**; diagnostic inventory verifies again.
- Final post-format hydration/import checks: **20 passed**; actual UI-ready census **973/973**.
- All six derived checks pass locally: generated stylesheets, profile paths, diagnostic inventory, Backlog IDs, schema allowlist (**115 tables**), and index decisions (**282 names / 67 plan pins**).
- Diagnostic statement changes were reviewed before inventory regeneration; new messages contain fixed status text and add no persistent sink.
- Nineteen changed Python files parse with zero introduced Ruff diagnostics or formatter changes on modified ranges. The SQL allowlist addition retains unchanged existing lint debt. Diff whitespace checks pass.
- Independent final source review found no Important or Critical issues, including the canonical ADR-095 evidence for three corrected legacy settings tests.
- Earlier rendered native UX review and 60x20/80x24 approval checks remain documented in `Docs/Development/Reviews/2026-09-08-chatbook-buddy-persona-ux.md`; earlier test counts overlap and are not added to the fresh totals.

No full local suite, live model-provider turn, physical microphone or audible playback was performed. Remote required checks and Qodo's latest state are checked again on the published head before merge.
