### PR TITLE
Widen Library navigation and item columns

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -168,7 +168,8 @@ the landing does not.
 ```
 
 When the rail is beside content, its automatic width follows the existing
-3:13 Library-to-canvas proportion and stays between 24 and 34 cells. An
+3:13 Library-to-canvas proportion plus five cells and stays between 29 and 39
+cells when space allows. Destination item lists default to 50 cells. An
 explicit custom preference can be 24–48 cells; ordinary two-pane views may
 temporarily shrink it to preserve 40 content cells, while adaptive readers
 may collapse or prioritize panes. These responsive changes never overwrite

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -795,12 +795,13 @@ Escape's return to the list live at 100x30).*
 ## Related settings & docs
 
 - Appearance settings remember the preferred Library/Items pane states.
-  Automatic Library-rail width follows 3:13, bounded to 24–34 cells. When
+  Automatic Library-rail width follows 3:13 plus five cells, bounded to 29–39
+  cells when space allows. When
   explicitly enabled, custom widths remain Library 24–48 and Items 32–72;
   ordinary layouts may temporarily compress the rail to preserve 40 content
   cells, while these adaptive readers may collapse or prioritize panes.
   **Reset layout** restores both panes open, automatic width, a dormant
-  31-cell Library preference, and 40-cell Items preferences. Below 64 columns,
+  36-cell Library preference, and 50-cell Items preferences. Below 64 columns,
   ordinary Library routes switch between full-width rail and canvas stages via
   **‹ Library** (or **< Library** with ASCII glyphs). Responsive changes never
   overwrite saved preferences.

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -303,12 +303,13 @@ editing and deeper visual preview." **Global visual defaults** holds **Theme**,
 and scrolling** holds **Animations** and **Smooth scrolling**, each a button
 whose label is its state (Enabled / Disabled). **Shared Library rail**
 remembers whether the rail and destination Items panes are open. **Automatic
-width** follows the 3:13 Library-to-canvas proportion, bounded to 24–34 cells.
+width** follows the 3:13 Library-to-canvas proportion plus five cells, bounded to 29–39 cells
+when space allows.
 **Custom width** enables explicit preferences (Library 24–48, Items 32–72);
 ordinary layouts may temporarily shrink the rail to preserve 40 content cells,
 and adaptive readers may collapse or prioritize panes. **Reset layout** restores
-both panes open, automatic width, a 31-cell dormant Library preference, and
-40-cell Items preferences. Below 64 columns, ordinary routes show either the
+both panes open, automatic width, a 36-cell dormant Library preference, and
+50-cell Items preferences. Below 64 columns, ordinary routes show either the
 rail or canvas and provide **‹ Library** (or **< Library** with ASCII glyphs)
 to return. Responsive compression, collapse, resizing, and mode changes are
 temporary and never saved.

--- a/Tests/App/test_boot_worker_stagger_policy.py
+++ b/Tests/App/test_boot_worker_stagger_policy.py
@@ -26,8 +26,12 @@ from types import SimpleNamespace
 
 import pytest
 
-from Tests.Performance.test_boot_worker_census import ALLOWED_BOOT_WORKERS
+from Tests.Performance.test_boot_worker_census import (
+    ALLOWED_BOOT_WORKERS,
+    EXPECTED_BOOT_WORKERS,
+)
 from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.config import save_setting_to_cli_config
 from tldw_chatbook.Utils.boot_worker_policy import (
     BOOT_WORKER_KEY_BY_IDENTITY,
     BOOT_WORKER_POLICY,
@@ -58,6 +62,16 @@ def test_every_policy_row_is_on_the_boot_worker_census_allowlist():
         f"boot worker policy rows missing from the TASK-22222 census "
         f"allowlist: {sorted(unknown)}"
     )
+
+
+def test_census_does_not_require_staggered_workers_inside_its_settle_window():
+    """Prior workers may keep any staggered member queued past the census."""
+    staggered = {
+        (spec.name, spec.group)
+        for spec in BOOT_WORKER_POLICY
+        if spec.tier is BootWorkerTier.STAGGERED
+    }
+    assert EXPECTED_BOOT_WORKERS.isdisjoint(staggered)
 
 
 def test_staggered_order_runs_prefetches_before_the_resumable_backfills():
@@ -249,6 +263,8 @@ async def test_every_staggered_body_runs_after_the_ui_is_ready():
     ``on_mount``, so they observed ``_ui_ready`` False. Also the
     anti-starvation pin -- all four must actually run, not merely be queued.
     """
+    # Exercise post-ready workers without waiting through the splash animation.
+    save_setting_to_cli_config("splash_screen", "enabled", False)
     app = _build_test_app()
     observed: dict[str, bool] = {}
     done = threading.Event()

--- a/Tests/Library/test_library_adaptive_reader_state.py
+++ b/Tests/Library/test_library_adaptive_reader_state.py
@@ -49,7 +49,7 @@ def test_media_compatibility_names_reexport_shared_layout_types() -> None:
 def test_adaptive_profile_exposes_approved_widths() -> None:
     assert MEDIA_PROFILE == AdaptiveReaderLayoutProfile(
         list_min_width=32,
-        list_target_width=40,
+        list_target_width=50,
         list_comfort_width=56,
         list_max_width=72,
         work_min_width=44,
@@ -89,9 +89,9 @@ def test_shared_normalization_matches_current_media_custom_width_behavior() -> N
         # two grips from five cells each to one, so every Media row below also
         # carries the eight cells they gave back. The generic column is
         # untouched by both.
-        (160, (True, True, 30, 40, 80), (True, True, 30, 56, 72)),
-        (120, (True, True, 24, 40, 46), (True, True, 24, 44, 50)),
-        (100, (False, True, 0, 46, 44), (False, True, 0, 52, 46)),
+        (160, (True, True, 35, 50, 65), (True, True, 35, 56, 67)),
+        (120, (False, True, 0, 56, 54), (False, True, 0, 56, 62)),
+        (100, (False, False, 0, 0, 90), (False, True, 0, 52, 46)),
         (80, (False, False, 0, 0, 70), (False, False, 0, 0, 78)),
         (60, (False, False, 0, 0, 50), (False, False, 0, 0, 58)),
     ],
@@ -232,7 +232,7 @@ def test_explicit_open_priority_protects_the_requested_pane_when_possible(
     priority: str,
 ) -> None:
     layout = resolve_adaptive_reader_layout(
-        120,
+        140,
         AdaptiveReaderLayoutPreferences(),
         MEDIA_PROFILE,
         priority=priority,  # type: ignore[arg-type]
@@ -244,22 +244,30 @@ def test_explicit_open_priority_protects_the_requested_pane_when_possible(
 
 def test_shared_resolution_preserves_hysteresis() -> None:
     preferences = AdaptiveReaderLayoutPreferences()
-    collapsed = resolve_adaptive_reader_layout(117, preferences, MEDIA_PROFILE)
+    collapsed = resolve_adaptive_reader_layout(133, preferences, MEDIA_PROFILE)
 
     boundary = resolve_adaptive_reader_layout(
-        118,
+        134,
         preferences,
         MEDIA_PROFILE,
         previous=collapsed,
     )
+    # The fractional rail gains another cell before hysteresis clears.
+    still_collapsed = resolve_adaptive_reader_layout(
+        134 + LAYOUT_HYSTERESIS_WIDTH,
+        preferences,
+        MEDIA_PROFILE,
+        previous=boundary,
+    )
     reopened = resolve_adaptive_reader_layout(
-        118 + LAYOUT_HYSTERESIS_WIDTH,
+        135 + LAYOUT_HYSTERESIS_WIDTH,
         preferences,
         MEDIA_PROFILE,
         previous=boundary,
     )
 
     assert boundary.library_open is False
+    assert still_collapsed.library_open is False
     assert reopened.library_open is True
 
 
@@ -355,7 +363,7 @@ def test_notes_navigator_explicit_items_priority_uses_projected_library_request(
 
 @pytest.mark.parametrize(
     ("width", "items_open"),
-    [(116, True), (100, True), (80, False), (60, False)],
+    [(116, True), (108, True), (107, False), (100, False), (80, False), (60, False)],
 )
 def test_notes_editor_preserves_work_before_items_at_production_widths(
     width: int, items_open: bool
@@ -418,9 +426,9 @@ def test_custom_mode_preserves_every_normalized_library_request_across_profiles(
     [
         (1, 24),
         (999, 48),
-        ("not-a-number", 31),
-        (True, 31),
-        (None, 31),
+        ("not-a-number", 36),
+        (True, 36),
+        (None, 36),
     ],
 )
 def test_custom_width_normalization_uses_explicit_range_not_default_ceiling(
@@ -530,35 +538,27 @@ def test_every_profile_reserves_exactly_the_grip_columns_it_paints(width: int) -
 @pytest.mark.parametrize(
     ("surface", "width", "expected"),
     [
-        # Recorded from the resolver at badff73f1, before list growth existed,
-        # and RE-ANCHORED by task-31951: the three siblings joined Media on
-        # the one-cell grip, so each row gained the eight cells their two
-        # five-cell grips used to hold back. Growth is still off for all
-        # three -- every cell below lands on the pane the resolver already
-        # gave the surplus to. Old value beside each row.
-        #
-        # `required_width()` counts the grips, so the rail-open threshold
-        # moved down by eight on every sibling as well: 118 -> 110 on
-        # Conversations, 122 -> 114 on Skills and Collections. Both edges of
-        # each moved band are pinned underneath.
-        ("conversations", 100, (False, True, 0, 54, 44)),  # was (…, 0, 46, 44)
-        ("conversations", 109, (False, True, 0, 56, 51)),  # was (…, 0, 55, 44)
-        ("conversations", 110, (True, True, 24, 40, 44)),  # was (False, …, 56, 44)
-        ("conversations", 117, (True, True, 24, 40, 51)),  # was (False, …, 56, 51)
-        ("conversations", 118, (True, True, 24, 40, 52)),  # was (…, 24, 40, 44)
-        ("conversations", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
-        ("skills", 100, (False, True, 0, 50, 48)),  # was (…, 0, 42, 48)
-        ("skills", 113, (False, True, 0, 56, 55)),  # was (…, 0, 55, 48)
-        ("skills", 114, (True, True, 24, 40, 48)),  # was (False, …, 56, 48)
-        ("skills", 121, (True, True, 24, 40, 55)),  # was (False, …, 56, 55)
-        ("skills", 122, (True, True, 24, 40, 56)),  # was (…, 24, 40, 48)
-        ("skills", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
-        ("collections", 100, (False, True, 0, 50, 48)),  # was (…, 0, 42, 48)
-        ("collections", 113, (False, True, 0, 56, 55)),  # was (…, 0, 55, 48)
-        ("collections", 114, (True, True, 24, 40, 48)),  # was (False, …, 56, 48)
-        ("collections", 121, (True, True, 24, 40, 55)),  # was (False, …, 56, 55)
-        ("collections", 122, (True, True, 24, 40, 56)),  # was (…, 24, 40, 48)
-        ("collections", 235, (True, True, 34, 40, 159)),  # was (…, 34, 40, 151)
+        # Wider automatic defaults move the rail-open boundaries to 125
+        # for Conversations and 129 for Skills/Collections. Pin both sides
+        # and nearby widths; these profiles still give surplus to the Reader.
+        ("conversations", 100, (False, True, 0, 54, 44)),
+        ("conversations", 124, (False, True, 0, 56, 66)),
+        ("conversations", 125, (True, True, 29, 50, 44)),
+        ("conversations", 126, (True, True, 29, 50, 45)),
+        ("conversations", 132, (True, True, 30, 50, 50)),
+        ("conversations", 235, (True, True, 39, 50, 144)),
+        ("skills", 100, (False, True, 0, 50, 48)),
+        ("skills", 128, (False, True, 0, 56, 70)),
+        ("skills", 129, (True, True, 29, 50, 48)),
+        ("skills", 130, (True, True, 29, 50, 49)),
+        ("skills", 136, (True, True, 31, 50, 53)),
+        ("skills", 235, (True, True, 39, 50, 144)),
+        ("collections", 100, (False, True, 0, 50, 48)),
+        ("collections", 128, (False, True, 0, 56, 70)),
+        ("collections", 129, (True, True, 29, 50, 48)),
+        ("collections", 130, (True, True, 29, 50, 49)),
+        ("collections", 136, (True, True, 31, 50, 53)),
+        ("collections", 235, (True, True, 39, 50, 144)),
     ],
 )
 def test_sibling_reader_layouts_are_untouched_by_media_list_growth(
@@ -576,27 +576,13 @@ def test_sibling_reader_layouts_are_untouched_by_media_list_growth(
 @pytest.mark.parametrize(
     ("width", "expected"),
     [
-        # ``required_width()`` counts the grips, so the eight cells Media's
-        # one-cell grips gave back (task-31633 AC#2) moved the open-all-three
-        # threshold down from 120 to 112. These rows pin BOTH edges of the
-        # band that moved, with the pre-AC#2 layout beside each:
-        #
-        #   100  was (False, 0, 44, 46)  -- rail closed either way, and the
-        #        Reader is on its 46-cell minimum, so this is the one row with
-        #        no surplus: all eight cells go to the list.
-        #   111  was (False, 0, 55, 46)  -- still below the threshold, so the
-        #        rail stays closed and the list takes its comfort ceiling.
-        #   112  was (False, 0, 56, 46)  -- the new threshold: the rail OPENS
-        #        here now, and the list drops from its 56-cell ceiling to 40.
-        #   119  was (False, 0, 56, 53)  -- inside the band, rail open.
-        #   120  was (True, 24, 40, 46)  -- the old threshold; the rail was
-        #        already open, so here the eight cells are a plain surplus,
-        #        split 4/4 between list and Reader by ``surplus // 2``.
+        # Media seats both wider default columns at 127 cells. Pin the
+        # last collapsed width, first open width, and surplus-growth onset.
         (100, (False, True, 0, 52, 46)),
-        (111, (False, True, 0, 56, 53)),
-        (112, (True, True, 24, 40, 46)),
-        (119, (True, True, 24, 43, 50)),
-        (120, (True, True, 24, 44, 50)),
+        (126, (False, True, 0, 56, 68)),
+        (127, (True, True, 29, 50, 46)),
+        (128, (True, True, 29, 50, 47)),
+        (129, (True, True, 29, 51, 47)),
     ],
 )
 def test_media_layout_across_the_rail_open_threshold(
@@ -610,13 +596,10 @@ def test_media_layout_across_the_rail_open_threshold(
 @pytest.mark.parametrize(
     ("width", "expected"),
     [
-        # 235: was (True, True, 34, 40, 151) -- 105 surplus cells all went to
-        # the Reader. 122 is the narrowest width where growth moves a cell:
-        # was (True, True, 24, 40, 48). Both rows then gained the eight cells
-        # the one-cell grips gave back (task-31633 AC#2): 135 -> 143 on the
-        # Reader at 235, and 41 -> 45 on the list at 122.
-        (235, (True, True, 34, 56, 143)),
-        (122, (True, True, 24, 45, 51)),
+        # At 235 the list reaches its comfort ceiling; 129 is the first
+        # open-rail width with two surplus cells, shared between both panes.
+        (235, (True, True, 39, 56, 138)),
+        (129, (True, True, 29, 51, 47)),
     ],
 )
 def test_media_items_column_grows_once_the_reader_is_comfortable(
@@ -651,7 +634,9 @@ def test_a_typed_custom_items_width_is_obeyed_by_the_growth_gate(
     )
 
     grown = resolve_media_reader_layout(width, custom)
-    ungrown = resolve_adaptive_reader_layout(width, custom, MEDIA_PROFILE_WITHOUT_GROWTH)
+    ungrown = resolve_adaptive_reader_layout(
+        width, custom, MEDIA_PROFILE_WITHOUT_GROWTH
+    )
 
     assert grown.items_width == custom_items_width
     assert grown == ungrown
@@ -743,11 +728,11 @@ def test_empty_reader_gives_freed_columns_to_the_items_list_at_235() -> None:
     no_item = resolve_media_reader_layout(235, prefs, reader_has_item=False)
 
     # Item open: exactly the pre-task split (do not regress it).
-    assert _pane_widths(with_item) == (True, True, 34, 56, 143)
+    assert _pane_widths(with_item) == (True, True, 39, 56, 138)
     # No item open: the Items pane absorbs the freed Reader columns down to
     # the Reader's floor, so a 98-char title stops truncating at ~56 cells.
     assert no_item.reader_width == MEDIA_READER_LAYOUT_PROFILE.work_min_width
-    assert no_item.items_width == 153
+    assert no_item.items_width == 148
     assert no_item.items_width > with_item.items_width
     # Both panes and the two grips still tile the full terminal width.
     assert (

--- a/Tests/Library/test_library_collections_config.py
+++ b/Tests/Library/test_library_collections_config.py
@@ -22,10 +22,10 @@ def test_collections_reader_defaults_are_source_neutral_and_fixed(
 
     assert library["collections_reader"] == {
         "items_open": True,
-        "items_width": 40,
+        "items_width": 50,
     }
     assert appearance.library_collections_items_open is True
-    assert appearance.library_collections_items_width == 40
+    assert appearance.library_collections_items_width == 50
     assert appearance.library_reader_custom_widths_enabled is False
 
 

--- a/Tests/Library/test_library_media_reader_state.py
+++ b/Tests/Library/test_library_media_reader_state.py
@@ -13,7 +13,6 @@ from tldw_chatbook.Library.library_media_reader_state import (
     LIBRARY_MIN_WIDTH,
     LIBRARY_TARGET_WIDTH,
     MEDIA_READER_LAYOUT_PROFILE,
-    PANE_GRIP_WIDTH,
     READER_COMFORT_WIDTH,
     SELECTION_SETTLE_SECONDS,
     LibraryMediaReaderSessionState,
@@ -52,7 +51,7 @@ def test_default_preferences_are_both_open_and_fixed() -> None:
 
 
 def test_default_library_preference_uses_the_shared_reference_width() -> None:
-    assert LIBRARY_TARGET_WIDTH == LIBRARY_REFERENCE_WIDTH == 31
+    assert LIBRARY_TARGET_WIDTH == LIBRARY_REFERENCE_WIDTH == 36
 
 
 @pytest.mark.parametrize(
@@ -121,7 +120,7 @@ def test_responsive_collapse_does_not_mutate_preferences() -> None:
 
 @pytest.mark.parametrize(
     ("width", "library_open", "items_open"),
-    [(160, True, True), (120, True, True), (80, False, False)],
+    [(160, True, True), (127, True, True), (126, False, True), (80, False, False)],
 )
 def test_normal_resolution_collapses_library_then_items(
     width: int, library_open: bool, items_open: bool
@@ -153,7 +152,7 @@ def test_explicit_open_collapses_other_pane_first_and_uses_requested_minimum(
     preferences = normalize_media_reader_preferences({f"{priority}_open": False})
 
     layout = resolve_media_reader_layout(
-        80,
+        70,
         preferences,
         priority=priority,  # type: ignore[arg-type]
     )
@@ -237,17 +236,25 @@ def test_hysteresis_prevents_one_column_resize_thrashing() -> None:
         preferences,
         previous=collapsed,
     )
-    reopened = resolve_media_reader_layout(
+    # Projection grows from 29 to 30 at 131, extending this transition by
+    # one cell beyond the four-cell hysteresis for a fixed rail.
+    still_collapsed = resolve_media_reader_layout(
         nominal_width + LAYOUT_HYSTERESIS_WIDTH,
+        preferences,
+        previous=boundary,
+    )
+    reopened = resolve_media_reader_layout(
+        nominal_width + LAYOUT_HYSTERESIS_WIDTH + 1,
         preferences,
         previous=boundary,
     )
 
     assert collapsed.library_open is False
     assert boundary.library_open is False
+    assert still_collapsed.library_open is False
     assert reopened.library_open is True
     assert reopened.library_width == project_default_library_width(
-        nominal_width + LAYOUT_HYSTERESIS_WIDTH
+        nominal_width + LAYOUT_HYSTERESIS_WIDTH + 1
     )
 
 

--- a/Tests/Library/test_library_rail_width.py
+++ b/Tests/Library/test_library_rail_width.py
@@ -28,23 +28,23 @@ def test_width_policy_constants_express_the_approved_bounds() -> None:
         LIBRARY_CUSTOM_MAX_WIDTH,
         LIBRARY_CANVAS_MIN_WIDTH,
         LIBRARY_EMERGENCY_WIDTH,
-    ) == (31, 24, 34, 48, 40, 64)
+    ) == (36, 24, 39, 48, 40, 64)
     assert LIBRARY_EMERGENCY_WIDTH == LIBRARY_MIN_WIDTH + LIBRARY_CANVAS_MIN_WIDTH
 
 
 @pytest.mark.parametrize(
     ("content_width", "expected"),
     [
-        (1, 24),
-        (24, 24),
-        (127, 24),
-        (128, 24),
-        (152, 29),
-        (163, 31),
-        (165, 31),
-        (178, 33),
-        (181, 34),
-        (10000, 34),
+        (1, 29),
+        (24, 29),
+        (127, 29),
+        (128, 29),
+        (152, 34),
+        (163, 36),
+        (165, 36),
+        (178, 38),
+        (181, 39),
+        (10000, 39),
     ],
 )
 def test_project_default_library_width_is_bounded_fractional(
@@ -72,10 +72,10 @@ def test_ordinary_emergency_is_required_only_below_sixty_four_columns(
     assert ordinary_emergency_required(content_width) is expected
 
 
-def test_default_alongside_contract_uses_native_fractional_width() -> None:
+def test_default_alongside_contract_preserves_the_canvas_minimum() -> None:
     assert resolve_ordinary_rail_contract(
         64, OrdinaryRailPresentation.ALONGSIDE, False, 31
-    ) == OrdinaryRailStyleContract(True, "3fr", 24, 34)
+    ) == OrdinaryRailStyleContract(True, 24, 24, 24)
 
 
 @pytest.mark.parametrize(

--- a/Tests/Performance/test_boot_worker_census.py
+++ b/Tests/Performance/test_boot_worker_census.py
@@ -25,7 +25,8 @@ every policy row against the allowlist below, so the two cannot drift: WHICH
 workers may start is pinned here, WHEN and HOW MANY AT ONCE is pinned there.
 No allowlist row changed for that task -- the four staggered members kept
 their (name, group) identity and merely moved from ``on_mount`` to the
-post-``_ui_ready`` tier, which is still inside this census's settle window.
+post-``_ui_ready`` tier. They remain allowed, but may start after this
+census's settle window if preceding workers are still running.
 
 Raising/extending: when this fails, the message prints the unlisted
 starters. Name the feature that added each, decide whether it must really
@@ -121,9 +122,10 @@ ALLOWED_BOOT_THREADS: frozenset[tuple[str, str, str]] = frozenset(
 #: Anti-vacuity: a real boot MUST start these. If none are recorded the
 #: probe instrumented nothing (or never reached _ui_ready) and the census
 #: is measuring an empty list, which must fail rather than pass.
+# Staggered workers may still be queued behind recovery at the one-second
+# cutoff. Keep them allowed above, but use only immediate workers as sentinels.
 EXPECTED_BOOT_WORKERS: frozenset[tuple[str, str]] = frozenset(
     {
-        ("_backfill_chachanotes_messages_fts", "chachanotes-fts-backfill"),
         ("load", "console-prompt-history"),
         ("run", "scheduling"),
     }

--- a/Tests/UI/test_library_adaptive_reader_shell.py
+++ b/Tests/UI/test_library_adaptive_reader_shell.py
@@ -771,6 +771,13 @@ async def test_media_items_pane_grows_with_the_terminal_once_reader_is_comfortab
 
     async with host.run_test(size=size) as pilot:
         screen = await _open_media_list(host, pilot)
+        # Measure a populated reader; the empty reader gives its space to Items.
+        screen.query_one("#library-media-row-0", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._media_state.reader_session.loaded_id is not None,
+            message="Media reader did not finish opening the selected item",
+        )
         for _ in range(4):
             await pilot.pause()
 

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -5499,9 +5499,9 @@ async def test_library_route_matrix_keeps_default_ordinary_rail_edge_stable() ->
             )
             rail = screen.query_one("#library-rail", LibraryRail)
             canvas = screen.query_one("#library-canvas")
-            assert str(rail.styles.width) == "3fr"
-            assert rail.styles.min_width.value == 24
-            assert rail.styles.max_width.value == 34
+            assert rail.styles.width.value == landing_width
+            assert rail.styles.min_width.value == landing_width
+            assert rail.styles.max_width.value == landing_width
             assert abs(rail.region.width - landing_width) <= 1
             assert abs(rail.region.right - canvas.region.x) <= 1
 

--- a/Tests/UI/test_settings_appearance_defaults.py
+++ b/Tests/UI/test_settings_appearance_defaults.py
@@ -18,7 +18,7 @@ def test_load_appearance_defaults_uses_safe_defaults():
     assert defaults.animations_enabled is True
     assert defaults.smooth_scrolling is True
     assert defaults.console_transcript_style == "role_accents"
-    assert defaults.library_reader_library_width == 31
+    assert defaults.library_reader_library_width == 36
 
 
 def test_load_appearance_defaults_reads_general_web_and_appearance_sections():
@@ -176,22 +176,22 @@ def test_build_appearance_save_sections_preserves_unrelated_config():
             "reader": {
                 "library_open": True,
                 "custom_widths_enabled": False,
-                "library_width": 31,
+                "library_width": 36,
             },
             "media_reader": {
                 "items_open": True,
-                "items_width": 40,
+                "items_width": 50,
             },
-            "collections_reader": {"items_open": True, "items_width": 40},
-            "conversations_reader": {"items_open": True, "items_width": 40},
+            "collections_reader": {"items_open": True, "items_width": 50},
+            "conversations_reader": {"items_open": True, "items_width": 50},
             "notes_reader": {
                 "items_open": True,
-                "items_width": 40,
+                "items_width": 50,
                 "files_tree_open": True,
-                "files_tree_width": 40,
+                "files_tree_width": 50,
             },
-            "prompts_reader": {"items_open": True, "items_width": 40},
-            "skills_reader": {"items_open": True, "items_width": 40},
+            "prompts_reader": {"items_open": True, "items_width": 50},
+            "skills_reader": {"items_open": True, "items_width": 50},
         },
     }
 

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -2248,7 +2248,7 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
             search_labels["settings-appearance-library-media-library-open"]
             == "Shared Library rail"
         )
-        assert "Automatic: 3:13, bounded to 24–34 cells." in visible
+        assert "Automatic: 3:13 plus five, bounded to 29–39 cells." in visible
         assert "Custom: preferred 24–48 cells" in visible
         assert "keep 40 content cells" in visible
         assert "Adaptive readers may collapse panes" in visible
@@ -2285,7 +2285,7 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
             screen.query_one(
                 "#settings-appearance-library-notes-files-tree-width", Input
             ).value
-            == "40"
+            == "50"
         )
 
         await pilot.click("#settings-save-category")
@@ -2297,25 +2297,25 @@ async def test_settings_appearance_library_reader_controls_round_trip_all_destin
             "future_shared": "keep",
             "library_open": True,
             "custom_widths_enabled": False,
-            "library_width": 31,
+            "library_width": 36,
         },
         "media_reader": {
             "items_open": True,
-            "items_width": 40,
+            "items_width": 50,
         },
-        "collections_reader": {"items_open": True, "items_width": 40},
-        "conversations_reader": {"items_open": True, "items_width": 40},
+        "collections_reader": {"items_open": True, "items_width": 50},
+        "conversations_reader": {"items_open": True, "items_width": 50},
         "notes_reader": {
             "items_open": True,
-            "items_width": 40,
+            "items_width": 50,
             "files_tree_open": True,
-            "files_tree_width": 40,
+            "files_tree_width": 50,
         },
-        "prompts_reader": {"items_open": True, "items_width": 40},
+        "prompts_reader": {"items_open": True, "items_width": 50},
         "skills_reader": {
             "future_skills": "keep",
             "items_open": True,
-            "items_width": 40,
+            "items_width": 50,
         },
     }
     assert app._library_reader_layout_refresh_generation == 1

--- a/Tests/test_config_library_defaults.py
+++ b/Tests/test_config_library_defaults.py
@@ -23,7 +23,7 @@ def test_load_settings_exposes_library_defaults(tmp_path, monkeypatch):
     }
     assert settings["library"]["media_reader"] == {
         "items_open": True,
-        "items_width": 40,
+        "items_width": 50,
         "library_open": True,
         "custom_widths_enabled": False,
         "library_width": LIBRARY_REFERENCE_WIDTH,
@@ -35,17 +35,17 @@ def test_load_settings_exposes_library_defaults(tmp_path, monkeypatch):
     ):
         assert settings["library"][section] == {
             "items_open": True,
-            "items_width": 40,
+            "items_width": 50,
         }
     assert settings["library"]["notes_reader"] == {
         "items_open": True,
-        "items_width": 40,
+        "items_width": 50,
         "files_tree_open": True,
-        "files_tree_width": 40,
+        "files_tree_width": 50,
     }
 
 
-def test_shipped_template_keeps_shared_reader_empty_and_legacy_reference_at_31():
+def test_shipped_template_keeps_shared_reader_empty_and_legacy_reference_at_36():
     template = tomllib.loads(config_module.CONFIG_TOML_CONTENT)
 
     assert template["library"]["reader"] == {}
@@ -387,7 +387,7 @@ future_key = "keep"
         "items_open": True,
         "items_width": 52,
         "files_tree_open": True,
-        "files_tree_width": 40,
+        "files_tree_width": 50,
     }
     assert library["prompts_reader"] == {"items_open": False, "items_width": 60}
     assert library["skills_reader"] == {
@@ -421,7 +421,7 @@ files_tree_width = 500
         "items_open": False,
         "items_width": 68,
         "files_tree_open": True,
-        "files_tree_width": 40,
+        "files_tree_width": 50,
     }
 
 
@@ -451,7 +451,7 @@ items_width = true
         "items_open": True,
         "custom_widths_enabled": "no",
         "library_width": "wide",
-        "items_width": 40,
+        "items_width": 50,
     }
 
     assert config_module.load_settings(force_reload=True)["library"]["reader"] == {

--- a/backlog/decisions/086-library-adaptive-reader-shell.md
+++ b/backlog/decisions/086-library-adaptive-reader-shell.md
@@ -31,19 +31,19 @@ through Settings rather than by turning the grips into drag handles.
 
 The default Library width when displayed alongside content is one shared bounded-fractional
 policy. For positive Library-shell content width `W`, it follows the ordinary workbench's 3:13
-Library-to-canvas proportion as `floor((3W + 8) / 16)` (exact halves round upward), clamped to
-24–34 cells. Ordinary destinations retain native Textual fractional allocation; adaptive readers
-project the same policy from `LibraryAdaptiveReaderShell.content_region.width` to the exact cell
-width required by their pure resolver. At the same settled shell width, the two adapters may
-differ by at most one cell. A zero-width pre-layout state remains an all-zero effective sentinel;
-31 is the representative new/reset preference value, not zero-width geometry.
+Library-to-canvas proportion as `floor((3W + 8) / 16) + 5` (exact halves round upward), clamped to
+29–39 cells. Ordinary destinations and adaptive readers project the same policy from their
+settled content width to exact cells. Ordinary destinations compress the result when necessary
+to preserve the 40-cell canvas minimum; adaptive readers retain resolver-owned collapse.
+Destination Items preferences default to 50 cells. A zero-width pre-layout state remains an all-zero effective sentinel;
+36 is the representative new/reset preference value, not zero-width geometry.
 
 The existing custom-width opt-in remains distinct from the default bound. When enabled, an
 explicit 24–48-cell Library width applies to ordinary and adaptive destinations whenever the rail
-is displayed alongside content and responsive layout can fit it. Values above 34 are deliberate
+is displayed alongside content and responsive layout can fit it. Values above 39 are deliberate
 overrides and are not normalized down to the default ceiling. Existing stored 28 values are not
 migrated: they remain dormant while custom mode is off and become active if custom mode is later
-enabled; new/reset preferences use 31. Auto-collapse, extreme-width compression, and ordinary
+enabled; new/reset preferences use 36. Auto-collapse, extreme-width compression, and ordinary
 compact rail-only or canvas-only takeovers remain transient effective states and never rewrite the
 requested width.
 
@@ -54,7 +54,7 @@ preference: for positive co-present content width `W`, its effective width is
 using this ordinary two-pane compression formula.
 
 `LibraryScreen` owns the shared normalized preference snapshot and effective ordinary state.
-`LibraryRail` owns the reversible style transition: bounded `3fr` while alongside content with
+`LibraryRail` owns the reversible style transition: the projected, canvas-safe exact width while alongside content with
 custom mode off, the transiently compressed exact custom result while alongside content with
 custom mode on, fill while rail-only, and hidden under existing collapse/canvas-only contracts.
 Wide recovery restores the applicable bounded or saved custom declaration. Adaptive shells
@@ -134,7 +134,7 @@ recorded as an ADR.
   preference values through compatibility normalization.
 - Library visibility and custom-width opt-in have one shared preference owner; each destination
   list has its own visibility and width keys.
-- Default Library width is bounded fractional (3:13, 24–34); explicit custom widths retain the
+- Default Library width is bounded fractional (3:13 plus five cells, 29–39); explicit custom widths retain the
   existing 24–48 range across ordinary and adaptive destinations.
 - Responsive adaptation never performs data work or writes preferences.
 - Every detail load distinguishes selected and loaded identity and rejects late results using a

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -13039,3 +13039,18 @@ explicit limitation. Preserve startup controls and raw stacks before interpretin
 scenario timeouts, and distinguish a working alternative toolchain from a fix to
 the original runtime. [The receipts](../../Docs/QA/tts-macos-burndown-2026-09-09/native/sanitizer/linux-qualified-02/README.md)
 retain both failures and the passing alternative.
+
+
+## A bounded boot census cannot require a queued background worker
+
+**PR #2550, 2026-09-09.** Two Linux Perf Guard runs failed because the
+one-second post-ready census required the ChaChaNotes FTS backfill to start.
+TASK-22215 queues it behind two actor-pack workers with a concurrency cap of
+one, so their completion time determines its admission. The same base commit
+had a passing run; the Library width change did not alter the worker policy.
+Keep staggered workers in the allowed set, but use immediate workers for the
+required-presence check. The policy regression now asserts that the required
+set contains no staggered members; admission/completion tests cover the queue.
+The mounted policy check also needed splash disabled in its isolated on-disk
+config: its six-second wait expired during the seven-second splash, and the
+factory snapshot alone does not control the compose-time configuration read.

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -14894,7 +14894,7 @@ class SettingsScreen(BaseAppScreen):
                 (
                     "Purpose",
                     "Sets the shared Library rail and width mode. Automatic width "
-                    "follows 3:13 within 24–34 cells; custom width accepts 24–48 "
+                    "adds five cells to 3:13, within 29–39 cells; custom width accepts 24–48 "
                     "and may shrink temporarily to preserve 40 content cells. "
                     "Adaptive collapse remains session-only. Destination Items "
                     "preferences are saved under library.<destination>_reader.",
@@ -19408,7 +19408,7 @@ class SettingsScreen(BaseAppScreen):
                         disabled=not custom_widths,
                     )
                 yield Static(
-                    "Automatic: 3:13, bounded to 24–34 cells. Custom: preferred "
+                    "Automatic: 3:13 plus five, bounded to 29–39 cells. Custom: preferred "
                     "24–48 cells; it may shrink temporarily to keep 40 content "
                     "cells. Adaptive readers may collapse panes. In ordinary "
                     "views below 64 columns, use ‹ Library (< Library in ASCII) "

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -27,7 +27,7 @@ from .library_rail_width import (
 
 LIBRARY_TARGET_WIDTH = LIBRARY_REFERENCE_WIDTH
 LIBRARY_MAX_WIDTH = LIBRARY_CUSTOM_MAX_WIDTH
-ITEMS_TARGET_WIDTH = 40
+ITEMS_TARGET_WIDTH = 50
 ITEMS_MIN_WIDTH = 32
 ITEMS_MAX_WIDTH = 72
 READER_COMFORT_WIDTH = 44
@@ -88,7 +88,7 @@ class AdaptiveReaderLayoutProfile:
     """
 
     list_min_width: int = 32
-    list_target_width: int = 40
+    list_target_width: int = ITEMS_TARGET_WIDTH
     list_comfort_width: int = 56
     list_max_width: int = 72
     work_min_width: int = 44

--- a/tldw_chatbook/Utils/library_rail_width.py
+++ b/tldw_chatbook/Utils/library_rail_width.py
@@ -10,9 +10,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-LIBRARY_REFERENCE_WIDTH = 31
+LIBRARY_REFERENCE_WIDTH = 36
 LIBRARY_MIN_WIDTH = 24
-LIBRARY_DEFAULT_MAX_WIDTH = 34
+LIBRARY_DEFAULT_MIN_WIDTH = 29
+LIBRARY_DEFAULT_MAX_WIDTH = 39
 LIBRARY_CUSTOM_MAX_WIDTH = 48
 LIBRARY_CANVAS_MIN_WIDTH = 40
 LIBRARY_EMERGENCY_WIDTH = LIBRARY_MIN_WIDTH + LIBRARY_CANVAS_MIN_WIDTH
@@ -42,20 +43,22 @@ def _require_positive_content_width(content_width: int) -> None:
 
 
 def project_default_library_width(content_width: int) -> int:
-    """Project the bounded 3:13 default rail width from available content.
+    """Project the bounded 3:13 rail width with five extra cells.
 
     Args:
         content_width: Positive available Library shell width in terminal cells.
 
     Returns:
-        The 3:13 projection clamped to the default 24–34 cell range.
+        The 3:13 projection plus five cells, clamped to 29–39 cells.
 
     Raises:
         ValueError: If ``content_width`` is not a positive integer, including bool.
     """
     _require_positive_content_width(content_width)
-    fractional_width = (3 * content_width + 8) // 16
-    return min(max(fractional_width, LIBRARY_MIN_WIDTH), LIBRARY_DEFAULT_MAX_WIDTH)
+    fractional_width = (3 * content_width + 8) // 16 + 5
+    return min(
+        max(fractional_width, LIBRARY_DEFAULT_MIN_WIDTH), LIBRARY_DEFAULT_MAX_WIDTH
+    )
 
 
 def ordinary_emergency_required(content_width: int) -> bool:
@@ -123,8 +126,12 @@ def resolve_ordinary_rail_contract(
             f"{LIBRARY_EMERGENCY_WIDTH}."
         )
     if not custom_widths_enabled:
+        effective_width = min(
+            project_default_library_width(content_width),
+            content_width - LIBRARY_CANVAS_MIN_WIDTH,
+        )
         return OrdinaryRailStyleContract(
-            True, "3fr", LIBRARY_MIN_WIDTH, LIBRARY_DEFAULT_MAX_WIDTH
+            True, effective_width, effective_width, effective_width
         )
 
     effective_width = max(

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -3701,36 +3701,36 @@ library_open = true
 items_open = true
 custom_widths_enabled = false
 # Compatibility fallback for fresh profiles; matches LIBRARY_REFERENCE_WIDTH.
-library_width = 31
-items_width = 40
+library_width = 36
+items_width = 50
 
 [library.collections_reader]
 # Environment overrides use TLDW_LIBRARY_COLLECTIONS_READER_<KEY>.
 items_open = true
-items_width = 40
+items_width = 50
 
 [library.conversations_reader]
 # Environment overrides use TLDW_LIBRARY_CONVERSATIONS_READER_<KEY>.
 items_open = true
-items_width = 40
+items_width = 50
 
 [library.notes_reader]
 # Items environment overrides use TLDW_LIBRARY_NOTES_READER_ITEMS_<KEY>.
 # Folder-tree overrides use TLDW_LIBRARY_NOTES_READER_FILES_TREE_<KEY>.
 items_open = true
-items_width = 40
+items_width = 50
 files_tree_open = true
-files_tree_width = 40
+files_tree_width = 50
 
 [library.prompts_reader]
 # Environment overrides use TLDW_LIBRARY_PROMPTS_READER_<KEY>.
 items_open = true
-items_width = 40
+items_width = 50
 
 [library.skills_reader]
 # Environment overrides use TLDW_LIBRARY_SKILLS_READER_<KEY>.
 items_open = true
-items_width = 40
+items_width = 50
 
 # Per-type ingestion options are persisted here by the Library ingest canvas.
 [library.ingest_options]


### PR DESCRIPTION
Increase the Library navigation rail by five terminal cells and the default middle Items column from 40 to 50 cells. The responsive rail range becomes 29–39 cells, with a 36-cell reset preference. Ordinary views use the same projection while preserving their 40-cell canvas minimum. Custom widths, responsive collapse, Media list growth, and empty-reader behavior remain intact.

Update shipped defaults, Settings descriptions, user guides, ADR-086, and geometry/configuration/reset expectations. The mounted Media width check opens an item before measuring so it exercises the populated reader.

Correct two boot-test timing assumptions exposed by CI: staggered FTS workers remain allowed but are no longer required within the one-second census window, and the mounted admission test disables the seven-second splash in its isolated configuration. Immediate worker sentinels, unknown-worker rejection, and staggered admission/completion coverage remain enforced.

Validation: 494 targeted Library tests passed after rebasing onto dev, plus 22 review/configuration/boot tests after the corrections. Ruff checks and git diff --check passed. All three Qodo findings are addressed. No full-suite run.
