### PR TITLE
Restore Library collapse controls and narrow layouts

### DIFF
--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -22,7 +22,7 @@ fills the center of the screen.
 ```text
 Wide (Media)
 
-+ Library ----+‹+ Items ------+‹+ Reader ---------------------------+
++ Library ----+<---+ Items ------+<---+ Reader ---------------------------+
 | Browse       | Filter        | title · source · date              |
 | Media        | item rows     | Find · Read later · Use in Console |
 | ...          | ...           | Read · Analysis · Highlights · Info|
@@ -30,14 +30,13 @@ Wide (Media)
 
 Narrow (Media)
 
-+›+ Items ----------------------------------+›+ Reader -------------+
++--->+ Items ----------------------------------+--->+ Reader -------------+
 | ‹ Library                                  | Select a media item  |
 | filter · type · sort · item rows           | to read it here.     |
 ```
 
-Media's two grips are one column each — the `‹` (open pane) and `›`
-(collapsed pane) above. Conversations, Skills and Collections use the same
-one-column grips; Notes, File Notes and Prompts keep the wider `+--->+` grip.
+Every Library reader uses two full-height, five-column collapse controls.
+The full width is clickable, including the space around the arrows.
 
 Media has three stable roles:
 
@@ -49,21 +48,16 @@ Media has three stable roles:
 - **Reader** — a permanent reading surface. Selecting another row updates
   Reader in place; the Items list is not replaced.
 
-Library and Items each have a full-height grip. On Media, Conversations,
-Skills and Collections the grip is **one column** and paints **`‹`** to
-collapse the pane to its left and **`›`** to expand it; Notes, File Notes and
-Prompts keep the five-column **`<---`** / **`--->`** grip. Because the screen
-holds back exactly the columns a grip paints, the narrow grip also moves the
-width at which the navigation rail joins: on Conversations it now appears at
-110 columns (was 118) and on Skills and Collections at 114 (was 122). The
-grips are clickable and keyboard-operable. Reader has no grip and never
-collapses. Your manual pane choices are remembered. If the terminal is too
-narrow, the screen temporarily collapses Library first and then Items;
-widening the terminal restores the remembered layout instead of saving the
-temporary responsive state.
+Library and Items each have a full-height, five-column grip. **`<---`**
+collapses the pane to its left and **`--->`** expands it. The grips support
+clicks, Enter, and Space. Reader has no grip and never collapses. Your manual
+pane choices are remembered.
 
-On Media nothing sits between the panes but those two one-cell grips, and the
-list uses the width that frees up:
+The default Library and Items columns prefer five and ten extra cells,
+respectively. At narrower widths those additions yield before the screen
+collapses Library, then Items. This preserves the earlier collapse boundaries
+with the five-column controls. Widening restores the preferred widths without
+rewriting your settings. Explicitly reopening a pane takes effect immediately.
 
 - **The Items column grows with the terminal.** Once the Reader is
   comfortable the surplus is split between them, up to a 56-cell ceiling, so
@@ -154,7 +148,7 @@ full stored keyword but drops a dangling half-flag so that surface's frame
 does not drift either (the edit form still prefills the stored keyword
 verbatim).
 
-*Verified against fix/media-riders-n — 2026-09-07 (task-31951: Conversations,
+*Historical verification (grip sizes and thresholds superseded by the five-column restoration, TASK-32184). Verified against fix/media-riders-n — 2026-09-07 (task-31951: Conversations,
 Skills and Collections opened live at 235x52. Each painted one-cell `‹` grips
 — the Library grip at columns 37 on two rows, the Items grip at column 78 on
 one — and no `<---`/`--->` run appeared anywhere on the three surfaces.
@@ -559,10 +553,9 @@ displaced the tab row and body by 19 rows behind ~16 blank ones. The
 button paints "More ▴" while open and "More" once closed, and focus stays
 on it across both toggles. AC#1/AC#2 layout numbers -- the 56-cell Items
 ceiling and its 46 painted title characters at 235x52, 15 items in a
-52-row terminal, the one-cell grips, and the 112- and 88-column
-thresholds -- are the resolver's own answers and the painted pins that
-hold them, cross-checked against the live captures in the task 1 and
-task 2 reports.)*
+52-row terminal, the then-one-cell grips, and the then-112- and 88-column
+thresholds were cross-checked against that revision. Grip sizes and collapse
+thresholds are superseded by the five-column restoration (TASK-32184).)*
 
 ### Review sets
 

--- a/Tests/Library/test_library_adaptive_reader_state.py
+++ b/Tests/Library/test_library_adaptive_reader_state.py
@@ -7,7 +7,6 @@ from dataclasses import replace
 import pytest
 
 from tldw_chatbook.Utils.adaptive_reader_state import (
-    LAYOUT_HYSTERESIS_WIDTH,
     PANE_GRIP_WIDTH,
     READER_COMFORT_WIDTH,
     AdaptiveReaderEffectiveLayout,
@@ -83,17 +82,13 @@ def test_shared_normalization_matches_current_media_custom_width_behavior() -> N
 @pytest.mark.parametrize(
     ("width", "expected_geometry", "expected_media_geometry"),
     [
-        # task-31633: the Media profile shares the Reader's surplus with its
-        # Items column, so it diverges from the generic profile wherever the
-        # Reader sits above its 46-cell minimum -- and AC#2 narrowed Media's
-        # two grips from five cells each to one, so every Media row below also
-        # carries the eight cells they gave back. The generic column is
-        # untouched by both.
-        (160, (True, True, 35, 50, 65), (True, True, 35, 56, 67)),
-        (120, (False, True, 0, 56, 54), (False, True, 0, 56, 62)),
-        (100, (False, False, 0, 0, 90), (False, True, 0, 52, 46)),
-        (80, (False, False, 0, 0, 70), (False, False, 0, 0, 78)),
-        (60, (False, False, 0, 0, 50), (False, False, 0, 0, 58)),
+        # Five-cell controls remain reserved; extra default pane width yields
+        # before a pane collapses. Media still shares reader surplus.
+        (160, (True, True, 35, 50, 65), (True, True, 35, 56, 59)),
+        (120, (True, True, 26, 40, 44), (True, True, 24, 40, 46)),
+        (100, (False, True, 0, 46, 44), (False, True, 0, 44, 46)),
+        (80, (False, False, 0, 0, 70), (False, False, 0, 0, 70)),
+        (60, (False, False, 0, 0, 50), (False, False, 0, 0, 50)),
     ],
 )
 def test_shared_resolution_uses_adaptive_width_classes(
@@ -196,11 +191,9 @@ def test_media_profile_protects_the_rendered_toolbar_work_minimum() -> None:
     assert MEDIA_READER_LAYOUT_PROFILE.work_min_width == 46
     assert layout.library_open is False
     assert layout.items_open is True
-    # 44 / 90 while Media's two grips still cost five cells each; the eight
-    # they gave back land on the list, because the Reader is on its minimum.
-    assert layout.items_width == 52
+    assert layout.items_width == 44
     assert layout.reader_width >= 46
-    assert layout.items_width + layout.reader_width == 98
+    assert layout.items_width + layout.reader_width == 90
 
 
 @pytest.mark.parametrize(
@@ -244,31 +237,23 @@ def test_explicit_open_priority_protects_the_requested_pane_when_possible(
 
 def test_shared_resolution_preserves_hysteresis() -> None:
     preferences = AdaptiveReaderLayoutPreferences()
-    collapsed = resolve_adaptive_reader_layout(133, preferences, MEDIA_PROFILE)
-
-    boundary = resolve_adaptive_reader_layout(
-        134,
-        preferences,
-        MEDIA_PROFILE,
-        previous=collapsed,
-    )
-    # The fractional rail gains another cell before hysteresis clears.
-    still_collapsed = resolve_adaptive_reader_layout(
-        134 + LAYOUT_HYSTERESIS_WIDTH,
-        preferences,
-        MEDIA_PROFILE,
-        previous=boundary,
-    )
-    reopened = resolve_adaptive_reader_layout(
-        135 + LAYOUT_HYSTERESIS_WIDTH,
-        preferences,
-        MEDIA_PROFILE,
-        previous=boundary,
-    )
+    collapsed = resolve_adaptive_reader_layout(117, preferences, MEDIA_PROFILE)
+    boundary = resolve_adaptive_reader_layout(118, preferences, MEDIA_PROFILE, previous=collapsed)
+    still_collapsed = resolve_adaptive_reader_layout(121, preferences, MEDIA_PROFILE, previous=boundary)
+    reopened = resolve_adaptive_reader_layout(122, preferences, MEDIA_PROFILE, previous=boundary)
 
     assert boundary.library_open is False
     assert still_collapsed.library_open is False
     assert reopened.library_open is True
+
+
+@pytest.mark.parametrize("pane,width", [("library", 120), ("items", 96)])
+def test_explicit_reopen_is_not_delayed_by_resize_hysteresis(pane, width):
+    preferences = AdaptiveReaderLayoutPreferences(library_open=pane == "library")
+    previous = resolve_media_reader_layout(width - 4, preferences)
+    assert not getattr(previous, f"{pane}_open")
+    reopened = resolve_media_reader_layout(width, preferences, previous=previous, priority=pane)
+    assert getattr(reopened, f"{pane}_open")
 
 
 @pytest.mark.parametrize("width", [10, 11, 59, 60, 80, 100, 120, 122, 160])
@@ -363,7 +348,7 @@ def test_notes_navigator_explicit_items_priority_uses_projected_library_request(
 
 @pytest.mark.parametrize(
     ("width", "items_open"),
-    [(116, True), (108, True), (107, False), (100, False), (80, False), (60, False)],
+    [(116, True), (100, True), (98, True), (97, False), (80, False), (60, False)],
 )
 def test_notes_editor_preserves_work_before_items_at_production_widths(
     width: int, items_open: bool
@@ -463,14 +448,6 @@ SIBLING_PROFILES = {
     "skills": LIBRARY_SKILLS_READER_PROFILE,
     "collections": LIBRARY_COLLECTIONS_READER_PROFILE,
 }
-# task-31951: the three sibling readers joined Media on the one-cell grip.
-# Notes, File Notes and Prompts keep the five-cell default, so this is the
-# opt-in list, not "everything but Media".
-ONE_CELL_GRIP_PROFILE_NAMES = {
-    "LIBRARY_CONVERSATION_READER_PROFILE",
-    "LIBRARY_SKILLS_READER_PROFILE",
-    "LIBRARY_COLLECTIONS_READER_PROFILE",
-}
 DECLARED_PROFILES = {
     name: value
     for name, value in vars(screen_constants).items()
@@ -499,14 +476,9 @@ LIST_GROWTH_PROFILE_NAMES = {"LIBRARY_NOTES_READER_PROFILE"}
 
 def test_only_the_media_profile_opts_into_list_growth() -> None:
     assert MEDIA_READER_LAYOUT_PROFILE.list_grows is True
-    # task-31633 AC#2: the one-cell grip is opt-in the same way. task-31951
-    # opted the three sibling readers in as well (each was PANE_GRIP_WIDTH);
-    # the default and the destinations that did not opt in stay at five.
-    assert MEDIA_READER_LAYOUT_PROFILE.grip_width == 1
+    assert MEDIA_READER_LAYOUT_PROFILE.grip_width == PANE_GRIP_WIDTH == 5
     for name, profile in DECLARED_PROFILES.items():
-        expected = 1 if name in ONE_CELL_GRIP_PROFILE_NAMES else PANE_GRIP_WIDTH
-        assert profile.grip_width == expected, name
-    assert ONE_CELL_GRIP_PROFILE_NAMES <= set(DECLARED_PROFILES)
+        assert profile.grip_width == PANE_GRIP_WIDTH, name
     assert AdaptiveReaderLayoutProfile().grip_width == PANE_GRIP_WIDTH
     assert set(SIBLING_PROFILES.values()) <= set(DECLARED_PROFILES.values())
     assert len(DECLARED_PROFILES) >= 6, sorted(DECLARED_PROFILES)
@@ -546,27 +518,25 @@ def test_every_profile_reserves_exactly_the_grip_columns_it_paints(width: int) -
 @pytest.mark.parametrize(
     ("surface", "width", "expected"),
     [
-        # Wider automatic defaults move the rail-open boundaries to 125
-        # for Conversations and 129 for Skills/Collections. Pin both sides
-        # and nearby widths; these profiles still give surplus to the Reader.
-        ("conversations", 100, (False, True, 0, 54, 44)),
-        ("conversations", 124, (False, True, 0, 56, 66)),
-        ("conversations", 125, (True, True, 29, 50, 44)),
-        ("conversations", 126, (True, True, 29, 50, 45)),
-        ("conversations", 132, (True, True, 30, 50, 50)),
-        ("conversations", 235, (True, True, 39, 50, 144)),
-        ("skills", 100, (False, True, 0, 50, 48)),
-        ("skills", 128, (False, True, 0, 56, 70)),
-        ("skills", 129, (True, True, 29, 50, 48)),
-        ("skills", 130, (True, True, 29, 50, 49)),
-        ("skills", 136, (True, True, 31, 50, 53)),
-        ("skills", 235, (True, True, 39, 50, 144)),
-        ("collections", 100, (False, True, 0, 50, 48)),
-        ("collections", 128, (False, True, 0, 56, 70)),
-        ("collections", 129, (True, True, 29, 50, 48)),
-        ("collections", 130, (True, True, 29, 50, 49)),
-        ("collections", 136, (True, True, 31, 50, 53)),
-        ("collections", 235, (True, True, 39, 50, 144)),
+        # Preserve the pre-increase collapse boundaries with five-cell controls.
+        ("conversations", 100, (False, True, 0, 46, 44)),
+        ("conversations", 117, (False, True, 0, 56, 51)),
+        ("conversations", 118, (True, True, 24, 40, 44)),
+        ("conversations", 119, (True, True, 25, 40, 44)),
+        ("conversations", 122, (True, True, 28, 40, 44)),
+        ("conversations", 235, (True, True, 39, 50, 136)),
+        ("skills", 100, (False, True, 0, 42, 48)),
+        ("skills", 121, (False, True, 0, 56, 55)),
+        ("skills", 122, (True, True, 24, 40, 48)),
+        ("skills", 123, (True, True, 25, 40, 48)),
+        ("skills", 126, (True, True, 28, 40, 48)),
+        ("skills", 235, (True, True, 39, 50, 136)),
+        ("collections", 100, (False, True, 0, 42, 48)),
+        ("collections", 121, (False, True, 0, 56, 55)),
+        ("collections", 122, (True, True, 24, 40, 48)),
+        ("collections", 123, (True, True, 25, 40, 48)),
+        ("collections", 126, (True, True, 28, 40, 48)),
+        ("collections", 235, (True, True, 39, 50, 136)),
     ],
 )
 def test_sibling_reader_layouts_are_untouched_by_media_list_growth(
@@ -584,13 +554,11 @@ def test_sibling_reader_layouts_are_untouched_by_media_list_growth(
 @pytest.mark.parametrize(
     ("width", "expected"),
     [
-        # Media seats both wider default columns at 127 cells. Pin the
-        # last collapsed width, first open width, and surplus-growth onset.
-        (100, (False, True, 0, 52, 46)),
-        (126, (False, True, 0, 56, 68)),
-        (127, (True, True, 29, 50, 46)),
-        (128, (True, True, 29, 50, 47)),
-        (129, (True, True, 29, 51, 47)),
+        (100, (False, True, 0, 44, 46)),
+        (119, (False, True, 0, 56, 53)),
+        (120, (True, True, 24, 40, 46)),
+        (121, (True, True, 25, 40, 46)),
+        (127, (True, True, 29, 42, 46)),
     ],
 )
 def test_media_layout_across_the_rail_open_threshold(
@@ -604,10 +572,10 @@ def test_media_layout_across_the_rail_open_threshold(
 @pytest.mark.parametrize(
     ("width", "expected"),
     [
-        # At 235 the list reaches its comfort ceiling; 129 is the first
+        # At 235 the list reaches its comfort ceiling; 139 is the first
         # open-rail width with two surplus cells, shared between both panes.
-        (235, (True, True, 39, 56, 138)),
-        (129, (True, True, 29, 51, 47)),
+        (235, (True, True, 39, 56, 130)),
+        (139, (True, True, 31, 51, 47)),
     ],
 )
 def test_media_items_column_grows_once_the_reader_is_comfortable(
@@ -675,9 +643,9 @@ def test_a_typed_custom_items_width_is_still_widened_once_the_library_closes(
 
     layout = resolve_media_reader_layout(100, custom, priority=priority)
 
-    # A typed 32 paints 52: 100 cells less the two one-cell grips and the
+    # A typed 32 paints 44: 100 cells less the two five-cell grips and the
     # 46-cell Reader minimum.
-    assert (layout.library_open, layout.items_width) == (False, 52)
+    assert (layout.library_open, layout.items_width) == (False, 44)
 
 
 def test_media_items_column_is_wider_at_235_than_at_100() -> None:
@@ -736,11 +704,11 @@ def test_empty_reader_gives_freed_columns_to_the_items_list_at_235() -> None:
     no_item = resolve_media_reader_layout(235, prefs, reader_has_item=False)
 
     # Item open: exactly the pre-task split (do not regress it).
-    assert _pane_widths(with_item) == (True, True, 39, 56, 138)
+    assert _pane_widths(with_item) == (True, True, 39, 56, 130)
     # No item open: the Items pane absorbs the freed Reader columns down to
     # the Reader's floor, so a 98-char title stops truncating at ~56 cells.
     assert no_item.reader_width == MEDIA_READER_LAYOUT_PROFILE.work_min_width
-    assert no_item.items_width == 148
+    assert no_item.items_width == 140
     assert no_item.items_width > with_item.items_width
     # Both panes and the two grips still tile the full terminal width.
     assert (

--- a/Tests/Library/test_library_media_reader_state.py
+++ b/Tests/Library/test_library_media_reader_state.py
@@ -101,9 +101,7 @@ def test_fixed_mode_ignores_saved_custom_width_values() -> None:
     )
 
 
-# task-31633 AC#2: Media's two grips are one cell each, not the shared
-# five, so every Media width sum below is against the Media profile's own
-# reservation rather than the shared constant.
+# The resolver reserves both five-cell controls in every width budget.
 MEDIA_GRIP_CELLS = 2 * MEDIA_READER_LAYOUT_PROFILE.grip_width
 
 
@@ -120,7 +118,7 @@ def test_responsive_collapse_does_not_mutate_preferences() -> None:
 
 @pytest.mark.parametrize(
     ("width", "library_open", "items_open"),
-    [(160, True, True), (127, True, True), (126, False, True), (80, False, False)],
+    [(160, True, True), (120, True, True), (119, False, True), (80, False, False)],
 )
 def test_normal_resolution_collapses_library_then_items(
     width: int, library_open: bool, items_open: bool
@@ -180,8 +178,7 @@ def test_two_grips_and_reader_remain_reachable_at_sixty_columns() -> None:
 
     assert layout.library_width == 0
     assert layout.items_width == 0
-    # 50 while Media's two grips still cost five cells each (task-31633 AC#2).
-    assert layout.reader_width == 58
+    assert layout.reader_width == 50
     assert layout.reader_width + MEDIA_GRIP_CELLS == 60
 
 
@@ -211,51 +208,23 @@ def test_explicit_open_priority_survives_narrow_resize_resolution() -> None:
     resized = resolve_media_reader_layout(81, preferences, previous=opened)
 
     assert resized.items_open is True
-    # The priority branch caps the list at whatever the width leaves once the
-    # grips and the Reader's minimum are paid for -- so at 81 columns it lands
-    # ABOVE ITEMS_MIN_WIDTH now (it was exactly 32 at five-cell grips, where
-    # the same subtraction left less than the minimum).
-    assert resized.items_width == 81 - MEDIA_GRIP_CELLS - (
-        MEDIA_READER_LAYOUT_PROFILE.work_min_width
-    )
-    assert resized.items_width > ITEMS_MIN_WIDTH
+    assert resized.items_width == ITEMS_MIN_WIDTH
     assert resized.priority_pane == "items"
 
 
 def test_hysteresis_prevents_one_column_resize_thrashing() -> None:
     preferences = normalize_media_reader_preferences({})
-    nominal_width = (
-        MEDIA_GRIP_CELLS
-        + project_default_library_width(120)
-        + ITEMS_TARGET_WIDTH
-        + MEDIA_READER_LAYOUT_PROFILE.work_min_width
-    )
+    nominal_width = 120
     collapsed = resolve_media_reader_layout(nominal_width - 1, preferences)
-    boundary = resolve_media_reader_layout(
-        nominal_width,
-        preferences,
-        previous=collapsed,
-    )
-    # Projection grows from 29 to 30 at 131, extending this transition by
-    # one cell beyond the four-cell hysteresis for a fixed rail.
-    still_collapsed = resolve_media_reader_layout(
-        nominal_width + LAYOUT_HYSTERESIS_WIDTH,
-        preferences,
-        previous=boundary,
-    )
-    reopened = resolve_media_reader_layout(
-        nominal_width + LAYOUT_HYSTERESIS_WIDTH + 1,
-        preferences,
-        previous=boundary,
-    )
+    boundary = resolve_media_reader_layout(nominal_width, preferences, previous=collapsed)
+    still_collapsed = resolve_media_reader_layout(nominal_width + LAYOUT_HYSTERESIS_WIDTH - 1, preferences, previous=boundary)
+    reopened = resolve_media_reader_layout(nominal_width + LAYOUT_HYSTERESIS_WIDTH, preferences, previous=boundary)
 
     assert collapsed.library_open is False
     assert boundary.library_open is False
     assert still_collapsed.library_open is False
     assert reopened.library_open is True
-    assert reopened.library_width == project_default_library_width(
-        nominal_width + LAYOUT_HYSTERESIS_WIDTH + 1
-    )
+    assert (reopened.library_width, reopened.items_width, reopened.reader_width) == (28, 40, 46)
 
 
 def test_shrink_expand_cycles_are_idempotent() -> None:

--- a/Tests/UI/test_library_adaptive_reader_shell.py
+++ b/Tests/UI/test_library_adaptive_reader_shell.py
@@ -130,11 +130,8 @@ def _painted_rows_containing(app: _ProbeApp, widget: Widget, token: str) -> list
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("grip_width", "arrow"),
-    # task-31633 AC#2: the grip width is the destination profile's, and the
-    # arrow is as wide as the grip. Five columns is the shared default Notes,
-    # File Notes and Prompts still use; one column is Media's, and since
-    # task-31951 also Conversations', Skills' and Collections'.
-    [(PANE_GRIP_WIDTH, "<---"), (MEDIA_READER_LAYOUT_PROFILE.grip_width, "‹")],
+    # Library destinations retain the full five-cell pointer target.
+    [(PANE_GRIP_WIDTH, "<---"), (MEDIA_READER_LAYOUT_PROFILE.grip_width, "<---")],
 )
 async def test_shell_mounts_three_concrete_widgets_and_two_profile_width_grips(
     grip_width: int,
@@ -748,12 +745,8 @@ def _painted_lines(host, region) -> list[str]:
         # 56 is the profile's list comfort ceiling, the same one the
         # library-closed branch of the resolver already uses.
         ((235, 52), 56, 46),
-        # 100x30 was 44 cells / 39 painted title characters while the two pane
-        # grips still cost five columns each (task-31633 AC#2). The Reader is
-        # on its 46-cell minimum here, so the eight cells the grips gave back
-        # went to the list -- and the same 98-character title now survives to
-        # the same 46 characters at BOTH sizes.
-        ((100, 30), 52, 46),
+        # Five-cell controls reserve ten columns while preserving the reader.
+        ((100, 30), 44, 39),
     ],
 )
 @pytest.mark.asyncio
@@ -807,16 +800,11 @@ async def test_media_items_pane_grows_with_the_terminal_once_reader_is_comfortab
 
 
 # ---------------------------------------------------------------------------
-# task-31633 AC#2: no 5-cell dead gutter between rail, list and Reader.
-#
-# Painted, not region-only: the gutter is the pane grip's own columns, and a
-# region assertion is blind to what those columns actually carry. The slice
-# bounds come from the pane regions, but every assertion below reads glyphs --
-# the panes' own border glyphs anchor the slice, and the slice itself must be
-# dead (the grip's arrow paints on its own rows, not on a list row).
-# ---------------------------------------------------------------------------
+# Five intentionally wide controls separate the panes. Measure their full
+# painted span, including the columns around the arrows, to protect the
+# pointer target that was previously mistaken for wasted gutter space.
 
-MAX_PANE_GUTTER_CELLS = 2
+PANE_CONTROL_CELLS = 5
 
 
 def _dead_gutters(host, screen, shell) -> tuple[str, str]:
@@ -830,7 +818,7 @@ def _dead_gutters(host, screen, shell) -> tuple[str, str]:
 
 
 @pytest.mark.asyncio
-async def test_no_dead_gutter_flanks_the_media_items_pane_at_235x52() -> None:
+async def test_full_width_collapse_controls_flank_the_media_items_pane_at_235x52() -> None:
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_two_media_items())
     host = LibraryProductionCSSHarness(app)
@@ -855,5 +843,5 @@ async def test_no_dead_gutter_flanks_the_media_items_pane_at_235x52() -> None:
 
         assert left_gutter.strip() == "", (left_gutter, painted)
         assert right_gutter.strip() == "", (right_gutter, painted)
-        assert len(left_gutter) <= MAX_PANE_GUTTER_CELLS, (left_gutter, painted)
-        assert len(right_gutter) <= MAX_PANE_GUTTER_CELLS, (right_gutter, painted)
+        assert len(left_gutter) == PANE_CONTROL_CELLS, (left_gutter, painted)
+        assert len(right_gutter) == PANE_CONTROL_CELLS, (right_gutter, painted)

--- a/Tests/UI/test_library_collections_reader_geometry.py
+++ b/Tests/UI/test_library_collections_reader_geometry.py
@@ -30,14 +30,10 @@ PREFERENCES = AdaptiveReaderLayoutPreferences()
 @pytest.mark.parametrize(
     ("width", "expected"),
     (
-        # task-31951 re-anchored these to the one-cell grip: each row gained
-        # the eight cells the two five-cell grips used to hold back, and the
-        # rail now opens at 114 instead of 122 -- which is why 120 flipped
-        # from a library-closed 56-cell list to the rail beside a 40-cell one.
-        (160, (30, 40, 88)),  # was (30, 40, 80)
-        (120, (24, 40, 54)),  # was (0, 56, 54)
-        (100, (0, 50, 48)),  # was (0, 42, 48)
-        (80, (0, 0, 78)),  # was (0, 0, 70)
+        (160, (35, 50, 65)),
+        (120, (0, 56, 54)),
+        (100, (0, 42, 48)),
+        (80, (0, 0, 70)),
     ),
 )
 def test_collections_profile_has_pinned_pure_geometry(width, expected) -> None:
@@ -91,8 +87,8 @@ async def test_mounted_collections_geometry_matches_one_settled_resolution(size)
         assert shell.items.region.width == expected.items_width
         assert shell.work.region.width == expected.reader_width
         # task-31951/31952: painted width IS the resolver's reservation.
-        assert shell.library_grip.region.width == 1
-        assert shell.items_grip.region.width == 1
-        assert expected.grip_width == 1
+        assert shell.library_grip.region.width == 5
+        assert shell.items_grip.region.width == 5
+        assert expected.grip_width == 5
         assert shell.work.is_mounted and shell.work.display
         assert sum(child.region.width for child in shell.children) == measured_width

--- a/Tests/UI/test_library_conversation_reader.py
+++ b/Tests/UI/test_library_conversation_reader.py
@@ -1991,10 +1991,8 @@ async def test_conversations_geometry_contains_protected_work_and_restore_grips(
         assert shell.work in visible and shell.region.contains_region(shell.work.region)
         for grip in (shell.library_grip, shell.items_grip):
             assert grip in visible
-            # task-31951: one cell, was 5 -- Conversations joined Media on
-            # the one-cell grip, so eight of the ten columns the two grips
-            # used to hold back are back in the panes.
-            assert grip.region.width == 1
+            # Keep the intentionally wide collapse targets on every reader.
+            assert grip.region.width == 5
             assert shell.region.contains_region(grip.region)
             assert grip.can_focus
         for pane, open_ in (

--- a/Tests/UI/test_library_layout_repair.py
+++ b/Tests/UI/test_library_layout_repair.py
@@ -1,0 +1,114 @@
+"""Keep Library's wide collapse targets and usable panes during resizing."""
+
+from pathlib import Path
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_library_adaptive_reader_shell import _ProbeApp
+from Tests.UI.test_library_media_side_by_side import (
+    _build_media_test_app,
+    _open_media_list,
+    _two_media_items,
+)
+from Tests.UI.test_library_shell import (
+    LibraryProductionCSSHarness,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_condition,
+)
+from tldw_chatbook.Library.library_media_reader_state import MEDIA_READER_LAYOUT_PROFILE
+from tldw_chatbook.UI.Library_Modules import screen_constants
+from tldw_chatbook.Utils.adaptive_reader_state import (
+    AdaptiveReaderLayoutPreferences,
+    AdaptiveReaderLayoutProfile,
+    resolve_adaptive_reader_layout,
+)
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
+    LibraryAdaptiveReaderShell,
+)
+
+
+PROFILES = {
+    name: profile
+    for name, profile in vars(screen_constants).items()
+    if isinstance(profile, AdaptiveReaderLayoutProfile)
+}
+PROFILES["media"] = MEDIA_READER_LAYOUT_PROFILE
+
+
+@pytest.mark.parametrize("profile", PROFILES.values(), ids=PROFILES.keys())
+@pytest.mark.parametrize("width", [100, 120, 160, 235])
+async def test_reader_keeps_usable_panes_and_five_cell_click_targets(profile, width):
+    layout = resolve_adaptive_reader_layout(
+        width, AdaptiveReaderLayoutPreferences(), profile
+    )
+    app = _ProbeApp(layout, grip_width=layout.grip_width)
+    async with app.run_test(size=(width, 30)) as pilot:
+        await pilot.pause()
+        shell = app.query_one("#probe-shell", LibraryAdaptiveReaderShell)
+        assert shell.items.display, "The list can still fit beside the reader"
+        if width > 120 or (width == 120 and profile.work_min_width <= 46):
+            assert shell.library.display, "All three panes can still fit"
+        assert shell.work.region.width >= profile.work_min_width
+        assert sum(child.region.width for child in shell.children) == width
+        for grip in (shell.library_grip, shell.items_grip):
+            assert grip.region.width == 5
+            # The outer column must be clickable, not just the arrow's cell.
+            await pilot.click(grip, offset=(4, grip.region.height // 2))
+        assert app.toggles == ["library", "items"]
+
+
+@pytest.mark.parametrize("width", [100, 124, 160])
+async def test_real_media_reader_preserves_visible_list_after_opening_item(
+    width, tmp_path
+):
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    host = LibraryProductionCSSHarness(app)
+    async with host.run_test(size=(160, 35)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        screen.query_one("#library-media-row-0", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._media_state.reader_session.loaded_id is not None,
+            message="Media reader did not open",
+        )
+        for _ in range(3):
+            await pilot.pause()
+        await pilot.resize_terminal(width, 35)
+        for _ in range(3):
+            await pilot.pause()
+        shell = screen.query_one(".library-media-route", LibraryAdaptiveReaderShell)
+        Path(tmp_path, f"media-{width}.svg").write_text(host.export_screenshot())
+        assert shell.items.display
+        assert shell.items.region.width >= MEDIA_READER_LAYOUT_PROFILE.list_min_width
+        assert shell.work.region.width >= MEDIA_READER_LAYOUT_PROFILE.work_min_width
+        if width >= 120:
+            assert shell.library.display
+        assert shell.library_grip.region.width == shell.items_grip.region.width == 5
+        for pane, grip in (
+            ("library", shell.library_grip),
+            ("items", shell.items_grip),
+        ):
+            if not getattr(shell, pane).display:
+                continue
+            await pilot.click(grip, offset=(4, grip.region.height // 2))
+            await _wait_for_condition(
+                pilot,
+                lambda: not getattr(shell, pane).display,
+                message=f"Click did not collapse {pane}",
+            )
+            grip.focus()
+            # Textual ignores another activation during a Button's click effect.
+            await _wait_for_condition(
+                pilot,
+                lambda: grip.has_focus and not grip.has_class("-active"),
+                message="Collapse button did not finish its click effect",
+            )
+            await pilot.press("enter")
+            await _wait_for_condition(
+                pilot,
+                lambda: getattr(shell, pane).display,
+                message=f"Enter did not restore {pane}",
+            )

--- a/Tests/UI/test_library_layout_repair.py
+++ b/Tests/UI/test_library_layout_repair.py
@@ -29,6 +29,10 @@ from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
 )
 
 
+# User-required click-target width, deliberately independent of the resolver.
+EXPECTED_PANE_GRIP_WIDTH = 5
+
+
 PROFILES = {
     name: profile
     for name, profile in vars(screen_constants).items()
@@ -53,9 +57,11 @@ async def test_reader_keeps_usable_panes_and_five_cell_click_targets(profile, wi
         assert shell.work.region.width >= profile.work_min_width
         assert sum(child.region.width for child in shell.children) == width
         for grip in (shell.library_grip, shell.items_grip):
-            assert grip.region.width == 5
+            assert grip.region.width == EXPECTED_PANE_GRIP_WIDTH
             # The outer column must be clickable, not just the arrow's cell.
-            await pilot.click(grip, offset=(4, grip.region.height // 2))
+            await pilot.click(
+                grip, offset=(EXPECTED_PANE_GRIP_WIDTH - 1, grip.region.height // 2)
+            )
         assert app.toggles == ["library", "items"]
 
 
@@ -86,14 +92,20 @@ async def test_real_media_reader_preserves_visible_list_after_opening_item(
         assert shell.work.region.width >= MEDIA_READER_LAYOUT_PROFILE.work_min_width
         if width >= 120:
             assert shell.library.display
-        assert shell.library_grip.region.width == shell.items_grip.region.width == 5
+        assert (
+            shell.library_grip.region.width
+            == shell.items_grip.region.width
+            == EXPECTED_PANE_GRIP_WIDTH
+        )
         for pane, grip in (
             ("library", shell.library_grip),
             ("items", shell.items_grip),
         ):
             if not getattr(shell, pane).display:
                 continue
-            await pilot.click(grip, offset=(4, grip.region.height // 2))
+            await pilot.click(
+                grip, offset=(EXPECTED_PANE_GRIP_WIDTH - 1, grip.region.height // 2)
+            )
             await _wait_for_condition(
                 pilot,
                 lambda: not getattr(shell, pane).display,

--- a/Tests/UI/test_library_media_reader_shell.py
+++ b/Tests/UI/test_library_media_reader_shell.py
@@ -28,12 +28,6 @@ from tldw_chatbook.Library.library_media_reader_state import (
     resolve_media_reader_layout,
 )
 
-# task-31633 AC#2: Media's grips are one cell each -- what they paint and what
-# the resolver holds back for them -- while every sibling reader keeps the
-# shared five (Tests/Library/test_library_adaptive_reader_state.py pins that).
-MEDIA_GRIP_WIDTH = MEDIA_READER_LAYOUT_PROFILE.grip_width
-MEDIA_GRIP_COLLAPSE = "‹"
-MEDIA_GRIP_EXPAND = "›"
 from tldw_chatbook.Library.library_media_viewer_state import (
     build_library_media_viewer_state,
 )
@@ -53,6 +47,11 @@ from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
     PaneToggleRequested as SharedPaneToggleRequested,
 )
 from tldw_chatbook.app import TldwCli
+
+# The profile reserves the same five-cell controls that the shell paints.
+MEDIA_GRIP_WIDTH = MEDIA_READER_LAYOUT_PROFILE.grip_width
+MEDIA_GRIP_COLLAPSE = "<---"
+MEDIA_GRIP_EXPAND = "--->"
 
 
 def _painted_text_in_region(app, region) -> str:
@@ -506,7 +505,7 @@ class _SixtyColumnMediaShellApp(ConsolidatedCSSApp):
 
 
 @pytest.mark.asyncio
-async def test_two_grips_leave_fifty_eight_columns_for_reader_at_sixty_shell_columns():
+async def test_two_grips_leave_fifty_columns_for_reader_at_sixty_shell_columns():
     app = _SixtyColumnMediaShellApp()
 
     async with app.run_test(size=(60, 24)) as pilot:
@@ -515,8 +514,7 @@ async def test_two_grips_leave_fifty_eight_columns_for_reader_at_sixty_shell_col
         reader = shell.query_one("#library-media-viewer", LibraryMediaViewer)
 
         assert shell.region.width == 60
-        # 50 while Media's two grips still cost five cells each.
-        assert reader.region.width == 58
+        assert reader.region.width == 50
         assert reader.region.right <= shell.region.right
         assert (
             sum(grip.region.width for grip in shell.query(".library-media-pane-grip"))

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -1718,16 +1718,12 @@ async def test_reader_body_wraps_at_a_reading_measure():
         await _open_first_reader_row(screen, pilot)
         box = screen.query_one("#library-media-viewer-content")
         body = screen.query_one("#library-media-viewer-content-text")
-        # task-31633: the Items column now takes half of the Reader's surplus
-        # and each grip costs one cell instead of five, so the Reader pane of
-        # the 231-cell shell is 139 cells rather than 147. The box still spans
-        # the whole pane -- only the prose inside it is capped.
+        # The box spans the full pane while the text retains its reading
+        # measure. Wider navigation and five-cell controls reduce the pane's
+        # spare columns without changing the prose cap.
         work = screen.query_one(".library-adaptive-reader-work")
         assert box.region.width == work.region.width, (box.region, work.region)
-        # The equality alone would also hold if the pane itself collapsed, so
-        # keep an absolute floor now that the pane width is dynamic. 139 is the
-        # measured pane width here, not a comfort minimum.
-        assert work.region.width >= 139, work.region
+        assert work.region.width > 92, work.region
         assert body.region.width <= 92, (body.region, box.region)
         # Painted proof the wrap index was built at the capped width: the
         # long line's tail lands on the row below it, not off at column 150.

--- a/Tests/UI/test_library_skills_reader.py
+++ b/Tests/UI/test_library_skills_reader.py
@@ -414,11 +414,9 @@ async def test_skills_reader_live_matrix_preserves_modes_work_floor_and_grips(
             await pilot.pause()
 
         assert shell.work.region.width >= 48
-        # task-31951: one cell each, was 5 -- Skills joined Media on the
-        # one-cell grip, so eight of the ten columns the two grips used to
-        # hold back are back in the panes.
-        assert shell.library_grip.region.width == 1
-        assert shell.items_grip.region.width == 1
+        # Keep the intentionally wide collapse targets on every reader.
+        assert shell.library_grip.region.width == 5
+        assert shell.items_grip.region.width == 5
         assert shell.library_grip.display and shell.items_grip.display
         assert screen.query_one("#library-skill-overview-region").display is True
 

--- a/backlog/decisions/086-library-adaptive-reader-shell.md
+++ b/backlog/decisions/086-library-adaptive-reader-shell.md
@@ -35,6 +35,12 @@ Library-to-canvas proportion as `floor((3W + 8) / 16) + 5` (exact halves round u
 29–39 cells. Ordinary destinations and adaptive readers project the same policy from their
 settled content width to exact cells. Ordinary destinations compress the result when necessary
 to preserve the 40-cell canvas minimum; adaptive readers retain resolver-owned collapse.
+Adaptive readers treat the added five Library cells and ten Items cells as
+preferred space: they use the preceding bounded rail width and 40-cell Items
+target to decide whether panes fit, then allocate spare space to the Library
+increase followed by the Items increase. This preserves the earlier collapse
+boundaries with the intentionally five-cell controls. Explicit reopening bypasses
+resize hysteresis for the requested pane; custom widths keep their exact policy.
 Destination Items preferences default to 50 cells. A zero-width pre-layout state remains an all-zero effective sentinel;
 36 is the representative new/reset preference value, not zero-width geometry.
 

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -13082,3 +13082,18 @@ failed too (`#library-notes-row-0` is a flat-list id; the tree indexes its
 note rows across its folder rows). That line was already red at the wave base,
 which had never reached it — a test that fails early hides whatever fails
 later, so re-run to green rather than to "past my line".
+
+## Pane controls are intentional click targets, and width increases need narrow-view checks
+
+**PR #2550 follow-up, 2026-09-09.** The user reported broken Library layouts and
+rejected one-cell collapse controls. The controls had been narrowed by earlier
+changes that treated their five-cell regions as dead gutters. PR #2550 then made
+larger preferred pane widths into larger collapse thresholds; its tests were
+updated to accept earlier disappearance. Restoring five-cell controls alone would
+hide both navigation and Items at 100 columns. The correction reserves the full
+click targets and gives up only the added default space before collapsing panes.
+
+**What to do.** Verify the complete painted view and click the outer cells of
+controls before treating blank space as removable. Test resize and explicit
+reopening with a selected item as well as an empty reader. Do not turn a new
+collapse boundary into a test expectation without checking the user's workflow.

--- a/backlog/tasks/task-32184 - Restore-Library-collapse-controls-and-preserve-usable-narrow-layouts.md
+++ b/backlog/tasks/task-32184 - Restore-Library-collapse-controls-and-preserve-usable-narrow-layouts.md
@@ -1,0 +1,47 @@
+---
+id: TASK-32184
+title: Restore Library collapse controls and preserve usable narrow layouts
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-09 19:35'
+updated_date: '2026-09-09 19:51'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Correct the Library layout regression reported after PR #2550 and restore the intentionally wide collapse controls.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Every Library reader retains full-height five-cell collapse controls with working pointer and keyboard targets.
+- [x] #2 The requested wider default columns fit without hiding a list or rail that can still fit beside the reader.
+- [x] #3 Production-styled rendered checks cover narrow and wide layouts, populated readers, and collapse and restore interactions.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce the five-cell grip and narrow-view regressions with the production Library shell and CSS.
+2. Restore five-cell collapse controls and make automatic preferred widths yield to available space before a still-usable pane disappears; retain custom-width behavior.
+3. Verify populated and empty readers at narrow and wide sizes, including pointer/keyboard collapse and restore; review the correction.
+ADR required: no
+ADR path: backlog/decisions/086-library-adaptive-reader-shell.md
+Reason: repair the existing adaptive geometry and control-size contract; no new ownership or architecture.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Restored the shared five-cell collapse controls on Media, Conversations, Skills and Collections. Automatic layouts surrender only the added five Library and ten Items cells before using the earlier collapse boundaries; wide layouts recover the requested increases. Explicit reopen bypasses resize hysteresis for its requested pane. Custom-width handling, reader floors and saved preferences remain intact.
+
+Changed the four production width/profile files, added rendered click-and-keyboard regressions, updated affected geometry expectations, and clarified the guide and ADR-086. No new ADR required: this repairs the existing geometry and control-size contract.
+
+Validation: 460 focused layout tests passed; 109 Media/Conversations/Skills interaction tests passed; Ruff and diff checks passed. Independent review found and verified the explicit-reopen edge fix. Production-CSS captures inspected at terminal widths100,124,160; Media shell width is100 in compact mode,120 at terminal124, and156 at terminal160.
+
+Adjacent check: test_more_stays_compact_at_the_narrow_reader_width still fails because Move to trash is clipped. Reproduced unchanged on the original PR branch938a1d8b; it predates this repair and is not hidden by a changed expectation.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_media_reader_state.py
+++ b/tldw_chatbook/Library/library_media_reader_state.py
@@ -39,9 +39,6 @@ MEDIA_READER_LAYOUT_PROFILE = AdaptiveReaderLayoutProfile(
     # the LIST rather than an empty Reader (60x24 showed neither a list nor a
     # way back to the rail).
     list_first_when_empty=True,
-    # task-31633 AC#2: one cell per grip, not five. Ten dead columns flanked
-    # the Items pane, so the widest terminal painted the narrowest list.
-    grip_width=1,
 )
 normalize_media_reader_preferences = normalize_adaptive_reader_preferences
 

--- a/tldw_chatbook/UI/Library_Modules/screen_constants.py
+++ b/tldw_chatbook/UI/Library_Modules/screen_constants.py
@@ -45,19 +45,11 @@ from ...Widgets.Library import PROMPT_DISCARD_TOOLTIP_BUSY
 LIBRARY_SKILLS_IMPORT_WORKER_GROUP = "library_skills_import"
 
 
-# task-31951: Conversations, Skills and Collections join Media on the
-# one-cell grip (task-31633 AC#2 shipped it for Media alone). Each surface was
-# spending ten columns on two five-column grips that paint a single arrow;
-# the resolver reserves what the grip paints, so eight of those ten cells now
-# go to the panes (the two the one-cell grips paint stay reserved) -- and the
-# rail-open threshold drops by the same eight (118 -> 110 here,
-# 122 -> 114 on Skills and Collections), the ordinary consequence of a
-# cheaper `required_width()`. Notes, File Notes and Prompts keep the default.
-LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile(grip_width=1)
+# All destinations retain the shared five-cell collapse controls.
+LIBRARY_CONVERSATION_READER_PROFILE = AdaptiveReaderLayoutProfile()
 LIBRARY_COLLECTIONS_READER_PROFILE = AdaptiveReaderLayoutProfile(
     work_min_width=48,
     work_comfort_width=56,
-    grip_width=1,
 )
 # task-32127: Notes joined Media on `list_grows` and raised its comfort
 # ceiling to 64. At 235 columns the list was pinned at the 40-cell target
@@ -72,7 +64,6 @@ LIBRARY_FILE_NOTES_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=3
 LIBRARY_PROMPTS_READER_PROFILE = AdaptiveReaderLayoutProfile(work_min_width=48)
 LIBRARY_SKILLS_READER_PROFILE = AdaptiveReaderLayoutProfile(
     work_min_width=48,
-    grip_width=1,
 )
 LIBRARY_CONVERSATION_READER_MAX_CHARS = 8000
 LIBRARY_SOURCE_PAGE_SIZES = {

--- a/tldw_chatbook/Utils/adaptive_reader_state.py
+++ b/tldw_chatbook/Utils/adaptive_reader_state.py
@@ -19,6 +19,7 @@ from typing import Any, Literal, Mapping
 
 from .library_rail_width import (
     LIBRARY_CUSTOM_MAX_WIDTH,
+    LIBRARY_DEFAULT_EXTRA_WIDTH,
     LIBRARY_EMERGENCY_WIDTH,
     LIBRARY_MIN_WIDTH,
     LIBRARY_REFERENCE_WIDTH,
@@ -28,6 +29,7 @@ from .library_rail_width import (
 LIBRARY_TARGET_WIDTH = LIBRARY_REFERENCE_WIDTH
 LIBRARY_MAX_WIDTH = LIBRARY_CUSTOM_MAX_WIDTH
 ITEMS_TARGET_WIDTH = 50
+ITEMS_DEFAULT_EXTRA_WIDTH = 10
 ITEMS_MIN_WIDTH = 32
 ITEMS_MAX_WIDTH = 72
 READER_COMFORT_WIDTH = 44
@@ -80,11 +82,8 @@ class AdaptiveReaderLayoutProfile:
         grip_width: Width of EACH of the two pane grips -- both what a grip
             paints and what the resolver holds back for it, so the two can
             never disagree (the resolved layout carries this width to the
-            shell). Defaults to ``PANE_GRIP_WIDTH`` (5). Media passes 1: its
-            two five-column grips left ten dead columns around the Items pane
-            (task-31633 AC#2), and task-31951 opted Conversations, Skills and
-            Collections in for the same reason. A grip narrower than four
-            cells paints the one-cell guillemet instead of the ``<---`` run.
+            shell). Every Library destination uses ``PANE_GRIP_WIDTH`` (5):
+            the full-height controls are deliberately wide pointer targets.
     """
 
     list_min_width: int = 32
@@ -280,6 +279,7 @@ def resolve_adaptive_reader_layout(
         if preferences.custom_widths_enabled
         else project_default_library_width(width)
     )
+    explicit_priority = priority
     if priority is None and previous is not None:
         inherited = previous.priority_pane
         if (
@@ -292,6 +292,20 @@ def resolve_adaptive_reader_layout(
 
     grip_width = 2 * profile.grip_width
     work_min_width = max(profile.work_min_width, 0)
+    # The added default space is preferred, not a new collapse threshold.
+    # Keep the established narrow layout before allocating the extra cells.
+    # Explicit custom widths retain their existing exact-width policy.
+    library_fit_width = requested_library_width
+    items_fit_width = preferences.items_width
+    if not preferences.custom_widths_enabled:
+        library_fit_width -= LIBRARY_DEFAULT_EXTRA_WIDTH
+        items_fit_width = min(
+            preferences.items_width,
+            max(
+                profile.list_min_width,
+                preferences.items_width - ITEMS_DEFAULT_EXTRA_WIDTH,
+            ),
+        )
     library_open = preferences.library_open
     items_open = preferences.items_open
     if priority is not None:
@@ -302,8 +316,8 @@ def resolve_adaptive_reader_layout(
 
         full_width = (
             grip_width
-            + (requested_library_width if library_open else 0)
-            + (preferences.items_width if items_open else 0)
+            + (library_fit_width if library_open else 0)
+            + (items_fit_width if items_open else 0)
             + work_min_width
         )
         if width < full_width:
@@ -347,8 +361,8 @@ def resolve_adaptive_reader_layout(
     def required_width(open_library: bool, open_items: bool) -> int:
         return (
             grip_width
-            + (requested_library_width if open_library else 0)
-            + (preferences.items_width if open_items else 0)
+            + (library_fit_width if open_library else 0)
+            + (items_fit_width if open_items else 0)
             + work_min_width
         )
 
@@ -362,12 +376,14 @@ def resolve_adaptive_reader_layout(
         if (
             library_open
             and not previous.library_open
+            and explicit_priority != "library"
             and width < nominal_width + LAYOUT_HYSTERESIS_WIDTH
         ):
             library_open = False
         if (
             items_open
             and not previous.items_open
+            and explicit_priority != "items"
             and width
             < required_width(library_open, items_open) + LAYOUT_HYSTERESIS_WIDTH
         ):
@@ -416,8 +432,17 @@ def resolve_adaptive_reader_layout(
             grip_width=profile.grip_width,
         )
 
-    library_width = requested_library_width if library_open else 0
-    items_width = preferences.items_width if items_open else 0
+    library_width = library_fit_width if library_open else 0
+    items_width = items_fit_width if items_open else 0
+    spare_width = max(
+        width - grip_width - library_width - items_width - work_min_width, 0
+    )
+    if library_open:
+        extra = min(requested_library_width - library_width, spare_width)
+        library_width += extra
+        spare_width -= extra
+    if items_open:
+        items_width += min(preferences.items_width - items_width, spare_width)
     if items_open and not library_open:
         # task-31953: this clamp is deliberately NOT gated on
         # `custom_widths_enabled` -- with the Library pane gone a typed 32

--- a/tldw_chatbook/Utils/library_rail_width.py
+++ b/tldw_chatbook/Utils/library_rail_width.py
@@ -11,6 +11,7 @@ from dataclasses import dataclass
 from enum import Enum
 
 LIBRARY_REFERENCE_WIDTH = 36
+LIBRARY_DEFAULT_EXTRA_WIDTH = 5
 LIBRARY_MIN_WIDTH = 24
 LIBRARY_DEFAULT_MIN_WIDTH = 29
 LIBRARY_DEFAULT_MAX_WIDTH = 39
@@ -55,7 +56,7 @@ def project_default_library_width(content_width: int) -> int:
         ValueError: If ``content_width`` is not a positive integer, including bool.
     """
     _require_positive_content_width(content_width)
-    fractional_width = (3 * content_width + 8) // 16 + 5
+    fractional_width = (3 * content_width + 8) // 16 + LIBRARY_DEFAULT_EXTRA_WIDTH
     return min(
         max(fractional_width, LIBRARY_DEFAULT_MIN_WIDTH), LIBRARY_DEFAULT_MAX_WIDTH
     )


### PR DESCRIPTION
Restores the intentionally wide, full-height five-cell collapse controls on Media, Conversations, Skills, and Collections. PR #2550 also turned the requested extra column space into larger collapse thresholds. Automatic layouts now give up those extra five Library cells and ten Items cells before collapsing panes, and restore the wider defaults when space permits.

Explicitly reopening a pane takes effect immediately even at a resize hysteresis boundary. Custom widths, reader minimums, and saved choices retain their existing behavior.

Validation:
- 460 focused resolver and production-CSS layout tests passed, including clicks on the outermost control cell and keyboard restoration.
- 109 Media, Conversations, and Skills interaction tests passed.
- Rendered Media captures inspected at terminal widths 100, 124, and 160; independent review completed; Ruff and diff checks passed.
- Perf Guard inherits the existing dev CSS-byte-budget failure: all six measured stylesheets are byte-identical to base dev, totaling 805,669 bytes against the unchanged 804,000 limit. The latency tests passed. Base dev fails the same workflow: https://github.com/rmusser01/tldw_chatbook/actions/runs/34397408881.
- An adjacent More-menu test still reports a clipped “Move to trash” label. The same failure was reproduced on the original PR branch before this repair; its expectation was not changed.

Tracks TASK-32184; clarifies the existing ADR-086 contract.
