### PR TITLE
fix(buddy): accept pasted pack paths and explain import failures

### DIFF
--- a/Docs/User_Guide/buddy.md
+++ b/Docs/User_Guide/buddy.md
@@ -139,6 +139,24 @@ When an approval appears, inspect the tool, inputs, target, and permission in
 indicator, not an approval control. See
 [Agent runs and tools](console/agent-runs-and-tools.md).
 
+## Import a Buddy without a Persona
+
+In Console, choose **Menu → Buddy** to open **Buddy & Persona Management**.
+Expand **Import pack & size**, enter the downloaded `.tldw-persona-vpack` file's
+path, and choose **Apply**. This installs an independent Buddy; it does not create
+a Persona. Enable the Buddy and choose a conversation or workspace to follow.
+
+Use a full local path or `~/Downloads/trenchcoat.tldw-persona-vpack`. Matching
+quotes around a pasted path are accepted. Download the actual archive using
+GitHub's **Download raw file** button; a GitHub page address or a saved HTML page
+is not an importable pack. Choose a regular local file, not a directory or link.
+
+If import fails, the dialog keeps your entered path and previous Buddy selection.
+A missing-file message means to check the download location. An invalid-pack
+message means to download the archive again. An installation error means the
+archive was read, but profile storage could not be updated; check its permissions
+and free space before retrying.
+
 ## Use your own Persona Visual pack
 
 Open a saved local Persona's editor and find **Persona Visual**. Select a state

--- a/Tests/Persona_Buddy/test_buddy_management_coordinator.py
+++ b/Tests/Persona_Buddy/test_buddy_management_coordinator.py
@@ -261,6 +261,7 @@ async def test_independent_visibility_does_not_read_or_change_persona(
 @pytest.mark.asyncio
 async def test_import_retry_after_save_failure_reuses_publication_and_keeps_revision_guard(
     monkeypatch,
+    tmp_path,
 ):
     from tldw_chatbook import config
     from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
@@ -282,17 +283,19 @@ async def test_import_retry_after_save_failure_reuses_publication_and_keeps_revi
         controller=controller,
         library=library,
     )
-    choice = BuddyManagementChoice(enabled=True, import_path="pack.zip")
+    path = tmp_path / "pack.zip"
+    path.write_bytes(b"reviewed by test library")
+    choice = BuddyManagementChoice(enabled=True, import_path=str(path))
     imports = {}
     monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: False)
     with pytest.raises(ValueError) as failed:
         await manager.apply_choice(choice, expected_revision=0, imports=imports)
     revision = failed.value.buddy_retry_revision
-    assert imports == {"pack.zip": "imported"}
+    assert imports == {str(path): "imported"}
     assert controller.current_preferences().selection is None
     monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: True)
     await manager.apply_choice(choice, expected_revision=revision, imports=imports)
-    assert published == ["pack.zip"]
+    assert published == [path]
     assert controller.current_preferences().selection == BuddySelection("imported")
     controller.apply_preferences_patch(selection=BuddySelection("newer"))
     with pytest.raises(ValueError, match="changed elsewhere"):
@@ -301,7 +304,9 @@ async def test_import_retry_after_save_failure_reuses_publication_and_keeps_revi
 
 
 @pytest.mark.asyncio
-async def test_invalid_import_error_is_actionable_and_does_not_expose_internal_code():
+async def test_invalid_import_error_is_actionable_and_does_not_expose_internal_code(
+    tmp_path,
+):
     from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
     from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
         BuddyManagementChoice,
@@ -310,13 +315,15 @@ async def test_invalid_import_error_is_actionable_and_does_not_expose_internal_c
     def invalid(_):
         raise ValueError("persona_visual_import_invalid")
 
+    path = tmp_path / "invalid.zip"
+    path.write_bytes(b"invalid")
     manager = coordinator_module().BuddyManagementCoordinator(
         SimpleNamespace(app_config={}, console_runtime=None),
         controller=PersonaBuddyController(),
         library=SimpleNamespace(review_archive=invalid),
     )
     with pytest.raises(ValueError) as failed:
-        await manager.apply_choice(BuddyManagementChoice(import_path="missing.zip"))
+        await manager.apply_choice(BuddyManagementChoice(import_path=str(path)))
     assert "Check the path" in str(failed.value)
     assert "persona_visual_import_invalid" not in str(failed.value)
 

--- a/Tests/Persona_Buddy/test_buddy_management_import.py
+++ b/Tests/Persona_Buddy/test_buddy_management_import.py
@@ -1,0 +1,241 @@
+"""Pasted pack paths reach real validation and publication without changing authority."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from Tests.Persona_Visual.test_persona_visual_importer import (
+    _archive_payloads,
+    _write_archive,
+)
+from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
+from tldw_chatbook.Persona_Buddy.controller import PersonaBuddyController
+from tldw_chatbook.Persona_Buddy.library import BuddyLibrary
+from tldw_chatbook.Persona_Buddy.preferences import (
+    BuddySelection,
+    PersonaBuddyPreferences,
+)
+from tldw_chatbook.UI.Navigation.buddy_management import BuddyManagementCoordinator
+from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+    BuddyManagementChoice,
+)
+
+
+@pytest.fixture
+def imports(tmp_path, monkeypatch):
+    from tldw_chatbook import config
+
+    profile = tmp_path / "profile"
+    profile.mkdir(mode=0o700)
+    db = CharactersRAGDB(tmp_path / "buddy.db", "buddy-import-input")
+    library = BuddyLibrary(db, profile)
+    previous = PersonaBuddyPreferences(selection=BuddySelection("previous"))
+    controller = PersonaBuddyController(preferences=previous)
+    manager = BuddyManagementCoordinator(
+        SimpleNamespace(app_config={}, console_runtime=None),
+        controller=controller,
+        library=library,
+    )
+    archive = _write_archive(
+        tmp_path / "my buddy.tldw-persona-vpack", _archive_payloads()
+    )
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: True)
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: tmp_path))
+    try:
+        yield manager, archive, previous
+    finally:
+        db.close_connection()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "style", ["absolute", "home", "home-double-slash", "single-quoted", "double-quoted"]
+)
+async def test_pasted_path_imports_independent_artwork(imports, style):
+    manager, archive, _ = imports
+    entered = {
+        "absolute": str(archive),
+        "home": "~/" + archive.name,
+        "home-double-slash": "~//" + archive.name,
+        "single-quoted": "'" + str(archive) + "'",
+        "double-quoted": '"~/' + archive.name + '"',
+    }[style]
+    await manager.apply_choice(BuddyManagementChoice(import_path=entered))
+    selected = manager.controller.current_preferences().selection.buddy_id
+    assert selected != "previous"
+    assert len(manager.library.list_buddies()) == 1
+    assert manager.library.get_graph(selected).identity.persona_id is None
+    assert manager.library.resolve_preview(selected).reason is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("kind", "message"),
+    [
+        ("missing", "not found"),
+        ("directory", "regular file"),
+        ("symlink", "regular file"),
+        ("html", "Download raw file"),
+        ("relative", "absolute path"),
+        ("url", "Download the pack"),
+        ("unsafe", "Check the path"),
+    ],
+)
+async def test_bad_input_explains_recovery_and_retains_selection(
+    imports, kind, message
+):
+    manager, archive, previous = imports
+    if kind == "symlink":
+        link = archive.with_name("linked.zip")
+        link.symlink_to(archive)
+        entered = str(link)
+    elif kind == "html":
+        archive.write_text("<!doctype html><title>GitHub file page</title>")
+        entered = str(archive)
+    else:
+        entered = {
+            "missing": str(archive.with_name("missing.zip")),
+            "directory": str(archive.parent),
+            "relative": archive.name,
+            "url": "https://github.com/example/buddy.zip",
+            "unsafe": str(archive) + "\x00",
+        }[kind]
+    with pytest.raises(ValueError, match=message) as failed:
+        await manager.apply_choice(BuddyManagementChoice(import_path=entered))
+    assert str(archive.parent) not in str(failed.value)
+    assert manager.controller.current_preferences() == previous
+    assert manager.library.list_buddies() == ()
+
+
+@pytest.mark.asyncio
+async def test_install_failure_identifies_storage_and_retains_selection(
+    imports, monkeypatch
+):
+    manager, archive, previous = imports
+
+    def fail_publish(_):
+        raise OSError("private profile path must not reach the UI")
+
+    monkeypatch.setattr(manager.library, "publish_review", fail_publish)
+    with pytest.raises(ValueError, match="profile storage") as failed:
+        await manager.apply_choice(BuddyManagementChoice(import_path=str(archive)))
+    assert "private profile path" not in str(failed.value)
+    assert manager.controller.current_preferences() == previous
+
+
+@pytest.mark.asyncio
+async def test_unreadable_file_is_not_reported_as_an_invalid_pack(imports, monkeypatch):
+    from tldw_chatbook.Persona_Visual import importer
+
+    manager, archive, previous = imports
+    original_open = importer.os.open
+
+    def deny_archive(path, *args, **kwargs):
+        if path == archive:
+            raise PermissionError("private filename must not reach the UI")
+        return original_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(importer.os, "open", deny_archive)
+    with pytest.raises(ValueError, match="file access permissions") as failed:
+        await manager.apply_choice(BuddyManagementChoice(import_path=str(archive)))
+    assert "private filename" not in str(failed.value)
+    assert manager.controller.current_preferences() == previous
+    assert manager.library.list_buddies() == ()
+
+
+@pytest.mark.asyncio
+async def test_review_cannot_hide_a_concurrent_settings_change(imports, monkeypatch):
+    manager, archive, _ = imports
+    review_archive = manager.library.review_archive
+
+    def change_while_reviewing(path):
+        review = review_archive(path)
+        manager.controller.apply_preferences_patch(selection=BuddySelection("newer"))
+        return review
+
+    monkeypatch.setattr(manager.library, "review_archive", change_while_reviewing)
+    with pytest.raises(ValueError, match="changed elsewhere"):
+        await manager.apply_choice(
+            BuddyManagementChoice(import_path=str(archive)), expected_revision=0
+        )
+    assert manager.controller.current_preferences().selection == BuddySelection("newer")
+    assert manager.library.list_buddies() == ()
+
+
+@pytest.mark.asyncio
+async def test_changed_archive_is_not_reported_as_storage_failure(imports, monkeypatch):
+    manager, archive, previous = imports
+    review_archive = manager.library.review_archive
+
+    def replace_after_review(path):
+        review = review_archive(path)
+        archive.write_bytes(b"replacement content")
+        return review
+
+    monkeypatch.setattr(manager.library, "review_archive", replace_after_review)
+    with pytest.raises(ValueError, match="changed during import"):
+        await manager.apply_choice(BuddyManagementChoice(import_path=str(archive)))
+    assert manager.controller.current_preferences() == previous
+    assert manager.library.list_buddies() == ()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("category", "message"),
+    [("unsupported", "unsupported format"), ("stale", "changed during import")],
+)
+async def test_review_category_provides_safe_recovery(
+    imports, monkeypatch, category, message
+):
+    from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportError
+
+    manager, archive, previous = imports
+
+    def fail_review(_):
+        raise PersonaVisualImportError("persona_visual_import_" + category)
+
+    monkeypatch.setattr(manager.library, "review_archive", fail_review)
+    with pytest.raises(ValueError, match=message) as failed:
+        await manager.apply_choice(BuddyManagementChoice(import_path=str(archive)))
+    assert "persona_visual_import_" not in str(failed.value)
+    assert manager.controller.current_preferences() == previous
+
+
+@pytest.mark.asyncio
+async def test_modal_can_recover_from_a_missing_file_and_import_the_pasted_path(
+    imports,
+):
+    import asyncio
+
+    from textual.app import App
+    from textual.widgets import Button, Input
+
+    from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
+        BuddyManagementModal,
+    )
+
+    manager, archive, previous = imports
+    app = App()
+    async with app.run_test(size=(100, 40)) as pilot:
+        modal = BuddyManagementModal(
+            initial=BuddyManagementChoice(import_path="~/missing.zip"),
+            apply=manager.apply_choice,
+        )
+        app.push_screen(modal)
+        await pilot.pause()
+        modal.query_one("#buddy-apply", Button).press()
+        async with asyncio.timeout(5):
+            while "not found" not in str(
+                modal.query_one("#buddy-import-error").render()
+            ):
+                await pilot.pause()
+        assert app.screen is modal
+        assert manager.controller.current_preferences() == previous
+        modal.query_one("#buddy-import", Input).value = '"~/' + archive.name + '"'
+        modal.query_one("#buddy-apply", Button).press()
+        async with asyncio.timeout(5):
+            while app.screen is modal:
+                await pilot.pause()
+        assert len(manager.library.list_buddies()) == 1
+        assert manager.controller.current_preferences().selection != previous.selection

--- a/Tests/Persona_Buddy/test_buddy_management_import.py
+++ b/Tests/Persona_Buddy/test_buddy_management_import.py
@@ -70,6 +70,66 @@ async def test_pasted_path_imports_independent_artwork(imports, style):
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("retry_style", ["absolute", "home", "double-quoted-home"])
+async def test_equivalent_retry_paths_reuse_installed_buddy_after_save_failure(
+    imports, monkeypatch, retry_style
+):
+    from tldw_chatbook import config
+
+    manager, archive, previous = imports
+    cached_imports = {}
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: False)
+    with pytest.raises(ValueError, match="Could not save Buddy settings") as failed:
+        await manager.apply_choice(
+            BuddyManagementChoice(import_path="'" + str(archive) + "'"),
+            expected_revision=0,
+            imports=cached_imports,
+        )
+    installed = manager.library.list_buddies()
+    assert len(installed) == 1
+    assert manager.controller.current_preferences() == previous
+    retry_path = {
+        "absolute": str(archive),
+        "home": "~/" + archive.name,
+        "double-quoted-home": '"~/' + archive.name + '"',
+    }[retry_style]
+    monkeypatch.setattr(config, "save_settings_to_cli_config", lambda _: True)
+    await manager.apply_choice(
+        BuddyManagementChoice(import_path=retry_path),
+        expected_revision=failed.value.buddy_retry_revision,
+        imports=cached_imports,
+    )
+    assert manager.library.list_buddies() == installed
+    assert manager.controller.current_preferences().selection == BuddySelection(
+        installed[0].id
+    )
+    assert cached_imports == {str(archive): installed[0].id}
+
+
+@pytest.mark.parametrize(
+    "value", [None, 7, b"pack.zip", [], {"path": "private-input"}, "x" * 4097]
+)
+def test_shared_import_path_boundary_rejects_invalid_values_without_echoing_them(value):
+    from tldw_chatbook.Utils.input_validation import validate_buddy_import_path
+
+    with pytest.raises(ValueError) as failed:
+        validate_buddy_import_path(value)
+    assert str(failed.value) == "Check the path. Enter a local Buddy pack filename."
+
+
+def test_shared_import_path_key_keeps_a_link_distinct_from_its_target(imports):
+    from tldw_chatbook.Utils.input_validation import validate_buddy_import_path
+
+    _, archive, _ = imports
+    link = archive.with_name("linked.zip")
+    link.symlink_to(archive)
+    assert validate_buddy_import_path('"~/' + link.name + '"') == str(link)
+    assert validate_buddy_import_path(str(link)) != validate_buddy_import_path(
+        str(archive)
+    )
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("kind", "message"),
     [

--- a/backlog/tasks/task-32172 - Accept-pasted-Buddy-pack-paths-and-clarify-import-failures.md
+++ b/backlog/tasks/task-32172 - Accept-pasted-Buddy-pack-paths-and-clarify-import-failures.md
@@ -1,0 +1,48 @@
+---
+id: TASK-32172
+title: Accept pasted Buddy pack paths and clarify import failures
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-09 17:02'
+updated_date: '2026-09-09 17:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A user importing Trenchcoat on dev receives a generic failure. The published archive works with an absolute path, but common home-relative and quoted path inputs fail identically. Make the import input usable and provide actionable failure messages without changing archive validation or existing selections.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Buddy management imports valid native packs entered as absolute paths, home-relative paths, or quoted local paths.
+- [x] #2 Missing files, invalid archives, unsupported packs, stale sources and storage publication failures give actionable path-free messages while preserving prior Buddy settings.
+- [x] #3 Existing no-follow source checks and rejection of links, unsafe input and malformed pack content remain enforced; focused regressions and the actual Trenchcoat archive are verified.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no
+ADR path: backlog/decisions/139-independent-buddy-conversation-and-workspace-bindings.md (existing); backlog/decisions/074-portable-actor-packs-and-local-persona-visual-runtime.md (existing)
+Reason: Routine import-input and error-copy correction; immutable review, no-follow checks, publication and ownership contracts stay unchanged.
+1. Reproduce the published Trenchcoat archive and common path inputs on latest dev.
+2. Add focused failing regressions through Buddy management using real archive validation and SQLite publication, plus failure/selection preservation cases.
+3. Normalize home-relative and quoted local paths in the UI worker; retain no-follow validation and provide safe actionable errors for input, review and publication.
+4. Run targeted library, coordinator and modal checks; repeat the actual pack import and review the diff.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented pasted-path handling in Buddy Management: current-home shorthand and matching outer quotes are normalized without resolving links or executing shell text. Missing/non-regular files, invalid/unsupported archives, stale sources, read permissions, storage installation and concurrent settings changes have distinct path-free recovery messages. Source-read OSError uses the existing failed category at the snapshot pinning boundary; decoder/content failures remain invalid. Previous selections and import retry identities remain intact. Updated the import placeholder and Buddy guide.
+
+Validation on dev base e574c81d22: 98 targeted tests passed across new management-import regressions, coordinator, library, modal and native importer. Initial regressions failed on the old path/error behavior; additional source-mutation, permission and double-slash-home regressions also failed before their fixes. Ruff lint/format, compile and git diff --check passed. Independent read-only review found the permission-message issue and verified it and home-prefix handling fixed.
+
+The published Trenchcoat archive is 217491 bytes, SHA-256 620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f (Git blob 30207a60400e92f079f5a3bb76adfdb38dd2e75c confirmed with GitHub API). Actual bytes passed the mounted headless Textual dialog with absolute, home-relative, single-quoted and double-quoted-home inputs, independent publication and native preview in disposable profiles. This is not native-terminal or Windows qualification. The original reporter OS, download method and exact input remain unconfirmed, so the fix addresses a reproduced path/error problem without asserting their precise root cause.
+
+ADR required: no new ADR; existing ADR-139 and ADR-074 ownership, review and validation boundaries are preserved.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32172 - Accept-pasted-Buddy-pack-paths-and-clarify-import-failures.md
+++ b/backlog/tasks/task-32172 - Accept-pasted-Buddy-pack-paths-and-clarify-import-failures.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-09 17:02'
-updated_date: '2026-09-09 17:12'
+updated_date: '2026-09-09 19:26'
 labels: []
 dependencies: []
 ---
@@ -21,6 +21,7 @@ A user importing Trenchcoat on dev receives a generic failure. The published arc
 - [x] #1 Buddy management imports valid native packs entered as absolute paths, home-relative paths, or quoted local paths.
 - [x] #2 Missing files, invalid archives, unsupported packs, stale sources and storage publication failures give actionable path-free messages while preserving prior Buddy settings.
 - [x] #3 Existing no-follow source checks and rejection of links, unsafe input and malformed pack content remain enforced; focused regressions and the actual Trenchcoat archive are verified.
+- [x] #4 Equivalent quoted, home-relative and absolute retry paths reuse the installed Buddy after a settings-write failure, using shared input validation and without resolving links.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -33,6 +34,7 @@ Reason: Routine import-input and error-copy correction; immutable review, no-fol
 2. Add focused failing regressions through Buddy management using real archive validation and SQLite publication, plus failure/selection preservation cases.
 3. Normalize home-relative and quoted local paths in the UI worker; retain no-follow validation and provide safe actionable errors for input, review and publication.
 4. Run targeted library, coordinator and modal checks; repeat the actual pack import and review the diff.
+5. PR #2551 Qodo: normalize through a shared strict Pydantic input boundary, use the lexical normalized path consistently for retry cache identity, cover failed-save retries and update public Args/Returns/Raises documentation.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -45,4 +47,8 @@ Validation on dev base e574c81d22: 98 targeted tests passed across new managemen
 The published Trenchcoat archive is 217491 bytes, SHA-256 620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f (Git blob 30207a60400e92f079f5a3bb76adfdb38dd2e75c confirmed with GitHub API). Actual bytes passed the mounted headless Textual dialog with absolute, home-relative, single-quoted and double-quoted-home inputs, independent publication and native preview in disposable profiles. This is not native-terminal or Windows qualification. The original reporter OS, download method and exact input remain unconfirmed, so the fix addresses a reproduced path/error problem without asserting their precise root cause.
 
 ADR required: no new ADR; existing ADR-139 and ADR-074 ownership, review and validation boundaries are preserved.
+
+PR #2551 Qodo follow-up: rebased on dev 04f6ae4eca. Reproduced duplicate installation after a failed settings write with three equivalent path spellings (3 failing real-SQLite regressions). Shared strict BuddyImportPathInput plus validate_buddy_import_path now provide one normalized lexical value for archive review and retry cache lookup/insertion, retaining links as distinct paths. Added argument/return/error contracts for apply_choice and read_buddy_archive. Invalid boundary values remain path-free.
+
+Verification after review fixes: 108 targeted tests passed; mounted Trenchcoat import/preview passed again for all four path forms. Ruff format, compilation and diff checks passed. The five Buddy-specific Python files have no Ruff findings; input_validation.py retains the same 8 unrelated pre-existing findings as the rebased base, with zero new findings. Independent read-only review found no remaining issues.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Persona_Visual/snapshot.py
+++ b/tldw_chatbook/Persona_Visual/snapshot.py
@@ -71,8 +71,19 @@ def _validate_manifest(
 def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
     """Read a pinned native archive without staging files or creating a Persona.
 
+    Args:
+        path: Absolute native archive filename. The source must be a regular,
+            singly linked file; no-follow checks reject a symbolic link.
+
+    Returns:
+        Immutable validated artwork, assets and metadata with a private guard
+        that revalidates the source before publication.
+
     Raises:
-        PersonaVisualImportError: Native validation fails or the source changes.
+        PersonaVisualImportError: Source access or reading fails (the
+            ``persona_visual_import_failed`` category), path or native archive
+            validation fails, the format is unsupported, or the source changes
+            during review. Exception categories contain no private path text.
     """
     from tldw_chatbook.Utils.path_validation import validate_path_simple
 

--- a/tldw_chatbook/Persona_Visual/snapshot.py
+++ b/tldw_chatbook/Persona_Visual/snapshot.py
@@ -79,7 +79,14 @@ def read_buddy_archive(path: os.PathLike[str] | str) -> BuddySnapshot:
     try:
         # The importer owns no-follow identity checks; do not resolve links here.
         validated_path = validate_path_simple(path, probe_existing=False)
-        source = importer._pin_source(validated_path)
+        try:
+            source = importer._pin_source(validated_path)
+        except OSError:
+            # A source read failure says nothing about the archive's validity.
+            # Keep this narrow: decoder errors later still mean invalid content.
+            raise importer.PersonaVisualImportError(
+                "persona_visual_import_failed"
+            ) from None
         with zipfile.ZipFile(BytesIO(source.data)) as archive:
             members, pack, records = importer._validated_archive(archive, lambda: False)
             assets = []

--- a/tldw_chatbook/UI/Navigation/buddy_management.py
+++ b/tldw_chatbook/UI/Navigation/buddy_management.py
@@ -15,6 +15,78 @@ from tldw_chatbook.Persona_Buddy.interaction import (
 )
 
 
+def _review_buddy_import(library: Any, entered_path: str) -> Any:
+    """Interpret pasted local paths on the import worker, retaining no-follow review."""
+    import os
+    import stat
+    from pathlib import Path
+
+    from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportError
+    from tldw_chatbook.Utils.path_validation import validate_path_simple
+
+    invalid_path = "Check the path. Enter a local Buddy pack filename."
+    if type(entered_path) is not str or not 1 <= len(entered_path) <= 4096:
+        raise ValueError(invalid_path)
+    value = entered_path.strip()
+    if len(value) >= 2 and value[0] in {"'", '"'} and value[-1] == value[0]:
+        value = value[1:-1]
+    if value.lower().startswith(("http://", "https://", "file://")):
+        raise ValueError(
+            "Download the pack first, then enter its local filesystem path."
+        )
+    # Expand only the current user's home shorthand. Never evaluate shell text or
+    # resolve links: the importer must still inspect the exact selected file.
+    if value.startswith("~/") or (os.name == "nt" and value.startswith("~\\")):
+        value = str(Path.home()) + value[1:]
+    try:
+        path = validate_path_simple(value, probe_existing=False)
+    except ValueError:
+        raise ValueError(invalid_path) from None
+    if not path.is_absolute():
+        raise ValueError(
+            "Enter an absolute path or a path starting with ~/ to the downloaded pack."
+        )
+    # This preflight supplies recovery copy only. The review below independently
+    # pins/revalidates the file, so a successful stat never grants read authority.
+    try:
+        entry = path.lstat()
+    except FileNotFoundError:
+        raise ValueError(
+            "Buddy pack not found. Check the filename and download location."
+        ) from None
+    except OSError:
+        raise ValueError(
+            "Could not read the Buddy pack. Check file access permissions and retry."
+        ) from None
+    if not stat.S_ISREG(entry.st_mode) or entry.st_nlink != 1:
+        raise ValueError(
+            "Choose a regular file copied to this device, not a folder or linked file."
+        )
+    try:
+        return library.review_archive(path)
+    except PersonaVisualImportError as exc:
+        message = {
+            "persona_visual_import_invalid": (
+                "This file is not a valid native Buddy pack. Download the .tldw-persona-vpack "
+                "again using GitHub's Download raw file button, then retry."
+            ),
+            "persona_visual_import_unsupported": (
+                "This pack uses an unsupported format or renderer. Choose a native "
+                ".tldw-persona-vpack compatible with this Chatbook version."
+            ),
+            "persona_visual_import_stale": "The pack changed during import. Finish downloading it, then retry.",
+            "persona_visual_import_cancelled": "Buddy import was cancelled. Retry when ready.",
+        }.get(
+            exc.category,
+            "Could not read the Buddy pack. Check file access permissions and retry.",
+        )
+        raise ValueError(message) from exc
+    except Exception as exc:
+        raise ValueError(
+            "Could not read the Buddy pack. Check the path and file access permissions, then retry."
+        ) from exc
+
+
 class BuddyManagementCoordinator:
     """Own staged-management application and scope; never own Console execution."""
 
@@ -504,17 +576,24 @@ class BuddyManagementCoordinator:
                     imports.get(choice.import_path) if imports is not None else None
                 )
                 if selected_id is None:
+                    review = await asyncio.to_thread(
+                        _review_buddy_import, self.library, choice.import_path
+                    )
+                    require_current()
                     try:
-                        review = await asyncio.to_thread(
-                            self.library.review_archive, choice.import_path
-                        )
-                        require_current()
                         record = await asyncio.to_thread(
                             self.library.publish_review, review
                         )
                     except Exception as exc:
+                        if isinstance(exc, ValueError) and str(exc) in {
+                            "buddy_source_changed",
+                            "persona_visual_authority_changed",
+                        }:
+                            raise ValueError(
+                                "The pack changed during import. Finish downloading it, then retry."
+                            ) from exc
                         raise ValueError(
-                            "Could not import this Buddy pack. Check the path, pack format and profile storage, then retry."
+                            "The pack was read but could not be installed. Check profile storage permissions and free space, then retry."
                         ) from exc
                     selected_id = record.id
                     if imports is not None:

--- a/tldw_chatbook/UI/Navigation/buddy_management.py
+++ b/tldw_chatbook/UI/Navigation/buddy_management.py
@@ -15,37 +15,14 @@ from tldw_chatbook.Persona_Buddy.interaction import (
 )
 
 
-def _review_buddy_import(library: Any, entered_path: str) -> Any:
-    """Interpret pasted local paths on the import worker, retaining no-follow review."""
-    import os
+def _review_buddy_import(library: Any, archive_path: str) -> Any:
+    """Review a lexically validated path on the worker, retaining no-follow checks."""
     import stat
     from pathlib import Path
 
     from tldw_chatbook.Persona_Visual.importer import PersonaVisualImportError
-    from tldw_chatbook.Utils.path_validation import validate_path_simple
 
-    invalid_path = "Check the path. Enter a local Buddy pack filename."
-    if type(entered_path) is not str or not 1 <= len(entered_path) <= 4096:
-        raise ValueError(invalid_path)
-    value = entered_path.strip()
-    if len(value) >= 2 and value[0] in {"'", '"'} and value[-1] == value[0]:
-        value = value[1:-1]
-    if value.lower().startswith(("http://", "https://", "file://")):
-        raise ValueError(
-            "Download the pack first, then enter its local filesystem path."
-        )
-    # Expand only the current user's home shorthand. Never evaluate shell text or
-    # resolve links: the importer must still inspect the exact selected file.
-    if value.startswith("~/") or (os.name == "nt" and value.startswith("~\\")):
-        value = str(Path.home()) + value[1:]
-    try:
-        path = validate_path_simple(value, probe_existing=False)
-    except ValueError:
-        raise ValueError(invalid_path) from None
-    if not path.is_absolute():
-        raise ValueError(
-            "Enter an absolute path or a path starting with ~/ to the downloaded pack."
-        )
+    path = Path(archive_path)
     # This preflight supplies recovery copy only. The review below independently
     # pins/revalidates the file, so a successful stat never grants read authority.
     try:
@@ -539,6 +516,23 @@ class BuddyManagementCoordinator:
 
         Import failure cannot change selection. A failed preference write rolls back
         only this exact in-memory revision, preserving any newer user changes.
+
+        Args:
+            choice: Staged artwork, binding, Persona and presentation choices.
+                Import paths accept absolute or current-home-relative local paths
+                with optional matching outer quotes.
+            expected_revision: Preference generation observed by the caller; a
+                changed generation blocks applying stale choices.
+            imports: Optional dialog-scoped map of normalized lexical paths to
+                already installed Buddy IDs. Retain it across retries after a
+                settings-write failure to reuse the installed artwork copy.
+
+        Raises:
+            ValueError: A selection or binding is invalid or stale; the import
+                path is missing, unsafe or unreadable; pack validation or source
+                revalidation fails; artwork installation, preference persistence
+                or the requested Persona assignment fails. Messages describe
+                recovery without exposing private paths or raw backend errors.
         """
         from tldw_chatbook.Persona_Buddy.preferences import BuddySelection
         from tldw_chatbook.Widgets.Persona_Widgets.buddy_management_modal import (
@@ -572,12 +566,18 @@ class BuddyManagementCoordinator:
                 assignment = None
             selected_id = choice.buddy_id
             if choice.import_path:
-                selected_id = (
-                    imports.get(choice.import_path) if imports is not None else None
+                from tldw_chatbook.Utils.input_validation import (
+                    validate_buddy_import_path,
                 )
+
+                archive_path = await asyncio.to_thread(
+                    validate_buddy_import_path, choice.import_path
+                )
+                require_current()
+                selected_id = imports.get(archive_path) if imports is not None else None
                 if selected_id is None:
                     review = await asyncio.to_thread(
-                        _review_buddy_import, self.library, choice.import_path
+                        _review_buddy_import, self.library, archive_path
                     )
                     require_current()
                     try:
@@ -597,7 +597,7 @@ class BuddyManagementCoordinator:
                         ) from exc
                     selected_id = record.id
                     if imports is not None:
-                        imports[choice.import_path] = selected_id
+                        imports[archive_path] = selected_id
                 elif (
                     await asyncio.to_thread(self.library.get_buddy, selected_id) is None
                 ):

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -777,6 +777,59 @@ class BuddyManagementInput(BaseModel):
         return validate_bounded_integer(value, minimum=minimum, maximum=maximum)
 
 
+class BuddyImportPathInput(BaseModel):
+    """Strict raw input for a Buddy pack path before lexical normalization."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    path: str = Field(min_length=1, max_length=4096)
+
+
+def validate_buddy_import_path(value: object) -> str:
+    """Return a stable lexical pack path without probing files or resolving links.
+
+    Args:
+        value: Pasted absolute or current-home-relative path, optionally quoted.
+
+    Returns:
+        Validated absolute path text for both archive review and retry identity.
+
+    Raises:
+        ValueError: Input has an invalid type, length or unsafe path syntax, is a
+            URL, or remains relative after expanding the current home shorthand.
+    """
+    import os
+    from pathlib import Path
+
+    from .path_validation import validate_path_simple
+
+    invalid_path = "Check the path. Enter a local Buddy pack filename."
+    try:
+        entered = BuddyImportPathInput.model_validate({"path": value}).path
+    except PydanticValidationError:
+        raise ValueError(invalid_path) from None
+    entered = entered.strip()
+    if len(entered) >= 2 and entered[0] in {"'", '"'} and entered[-1] == entered[0]:
+        entered = entered[1:-1]
+    if entered.lower().startswith(("http://", "https://", "file://")):
+        raise ValueError(
+            "Download the pack first, then enter its local filesystem path."
+        )
+    # Concatenation preserves the home prefix even for ~// paths. Do not resolve
+    # links or collapse parent components: the native reader owns file authority.
+    if entered.startswith("~/") or (os.name == "nt" and entered.startswith("~\\")):
+        entered = str(Path.home()) + entered[1:]
+    try:
+        path = validate_path_simple(entered, probe_existing=False)
+    except ValueError:
+        raise ValueError(invalid_path) from None
+    if not path.is_absolute():
+        raise ValueError(
+            "Enter an absolute path or a path starting with ~/ to the downloaded pack."
+        )
+    return str(path)
+
+
 def validate_port(port: Union[str, int]) -> bool:
     """Validate port number."""
     log_counter("input_validation_port_attempt")

--- a/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
+++ b/tldw_chatbook/Widgets/Persona_Widgets/buddy_management_modal.py
@@ -249,7 +249,7 @@ class BuddyManagementModal(
                     )
                     yield Input(
                         value=initial.import_path,
-                        placeholder="Path to pack; installed when you Apply",
+                        placeholder="Absolute path or ~/Downloads/pack.tldw-persona-vpack",
                         id="buddy-import",
                     )
                     yield Static("", id="buddy-import-error", markup=False)


### PR DESCRIPTION
Buddy Management rejects common pasted paths such as `~/Downloads/trenchcoat.tldw-persona-vpack` or quoted filenames and reports the same generic error for unrelated failures. Normalize those inputs at the UI boundary and preserve the native archive's no-follow validation and immutable publication checks.

The dialog now distinguishes missing files, unsupported/invalid archives, read permissions, changed sources, installation failures, and concurrent settings changes. Failed imports preserve the current Buddy selection. The guide and path hint describe accepted inputs and GitHub's raw-file download. Equivalent path spellings reuse the installed Buddy on settings-save retries through a shared strict input validator.

Validation:
- 108 targeted tests passed across the management import, coordinator, library, modal, and native importer suites.
- Ruff formatting, compilation, and `git diff --check` passed. No new Ruff findings; the shared validator retains eight unrelated baseline findings. Independent review findings were addressed and rechecked.
- The published 217,491-byte Trenchcoat archive passed the mounted Textual dialog with absolute, home-relative, and quoted paths, followed by independent publication and native preview. SHA-256: `620f06958112d9be1dce0d6592842f47ada9c8c4d9f359c0ed92d878af4ab80f`.

The reported pack also imports on unmodified dev with a full unquoted path. The reporter's OS, download method, and exact input remain unconfirmed; this addresses reproduced path/error failures without claiming their precise cause is established. Validation used disposable profiles and a headless mounted dialog, not a native-terminal or Windows run.

Backlog: TASK-32172. Existing ADR-139 and ADR-074 apply; no ownership or archive-format change.
