### PR TITLE
Fix native Speak Replies resolution and Chatterbox installs

### DIFF
--- a/Docs/Development/release-recovery-setup.md
+++ b/Docs/Development/release-recovery-setup.md
@@ -14,9 +14,34 @@ Missing optional features do not mean Chatbook is broken. They mean the user has
 | --- | --- | --- | --- | --- |
 | RAG and retrieval | `embeddings_rag` | `pip install -e ".[embeddings_rag]"` | `pip install "tldw_chatbook[embeddings_rag]"` | Library Search/RAG |
 | Media ingestion and transcription | `audio`, `video`, `pdf`, `ebook` | `pip install -e ".[audio,video,pdf,ebook]"` | `pip install "tldw_chatbook[audio,video,pdf,ebook]"` | Library import/media |
+| Local Chatterbox speech | `chatterbox` | `pip install -e ".[chatterbox]"` | `pip install "tldw_chatbook[chatterbox]"` | Speech Lab and Speak replies |
 | MCP integration | `mcp` | `pip install -e ".[mcp]"` | `pip install "tldw_chatbook[mcp]"` | MCP destination |
 | Local inference | `local_vllm`, `local_mlx`, `local_transformers` | `pip install -e ".[local_vllm]"` | `pip install "tldw_chatbook[local_vllm]"` | Console/provider setup |
 | Web access | `web` | `pip install -e ".[web]"` | `pip install "tldw_chatbook[web]"` | Web/browser serving |
+
+## Chatterbox installation and recovery
+
+Install the `chatterbox` extra in the environment that runs Chatbook, using the
+source or packaged command above. It requires Chatterbox 0.1.7 or newer to avoid
+older releases' `pkuseg` source-build failure. The `chatterbox` and `all-tools`
+extras also include a temporary `setuptools<82` runtime requirement for Perth's
+watermarker; the core install has neither requirement.
+
+If an older installation reports `No module named 'pkg_resources'`, or model
+loading fails with `'NoneType' object is not callable` inside Perth, repair that
+environment with:
+
+```bash
+python -m pip install "chatterbox-tts>=0.1.7" "setuptools<82"
+```
+
+Perth 1.0.1 uses `pkg_resources` to locate its bundled watermarker assets but
+does not declare that dependency. It catches the failed import, so importing
+Chatterbox alone can succeed while loading a model fails. Setuptools
+[removed `pkg_resources` in version 82](https://setuptools.pypa.io/en/latest/history.html#v82-0-0).
+Remove the compatibility cap when the supported Perth release replaces this
+import and declares its runtime dependencies, after verifying a fresh extra
+install can import the watermarker and locate its bundled assets.
 
 ## Standalone MCP recovery contract
 

--- a/Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md
@@ -10,9 +10,12 @@ or audio output was replaced with a fixture in these live runs.
 - **audio.cpp Speak replies:** Speech Lab could generate successfully, but the
   Console destination check omitted the native capability reader and rejected
   an exact model with `TTSEffectiveResolutionError: catalog_unavailable` before
-  synthesis. The handler now uses the service's public capability snapshot API.
-  This retains managed-runtime fencing, exact model/voice validation, and final
-  endpoint authorization. The Console regression crosses destination resolution
+  synthesis. The handler now deliberately refreshes the native catalog before
+  using the service's passive public capability snapshot API. This starts a
+  stopped managed child and applies eligible staged settings while retaining
+  exact model/voice validation and final endpoint authorization. Qodo found the
+  stopped-child gap in the initial repair; eight new cases reproduced it before
+  the follow-up fix. The original Console regression crosses destination resolution
   and admission for both an explicit voice and the server default voice; both
   cases failed before the repair and passed afterward.
 - **Chatterbox installation:** an unbounded extra could resolve Chatterbox
@@ -32,6 +35,9 @@ or audio output was replaced with a fixture in these live runs.
   `27a7555c2e3333d4c5e38a48626cfdb18aa8226c`. The successful audio.cpp runs
   include this task's destination-reader repair. The initial failing run is
   retained separately.
+- Managed cold-start follow-up runs use dev
+  `7e81ed55db66ace04cb3dd1f8feb6d40a21f6f48` plus this task's repairs.
+  The tested TTS runtime tree was unchanged by the rebase before that follow-up.
 - Chatterbox 0.1.7, Torch/Torchaudio 2.6.0, Transformers 5.2.0, NumPy 1.26.4,
   Perth 1.0.1, setuptools 80.10.2, pydub 0.25.1, SoundFile 0.14.0 and
   sounddevice 0.5.6. Actual worker initialization logs identify CPU or MPS;
@@ -91,6 +97,25 @@ The primary verifier for MPS and native runs is `Systran/faster-whisper-base.en`
 at `3d3d5dee26484f91867d81cb899cfcf72b96be6c`, CPU/int8. The Chatterbox CPU run
 passed with tiny.en at `0d3d19a32d3338f10357c0889762bd8d64bbdeba`.
 
+### Managed cold-start follow-up
+
+The real app supervisor also owns separate CPU and Metal runs. Mounting leaves
+the process stopped at generation 0; destination resolution starts generation 1.
+Before each of two automatic replies, the harness explicitly shuts down the
+child. The production request handler then starts generations 2 and 3, generates
+the complete sentence and drains the real speaker stream. Service shutdown joins
+all owned resources and returns to Stopped. These runs exercise Console speech;
+the mounted Speech Lab pane receives no Generate action in this follow-up.
+
+| Managed route | Reply 1 decoded / device drain | Reply 2 decoded / device drain | Complete content |
+| --- | --- | --- | --- |
+| CPU, Supertonic F16 | 6.455 / 6.506 s | 6.446 / 6.492 s | Both |
+| Metal, Supertonic F16 | 6.453 / 6.494 s | 6.447 / 6.491 s | Both |
+
+All four recordings pass the same full-file transcription and audio checks.
+Together with the initial WAV and installed-wheel MP3 runs, the evidence covers
+**19 real clips across seven configurations**.
+
 ## Installation verification
 
 An unseeded Python 3.12 uv environment could not install the original wheel's
@@ -116,24 +141,30 @@ claim to exercise the separate audio.cpp source repair.
 All three MP3 clips decoded and transcribed completely and played through real
 afplay processes with exit code 0. Speech Lab decoded/player time was
 4.880/5.899 s; the two automatic replies were 4.760/5.904 s and 4.840/5.892 s.
-Both replies reached `playing → stopped`. This brings the live evidence to
-**15 clips across five configurations**. The installed wheel's SHA-256 is
+Both replies reached `playing → stopped`. These initial runs account for
+15 clips across five configurations. The installed wheel's SHA-256 is
 `26829fbcefc8d739bb40cd2a45961014b1b95b56e1f52e99a4e4c7b57bd4bacb`;
 its exact runtime versions and separate run evidence are retained locally.
 
 ## Automated checks and review
 
 - Native destination regression: **2 failed before / 2 passed after** the fix.
-- Console/native/effective-selection/diagnostic cohort: **181 passed**.
+- Managed/Console/native/effective-selection/diagnostic cohort: **270 passed**.
+  The managed follow-up adds **8 failed before / 11 passed after** cases covering
+  cold start, restart, staged configuration, exact selection rejection, changes
+  between preparation and passive validation, and old-consent rejection after a
+  port change. Passive settings/profile discovery still does not launch a child.
 - Chatterbox delivery and audio.cpp adapter cohort: **215 passed**, including
   the real Chatterbox subprocess protocol test. No optional backend skip.
-- Independent review checked public versus prepared capability access,
-  managed-runtime fencing, and final destination authorization. Its two
-  revised Console cases plus removed-model/removed-voice controls passed.
-- All six derived-artifact preflight checks passed. Both changed Python files
+- Independent follow-up review checked the deliberate preparation boundary,
+  passive validation races and GET-only destination discovery; it found no
+  additional correctness or security issue. Final synthesis retains its separate
+  admitted-endpoint authorization check.
+- All six derived-artifact preflight checks passed. All three changed Python files
   pass formatting and syntax/undefined-name checks. Full Ruff has the same
-  57 existing handler and 5 existing test diagnostics as the base, with no
-  added diagnostics.
+  57 existing handler, 5 existing Console-test and 3 existing managed-test
+  diagnostics as the base, with no added diagnostics. The two targeted cohorts
+  contain **485 distinct passing tests**.
 
 No full repository test sweep was run. Initial tests reported a missing
 pytest-timeout plugin; it was installed before the final backend cohort.
@@ -147,6 +178,9 @@ Local evidence root: `/private/tmp/tts-macos-live-validation`.
 - `validate_live.py`: mounted application synthesis/playback harness.
 - `run_native_validation.py`: loopback server ownership, readiness, real app run,
   and process termination/reaping. CPU uses port 18731; Metal uses port 18732.
+- `validate_managed_live.py` and `verify_managed_content.py`: real managed cold
+  start/restart playback and complete-file transcription; results are in
+  `runs/audio_cpp-{cpu,metal}-wav-managed-cold/evidence.json`.
 - `verify_content.py`: complete-file independent transcription and content checks.
 - `live-summary.json`, `runtime-versions.json`, model provenance files, and
   `runs/{chatterbox-cpu-wav,chatterbox-mps-wav,audio_cpp-cpu-wav-fixed,audio_cpp-metal-wav}/evidence.json`.
@@ -161,7 +195,8 @@ Local evidence root: `/private/tmp/tts-macos-live-validation`.
 
 The native config selects backend CPU or Metal, lazy loading, offline task TTS,
 the absolute Supertonic GGUF/spec paths, and server-default M1. CORS and request
-body logging are disabled. Both owned native servers stopped and were reaped.
+body logging are disabled. Externally launched servers were reaped; the managed
+follow-up joined service shutdown after three owned generations per compute path.
 Application config, data, caches and newly installed runtime/model assets are
 isolated under this task's evidence root. The CPU transcription check reused
 the earlier Kokoro validation's tiny.en model cache read-only, as recorded in

--- a/Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md
+++ b/Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md
@@ -1,0 +1,197 @@
+# Real local TTS on macOS ARM — 2026-09-08
+
+TASK-32096 follows the delivery checks in PR #2520. Chatterbox CPU/MPS and
+audio.cpp CPU/Metal now have real inference, whole-file decoding, physical audio
+device completion, and independent transcription evidence. No model inference
+or audio output was replaced with a fixture in these live runs.
+
+## Defects found and repaired
+
+- **audio.cpp Speak replies:** Speech Lab could generate successfully, but the
+  Console destination check omitted the native capability reader and rejected
+  an exact model with `TTSEffectiveResolutionError: catalog_unavailable` before
+  synthesis. The handler now uses the service's public capability snapshot API.
+  This retains managed-runtime fencing, exact model/voice validation, and final
+  endpoint authorization. The Console regression crosses destination resolution
+  and admission for both an explicit voice and the server default voice; both
+  cases failed before the repair and passed afterward.
+- **Chatterbox installation:** an unbounded extra could resolve Chatterbox
+  0.1.3 and fail building its obsolete `pkuseg` dependency. Even with 0.1.7,
+  Perth 1.0.1 imports undeclared `pkg_resources`, suppresses its absence, and
+  exposes a non-callable watermarker. Model loading then fails despite a
+  successful Chatterbox import. The Chatterbox and all-tools extras now require
+  `chatterbox-tts>=0.1.7` and `setuptools<82`. Core and build-system requirements
+  are unchanged; watermarking is retained. The recovery guide explains the
+  temporary cap and its removal condition.
+
+## Runtime and source identity
+
+- Host: Apple M5 Max, 128 GiB RAM, arm64, macOS 26.5.2; output device:
+  **MacBook Pro Speakers**. Python 3.12.11 and Textual 8.2.8.
+- Application base for the live runs:
+  `27a7555c2e3333d4c5e38a48626cfdb18aa8226c`. The successful audio.cpp runs
+  include this task's destination-reader repair. The initial failing run is
+  retained separately.
+- Chatterbox 0.1.7, Torch/Torchaudio 2.6.0, Transformers 5.2.0, NumPy 1.26.4,
+  Perth 1.0.1, setuptools 80.10.2, pydub 0.25.1, SoundFile 0.14.0 and
+  sounddevice 0.5.6. Actual worker initialization logs identify CPU or MPS;
+  MPS availability and tensor execution were checked outside the sandbox.
+- Model: `ResembleAI/chatterbox`, revision
+  `5bb1f6ee58e50c3b8d408bc82a6d3740c2db6e18`; downloaded checkpoint files are
+  recorded in `chatterbox-model-provenance.json` under the evidence root below.
+- Native runtime: `0xShug0/audio.cpp`, `release-0.5.1`, unchanged source commit
+  `238ab6a9e321c17de8e120559f57efeedaeb1345`. Separate Release arm64 CPU and
+  Metal binaries, six build jobs, custom `pocket_tts,supertonic` model set.
+- Native model actually exercised: **Supertonic 3 F16**, preset **M1**,
+  curated artifact `audio-cpp-supertonic-3-f16`, recipe
+  `audio-cpp-0.5.1.supertonic.supertonic_3_f16` revision 1. Model repository
+  `audio-cpp/audio.cpp-gguf`, revision
+  `597048d9a920592808d7d4e2acd7b9c4596a143a`.
+  GGUF: 312,784,196 bytes, SHA-256
+  `b312b57797d40ac5c09d915893dbdbaf6405b7dc043f544776c5c95712dff88c`.
+  Configuration and all ten voice styles are embedded in the package.
+- CPU server SHA-256:
+  `28afedc4a263bc6710cbd6985b77e7bf6d249bd9282c751b0e227d572dd1bf6f`.
+  Metal server SHA-256:
+  `d00827005f6b14ecbb6b343e77b5477d5cdc07d5b1ba8d4eb8bbe0c1e5d5aedb`.
+
+## Live playback results
+
+Each route mounts the production Speech Lab pane in a minimal Textual host,
+presses Generate, and uses the production resolver, registry, backend, and
+player. Two different Console messages then pass through the real auto-speak
+decision with Speak replies enabled, trusted message snapshots, destination
+authorization, TTS event handling, and audio-device drain.
+
+| Route / WAV output | Speech Lab decoded / player time | Reply 1 decoded / device drain | Reply 2 decoded / device drain | Complete content |
+| --- | --- | --- | --- | --- |
+| Chatterbox CPU | 4.400 / 5.231 s | 5.080 / 5.134 s | 4.600 / 4.634 s | All 3 |
+| Chatterbox MPS | 5.200 / 5.992 s | 5.080 / 5.134 s | 4.600 / 4.624 s | All 3 |
+| audio.cpp CPU, Supertonic F16 | 6.252 / 7.256 s | 6.455 / 6.500 s | 6.446 / 6.492 s | All 3 |
+| audio.cpp Metal, Supertonic F16 | 6.250 / 7.113 s | 6.453 / 6.476 s | 6.447 / 6.462 s | All 3 |
+
+Speech Lab uses real `afplay` processes, all exit code 0. Its first three
+timings come from application player-start/finish timestamps; the Metal run
+records a monotonic timer. Console uses real sounddevice streams at the model's
+sample rate: Chatterbox 24 kHz and Supertonic 44.1 kHz. Each reply reaches
+`playing → stopped`; each run records two SinkStarted and two SinkDrained events
+and no SinkFailed. Saved clips decode fully, contain finite non-silent samples,
+and match their recorded SHA-256 hashes.
+
+The three utterances exercise a Speech Lab sentence, a first automatic reply,
+and a second reply ending with “playback complete successfully.” The complete
+files were independently transcribed using cached faster-whisper English models.
+The tiny recognizer read “Speak” as “Speed” in one MPS clip; the larger base.en
+model correctly recovered the unchanged recording. Raw transcripts are retained.
+Content checks allow punctuation/case, `SpeechLab` spacing, and the recognizer's
+`complete`/`completes` verb-agreement variation; they require beginning, middle,
+and end content. No audio was edited to satisfy those checks.
+
+The primary verifier for MPS and native runs is `Systran/faster-whisper-base.en`
+at `3d3d5dee26484f91867d81cb899cfcf72b96be6c`, CPU/int8. The Chatterbox CPU run
+passed with tiny.en at `0d3d19a32d3338f10357c0889762bd8d64bbdeba`.
+
+## Installation verification
+
+An unseeded Python 3.12 uv environment could not install the original wheel's
+unconstrained Chatterbox extra because of the old `pkuseg` build. Selecting
+Chatterbox 0.1.7 with the original wheel then installed setuptools 84.0.0 and
+reproduced the missing-watermarker failure. Importing Chatterbox alone passed.
+
+A second unseeded environment installed only the repaired wheel's `[chatterbox]`
+extra from the populated package cache, without dependency overrides or shared
+site-packages. All five checks passed: package isolation, Chatterbox import,
+Perth resource import, callable watermarker plus bundled assets, and Chatbook
+backend import. `uv pip check` passed for all 158 installed packages. Wheel
+metadata checks cover both extras and the absence of these runtime constraints
+from core. The large all-tools extra was not installed as a whole.
+
+After preserving that extra-only evidence, a final **installed-wheel MPS/MP3**
+run added sounddevice solely for playback observation and upgraded setuptools
+to **81.0.0**, the newest version allowed by the compatibility cap. Python `-I`
+kept the checkout off the import path. The wheel contains the original dev
+runtime plus the repaired dependency metadata; this Chatterbox run does not
+claim to exercise the separate audio.cpp source repair.
+
+All three MP3 clips decoded and transcribed completely and played through real
+afplay processes with exit code 0. Speech Lab decoded/player time was
+4.880/5.899 s; the two automatic replies were 4.760/5.904 s and 4.840/5.892 s.
+Both replies reached `playing → stopped`. This brings the live evidence to
+**15 clips across five configurations**. The installed wheel's SHA-256 is
+`26829fbcefc8d739bb40cd2a45961014b1b95b56e1f52e99a4e4c7b57bd4bacb`;
+its exact runtime versions and separate run evidence are retained locally.
+
+## Automated checks and review
+
+- Native destination regression: **2 failed before / 2 passed after** the fix.
+- Console/native/effective-selection/diagnostic cohort: **181 passed**.
+- Chatterbox delivery and audio.cpp adapter cohort: **215 passed**, including
+  the real Chatterbox subprocess protocol test. No optional backend skip.
+- Independent review checked public versus prepared capability access,
+  managed-runtime fencing, and final destination authorization. Its two
+  revised Console cases plus removed-model/removed-voice controls passed.
+- All six derived-artifact preflight checks passed. Both changed Python files
+  pass formatting and syntax/undefined-name checks. Full Ruff has the same
+  57 existing handler and 5 existing test diagnostics as the base, with no
+  added diagnostics.
+
+No full repository test sweep was run. Initial tests reported a missing
+pytest-timeout plugin; it was installed before the final backend cohort.
+Upstream pydub/pkg_resources deprecations and the host's joblib semaphore warning
+remain recorded in the logs.
+
+## Evidence and reproduction
+
+Local evidence root: `/private/tmp/tts-macos-live-validation`.
+
+- `validate_live.py`: mounted application synthesis/playback harness.
+- `run_native_validation.py`: loopback server ownership, readiness, real app run,
+  and process termination/reaping. CPU uses port 18731; Metal uses port 18732.
+- `verify_content.py`: complete-file independent transcription and content checks.
+- `live-summary.json`, `runtime-versions.json`, model provenance files, and
+  `runs/{chatterbox-cpu-wav,chatterbox-mps-wav,audio_cpp-cpu-wav-fixed,audio_cpp-metal-wav}/evidence.json`.
+  Each run retains its config, application log, and complete audio artifacts.
+- `runs/chatterbox-mps-mp3-installed-wheel/evidence.json` and
+  `installed-wheel-runtime-versions.json`: the separate installed-wheel MP3 run.
+- `audio-cpp/setup.md`: exact source checkout, build flags, model download URLs,
+  hashes, and server configuration. `audio-cpp/runtime-manifest.json` and
+  `package-manifest.json` retain binary/package identity.
+- `chatterbox-packaging-check/`: original/repaired wheels, isolated environments,
+  probe code, metadata, install results, and failure/success logs.
+
+The native config selects backend CPU or Metal, lazy loading, offline task TTS,
+the absolute Supertonic GGUF/spec paths, and server-default M1. CORS and request
+body logging are disabled. Both owned native servers stopped and were reaped.
+Application config, data, caches and newly installed runtime/model assets are
+isolated under this task's evidence root. The CPU transcription check reused
+the earlier Kokoro validation's tiny.en model cache read-only, as recorded in
+its evidence; the other recognizer assets were downloaded for this task.
+The user's config hash matches its pre-validation value; the dirty main
+checkout was not modified.
+
+## Limits and platform observations
+
+- These are real mounted production speech paths, not a complete manual GUI
+  acceptance session or a human listening-quality assessment.
+- This host lacks the offline `metal` compiler. The pinned runtime supports
+  embedding shader source and compiling it at runtime; that build worked.
+  Metal logs prove GPU selection, compiled compute pipelines and completed
+  inference. Its optional tensor API probe fails and disables that optimization;
+  ordinary Metal inference still succeeds.
+- A temporary attempt to reuse another environment's site-packages exposed an
+  incompatible TorchVision installation. That test harness contamination was
+  removed before successful runs; all runtime environments are isolated.
+- Sandboxed OpenMP initialization aborted a subprocess regression. The unchanged
+  test passes outside the sandbox. Joblib reports the host's existing semaphore
+  shortage and runs serially; disk free space was checked separately.
+- Downloading PocketTTS Q8 does not qualify its runtime. Its named Alba voice
+  asset returned HTTP 401, so the live native checks use the publicly available
+  Supertonic package. No authenticated voice download was attempted.
+- Other audio.cpp model families, Kokoro's PyTorch engine, Higgs, AllTalk and
+  authenticated OpenAI/ElevenLabs inference remain outside this live matrix.
+  Linux/Windows and CUDA were not exercised.
+
+ADR required: no. Existing ADRs 023 and 050 govern the unchanged adapter and
+native-runtime boundaries. The changes repair existing capability wiring and
+installation requirements; no new runtime architecture or storage contract is
+introduced.

--- a/Tests/TTS/test_audio_cpp_managed_integration.py
+++ b/Tests/TTS/test_audio_cpp_managed_integration.py
@@ -9,6 +9,7 @@ import os
 import socket
 import struct
 from collections.abc import Awaitable, Callable, Mapping
+from dataclasses import replace
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
@@ -18,6 +19,13 @@ import httpx
 import pytest
 
 from Tests.TTS.fixtures.fake_audiocpp_server import write_executable_wrapper
+from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    TTSCompleteEvent,
+    TTSEventHandler,
+    TTSMessageSpeechRequestEvent,
+)
 from tldw_chatbook.TTS.adapters import audio_cpp as audio_cpp_adapter_module
 from tldw_chatbook.TTS import audio_cpp_supervisor as supervisor_module
 from tldw_chatbook.TTS.adapter_registry import TTSAdapterRegistry
@@ -57,6 +65,7 @@ from tldw_chatbook.TTS.audio_cpp_supervisor import (
 )
 from tldw_chatbook.TTS.effective_settings import (
     TTSCharacterProfileSelection,
+    TTSEffectiveResolutionError,
     TTSSelectionOverrides,
 )
 from tldw_chatbook.TTS.preferences import TTSPreferencesSnapshot
@@ -560,6 +569,7 @@ def _service(
     *,
     shutdown_timeout_seconds: float = 10.0,
     transport_handler: Callable[[httpx.Request], httpx.Response] | None = _handler,
+    preferences_snapshot: TTSPreferencesSnapshot | None = None,
 ) -> tuple[TTSService, list[dict[str, Any]]]:
     factory_configs: list[dict[str, Any]] = []
 
@@ -601,7 +611,7 @@ def _service(
     return (
         TTSService(
             registry,
-            preferences_snapshot=_preferences(),
+            preferences_snapshot=preferences_snapshot or _preferences(),
             audio_cpp_supervisor=supervisor,  # type: ignore[arg-type]
         ),
         factory_configs,
@@ -1193,6 +1203,205 @@ async def test_console_and_roleplay_admission_apply_stage_before_read_gate(
         assert (
             await service.registry.provider_configuration_snapshot("audio_cpp")
         ).staged_config is None
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("staged", [False, True])
+@pytest.mark.parametrize(
+    "preferences",
+    [
+        _preferences(),
+        replace(_preferences(), model_mode="exact", model_id="model"),
+        replace(
+            _preferences(),
+            model_mode="exact",
+            model_id="model",
+            voice_mode="exact",
+            voice_id="default",
+        ),
+    ],
+    ids=["first-available", "exact-server-default", "exact-voice"],
+)
+async def test_console_destination_prepares_stopped_managed_runtime(
+    tmp_path: Path,
+    staged: bool,
+    preferences: TTSPreferencesSnapshot,
+) -> None:
+    supervisor = _PreparationSupervisor()
+    port = 19_153
+    managed = _managed_config(tmp_path, "console-destination", port)
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _handler(request)
+
+    service, _factory_configs = _service(
+        _external_config() if staged else managed,
+        supervisor,
+        transport_handler=capture,
+        preferences_snapshot=preferences,
+    )
+    if staged:
+        await _stage(service, managed)
+    handler = TTSEventHandler(default_profile_id_reader=lambda: None)
+    handler._tts_service = service
+
+    try:
+        assert supervisor.launches == 0
+        for generation in (1, 2):
+            destination = await handler.resolve_console_speech_destination(None, None)
+
+            assert destination is not None
+            assert destination.sanitized_destination == f"http://127.0.0.1:{port}"
+            assert destination.charges_may_apply is False
+            assert supervisor.launches == generation
+            assert (
+                await service.registry.provider_configuration_snapshot("audio_cpp")
+            ).staged_config is None
+            # Destination discovery may prepare the child, but never sends text.
+            assert all(request.method == "GET" for request in requests)
+            await supervisor.force_exit()
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("model_id", "voice_id", "axis"),
+    [("missing-model", "default", "model_id"), ("model", "missing-voice", "voice_id")],
+)
+async def test_console_destination_rejects_missing_managed_selection_after_start(
+    tmp_path: Path,
+    model_id: str,
+    voice_id: str,
+    axis: str,
+) -> None:
+    supervisor = _PreparationSupervisor()
+    managed = _managed_config(tmp_path, "console-missing-selection", 19_154)
+    service, _factory_configs = _service(
+        managed,
+        supervisor,
+        preferences_snapshot=replace(
+            _preferences(),
+            model_mode="exact",
+            model_id=model_id,
+            voice_mode="exact",
+            voice_id=voice_id,
+        ),
+    )
+    handler = TTSEventHandler(default_profile_id_reader=lambda: None)
+    handler._tts_service = service
+
+    try:
+        with pytest.raises(TTSEffectiveResolutionError) as caught:
+            await handler.resolve_console_speech_destination(None, None)
+
+        assert caught.value.code == "missing_exact"
+        assert caught.value.axis == axis
+        assert supervisor.launches == 1
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("change", ["exit", "stage"])
+async def test_console_destination_rejects_native_change_after_preparation(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    change: str,
+) -> None:
+    supervisor = _PreparationSupervisor()
+    managed = _managed_config(tmp_path, "console-race", 19_155)
+    service, _factory_configs = _service(
+        managed,
+        supervisor,
+        preferences_snapshot=replace(
+            _preferences(), model_mode="exact", model_id="model"
+        ),
+    )
+    handler = TTSEventHandler(default_profile_id_reader=lambda: None)
+    handler._tts_service = service
+    original_snapshot = service.get_native_capability_snapshot
+
+    async def change_before_validation(provider_id, model_ids):
+        assert supervisor.launches == 1
+        if change == "exit":
+            await supervisor.force_exit()
+        else:
+            await _stage(service, _managed_config(tmp_path, "changed", 19_156))
+        return await original_snapshot(provider_id, model_ids)
+
+    monkeypatch.setattr(
+        service, "get_native_capability_snapshot", change_before_validation
+    )
+    try:
+        with pytest.raises(TTSEffectiveResolutionError) as caught:
+            await handler.resolve_console_speech_destination(None, None)
+
+        assert caught.value.code == "revision_incoherent"
+        assert supervisor.launches == 1
+    finally:
+        await service.close()
+        await service.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_console_destination_port_change_rejects_previous_consent(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    supervisor = _PreparationSupervisor()
+    managed = _managed_config(tmp_path, "console-consent", 19_157)
+    requests: list[httpx.Request] = []
+
+    def capture(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return _handler(request)
+
+    service, _factory_configs = _service(managed, supervisor, transport_handler=capture)
+    handler = TTSEventHandler(default_profile_id_reader=lambda: None)
+    handler._tts_service = service
+    completions: list[TTSCompleteEvent] = []
+    monkeypatch.setattr(handler, "post_message", completions.append, raising=False)
+    store = ConsoleChatStore()
+    session = store.create_session()
+    message = store.append_message(
+        session.id,
+        role=ConsoleMessageRole.ASSISTANT,
+        content="This reply must not reach the changed destination.",
+    )
+    outcomes: list[bool] = []
+
+    try:
+        destination = await handler.resolve_console_speech_destination(None, None)
+        assert destination is not None
+        await supervisor.force_exit()
+        await _stage(service, _managed_config(tmp_path, "changed-consent", 19_158))
+
+        await handler.handle_tts_request(
+            TTSMessageSpeechRequestEvent(
+                store.issue_tts_message_speech_snapshot(message.id),
+                store.validate_tts_message_speech_snapshot,
+                outcome_callback=outcomes.append,
+                expected_destination_fingerprint=destination.fingerprint,
+            )
+        )
+
+        assert outcomes == [False]
+        assert supervisor.launches == 2
+        assert len(completions) == 1
+        assert "destination changed" in completions[0].error.lower()
+        assert all(request.method == "GET" for request in requests)
+        current = await handler.resolve_console_speech_destination(None, None)
+        assert current is not None
+        assert current.sanitized_destination == "http://127.0.0.1:19158"
+        assert current.fingerprint != destination.fingerprint
     finally:
         await service.close()
         await service.wait_closed()

--- a/Tests/TTS/test_console_audio_cpp_native.py
+++ b/Tests/TTS/test_console_audio_cpp_native.py
@@ -206,6 +206,9 @@ class _CapturingAdapter:
     async def ensure_ready(self) -> None:
         return
 
+    def admitted_outbound_endpoint(self) -> str:
+        return "http://127.0.0.1:8080"
+
     async def get_catalog(self, refresh: bool = False) -> TTSProviderCatalog:
         del refresh
         return TTSProviderCatalog(
@@ -701,9 +704,10 @@ def _sink_unavailable_by_default(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_ids() -> (
-    None
-):
+@pytest.mark.parametrize("voice", ["[Voice]", None])
+async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_ids(
+    voice: str | None,
+) -> None:
     timeline: list[str] = []
     adapter = _CapturingAdapter(timeline)
     registry = TTSAdapterRegistry(
@@ -721,11 +725,14 @@ async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_
         ),
         aliases={},
     )
+    preferences = _external_preferences()
+    preferences["app_tts"]["default_voice_mode"] = (
+        "exact" if voice is not None else "server_default"
+    )
+    preferences["app_tts"]["default_voice"] = voice or ""
     service = TTSService(
         registry,
-        preferences_snapshot=TTSPreferencesSnapshot.from_settings(
-            _external_preferences()
-        ),
+        preferences_snapshot=TTSPreferencesSnapshot.from_settings(preferences),
     )
     legacy_calls = 0
 
@@ -768,10 +775,15 @@ async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_
     )
     artifact: Path | None = None
     try:
+        destination = await handler.resolve_console_speech_destination(None, None)
+        assert destination is not None
+        assert destination.sanitized_destination == "http://127.0.0.1:8080"
+        assert destination.charges_may_apply is False
         await handler.handle_tts_request(
             TTSMessageSpeechRequestEvent(
                 store.issue_tts_message_speech_snapshot(message.id),
                 store.validate_tts_message_speech_snapshot,
+                expected_destination_fingerprint=destination.fingerprint,
             )
         )
         await asyncio.wait_for(
@@ -791,7 +803,7 @@ async def test_console_audio_cpp_snapshot_uses_native_default_without_rewriting_
                 provider_id="audio_cpp",
                 model_id="<Opaque:Model>",
                 text="Character response",
-                voice="[Voice]",
+                voice=voice,
                 response_format="wav",
                 speed=1.0,
                 options={},

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12540,10 +12540,18 @@ real-service regression reproduced the failure for explicit and server-default
 voices. Wiring the public capability reader fixed both tests and real CPU/Metal
 playback, without weakening exact model/voice validation.
 
+Qodo then identified a second gap: those live runs used an already-running
+external server. The public snapshot intentionally cannot start a stopped
+managed child. Eight managed cases failed until destination resolution used
+the existing deliberate catalog refresh before passive validation. Real managed
+CPU and Metal runs then passed cold start and shutdown/restart before each reply.
+
 **Practice.** Exercise the same destination-resolution and authorization path
 as automatic speech, before admitting and draining its audio request. A working
 adapter, Speech Lab run, or handler call without a destination fingerprint does
-not prove Speak replies can reach that adapter.
+not prove Speak replies can reach that adapter. Include a stopped managed child
+when the provider supports app-owned startup; keep passive observation tests
+separate so fixing deliberate first use does not make background reads launch it.
 
 ## Optional runtime imports can conceal an unusable model dependency
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -12527,3 +12527,36 @@ had no persisted conversation when the transform ran, so the applier returned
 unchanged text. Persist first, assert transformed wire content, and verify the
 origin's `active_request` row and exact source pin before claiming transform
 coverage. Both corrected controls passed with the discard fix.
+
+## Native Console speech tests must resolve the destination first
+
+**Incident (TASK-32096, 2026-09-08).** Real Supertonic inference through the
+pinned audio.cpp runtime worked in Speech Lab, but Speak replies failed with
+`TTSEffectiveResolutionError: catalog_unavailable`. The Console destination
+check omitted the native capability reader. Earlier native request tests passed
+because they called the handler without first resolving a destination or
+supplying its expected fingerprint. Adding both operations to the existing
+real-service regression reproduced the failure for explicit and server-default
+voices. Wiring the public capability reader fixed both tests and real CPU/Metal
+playback, without weakening exact model/voice validation.
+
+**Practice.** Exercise the same destination-resolution and authorization path
+as automatic speech, before admitting and draining its audio request. A working
+adapter, Speech Lab run, or handler call without a destination fingerprint does
+not prove Speak replies can reach that adapter.
+
+## Optional runtime imports can conceal an unusable model dependency
+
+**Incident (TASK-32096, 2026-09-08).** Chatterbox 0.1.7 imported successfully in a
+fresh environment, but model construction failed because Perth 1.0.1 suppressed
+a missing `pkg_resources` import and exported `PerthImplicitWatermarker=None`.
+An unseeded wheel-extra install reproduced the failure with setuptools 84;
+the repaired extra selected a version below 82 and passed watermarker-callable
+and bundled-resource checks. The unconstrained extra also resolved an older
+Chatterbox release with a broken `pkuseg` source build, requiring a minimum
+Chatterbox version in that extra.
+
+**Practice.** Validate optional runtime installation from a built wheel in an
+unseeded environment. Probe the capability and required resources, not just the
+top-level import or declared dependency consistency. Preserve the original
+extra-only evidence before adding test instrumentation.

--- a/backlog/tasks/task-32096 - Validate-real-Chatterbox-and-audio.cpp-speech-on-macOS-ARM.md
+++ b/backlog/tasks/task-32096 - Validate-real-Chatterbox-and-audio.cpp-speech-on-macOS-ARM.md
@@ -1,11 +1,11 @@
 ---
 id: TASK-32096
 title: Validate real Chatterbox and audio.cpp speech on macOS ARM
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-08 22:15'
-updated_date: '2026-09-08 23:05'
+updated_date: '2026-09-08 23:48'
 labels: []
 dependencies: []
 ---
@@ -41,5 +41,5 @@ Reason: verify and, if necessary, repair existing inference and playback contrac
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Validated real Chatterbox CPU/MPS and pinned audio.cpp CPU/Metal synthesis through mounted Speech Lab and repeated Speak replies, with full decode, actual device completion and independent transcription. A further installed-wheel MPS/MP3 run validates setuptools 81; 15 real clips passed. Fixed missing native capability wiring in Console destination resolution and repaired Chatterbox extra dependency bounds after fresh-wheel installation failures. The two native regressions failed before and passed after; 181 Console/resolver and 215 backend cases pass. Fresh-wheel import/resource/isolation checks and all six preflight checks pass. Updated recovery guidance and evidence lessons. Exact runtimes, hashes, model limits and evidence are in Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md. Existing ADRs 023 and 050 apply; no new boundary or ADR required. PR integration and hosted review remain pending.
+Validated real Chatterbox CPU/MPS and pinned audio.cpp CPU/Metal through Speech Lab and repeated Speak replies, with full decode, actual device completion and independent transcription. Installed-wheel MPS/MP3 also validates setuptools 81. Qodo identified a stopped managed child gap; the deliberate catalog refresh now precedes passive native validation. Real managed CPU and Metal runs pass cold destination resolution and restart before each reply, for 19 verified clips across seven configurations. Regression coverage proves exact model/voice rejection, passive discovery, post-preparation races and changed-port consent rejection. All 485 distinct targeted tests pass across the 270 managed/Console/resolver and 215 backend cohorts. Eight managed cases failed before the follow-up repair; all eleven follow-up regressions pass. Fresh-wheel installation/resource/isolation checks, six preflight checks and formatting pass with no new Ruff diagnostics. Independent review found no remaining issues. Recovery guidance, evidence lessons and Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md record the exact runtime/model identities, setup failures and limitations. User configuration remains unchanged. Submitted as PR #2532 against current dev. Existing ADRs 023 and 050 apply; no new architecture or ADR required.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32096 - Validate-real-Chatterbox-and-audio.cpp-speech-on-macOS-ARM.md
+++ b/backlog/tasks/task-32096 - Validate-real-Chatterbox-and-audio.cpp-speech-on-macOS-ARM.md
@@ -1,0 +1,45 @@
+---
+id: TASK-32096
+title: Validate real Chatterbox and audio.cpp speech on macOS ARM
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-08 22:15'
+updated_date: '2026-09-08 23:05'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the live inference gaps remaining after TASK-32076 by exercising the real local models and audio device on Apple Silicon.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Chatterbox CPU and MPS generation and playback have recorded real-model outcomes.
+- [x] #2 Pinned audio.cpp CPU and Metal generation and playback have recorded real-model outcomes.
+- [x] #3 Repeated Speak replies and Speech Lab paths are exercised with full-content audio verification, or a concrete runtime blocker is documented.
+- [x] #4 Any confirmed application defects have focused regression evidence and are repaired before successful paths are claimed.
+- [x] #5 Runtime, model, configuration isolation, and remaining limitations are documented without modifying the user profile.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Pin current dev and isolated runtime/model/config paths.
+2. Install the released Chatterbox runtime and build the compatible audio.cpp release for CPU and Metal.
+3. Exercise real Speech Lab and Speak replies admission, repeated generation, full decoding, actual device playback, and independent transcription for each available compute path.
+4. Reproduce any application defect, add focused regression coverage, repair its cause, and repeat the affected live run.
+5. Record exact runtime/model identities and outcomes, including unavailable or failed paths.
+ADR required: no
+ADR path: N/A; existing backlog/decisions/023-tts-adapter-registry-and-audio-cpp-runtime-boundary.md and backlog/decisions/050-audio-cpp-generated-model-setup-ownership.md apply.
+Reason: verify and, if necessary, repair existing inference and playback contracts without changing architectural boundaries.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Validated real Chatterbox CPU/MPS and pinned audio.cpp CPU/Metal synthesis through mounted Speech Lab and repeated Speak replies, with full decode, actual device completion and independent transcription. A further installed-wheel MPS/MP3 run validates setuptools 81; 15 real clips passed. Fixed missing native capability wiring in Console destination resolution and repaired Chatterbox extra dependency bounds after fresh-wheel installation failures. The two native regressions failed before and passed after; 181 Console/resolver and 215 backend cases pass. Fresh-wheel import/resource/isolation checks and all six preflight checks pass. Updated recovery guidance and evidence lessons. Exact runtimes, hashes, model limits and evidence are in Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md. Existing ADRs 023 and 050 apply; no new boundary or ADR required. PR integration and hosted review remain pending.
+<!-- SECTION:NOTES:END -->

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,7 +241,10 @@ media_processing = [
     # pip install -e ".[media_processing,transcription_parakeet]"
 ]
 chatterbox = [
-    "chatterbox-tts",
+    "chatterbox-tts>=0.1.7",  # Avoid older releases' broken pkuseg source install
+    # Perth 1.0.1 needs pkg_resources at runtime (removed in setuptools 82).
+    # Remove this cap once Perth replaces that import and declares its runtime deps.
+    "setuptools<82",
     "torchaudio",
     "torch",
     "faster-whisper",  # For validation of generated audio
@@ -415,7 +418,8 @@ all-tools = [
     "librosa",
     
     # === TTS (Text-to-Speech) ===
-    "chatterbox-tts",
+    "chatterbox-tts>=0.1.7",
+    "setuptools<82",  # Perth runtime compatibility; see the chatterbox extra above
     "torchaudio",
     "kokoro-onnx",
     "onnxruntime",

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -47,6 +47,7 @@ from tldw_chatbook.TTS.character_request_resolver import TTSVoiceRefusalDomain
 from tldw_chatbook.TTS.legacy_bridge import UnknownLegacyModelError
 from tldw_chatbook.TTS.adapter_types import (
     TTSConfigurationRevisionError,
+    TTSNativeCapabilitySnapshot,
     TTSOperationError,
     TTSProgress,
     TTSProviderReconfiguringError,
@@ -1274,11 +1275,22 @@ class TTSEventHandler:
                     reference=resolution.reference,
                 )
 
+        async def read_native_capability(
+            provider_id: str,
+            model_id: str,
+            voice_id: str | None,
+        ) -> TTSNativeCapabilitySnapshot:
+            return await service.get_native_capability_snapshot(
+                provider_id,
+                (model_id,) if voice_id is not None else (),
+            )
+
         effective = await TTSEffectiveSettingsResolver().resolve_non_studio(
             global_preferences=service.preferences_snapshot(),
             global_preferences_revision=service.preferences_generation(),
             provider_revision_reader=service.configuration_revision,
             catalog_reader=service.get_catalog,
+            native_capability_reader=read_native_capability,
             character_profile=character_profile,
             default_profile=default_profile,
         )

--- a/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
+++ b/tldw_chatbook/Event_Handlers/TTS_Events/tts_events.py
@@ -50,6 +50,7 @@ from tldw_chatbook.TTS.adapter_types import (
     TTSNativeCapabilitySnapshot,
     TTSOperationError,
     TTSProgress,
+    TTSProviderCatalog,
     TTSProviderReconfiguringError,
     TTSProviderUnavailableError,
     TTSRequest,
@@ -1275,11 +1276,19 @@ class TTSEventHandler:
                     reference=resolution.reference,
                 )
 
+        async def read_catalog(provider_id: str) -> TTSProviderCatalog:
+            if provider_id == "audio_cpp":
+                # Speak is deliberate: prepare a stopped child and apply any
+                # eligible saved configuration before validating its catalog.
+                return await service.get_catalog(provider_id, refresh=True)
+            return await service.get_catalog(provider_id)
+
         async def read_native_capability(
             provider_id: str,
             model_id: str,
             voice_id: str | None,
         ) -> TTSNativeCapabilitySnapshot:
+            await read_catalog(provider_id)
             return await service.get_native_capability_snapshot(
                 provider_id,
                 (model_id,) if voice_id is not None else (),
@@ -1289,7 +1298,7 @@ class TTSEventHandler:
             global_preferences=service.preferences_snapshot(),
             global_preferences_revision=service.preferences_generation(),
             provider_revision_reader=service.configuration_revision,
-            catalog_reader=service.get_catalog,
+            catalog_reader=read_catalog,
             native_capability_reader=read_native_capability,
             character_profile=character_profile,
             default_profile=default_profile,


### PR DESCRIPTION
audio.cpp could generate in Speech Lab while Speak replies failed with `TTSEffectiveResolutionError` before synthesis: Console destination resolution omitted the native capability reader. The destination check now deliberately refreshes the native catalog before passive exact model/voice validation. This also prepares a stopped managed child and applies eligible saved settings. Destination discovery sends metadata requests only, and final synthesis retains its admitted-endpoint authorization.

Fresh Chatterbox installs could resolve an obsolete release with a broken `pkuseg` build, or load Perth without its required `pkg_resources` watermarker dependency. Require `chatterbox-tts>=0.1.7` and `setuptools<82` in the two speech extras, with recovery/removal guidance. Core and build-system requirements remain unchanged.

Validation:

- 485 distinct targeted managed-runtime, Console, resolver, Chatterbox and audio.cpp tests passed. The original native destination cases failed before the repair; eight managed cases reproduced the Qodo finding, and all eleven managed follow-up regressions pass.
- 19 real clips passed generation, full decoding, macOS speaker completion and independent transcription: Chatterbox CPU/MPS WAV, audio.cpp CPU/Metal with pinned Supertonic F16, installed-wheel Chatterbox MPS MP3 with setuptools 81, and managed CPU/Metal cold starts with restart before each reply.
- Regressions retain passive settings/profile observation, exact model/voice rejection, process/configuration fencing and old-consent rejection after a port change without sending message text.
- The repaired built-wheel extra passes isolated installation, watermarker/resource/import checks and dependency consistency. All six derived-artifact checks and formatting pass, with no new Ruff diagnostics. Independent follow-up review found no further issues.

Exact runtime/model identities, evidence and limits are recorded in [the validation report](Docs/superpowers/qa/tts-macos-live-2026-09-08/verification.md). No full repository test sweep was run. Resolves TASK-32096.
