### PR TITLE
fix(library-media): clear the reader on a 0-result filter; drop a lone half-flag on the Info tab (32086, 32087)

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -102,12 +102,15 @@ than showing a now-absent item. A filter that still has matches moves the
 Reader to its first result instead. Undoing a delete re-adds the row, which
 opens normally again.
 
-*Verified against fix/media-crit7-readerdesync — 2026-09-08 (task-32043:
-app-test pins at 170x48 — opening an item then applying a 0-result filter, and
-bulk-deleting the open item, both leave the Reader on its no-selection
-placeholder; the crit6 empty-reader widening, three-pane ladder, scroll-
-restore and bulk-delete Undo pins stay green. Confirmed in tests, not
-re-verified live.)*
+*Verified against fix/media-crit8-gaps — 2026-09-08 (task-32086: a 0-result
+filter now repaints the MOUNTED Reader placeholder, not just the session —
+task-32043 cleared the state but the canvas-scoped Items sync left the sibling
+viewer painting the filtered-out document (critique #8 caps 07/65). App-test
+pin at 170x48 drives the live auto-follow path (a filter with a hit, then
+narrowing to zero) and asserts the Reader repaints its empty placeholder;
+the task-32043 session pins, bulk-delete, and filter-restore pins stay green.
+Live-verified in tmux at 235x52: filter to a hit, then narrow to zero — the
+Reader falls back to "Select a media item to read it here.".)*
 
 **Row markers.** An item's second row says what it is and how old it is, and
 adds **· analysed** when that item already carries an analysis — so you can

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -139,7 +139,11 @@ wide CJK characters, or five flag emoji) to keep the line short — the cut
 counts a flag by the two columns it paints and never leaves half of one, so
 the row frame does not drift. It can still be too long for a narrow Items pane: at the
 pane's narrowest the row clips mid-term at the pane edge, and a row that is
-both analysed and a keyword hit can clip at the default width too.
+both analysed and a keyword hit can clip at the default width too. The
+Reader's **Info** tab "Keywords:" line applies the same guard: it shows the
+full stored keyword but drops a dangling half-flag so that surface's frame
+does not drift either (the edit form still prefills the stored keyword
+verbatim).
 
 *Verified against fix/media-riders-n — 2026-09-07 (task-31951: Conversations,
 Skills and Collections opened live at 235x52. Each painted one-cell `‹` grips

--- a/Tests/Library/test_library_media_viewer_state.py
+++ b/Tests/Library/test_library_media_viewer_state.py
@@ -831,3 +831,68 @@ def test_build_state_video_transcript_without_markdown_syntax_stays_raw():
         }
     )
     assert state.is_markdown is False
+
+
+def test_info_keywords_line_drops_a_lone_half_flag_but_keeps_whole_pairs():
+    """task-32087 (critique #8 gap in 32044): the Info 'Keywords:' line must
+    not paint a lone half-flag.
+
+    A regional-indicator flag is a PAIR painted as one 2-cell glyph. task-32044
+    made the LIST-ROW keyword suffix drop a dangling half indicator (rich and
+    Textual measure it as 1 cell, a terminal paints it as a 2-cell box, drifting
+    the frame +2) but never touched the Reader Info line, which renders the raw
+    keyword. A keyword that is, or ends in, a lone indicator therefore still
+    drifted the Info frame. This asserts the Info line's trailing
+    regional-indicator run is always EVEN (measured width == painted width),
+    while whole flags survive and the edit form still prefills the raw value.
+    """
+    from rich.cells import cell_len
+
+    def _trailing_ri(text: str) -> int:
+        count = 0
+        for ch in reversed(text):
+            if 0x1F1E6 <= ord(ch) <= 0x1F1FF:
+                count += 1
+            else:
+                break
+        return count
+
+    jp = "\U0001F1EF\U0001F1F5"  # a whole JP flag: two indicators = one 2-cell glyph
+    half = "\U0001F1EF"  # a lone regional indicator = a half-flag
+
+    # (1) a keyword ending in a lone indicator: the Info line drops the half,
+    #     but the edit form keeps the stored value verbatim for a clean save.
+    state = build_library_media_viewer_state(
+        {"id": "m1", "title": "t", "type": "article", "keywords": ["crit8a", half]},
+        now=NOW,
+    )
+    kw_line = next(
+        line for line in state.metadata_lines if line.startswith("Keywords: ")
+    )
+    assert _trailing_ri(kw_line) % 2 == 0, kw_line
+    assert not kw_line.endswith(half), kw_line
+    assert state.edit_fields["keywords"] == "crit8a, \U0001F1EF"
+
+    # (2) a whole flag PAIR is measured as two cells by rich, matching the
+    #     terminal -- it survives untouched, so the line still names the flag.
+    paired = build_library_media_viewer_state(
+        {"id": "m2", "title": "t", "type": "article", "keywords": ["crit8a", jp]},
+        now=NOW,
+    )
+    paired_line = next(
+        line for line in paired.metadata_lines if line.startswith("Keywords: ")
+    )
+    assert jp in paired_line, paired_line
+    assert _trailing_ri(paired_line) % 2 == 0, paired_line
+    # rich measures the whole pair as two cells (what a terminal paints).
+    assert cell_len(jp) == 2
+
+    # (3) an odd run (pair + dangling half) keeps the whole pair, drops the half.
+    odd = build_library_media_viewer_state(
+        {"id": "m3", "title": "t", "type": "article", "keywords": [jp + half]},
+        now=NOW,
+    )
+    odd_line = next(
+        line for line in odd.metadata_lines if line.startswith("Keywords: ")
+    )
+    assert odd_line == "Keywords: " + jp, odd_line

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -922,6 +922,81 @@ async def test_zero_result_filter_clears_the_reader_it_was_painting():
 
 
 @pytest.mark.asyncio
+async def test_zero_result_filter_repaints_the_mounted_reader_placeholder():
+    """task-32086 (critique #8 gap in 32043): the MOUNTED Reader must repaint.
+
+    task-32043 cleared the Reader SESSION on a 0-result filter (verified by
+    ``test_zero_result_filter_clears_the_reader_it_was_painting``), but this
+    seam rebuilds only the Items pane through ``_sync_library_canvas`` and
+    leaves the sibling ``LibraryMediaViewer`` untouched -- so the mounted
+    widget kept its ``#library-media-viewer-title`` and full document
+    standing while the Items list read "Media (0)" (critique #8 caps 07/65:
+    a stale item + "‹ Back" into an empty list). Drives the live auto-follow
+    path -- a filter WITH a hit re-points the Reader, then narrowing to zero
+    -- and asserts the mounted Reader repainted its empty placeholder.
+    """
+    app, service = _flow_app(count=5)
+    host = LibraryProductionCSSHarness(app)
+
+    async with host.run_test(size=WIDE_SIZE) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _load_row_0(screen, service, pilot)
+
+        # A filter WITH a match auto-follows the Reader to the sole hit.
+        screen.query_one("#library-media-filter", Input).value = "Media item 03"
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_media_browse_controller.applied_scope is not None
+                and screen._library_media_browse_controller.applied_scope.query
+                == "Media item 03"
+                and not screen._library_media_browse_controller.loading
+            ),
+            message="Matching filter did not apply.",
+        )
+        match_id = str(
+            screen._library_media_browse_controller.retained_items[0]["id"]
+        )
+        for match in screen._library_media_browse_controller.retained_items:
+            service.release(int(str(match["id"]).rsplit(":", 1)[-1]))
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._media_state.reader_session.loaded_id == match_id
+                and bool(screen.query("#library-media-viewer-title"))
+            ),
+            message="Matched filter did not paint the Reader item.",
+        )
+        await pilot.pause()
+
+        # Narrowing that filter to zero must repaint the empty placeholder.
+        screen.query_one("#library-media-filter", Input).value = "Media item 03zzz"
+        await _wait_for_condition(
+            pilot,
+            lambda: (
+                screen._library_media_browse_controller.applied_scope is not None
+                and screen._library_media_browse_controller.applied_scope.query
+                == "Media item 03zzz"
+                and not screen._library_media_browse_controller.loading
+            ),
+            message="Zero-result filter did not apply.",
+        )
+        assert len(screen._library_media_browse_controller.retained_items) == 0
+        assert screen._media_state.reader_session.loaded_id is None
+
+        # The MOUNTED Reader stops painting the filtered-out item and shows
+        # its "Select a media item…" placeholder -- not just the session.
+        await _wait_for_condition(
+            pilot,
+            lambda: bool(screen.query("#library-media-reader-empty")),
+            message="Reader placeholder did not repaint after the 0-result filter.",
+        )
+        assert not screen.query("#library-media-viewer-title")
+        for media_id in tuple(service.detail_release):
+            service.release(media_id)
+
+
+@pytest.mark.asyncio
 async def test_bulk_deleting_the_open_reader_item_clears_the_reader():
     """task-32043 Pin B: bulk-deleting the loaded item stops the Reader painting it.
 

--- a/backlog/tasks/task-32086 - Library-media-the-reader-is-not-cleared-when-a-0-result-filter-hides-its-loaded-item.md
+++ b/backlog/tasks/task-32086 - Library-media-the-reader-is-not-cleared-when-a-0-result-filter-hides-its-loaded-item.md
@@ -3,9 +3,10 @@ id: TASK-32086
 title: >-
   Library media: the reader is not cleared when a 0-result filter hides its
   loaded item
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-08 20:48'
+updated_date: '2026-09-08 22:01'
 labels:
   - library
   - media
@@ -22,7 +23,13 @@ Critique #8 gap in task-32043. task-32043 added `_reset_library_media_reader_to_
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Applying a filter that returns zero results while a media item is loaded clears the reader to its no-selection state (does not keep painting the filtered-out item), verified LIVE and by a pin that drives the actual filter-input path (not only the internal `_apply` seam)
-- [ ] #2 A filter with results still re-points to a matching item; a page turn and a mid-load do NOT clear the reader (no over-fire)
-- [ ] #3 The pin reproduces the critique #8 scenario (reader open, then filter to zero) and would fail against the current guard
+- [x] #1 Applying a filter that returns zero results while a media item is loaded clears the reader to its no-selection state (does not keep painting the filtered-out item), verified LIVE and by a pin that drives the actual filter-input path (not only the internal `_apply` seam)
+- [x] #2 A filter with results still re-points to a matching item; a page turn and a mid-load do NOT clear the reader (no over-fire)
+- [x] #3 The pin reproduces the critique #8 scenario (reader open, then filter to zero) and would fail against the current guard
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+task-32043's 0-result-filter reset cleared the reader SESSION (`loaded_id`→None, so its state-pin passed) but the FILTER path re-renders only the Items pane via `_sync_library_canvas('media')` and never refreshes the sibling mounted `LibraryMediaViewer`, so it kept painting the filtered-out item; the DELETE path escaped this via a whole-screen `refresh(recompose=True)`. Fix: mirror the delete path on the settled 0-result reset branch in `_sync_library_media_browse_state` — `refresh(recompose=True)` + `is_mounted` guard + `call_after_refresh(self._focus_library_control, focus_identity)` + `return` (after the reset `loaded_id` is None so the branch can't re-fire — no recompose loop). Over-fire guards intact (page turn has rows; mid-load short-circuits; filter-with-results re-points via applied_selection_id). New pin `test_zero_result_filter_repaints_the_mounted_reader_placeholder` drives the REAL filter-Input path (not the internal seam the 32043 pin used) and asserts the MOUNTED widget (`#library-media-reader-empty` present, `#library-media-viewer-title` gone); red first. Live-verified at 235x52. LESSON (lessons-testing-evidence): clearing a state object is not clearing the UI — a sibling mounted widget rendering from that state must be recomposed, or a state-only pin passes while the screen paints the stale item. Files: library_screen.py, Tests/UI/test_library_media_render_fixes.py (or the reader pin file).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32086 - Library-media-the-reader-is-not-cleared-when-a-0-result-filter-hides-its-loaded-item.md
+++ b/backlog/tasks/task-32086 - Library-media-the-reader-is-not-cleared-when-a-0-result-filter-hides-its-loaded-item.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32086
+title: >-
+  Library media: the reader is not cleared when a 0-result filter hides its
+  loaded item
+status: To Do
+assignee: []
+created_date: '2026-09-08 20:48'
+labels:
+  - library
+  - media
+  - ux
+dependencies: []
+priority: medium
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #8 gap in task-32043. task-32043 added `_reset_library_media_reader_to_no_selection` and clears the reader when the loaded item is DELETED (works), and intended to clear it on a 0-result filter too (its AC#1). But critique #8 found live that a filter returning zero results still leaves the reader painting the filtered-out item, with '‹ Back' into an empty list. The filter-path guard in `_sync_library_media_browse_state` (settled page + zero retained rows + still-holding a local reader item) does not fire on the live filter path the assessors took, so AC#1's 0-result-filter half is unmet in practice even though its pin passes. Find why the guard misses the live scenario (e.g. `applied_selection_id`/`retained_items`/settled-state at the check moment, or the reader item's state) and widen it so the reader clears on a settled 0-result filter without over-firing on a page turn or mid-load.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Applying a filter that returns zero results while a media item is loaded clears the reader to its no-selection state (does not keep painting the filtered-out item), verified LIVE and by a pin that drives the actual filter-input path (not only the internal `_apply` seam)
+- [ ] #2 A filter with results still re-points to a matching item; a page turn and a mid-load do NOT clear the reader (no over-fire)
+- [ ] #3 The pin reproduces the critique #8 scenario (reader open, then filter to zero) and would fail against the current guard
+<!-- AC:END -->

--- a/backlog/tasks/task-32087 - Library-media-a-regional-indicator-flag-keyword-drifts-the-reader-Info-Keywords-line-2-cells.md
+++ b/backlog/tasks/task-32087 - Library-media-a-regional-indicator-flag-keyword-drifts-the-reader-Info-Keywords-line-2-cells.md
@@ -3,9 +3,10 @@ id: TASK-32087
 title: >-
   Library media: a regional-indicator flag keyword drifts the reader Info
   Keywords line +2 cells
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-08 20:48'
+updated_date: '2026-09-08 22:01'
 labels:
   - library
   - media
@@ -22,7 +23,13 @@ Critique #8 gap in task-32044. task-32044 made the LIST-ROW keyword-reason suffi
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A keyword containing a regional-indicator flag emoji does not drift the reader Info 'Keywords:' line frame width or overpaint neighbouring content, at 235x52 and 100x30
-- [ ] #2 The Info 'Keywords:' rendering uses the same flag-pair-aware width handling task-32044 applied to the list suffix (or an equivalent), rather than mis-measuring the pair
-- [ ] #3 A pin paints a flag-keyword Info line and asserts the frame stays aligned
+- [x] #1 A keyword containing a regional-indicator flag emoji does not drift the reader Info 'Keywords:' line frame width or overpaint neighbouring content, at 235x52 and 100x30
+- [x] #2 The Info 'Keywords:' rendering uses the same flag-pair-aware width handling task-32044 applied to the list suffix (or an equivalent), rather than mis-measuring the pair
+- [x] #3 A pin paints a flag-keyword Info line and asserts the frame stays aligned
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+task-32044 made the LIST-ROW keyword suffix flag-pair-aware but the reader Info 'Keywords:' line rendered the raw keyword. RULING (verified at review): a WHOLE regional-indicator flag PAIR does NOT drift — rich AND Textual measure it as 2 cells (cell_len('🇯🇵')==2; Content.cell_length matches), matching a compliant terminal, so the frame does not drift on a whole pair; critique #8's inferred '+2 drift' was a LONE half-flag or a Textual `Content.wrap(overflow=fold)` split of a pair mid-grapheme at narrow widths. Fixed the universal case: `_display_keywords_text` (library_media_viewer_state.py) drops a dangling trailing regional indicator on the Info line (reusing task-32044's `_trailing_regional_indicators`), keeping whole pairs; the EDIT field keeps the raw keyword (saves round-trip verbatim). LEDGERED out of scope: Textual's fold-wrap splitting a whole pair mid-grapheme at a fold is a framework segmentation limit, not dependency-free fixable in this seam (needs nowrap/ellipsis or an upstream fix). Pin `test_info_keywords_line_drops_a_lone_half_flag_but_keeps_whole_pairs`, red first. Files: library_media_viewer_state.py, Tests/Library/test_library_media_viewer_state.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32087 - Library-media-a-regional-indicator-flag-keyword-drifts-the-reader-Info-Keywords-line-2-cells.md
+++ b/backlog/tasks/task-32087 - Library-media-a-regional-indicator-flag-keyword-drifts-the-reader-Info-Keywords-line-2-cells.md
@@ -1,0 +1,28 @@
+---
+id: TASK-32087
+title: >-
+  Library media: a regional-indicator flag keyword drifts the reader Info
+  Keywords line +2 cells
+status: To Do
+assignee: []
+created_date: '2026-09-08 20:48'
+labels:
+  - library
+  - media
+  - ux
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #8 gap in task-32044. task-32044 made the LIST-ROW keyword-reason suffix flag-pair-aware (never paints a half-flag), but the reader's Info tab renders the raw keyword on its 'Keywords:' line, and a regional-indicator flag pair there still drifts the row frame +2 cells (line measures 237 vs 235; the right border lands at col 236 vs 234). The flag-pair width miscount lives on this second surface, uncovered by 32044.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 A keyword containing a regional-indicator flag emoji does not drift the reader Info 'Keywords:' line frame width or overpaint neighbouring content, at 235x52 and 100x30
+- [ ] #2 The Info 'Keywords:' rendering uses the same flag-pair-aware width handling task-32044 applied to the list suffix (or an equivalent), rather than mis-measuring the pair
+- [ ] #3 A pin paints a flag-keyword Info line and asserts the frame stays aligned
+<!-- AC:END -->

--- a/tldw_chatbook/Library/library_media_viewer_state.py
+++ b/tldw_chatbook/Library/library_media_viewer_state.py
@@ -12,6 +12,7 @@ from typing import Any, Mapping, Sequence
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
+from tldw_chatbook.Library.library_media_state import _trailing_regional_indicators
 
 _ID_KEYS = ("id", "media_id", "uuid")
 _TYPE_KEYS = ("type", "media_type")
@@ -161,6 +162,31 @@ def _keywords_text(detail: Mapping[str, Any]) -> str:
         items = [str(item).strip() for item in keywords if str(item).strip()]
         return ", ".join(items)
     return ""
+
+
+def _display_keywords_text(keywords_text: str) -> str:
+    """The Info 'Keywords:' line, with any dangling half-flag dropped (task-32087).
+
+    A regional-indicator flag is a PAIR of code points painted as one 2-cell
+    glyph; a LONE trailing indicator is measured as one cell by rich/Textual
+    but painted as a 2-cell box by a terminal, so the Reader Info frame drifts
+    +2 (critique #8: the "Keywords:" line the list-row suffix guard task-32044
+    never reached). Reuse that guard's ``_trailing_regional_indicators`` per
+    comma-separated keyword so only WHOLE flags -- which rich and the terminal
+    both measure as 2 cells -- ever paint here; the measured width is then the
+    painted width and the frame stays aligned. Display only: the RAW
+    ``_keywords_text`` still feeds the edit form so a save round-trips the
+    stored keyword verbatim. (Not covered: Textual's own ``Content.wrap`` can
+    still split a whole pair mid-grapheme when a single keyword is wider than
+    the pane -- a framework segmentation limit, not a value this seam owns.)
+    """
+    parts: list[str] = []
+    for part in keywords_text.split(", "):
+        if _trailing_regional_indicators(part) % 2:
+            part = part[:-1]
+        if part:
+            parts.append(part)
+    return ", ".join(parts)
 
 
 def _version(detail: Mapping[str, Any]) -> int | None:
@@ -342,8 +368,9 @@ def build_library_media_viewer_state(
         # user-meaningful link -- hide it from the metadata lines while
         # still prefilling it in the edit form's URL field (L3).
         lines.append(f"URL: {url}")
-    if keywords_text:
-        lines.append(f"Keywords: {keywords_text}")
+    keywords_display = _display_keywords_text(keywords_text)
+    if keywords_display:
+        lines.append(f"Keywords: {keywords_display}")
     if updated_age:
         lines.append(f"Updated: {updated_age}")
 

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -15848,6 +15848,27 @@ class LibraryScreen(BaseAppScreen):
                 )
             ):
                 self._reset_library_media_reader_to_no_selection()
+                # task-32086 (critique #8 gap in 32043): the reset above cleared
+                # the Reader SESSION, but this seam's tail rebuilds ONLY the
+                # Items pane (``_sync_library_canvas``) and leaves the sibling
+                # ``LibraryMediaViewer`` painting the filtered-out document --
+                # "Media (0)" beside a full stale item with "‹ Back" into an
+                # empty list. The delete path clears the identical split-brain
+                # with a whole-screen recompose (``_delete_library_media_
+                # selection``'s tail); mirror it here so the Reader actually
+                # repaints its "Select a media item…" placeholder. This fires
+                # only on a settled 0-result filter that was holding a loaded
+                # Reader -- as rare as a delete, and never on a page turn
+                # (non-empty ``retained_items``) or mid-load (``loading``
+                # short-circuits the whole block), so the recompose cost is
+                # the delete path's own one-shot completion, not a hot path.
+                if self.is_mounted:
+                    self.refresh(recompose=True)
+                    if focus_identity:
+                        self.call_after_refresh(
+                            self._focus_library_control, focus_identity
+                        )
+                return
         if (
             applied_selection_id
             and self._media_state.reader_session.selected_id != applied_selection_id


### PR DESCRIPTION
## Summary

Critique #8's two gaps in just-landed fixes (tasks 32086, 32087).

- **32086 — the reader now clears on a 0-result filter, not just on delete.** Task-32043's reset cleared the reader *session* (why its pin passed), but the filter path re-rendered only the Items pane and never refreshed the mounted `LibraryMediaViewer`, so it kept painting the filtered-out item; the delete path had escaped this with a whole-screen recompose. The fix mirrors the delete path on the settled 0-result reset (`refresh(recompose=True)` + mount guard + focus restore + `return`, so it can't re-fire). The over-fire guards (page turn, mid-load, filter-with-results) are intact. The new pin drives the real filter-Input path (the 32043 pin drove the internal seam and missed this) and asserts the mounted widget; live-verified.
- **32087 — the reader Info "Keywords:" line no longer paints a lone half-flag.** A whole flag pair does not drift (rich and Textual both measure it as two cells, matching a compliant terminal); critique #8's inferred "+2 drift" was a lone half-flag or a Textual fold-wrap splitting a pair mid-grapheme at narrow widths. The Info line now drops a dangling regional indicator (reusing task-32044's helper), keeping whole pairs; the edit field keeps the raw keyword. The fold-split-mid-pair is a framework segmentation limit, ledgered out of scope.

## Verification

Task review (Opus): Approved, no Important issues. The reviewer confirmed 32086's recompose is unreachable from the pre-existing focus-paint tests (which drive a direct whole-screen recompose, not the filter path, and whose failures reproduce on unmodified HEAD), and independently verified 32087's ruling by probing that a whole pair measures two cells in both rich and Textual and that the fold-split is real and correctly ledgered.

| run | result |
|---|---|
| new pins (filter reader-repaint; Info lone-half-flag) | passed, red first |
| `Tests/Library/test_library_media_viewer_state.py` | 65 passed |
| delete-clear + 32043 session + filter-restore + crit6 scroll-restore pins | passed |
| `test_library_media_reader_flow.py` | 83 passed, 4 pre-existing paint-focus reds (unrelated, reproduce on HEAD) |

Diagnostic inventory verified; no new logger call sites; no CSS; preflight green. Closes tasks 32086 and 32087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two critique #8 gaps: a 0-result filter now repaints the mounted reader placeholder instead of leaving the filtered-out item on screen, and the Info tab's "Keywords:" line no longer drifts when a keyword ends in a lone half-flag.

**Bug Fixes**
- The filter path now mirrors the delete path's screen recompose, so the reader shows its empty placeholder; page-turn and mid-load guards are untouched.
- The Info line drops a dangling regional indicator (reusing the list-row guard) but keeps whole flags; the edit form still prefills the raw keyword.

<sup>Written for commit 37b9cd37ef5e46c98cfe47bb86ab821bc76cc0b8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

