### PR TITLE
Widen Watchlists Feed Items by 10 columns

### DIFF
--- a/Docs/superpowers/specs/2026-09-09-watchlists-feed-items-width-design.md
+++ b/Docs/superpowers/specs/2026-09-09-watchlists-feed-items-width-design.md
@@ -1,0 +1,46 @@
+# Watchlists Feed Items Width Design
+
+## Goal
+
+Give the Feed Items pane immediately left of the Reader 10 more terminal columns
+without changing the other Watchlists panes or the existing responsive layout
+policy.
+
+## Design
+
+Increase the Read-mode Feed Items pane's minimum width from 32 to 42 columns and
+its preferred/maximum width from 40 to 50 columns. Keep the pane flexible between
+those bounds. In production CSS, change the main rule to `width: 50fr`,
+`min-width: 42`, and `max-width: 50`, and change the expanded-side-pane override
+to the same 42-column minimum. Update the pure responsive-layout minimum to 42
+columns so Watchlists collapses side panes before squeezing Feed Items below its
+new minimum.
+
+This shifts only Read-mode collapse and reopening thresholds that include Feed
+Items. Management-tab geometry remains unchanged. The Reader remains the permanent
+centre, and the existing Inspector, Navigation, then Feed Items collapse priority
+is preserved.
+
+## Verification
+
+- Update every Feed-Items-dependent Read-mode boundary by exactly 10 columns:
+  nominal thresholds `145/115/91` become `155/125/101`, with corresponding reopen
+  thresholds moving by 10. Management-tab thresholds remain unchanged.
+- Update the focused pure, mounted, hysteresis, and scoped-rebuild layout coverage,
+  including `test_watchlists_responsive_layout.py`,
+  `test_watchlists_workbench.py`, `test_watchlists_layout_hysteresis_probe.py`, and
+  `test_watchlists_scoped_rebuilds.py` wherever those Read thresholds are encoded.
+- Verify both production CSS declarations carry the new 42-column minimum and the
+  main rule carries the 50-column preferred/maximum width.
+- Regenerate `tldw_cli_modular.tcss`, run the focused Watchlists layout tests, and
+  run the CSS bundle integrity checks.
+
+## Architecture Decision
+
+ADR required: no
+
+ADR path: `backlog/decisions/042-watchlists-reader-first-ia.md`
+
+Reason: ADR-042 already owns the permanent Reader, side-pane minimums, and
+responsive-collapse policy. This is a small presentation refinement within that
+accepted boundary.

--- a/Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py
+++ b/Tests/Watchlists/test_watchlists_layout_hysteresis_probe.py
@@ -10,7 +10,7 @@ across such an oscillation at the management-mode RIGHT_RAIL boundary
 `_recompute_effective_layout` -> `request_region_layout` -> mount/remove
 pipeline with only the width *measurement* stubbed. The screen opens on its
 default Read section (`active_section = "items"`), whose all-open
-requirement is 145 = 44 centre + 3*5 grips + 24 + 32 + 30; RIGHT_RAIL is
+requirement is 155 = 44 centre + 3*5 grips + 24 + 42 + 30; RIGHT_RAIL is
 the first collapse candidate below it.
 
 The conftest `isolate_test_environment` fixture patches
@@ -35,7 +35,7 @@ from tldw_chatbook.UI.Watchlists_Modules.watchlists_workbench import (
 pytestmark = pytest.mark.asyncio
 
 #: Read mode all-open requirement: RIGHT_RAIL collapses below this.
-READ_BOUNDARY_WIDTH = 145
+READ_BOUNDARY_WIDTH = 155
 
 
 class _RegionBuildCounter:
@@ -93,7 +93,7 @@ async def test_one_cell_resize_oscillation_at_the_boundary_causes_no_churn():
         width_box = {"value": READ_BOUNDARY_WIDTH}
         screen._available_layout_width = lambda: width_box["value"]
 
-        # Settle exactly at the boundary: everything still fits at 145.
+        # Settle exactly at the boundary: everything still fits at 155.
         await _resize_to(screen, pilot, width_box, READ_BOUNDARY_WIDTH)
         assert workbench._mounted_region_body(Region.RIGHT_RAIL) is not None
 
@@ -106,10 +106,10 @@ async def test_one_cell_resize_oscillation_at_the_boundary_causes_no_churn():
                     screen, pilot, width_box, READ_BOUNDARY_WIDTH
                 )
 
-            # The first 144 collapses the rail; every later +/-1 step must
+            # The first 154 collapses the rail; every later +/-1 step must
             # be absorbed: NO region body is ever rebuilt during the
             # oscillation, and the rail stays collapsed (no re-mount at
-            # 145, which is inside the hysteresis band).
+            # 155, which is inside the hysteresis band).
             assert builds.regions == [], (
                 "a +/-1-cell oscillation must cause zero region-body "
                 f"rebuilds; got {builds.regions!r}"

--- a/Tests/Watchlists/test_watchlists_responsive_layout.py
+++ b/Tests/Watchlists/test_watchlists_responsive_layout.py
@@ -29,7 +29,7 @@ def test_declared_widths_orders_and_default_priorities():
     assert region_layout.PANE_GRIP_WIDTH == 5
     assert region_layout.PANE_MINIMUM_WIDTHS == {
         Region.LEFT_RAIL: 24,
-        Region.ITEMS: 32,
+        Region.ITEMS: 42,
         Region.RIGHT_RAIL: 30,
     }
     assert region_layout.CENTRE_COMFORT_WIDTH == 44
@@ -56,14 +56,14 @@ def test_declared_widths_orders_and_default_priorities():
 
 def test_read_all_open_boundary_collapses_inspector_first():
     preferred = RegionLayout()
-    assert resolve(preferred, 145).collapsed == frozenset()
-    assert resolve(preferred, 144).collapsed == frozenset({Region.RIGHT_RAIL})
+    assert resolve(preferred, 155).collapsed == frozenset()
+    assert resolve(preferred, 154).collapsed == frozenset({Region.RIGHT_RAIL})
 
 
 def test_read_navigation_and_feed_items_boundary_collapses_navigation_next():
     preferred = RegionLayout().toggle_preferred(Region.RIGHT_RAIL)
-    assert resolve(preferred, 115).collapsed == frozenset({Region.RIGHT_RAIL})
-    assert resolve(preferred, 114).collapsed == frozenset(
+    assert resolve(preferred, 125).collapsed == frozenset({Region.RIGHT_RAIL})
+    assert resolve(preferred, 124).collapsed == frozenset(
         {Region.LEFT_RAIL, Region.RIGHT_RAIL}
     )
 
@@ -74,10 +74,10 @@ def test_read_feed_items_only_boundary_collapses_every_side_pane():
         .toggle_preferred(Region.LEFT_RAIL)
         .toggle_preferred(Region.RIGHT_RAIL)
     )
-    assert resolve(preferred, 91).collapsed == frozenset(
+    assert resolve(preferred, 101).collapsed == frozenset(
         {Region.LEFT_RAIL, Region.RIGHT_RAIL}
     )
-    assert resolve(preferred, 90).collapsed == frozenset(
+    assert resolve(preferred, 100).collapsed == frozenset(
         region_layout.COLLAPSIBLE_REGIONS
     )
 
@@ -127,7 +127,7 @@ def test_priority_target_is_protected_until_every_other_eligible_pane_collapses(
     preferred = RegionLayout()
     protected = resolve(
         preferred,
-        114,
+        124,
         priority_target=Region.RIGHT_RAIL,
     )
     assert protected.collapsed == frozenset({Region.LEFT_RAIL, Region.ITEMS})
@@ -147,8 +147,8 @@ def test_preferred_closed_panes_stay_closed():
 
 def test_repeated_resolution_is_idempotent():
     preferred = RegionLayout()
-    effective = resolve(preferred, 114)
-    assert resolve(effective, 114) == effective
+    effective = resolve(preferred, 124)
+    assert resolve(effective, 124) == effective
 
 
 @pytest.mark.parametrize("width", [59, 30, 1, 0, -1])
@@ -172,7 +172,7 @@ def test_resolver_discards_a_retired_reader_collapse_value():
     preferred = RegionLayout(
         collapsed=frozenset({Region.LEFT_RAIL, Region.CONTENT})
     )
-    effective = resolve(preferred, 145)
+    effective = resolve(preferred, 155)
     assert effective.collapsed == frozenset({Region.LEFT_RAIL})
     assert not effective.is_collapsed(Region.CONTENT)
 
@@ -180,9 +180,9 @@ def test_resolver_discards_a_retired_reader_collapse_value():
 # --- Hysteresis at the collapse boundaries (TASK-22211) -------------------
 #
 # Boundary map (read mode, everything preferred open):
-#   145 = 44 (centre) + 3*5 (grips) + 24 + 32 + 30  -> RIGHT_RAIL collapses < 145
-#   115 = 145 - 30                                  -> LEFT_RAIL collapses < 115
-#    91 = 115 - 24                                  -> ITEMS collapses < 91
+#   155 = 44 (centre) + 3*5 (grips) + 24 + 42 + 30  -> RIGHT_RAIL collapses < 155
+#   125 = 155 - 30                                  -> LEFT_RAIL collapses < 125
+#   101 = 125 - 24                                  -> ITEMS collapses < 101
 # Management mode: 108 -> RIGHT_RAIL, 78 -> LEFT_RAIL.
 # A collapsed pane re-expands only once the width clears its boundary by
 # LAYOUT_HYSTERESIS_WIDTH (the Library reader precedent).
@@ -198,41 +198,41 @@ def test_hysteresis_constant_matches_the_library_reader_precedent():
 
 def test_one_cell_oscillation_at_the_read_inspector_boundary_is_stable():
     preferred = RegionLayout()
-    layout = resolve(preferred, 145)
+    layout = resolve(preferred, 155)
     assert layout.collapsed == frozenset()
     for _ in range(5):
-        layout = resolve(preferred, 144, previous=layout)
+        layout = resolve(preferred, 154, previous=layout)
         assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
-        layout = resolve(preferred, 145, previous=layout)
+        layout = resolve(preferred, 155, previous=layout)
         assert layout.collapsed == frozenset({Region.RIGHT_RAIL})
 
 
 def test_expansion_requires_clearing_the_boundary_by_the_hysteresis_width():
     preferred = RegionLayout()
-    collapsed = resolve(preferred, 144, previous=resolve(preferred, 145))
+    collapsed = resolve(preferred, 154, previous=resolve(preferred, 155))
     assert collapsed.collapsed == frozenset({Region.RIGHT_RAIL})
 
-    still_held = resolve(preferred, 148, previous=collapsed)
+    still_held = resolve(preferred, 158, previous=collapsed)
     assert still_held.collapsed == frozenset({Region.RIGHT_RAIL})
 
-    reopened = resolve(preferred, 149, previous=collapsed)
+    reopened = resolve(preferred, 159, previous=collapsed)
     assert reopened.collapsed == frozenset()
 
     # The expand boundary is itself stable in both directions: once open,
     # dropping one cell below it does not re-collapse (the bare threshold,
-    # 145, governs collapse).
-    assert resolve(preferred, 148, previous=reopened).collapsed == frozenset()
+    # 155, governs collapse).
+    assert resolve(preferred, 158, previous=reopened).collapsed == frozenset()
 
 
 def test_crossing_by_at_least_the_hysteresis_width_still_flips_both_ways():
     preferred = RegionLayout()
-    open_layout = resolve(preferred, 149)
+    open_layout = resolve(preferred, 159)
     assert open_layout.collapsed == frozenset()
 
-    collapsed = resolve(preferred, 144, previous=open_layout)
+    collapsed = resolve(preferred, 154, previous=open_layout)
     assert collapsed.collapsed == frozenset({Region.RIGHT_RAIL})
 
-    reopened = resolve(preferred, 149, previous=collapsed)
+    reopened = resolve(preferred, 159, previous=collapsed)
     assert reopened.collapsed == frozenset()
 
 
@@ -256,19 +256,19 @@ def test_hysteresis_composes_per_region_when_two_boundaries_are_near():
         collapsed=frozenset({Region.RIGHT_RAIL, Region.LEFT_RAIL})
     )
 
-    # LEFT_RAIL's expand boundary (115 + 4) is evaluated with RIGHT_RAIL's
+    # LEFT_RAIL's expand boundary (125 + 4) is evaluated with RIGHT_RAIL's
     # suppressed width already deducted -- per-region state, not one flag.
-    held = resolve(preferred, 118, previous=prev)
+    held = resolve(preferred, 128, previous=prev)
     assert held.collapsed == frozenset({Region.RIGHT_RAIL, Region.LEFT_RAIL})
 
-    left_back = resolve(preferred, 119, previous=prev)
+    left_back = resolve(preferred, 129, previous=prev)
     assert left_back.collapsed == frozenset({Region.RIGHT_RAIL})
 
     # RIGHT_RAIL's own expand boundary is the all-open requirement + 4.
-    assert resolve(preferred, 148, previous=prev).collapsed == frozenset(
+    assert resolve(preferred, 158, previous=prev).collapsed == frozenset(
         {Region.RIGHT_RAIL}
     )
-    assert resolve(preferred, 149, previous=prev).collapsed == frozenset()
+    assert resolve(preferred, 159, previous=prev).collapsed == frozenset()
 
 
 def test_hysteresis_applies_to_the_priority_target_too():
@@ -297,10 +297,10 @@ def test_article_focus_still_collapses_everything_regardless_of_previous():
 
 def test_resolution_with_previous_reaches_a_fixed_point():
     preferred = RegionLayout()
-    layout = resolve(preferred, 144, previous=resolve(preferred, 145))
-    assert resolve(preferred, 144, previous=layout) == layout
-    layout = resolve(preferred, 118, previous=layout)
-    assert resolve(preferred, 118, previous=layout) == layout
+    layout = resolve(preferred, 154, previous=resolve(preferred, 155))
+    assert resolve(preferred, 154, previous=layout) == layout
+    layout = resolve(preferred, 128, previous=layout)
+    assert resolve(preferred, 128, previous=layout) == layout
 
 
 @pytest.mark.parametrize("read_mode", [True, False])
@@ -336,7 +336,7 @@ def test_hysteresis_never_holds_a_pane_open_the_bare_resolver_collapses(
 
 def test_no_previous_state_resolves_exactly_as_before():
     preferred = RegionLayout()
-    for width in (90, 91, 114, 115, 144, 145):
+    for width in (100, 101, 124, 125, 154, 155):
         assert resolve(preferred, width) == resolve(
             preferred, width, previous=None
         )
@@ -348,11 +348,11 @@ def test_no_previous_state_resolves_exactly_as_before():
 @pytest.mark.parametrize(
     ("read_mode", "threshold", "preferred_collapsed", "responsive_region"),
     [
-        (True, 145, frozenset(), Region.RIGHT_RAIL),
-        (True, 115, frozenset({Region.RIGHT_RAIL}), Region.LEFT_RAIL),
+        (True, 155, frozenset(), Region.RIGHT_RAIL),
+        (True, 125, frozenset({Region.RIGHT_RAIL}), Region.LEFT_RAIL),
         (
             True,
-            91,
+            101,
             frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}),
             Region.ITEMS,
         ),
@@ -422,7 +422,7 @@ def test_each_boundary_has_bidirectional_four_column_hysteresis(
     [
         (
             True,
-            (95, 119, 149),
+            (105, 129, 159),
             (
                 frozenset({Region.ITEMS}),
                 frozenset({Region.LEFT_RAIL, Region.ITEMS}),
@@ -465,7 +465,7 @@ def test_multiple_panes_reopen_in_reverse_collapse_order(
 @pytest.mark.parametrize(
     ("read_mode", "width", "expected_collapsed"),
     [
-        (True, 149, frozenset()),
+        (True, 159, frozenset()),
         (False, 112, frozenset()),
     ],
 )
@@ -509,7 +509,7 @@ def test_priority_adjustment_is_reversed_for_reopening_candidates():
     )
     second_reopened = resolve(
         preferred,
-        125,
+        135,
         priority_target=Region.RIGHT_RAIL,
         previous=first_reopened,
     )
@@ -522,12 +522,12 @@ def test_priority_adjustment_is_reversed_for_reopening_candidates():
 @pytest.mark.parametrize(
     ("read_mode", "priority_target", "width", "expected_collapsed"),
     [
-        (True, None, 145, frozenset()),
-        (True, None, 144, frozenset({Region.RIGHT_RAIL})),
+        (True, None, 155, frozenset()),
+        (True, None, 154, frozenset({Region.RIGHT_RAIL})),
         (
             True,
             Region.RIGHT_RAIL,
-            114,
+            124,
             frozenset({Region.LEFT_RAIL, Region.ITEMS}),
         ),
         (False, None, 108, frozenset()),

--- a/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
+++ b/Tests/Watchlists/test_watchlists_scoped_rebuilds.py
@@ -1096,7 +1096,7 @@ async def test_resize_hysteresis_suppresses_sub_band_layout_requests(
 ) -> None:
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
 
         workbench = screen.query_one(WatchlistsWorkbench)
@@ -1117,7 +1117,7 @@ async def test_resize_hysteresis_suppresses_sub_band_layout_requests(
 
         monkeypatch.setattr(workbench, "request_region_layout", record_request)
 
-        for width in (145, 146, 147, 148, 147, 148, 147, 148):
+        for width in (155, 156, 157, 158, 157, 158, 157, 158):
             await pilot.resize_terminal(width, 50)
             await _settle(pilot, host)
             assert screen._responsive_region_layout.is_collapsed(
@@ -1130,7 +1130,7 @@ async def test_resize_hysteresis_suppresses_sub_band_layout_requests(
 
         assert requests == []
 
-        await pilot.resize_terminal(149, 50)
+        await pilot.resize_terminal(159, 50)
         await _settle(pilot, host)
         assert len(requests) == 1
         assert not screen._responsive_region_layout.is_collapsed(
@@ -1142,7 +1142,7 @@ async def test_resize_hysteresis_suppresses_sub_band_layout_requests(
         ) is grip
         assert screen.focused is focused
 
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         assert len(requests) == 1
         assert not screen._responsive_region_layout.is_collapsed(
@@ -1151,7 +1151,7 @@ async def test_resize_hysteresis_suppresses_sub_band_layout_requests(
         assert screen.query_one("#wl-region-right_rail") is right_rail_body
         assert screen.focused is focused
 
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
         assert len(requests) == 2
         assert screen._responsive_region_layout.is_collapsed(Region.RIGHT_RAIL)
@@ -1195,7 +1195,7 @@ async def test_zero_width_never_seeds_or_replaces_responsive_history(
         ) == before_zero
         assert requests == []
 
-        monkeypatch.setattr(screen, "_available_layout_width", lambda: 144)
+        monkeypatch.setattr(screen, "_available_layout_width", lambda: 154)
         screen.on_resize(None)
         await _settle(pilot, host)
         baseline = screen._responsive_region_layout
@@ -1266,9 +1266,9 @@ async def test_responsive_grip_open_protects_preferred_open_pane(
     )
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         assert screen._effective_region_layout.is_collapsed(Region.RIGHT_RAIL)
         assert not screen.region_layout.is_collapsed(Region.RIGHT_RAIL)
@@ -1297,9 +1297,9 @@ async def test_article_focus_preserves_priority_lease_and_hidden_baseline(
 ) -> None:
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         screen.query_one("#wl-grip-right_rail", Button).press()
         await _settle(pilot, host)
@@ -1358,9 +1358,9 @@ async def test_article_focus_preserves_priority_lease_and_hidden_baseline(
 async def test_priority_lease_parks_across_management_and_replaces_in_read() -> None:
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         screen.query_one("#wl-grip-right_rail", Button).press()
         await _settle(pilot, host)
@@ -1395,20 +1395,20 @@ async def test_priority_lease_parks_across_management_and_replaces_in_read() -> 
 async def test_priority_lease_clears_only_after_origin_mode_fits_past_dead_band() -> None:
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         screen.query_one("#wl-grip-right_rail", Button).press()
         await _settle(pilot, host)
         lease = screen._responsive_priority_lease
 
-        for width in (145, 146, 147, 148, 147, 148):
+        for width in (155, 156, 157, 158, 157, 158):
             await pilot.resize_terminal(width, 50)
             await _settle(pilot, host)
             assert screen._responsive_priority_lease == lease
 
-        await pilot.resize_terminal(149, 50)
+        await pilot.resize_terminal(159, 50)
         await _settle(pilot, host)
         assert screen._responsive_priority_lease is None
 
@@ -1934,9 +1934,9 @@ async def test_failed_responsive_inspector_open_restores_layout_snapshots(
     )
     app = _build_test_app()
     async with _open(app) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
 
         workbench = screen.query_one(WatchlistsWorkbench)
@@ -2463,9 +2463,9 @@ async def test_section_factory_failure_rolls_back_mode_and_can_retry(
     app = _build_test_app()
     watchlist_id = _seed(app)
     async with _open(app, watchlist_id) as (screen, pilot, host):
-        await pilot.resize_terminal(144, 50)
+        await pilot.resize_terminal(154, 50)
         await _settle(pilot, host)
-        await pilot.resize_terminal(145, 50)
+        await pilot.resize_terminal(155, 50)
         await _settle(pilot, host)
         screen.query_one("#wl-grip-right_rail", Button).press()
         await _settle(pilot, host)

--- a/Tests/Watchlists/test_watchlists_workbench.py
+++ b/Tests/Watchlists/test_watchlists_workbench.py
@@ -128,7 +128,7 @@ def test_region_titles_cover_exactly_the_live_regions() -> None:
 
 @pytest.mark.parametrize(
     ("width", "centre_width"),
-    [(161, 44), (206, 89), (220, 103), (224, 107)],
+    [(171, 44), (206, 79), (220, 93), (224, 97)],
 )
 @pytest.mark.asyncio
 async def test_read_real_bundle_fills_wide_body_exactly(
@@ -141,7 +141,7 @@ async def test_read_real_bundle_fills_wide_body_exactly(
         assert app.layout.collapsed == frozenset()
         expected = {
             ".watchlists-region-left_rail": (28, 24),
-            ".watchlists-read-mode .watchlists-region-items": (40, 32),
+            ".watchlists-read-mode .watchlists-region-items": (50, 42),
             ".watchlists-region-right_rail": (34, 30),
         }
         for selector, (target, minimum) in expected.items():
@@ -157,7 +157,7 @@ async def test_read_real_bundle_fills_wide_body_exactly(
             read_mode=True,
             expected_widths={
                 "wl-region-left_rail": 28,
-                "wl-region-items": 40,
+                "wl-region-items": 50,
                 "wl-region-content": centre_width,
                 "wl-region-right_rail": 34,
             },
@@ -227,32 +227,32 @@ def _assert_real_bundle_geometry(
     ("width", "collapsed", "expected_widths"),
     [
         (
-            145,
+            155,
             frozenset(),
             {
                 "wl-region-left_rail": 24,
-                "wl-region-items": 32,
+                "wl-region-items": 42,
                 "wl-region-content": 44,
                 "wl-region-right_rail": 30,
             },
         ),
-        (144, frozenset({Region.RIGHT_RAIL}), {}),
+        (154, frozenset({Region.RIGHT_RAIL}), {}),
         (
-            115,
+            125,
             frozenset({Region.RIGHT_RAIL}),
             {
                 "wl-region-left_rail": 24,
-                "wl-region-items": 32,
+                "wl-region-items": 42,
                 "wl-region-content": 44,
             },
         ),
-        (114, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}), {}),
+        (124, frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}), {}),
         (
-            91,
+            101,
             frozenset({Region.LEFT_RAIL, Region.RIGHT_RAIL}),
-            {"wl-region-items": 32, "wl-region-content": 44},
+            {"wl-region-items": 42, "wl-region-content": 44},
         ),
-        (90, frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}), {}),
+        (100, frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}), {}),
         (60, frozenset({Region.LEFT_RAIL, Region.ITEMS, Region.RIGHT_RAIL}), {}),
         (
             40,

--- a/backlog/tasks/task-32135 - Widen-Watchlists-Feed-Items-by-ten-terminal-columns.md
+++ b/backlog/tasks/task-32135 - Widen-Watchlists-Feed-Items-by-ten-terminal-columns.md
@@ -1,0 +1,62 @@
+---
+id: TASK-32135
+title: Widen Watchlists Feed Items by ten terminal columns
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-09 07:07'
+updated_date: '2026-09-09 07:11'
+labels: []
+dependencies: []
+documentation:
+  - Docs/superpowers/specs/2026-09-09-watchlists-feed-items-width-design.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give the middle Feed Items pane more room for article titles while preserving the existing Reader and responsive pane behavior.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Read-mode Feed Items uses a 42-column minimum and 50-column preferred maximum.
+- [x] #2 Read collapse and reopen thresholds account for the extra ten columns; management layout behavior remains unchanged.
+- [x] #3 Focused layout tests and CSS bundle checks pass.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Apply the existing Feed Items width design: CSS bounds 42–50, matching resolver minimum 42.
+2. Update existing Read-mode layout and hysteresis expectations; keep management expectations.
+3. Regenerate CSS, run focused layout and bundle tests, and review the scoped diff.
+ADR required: no
+ADR path: backlog/decisions/042-watchlists-reader-first-ia.md
+Reason: Small presentation adjustment within the accepted Reader and responsive side-pane policy.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Widened Read-mode Feed Items from 32–40 to 42–50 terminal cells in features/_watchlists.tcss and matched the 42-cell resolver minimum in region_layout.py. Regenerated tldw_cli_modular.tcss; comparison against the pre-build bundle confirmed only the Watchlists width rules and generated timestamp changed. Updated existing geometry, responsive, hysteresis, and scoped-rebuild expectations; management thresholds remain unchanged.
+
+Validation: 172 targeted tests passed (2 warnings) across test_watchlists_responsive_layout.py, test_watchlists_workbench.py, test_watchlists_layout_hysteresis_probe.py, test_watchlists_scoped_rebuilds.py, test_css_bundle_sync_guard.py, and test_css_build_integrity.py. Ruff lint and git diff --check passed. Range-scoped Ruff formatting passed for all 71 edited ranges in five Python files. Whole-file Ruff format checks also flag all five original HEAD versions, so existing formatting was preserved. Self-review confirmed the CSS/resolver bounds agree and unrelated workspace edits were preserved.
+
+ADR required: no; this implements the existing width design within backlog/decisions/042-watchlists-reader-first-ia.md. No new logic, dependencies, storage, or security boundaries were introduced.
+
+PR verification against dev at 9faf96d9f8: 192 of 193 targeted tests passed.
+The unchanged test_management_scope_invalidates_reader_return_to_read_failure_is_honest
+fails because ArticleListPane.display is True where False is expected. The same
+single-test failure was reproduced independently in a clean checkout of that dev
+commit, establishing a pre-existing baseline failure. All edited geometry and
+responsive tests, CSS bundle checks, Ruff lint, 71 edited formatting ranges,
+whitespace checks, and the backlog ID/path guard passed. The bundle regenerated
+on dev changes only the four Watchlists width declarations.
+<!-- SECTION:NOTES:END -->
+
+## Renumbering provenance
+
+The CLI assigned TASK-31384, already used by the older Console unified interrupt
+surface task on remote branches. Renumbered this new task to TASK-32135 after
+sweeping local remote refs and worktrees (highest observed ID: 32115).

--- a/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
+++ b/tldw_chatbook/UI/Watchlists_Modules/region_layout.py
@@ -59,7 +59,7 @@ PANE_GRIP_WIDTH = 5
 #: Minimum expanded width of each side pane.
 PANE_MINIMUM_WIDTHS: dict[Region, int] = {
     Region.LEFT_RAIL: 24,
-    Region.ITEMS: 32,
+    Region.ITEMS: 42,
     Region.RIGHT_RAIL: 30,
 }
 

--- a/tldw_chatbook/css/features/_watchlists.tcss
+++ b/tldw_chatbook/css/features/_watchlists.tcss
@@ -168,9 +168,9 @@
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 40fr;
-    min-width: 32;
-    max-width: 40;
+    width: 50fr;
+    min-width: 42;
+    max-width: 50;
     height: 100%;
     overflow: hidden;
 }
@@ -218,7 +218,7 @@
 }
 
 .watchlists-has-expanded-side-pane.watchlists-read-mode .watchlists-region-items {
-    min-width: 32;
+    min-width: 42;
 }
 
 #watchlists-content-pane {

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -13935,9 +13935,9 @@ CodingWindow {
 }
 
 .watchlists-read-mode .watchlists-region-items {
-    width: 40fr;
-    min-width: 32;
-    max-width: 40;
+    width: 50fr;
+    min-width: 42;
+    max-width: 50;
     height: 100%;
     overflow: hidden;
 }
@@ -13985,7 +13985,7 @@ CodingWindow {
 }
 
 .watchlists-has-expanded-side-pane.watchlists-read-mode .watchlists-region-items {
-    min-width: 32;
+    min-width: 42;
 }
 
 #watchlists-content-pane {


### PR DESCRIPTION
Widen the Watchlists Read view's middle Feed Items column by 10 terminal cells: its minimum grows from 32 to 42 and its preferred/maximum width from 40 to 50. Move the associated collapse and reopen thresholds by 10 cells so the permanent Reader retains its space; management-tab sizing and collapse priority stay unchanged.

Updates existing rendered geometry and resize tests, regenerates the stylesheet bundle, and records TASK-32135 with the width design under ADR-042.

Validation on the latest dev base:

- Focused Watchlists layout, workbench, hysteresis, scoped-rebuild, and CSS bundle tests: 192 passed, 1 pre-existing failure.
- Ruff lint, formatting checks for every edited Python range, and `git diff --check`.
- Backlog task ID and path guard.

The failure is `test_management_scope_invalidates_reader_return_to_read_failure_is_honest`: `ArticleListPane.display` is `True` where the test expects `False`. It reproduces independently on unchanged `dev` at `9faf96d9f8` with the same assertion; the test is unchanged by this PR. All edited layout tests and CSS bundle checks pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Widens the Watchlists Read view's middle Feed Items pane by 10 terminal cells so article titles get more room while the permanent Reader keeps its space.

- Feed Items minimum grows from 32 to 42 columns; preferred/maximum from 40 to 50.
- Read-mode collapse and reopen thresholds shift by 10 cells; management-tab geometry and collapse priority are unchanged.
- Records the width design under TASK-32135 and ADR-042 and regenerates the CSS bundle.
- The pre-existing failure `test_management_scope_invalidates_reader_return_to_read_failure_is_honest` reproduces on unchanged `dev` and is not caused by this PR.

<sup>Written for commit 04222fe8eba9726b4b8cd18b48f2a7919a1607b2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

