### PR TITLE
feat(console): integrate template-aware local thinking replay

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -308,6 +308,27 @@ to hidden chain-of-thought.
   does not disable capture, saved history, compatible replay, or token
   accounting.
 
+For local models, **Settings > Console Behavior > Reasoning history** refines a
+conversation's **Auto** replay policy. **Automatic** is the default: reviewed
+server templates select either the current exchange (including its tool calls)
+or all available compatible thinking. An unrecognized or unavailable template
+uses the server default. You can choose **Current exchange**, **All available**,
+or **Off**, globally or for the active endpoint and model. A target override can
+be cleared with **Use default**. These choices never erase saved thinking. **All available** includes compatible
+fields in the request; the server template can still omit older reasoning. For
+example, Gemma 4 can preserve older tool-call thinking while omitting older final
+answer thinking.
+
+Conversation **Include** explicitly requests all compatible thinking; **Exclude**
+disables optional replay. Provider-required continuation remains **Required**.
+Settings shows the last detected template policy after a send. llama.cpp reports
+native tool support through its template capabilities; for vLLM or Ollama, enable
+the separate server native-tool option only when that endpoint is configured for
+native tool calls. The option is remembered for that endpoint and model. Gemma
+needs the native protocol to retain thinking across tool rounds: legacy fenced
+tool results appear to its template as new user messages and may discard even
+the active round's reasoning. The original trace remains available for review.
+
 If a persistent conversation backend cannot round-trip the adapter's resolved
 thinking format, Console refuses the send before contacting the provider and
 asks you to upgrade the backend. The draft remains available to retry, and no

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -11491,6 +11491,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1351,
-    "task_494_calls": 7659
+    "task_494_calls": 7660
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -4138,8 +4138,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 115,
-      "diagnostic_digest": "345819bc1ea2d921cbb1",
+      "call_count": 116,
+      "diagnostic_digest": "1a9fbd4b080ba48fbe99",
       "owner": "TASK-494",
       "path": "tldw_chatbook/config.py",
       "reason": "remaining Chatbook production diagnostic owner"

--- a/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
+++ b/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
@@ -1,0 +1,57 @@
+# Console local reasoning integration plan
+
+> **For agentic workers:** Use subagent-driven-development for the independent surfaces below; root owns integration and review. User has authorized rebase, review fixes and merge of PR 2575.
+
+**Goal:** Complete TASK-32273 and merge PR 2575 with model-aware local reasoning replay on current dev.
+**Architecture:** Keep ADR-090 canonical ThinkingEnvelope, typed provider events, generation ownership and trace admission. Replay settings refine optional conversation Auto; explicit Include/Exclude and Required retain their existing authority. Optional history is projected before serialization and accounting.
+**Tech Stack:** Python 3.12, Textual 8, SQLite, httpx, pytest.
+**Spec:** backlog/decisions/090-console-thinking-block-ownership-and-replay.md (integration amendment below).
+
+ADR required: yes.
+ADR path: backlog/decisions/090-console-thinking-block-ownership-and-replay.md.
+Reason: amend the existing provider/history interface without a second storage schema or parallel display system.
+
+## Global constraints
+- Only the isolated console-reasoning-history worktree may be edited. Keep the draft backup ref.
+- Preserve canonical thinking and continuation through variants, persistence, imports, exports and sync. No raw private hosted thinking exposure.
+- Optional Exclude wins; Required continuation is never removed. Explicit conversation Include retains strict compatibility errors and requests all eligible local history. Auto uses local global/endpoint-model preference (auto/current/all/off).
+- Review template fingerprints already captured in Tests/fixtures/reasoning_templates; unknown templates use server defaults. Native tools require declared support or explicit remembered configuration.
+- No full suite; focused tests plus relevant preflight guards. No merge until Qodo review of the final change and required checks are resolved.
+
+## Shared interfaces
+`local_reasoning.py` owns immutable `ReasoningReplayPolicy(mode, source, template_family='', supports_preserve=False, verified=False, native_tools=False)`, existing `resolve_reasoning_policy`, `reasoning_override_key`, `reasoning_mode_setting`, `reasoning_replay_context`, `apply_local_reasoning_template_options`, `supports_local_reasoning`, `REASONING_HISTORY_OPTIONS`.
+`ConsoleProviderResolution.reasoning_replay: ReasoningReplayPolicy | None` freezes policy for the request. `ThinkingReplayTarget.reasoning_replay` carries it into canonical history resolution. No persisted LocalReasoningReplay body.
+`AgentConfig.reasoning_replay` passes policy to native-tool selection, budget estimation and child config. Internal per-call thinking references are consumed in the bridge before preparation; canonical envelopes remain the only thinking source.
+Runtime guidance uses `EXCHANGE_CONTINUATION_KEY = '_tldw_exchange_continuation'`; real user rows start exchanges; fenced tool rows and project instructions do not.
+
+## Task 1: Canonical history and template policy (history worker)
+Files: Chat/local_reasoning.py, console_thinking_history.py, console_prepared_request.py, console_history_budget.py; focused history tests.
+- [ ] Replace original duplicate replay records with policy-only helpers; preserve reviewed fixtures.
+- [ ] Add failing tests using canonical ThinkingEnvelope sidecars: structured reasoning_content/reasoning serialization, current vs old owner groups, Off/Exclude, Include safety, same-model/provider-family eligibility, no tool-trace aggregation.
+- [ ] Implement policy projection on complete semantic units, filtering matching thinking provenance with the same groups. Serialization and provenance must agree on both content and separate reasoning fields.
+- [ ] Preserve runtime guidance as current exchange, and reviewed Gemma/Qwen rendered templates without losing provenance. Coordinate row-shape changes with root before implementing.
+- [ ] Run focused thinking history/prepared-request tests and report evidence. Do not commit during root's rebase.
+
+## Task 2: Per-call agent ownership (agent worker)
+Files: Chat/console_agent_bridge.py, console_thinking_capture.py; Agents/agent_models.py, agent_service.py, agent_runtime.py, native_tools.py; focused agent tests.
+- [ ] Add failing active native-tool regression using typed thinking events and canonical envelopes, not fabricated aggregate text.
+- [ ] Carry exact successful per-call canonical thinking through assistant echoes, consumed before gateway/trace preparation. A child owns only its own call thinking and inherits policy.
+- [ ] Distinguish tool-round thinking from final-answer reasoning in canonical source provenance so saved tool traces cannot be replayed as final-answer thoughts. A final call without reasoning must not inherit an earlier tool thought.
+- [ ] Pin policy to AgentConfig; count the same projected fields sent, preserve native protocol independently from Off, annotate runtime guidance as exchange continuation.
+- [ ] Run focused agent and capture tests and report evidence. Do not commit during root's rebase.
+
+## Task 3: Canonical settings (settings worker)
+Files: config.py, UI/Screens/settings_screen.py, Tests/UI/test_settings_console_reasoning_history.py.
+- [ ] Add mounted UI/persistence tests for Automatic default, current/all/off, normalized endpoint/model overrides, clear override, explicit native-server setting.
+- [ ] Port the original draft replay controls from backup ref, retain existing dev Show model thinking UI and conversation Auto/Include/Exclude. Explain that controls refine conversation Auto.
+- [ ] Reuse endpoint/config authority and snapshots; no duplicate show_thinking toggle or legacy display callback.
+- [ ] Run focused mounted tests and report evidence. Do not commit during root's rebase.
+
+## Task 4: Gateway and integrated verification (root)
+Files: Chat/console_provider_gateway.py, Chat/Chat_Functions.py, LLM_Calls/LLM_API_Calls_Local.py, provider/trace regressions, user guide.
+- [ ] Add failing structured local reasoning capture and native-tool transport tests at real adapter boundaries.
+- [ ] Resolve bounded template metadata against the frozen endpoint each send; carry immutable policy. Retain existing trace admission and exact serialized payloads.
+- [ ] Emit typed local reasoning events for declared formats, support native local tool responses and template preservation options, with streaming and non-streaming parity.
+- [ ] Integrate workers; run canonical persistence/display, provider/prepared/trace/agent/UI regression matrix and available live Gemma checks.
+- [ ] Review final diff independently, finish rebase, push with exact force-with-lease, update PR description and mark ready for Qodo.
+- [ ] Address review comments with evidence, rerun affected checks, confirm reviewed commit/checks/base, then merge as authorized.

--- a/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
+++ b/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
@@ -26,32 +26,32 @@ Runtime guidance uses `EXCHANGE_CONTINUATION_KEY = '_tldw_exchange_continuation'
 
 ## Task 1: Canonical history and template policy (history worker)
 Files: Chat/local_reasoning.py, console_thinking_history.py, console_prepared_request.py, console_history_budget.py; focused history tests.
-- [ ] Replace original duplicate replay records with policy-only helpers; preserve reviewed fixtures.
-- [ ] Add failing tests using canonical ThinkingEnvelope sidecars: structured reasoning_content/reasoning serialization, current vs old owner groups, Off/Exclude, Include safety, same-model/provider-family eligibility, no tool-trace aggregation.
-- [ ] Implement policy projection on complete semantic units, filtering matching thinking provenance with the same groups. Serialization and provenance must agree on both content and separate reasoning fields.
-- [ ] Preserve runtime guidance as current exchange, and reviewed Gemma/Qwen rendered templates without losing provenance. Coordinate row-shape changes with root before implementing.
-- [ ] Run focused thinking history/prepared-request tests and report evidence. Do not commit during root's rebase.
+- [x] Replace original duplicate replay records with policy-only helpers; preserve reviewed fixtures.
+- [x] Add failing tests using canonical ThinkingEnvelope sidecars: structured reasoning_content/reasoning serialization, current vs old owner groups, Off/Exclude, Include safety, same-model/provider-family eligibility, no tool-trace aggregation.
+- [x] Implement policy projection on complete semantic units, filtering matching thinking provenance with the same groups. Serialization and provenance must agree on both content and separate reasoning fields.
+- [x] Preserve runtime guidance as current exchange, and reviewed Gemma/Qwen rendered templates without losing provenance. Coordinate row-shape changes with root before implementing.
+- [x] Run focused thinking history/prepared-request tests and report evidence. Do not commit during root's rebase.
 
 ## Task 2: Per-call agent ownership (agent worker)
 Files: Chat/console_agent_bridge.py, console_thinking_capture.py; Agents/agent_models.py, agent_service.py, agent_runtime.py, native_tools.py; focused agent tests.
-- [ ] Add failing active native-tool regression using typed thinking events and canonical envelopes, not fabricated aggregate text.
-- [ ] Carry exact successful per-call canonical thinking through assistant echoes, consumed before gateway/trace preparation. A child owns only its own call thinking and inherits policy.
-- [ ] Distinguish tool-round thinking from final-answer reasoning in canonical source provenance so saved tool traces cannot be replayed as final-answer thoughts. A final call without reasoning must not inherit an earlier tool thought.
-- [ ] Pin policy to AgentConfig; count the same projected fields sent, preserve native protocol independently from Off, annotate runtime guidance as exchange continuation.
-- [ ] Run focused agent and capture tests and report evidence. Do not commit during root's rebase.
+- [x] Add failing active native-tool regression using typed thinking events and canonical envelopes, not fabricated aggregate text.
+- [x] Carry exact successful per-call canonical thinking through assistant echoes, consumed before gateway/trace preparation. A child owns only its own call thinking and inherits policy.
+- [x] Distinguish tool-round thinking from final-answer reasoning in canonical source provenance so saved tool traces cannot be replayed as final-answer thoughts. A final call without reasoning must not inherit an earlier tool thought.
+- [x] Pin policy to AgentConfig; count the same projected fields sent, preserve native protocol independently from Off, annotate runtime guidance as exchange continuation.
+- [x] Run focused agent and capture tests and report evidence. Do not commit during root's rebase.
 
 ## Task 3: Canonical settings (settings worker)
 Files: config.py, UI/Screens/settings_screen.py, Tests/UI/test_settings_console_reasoning_history.py.
-- [ ] Add mounted UI/persistence tests for Automatic default, current/all/off, normalized endpoint/model overrides, clear override, explicit native-server setting.
-- [ ] Port the original draft replay controls from backup ref, retain existing dev Show model thinking UI and conversation Auto/Include/Exclude. Explain that controls refine conversation Auto.
-- [ ] Reuse endpoint/config authority and snapshots; no duplicate show_thinking toggle or legacy display callback.
-- [ ] Run focused mounted tests and report evidence. Do not commit during root's rebase.
+- [x] Add mounted UI/persistence tests for Automatic default, current/all/off, normalized endpoint/model overrides, clear override, explicit native-server setting.
+- [x] Port the original draft replay controls from backup ref, retain existing dev Show model thinking UI and conversation Auto/Include/Exclude. Explain that controls refine conversation Auto.
+- [x] Reuse endpoint/config authority and snapshots; no duplicate show_thinking toggle or legacy display callback.
+- [x] Run focused mounted tests and report evidence. Do not commit during root's rebase.
 
 ## Task 4: Gateway and integrated verification (root)
 Files: Chat/console_provider_gateway.py, Chat/Chat_Functions.py, LLM_Calls/LLM_API_Calls_Local.py, provider/trace regressions, user guide.
-- [ ] Add failing structured local reasoning capture and native-tool transport tests at real adapter boundaries.
-- [ ] Resolve bounded template metadata against the frozen endpoint each send; carry immutable policy. Retain existing trace admission and exact serialized payloads.
-- [ ] Emit typed local reasoning events for declared formats, support native local tool responses and template preservation options, with streaming and non-streaming parity.
-- [ ] Integrate workers; run canonical persistence/display, provider/prepared/trace/agent/UI regression matrix and available live Gemma checks.
-- [ ] Review final diff independently, finish rebase, push with exact force-with-lease, update PR description and mark ready for Qodo.
+- [x] Add failing structured local reasoning capture and native-tool transport tests at real adapter boundaries.
+- [x] Resolve bounded template metadata against the frozen endpoint each send; carry immutable policy. Retain existing trace admission and exact serialized payloads.
+- [x] Emit typed local reasoning events for declared formats, support native local tool responses and template preservation options, with streaming and non-streaming parity.
+- [x] Integrate workers; run canonical persistence/display, provider/prepared/trace/agent/UI regression matrix and available live Gemma checks.
+- [x] Review final diff independently, finish rebase, push with exact force-with-lease, update PR description and mark ready for Qodo.
 - [ ] Address review comments with evidence, rerun affected checks, confirm reviewed commit/checks/base, then merge as authorized.

--- a/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
+++ b/Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md
@@ -54,4 +54,5 @@ Files: Chat/console_provider_gateway.py, Chat/Chat_Functions.py, LLM_Calls/LLM_A
 - [x] Emit typed local reasoning events for declared formats, support native local tool responses and template preservation options, with streaming and non-streaming parity.
 - [x] Integrate workers; run canonical persistence/display, provider/prepared/trace/agent/UI regression matrix and available live Gemma checks.
 - [x] Review final diff independently, finish rebase, push with exact force-with-lease, update PR description and mark ready for Qodo.
-- [ ] Address review comments with evidence, rerun affected checks, confirm reviewed commit/checks/base, then merge as authorized.
+- [x] Address all 11 Qodo findings with evidence and rerun affected checks; Qodo verified e3e8431816 with zero bugs and zero rule violations. Post-rebase focused checks: 62 passed.
+- Merge gate: confirm final GitHub checks and reviewed head/base, then merge PR 2575 as authorized. The PR records the final merge result.

--- a/Tests/Agents/test_agent_service.py
+++ b/Tests/Agents/test_agent_service.py
@@ -460,7 +460,7 @@ def test_catalog_schema_tokens_measures_one_complete_native_schema_set(monkeypat
 
     monkeypatch.setattr(agent_service, "estimate_tokens", estimate)
     monkeypatch.setattr(
-        agent_service, "provider_supports_native_tools", lambda _endpoint: True
+        agent_service, "provider_supports_native_tools", lambda _endpoint, **_kwargs: True
     )
 
     assert (

--- a/Tests/Agents/test_fleet_continuation.py
+++ b/Tests/Agents/test_fleet_continuation.py
@@ -84,6 +84,7 @@ from tldw_chatbook.Agents.fleet_coordinator import (
     DEFAULT_RETAINED_TRANSCRIPTS,
     FleetCoordinator,
 )
+from tldw_chatbook.Chat.local_reasoning import EXCHANGE_CONTINUATION_KEY
 from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
 
 # LoopDeps plumbing shared with the Task 1 suite (one `make_deps`, one
@@ -421,7 +422,7 @@ def test_delivered_steering_rides_the_coherent_transcript():
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": fence_text},
         {"role": "user", "content": f"{FENCE_TOOL_RESULT_PREFIX}calculator: 42"},
-        {"role": "user", "content": labeled},
+        {"role": "user", "content": labeled, EXCHANGE_CONTINUATION_KEY: True},
         {"role": "assistant", "content": "done."},
     ]
 
@@ -841,7 +842,7 @@ def test_send_to_agent_to_a_finished_child_starts_a_resumed_seeded_run(db):
     resumed_payload = original_calls[2]["messages_payload"]
     assert resumed_payload[0]["role"] == "system"
     assert resumed_payload[1:] == retained_history + [
-        {"role": "user", "content": labeled}
+        {"role": "user", "content": labeled, EXCHANGE_CONTINUATION_KEY: True}
     ]
 
     # Lineage: a NEW row, resumed_from the OLD run, parented to the
@@ -1362,8 +1363,16 @@ def test_undelivered_queued_steering_rides_the_seed_with_original_labels(db):
     )
     # Original label, original position: queued remnant FIRST, the new
     # supervisor message LAST.
-    assert resumed_payload[-2] == {"role": "user", "content": user_labeled}
-    assert resumed_payload[-1] == {"role": "user", "content": supervisor_labeled}
+    assert resumed_payload[-2] == {
+        "role": "user",
+        "content": user_labeled,
+        EXCHANGE_CONTINUATION_KEY: True,
+    }
+    assert resumed_payload[-1] == {
+        "role": "user",
+        "content": supervisor_labeled,
+        EXCHANGE_CONTINUATION_KEY: True,
+    }
 
 
 def test_retained_live_send_preserves_its_cause_on_resumed_steering(db):

--- a/Tests/Chat/test_console_agent_bridge.py
+++ b/Tests/Chat/test_console_agent_bridge.py
@@ -880,7 +880,7 @@ def test_fenced_nested_delivery_counts_exact_transformed_payload_before_mark(
     )
     events = []
     monkeypatch.setattr(agent_service_module, "get_model_token_limit", lambda *_: 100)
-    monkeypatch.setattr(agent_service_module, "_count_model_messages", lambda *_: 10)
+    monkeypatch.setattr(agent_service_module, "_count_model_messages", lambda *_, **_kwargs: 10)
     monkeypatch.setattr(
         bridge_module, "get_model_token_limit", lambda *_: 100, raising=False
     )

--- a/Tests/Chat/test_console_agent_call_thinking.py
+++ b/Tests/Chat/test_console_agent_call_thinking.py
@@ -1,0 +1,728 @@
+"""Local tool calls retain their own canonical thinking through the live loop."""
+
+from dataclasses import replace
+
+from Tests.Chat.test_console_agent_bridge import (
+    _bridge_with_gateway,
+    _ChunkGateway,
+    _native_calls,
+    _native_resolution,
+    _run,
+)
+from tldw_chatbook.Chat.console_provider_gateway import ProviderThinkingDelta
+from tldw_chatbook.Chat.console_thinking_capture import ThinkingCapture
+
+
+def _delta(text):
+    return ProviderThinkingDelta(
+        text=text,
+        provider="llama_cpp",
+        model="reasoner",
+        protocol="chat_completions",
+        source_format="reasoning_content",
+    )
+
+
+def test_aggregate_tool_thinking_cannot_become_final_answer_thinking():
+    capture = ThinkingCapture(assistant_owner_id="answer")
+    capture.observe(_delta("tool thought"))
+    capture.observe_tool()
+    capture.observe_answer("final answer without thinking")
+    envelope = capture.settle("complete").envelope
+    assert envelope.blocks[0].source_format == "reasoning_content:tool_call"
+
+
+def test_live_native_loop_passes_exact_call_envelope_before_preparation(tmp_path):
+    class Gateway(_ChunkGateway):
+        def __init__(self):
+            super().__init__(
+                [
+                    [
+                        _delta("first tool"),
+                        _native_calls("calculator", {"expression": "1+1"}),
+                    ],
+                    [
+                        _delta("second tool"),
+                        _native_calls("calculator", {"expression": "2+2"}, "c2"),
+                    ],
+                    ["The answer is 4."],
+                ]
+            )
+            self.prepared = []
+
+        def prepare_chat_request(self, resolution, messages, **kwargs):
+            self.prepared.append((messages, kwargs["thinking_sidecar"]))
+            return messages
+
+    gateway = Gateway()
+    bridge, db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    outcome = _run(bridge, store, session, aid, resolution=_native_resolution())
+    assert outcome.final_text == "The answer is 4."
+    assert len(gateway.prepared) == 2
+    rows, sidecars = gateway.prepared[-1]
+    assert [s.envelope.blocks[0].text for s in sidecars] == [
+        "first tool",
+        "second tool",
+    ]
+    assert all(
+        s.envelope.blocks[0].source_format == "reasoning_content" for s in sidecars
+    )
+    assert all(s.envelope.blocks[0].status == "complete" for s in sidecars)
+    for row, sidecar in zip([r for r in rows if r.get("tool_calls")], sidecars):
+        assert sidecar.owner_message_id in row.values()
+        assert "_tldw_call_thinking" not in row
+    assert all(
+        block.source_format.endswith(":tool_call")
+        for block in store.get_message(aid).thinking.blocks
+    )
+    db.close()
+
+
+def test_local_native_capability_is_independent_of_reasoning_off():
+    from tldw_chatbook.Agents.native_tools import provider_supports_native_tools
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    enabled = ReasoningReplayPolicy("off", "override", native_tools=True)
+    disabled = replace(enabled, mode="all", native_tools=False)
+    assert provider_supports_native_tools("local_llamacpp", reasoning_replay=enabled)
+    assert not provider_supports_native_tools(
+        "local_llamacpp", reasoning_replay=disabled
+    )
+
+
+def test_agent_config_pins_immutable_reasoning_policy():
+    from dataclasses import FrozenInstanceError
+
+    import pytest
+
+    from tldw_chatbook.Agents.agent_models import AgentConfig
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    policy = ReasoningReplayPolicy("current", "override", native_tools=True)
+    config = AgentConfig(
+        model="org/exact-model", system_prompt="", reasoning_replay=policy
+    )
+    assert config.reasoning_replay is policy
+    with pytest.raises(FrozenInstanceError):
+        config.reasoning_replay.mode = "off"
+
+
+def test_runtime_steering_retains_current_exchange_annotation():
+    from Tests.Agents.test_agent_runtime import CFG, make_deps
+    from tldw_chatbook.Agents.agent_models import ModelTurn
+    from tldw_chatbook.Agents.agent_runtime import run_agent_loop
+    from tldw_chatbook.Chat.local_reasoning import EXCHANGE_CONTINUATION_KEY
+
+    deps = make_deps([ModelTurn(text="done")])
+    deps.drain_mailbox = lambda: [("user", "keep going")]
+    seen = []
+    deps.call_model = lambda rows, schemas: seen.extend(rows) or ModelTurn(text="done")
+    run_agent_loop(
+        config=CFG,
+        initial_messages=[{"role": "user", "content": "task"}],
+        active_schemas=[],
+        deps=deps,
+    )
+    assert seen[-1].get(EXCHANGE_CONTINUATION_KEY) is True
+
+
+def test_agent_budget_counts_exact_model_projected_reasoning():
+    from tldw_chatbook.Agents.agent_service import _count_model_messages
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    capture = ThinkingCapture(assistant_owner_id="tool")
+    capture.observe(
+        ProviderThinkingDelta(
+            text="a long thought " * 40,
+            provider="llama_cpp",
+            model="org/exact-model",
+            protocol="chat_completions",
+            source_format="reasoning_content",
+        )
+    )
+    envelope = capture.settle("complete").envelope
+    messages = [
+        {"role": "user", "content": "task"},
+        {"role": "assistant", "content": "call", "_tldw_call_thinking": envelope},
+    ]
+    policy = ReasoningReplayPolicy("all", "override")
+    included = _count_model_messages(
+        messages,
+        "org/exact-model",
+        "llama_cpp",
+        reasoning_replay=policy,
+        tokenizer_model="exact-model",
+    )
+    excluded = _count_model_messages(
+        messages,
+        "org/exact-model",
+        "llama_cpp",
+        reasoning_replay=replace(policy, mode="off"),
+        tokenizer_model="exact-model",
+    )
+    assert included > excluded + 100
+
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    "conversation_policy,expected",
+    [("auto", None), ("include", "first tool"), ("exclude", None)],
+)
+def test_local_live_native_payload_respects_conversation_override(
+    tmp_path, conversation_policy, expected
+):
+    import asyncio
+
+    from tldw_chatbook.Chat.console_prepared_request import (
+        PreparedProviderRequest,
+        thaw_json,
+    )
+    from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    real_gateway = ConsoleProviderGateway(config_provider=dict, environ={})
+
+    class Gateway(_ChunkGateway):
+        prepare_chat_request = real_gateway.prepare_chat_request
+
+        async def stream_chat(self, resolution, messages, tools=None, **kwargs):
+            if isinstance(messages, PreparedProviderRequest):
+                tools = [thaw_json(tool) for tool in messages.tools]
+                messages = [thaw_json(row) for row in messages.messages]
+            async for chunk in super().stream_chat(
+                resolution, messages, tools=tools, **kwargs
+            ):
+                yield chunk
+
+    gateway = Gateway(
+        [
+            [_delta("first tool"), _native_calls("calculator", {"expression": "1+1"})],
+            ["The answer is 2."],
+        ]
+    )
+    bridge, db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    resolution = replace(
+        _native_resolution(),
+        provider="llama_cpp",
+        execution_key="llama_cpp",
+        model="reasoner",
+        local_structured_thinking=True,
+        reasoning_replay=ReasoningReplayPolicy("off", "override", native_tools=True),
+    )
+    try:
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            aid,
+            resolution=resolution,
+            model=resolution.model,
+            thinking_policy=conversation_policy,
+        )
+        assert outcome.final_text == "The answer is 2."
+        assert gateway.tools_seen[0]
+        tool_owner = next(
+            row for row in gateway.messages_seen[-1] if row.get("tool_calls")
+        )
+        assert tool_owner.get("reasoning_content") == expected
+        assert all(
+            not key.startswith("_tldw_")
+            for row in gateway.messages_seen[-1]
+            for key in row
+        )
+    finally:
+        db.close()
+        asyncio.run(real_gateway.aclose())
+
+
+@pytest.mark.parametrize("child_model", ["test-model", "child-model"])
+def test_child_inherits_policy_and_only_replays_its_own_calls(
+    tmp_path, monkeypatch, child_model
+):
+    from tldw_chatbook.Agents import agent_service
+    from tldw_chatbook.Agents.agent_models import SPAWN_TOOL_NAME, AgentDefinition
+    from tldw_chatbook.Chat.console_agent_bridge import _StreamingModelAdapter
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    real_setting = agent_service._setting
+    monkeypatch.setattr(
+        agent_service,
+        "_setting",
+        lambda key, default: (
+            1
+            if key == agent_service.MAX_LIVE_SUBAGENTS_KEY
+            else real_setting(key, default)
+        ),
+    )
+    policy = ReasoningReplayPolicy("all", "override", native_tools=True)
+
+    configs = []
+    real_config = agent_service.AgentConfig
+
+    def capture_config(**kwargs):
+        config = real_config(**kwargs)
+        configs.append(config)
+        return config
+
+    monkeypatch.setattr(agent_service, "AgentConfig", capture_config)
+
+    class Gateway(_ChunkGateway):
+        def prepare_chat_request(self, resolution, messages, **kwargs):
+            expected = policy if resolution.model == "test-model" else None
+            assert resolution.reasoning_replay is expected
+            assert resolution.local_structured_thinking is (expected is policy)
+            thoughts = [
+                sidecar.envelope.blocks[0].text
+                for sidecar in kwargs["thinking_sidecar"]
+            ]
+            if _StreamingModelAdapter._is_subagent(messages):
+                assert thoughts == ["child tool"]
+            else:
+                assert thoughts == ["parent spawn"]
+            return messages
+
+    gateway = Gateway(
+        [
+            [
+                _delta("parent spawn"),
+                _native_calls(
+                    SPAWN_TOOL_NAME, {"task": "calculate two", "agent": "worker"}
+                ),
+            ],
+            [
+                _delta("child tool"),
+                _native_calls("calculator", {"expression": "1+1"}, "child-call"),
+            ],
+            ["child done"],
+            ["parent done"],
+        ]
+    )
+    bridge, db, store, session, aid = _bridge_with_gateway(tmp_path, gateway)
+    db.create_agent_definition(
+        AgentDefinition(name="worker", instructions="Calculate.", model=child_model)
+    )
+    try:
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            aid,
+            resolution=replace(
+                _native_resolution(),
+                model="test-model",
+                reasoning_replay=policy,
+                local_structured_thinking=True,
+            ),
+        )
+        assert outcome.final_text == "parent done"
+        assert gateway.calls == 4
+        assert configs
+        assert all(
+            config.reasoning_replay is (policy if child_model == "test-model" else None)
+            for config in configs
+        )
+        assert [block.text for block in store.get_message(aid).thinking.blocks] == [
+            "parent spawn"
+        ]
+    finally:
+        db.close()
+
+
+def test_active_local_call_thinking_keeps_trace_owner_through_real_admission(
+    tmp_path,
+):
+    from Tests.Chat.test_console_agent_bridge import (
+        RUN_DONE,
+        CharactersRAGDB,
+        ConsoleProviderGateway,
+        ConsoleRequestRoute,
+        ConsoleTraceCallBoundary,
+        ConsoleTraceCaptureMode,
+        ConsoleTraceRepository,
+        ConsoleTraceService,
+        FrozenTracePolicy,
+        SavedRevisionTraceProvenance,
+        SurfaceDeltaAdmission,
+        TraceCallIdentity,
+        TraceCallState,
+        TraceProvenanceSource,
+        _test_resolution,
+        build_console_request,
+        new_opaque_id,
+    )
+    from tldw_chatbook.Chat.console_trace_provenance import TraceTransformKind
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    trace_db = CharactersRAGDB(tmp_path / "trace.sqlite", "reasoning-agent-trace")
+    repository = ConsoleTraceRepository()
+    service = ConsoleTraceService(repository)
+    conversation_id = trace_db.add_conversation({"title": "agent trace"})
+    assert conversation_id is not None
+    message_id = trace_db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "user",
+            "content": "hi",
+        }
+    )
+    assert message_id is not None
+    policy = FrozenTracePolicy(
+        policy_id=new_opaque_id(),
+        credential_filter_version="credentials-v1",
+        pii_redaction_enabled=False,
+        pii_ruleset_revision_id=None,
+    )
+    with trace_db.transaction() as cursor:
+        revision_row = cursor.execute(
+            """SELECT revision_id FROM console_trace_semantic_revisions
+                 WHERE source_message_id = ?
+                 ORDER BY revision_sequence DESC LIMIT 1""",
+            (message_id,),
+        ).fetchone()
+        assert revision_row is not None
+        saved_user = SavedRevisionTraceProvenance(str(revision_row[0]))
+        segment = repository.create_segment(cursor)
+        owner = repository.attach_owner(
+            cursor,
+            conversation_id=conversation_id,
+            root_segment_id=segment.segment_id,
+        )
+        repository.ensure_policy(cursor, policy)
+
+    routes: list[ConsoleRequestRoute] = []
+    provenances = []
+    capture_policies = []
+    adapter_requests = []
+    adapter_entries = 0
+
+    boundary_errors = []
+
+    def prepare_boundary(request, _resolution, route):
+        sequence = len(routes)
+        provenance = request.provenance
+        assert provenance is not None
+        preparation_identity = new_opaque_id()
+        with trace_db.transaction() as cursor:
+            tail = repository.get_surface_tail(cursor, segment.segment_id)
+            prefix_length = 0 if tail is None else tail.sequence + 1
+            delta = tuple(provenance.messages_payload[prefix_length:])
+            admission = SurfaceDeltaAdmission(
+                owner_id=owner.owner_id,
+                segment_id=segment.segment_id,
+                predecessor_surface_head_id=(None if tail is None else tail.node_id),
+                route_identity=route.value,
+                preparation_identity=preparation_identity,
+                descriptors=delta,
+            )
+            surface_boundary = service.prepare_surface_provenance(
+                cursor,
+                None,
+                provenance=provenance,
+                admission=admission,
+                values=tuple(request.messages_payload),
+            )
+        routes.append(route)
+        provenances.append(provenance)
+        assert request.semantic.provenance is not None
+        capture_policies.append(request.semantic.provenance.capture_policy)
+        return ConsoleTraceCallBoundary(
+            service=service,
+            database=trace_db,
+            identity=TraceCallIdentity(
+                owner_id=owner.owner_id,
+                segment_id=segment.segment_id,
+                turn_id="turn-1",
+                run_id="run-1",
+                call_sequence=sequence,
+                idempotency_key=new_opaque_id(),
+                policy_id=policy.policy_id,
+            ),
+            admission=admission,
+            occurred_at_factory=lambda: "2026-08-29T20:00:00Z",
+            surface_boundary=surface_boundary,
+        )
+
+    def boundary_factory(request, resolution, route):
+        try:
+            return prepare_boundary(request, resolution, route)
+        except Exception as exc:
+            boundary_errors.append(exc)
+            raise
+
+    def adapter(**kwargs):
+        nonlocal adapter_entries
+        calls = repository.read_calls(
+            trace_db.get_connection().cursor(), owner.owner_id
+        )
+        assert calls[-1].state is TraceCallState.DISPATCH_STARTED
+        adapter_requests.append(tuple(kwargs["messages_payload"]))
+        adapter_entries += 1
+        assert kwargs["tools"]
+        message = {"content": "42"}
+        if adapter_entries == 1:
+            message = {
+                "content": "",
+                "reasoning_content": "EXACT-LOCAL-TOOL-THOUGHT",
+                "tool_calls": list(
+                    _native_calls("calculator", {"expression": "6*7"}).tool_calls
+                ),
+            }
+        return {"choices": [{"message": message}]}
+
+    gateway = ConsoleProviderGateway(
+        chat_api_call_fn=adapter,
+        trace_call_boundary_factory=boundary_factory,
+    )
+    bridge, runs_db, store, session, aid = _bridge_with_gateway(
+        tmp_path / "agent", gateway
+    )
+    try:
+        outcome = _run(
+            bridge,
+            store,
+            session,
+            aid,
+            resolution=_test_resolution(
+                provider="local_vllm",
+                execution_key="local_vllm",
+                base_url="http://127.0.0.1:9099/v1",
+                model="reasoner",
+                streaming=False,
+                local_structured_thinking=True,
+                reasoning_replay=ReasoningReplayPolicy(
+                    "all", "override", native_tools=True
+                ),
+            ),
+            model="reasoner",
+            capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+            propagate_trace_call_persistence_errors=True,
+            trace_request=build_console_request(
+                [{"role": "user", "content": "hi"}],
+                message_provenance=(saved_user,),
+                memory_provenance=(),
+                mandatory_provenance=(),
+                tool_provenance=(),
+                capture_policy=policy,
+                capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+            ),
+        )
+        calls = repository.read_calls(
+            trace_db.get_connection().cursor(), owner.owner_id
+        )
+        assert outcome.status == RUN_DONE, outcome.steps
+        assert adapter_entries == 2
+        assert routes == [
+            ConsoleRequestRoute.AGENT_FIRST,
+            ConsoleRequestRoute.TOOL_LOOP,
+        ]
+        assert [call.call_sequence for call in calls] == [0, 1]
+        assert all(call.state is TraceCallState.COMPLETE for call in calls)
+        links = [
+            repository.get_response_link(
+                trace_db.get_connection().cursor(), call.call_id
+            )
+            for call in calls
+        ]
+        assert all(link is not None and link.link_kind == "artifact" for link in links)
+        assert capture_policies == [policy, policy]
+        assert provenances[0].messages_payload == (saved_user,)
+        assert provenances[1].messages_payload[0] == saved_user
+        assert len(provenances[1].thinking) == 1
+        attachment = provenances[1].thinking[0]
+        assert attachment.transform is TraceTransformKind.THINKING_ATTACHMENT
+        assert attachment.inputs[0].source is TraceProvenanceSource.TOOL_CALL
+        rewritten_owner = provenances[1].messages_payload[1]
+        assert rewritten_owner.transform is TraceTransformKind.MESSAGE_REWRITE
+        assert rewritten_owner.inputs[0] == attachment.inputs[0]
+        assert attachment in rewritten_owner.inputs
+        assert (
+            provenances[1].messages_payload[2].source
+            is TraceProvenanceSource.TOOL_RESULT
+        )
+        assert [len(request) for request in adapter_requests] == [1, 3]
+        assert adapter_requests[1][1]["role"] == "assistant"
+        assert adapter_requests[1][2]["role"] == "tool"
+        assert adapter_requests[1][1]["reasoning_content"] == "EXACT-LOCAL-TOOL-THOUGHT"
+        assert all(
+            not key.startswith("_tldw_")
+            for request in adapter_requests
+            for row in request
+            for key in row
+        )
+        assert store.get_message(aid).content == "42"
+        assert (
+            store.get_message(aid).thinking.blocks[0].source_format
+            == "reasoning_content:tool_call"
+        )
+    finally:
+        runs_db.close()
+        trace_db.close_connection()
+        if boundary_errors:
+            raise boundary_errors[0]
+
+
+def test_fallback_cannot_inherit_another_local_servers_native_approval(
+    tmp_path, monkeypatch
+):
+    from Tests.Agents.test_agent_service import CFG, _service_with, provider_reply
+    from tldw_chatbook.Chat.Chat_Deps import ChatProviderError
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+    calls = []
+
+    def chat(**kwargs):
+        calls.append(kwargs)
+        if kwargs["api_endpoint"] == "llama_cpp":
+            raise ChatProviderError("quota", status_code=402)
+        return provider_reply("fallback complete")
+
+    db = AgentRunsDB(tmp_path / "fallback.db", client_id="fallback-policy")
+    service = _service_with(db, chat)
+    monkeypatch.setattr(service, "_provider_is_ready", lambda _provider: True)
+    try:
+        _, outcome = service.run_turn(
+            conversation_id="fallback",
+            messages=[{"role": "user", "content": "task"}],
+            config=replace(
+                CFG,
+                provider="llama_cpp",
+                fallback_providers=("local_vllm",),
+                reasoning_replay=ReasoningReplayPolicy(
+                    "all", "primary override", native_tools=True
+                ),
+            ),
+            api_endpoint="llama_cpp",
+            should_cancel=lambda: False,
+        )
+        assert outcome.final_text == "fallback complete"
+        assert len(calls) == 2
+        assert calls[0]["tools"]
+        assert not calls[1].get("tools")
+        assert "tool_call" in calls[1]["messages_payload"][0]["content"]
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("native", [False, True])
+@pytest.mark.parametrize("mode", ["current", "all"])
+@pytest.mark.parametrize("child_model", ["reasoner", "child-model"])
+def test_resumed_child_retains_its_final_call_thinking_only(
+    tmp_path, monkeypatch, native, mode, child_model
+):
+    from Tests.Agents.test_agent_service import fence, provider_reply
+    from Tests.Agents.test_fleet_continuation import (
+        RESUME_CFG,
+        _await_retained,
+        _finished_child,
+    )
+    from Tests.Agents.test_fleet_continuation import _run as run_fleet
+    from Tests.Agents.test_fleet_runtime import make_fleet_service
+    from tldw_chatbook.Agents import agent_service
+    from tldw_chatbook.Agents.agent_models import (
+        SEND_TO_AGENT_TOOL_NAME,
+        SPAWN_TOOL_NAME,
+        WAIT_AGENTS_TOOL_NAME,
+        AgentDefinition,
+    )
+    from tldw_chatbook.Chat.console_agent_bridge import _StreamingProviderResponse
+    from tldw_chatbook.Chat.local_reasoning import (
+        ReasoningReplayPolicy,
+        project_reasoning_history,
+    )
+    from tldw_chatbook.DB.AgentRuns_DB import AgentRunsDB
+
+    configs = []
+    real_config = agent_service.AgentConfig
+
+    def capture_config(**kwargs):
+        config = real_config(**kwargs)
+        configs.append(config)
+        return config
+
+    monkeypatch.setattr(agent_service, "AgentConfig", capture_config)
+    capture = ThinkingCapture(assistant_owner_id="child-final")
+    capture.observe(replace(_delta("CHILD-FINAL-THOUGHT"), model=child_model))
+    envelope = capture.settle("complete").envelope
+    holder = {}
+    db = AgentRunsDB(tmp_path / "retained.db", client_id="retained-thinking")
+    db.create_agent_definition(
+        AgentDefinition(name="worker", instructions="Calculate.", model=child_model)
+    )
+    service, chat, coordinator = make_fleet_service(
+        db,
+        [
+            fence(SPAWN_TOOL_NAME, {"task": "calculate", "agent": "worker"}),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "parent done",
+            lambda: fence(
+                SEND_TO_AGENT_TOOL_NAME, {"id": holder["id"], "message": "check again"}
+            ),
+            fence(WAIT_AGENTS_TOOL_NAME, {}),
+            "parent checked",
+        ],
+        {"calculate": ["child done", "child checked"]},
+    )
+    chat._reply = lambda item: _StreamingProviderResponse(
+        provider_reply(item), None, envelope if item == "child done" else None
+    )
+    policy = ReasoningReplayPolicy(mode, "override", native_tools=True)
+    config = replace(
+        RESUME_CFG, model="reasoner", native_tools=native, reasoning_replay=policy
+    )
+    try:
+        _, first = run_fleet(service, config=config)
+        assert first.status == "done"
+        child = _finished_child(coordinator)
+        holder["id"] = child.handle_id
+        _await_retained(coordinator, child.handle_id)
+        retained = coordinator.get_retained(child.handle_id)
+        _, second = run_fleet(service, config=config)
+        assert second.status == "done"
+        assert len(configs) == 2
+        assert all(
+            cfg.reasoning_replay is (policy if child_model == "reasoner" else None)
+            for cfg in configs
+        )
+        assert retained.messages[-1].get("_tldw_call_thinking") is envelope
+        resumed_rows = chat.child_calls["calculate"][1]["messages_payload"]
+        projected = project_reasoning_history(
+            resumed_rows, provider="llama_cpp", model=child_model, policy=policy
+        )
+        assert [
+            row["reasoning_content"] for row in projected if "reasoning_content" in row
+        ] == ["CHILD-FINAL-THOUGHT"]
+        assert all("_tldw_call_thinking" not in row for row in projected)
+        resumed_handle = next(
+            handle
+            for handle in coordinator.snapshot()
+            if handle.handle_id != child.handle_id
+        )
+        _await_retained(coordinator, resumed_handle.handle_id)
+        assert (
+            "_tldw_call_thinking"
+            not in coordinator.get_retained(resumed_handle.handle_id).messages[-1]
+        )
+    finally:
+        db.close()
+
+
+def test_retained_transcript_cap_counts_canonical_thinking_text():
+    from Tests.Agents.test_fleet_continuation import _coord, _finished_handle
+
+    coordinator = _coord(retained_transcript_max_chars=2000)
+    handle = _finished_handle(coordinator)
+    capture = ThinkingCapture(assistant_owner_id="large-final")
+    capture.observe(_delta("large thought " * 1000))
+    envelope = capture.settle("complete").envelope
+    rows = [
+        {
+            "role": "assistant",
+            "content": "small answer",
+            "_tldw_call_thinking": envelope,
+        }
+    ]
+    assert coordinator.retain_transcript(handle.handle_id, rows) is False
+    assert coordinator.get_retained(handle.handle_id) is None

--- a/Tests/Chat/test_console_controller_local_reasoning.py
+++ b/Tests/Chat/test_console_controller_local_reasoning.py
@@ -1,0 +1,65 @@
+"""The durable controller trace path honors local structured replay capability."""
+
+from dataclasses import replace
+
+import pytest
+
+from Tests.Chat.test_console_trace_sidecar_replay import (
+    replay_harness as replay_harness,  # noqa: PLC0414
+)
+from tldw_chatbook.Chat.console_prepared_request import thaw_json
+from tldw_chatbook.Chat.console_trace_native_reader import ConsoleTraceNativeReader
+from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "replay_harness", [(False, "thinking"), (True, "thinking")], indirect=True
+)
+@pytest.mark.parametrize(
+    "mode,expected", [("all", True), ("off", False), ("current", False)]
+)
+async def test_controller_structured_alias_replay_matches_capture_mode(
+    replay_harness, monkeypatch, mode, expected
+):
+    harness = replay_harness
+    canonical = harness.store.get_message(harness.prior.id).thinking
+    canonical = replace(
+        canonical,
+        blocks=(replace(canonical.blocks[0], source_format="reasoning_content"),),
+    )
+    harness.store.replace_message_thinking(harness.prior.id, canonical)
+    assert harness.store.persist_selected_generation(harness.prior.id)
+    gateway = harness.controller.provider_gateway
+    original_resolve = gateway.resolve_for_send
+
+    async def resolve(selection):
+        resolution = await original_resolve(selection)
+        return replace(
+            resolution,
+            thinking_stream_disposition="ignored",
+            thinking_round_trip_version=None,
+            local_structured_thinking=True,
+            reasoning_replay=ReasoningReplayPolicy(mode, "test"),
+        )
+
+    monkeypatch.setattr(gateway, "resolve_for_send", resolve)
+    result = await harness.controller.submit_draft(
+        "ordinary successor", session_id="session-1"
+    )
+    assert result.accepted and result.provider_started, (
+        result,
+        harness.failures,
+        harness.build_errors,
+    )
+    messages = thaw_json(harness.entries[-1]["messages_payload"])
+    prior = next(row for row in messages if row["content"] == "prior answer")
+    assert prior.get("reasoning_content") == (
+        "REPLAY_THINKING_CANARY" if expected else None
+    )
+    if harness.capture_on:
+        user = harness.store.get_message(result.user_message_id)
+        traces = ConsoleTraceNativeReader(harness.database).read_calls(
+            user.persisted_message_id
+        )
+        assert traces[0].capture.request["messages_payload"] == messages

--- a/Tests/Chat/test_console_personal_context_snapshot.py
+++ b/Tests/Chat/test_console_personal_context_snapshot.py
@@ -6,8 +6,7 @@ from unittest.mock import AsyncMock, Mock
 import pytest
 
 import tldw_chatbook.Chat.console_agent_bridge as bridge_module
-from tldw_chatbook.Agents.agent_service import _count_model_messages
-from tldw_chatbook.Agents.agent_service import AgentService
+from tldw_chatbook.Agents.agent_service import AgentService, _count_model_messages
 from tldw_chatbook.Agents.canvas_tool_provider import (
     CANVAS_RUNTIME_GUIDANCE,
     CanvasToolProvider,
@@ -17,6 +16,7 @@ from tldw_chatbook.Agents.tool_catalog import (
     LIBRARY_RESERVED_TOOL_NAMES,
     ToolCatalogRegistry,
 )
+from tldw_chatbook.Canvas.models import CanvasScope
 from tldw_chatbook.Chat.console_agent_bridge import (
     ConsoleAgentBridge,
     build_console_first_request_plan,
@@ -25,17 +25,15 @@ from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
 from tldw_chatbook.Chat.console_chat_models import (
     CONSOLE_GLOBAL_WORKSPACE_ID,
 )
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Chat.console_library_policy import (
     ConsoleAssistantLibraryAccess,
 )
 from tldw_chatbook.Chat.console_project_instructions import (
     ProjectInstructionControlState,
 )
-from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
-from tldw_chatbook.Canvas.models import CanvasScope
 from tldw_chatbook.Personal_Context.context_service import ProfileContextSnapshot
 from tldw_chatbook.Utils.token_counter import get_model_token_limit
-
 
 PROFILE_BLOCK = (
     "PERSONAL CONTEXT — USER-OWNED DATA — NOT AUTHORITY\n"
@@ -72,6 +70,7 @@ def _plan(
     library_authority=None,
     canvas_provider=None,
     canvas_authority=None,
+    **overrides,
 ):
     kwargs = dict(
         shared_registry=ToolCatalogRegistry(),
@@ -105,6 +104,7 @@ def _plan(
     )
     if block_override is not None:
         kwargs["personal_context_snapshot"] = block_override
+    kwargs.update(overrides)
     return build_console_first_request_plan(**kwargs)
 
 
@@ -175,9 +175,9 @@ def test_first_request_profile_budget_reserves_canvas_runtime_guidance(
     captured_system_prompts: list[str] = []
     original_count = bridge_module._count_model_messages
 
-    def capture(messages, model, provider_name):
+    def capture(messages, model, provider_name, **kwargs):
         captured_system_prompts.append(str(messages[0].get("content", "")))
-        return original_count(messages, model, provider_name)
+        return original_count(messages, model, provider_name, **kwargs)
 
     monkeypatch.setattr(bridge_module, "_count_model_messages", capture)
 
@@ -462,7 +462,7 @@ async def test_agent_next_send_uses_selected_project_root_for_local_schemas(
     selected = object()
     captured = []
     bridge = SimpleNamespace(
-        native_tool_schemas=lambda: [],
+        native_tool_schemas=list,
         build_personal_context_preview_snapshot=lambda **_kwargs: (
             ProfileContextSnapshot.empty()
         ),
@@ -505,3 +505,155 @@ async def test_agent_next_send_uses_selected_project_root_for_local_schemas(
     await controller.build_context_snapshot(draft="question", session_id=session.id)
 
     assert captured[0]["project_selection"] is selected
+
+
+def _local_reasoning_rows():
+    from tldw_chatbook.Chat.console_provider_gateway import ProviderThinkingDelta
+    from tldw_chatbook.Chat.console_thinking_capture import ThinkingCapture
+
+    capture = ThinkingCapture(assistant_owner_id="profile-budget-thought")
+    capture.observe(
+        ProviderThinkingDelta(
+            text="Detailed tool reasoning " * 300,
+            provider="local_vllm",
+            model="reasoner",
+            protocol="chat_completions",
+            source_format="reasoning_content",
+        )
+    )
+    return [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "I checked.",
+            "_tldw_call_thinking": capture.settle("complete").envelope,
+        },
+    ]
+
+
+def _prepared_local_reasoning_rows(resolution, messages):
+    import asyncio
+
+    from tldw_chatbook.Chat.console_prepared_request import thaw_json
+    from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
+    from tldw_chatbook.Chat.console_thinking_capture import consume_call_thinking
+
+    owner_key = "_tldw_call_thinking_owner"
+    rows, sidecars = consume_call_thinking(messages, owner_key=owner_key)
+    gateway = ConsoleProviderGateway()
+    try:
+        prepared = gateway.prepare_chat_request(
+            resolution,
+            rows,
+            thinking_sidecar=sidecars,
+            thinking_owner_key=owner_key,
+            apply_safety_window=False,
+        )
+        return [thaw_json(row) for row in prepared.messages]
+    finally:
+        asyncio.run(gateway.aclose())
+
+
+@pytest.mark.parametrize("mode", ["off", "all", None])
+def test_profile_capacity_counts_the_dispatched_reasoning_projection(
+    tmp_path,
+    monkeypatch,
+    mode,
+):
+    from tldw_chatbook.Chat.console_history_budget import count_console_messages_tokens
+    from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    limit = 20_000
+    monkeypatch.setattr(bridge_module, "get_model_token_limit", lambda *_: limit)
+    policy = ReasoningReplayPolicy(mode, "test") if mode else None
+    resolution = ConsoleProviderResolution(
+        provider="local_vllm",
+        execution_key="local_vllm",
+        base_url="",
+        model="reasoner",
+        ready=True,
+        max_tokens=1024,
+        local_structured_thinking=True,
+        reasoning_replay=policy,
+    )
+    builder = _ProfileContextBuilder()
+
+    def empty_snapshot(request):
+        builder.requests.append(request)
+        return ProfileContextSnapshot.empty()
+
+    builder.build_snapshot = empty_snapshot
+    plan = _plan(
+        builder,
+        resolution=resolution,
+        native_tools=False,
+        agent_messages=_local_reasoning_rows(),
+    )
+    service = AgentService(
+        tmp_path / "unused.db", plan.registry, chat_call=lambda **_: {}
+    )
+    request = service._build_model_request(
+        plan.config,
+        plan.api_endpoint,
+        list(plan.schemas.runtime_schemas),
+        list(plan.messages),
+        plan.schemas.active_schemas,
+        plan.schemas.log_active,
+    )
+    wire_rows = _prepared_local_reasoning_rows(resolution, list(request.messages))
+    assert any("reasoning_content" in row for row in wire_rows) is (mode != "off")
+    assert builder.requests[0].available_input_tokens == (
+        limit
+        - resolution.max_tokens
+        - count_console_messages_tokens(wire_rows, "reasoner")
+    )
+
+
+@pytest.mark.parametrize("mode", ["off", "all"])
+def test_fenced_instruction_capacity_counts_the_dispatched_reasoning_projection(
+    monkeypatch,
+    mode,
+):
+    from dataclasses import replace
+
+    from tldw_chatbook.Chat.console_history_budget import count_console_messages_tokens
+    from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderResolution
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    rows = _local_reasoning_rows()
+    policy = ReasoningReplayPolicy(mode, "test")
+    resolution = ConsoleProviderResolution(
+        provider="local_vllm",
+        execution_key="local_vllm",
+        base_url="",
+        model="reasoner",
+        ready=True,
+        local_structured_thinking=True,
+        reasoning_replay=policy,
+    )
+    wire_off = _prepared_local_reasoning_rows(
+        replace(resolution, reasoning_replay=replace(policy, mode="off")),
+        rows,
+    )
+    wire_all = _prepared_local_reasoning_rows(
+        replace(resolution, reasoning_replay=replace(policy, mode="all")),
+        rows,
+    )
+    reserve = 10
+    limit = (
+        reserve
+        + (
+            count_console_messages_tokens(wire_off, "reasoner")
+            + count_console_messages_tokens(wire_all, "reasoner")
+        )
+        // 2
+    )
+    monkeypatch.setattr(bridge_module, "get_model_token_limit", lambda *_: limit)
+    assert bridge_module._fenced_project_instruction_payload_fits(
+        rows,
+        model="reasoner",
+        provider="local_vllm",
+        response_reserve_tokens=reserve,
+        reasoning_replay=policy,
+    ) is (mode == "off")

--- a/Tests/Chat/test_console_provider_gateway.py
+++ b/Tests/Chat/test_console_provider_gateway.py
@@ -2521,7 +2521,10 @@ async def test_resolve_for_send_dispatches_llamacpp_selection():
     assert resolved.model == "server-model"
     assert resolved.thinking_stream_disposition == "ignored"
     assert resolved.thinking_round_trip_version is None
-    assert resolved.may_emit_thinking is False
+    # Explicit structured fields are captureable even when this model has
+    # no declared inline <think> parser.
+    assert resolved.local_structured_thinking is True
+    assert resolved.may_emit_thinking is True
 
 
 @pytest.mark.asyncio
@@ -2529,6 +2532,8 @@ async def test_same_llamacpp_endpoint_resolves_model_specific_thinking_replay():
     endpoint = "http://127.0.0.1:9099"
 
     async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/props":
+            return httpx.Response(404)
         assert request.url.path == "/health"
         return httpx.Response(200, json={"status": "ok"})
 
@@ -2694,7 +2699,10 @@ async def test_resolve_for_send_normalizes_scheme_less_llamacpp_base_url_before_
 
     assert resolved.ready is True
     assert resolved.base_url == "http://127.0.0.1:9099"
-    assert seen_urls == ["http://127.0.0.1:9099/v1/models"]
+    assert seen_urls == [
+        "http://127.0.0.1:9099/v1/models",
+        "http://127.0.0.1:9099/props",
+    ]
 
 
 @pytest.mark.asyncio
@@ -2733,6 +2741,8 @@ async def test_gateway_resolves_direct_llamacpp_without_importing_chat_functions
         return real_import(name, *args, **kwargs)
 
     async def handler(request: httpx.Request) -> httpx.Response:
+        if request.url.path == "/props":
+            return httpx.Response(404)
         assert request.url.path == "/health"
         return httpx.Response(200, json={"status": "ok"})
 
@@ -7973,6 +7983,11 @@ async def test_console_persisted_explicit_keyless_llamacpp_sends_no_authorizatio
 
     async def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
+        if request.url.path == "/props":
+            return httpx.Response(404)
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        assert request.url.path == "/v1/chat/completions"
         return httpx.Response(
             200,
             content=(
@@ -8018,7 +8033,11 @@ async def test_console_persisted_explicit_keyless_llamacpp_sends_no_authorizatio
     assert resolution.ready is True
     assert resolution.api_key is None
     assert chunks == ["ok"]
-    assert [request.method for request in requests] == ["GET", "POST"]
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/health"),
+        ("GET", "/props"),
+        ("POST", "/v1/chat/completions"),
+    ]
     assert all("Authorization" not in request.headers for request in requests)
 
 
@@ -8028,6 +8047,11 @@ async def test_console_llamacpp_explicit_stored_source_reaches_probe_and_chat():
 
     async def handler(request: httpx.Request) -> httpx.Response:
         requests.append(request)
+        if request.url.path == "/props":
+            return httpx.Response(404)
+        if request.url.path == "/health":
+            return httpx.Response(200, json={"status": "ok"})
+        assert request.url.path == "/v1/chat/completions"
         return httpx.Response(
             200,
             content=(
@@ -8073,7 +8097,13 @@ async def test_console_llamacpp_explicit_stored_source_reaches_probe_and_chat():
     assert resolution.ready is True
     assert resolution.api_key_source == "config:api_settings.llama_cpp.api_key"
     assert chunks == ["ok"]
+    assert [(request.method, request.url.path) for request in requests] == [
+        ("GET", "/health"),
+        ("GET", "/props"),
+        ("POST", "/v1/chat/completions"),
+    ]
     assert [request.headers.get("Authorization") for request in requests] == [
+        "Bearer stored-llama-request-canary",
         "Bearer stored-llama-request-canary",
         "Bearer stored-llama-request-canary",
     ]

--- a/Tests/Chat/test_local_reasoning_gateway.py
+++ b/Tests/Chat/test_local_reasoning_gateway.py
@@ -365,3 +365,166 @@ def test_structured_capture_accepts_only_declared_transport_encoding(provider, k
         )
         is None
     )
+
+
+@pytest.mark.asyncio
+async def test_local_llm_template_control_reaches_actual_http_payload(monkeypatch):
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
+    sent = []
+
+    def post(_session, url, **kwargs):
+        sent.append((url, kwargs["json"]))
+        response = Mock(status_code=200)
+        response.json.return_value = {"choices": [{"message": {"content": "done"}}]}
+        return response
+
+    monkeypatch.setattr("requests.Session.post", post)
+    monkeypatch.setattr(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.get_runtime_config_snapshot",
+        lambda: SimpleNamespace(values={"api_settings": {}}),
+    )
+    gateway = ConsoleProviderGateway()
+    resolution = ConsoleProviderResolution(
+        provider="local-llm",
+        execution_key="local-llm",
+        model="alias",
+        base_url="http://localhost:12345",
+        ready=True,
+        streaming=False,
+        reasoning_replay=ReasoningReplayPolicy(
+            "all", "override", supports_preserve=True
+        ),
+    )
+    assert [
+        x
+        async for x in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "test"}]
+        )
+    ] == ["done"]
+    assert sent == [
+        (
+            "http://localhost:12345/v1/chat/completions",
+            {**sent[0][1], "chat_template_kwargs": {"preserve_thinking": True}},
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_template_metadata_cache_reuses_facts_but_reapplies_preferences(
+    monkeypatch,
+):
+    from dataclasses import replace
+
+    now = [100.0]
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.console_provider_gateway.monotonic",
+        lambda: now[0],
+        raising=False,
+    )
+    seen = []
+    template = Path("Tests/fixtures/reasoning_templates/gemma4.jinja").read_text()
+
+    def respond(request):
+        seen.append(str(request.url))
+        if len(seen) == 2:
+            return httpx.Response(503)
+        return httpx.Response(
+            200,
+            json={
+                "chat_template": template,
+                "chat_template_caps": {
+                    "supports_tools": True,
+                    "supports_tool_calls": True,
+                },
+            },
+        )
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        resolution = ConsoleProviderResolution(
+            provider="llama_cpp",
+            model="alias",
+            base_url="http://localhost:9099",
+            ready=True,
+        )
+        first = await gateway._resolve_reasoning_history(resolution, {})
+        again = await gateway._resolve_reasoning_history(
+            replace(resolution, base_url="http://localhost:9099/v1"),
+            {"console": {"reasoning_history": "off"}},
+        )
+        assert len(seen) == 1
+        assert first.reasoning_replay.mode == "current"
+        assert again.reasoning_replay.mode == "off"
+        now[0] += 61
+        stale = await gateway._resolve_reasoning_history(resolution, {})
+        assert stale.reasoning_replay.template_family == "Gemma 4"
+        assert stale.reasoning_replay.native_tools
+        assert len(seen) == 2
+        await gateway._resolve_reasoning_history(resolution, {})
+        assert len(seen) == 2
+        await gateway._resolve_reasoning_history(
+            replace(resolution, model="different"), {}
+        )
+        assert len(seen) == 3
+
+
+@pytest.mark.asyncio
+async def test_failed_metadata_probe_has_bounded_negative_cache(monkeypatch):
+    now = [100.0]
+    monkeypatch.setattr(
+        "tldw_chatbook.Chat.console_provider_gateway.monotonic",
+        lambda: now[0],
+        raising=False,
+    )
+    seen = []
+
+    def respond(request):
+        seen.append(request)
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        resolution = ConsoleProviderResolution(
+            provider="local_vllm",
+            model="alias",
+            base_url="http://localhost:8000",
+            ready=True,
+        )
+        for _ in range(2):
+            result = await gateway._resolve_reasoning_history(resolution, {})
+            assert result.reasoning_replay.mode == "server_default"
+        assert len(seen) == 1
+        now[0] += 16
+        await gateway._resolve_reasoning_history(resolution, {})
+        assert len(seen) == 2
+
+
+@pytest.mark.asyncio
+async def test_metadata_cache_evicts_old_targets_instead_of_growing():
+    from dataclasses import replace
+
+    requests = []
+
+    def respond(request):
+        requests.append(request)
+        return httpx.Response(404)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        resolution = ConsoleProviderResolution(
+            provider="local_vllm",
+            model="0",
+            base_url="http://localhost:8000",
+            ready=True,
+        )
+        for number in range(33):
+            await gateway._resolve_reasoning_history(
+                replace(resolution, model=str(number)), {}
+            )
+        assert len(gateway._reasoning_metadata_cache) == 32
+        await gateway._resolve_reasoning_history(resolution, {})
+        assert len(requests) == 34
+        assert len(gateway._reasoning_metadata_cache) == 32

--- a/Tests/Chat/test_local_reasoning_gateway.py
+++ b/Tests/Chat/test_local_reasoning_gateway.py
@@ -1,0 +1,367 @@
+"""Local structured reasoning reaches canonical events and native tool transport."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import Mock
+
+import httpx
+import pytest
+
+from tldw_chatbook.Chat.console_provider_gateway import (
+    ConsoleProviderGateway,
+    ConsoleProviderResolution,
+    ProviderThinkingDelta,
+    ProviderToolCalls,
+)
+from tldw_chatbook.Chat.local_reasoning import resolve_reasoning_policy
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("streaming", [True, False])
+async def test_llama_separate_reasoning_is_typed_and_not_answer(streaming):
+    def respond(request):
+        message = {"content": "221", "reasoning_content": "Compute the product"}
+        body = {"choices": [{"message": message}]}
+        if streaming:
+            return httpx.Response(
+                200,
+                text="data: "
+                + json.dumps({"choices": [{"delta": message}]})
+                + "\n\ndata: [DONE]\n\n",
+            )
+        return httpx.Response(200, json=body)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        result = [
+            item
+            async for item in gateway.stream_chat(
+                ConsoleProviderResolution(
+                    provider="llama_cpp",
+                    execution_key="llama_cpp",
+                    model="alias",
+                    base_url="http://localhost:9099",
+                    ready=True,
+                    streaming=streaming,
+                    thinking_stream_disposition="displayable",
+                    thinking_round_trip_version=1,
+                ),
+                [{"role": "user", "content": "13*17"}],
+            )
+        ]
+    assert "".join(x for x in result if isinstance(x, str)) == "221"
+    events = [x for x in result if isinstance(x, ProviderThinkingDelta)]
+    assert [(x.text, x.source_format) for x in events] == [
+        ("Compute the product", "reasoning_content")
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider,key", [("local_vllm", "reasoning_content"), ("local_ollama", "reasoning")]
+)
+@pytest.mark.parametrize("streaming", [True, False])
+async def test_generic_local_reasoning_is_a_typed_event(provider, key, streaming):
+    message = {"content": "done", key: "Retained thought"}
+
+    def chat_call(**kwargs):
+        if not streaming:
+            return {"choices": [{"message": message}]}
+        return iter(
+            [
+                "data: "
+                + json.dumps({"choices": [{"delta": {key: "Retained thought"}}]}),
+                "data: " + json.dumps({"choices": [{"delta": {"content": "done"}}]}),
+                "data: [DONE]",
+            ]
+        )
+
+    gateway = ConsoleProviderGateway(chat_api_call_fn=chat_call)
+    result = [
+        item
+        async for item in gateway.stream_chat(
+            ConsoleProviderResolution(
+                provider=provider,
+                execution_key=provider,
+                model="alias",
+                base_url="http://localhost:9099",
+                ready=True,
+                streaming=streaming,
+                thinking_stream_disposition="displayable",
+                thinking_round_trip_version=1,
+            ),
+            [{"role": "user", "content": "test"}],
+        )
+    ]
+    assert "".join(x for x in result if isinstance(x, str)) == "done"
+    assert [
+        (x.text, x.source_format)
+        for x in result
+        if isinstance(x, ProviderThinkingDelta)
+    ] == [("Retained thought", key)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "provider,key",
+    [
+        ("llama_cpp", "reasoning_content"),
+        ("local_vllm", "reasoning_content"),
+        ("local_ollama", "reasoning"),
+    ],
+)
+@pytest.mark.parametrize("streaming", [True, False])
+@pytest.mark.parametrize("capture_on", [True, False])
+async def test_real_local_dispatcher_preserves_native_schema_and_reasoning(
+    monkeypatch, provider, key, streaming, capture_on
+):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(
+        "tldw_chatbook.LLM_Calls.LLM_API_Calls_Local.get_runtime_config_snapshot",
+        lambda: SimpleNamespace(
+            values={
+                "api_settings": {
+                    name: {"api_key": "STALE-KEY-CANARY", "credential_source": "none"}
+                    for name in (
+                        "llama_cpp",
+                        "local_llamacpp",
+                        "vllm",
+                        "vllm_api",
+                        "local_vllm",
+                        "ollama",
+                        "local_ollama",
+                    )
+                }
+            }
+        ),
+    )
+    sent = []
+    call = {
+        "id": "calc-1",
+        "type": "function",
+        "function": {"name": "calculator", "arguments": '{"expression":"13*17"}'},
+    }
+    message = {"content": "", key: "Use calculator", "tool_calls": [call]}
+
+    def respond(session, url, **kwargs):
+        assert "Authorization" not in kwargs.get("headers", {})
+        sent.append((url, kwargs["json"]))
+        response = Mock(status_code=200)
+        response.json.return_value = {
+            "choices": [{"message": message, "finish_reason": "tool_calls"}]
+        }
+        delta = {**message, "tool_calls": [{"index": 0, **call}]}
+        response.iter_lines.return_value = iter(
+            [
+                "data: "
+                + json.dumps(
+                    {"choices": [{"delta": delta, "finish_reason": "tool_calls"}]}
+                ),
+                "data: [DONE]",
+            ]
+        )
+        return response
+
+    monkeypatch.setattr("requests.Session.post", respond)
+    template = Path("Tests/fixtures/reasoning_templates/gemma4.jinja").read_text()
+    resolution = ConsoleProviderResolution(
+        provider=provider,
+        execution_key=provider,
+        model="alias",
+        base_url="http://localhost:12345",
+        ready=True,
+        streaming=streaming,
+        thinking_stream_disposition="displayable",
+        thinking_round_trip_version=1,
+        reasoning_replay=resolve_reasoning_policy(
+            "auto", template=template, native_tools=True
+        ),
+    )
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "calculator",
+                "description": "Calculate",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"expression": {"type": "string"}},
+                },
+            },
+        }
+    ]
+    gateway = ConsoleProviderGateway()
+    if capture_on:
+        from Tests.Chat.test_console_provider_gateway import (
+            _capture_on_prepared_request,
+        )
+        from tldw_chatbook.Chat.console_trace_provenance import (
+            ConsoleRequestRoute,
+            ConsoleTraceCaptureMode,
+        )
+
+        prepared = _capture_on_prepared_request(gateway, resolution, tools=tools)
+        result = [
+            item
+            async for item in gateway.stream_chat(
+                resolution,
+                prepared,
+                route=ConsoleRequestRoute.FRESH,
+                capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON,
+            )
+        ]
+    else:
+        result = [
+            item
+            async for item in gateway.stream_chat(
+                resolution, [{"role": "user", "content": "13*17"}], tools=tools
+            )
+        ]
+    assert sent[0][0] == "http://localhost:12345/v1/chat/completions"
+    assert sent[0][1]["tools"] == tools
+    assert [x.text for x in result if isinstance(x, ProviderThinkingDelta)] == [
+        "Use calculator"
+    ]
+    assert [
+        dict(x.tool_calls[0]) for x in result if isinstance(x, ProviderToolCalls)
+    ] == [call]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("suffix", ["", "/v1", "/v1/chat/completions"])
+async def test_optional_template_probe_uses_server_root_and_exact_fingerprint(suffix):
+    requests = []
+    template = Path("Tests/fixtures/reasoning_templates/qwen38.jinja").read_text()
+
+    def respond(request):
+        requests.append(str(request.url))
+        return httpx.Response(200, json={"chat_template": template})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(respond)) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        resolution = await gateway._resolve_reasoning_history(
+            ConsoleProviderResolution(
+                provider="local_vllm",
+                model="unrelated-alias",
+                base_url="http://localhost:8000" + suffix,
+                ready=True,
+            ),
+            {},
+        )
+    assert requests == ["http://localhost:8000/tokenizer_info"]
+    assert resolution.reasoning_replay.mode == "all"
+    assert resolution.reasoning_replay.template_family == "Qwen3.8"
+    assert resolution.local_structured_thinking
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "response",
+    [
+        httpx.Response(404),
+        httpx.Response(200, text="bad json"),
+        httpx.Response(200, text="x" * 262145),
+    ],
+)
+async def test_optional_template_metadata_failure_preserves_server_default(response):
+    async with httpx.AsyncClient(
+        transport=httpx.MockTransport(lambda _: response)
+    ) as client:
+        gateway = ConsoleProviderGateway(http_client=client)
+        resolved = await gateway._resolve_reasoning_history(
+            ConsoleProviderResolution(
+                provider="llama_cpp",
+                model="alias",
+                base_url="http://localhost:9099",
+                ready=True,
+            ),
+            {},
+        )
+    assert resolved.ready
+    assert resolved.reasoning_replay.mode == "server_default"
+    assert not resolved.reasoning_replay.native_tools
+
+
+def test_final_trace_verifier_uses_paired_template_projection():
+    from Tests.Chat.test_reasoning_history_policy import prepare
+    from tldw_chatbook.Chat.console_trace_provenance import ConsoleTraceCaptureMode
+
+    prepared, _, _ = prepare(family="Gemma 4")
+    resolution = ConsoleProviderResolution(
+        provider="llama_cpp",
+        execution_key="llama_cpp",
+        model="alias",
+        base_url="http://localhost:9099",
+        ready=True,
+        reasoning_replay=prepared.semantic.reasoning_replay,
+    )
+    gateway = ConsoleProviderGateway()
+    kwargs = gateway._chat_api_kwargs_from_prepared(resolution, prepared)
+    shadow = gateway._verify_trace_shadow(
+        resolution, prepared, kwargs, capture_mode=ConsoleTraceCaptureMode.CAPTURE_ON
+    )
+    assert shadow.available
+    assert kwargs["messages_payload"][-1]["role"] == "tool"
+    assert "keep going" in kwargs["messages_payload"][-1]["content"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["local_vllm", "local_ollama"])
+@pytest.mark.parametrize("streaming", [True, False])
+async def test_generic_reasoning_only_does_not_invent_answer_without_signals(
+    provider, streaming
+):
+    key = "reasoning" if provider == "local_ollama" else "reasoning_content"
+    thought = {key: "only thought", "content": ""}
+    response = (
+        {"choices": [{"message": thought}]}
+        if not streaming
+        else iter(
+            ["data: " + json.dumps({"choices": [{"delta": thought}]}), "data: [DONE]"]
+        )
+    )
+    gateway = ConsoleProviderGateway(chat_api_call_fn=lambda **_: response)
+    resolution = ConsoleProviderResolution(
+        provider=provider,
+        execution_key=provider,
+        model="alias",
+        base_url="http://localhost:9099",
+        ready=True,
+        streaming=streaming,
+        local_structured_thinking=True,
+    )
+    result = [
+        x
+        async for x in gateway.stream_chat(
+            resolution, [{"role": "user", "content": "test"}]
+        )
+    ]
+    assert [x.text for x in result if isinstance(x, ProviderThinkingDelta)] == [
+        "only thought"
+    ]
+    assert not [x for x in result if isinstance(x, str)]
+
+
+@pytest.mark.parametrize(
+    "provider,key",
+    [
+        ("llama_cpp", "reasoning"),
+        ("local_vllm", "reasoning"),
+        ("local_ollama", "reasoning_content"),
+    ],
+)
+def test_structured_capture_accepts_only_declared_transport_encoding(provider, key):
+    from tldw_chatbook.Chat.console_provider_gateway import _structured_local_thinking
+
+    assert (
+        _structured_local_thinking(
+            {"choices": [{"message": {key: "undeclared"}}]},
+            provider=provider,
+            model="alias",
+            protocol="chat_completions",
+        )
+        is None
+    )

--- a/Tests/Chat/test_reasoning_history_policy.py
+++ b/Tests/Chat/test_reasoning_history_policy.py
@@ -1,0 +1,514 @@
+"""Canonical local replay policy, wire accounting, and causal provenance."""
+
+from pathlib import Path
+
+import pytest
+
+from tldw_chatbook.Chat import local_reasoning as replay
+from tldw_chatbook.Chat.console_prepared_request import (
+    THINKING_OWNER_KEY,
+    build_console_request,
+    prepare_provider_request,
+    resolve_request_capacity,
+    thaw_json,
+)
+from tldw_chatbook.Chat.console_thinking_history import (
+    ProviderThinkingSidecar,
+    ThinkingHistorySerializationError,
+    ThinkingReplayTarget,
+    resolve_thinking_history,
+)
+from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy, new_opaque_id
+from tldw_chatbook.Chat.console_trace_provenance import (
+    DerivedTraceProvenance,
+    SavedRevisionTraceProvenance,
+)
+from tldw_chatbook.Chat.thinking_blocks import (
+    DisplayableThinkingBlock,
+    ThinkingEnvelope,
+)
+
+FIXTURES = Path(__file__).parents[1] / "fixtures" / "reasoning_templates"
+
+
+def sidecar(
+    owner, text, source_format="reasoning_content", provider="llama_cpp", model="alias"
+):
+    return ProviderThinkingSidecar(
+        owner,
+        ThinkingEnvelope(
+            (
+                DisplayableThinkingBlock(
+                    block_id=owner,
+                    round_ordinal=0,
+                    provider=provider,
+                    model=model,
+                    protocol="chat_completions",
+                    source_format=source_format,
+                    status="complete",
+                    text=text,
+                ),
+            )
+        ),
+    )
+
+
+def prepare(mode="current", preference="auto", family="", rows=None, sidecars=None):
+    policy = replay.ReasoningReplayPolicy(mode, "test", family)
+    target = ThinkingReplayTarget(
+        "llama_cpp",
+        "alias",
+        "chat_completions",
+        "displayable",
+        1,
+        reasoning_replay=policy,
+    )
+    resolved = resolve_thinking_history(
+        target=target,
+        policy=preference,
+        sidecars=tuple(
+            sidecars
+            or (sidecar("old", "OLD_THOUGHT"), sidecar("active", "ACTIVE_THOUGHT"))
+        ),
+    )
+    rows = rows or [
+        {"role": "user", "content": "old question"},
+        {"role": "assistant", "content": "old answer", THINKING_OWNER_KEY: "old"},
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": "",
+            THINKING_OWNER_KEY: "active",
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "content": "found", "tool_call_id": "a"},
+        {
+            "role": "user",
+            "content": "keep going",
+            replay.EXCHANGE_CONTINUATION_KEY: True,
+        },
+    ]
+    eligible = {group.owner_message_id for group in resolved.groups}
+    rows = [
+        {
+            key: value
+            for key, value in row.items()
+            if key != THINKING_OWNER_KEY or value in eligible
+        }
+        for row in rows
+    ]
+    revisions = tuple(SavedRevisionTraceProvenance(new_opaque_id()) for _ in rows)
+    semantic = build_console_request(
+        rows,
+        thinking_groups=resolved.groups,
+        thinking_policy=resolved.saved_policy,
+        effective_thinking_policy=resolved.effective_policy,
+        message_provenance=revisions,
+        memory_provenance=(),
+        mandatory_provenance=(),
+        tool_provenance=(),
+        capture_policy=FrozenTracePolicy(new_opaque_id(), "v1", False, None),
+    )
+    counted = []
+
+    def counter(messages, model):
+        counted.append(messages)
+        return len(str(messages))
+
+    result = prepare_provider_request(
+        semantic,
+        wire_style="distinct_roles",
+        model="alias",
+        provider="llama_cpp",
+        capacity=resolve_request_capacity(context_window_tokens=None),
+        reasoning_replay=policy,
+        count_fn=counter,
+    )
+    assert counted[-1] == [thaw_json(row) for row in result.messages]
+    return result, semantic, revisions
+
+
+def _render_reviewed_template(filename, messages):
+    """Render the exact captured server template with its native input shape."""
+    import copy
+    import json
+
+    from jinja2 import Environment
+
+    def fail(message):
+        raise AssertionError(message)
+
+    wire = copy.deepcopy(messages)
+    for row in wire:
+        for call in row.get("tool_calls", []):
+            call["function"]["arguments"] = json.loads(
+                call["function"]["arguments"]
+            )
+    return (
+        Environment()
+        .from_string((FIXTURES / f"{filename}.jinja").read_text())
+        .render(
+            messages=wire,
+            tools=[],
+            bos_token="<bos>",
+            add_generation_prompt=True,
+            enable_thinking=True,
+            raise_exception=fail,
+        )
+    )
+
+
+@pytest.mark.parametrize(
+    "mode,preference,owners",
+    [
+        ("current", "auto", ["active"]),
+        ("all", "auto", ["old", "active"]),
+        ("off", "auto", []),
+        ("all", "exclude", []),
+        ("off", "include", ["old", "active"]),
+    ],
+)
+def test_policy_filters_whole_groups_with_matching_provenance(mode, preference, owners):
+    result, semantic, _ = prepare(mode, preference)
+    assert [group.owner_message_id for group in result.thinking_groups] == owners
+    assert len(result.provenance.thinking) == len(owners)
+    assert result.semantic.active_request[0]["content"] == "current question"
+    for row in result.messages:
+        assert replay.EXCHANGE_CONTINUATION_KEY not in row
+    for row in result.messages:
+        if row["role"] == "assistant":
+            owner = "old" if row["content"] == "old answer" else "active"
+            assert row.get("reasoning_content") == (
+                f"{owner.upper()}_THOUGHT" if owner in owners else None
+            )
+    assert semantic.compactable[0].messages[1]["content"] == "old answer"
+
+
+def test_structured_fields_rewrite_trace_without_rewriting_answer():
+    result, _, revisions = prepare("all")
+    assert result.messages[1]["content"] == "old answer"
+    descriptor = result.provenance.messages[1]
+    assert isinstance(descriptor, DerivedTraceProvenance)
+    assert descriptor.inputs[0] == revisions[1]
+    assert descriptor.inputs[1] == result.provenance.thinking[0]
+
+
+@pytest.mark.parametrize(
+    "provider,source",
+    [
+        ("llama_cpp", "reasoning_content"),
+        ("local_vllm", "reasoning_content"),
+        ("ollama", "reasoning"),
+    ],
+)
+def test_structured_source_round_trips_only_with_eligible_local_family(
+    provider, source
+):
+    target = ThinkingReplayTarget(
+        provider, "alias", "chat_completions", "displayable", 1
+    )
+    resolved = resolve_thinking_history(
+        target=target,
+        policy="include",
+        sidecars=(sidecar("a", "thought", source, provider),),
+    )
+    assert len(resolved.groups) == 1
+    incompatible = resolve_thinking_history(
+        target=target,
+        policy="include",
+        sidecars=(sidecar("a", "thought", source, "openai"),),
+    )
+    assert incompatible.groups == ()
+
+
+def test_saved_tool_trace_does_not_become_final_answer_reasoning():
+    result, _, _ = prepare(
+        "all",
+        sidecars=[
+            sidecar("old", "TOOL_PRIVATE", "reasoning_content:tool_call"),
+            sidecar("active", "FINAL_PRIVATE"),
+        ],
+    )
+    assert "TOOL_PRIVATE" not in str(result.messages)
+    assert result.messages[3]["reasoning_content"] == "FINAL_PRIVATE"
+
+
+def test_include_keeps_strict_serialization_even_when_device_setting_off():
+    target = ThinkingReplayTarget(
+        "llama_cpp",
+        "alias",
+        "chat_completions",
+        "displayable",
+        1,
+        reasoning_replay=replay.ReasoningReplayPolicy("off", "test"),
+    )
+    with pytest.raises(ThinkingHistorySerializationError):
+        resolve_thinking_history(
+            target=target,
+            policy="include",
+            sidecars=(sidecar("a", "unsafe", "unknown"),),
+        )
+
+
+def test_gemma_control_merge_preserves_both_causes_and_tool_overlay():
+    result, semantic, revisions = prepare(family="Gemma 4")
+    assert len(result.messages) == 5
+    assert result.messages[-1]["role"] == "tool"
+    assert result.messages[-1]["content"] == "found\n\n[Runtime guidance]\nkeep going"
+    assert result.provenance.messages[-1].inputs == revisions[-2:]
+    assert result.provenance.tool_loop == (3, 4)
+    assert len(semantic.active_request) == 4
+
+
+def test_qwen_runtime_guidance_has_exact_wrapper_and_rewrite_provenance():
+    result, _, revisions = prepare(family="Qwen3.6")
+    assert (
+        result.messages[-1]["content"]
+        == "<tool_response>\nkeep going\n</tool_response>"
+    )
+    assert result.provenance.messages[-1].inputs == (revisions[-1],)
+
+
+@pytest.mark.parametrize(
+    "filename,mode",
+    [
+        ("gemma4", "current"),
+        ("qwen35", "current"),
+        ("qwen36", "current"),
+        ("qwen38", "all"),
+    ],
+)
+def test_reviewed_templates_resolve_without_alias_guessing(filename, mode):
+    assert (
+        replay.resolve_reasoning_policy(
+            "auto", template=(FIXTURES / f"{filename}.jinja").read_text()
+        ).mode
+        == mode
+    )
+
+
+def test_unknown_template_uses_server_default_and_scoped_keys_strip_credentials():
+    assert (
+        replay.resolve_reasoning_policy("auto", template="unreviewed").mode
+        == "server_default"
+    )
+    assert replay.reasoning_override_key(
+        "local_llamacpp", "http://u:p@HOST:8/v1/chat/completions", "x"
+    ) == replay.reasoning_override_key("llama_cpp", "http://host:8", "x")
+
+
+def test_budget_counter_includes_structured_reasoning(monkeypatch):
+    from tldw_chatbook.Chat import console_history_budget as budget
+
+    received = []
+
+    def count(rows, model):
+        received.extend(rows)
+        return sum(len(row["content"]) for row in rows)
+
+    monkeypatch.setattr(budget, "count_tokens_messages", count)
+    assert budget.count_console_messages_tokens(
+        [{"role": "assistant", "content": "answer", "reasoning_content": "thought"}],
+        "alias",
+    ) == len("answer thought")
+    assert received[0]["content"] == "answer thought"
+
+
+def test_runtime_guidance_transform_refuses_thinking_or_unrelated_second_input():
+    from tldw_chatbook.Chat.console_trace_provenance import (
+        ProviderArtifactTraceProvenance,
+        TraceProvenanceAlignmentError,
+        TraceProvenanceSource,
+        TraceTransformKind,
+    )
+
+    policy = FrozenTracePolicy(new_opaque_id(), "v1", False, None)
+    result = ProviderArtifactTraceProvenance(TraceProvenanceSource.TOOL_RESULT, policy)
+    thinking = ProviderArtifactTraceProvenance(TraceProvenanceSource.THINKING, policy)
+    with pytest.raises(TraceProvenanceAlignmentError):
+        DerivedTraceProvenance(TraceTransformKind.RUNTIME_GUIDANCE, (result, thinking))
+    with pytest.raises(TraceProvenanceAlignmentError):
+        DerivedTraceProvenance(TraceTransformKind.MESSAGE_REWRITE, (result, result))
+
+
+@pytest.mark.parametrize(
+    "filename,family",
+    [
+        ("gemma4", "Gemma 4"),
+        ("qwen35", "Qwen3.5"),
+        ("qwen36", "Qwen3.6"),
+        ("qwen38", "Qwen3.8"),
+    ],
+)
+def test_reviewed_render_retains_active_tool_thought_across_runtime_guidance(
+    filename, family
+):
+    result, _, _ = prepare(family=family)
+    wire = [thaw_json(row) for row in result.messages]
+    rendered = _render_reviewed_template(filename, wire)
+    assert "ACTIVE_THOUGHT" in rendered
+    assert "OLD_THOUGHT" not in rendered
+    assert "keep going" in rendered
+
+
+def test_gemma_all_sends_prior_final_but_template_keeps_only_tool_thinking():
+    """All is request-side; Gemma still omits reasoning from prior final answers."""
+    result, _, _ = prepare(mode="all", family="Gemma 4")
+    wire = [thaw_json(row) for row in result.messages]
+
+    assert wire[1]["reasoning_content"] == "OLD_THOUGHT"
+    assert wire[3]["reasoning_content"] == "ACTIVE_THOUGHT"
+
+    rendered = _render_reviewed_template("gemma4", wire)
+    assert "OLD_THOUGHT" not in rendered
+    assert "ACTIVE_THOUGHT" in rendered
+
+
+def test_gemma_fenced_tool_result_starts_new_user_turn_and_omits_active_thinking():
+    """Gemma retains active tool thinking only with the native tool protocol."""
+    wire = [
+        {"role": "user", "content": "old question"},
+        {
+            "role": "assistant",
+            "content": "old answer",
+            "reasoning_content": "OLD_THOUGHT",
+        },
+        {"role": "user", "content": "current question"},
+        {
+            "role": "assistant",
+            "content": '```tool\n{"name":"lookup","arguments":{}}\n```',
+            "reasoning_content": "ACTIVE_THOUGHT",
+        },
+        {
+            "role": "user",
+            "content": "Tool result: found\n\n[Runtime guidance]\nkeep going",
+        },
+    ]
+
+    assert wire[3]["reasoning_content"] == "ACTIVE_THOUGHT"
+    rendered = _render_reviewed_template("gemma4", wire)
+    assert "```tool" in rendered
+    assert "Tool result: found" in rendered
+    assert "ACTIVE_THOUGHT" not in rendered
+
+
+def test_ollama_and_openai_shape_local_fields_are_not_cross_translated():
+    target = ThinkingReplayTarget(
+        "ollama", "alias", "chat_completions", "displayable", 1
+    )
+    assert (
+        resolve_thinking_history(
+            target=target, policy="auto", sidecars=(sidecar("a", "private"),)
+        ).groups
+        == ()
+    )
+
+
+def test_incompatible_source_encodings_in_one_owner_are_skipped_or_strict():
+    envelope = ThinkingEnvelope(
+        (
+            sidecar("a", "first").envelope.blocks[0],
+            DisplayableThinkingBlock(
+                block_id="b",
+                round_ordinal=1,
+                provider="llama_cpp",
+                model="alias",
+                protocol="chat_completions",
+                source_format="start_anchored_think",
+                status="complete",
+                text="second",
+            ),
+        )
+    )
+    target = ThinkingReplayTarget(
+        "llama_cpp", "alias", "chat_completions", "displayable", 1
+    )
+    assert (
+        resolve_thinking_history(
+            target=target,
+            policy="auto",
+            sidecars=(ProviderThinkingSidecar("a", envelope),),
+        ).groups
+        == ()
+    )
+    with pytest.raises(ThinkingHistorySerializationError):
+        resolve_thinking_history(
+            target=target,
+            policy="include",
+            sidecars=(ProviderThinkingSidecar("a", envelope),),
+        )
+
+
+@pytest.mark.parametrize(
+    "provider,source", [("llama_cpp", "reasoning"), ("ollama", "reasoning_content")]
+)
+def test_declared_source_must_match_local_wire_field(provider, source):
+    target = ThinkingReplayTarget(
+        provider, "alias", "chat_completions", "displayable", 1
+    )
+    assert (
+        resolve_thinking_history(
+            target=target,
+            policy="auto",
+            sidecars=(sidecar("a", "private", source, provider),),
+        ).groups
+        == ()
+    )
+    with pytest.raises(ThinkingHistorySerializationError):
+        resolve_thinking_history(
+            target=target,
+            policy="include",
+            sidecars=(sidecar("a", "private", source, provider),),
+        )
+
+
+def test_agent_projection_uses_canonical_per_call_envelope_and_off_keeps_protocol():
+    from tldw_chatbook.Chat.console_thinking_capture import CALL_THINKING_KEY
+
+    rows = [
+        {"role": "user", "content": "question"},
+        {
+            "role": "assistant",
+            "content": "",
+            CALL_THINKING_KEY: sidecar("call", "EXACT_CALL").envelope,
+            "tool_calls": [
+                {
+                    "id": "a",
+                    "type": "function",
+                    "function": {"name": "lookup", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "a", "content": "found"},
+        {"role": "user", "content": "continue", replay.EXCHANGE_CONTINUATION_KEY: True},
+    ]
+    current = replay.project_reasoning_history(
+        rows,
+        provider="llama_cpp",
+        model="alias",
+        policy=replay.ReasoningReplayPolicy("current", "test", "Gemma 4"),
+    )
+    off = replay.project_reasoning_history(
+        rows,
+        provider="llama_cpp",
+        model="alias",
+        policy=replay.ReasoningReplayPolicy("off", "test", "Gemma 4"),
+    )
+    assert current[1]["reasoning_content"] == "EXACT_CALL"
+    assert "reasoning_content" not in off[1]
+    assert off[1]["tool_calls"] == current[1]["tool_calls"]
+    assert (
+        off[-1]["content"]
+        == current[-1]["content"]
+        == "found\n\n[Runtime guidance]\ncontinue"
+    )
+    assert CALL_THINKING_KEY not in str(current)
+    assert (
+        replay.project_reasoning_history([], provider="llama_cpp", model="alias") == []
+    )

--- a/Tests/UI/test_settings_console_reasoning_history.py
+++ b/Tests/UI/test_settings_console_reasoning_history.py
@@ -220,3 +220,30 @@ async def test_gemma_status_explains_fenced_tool_round_limit() -> None:
             "Native server tools are needed to retain Gemma thinking across tool rounds"
             in _visible_text(screen)
         )
+
+
+@pytest.mark.asyncio
+async def test_mounted_reasoning_selectors_use_shared_validation(monkeypatch) -> None:
+    app = _app_with_local_console_target()
+    calls: list[tuple[object, bool]] = []
+
+    def validate(value: object, *, allow_inherit: bool = False) -> str:
+        calls.append((value, allow_inherit))
+        return str(value)
+
+    monkeypatch.setattr(
+        settings_screen_module,
+        "validate_reasoning_history_selector",
+        validate,
+    )
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+
+        screen.query_one("#settings-console-reasoning-history", Select).value = "current"
+        screen.query_one("#settings-console-reasoning-override", Select).value = "all"
+        await pilot.pause()
+
+    assert ("current", False) in calls
+    assert ("all", True) in calls

--- a/Tests/UI/test_settings_console_reasoning_history.py
+++ b/Tests/UI/test_settings_console_reasoning_history.py
@@ -1,0 +1,222 @@
+"""Mounted Settings contracts for device-local local-reasoning replay policy."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from textual.widgets import Checkbox, Select
+
+import tldw_chatbook.UI.Screens.settings_screen as settings_screen_module
+from Tests.UI.test_destination_shells import (
+    DestinationHarness,
+    _active_destination_screen,
+    _build_test_app,
+    _visible_text,
+)
+from Tests.UI.test_settings_configuration_hub import _open_settings_category
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from tldw_chatbook.Chat.console_provider_gateway import ConsoleProviderGateway
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
+from tldw_chatbook.Chat.local_reasoning import (
+    ReasoningReplayPolicy,
+    reasoning_override_key,
+)
+from tldw_chatbook.config import DEFAULT_CONFIG_FROM_TOML, validate_config_keys
+
+
+def _app_with_local_console_target(
+    *,
+    provider: str = "local_vllm",
+    endpoint: str = "http://localhost:9099",
+    model: str = "alias",
+):
+    app = _build_test_app()
+    app.app_config["console"] = {}
+    app.app_config.setdefault("api_settings", {})[provider] = {"api_url": endpoint}
+    store = ConsoleChatStore()
+    store.ensure_session(
+        settings=ConsoleSessionSettings(provider=provider, model=model, base_url=None)
+    )
+    gateway = ConsoleProviderGateway(config_provider=lambda: app.app_config)
+    controller = ConsoleChatController(
+        store=store,
+        provider_gateway=gateway,
+        provider=provider,
+        model=model,
+        base_url=endpoint,
+    )
+    app.console_runtime = SimpleNamespace(
+        chat_store=store,
+        chat_controller=controller,
+        provider_gateway=gateway,
+    )
+    return app
+
+
+def test_reasoning_override_maps_are_known_freeform_console_config() -> None:
+    """Catches saved target digests being reported as unknown config keys."""
+
+    key = reasoning_override_key("local_vllm", "http://localhost:9099", "alias")
+
+    assert DEFAULT_CONFIG_FROM_TOML["console"]["reasoning_history_overrides"] == {}
+    assert DEFAULT_CONFIG_FROM_TOML["console"]["reasoning_native_tool_overrides"] == {}
+    assert (
+        validate_config_keys(
+            {
+                "console": {
+                    "reasoning_history_overrides": {key: "current"},
+                    "reasoning_native_tool_overrides": {key: True},
+                }
+            }
+        )
+        == []
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("saved_mode", ["current", "all", "off"])
+async def test_reasoning_history_defaults_automatic_and_persists_each_mode(
+    monkeypatch, saved_mode: str
+) -> None:
+    """Catches a missing mode option or saving replay under conversation policy."""
+
+    app = _app_with_local_console_target()
+    saved: list[dict[str, dict[str, object]]] = []
+
+    class FakeAdapter:
+        def save_sections(self, values):
+            saved.append(values)
+            return True
+
+    monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        default = screen.query_one("#settings-console-reasoning-history", Select)
+
+        assert default.value == "auto"
+        assert [(str(label), value) for label, value in default._options] == [
+            ("Automatic (recommended)", "auto"),
+            ("Current exchange", "current"),
+            ("All available", "all"),
+            ("Off", "off"),
+        ]
+        visible = _visible_text(screen)
+        assert "Conversation Auto" in visible
+        assert "Include and Exclude" in visible
+        assert "Required" in visible
+        assert "server template can still omit older reasoning" in visible
+
+        default.value = saved_mode
+        await pilot.pause()
+        await pilot.click("#settings-save-category")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert saved == [{"console": {"reasoning_history": saved_mode}}]
+        assert app.app_config["console"]["reasoning_history"] == saved_mode
+
+
+@pytest.mark.asyncio
+async def test_reasoning_history_remembers_normalized_target_and_clears_override(
+    monkeypatch,
+) -> None:
+    """Catches storing a raw URL/model or making native-tool support implicit."""
+
+    endpoint = "HTTP://user:secret@LOCALHOST:9099/v1/chat/completions?token=private"
+    app = _app_with_local_console_target(endpoint=endpoint, model="  alias  ")
+    saved: list[dict[str, dict[str, object]]] = []
+
+    class FakeAdapter:
+        def save_sections(self, values):
+            saved.append(values)
+            return True
+
+    monkeypatch.setattr(settings_screen_module, "SettingsConfigAdapter", FakeAdapter)
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+        override = screen.query_one("#settings-console-reasoning-override", Select)
+        native = screen.query_one("#settings-console-reasoning-native-tools", Checkbox)
+
+        assert override.value == "inherit"
+        assert next((str(label), value) for label, value in override._options) == (
+            "Use default",
+            "inherit",
+        )
+        assert native.value is False
+
+        override.value = "all"
+        native.value = True
+        await pilot.pause()
+        await pilot.click("#settings-save-category")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        key = reasoning_override_key("local_vllm", endpoint, "alias")
+        expected_first = {
+            "console": {
+                "reasoning_history_overrides": {key: "all"},
+                "reasoning_native_tool_overrides": {key: True},
+            }
+        }
+        assert saved == [expected_first]
+        assert app.app_config["console"]["reasoning_history_overrides"] == {key: "all"}
+        assert app.app_config["console"]["reasoning_native_tool_overrides"] == {
+            key: True
+        }
+        assert "secret" not in key and "private" not in key and "alias" not in key
+        target_copy = next(
+            str(widget.renderable)
+            for widget in screen.query(".settings-detail-row")
+            if "local_vllm / alias" in str(getattr(widget, "renderable", ""))
+        )
+        assert "secret" not in target_copy and "private" not in target_copy
+
+        override.value = "inherit"
+        await pilot.pause()
+        await pilot.click("#settings-save-category")
+        await pilot.app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert saved[-1] == {"console": {"reasoning_history_overrides": {}}}
+        assert app.app_config["console"]["reasoning_history_overrides"] == {}
+        assert app.app_config["console"]["reasoning_native_tool_overrides"] == {
+            key: True
+        }
+
+
+@pytest.mark.asyncio
+async def test_gemma_status_explains_fenced_tool_round_limit() -> None:
+    app = _app_with_local_console_target(
+        provider="local_vllm",
+        endpoint="http://localhost:9099",
+        model="gemma-4",
+    )
+    key = reasoning_override_key(
+        "local_vllm", "http://localhost:9099", "gemma-4"
+    )
+    app.console_runtime.provider_gateway.reasoning_policies = {
+        key: ReasoningReplayPolicy(
+            "current",
+            "Auto",
+            "Gemma 4",
+            supports_preserve=True,
+            verified=True,
+            native_tools=False,
+        )
+    }
+
+    host = DestinationHarness(app, "settings")
+    async with host.run_test(size=(190, 55)) as pilot:
+        await _open_settings_category(pilot, "#settings-category-console-behavior")
+        screen = _active_destination_screen(host)
+
+        assert (
+            "Native server tools are needed to retain Gemma thinking across tool rounds"
+            in _visible_text(screen)
+        )

--- a/Tests/Utils/test_reasoning_history_input_validation.py
+++ b/Tests/Utils/test_reasoning_history_input_validation.py
@@ -1,0 +1,29 @@
+"""Shared input boundary for Console reasoning-history selectors."""
+
+import pytest
+
+from tldw_chatbook.Utils.input_validation import (
+    validate_reasoning_history_selector,
+)
+
+
+@pytest.mark.parametrize("value", ["auto", "current", "all", "off"])
+def test_reasoning_history_selector_accepts_exact_modes(value: str) -> None:
+    assert validate_reasoning_history_selector(value) == value
+
+
+def test_reasoning_history_override_accepts_inherit_only_when_requested() -> None:
+    assert (
+        validate_reasoning_history_selector("inherit", allow_inherit=True)
+        == "inherit"
+    )
+    with pytest.raises(ValueError, match="selector value is invalid"):
+        validate_reasoning_history_selector("inherit")
+
+
+@pytest.mark.parametrize("value", [None, 1, True, "", "server_default"])
+def test_reasoning_history_selector_rejects_unlisted_or_coerced_values(
+    value: object,
+) -> None:
+    with pytest.raises(ValueError, match="selector value is invalid"):
+        validate_reasoning_history_selector(value, allow_inherit=True)

--- a/Tests/fixtures/reasoning_templates/gemma4.jinja
+++ b/Tests/fixtures/reasoning_templates/gemma4.jinja
@@ -1,0 +1,390 @@
+{#
+  Template: Google Gemma 4 Canonical Chat Template
+  Author: Google Gemma Engineering Team
+  Published: 2026-07-09
+  Context: Fixed tool-calling loops, turn closures, and thinking content-ordering.
+#}
+{%- macro format_parameters(properties, required, filter_keys=false) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if not filter_keys or key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([]), filter_keys=true) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is none -%}
+        {{- 'null' -}}
+    {%- elif argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{#- ===== SETUP ===== -#}
+{%- set ns = namespace(prev_message_type=None, prev_non_tool_role=None) -%}
+{%- set loop_messages = messages -%}
+{%- set enable_thinking = enable_thinking | default(false) -%}
+{%- set preserve_thinking = preserve_thinking | default(false) -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if enable_thinking or tools or (messages and messages[0]['role'] in ['system', 'developer']) -%}
+    {{- '<|turn>system\n' -}}
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+    {%- if messages and messages[0]['role'] in ['system', 'developer'] -%}
+        {%- if messages[0]['content'] is string -%}
+            {{- messages[0]['content'] | trim -}}
+        {%- elif messages[0]['content'] is sequence -%}
+            {%- for item in messages[0]['content'] -%}
+                {{- item['text'] | trim + ' '-}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation using tracked state — O(1) instead of O(n) backward scan -#}
+    {%- set continue_same_model_turn = (role == 'model' and ns.prev_non_tool_role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- set thinking_gate = (loop.index0 > ns_turn.last_user_idx) or (preserve_thinking and message.get('tool_calls')) -%}
+    {%- if thinking_text and thinking_gate -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message.get('tool_calls') -%}
+                {%- for tool_call in message.get('tool_calls') -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is none -%}
+                    {%- else -%}
+                        {{- raise_exception(
+                            "chat_template: tool_calls[].function.arguments must be a "
+                            "JSON object (mapping), not a string. Deserialize arguments "
+                            "before passing to the template."
+                        ) -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message.get('tool_responses') -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown', true), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') or 'unknown') -%}
+                        {%- for tc in message.get('tool_calls') -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') in ['image', 'image_url'] -%}
+                                    {{- '<|image|>' -}}
+                                {%- elif part.get('type') in ['audio', 'input_audio'] -%}
+                                    {{- '<|audio|>' -}}
+                                {%- elif part.get('type') == 'video' -%}
+                                    {{- '<|video|>' -}}
+                                {%- endif -%}
+                            {%- endfor -%}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- set captured_content -%}
+            {%- if message.get('content') is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message.get('content') is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item.get('type') == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item.get('type') in ['image', 'image_url'] -%}
+                        {{- '<|image|>' -}}
+                    {%- elif item.get('type') in ['audio', 'input_audio'] -%}
+                        {{- '<|audio|>' -}}
+                    {%- elif item.get('type') == 'video' -%}
+                        {{- '<|video|>' -}}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+            {%- endset -%}
+
+            {{- captured_content -}}
+            {%- set has_content = captured_content | trim | length > 0 -%}
+
+        {#- Forward-scan: find next non-tool message role for continuation detection -#}
+        {%- set next_nt = namespace(role=None, found=false) -%}
+        {%- for j in range(loop.index0 + 1, loop_messages | length) -%}
+            {%- if not next_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set next_nt.role = loop_messages[j]['role'] -%}
+                    {%- set next_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set continues_into_next = (
+            role == 'model'
+            and next_nt.role == 'assistant'
+            and (not message.get('tool_calls') or ns_tr_out.flag)
+        ) -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif continues_into_next -%}
+        {%- elif not (ns_tr_out.flag and not has_content and not next_nt.found) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+
+    {#- Track previous non-tool role for next iteration (avoids O(n) backward scan) -#}
+    {%- set ns.prev_non_tool_role = message['role'] -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- elif ns.prev_message_type == 'tool_response' and enable_thinking -%}
+        {{- '<|channel>thought\n' -}}
+    {%- endif -%}
+{%- endif -%}

--- a/Tests/fixtures/reasoning_templates/gemma4.source.txt
+++ b/Tests/fixtures/reasoning_templates/gemma4.source.txt
@@ -1,0 +1,2 @@
+https://huggingface.co/google/gemma-4-26B-A4B-it/raw/main/chat_template.jinja
+Retrieved 2026-09-10. Upstream template; retained for exact fingerprint and rendered-prompt regression checks.

--- a/Tests/fixtures/reasoning_templates/gemma4_legacy.jinja
+++ b/Tests/fixtures/reasoning_templates/gemma4_legacy.jinja
@@ -1,0 +1,347 @@
+{%- macro format_parameters(properties, required) -%}
+    {%- set standard_keys = ['description', 'type', 'properties', 'required', 'nullable'] -%}
+    {%- set ns = namespace(found_first=false) -%}
+    {%- for key, value in properties | dictsort -%}
+        {%- set add_comma = false -%}
+        {%- if key not in standard_keys -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {{ key }}:{
+            {%- if value['description'] -%}
+                description:<|"|>{{ value['description'] }}<|"|>
+                {%- set add_comma = true -%}
+            {%- endif -%}
+            {%- if value['type'] | upper == 'STRING' -%}
+                {%- if value['enum'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    enum:{{ format_argument(value['enum']) }}
+                {%- endif -%}
+            {%- elif value['type'] | upper == 'ARRAY' -%}
+                {%- if value['items'] is mapping and value['items'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    items:{
+                    {%- set ns_items = namespace(found_first=false) -%}
+                    {%- for item_key, item_value in value['items'] | dictsort -%}
+                        {%- if item_value is not none -%}
+                            {%- if ns_items.found_first %},{% endif -%}
+                            {%- set ns_items.found_first = true -%}
+                            {%- if item_key == 'properties' -%}
+                                properties:{
+                                {%- if item_value is mapping -%}
+                                    {{- format_parameters(item_value, value['items']['required'] | default([])) -}}
+                                {%- endif -%}
+                                }
+                            {%- elif item_key == 'required' -%}
+                                required:[
+                                {%- for req_item in item_value -%}
+                                    <|"|>{{- req_item -}}<|"|>
+                                    {%- if not loop.last %},{% endif -%}
+                                {%- endfor -%}
+                                ]
+                            {%- elif item_key == 'type' -%}
+                                {%- if item_value is string -%}
+                                    type:{{ format_argument(item_value | upper) }}
+                                {%- else -%}
+                                    type:{{ format_argument(item_value | map('upper') | list) }}
+                                {%- endif -%}
+                            {%- else -%}
+                                {{ item_key }}:{{ format_argument(item_value) }}
+                            {%- endif -%}
+                        {%- endif -%}
+                    {%- endfor -%}
+                    }
+                {%- endif -%}
+            {%- endif -%}
+            {%- if value['nullable'] %}
+                {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                nullable:true
+            {%- endif -%}
+            {%- if value['type'] | upper == 'OBJECT' -%}
+                {%- if value['properties'] is defined and value['properties'] is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value['properties'], value['required'] | default([])) -}}
+                    }
+                {%- elif value is mapping -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    properties:{
+                    {{- format_parameters(value, value['required'] | default([])) -}}
+                    }
+                {%- endif -%}
+                {%- if value['required'] -%}
+                    {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+                    required:[
+                    {%- for item in value['required'] | default([]) -%}
+                        <|"|>{{- item -}}<|"|>
+                        {%- if not loop.last %},{% endif -%}
+                    {%- endfor -%}
+                    ]
+                {%- endif -%}
+            {%- endif -%}
+            {%- if add_comma %},{%- else -%} {%- set add_comma = true -%} {% endif -%}
+            type:<|"|>{{ value['type'] | upper }}<|"|>}
+        {%- endif -%}
+    {%- endfor -%}
+{%- endmacro -%}
+{%- macro format_function_declaration(tool_data) -%}
+    declaration:{{- tool_data['function']['name'] -}}{description:<|"|>{{- tool_data['function']['description'] -}}<|"|>
+    {%- set params = tool_data['function']['parameters'] -%}
+    {%- if params -%}
+        ,parameters:{
+        {%- if params['properties'] -%}
+            properties:{ {{- format_parameters(params['properties'], params['required']) -}} },
+        {%- endif -%}
+        {%- if params['required'] -%}
+            required:[
+            {%- for item in params['required'] -%}
+                <|"|>{{- item -}}<|"|>
+                {{- ',' if not loop.last -}}
+            {%- endfor -%}
+            ],
+        {%- endif -%}
+        {%- if params['type'] -%}
+            type:<|"|>{{- params['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if 'response' in tool_data['function'] -%}
+        {%- set response_declaration = tool_data['function']['response'] -%}
+        ,response:{
+        {%- if response_declaration['description'] -%}
+            description:<|"|>{{- response_declaration['description'] -}}<|"|>,
+        {%- endif -%}
+        {%- if response_declaration['type'] | upper == 'OBJECT' -%}
+            type:<|"|>{{- response_declaration['type'] | upper -}}<|"|>}
+        {%- endif -%}
+    {%- endif -%}
+    }
+{%- endmacro -%}
+{%- macro format_argument(argument, escape_keys=True) -%}
+    {%- if argument is string -%}
+        {{- '<|"|>' + argument + '<|"|>' -}}
+    {%- elif argument is boolean -%}
+        {{- 'true' if argument else 'false' -}}
+    {%- elif argument is mapping -%}
+        {{- '{' -}}
+        {%- set ns = namespace(found_first=false) -%}
+        {%- for key, value in argument | dictsort -%}
+            {%- if ns.found_first %},{% endif -%}
+            {%- set ns.found_first = true -%}
+            {%- if escape_keys -%}
+                {{- '<|"|>' + key + '<|"|>' -}}
+            {%- else -%}
+                {{- key -}}
+            {%- endif -%}
+            :{{- format_argument(value, escape_keys=escape_keys) -}}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- elif argument is sequence -%}
+        {{- '[' -}}
+        {%- for item in argument -%}
+            {{- format_argument(item, escape_keys=escape_keys) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- ']' -}}
+    {%- else -%}
+        {{- argument -}}
+    {%- endif -%}
+{%- endmacro -%}
+{%- macro strip_thinking(text) -%}
+    {%- set ns = namespace(result='') -%}
+    {%- for part in text.split('<channel|>') -%}
+        {%- if '<|channel>' in part -%}
+            {%- set ns.result = ns.result + part.split('<|channel>')[0] -%}
+        {%- else -%}
+            {%- set ns.result = ns.result + part -%}
+        {%- endif -%}
+    {%- endfor -%}
+    {{- ns.result | trim -}}
+{%- endmacro -%}
+
+{%- macro format_tool_response_block(tool_name, response) -%}
+    {{- '<|tool_response>' -}}
+    {%- if response is mapping -%}
+        {{- 'response:' + tool_name + '{' -}}
+        {%- for key, value in response | dictsort -%}
+            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+            {%- if not loop.last %},{% endif -%}
+        {%- endfor -%}
+        {{- '}' -}}
+    {%- else -%}
+        {{- 'response:' + tool_name + '{value:' + format_argument(response, escape_keys=False) + '}' -}}
+    {%- endif -%}
+    {{- '<tool_response|>' -}}
+{%- endmacro -%}
+
+{%- set ns = namespace(prev_message_type=None) -%}
+{%- set loop_messages = messages -%}
+{{- bos_token -}}
+{#- Handle System/Tool Definitions Block -#}
+{%- if (enable_thinking is defined and enable_thinking) or tools or messages[0]['role'] in ['system', 'developer'] -%}
+    {{- '<|turn>system\n' -}}
+
+    {#- Inject Thinking token at the very top of the FIRST system turn -#}
+    {%- if enable_thinking is defined and enable_thinking -%}
+        {{- '<|think|>\n' -}}
+        {%- set ns.prev_message_type = 'think' -%}
+    {%- endif -%}
+
+    {%- if messages[0]['role'] in ['system', 'developer'] -%}
+        {{- messages[0]['content'] | trim -}}
+        {%- set loop_messages = messages[1:] -%}
+    {%- endif -%}
+
+    {%- if tools -%}
+        {%- for tool in tools %}
+            {{- '<|tool>' -}}
+            {{- format_function_declaration(tool) | trim -}}
+            {{- '<tool|>' -}}
+        {%- endfor %}
+        {%- set ns.prev_message_type = 'tool' -%}
+    {%- endif -%}
+
+    {{- '<turn|>\n' -}}
+{%- endif %}
+
+{#- Pre-scan: find last user message index for reasoning guard -#}
+{%- set ns_turn = namespace(last_user_idx=-1) -%}
+{%- for i in range(loop_messages | length) -%}
+    {%- if loop_messages[i]['role'] == 'user' -%}
+        {%- set ns_turn.last_user_idx = i -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{#- Loop through messages -#}
+{%- for message in loop_messages -%}
+    {%- if message['role'] != 'tool' -%}
+    {%- set ns.prev_message_type = None -%}
+    {%- set role = 'model' if message['role'] == 'assistant' else message['role'] -%}
+    {#- Detect continuation: suppress duplicate <|turn>model when previous non-tool message was also assistant -#}
+    {%- set prev_nt = namespace(role=None, found=false) -%}
+    {%- if loop.index0 > 0 -%}
+        {%- for j in range(loop.index0 - 1, -1, -1) -%}
+            {%- if not prev_nt.found -%}
+                {%- if loop_messages[j]['role'] != 'tool' -%}
+                    {%- set prev_nt.role = loop_messages[j]['role'] -%}
+                    {%- set prev_nt.found = true -%}
+                {%- endif -%}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+    {%- set continue_same_model_turn = (role == 'model' and prev_nt.role == 'assistant') -%}
+    {%- if not continue_same_model_turn -%}
+        {{- '<|turn>' + role + '\n' }}
+    {%- endif -%}
+
+    {#- Render reasoning/reasoning_content as thinking channel -#}
+    {%- set thinking_text = message.get('reasoning') or message.get('reasoning_content') -%}
+    {%- if thinking_text and loop.index0 > ns_turn.last_user_idx and message.get('tool_calls') -%}
+        {{- '<|channel>thought\n' + thinking_text + '\n<channel|>' -}}
+    {%- endif -%}
+
+            {%- if message['tool_calls'] -%}
+                {%- for tool_call in message['tool_calls'] -%}
+                    {%- set function = tool_call['function'] -%}
+                    {{- '<|tool_call>call:' + function['name'] + '{' -}}
+                    {%- if function['arguments'] is mapping -%}
+                        {%- set ns_args = namespace(found_first=false) -%}
+                        {%- for key, value in function['arguments'] | dictsort -%}
+                            {%- if ns_args.found_first %},{% endif -%}
+                            {%- set ns_args.found_first = true -%}
+                            {{- key -}}:{{- format_argument(value, escape_keys=False) -}}
+                        {%- endfor -%}
+                    {%- elif function['arguments'] is string -%}
+                        {{- function['arguments'] -}}
+                    {%- endif -%}
+                    {{- '}<tool_call|>' -}}
+                {%- endfor -%}
+                {%- set ns.prev_message_type = 'tool_call' -%}
+            {%- endif -%}
+
+            {%- set ns_tr_out = namespace(flag=false) -%}
+            {%- if message.get('tool_responses') -%}
+                {#- Legacy: tool_responses embedded on the assistant message (Google/Gemma native) -#}
+                {%- for tool_response in message['tool_responses'] -%}
+                    {{- format_tool_response_block(tool_response['name'] | default('unknown'), tool_response['response']) -}}
+                    {%- set ns_tr_out.flag = true -%}
+                    {%- set ns.prev_message_type = 'tool_response' -%}
+                {%- endfor -%}
+            {%- elif message.get('tool_calls') -%}
+                {#- OpenAI Chat Completions: forward-scan consecutive role:tool messages -#}
+                {%- set ns_tool_scan = namespace(stopped=false) -%}
+                {%- for k in range(loop.index0 + 1, loop_messages | length) -%}
+                    {%- if ns_tool_scan.stopped -%}
+                    {%- elif loop_messages[k]['role'] != 'tool' -%}
+                        {%- set ns_tool_scan.stopped = true -%}
+                    {%- else -%}
+                        {%- set follow = loop_messages[k] -%}
+                        {#- Resolve tool_call_id to function name -#}
+                        {%- set ns_tname = namespace(name=follow.get('name') | default('unknown')) -%}
+                        {%- for tc in message['tool_calls'] -%}
+                            {%- if tc.get('id') == follow.get('tool_call_id') -%}
+                                {%- set ns_tname.name = tc['function']['name'] -%}
+                            {%- endif -%}
+                        {%- endfor -%}
+                        {#- Handle content as string or content-parts array -#}
+                        {%- set tool_body = follow.get('content') -%}
+                        {%- if tool_body is string -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- elif tool_body is sequence and tool_body is not string -%}
+                            {%- set ns_txt = namespace(s='') -%}
+                            {%- for part in tool_body -%}
+                                {%- if part.get('type') == 'text' -%}
+                                    {%- set ns_txt.s = ns_txt.s + (part.get('text') | default('')) -%}
+                                {%- endif -%}
+                            {%- endfor -%}
+                            {{- format_tool_response_block(ns_tname.name, ns_txt.s) -}}
+                        {%- else -%}
+                            {{- format_tool_response_block(ns_tname.name, tool_body) -}}
+                        {%- endif -%}
+                        {%- set ns_tr_out.flag = true -%}
+                        {%- set ns.prev_message_type = 'tool_response' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+            {%- if message['content'] is string -%}
+                {%- if role == 'model' -%}
+                    {{- strip_thinking(message['content']) -}}
+                {%- else -%}
+                    {{- message['content'] | trim -}}
+                {%- endif -%}
+            {%- elif message['content'] is sequence -%}
+                {%- for item in message['content'] -%}
+                    {%- if item['type'] == 'text' -%}
+                        {%- if role == 'model' -%}
+                            {{- strip_thinking(item['text']) -}}
+                        {%- else -%}
+                            {{- item['text'] | trim -}}
+                        {%- endif -%}
+                    {%- elif item['type'] == 'image' -%}
+                        {{- '<|image|>' -}}
+                        {%- set ns.prev_message_type = 'image' -%}
+                    {%- elif item['type'] == 'audio' -%}
+                        {{- '<|audio|>' -}}
+                        {%- set ns.prev_message_type = 'audio' -%}
+                    {%- elif item['type'] == 'video' -%}
+                        {{- '<|video|>' -}}
+                        {%- set ns.prev_message_type = 'video' -%}
+                    {%- endif -%}
+                {%- endfor -%}
+            {%- endif -%}
+
+        {%- if ns.prev_message_type == 'tool_call' and not ns_tr_out.flag -%}
+            {{- '<|tool_response>' -}}
+        {%- elif not (ns_tr_out.flag and not message.get('content')) -%}
+            {{- '<turn|>\n' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{%- if add_generation_prompt -%}
+    {%- if ns.prev_message_type != 'tool_response' and ns.prev_message_type != 'tool_call' -%}
+        {{- '<|turn>model\n' -}}
+        {%- if not enable_thinking | default(false) -%}
+            {{- '<|channel>thought\n<channel|>' -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endif -%}

--- a/Tests/fixtures/reasoning_templates/gemma4_legacy.source.txt
+++ b/Tests/fixtures/reasoning_templates/gemma4_legacy.source.txt
@@ -1,0 +1,1 @@
+Captured from llama.cpp /props on localhost:9099, 2026-09-10. Gemma 4 26B A4B GGUF embedded template. Reviewed against Google Gemma 4 thinking guidance: current assistant tool calls only.

--- a/Tests/fixtures/reasoning_templates/qwen35.jinja
+++ b/Tests/fixtures/reasoning_templates/qwen35.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/Tests/fixtures/reasoning_templates/qwen35.source.txt
+++ b/Tests/fixtures/reasoning_templates/qwen35.source.txt
@@ -1,0 +1,2 @@
+https://huggingface.co/Qwen/Qwen3.5-27B/raw/main/chat_template.jinja
+Retrieved 2026-09-10. Upstream template; retained for exact fingerprint and rendered-prompt regression checks.

--- a/Tests/fixtures/reasoning_templates/qwen36.jinja
+++ b/Tests/fixtures/reasoning_templates/qwen36.jinja
@@ -1,0 +1,154 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if (preserve_thinking is defined and preserve_thinking is true) or (loop.index0 > ns.last_query_index) %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/Tests/fixtures/reasoning_templates/qwen36.source.txt
+++ b/Tests/fixtures/reasoning_templates/qwen36.source.txt
@@ -1,0 +1,2 @@
+https://huggingface.co/Qwen/Qwen3.6-27B/raw/main/chat_template.jinja
+Retrieved 2026-09-10. Upstream template; retained for exact fingerprint and rendered-prompt regression checks.

--- a/Tests/fixtures/reasoning_templates/qwen38.jinja
+++ b/Tests/fixtures/reasoning_templates/qwen38.jinja
@@ -1,0 +1,170 @@
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- set reasoning_instructions = '' %}
+{%- if enable_thinking is undefined or enable_thinking is true %}
+    {%- set resolved_reasoning_effort = reasoning_effort|default('xhigh') %}
+    {%- if resolved_reasoning_effort not in ('xhigh', 'medium', 'low') %}
+        {{- raise_exception('Unexpected reasoning effort ' ~ reasoning_effort ~ '. Supported types are xhigh (default), medium, and low.') }}
+    {%- endif %}
+    {%- if resolved_reasoning_effort == 'xhigh' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to xhigh. Please think carefully through the task, validate key assumptions, consider plausible alternatives, and prioritize correctness, consistency, and clarity in the final answer.' %}
+    {%- elif resolved_reasoning_effort == 'low' %}
+        {%- set reasoning_instructions = 'Reasoning effort is set to low. Keep your thinking brief and focused, moving directly to the conclusion without unnecessary elaboration.' %}
+    {%- endif %}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {%- if reasoning_instructions %}
+        {{- reasoning_instructions + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '<|im_start|>system\n' + (reasoning_instructions + '\n\n' if reasoning_instructions else '')  + content + '<|im_end|>\n' }}
+        {%- elif reasoning_instructions %}
+            {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- elif reasoning_instructions %}
+        {{- '<|im_start|>system\n' + reasoning_instructions + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {%- if preserve_thinking is undefined or preserve_thinking is true or loop.index0 > ns.last_query_index %}
+            {{- '<|im_start|>' + message.role + '\n<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + content }}
+        {%- endif %}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined and tool_call.arguments != '' %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/Tests/fixtures/reasoning_templates/qwen38.source.txt
+++ b/Tests/fixtures/reasoning_templates/qwen38.source.txt
@@ -1,0 +1,2 @@
+https://huggingface.co/Qwen/Qwen3.8-27B/raw/main/chat_template.jinja
+Retrieved 2026-09-10. Upstream template; retained for exact fingerprint and rendered-prompt regression checks.

--- a/Tests/integration/test_console_thinking_end_to_end.py
+++ b/Tests/integration/test_console_thinking_end_to_end.py
@@ -423,6 +423,9 @@ async def test_durable_owner_replay_is_counted_and_dispatched_exactly_once(
     async def handler(request: httpx.Request) -> httpx.Response:
         if request.url.path == "/health":
             return httpx.Response(200, json={"status": "ok"})
+        if request.url.path == "/props":
+            # Optional template discovery can be unavailable on older servers.
+            return httpx.Response(404)
         assert request.url.path == "/v1/chat/completions"
         dispatched.append(json.loads(request.content))
         return httpx.Response(
@@ -711,7 +714,7 @@ async def test_persistence_preflight_controls_dispatch(
 
 
 @pytest.mark.asyncio
-async def test_plain_local_model_uses_real_resolver_and_dispatches_on_v0_backend(
+async def test_local_structured_capability_refuses_v0_backend_before_dispatch(
     tmp_path,
 ) -> None:
     endpoint = "http://127.0.0.1:9099"
@@ -721,6 +724,9 @@ async def test_plain_local_model_uses_real_resolver_and_dispatches_on_v0_backend
         nonlocal provider_contacts
         if request.url.path == "/health":
             return httpx.Response(200, json={"status": "ok"})
+        if request.url.path == "/props":
+            # Optional template discovery can be unavailable on older servers.
+            return httpx.Response(404)
         assert request.url.path == "/v1/chat/completions"
         provider_contacts += 1
         return httpx.Response(
@@ -751,17 +757,19 @@ async def test_plain_local_model_uses_real_resolver_and_dispatches_on_v0_backend
         streaming=False,
     )
 
+    store.set_session_draft(session.id, "Plain model question")
     try:
         result = await controller.submit_draft("Plain model question")
 
-        assert result.accepted is True
-        assert provider_contacts == 1
-        assert [
-            message.content for message in store.messages_for_session(session.id)
-        ] == [
-            "Plain model question",
-            "PLAIN-MODEL-ANSWER",
-        ]
+        # An alias cannot establish that a local server will never emit its
+        # declared structured reasoning fields. Refuse before accepting an
+        # owner whose backend cannot preserve those fields.
+        assert result.accepted is False
+        assert result.provider_started is False
+        assert result.should_clear_draft is False
+        assert provider_contacts == 0
+        assert not store.messages_for_session(session.id)
+        assert store.session_draft(session.id) == "Plain model question"
     finally:
         await gateway.aclose()
         db.close_connection()

--- a/Tests/test_config_reasoning_history.py
+++ b/Tests/test_config_reasoning_history.py
@@ -1,0 +1,167 @@
+"""Raw bootstrap and precedence contracts for Console reasoning replay settings."""
+
+from __future__ import annotations
+
+import json
+
+from loguru import logger
+
+from tldw_chatbook import config as config_module
+from tldw_chatbook.Chat.local_reasoning import REASONING_HISTORY_OPTIONS
+from tldw_chatbook.Utils.reasoning_config import REASONING_HISTORY_MODES
+
+
+def _write_console_config(path, body: str) -> None:
+    path.write_text(f"[console]\n{body}", encoding="utf-8")
+
+
+def test_raw_bootstrap_migrates_legacy_replay_opt_out(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(config_path, "replay_thinking = false\n")
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    bootstrap = config_module.load_cli_config_and_ensure_existence(force_reload=True)
+    settings = config_module.load_settings(force_reload=True)
+
+    assert bootstrap["console"]["reasoning_history"] == "off"
+    assert settings["console"]["reasoning_history"] == "off"
+
+
+def test_raw_bootstrap_preserves_explicit_mode_over_legacy_opt_out(
+    tmp_path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(
+        config_path,
+        'replay_thinking = false\nreasoning_history = "current"\n',
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+
+    bootstrap = config_module.load_cli_config_and_ensure_existence(force_reload=True)
+
+    assert bootstrap["console"]["reasoning_history"] == "current"
+
+
+def test_reasoning_environment_values_override_toml(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(
+        config_path,
+        'reasoning_history = "current"\n'
+        'reasoning_history_overrides = { saved = "off" }\n'
+        "reasoning_native_tool_overrides = { saved = false }\n",
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("TLDW_CONSOLE_REASONING_HISTORY", "all")
+    monkeypatch.setenv(
+        "TLDW_CONSOLE_REASONING_HISTORY_OVERRIDES",
+        json.dumps({"environment": "current"}),
+    )
+    monkeypatch.setenv(
+        "TLDW_CONSOLE_REASONING_NATIVE_TOOL_OVERRIDES",
+        json.dumps({"environment": True}),
+    )
+
+    console = config_module.load_settings(force_reload=True)["console"]
+
+    assert console["reasoning_history"] == "all"
+    assert console["reasoning_history_overrides"] == {"environment": "current"}
+    assert console["reasoning_native_tool_overrides"] == {"environment": True}
+
+
+def test_blank_reasoning_environment_values_leave_toml_in_effect(
+    tmp_path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(config_path, 'reasoning_history = "off"\n')
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv("TLDW_CONSOLE_REASONING_HISTORY", "")
+
+    console = config_module.load_settings(force_reload=True)["console"]
+
+    assert console["reasoning_history"] == "off"
+
+
+def test_malformed_override_reports_only_sanitized_field_name(
+    tmp_path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    private_canary = "user:secret@private.invalid"
+    _write_console_config(
+        config_path,
+        f'reasoning_history = "current"\n'
+        f'reasoning_history_overrides = "{private_canary}"\n',
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        console = config_module.load_settings(force_reload=True)["console"]
+    finally:
+        logger.remove(sink)
+
+    diagnostic = "\n".join(messages)
+    assert console["reasoning_history"] == "current"
+    assert console["reasoning_history_overrides"] == {}
+    assert "reasoning_history_overrides" in diagnostic
+    assert private_canary not in diagnostic
+
+
+def test_invalid_environment_map_is_diagnostic_and_does_not_use_toml_map(
+    tmp_path, monkeypatch
+) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(
+        config_path,
+        'reasoning_history_overrides = { saved = "all" }\n',
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    monkeypatch.setenv(
+        "TLDW_CONSOLE_REASONING_HISTORY_OVERRIDES",
+        '{"private.invalid":',
+    )
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        console = config_module.load_settings(force_reload=True)["console"]
+    finally:
+        logger.remove(sink)
+
+    assert console["reasoning_history_overrides"] == {}
+    assert "reasoning_history_overrides" in "\n".join(messages)
+
+
+def test_nested_override_values_are_strictly_validated(tmp_path, monkeypatch) -> None:
+    config_path = tmp_path / "config.toml"
+    _write_console_config(
+        config_path,
+        'reasoning_history_overrides = { target = "sideways" }\n'
+        'reasoning_native_tool_overrides = { target = "true" }\n',
+    )
+    monkeypatch.setenv("TLDW_CONFIG_PATH", str(config_path))
+    messages: list[str] = []
+    sink = logger.add(messages.append, level="WARNING", format="{message}")
+    try:
+        console = config_module.load_settings(force_reload=True)["console"]
+    finally:
+        logger.remove(sink)
+
+    diagnostic = "\n".join(messages)
+    assert console["reasoning_history_overrides"] == {}
+    assert console["reasoning_native_tool_overrides"] == {}
+    assert "reasoning_history_overrides" in diagnostic
+    assert "reasoning_native_tool_overrides" in diagnostic
+
+
+def test_generated_config_documents_reasoning_environment_names() -> None:
+    for name in (
+        "TLDW_CONSOLE_REASONING_HISTORY",
+        "TLDW_CONSOLE_REASONING_HISTORY_OVERRIDES",
+        "TLDW_CONSOLE_REASONING_NATIVE_TOOL_OVERRIDES",
+    ):
+        assert name in config_module.CONFIG_TOML_CONTENT
+
+
+def test_config_model_modes_match_runtime_policy_options() -> None:
+    assert REASONING_HISTORY_MODES == {
+        value for _label, value in REASONING_HISTORY_OPTIONS
+    }

--- a/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
+++ b/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
@@ -150,13 +150,13 @@ continuation Discard or the retention of a distinct, non-deleted off-branch vari
 - [Console Assistant Turn Grouping](../../Docs/superpowers/specs/2026-08-21-console-assistant-turn-grouping-design.md)
 
 
-## Amendment: template-aware local reasoning replay (2026-09-10, TASK-32243)
+## Amendment: template-aware local reasoning replay (2026-09-10, TASK-32273)
 
 PR 2575 is reconciled with this ADR rather than introducing duplicate display or metadata-based thinking storage. Canonical envelopes and generation ownership remain authoritative. Local adapters can declare separate `reasoning_content` (llama.cpp/vLLM) or `reasoning` (Ollama) source encodings. Exact per-call thinking accompanies its assistant/tool owner in active exchanges; aggregate review traces must never be combined as a final-call reasoning value. Tool-round provenance is excluded when its actual tool-call owner is absent.
 
 The conversation's Exclude still disables optional replay, Include requests all eligible history with strict serialization checks, and Required continuation remains independent. Conversation Auto is refined by device-local `console.reasoning_history` (Automatic/current exchange/all available/off), with normalized provider/endpoint/model overrides. This preserves synced conversation preferences while allowing server-specific compatibility choices. Old explicit replay false migrates to Off.
 
-Automatic recognizes exact reviewed templates, not aliases. Reviewed Gemma 4 and Qwen3.5/3.6 use current exchange; reviewed Qwen3.8 uses all available. Unknown/custom/Ollama templates retain server defaults. Optional metadata reads are bounded and failure does not block send. Native-tool support is established separately through server capabilities or explicit configured-server preference, never by template identity alone.
+Automatic recognizes exact reviewed templates, not aliases. Reviewed Gemma 4 and Qwen3.5/3.6 use current exchange; reviewed Qwen3.8 uses all available. Unknown/custom/Ollama templates retain server defaults. Optional metadata reads are bounded and failure does not block send. Device-local metadata caches are limited to 32 normalized endpoint/model targets with a 60-second refresh interval; failed probes back off for 15 seconds and retain last successful facts. Replay preferences are reapplied on each send rather than cached with server metadata. Native-tool support is established separately through server capabilities or explicit configured-server preference, never by template identity alone.
 
 Projection occurs before serialization, token accounting and provider admission. Whole owner groups and their matching provenance are filtered together. Runtime guidance and tool results continue the active exchange; any provider-visible row rewrite must preserve causal trace provenance. Children inherit policy but never a parent's thinking owner. Capture, default-on display, canonical persistence and importable transcript export are unaffected by replay preferences.
 

--- a/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
+++ b/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
@@ -148,3 +148,16 @@ continuation Discard or the retention of a distinct, non-deleted off-branch vari
 - [ADR-064: DeepSeek Dual API Provider Boundary](064-deepseek-dual-api-provider-boundary.md)
 - [ADR-066: Local Provider Thinking Controls](066-local-provider-thinking-controls.md)
 - [Console Assistant Turn Grouping](../../Docs/superpowers/specs/2026-08-21-console-assistant-turn-grouping-design.md)
+
+
+## Amendment: template-aware local reasoning replay (2026-09-10, TASK-32243)
+
+PR 2575 is reconciled with this ADR rather than introducing duplicate display or metadata-based thinking storage. Canonical envelopes and generation ownership remain authoritative. Local adapters can declare separate `reasoning_content` (llama.cpp/vLLM) or `reasoning` (Ollama) source encodings. Exact per-call thinking accompanies its assistant/tool owner in active exchanges; aggregate review traces must never be combined as a final-call reasoning value. Tool-round provenance is excluded when its actual tool-call owner is absent.
+
+The conversation's Exclude still disables optional replay, Include requests all eligible history with strict serialization checks, and Required continuation remains independent. Conversation Auto is refined by device-local `console.reasoning_history` (Automatic/current exchange/all available/off), with normalized provider/endpoint/model overrides. This preserves synced conversation preferences while allowing server-specific compatibility choices. Old explicit replay false migrates to Off.
+
+Automatic recognizes exact reviewed templates, not aliases. Reviewed Gemma 4 and Qwen3.5/3.6 use current exchange; reviewed Qwen3.8 uses all available. Unknown/custom/Ollama templates retain server defaults. Optional metadata reads are bounded and failure does not block send. Native-tool support is established separately through server capabilities or explicit configured-server preference, never by template identity alone.
+
+Projection occurs before serialization, token accounting and provider admission. Whole owner groups and their matching provenance are filtered together. Runtime guidance and tool results continue the active exchange; any provider-visible row rewrite must preserve causal trace provenance. Children inherit policy but never a parent's thinking owner. Capture, default-on display, canonical persistence and importable transcript export are unaffected by replay preferences.
+
+Reviewed local runtime-control encoding uses the typed `RUNTIME_GUIDANCE` provenance transform. It retains the tool-result/control source and every appended guidance input; ordinary `MESSAGE_REWRITE` continues to accept only exact thinking/continuation attachments.

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -2485,3 +2485,13 @@ permissions or path containment under `$HOME`, outside the config directory the
 profile itself uses — and when a whole journey fails at step one for every
 assessor, check whether the harness is inside the feature's own exclusion rules
 before grading it.
+
+## Reasoning fields on the wire do not prove a template retained them
+
+**TASK-32273 / PR #2575, 2026-09-10.** Local replay payload assertions passed,
+but rendering the exact Gemma 4 template showed two limits: `preserve_thinking`
+retained older tool-call thinking while omitting older final-answer thinking,
+and legacy fenced tool results looked like new user turns and discarded active
+thinking. A live native calculator exchange on port 9099 retained its exact
+thinking in `/apply-template` and returned 221. Keep wire-field, rendered-prompt,
+and transcript-retention assertions separate; only claim the layer verified.

--- a/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
+++ b/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
@@ -7,7 +7,7 @@ status: In Progress
 assignee:
   - '@codex'
 created_date: '2026-09-10 19:32'
-updated_date: '2026-09-10 20:05'
+updated_date: '2026-09-10 20:28'
 labels: []
 dependencies: []
 ---
@@ -36,5 +36,5 @@ ADR required: yes. ADR path: backlog/decisions/090-console-thinking-block-owners
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-Integrated local replay with ADR-090 canonical ownership, typed local adapter events, exact per-call agent sidecars, paired projection/accounting/provenance and canonical Settings. Added frozen endpoint/model policy, explicit keyless credential handling and scoped native tools; preserved child-final thinking and bounded retained bodies. Tested reviewed Gemma/Qwen templates and live Gemma4 on localhost:9099 including native calculator replay. Targeted gateway 508 pass, final feature matrix75 pass, agent122 pass, history150 pass; known unchanged-dev stop/delete/layout failures reproduced independently. Qodo review and required CI pending before merge.
+Integrated template-aware local replay with ADR-090 canonical ownership and per-call thinking. Live Gemma4 on localhost:9099 verified Auto/All/Off and native calculator replay; exact reviewed Gemma/Qwen templates are retained. Addressed all 11 initial Qodo findings: strict sanitized config validation and environment precedence, legacy Off migration, shared settings validation, Local-LLM template forwarding, bounded metadata cache/backoff, policy-aligned profile capacity, API documentation/types and corrected ADR task link. Review-fix verification: gateway regressions 488 passed with 2 sandbox listener skips; config/settings 120 passed; import boundary 14 passed; profile/capture 38 passed; gateway cache focused 36 passed. Changed-line Ruff and diff checks passed. Reviewed the sole new diagnostic as a fixed field-name-only warning and regenerated its inventory. Initial GitHub fast lane and derived artifacts passed; final-head Qodo review and CI remain pending before merge.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
+++ b/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
@@ -1,0 +1,40 @@
+---
+id: TASK-32273
+title: >-
+  Integrate template-aware local reasoning history with canonical Console
+  thinking
+status: In Progress
+assignee:
+  - '@codex'
+created_date: '2026-09-10 19:32'
+updated_date: '2026-09-10 20:05'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reconcile PR 2575 with current dev so local Gemma and Qwen thinking is retained and replayed according to the active template without duplicating canonical thinking ownership.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Default-on display and canonical transcript persistence remain intact; optional replay never modifies saved thinking.
+- [x] #2 Automatic, Current exchange, All available and Off local replay modes and endpoint/model overrides compose with conversation Auto/Include/Exclude and required hosted continuation.
+- [x] #3 Supported llama.cpp, vLLM and Ollama adapters capture explicit structured reasoning and native tool calls; replay preserves exact response ownership and does not merge aggregate tool thoughts into final answers.
+- [x] #4 Policy projection, token accounting and trace provenance agree, including current-exchange tools and runtime guidance; children inherit policy without parent thinking.
+- [ ] #5 Targeted tests and rendered-template/live available-server checks pass; all actionable PR review findings are addressed before merge.
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes. ADR path: backlog/decisions/090-console-thinking-block-ownership-and-replay.md. Reason: extend canonical provider/history contracts without parallel storage. Execute Docs/superpowers/plans/2026-09-10-console-reasoning-dev-integration.md: canonical policy/serialization, per-call agent ownership, canonical settings, gateway integration, targeted verification, Qodo review and merge.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Integrated local replay with ADR-090 canonical ownership, typed local adapter events, exact per-call agent sidecars, paired projection/accounting/provenance and canonical Settings. Added frozen endpoint/model policy, explicit keyless credential handling and scoped native tools; preserved child-final thinking and bounded retained bodies. Tested reviewed Gemma/Qwen templates and live Gemma4 on localhost:9099 including native calculator replay. Targeted gateway 508 pass, final feature matrix75 pass, agent122 pass, history150 pass; known unchanged-dev stop/delete/layout failures reproduced independently. Qodo review and required CI pending before merge.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
+++ b/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-10 19:32'
-updated_date: '2026-09-10 20:31'
+updated_date: '2026-09-10 20:44'
 labels: []
 dependencies: []
 ---
@@ -39,4 +39,6 @@ ADR required: yes. ADR path: backlog/decisions/090-console-thinking-block-owners
 Integrated template-aware local replay with ADR-090 canonical ownership and per-call thinking. Live Gemma4 on localhost:9099 verified Auto/All/Off and native calculator replay; exact reviewed Gemma/Qwen templates are retained. Addressed all 11 initial Qodo findings: strict sanitized config validation and environment precedence, legacy Off migration, shared settings validation, Local-LLM template forwarding, bounded metadata cache/backoff, policy-aligned profile capacity, API documentation/types and corrected ADR task link. Review-fix verification: gateway regressions 488 passed with 2 sandbox listener skips; config/settings 120 passed; import boundary 14 passed; profile/capture 38 passed; gateway cache focused 36 passed. Changed-line Ruff and diff checks passed. Reviewed the sole new diagnostic as a fixed field-name-only warning and regenerated its inventory. Initial GitHub fast lane and derived artifacts passed; final-head Qodo review and CI remain pending before merge.
 
 Qodo verified e3e8431816 with zero bugs and zero rule violations; all 11 findings resolved and all 10 inline threads answered. Post-rebase focused config, gateway and mounted Settings checks: 62 passed. Implementation and review are complete; merge remains gated on final GitHub checks.
+
+Final merge preparation: refreshed again onto dev 41d14d1f74 after it advanced during CI. Range-diff confirmed unchanged implementation; Qodo reported zero findings on the rebased head. The diagnostic checker found only the aggregate total 7659 -> 7660: Git had coalesced identical +1 total edits from this PR and dev while retaining both correct per-file rows. Regenerated the aggregate; no additional diagnostic statements or sink changes were introduced.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
+++ b/backlog/tasks/task-32273 - Integrate-template-aware-local-reasoning-history-with-canonical-Console-thinking.md
@@ -3,11 +3,11 @@ id: TASK-32273
 title: >-
   Integrate template-aware local reasoning history with canonical Console
   thinking
-status: In Progress
+status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-10 19:32'
-updated_date: '2026-09-10 20:28'
+updated_date: '2026-09-10 20:31'
 labels: []
 dependencies: []
 ---
@@ -24,7 +24,7 @@ Reconcile PR 2575 with current dev so local Gemma and Qwen thinking is retained 
 - [x] #2 Automatic, Current exchange, All available and Off local replay modes and endpoint/model overrides compose with conversation Auto/Include/Exclude and required hosted continuation.
 - [x] #3 Supported llama.cpp, vLLM and Ollama adapters capture explicit structured reasoning and native tool calls; replay preserves exact response ownership and does not merge aggregate tool thoughts into final answers.
 - [x] #4 Policy projection, token accounting and trace provenance agree, including current-exchange tools and runtime guidance; children inherit policy without parent thinking.
-- [ ] #5 Targeted tests and rendered-template/live available-server checks pass; all actionable PR review findings are addressed before merge.
+- [x] #5 Targeted tests and rendered-template/live available-server checks pass; all actionable PR review findings are addressed before merge.
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -37,4 +37,6 @@ ADR required: yes. ADR path: backlog/decisions/090-console-thinking-block-owners
 
 <!-- SECTION:NOTES:BEGIN -->
 Integrated template-aware local replay with ADR-090 canonical ownership and per-call thinking. Live Gemma4 on localhost:9099 verified Auto/All/Off and native calculator replay; exact reviewed Gemma/Qwen templates are retained. Addressed all 11 initial Qodo findings: strict sanitized config validation and environment precedence, legacy Off migration, shared settings validation, Local-LLM template forwarding, bounded metadata cache/backoff, policy-aligned profile capacity, API documentation/types and corrected ADR task link. Review-fix verification: gateway regressions 488 passed with 2 sandbox listener skips; config/settings 120 passed; import boundary 14 passed; profile/capture 38 passed; gateway cache focused 36 passed. Changed-line Ruff and diff checks passed. Reviewed the sole new diagnostic as a fixed field-name-only warning and regenerated its inventory. Initial GitHub fast lane and derived artifacts passed; final-head Qodo review and CI remain pending before merge.
+
+Qodo verified e3e8431816 with zero bugs and zero rule violations; all 11 findings resolved and all 10 inline threads answered. Post-rebase focused config, gateway and mounted Settings checks: 62 passed. Implementation and review are complete; merge remains gated on final GitHub checks.
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Agents/agent_models.py
+++ b/tldw_chatbook/Agents/agent_models.py
@@ -10,10 +10,13 @@ import hashlib
 import json
 import math
 import re
-from collections.abc import Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import dataclass, field, replace
 from types import MappingProxyType
-from typing import Callable, Literal, Mapping, TypeAlias
+from typing import TYPE_CHECKING, Literal, TypeAlias
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
 
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationResult,
@@ -465,8 +468,9 @@ class ModelTurn:
     ``assistant_message`` carries the provider-shaped assistant message for
     native tool-call turns (content plus the raw ``tool_calls`` array,
     echoed verbatim into history so the follow-up ``role="tool"`` results
-    pair with their calls by id). ``None`` for fence-protocol turns, whose
-    history keeps the plain-text convention.
+    pair with their calls by id). Either protocol may attach an ephemeral
+    canonical thinking envelope; final assistant echoes retain that ownership
+    for in-memory child continuation.
     """
 
     text: str = ""
@@ -754,6 +758,7 @@ class AgentConfig:
     allowed_tools: tuple[str, ...] = ()
     budget: RunBudget = field(default_factory=RunBudget)
     native_tools: bool = True
+    reasoning_replay: ReasoningReplayPolicy | None = None
     workspace_context_note: str = ""
     personal_context_block: str = ""
     response_reserve_tokens: int = 2048

--- a/tldw_chatbook/Agents/agent_runtime.py
+++ b/tldw_chatbook/Agents/agent_runtime.py
@@ -1059,6 +1059,8 @@ def run_agent_loop(
     _MODEL_RETRY_POLICY = RetryPolicy(max_attempts=0, base_delay=1.0, max_delay=30.0)
     budget = config.budget
     steps: list[AgentStep] = []
+    from tldw_chatbook.Chat.local_reasoning import EXCHANGE_CONTINUATION_KEY
+
     messages = list(initial_messages)
     # PR3b Task 4: how much of `messages` is protocol-coherent -- i.e. up
     # to the LAST drain boundary (the pre-model-call point where every
@@ -1272,7 +1274,9 @@ def run_agent_loop(
             pass
         return step
 
-    def _outcome(status: str, **kw) -> RunOutcome:
+    def _outcome(
+        status: str, *, assistant_message: dict | None = None, **kw
+    ) -> RunOutcome:
         # Reports run spend on every terminal path; reads enclosing steps/
         # spawned/total_tokens at call time (no nonlocal, like add()).
         #
@@ -1293,7 +1297,9 @@ def run_agent_loop(
         ]
         if status == RUN_DONE:
             final_messages = final_messages + [
-                {"role": "assistant", "content": kw.get("final_text", "")}
+                dict(assistant_message)
+                if assistant_message is not None
+                else {"role": "assistant", "content": kw.get("final_text", "")}
             ]
         return RunOutcome(
             status,
@@ -1476,6 +1482,7 @@ def run_agent_loop(
                 {
                     "role": "user",
                     "content": BUDGET_WRAPUP_INSTRUCTION.format(kind=kind),
+                    EXCHANGE_CONTINUATION_KEY: True,
                 }
             )
             wrap_turn = (
@@ -1591,7 +1598,13 @@ def run_agent_loop(
                             if steer_source == STEERING_SOURCE_REDIRECT
                             else format_steering_message(steer_source, steer_text)
                         )
-                        messages.append({"role": "user", "content": steer_message})
+                        messages.append(
+                            {
+                                "role": "user",
+                                "content": steer_message,
+                                EXCHANGE_CONTINUATION_KEY: True,
+                            }
+                        )
                         add(
                             STEP_STEERING,
                             summary=steer_message[:200],
@@ -1911,7 +1924,13 @@ def run_agent_loop(
                         if steer_source == STEERING_SOURCE_REDIRECT
                         else format_steering_message(steer_source, steer_text)
                     )
-                    messages.append({"role": "user", "content": content})
+                    messages.append(
+                        {
+                            "role": "user",
+                            "content": content,
+                            EXCHANGE_CONTINUATION_KEY: True,
+                        }
+                    )
                     add(
                         STEP_STEERING,
                         summary=content[:200],
@@ -2089,7 +2108,9 @@ def run_agent_loop(
             # Emptiness was already classified before the continuation block
             # above (review I2), so a turn reaching here has real text.
             consecutive_empty_turns = 0
-            return _outcome(RUN_DONE, final_text=turn.text)
+            return _outcome(
+                RUN_DONE, final_text=turn.text, assistant_message=turn.assistant_message
+            )
         if not restoring_batch:
             messages.append(
                 turn.assistant_message or {"role": "assistant", "content": turn.text}

--- a/tldw_chatbook/Agents/agent_service.py
+++ b/tldw_chatbook/Agents/agent_service.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Any, Callable, Literal, Protocol, cast
 from loguru import logger
 
 if TYPE_CHECKING:
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
+
     from .agent_worktree import AgentWorktree
     from .run_log import RunLogWriter
 
@@ -596,12 +598,30 @@ class _ProjectInstructionPayloadError(RuntimeError):
     """Content-free terminal error for a staged row dropped by bounding."""
 
 
-def _count_model_messages(messages: list[dict], model: str, provider: str) -> int:
-    """Count ordinary rows directly, falling back for multimodal content."""
+def _count_model_messages(
+    messages: list[dict],
+    model: str,
+    provider: str,
+    *,
+    reasoning_replay: ReasoningReplayPolicy | None = None,
+    tokenizer_model: str | None = None,
+) -> int:
+    """Count the same canonical projection sent, keeping exact model eligibility."""
+    from tldw_chatbook.Chat.local_reasoning import project_reasoning_history
+
+    if reasoning_replay is not None or any(
+        "_tldw_call_thinking" in row for row in messages
+    ):
+        messages = project_reasoning_history(
+            messages, provider=provider, model=model, policy=reasoning_replay
+        )
+        return count_console_messages_tokens(messages, tokenizer_model or model)
     try:
-        return count_tokens_messages(messages, model, provider=provider)
+        return count_tokens_messages(
+            messages, tokenizer_model or model, provider=provider
+        )
     except (TypeError, ValueError):
-        return count_console_messages_tokens(messages, model)
+        return count_console_messages_tokens(messages, tokenizer_model or model)
 
 
 def _append_workspace_context_note(system_content: str, note: str) -> str:
@@ -811,6 +831,7 @@ def build_first_request_schema_plan(
                 model=config.model,
                 api_endpoint=api_endpoint,
                 native_tools=config.native_tools,
+                reasoning_replay=config.reasoning_replay,
             ),
         )
         if active is None:
@@ -835,6 +856,7 @@ def catalog_schema_tokens(
     model: str,
     api_endpoint: str,
     native_tools: bool,
+    reasoning_replay: ReasoningReplayPolicy | None = None,
 ) -> int:
     """Measure one complete provider-visible schema-set representation.
 
@@ -853,7 +875,9 @@ def catalog_schema_tokens(
     """
     if not schemas:
         return 0
-    native = native_tools and provider_supports_native_tools(api_endpoint)
+    native = native_tools and provider_supports_native_tools(
+        api_endpoint, reasoning_replay=reasoning_replay
+    )
     rendered = (
         json.dumps(
             schemas_to_openai_tools(list(schemas)),
@@ -881,7 +905,9 @@ def _first_request_plan_fits(
     reserve = config.response_reserve_tokens
     if type(reserve) is not int or reserve < 0:
         return False
-    native = config.native_tools and provider_supports_native_tools(api_endpoint)
+    native = config.native_tools and provider_supports_native_tools(
+        api_endpoint, reasoning_replay=config.reasoning_replay
+    )
     schemas = plan.runtime_schemas + plan.active_schemas
     system_content = plan.system_prompt
     if not native:
@@ -902,6 +928,7 @@ def _first_request_plan_fits(
         [{"role": "system", "content": system_content}, *messages],
         config.model,
         api_endpoint,
+        reasoning_replay=config.reasoning_replay,
     )
     if type(used) is not int or used <= 0:
         return False
@@ -911,6 +938,7 @@ def _first_request_plan_fits(
             model=config.model,
             api_endpoint=api_endpoint,
             native_tools=True,
+            reasoning_replay=config.reasoning_replay,
         )
     return used <= context_limit - reserve
 
@@ -2233,7 +2261,9 @@ class AgentService:
         trusted_role: Literal["primary", "subagent"] = "primary",
     ) -> ModelRequest:
         """Build the exact bounded messages and native tools sent on a turn."""
-        native = config.native_tools and provider_supports_native_tools(api_endpoint)
+        native = config.native_tools and provider_supports_native_tools(
+            api_endpoint, reasoning_replay=config.reasoning_replay
+        )
         schemas = runtime_schemas + list(active_schemas)
         system_content = config.system_prompt
         tools: list[dict] = []
@@ -2291,6 +2321,12 @@ class AgentService:
             native=native,
             enabled=evict_enabled,
             min_recent_rounds=min_recent_rounds,
+            count_fn=lambda rows, _model: _count_model_messages(
+                rows,
+                config.model,
+                api_endpoint,
+                reasoning_replay=config.reasoning_replay,
+            ),
         )
         return ModelRequest(
             messages=tuple(dict(message) for message in payload),
@@ -2313,7 +2349,10 @@ class AgentService:
             if type(reserve) is not int or reserve < 0:
                 return 0
             used = _count_model_messages(
-                list(request.messages), config.model, api_endpoint
+                list(request.messages),
+                config.model,
+                api_endpoint,
+                reasoning_replay=config.reasoning_replay,
             )
             if request.tools:
                 used += estimate_tokens(
@@ -2352,7 +2391,10 @@ class AgentService:
             ):
                 return False
             used = _count_model_messages(
-                list(request.messages), config.model, api_endpoint
+                list(request.messages),
+                config.model,
+                api_endpoint,
+                reasoning_replay=config.reasoning_replay,
             )
             if type(used) is not int or used <= 0:
                 return False
@@ -2562,7 +2604,9 @@ class AgentService:
         first_request_fits: bool = True,
         run_id: str | None = None,
     ):
-        native = config.native_tools and provider_supports_native_tools(api_endpoint)
+        native = config.native_tools and provider_supports_native_tools(
+            api_endpoint, reasoning_replay=config.reasoning_replay
+        )
         initial_context_checked = False
         context_observed = False
         staged = staged_delivery if staged_delivery is not None else {}
@@ -2736,6 +2780,12 @@ class AgentService:
                 native=native,
                 enabled=effective_log_active and evict_requested,
                 min_recent_rounds=min_recent_rounds,
+                count_fn=lambda rows, _model: _count_model_messages(
+                    rows,
+                    config.model,
+                    api_endpoint,
+                    reasoning_replay=config.reasoning_replay,
+                ),
                 continuation_groups=(
                     () if gateway_prepares_continuation else effective_groups
                 ),
@@ -2837,11 +2887,31 @@ class AgentService:
                     else config.model
                 )
                 tokens = _count_model_messages(
-                    payload, est_model, api_endpoint
+                    payload,
+                    config.model,
+                    api_endpoint,
+                    reasoning_replay=config.reasoning_replay,
+                    tokenizer_model=est_model,
                 ) + estimate_tokens(text, est_model, provider=api_endpoint)
+            thinking_envelope = getattr(resp, "thinking_envelope", None)
+            thinking_echo = None
+            if thinking_envelope is not None:
+                from tldw_chatbook.Chat.console_thinking_capture import (
+                    CALL_THINKING_KEY,
+                )
+                from tldw_chatbook.Chat.thinking_blocks import ThinkingEnvelope
+
+                if not isinstance(thinking_envelope, ThinkingEnvelope):
+                    raise ValueError("Call thinking metadata is malformed.")
+                thinking_echo = {
+                    "role": "assistant",
+                    "content": text,
+                    CALL_THINKING_KEY: thinking_envelope,
+                }
             if not native:
                 return ModelTurn(
                     text=text,
+                    assistant_message=thinking_echo,
                     tokens=tokens,
                     provider_continuation=provider_continuation,
                 )
@@ -2854,9 +2924,10 @@ class AgentService:
             if raw_calls:
                 message = {**message, "tool_calls": raw_calls}
             tool_calls = parse_native_tool_calls(message)
-            assistant_message = None
+            assistant_message = thinking_echo
             if tool_calls:
                 assistant_message = {
+                    **(thinking_echo or {}),
                     "role": "assistant",
                     "content": text,
                     "tool_calls": raw_calls,
@@ -5363,6 +5434,9 @@ class AgentService:
                 allowed_tools=child_allowed_tools,
                 budget=child_budget,
                 native_tools=config.native_tools,
+                reasoning_replay=(
+                    config.reasoning_replay if child_model == config.model else None
+                ),
                 # A sub-agent operates on the same workspace roots as its
                 # parent, so it inherits the same environment note verbatim
                 # (appended to its own prompt in call_model, after its identity
@@ -5960,6 +6034,9 @@ class AgentService:
                 allowed_tools=child_allowed_tools,
                 budget=child_budget,
                 native_tools=config.native_tools,
+                reasoning_replay=(
+                    config.reasoning_replay if child_model == config.model else None
+                ),
                 workspace_context_note=config.workspace_context_note,
                 personal_context_block=config.personal_context_block,
                 response_reserve_tokens=config.response_reserve_tokens,
@@ -6924,6 +7001,8 @@ class AgentService:
                     config,
                     model=candidate_model,
                     provider=candidate_endpoint,
+                    # Endpoint/model approval belongs only to the resolved primary.
+                    reasoning_replay=None,
                 )
                 return self._make_call_model(
                     candidate_config,

--- a/tldw_chatbook/Agents/fleet_coordinator.py
+++ b/tldw_chatbook/Agents/fleet_coordinator.py
@@ -635,8 +635,20 @@ class FleetCoordinator:
             return False
         if self._retained_transcript_max_chars <= 0:
             return False
+
+        def retained_json_value(value):
+            from tldw_chatbook.Chat.thinking_blocks import (
+                ThinkingEnvelope,
+                dump_thinking_blocks_json,
+            )
+
+            if isinstance(value, ThinkingEnvelope):
+                # Measure the canonical body; its private repr omits all text.
+                return json.loads(dump_thinking_blocks_json(value))
+            return str(value)
+
         try:
-            size = len(json.dumps(messages, default=str))
+            size = len(json.dumps(messages, default=retained_json_value))
         except Exception:  # noqa: BLE001 — an unmeasurable transcript
             return False  # cannot be size-bounded, so it is not kept
         if size > self._retained_transcript_max_chars:

--- a/tldw_chatbook/Agents/native_tools.py
+++ b/tldw_chatbook/Agents/native_tools.py
@@ -21,6 +21,10 @@ Pure module: no I/O, no provider imports.
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
 
 from .agent_models import ToolCall, ToolSchema
 
@@ -60,19 +64,33 @@ NATIVE_TOOLS_PROVIDERS = frozenset(
 )
 
 
-def provider_supports_native_tools(api_endpoint: str | None) -> bool:
+def provider_supports_native_tools(
+    api_endpoint: str | None, *, reasoning_replay: ReasoningReplayPolicy | None = None
+) -> bool:
     """Return whether ``api_endpoint`` supports native tool-calls end-to-end.
 
     Args:
         api_endpoint: The ``chat_api_call`` provider key. The Console passes
             ``ConsoleProviderResolution.execution_key`` — the key
             ``PROVIDER_PARAM_MAP`` is indexed by.
+        reasoning_replay: Frozen local endpoint facts; native support remains
+            independent of the optional reasoning replay mode.
 
     Returns:
         True when the provider forwards ``tools=`` AND returns the raw
         OpenAI-compatible response shape (see module docstring).
     """
-    return str(api_endpoint or "").strip().lower() in NATIVE_TOOLS_PROVIDERS
+    provider = str(api_endpoint or "").strip().lower()
+    if provider in {
+        "llama_cpp",
+        "local_llamacpp",
+        "vllm",
+        "local_vllm",
+        "ollama",
+        "local_ollama",
+    }:
+        return bool(reasoning_replay is not None and reasoning_replay.native_tools)
+    return provider in NATIVE_TOOLS_PROVIDERS
 
 
 def schemas_to_openai_tools(schemas: list[ToolSchema]) -> list[dict]:

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -536,6 +536,7 @@ PROVIDER_PARAM_MAP = {
         "chat_template_kwargs": "chat_template_kwargs",
     },
     "local-llm": {
+        "chat_template_kwargs": "chat_template_kwargs",
         "messages_payload": "input_data",
         "temp": "temp",
         "system_message": "system_message",

--- a/tldw_chatbook/Chat/Chat_Functions.py
+++ b/tldw_chatbook/Chat/Chat_Functions.py
@@ -430,6 +430,7 @@ PROVIDER_PARAM_MAP = {
         "stop": "stop",  # often 'stop_sequences'
     },
     "llama_cpp": {  # Has api_url as a positional argument which needs special handling if not None
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "temp": "temp",  # audit task-286: was a dead 'temperature' key (temp silently dropped); handler takes temp
         "messages_payload": "input_data",
@@ -453,6 +454,9 @@ PROVIDER_PARAM_MAP = {
         "top_logprobs": "top_logprobs",
         "reasoning_effort": "reasoning_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "koboldcpp": {
         "api_key": "api_key",
@@ -504,6 +508,7 @@ PROVIDER_PARAM_MAP = {
         "stop": "stop",
     },
     "vllm": {  # vllm_api_url consideration
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "messages_payload": "input_data",
         "temp": "temperature",
@@ -526,6 +531,9 @@ PROVIDER_PARAM_MAP = {
         "user_identifier": "user_identifier",
         "reasoning_effort": "reasoning_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "local-llm": {
         "messages_payload": "input_data",
@@ -543,6 +551,7 @@ PROVIDER_PARAM_MAP = {
         "thinking_budget_tokens": "thinking_budget_tokens",
     },
     "ollama": {  # api_url consideration
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",  # api_key is not used by ollama directly, url is more important
         "messages_payload": "input_data",
         "temp": "temperature",
@@ -557,6 +566,9 @@ PROVIDER_PARAM_MAP = {
         "response_format": "format",  # 'json' string
         "presence_penalty": "presence_penalty",
         "frequency_penalty": "frequency_penalty",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "aphrodite": {
         "api_key": "api_key",
@@ -660,6 +672,7 @@ PROVIDER_PARAM_MAP = {
     },
     # Local provider mappings (same as their non-local counterparts)
     "local_llamacpp": {
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "messages_payload": "input_data",
         "temp": "temp",  # audit task-286: generic name is 'temp'; the 'temperature' key was dead
@@ -679,8 +692,12 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "reasoning_effort": "reasoning_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "local_llamafile": {
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "messages_payload": "input_data",
         "temp": "temp",  # audit task-286: generic name is 'temp'; the 'temperature' key was dead
@@ -700,8 +717,12 @@ PROVIDER_PARAM_MAP = {
         "frequency_penalty": "frequency_penalty",
         "reasoning_effort": "reasoning_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "local_ollama": {
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "messages_payload": "input_data",
         "temp": "temperature",
@@ -716,8 +737,12 @@ PROVIDER_PARAM_MAP = {
         "response_format": "format",
         "presence_penalty": "presence_penalty",
         "frequency_penalty": "frequency_penalty",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "local_vllm": {
+        "api_key_resolved": "api_key_resolved",
         "api_key": "api_key",
         "messages_payload": "input_data",
         "temp": "temperature",
@@ -739,6 +764,9 @@ PROVIDER_PARAM_MAP = {
         "user_identifier": "user_identifier",
         "reasoning_effort": "reasoning_effort",
         "thinking_budget_tokens": "thinking_budget_tokens",
+        "tools": "tools",
+        "tool_choice": "tool_choice",
+        "chat_template_kwargs": "chat_template_kwargs",
     },
     "local_mlx_lm": {
         "api_key": "api_key",
@@ -951,6 +979,7 @@ def chat_api_call(
     request_retry_delay: Optional[float] = None,
     *,
     api_key_resolved: bool | None = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     """
     Acts as a unified dispatcher to call various LLM API providers.
@@ -1182,9 +1211,7 @@ def chat_api_call(
             # a usable number of seconds; the retry backoff honours it.
             retry_after_header = None
             try:
-                raw_retry_after = getattr(e.response, "headers", {}).get(
-                    "Retry-After"
-                )
+                raw_retry_after = getattr(e.response, "headers", {}).get("Retry-After")
                 if raw_retry_after is not None:
                     retry_after_header = float(str(raw_retry_after).strip())
             except (TypeError, ValueError):

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any, Callable, ContextManager, Sequence, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
+    from tldw_chatbook.Chat.local_reasoning import ReasoningReplayPolicy
     from tldw_chatbook.Persona_Buddy.console_adapter import PersonaBuddyConsoleAdapter
     from tldw_chatbook.Personal_Context.context_service import ProfileContextSnapshot
     from tldw_chatbook.UI.Screens.change_review_screen import (
@@ -2391,6 +2392,7 @@ def _fenced_project_instruction_payload_fits(
     model: str,
     provider: str,
     response_reserve_tokens: int,
+    reasoning_replay: ReasoningReplayPolicy | None = None,
 ) -> bool:
     """Validate the exact transformed fenced request before ledger advance."""
     try:
@@ -2401,6 +2403,7 @@ def _fenced_project_instruction_payload_fits(
             ),
             model,
             provider,
+            reasoning_replay=reasoning_replay,
         )
     except Exception:
         return False
@@ -4245,6 +4248,7 @@ def build_console_first_request_plan(
                 ],
                 resolved_model,
                 api_endpoint,
+                reasoning_replay=config.reasoning_replay,
             )
             if native_schema_rows:
                 required_tokens += _count_model_messages(
@@ -4260,6 +4264,7 @@ def build_console_first_request_plan(
                     ],
                     resolved_model,
                     api_endpoint,
+                    reasoning_replay=config.reasoning_replay,
                 )
             available_input_tokens = max(
                 0, input_limit - response_reserve - required_tokens
@@ -5204,6 +5209,7 @@ class ConsoleAgentBridge:
                         model=config.model,
                         provider=first_request_plan.api_endpoint,
                         response_reserve_tokens=config.response_reserve_tokens,
+                        reasoning_replay=config.reasoning_replay,
                     )
                 ),
             )

--- a/tldw_chatbook/Chat/console_agent_bridge.py
+++ b/tldw_chatbook/Chat/console_agent_bridge.py
@@ -193,7 +193,10 @@ from tldw_chatbook.Chat.console_provider_gateway import (
     ProviderTurnMetadata,
 )
 from tldw_chatbook.Chat.console_chat_store import require_thinking_persistence_support
-from tldw_chatbook.Chat.console_thinking_capture import ThinkingCapture
+from tldw_chatbook.Chat.console_thinking_capture import (
+    ThinkingCapture,
+    consume_call_thinking,
+)
 from tldw_chatbook.Chat.console_thinking_history import ProviderThinkingSidecar
 from tldw_chatbook.Chat.thinking_blocks import ThinkingEnvelope, ThinkingHistoryPolicy
 from tldw_chatbook.Chat.console_history_budget import DEFAULT_RESPONSE_RESERVATION
@@ -2312,8 +2315,10 @@ class _StreamingProviderResponse(dict[str, Any]):
         self,
         value: Mapping[str, Any],
         metadata: ProviderTurnMetadata | None,
+        thinking_envelope: ThinkingEnvelope | None = None,
     ) -> None:
         super().__init__(value)
+        self.thinking_envelope = thinking_envelope
         self._provider_continuation = (
             metadata.provider_continuation if metadata is not None else None
         )
@@ -2951,6 +2956,33 @@ class _StreamingModelAdapter:
             messages_payload, native_tools=self._native_tools
         )
         is_subagent = self._is_subagent(transport_messages)
+        # Resolve sidecars after the trace factory has built the neutral request.
+        # The reserved canonical key is valid only once its groups are attached.
+        # This temporary scalar also keeps mandatory continuation ownership separate.
+        call_thinking_owner_key = "_tldw_call_thinking_owner"
+        if not is_subagent and self._thinking_sidecar and self._thinking_owner_key:
+            historical_owners = {
+                sidecar.owner_message_id for sidecar in self._thinking_sidecar
+            }
+            for row in transport_messages:
+                historical_owner = row.get(self._thinking_owner_key)
+                if (
+                    isinstance(historical_owner, str)
+                    and historical_owner in historical_owners
+                ):
+                    row[call_thinking_owner_key] = historical_owner
+                if self._thinking_owner_key not in {
+                    call_thinking_owner_key,
+                    self._continuation_owner_key,
+                }:
+                    row.pop(self._thinking_owner_key, None)
+        transport_messages, call_sidecars = consume_call_thinking(
+            transport_messages, owner_key=call_thinking_owner_key
+        )
+        call_thinking_sidecar = (
+            () if is_subagent else self._thinking_sidecar
+        ) + call_sidecars
+        call_capture = ThinkingCapture(assistant_owner_id=new_opaque_id())
         # TASK-28227: a redirect aborts only the PRIMARY's in-flight
         # model stream. Children keep the plain cancel predicate --
         # cutting a fleet child's stream on a primary redirect would
@@ -2992,7 +3024,14 @@ class _StreamingModelAdapter:
         # parent/child turns, so keep that override immutable and call-local.
         call_resolution = self._resolution
         if model and model != self._resolution.model:
-            call_resolution = dataclass_replace(self._resolution, model=model)
+            # Endpoint/model metadata is frozen for the primary target; it is
+            # not rediscovered for overrides during a running agent loop.
+            call_resolution = dataclass_replace(
+                self._resolution,
+                model=model,
+                reasoning_replay=None,
+                local_structured_thinking=False,
+            )
         call_continuation_target = self._continuation_target
         if is_subagent and call_continuation_target is not None:
             call_continuation_target = dataclass_replace(
@@ -3064,9 +3103,9 @@ class _StreamingModelAdapter:
                     route_actor_id=route_actor_id,
                     route_chain_id=route_chain_id,
                     continuation_target=call_continuation_target,
-                    thinking_sidecar=() if is_subagent else self._thinking_sidecar,
+                    thinking_sidecar=call_thinking_sidecar,
                     thinking_policy=self._thinking_policy,
-                    thinking_owner_key=self._thinking_owner_key,
+                    thinking_owner_key=call_thinking_owner_key,
                     capture_mode=self._capture_mode,
                 )
                 stream_kwargs.pop("tools", None)
@@ -3083,17 +3122,16 @@ class _StreamingModelAdapter:
                     route_actor_id=route_actor_id,
                     route_chain_id=route_chain_id,
                     continuation_target=call_continuation_target,
-                    thinking_sidecar=() if is_subagent else self._thinking_sidecar,
+                    thinking_sidecar=call_thinking_sidecar,
                     thinking_policy=self._thinking_policy,
-                    thinking_owner_key=self._thinking_owner_key,
+                    thinking_owner_key=call_thinking_owner_key,
                     capture_mode=self._capture_mode,
                 )
                 stream_kwargs.pop("tools", None)
             elif (
-                not is_subagent
-                and (self._continuation_sidecar or self._thinking_sidecar)
-                and callable(prepare_request)
-            ):
+                call_thinking_sidecar
+                or (not is_subagent and self._continuation_sidecar)
+            ) and callable(prepare_request):
                 # The constructor sidecar belongs to the primary turn. A
                 # child has its own history and must never consume it.
                 dispatch_messages = prepare_request(
@@ -3104,11 +3142,13 @@ class _StreamingModelAdapter:
                     route_actor_id=route_actor_id,
                     route_chain_id=route_chain_id,
                     continuation_target=call_continuation_target,
-                    continuation_sidecar=self._continuation_sidecar,
+                    continuation_sidecar=()
+                    if is_subagent
+                    else self._continuation_sidecar,
                     continuation_owner_key=self._continuation_owner_key,
-                    thinking_sidecar=self._thinking_sidecar,
+                    thinking_sidecar=call_thinking_sidecar,
                     thinking_policy=self._thinking_policy,
-                    thinking_owner_key=self._thinking_owner_key,
+                    thinking_owner_key=call_thinking_owner_key,
                     capture_mode=self._capture_mode,
                 )
                 stream_kwargs.pop("tools", None)
@@ -3150,6 +3190,7 @@ class _StreamingModelAdapter:
                     chunk,
                     (ProviderThinkingDelta, ProviderProprietaryThinkingEvidence),
                 ):
+                    call_capture.observe(chunk)
                     if not is_subagent:
                         update = self._thinking_capture.observe(chunk)
                         if update.envelope is not None:
@@ -3307,7 +3348,10 @@ class _StreamingModelAdapter:
             )
         if usage is not None:
             response["usage"] = usage
-        return _StreamingProviderResponse(response, terminal_metadata)
+        call_envelope = call_capture.settle(
+            "stopped" if stream_cut() else "complete"
+        ).envelope
+        return _StreamingProviderResponse(response, terminal_metadata, call_envelope)
 
     @staticmethod
     def _is_subagent(messages_payload) -> bool:
@@ -4114,6 +4158,7 @@ def build_console_first_request_plan(
         allowed_tools=allowed_tools,
         budget=run_budget or console_run_budget(),
         native_tools=native_tools,
+        reasoning_replay=getattr(resolution, "reasoning_replay", None),
         workspace_context_note=workspace_note,
         response_reserve_tokens=response_reserve,
     )
@@ -4170,7 +4215,9 @@ def build_console_first_request_plan(
                 *schemas.runtime_schemas,
                 *schemas.active_schemas,
             ]
-            native = native_tools and provider_supports_native_tools(api_endpoint)
+            native = native_tools and provider_supports_native_tools(
+                api_endpoint, reasoning_replay=config.reasoning_replay
+            )
             native_schema_rows: list[dict] = []
             if native:
                 native_schema_rows = schemas_to_openai_tools(disclosed_schemas)
@@ -4903,6 +4950,16 @@ class ConsoleAgentBridge:
         profile_context_service: Any | None = None,
         personal_context_snapshot: ProfileContextSnapshot | None = None,
     ) -> tuple[str, RunOutcome]:
+        replay = getattr(resolution, "reasoning_replay", None)
+        if replay is not None and thinking_policy in {"include", "exclude"}:
+            resolution = dataclass_replace(
+                resolution,
+                reasoning_replay=dataclass_replace(
+                    replay,
+                    mode="all" if thinking_policy == "include" else "off",
+                    source="conversation",
+                ),
+            )
         canvas_turn_controller = None
         canvas_run_id = None
         lifecycle_reader = getattr(canvas_provider, "lifecycle_binding", None)
@@ -5138,7 +5195,10 @@ class ConsoleAgentBridge:
                 final_payload_fits=(
                     None
                     if config.native_tools
-                    and provider_supports_native_tools(first_request_plan.api_endpoint)
+                    and provider_supports_native_tools(
+                        first_request_plan.api_endpoint,
+                        reasoning_replay=config.reasoning_replay,
+                    )
                     else lambda rows: _fenced_project_instruction_payload_fits(
                         rows,
                         model=config.model,
@@ -5464,7 +5524,10 @@ class ConsoleAgentBridge:
             loop=turn_lifeline.loop,
             native_tools=(
                 config.native_tools
-                and provider_supports_native_tools(first_request_plan.api_endpoint)
+                and provider_supports_native_tools(
+                    first_request_plan.api_endpoint,
+                    reasoning_replay=config.reasoning_replay,
+                )
             ),
             provider_stream_signals=provider_stream_signals,
             continuation_sidecar=continuation_sidecar,

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -457,6 +457,7 @@ from tldw_chatbook.Chat.console_thinking_history import (
     resolve_thinking_history,
 )
 from tldw_chatbook.Chat.thinking_blocks import (
+    THINKING_ENVELOPE_VERSION,
     ThinkingEnvelope,
     ThinkingHistoryPolicy,
     normalize_thinking_history_policy,
@@ -8860,12 +8861,17 @@ class ConsoleChatController:
                     or getattr(resolution, "api_mode", None)
                     or "chat_completions"
                 ),
-                disposition=getattr(
-                    resolution, "thinking_stream_disposition", "ignored"
+                disposition=(
+                    "displayable"
+                    if getattr(resolution, "local_structured_thinking", False)
+                    else getattr(resolution, "thinking_stream_disposition", "ignored")
                 ),
-                round_trip_version=getattr(
-                    resolution, "thinking_round_trip_version", None
+                round_trip_version=(
+                    THINKING_ENVELOPE_VERSION
+                    if getattr(resolution, "local_structured_thinking", False)
+                    else getattr(resolution, "thinking_round_trip_version", None)
                 ),
+                reasoning_replay=getattr(resolution, "reasoning_replay", None),
             ),
             policy=self.store.session_thinking_history_policy(preparation.session_id),
             sidecars=thinking_sidecars,

--- a/tldw_chatbook/Chat/console_history_budget.py
+++ b/tldw_chatbook/Chat/console_history_budget.py
@@ -20,7 +20,6 @@ from tldw_chatbook.Chat.provider_continuation import (
     continuation_owner_group,
     validate_continuation_restore,
 )
-
 from tldw_chatbook.Utils.token_counter import (
     NON_TEXT_PART_TOKEN_ESTIMATE,
     count_tokens_messages,
@@ -179,6 +178,16 @@ def count_console_messages_tokens(
                 "content": (
                     f"{base_text} {json.dumps(tool_calls, default=str)}"
                 ).strip(),
+            }
+        reasoning = " ".join(
+            message[key]
+            for key in ("reasoning_content", "reasoning")
+            if isinstance(message.get(key), str) and message[key]
+        )
+        if reasoning:
+            entry = {
+                **entry,
+                "content": f"{entry.get('content') or ''} {reasoning}".strip(),
             }
         flattened.append(entry)
     return count_tokens_messages(flattened, model) + per_image_tokens * image_count
@@ -355,9 +364,7 @@ def prune_stale_tool_results(
             ):
                 candidates.append((index, message))
             index += 1
-    total_removable = sum(
-        len(message["content"]) - head for _i, message in candidates
-    )
+    total_removable = sum(len(message["content"]) - head for _i, message in candidates)
     if not candidates or total_removable < max(0, settings.min_reclaim_chars):
         return messages, ToolResultPruneStats()
     pruned = list(messages)
@@ -446,8 +453,7 @@ def retire_stale_images(
                         **message,
                         "content": [
                             _image_placeholder(part)
-                            if isinstance(part, dict)
-                            and part.get("type") != "text"
+                            if isinstance(part, dict) and part.get("type") != "text"
                             else part
                             for part in content
                         ],

--- a/tldw_chatbook/Chat/console_prepared_request.py
+++ b/tldw_chatbook/Chat/console_prepared_request.py
@@ -28,7 +28,7 @@ from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 from tldw_chatbook.Chat.console_thinking_history import (
     EffectiveThinkingHistoryPolicy,
     ThinkingOwnerGroup,
-    serialize_start_anchored_thinking,
+    serialize_thinking_message,
 )
 from tldw_chatbook.Chat.console_trace_models import FrozenTracePolicy
 from tldw_chatbook.Chat.console_trace_provenance import (
@@ -44,6 +44,13 @@ from tldw_chatbook.Chat.console_trace_provenance import (
     TraceProvenanceSource,
     TraceTransformKind,
     frozen_policy_from_provenance,
+)
+from tldw_chatbook.Chat.local_reasoning import (
+    EXCHANGE_CONTINUATION_KEY,
+    LOCAL_TOOL_RESULT_KEY,
+    ReasoningReplayPolicy,
+    effective_replay_policy,
+    starts_reasoning_exchange,
 )
 from tldw_chatbook.Chat.provider_continuation import ContinuationOwnerGroup
 from tldw_chatbook.Chat.thinking_blocks import ThinkingHistoryPolicy
@@ -144,11 +151,7 @@ def _is_fenced_tool_result(row: Mapping[str, Any]) -> bool:
 
 def _starts_user_turn(row: Mapping[str, Any]) -> bool:
     """Keep automatic project context in the turn that requested it."""
-    return (
-        row.get("role") == "user"
-        and not _is_fenced_tool_result(row)
-        and row.get(EPHEMERAL_ORIGIN_KEY) != "project_instructions"
-    )
+    return starts_reasoning_exchange(row)
 
 
 def _is_tool_loop_row(row: Mapping[str, Any]) -> bool:
@@ -211,6 +214,7 @@ class PreparedConsoleRequest:
     active_continuation_groups: tuple[ContinuationOwnerGroup, ...] = field(
         default=(), repr=False
     )
+    reasoning_replay: ReasoningReplayPolicy | None = None
     thinking_policy: ThinkingHistoryPolicy = "auto"
     effective_thinking_policy: EffectiveThinkingHistoryPolicy = "auto"
     tools: tuple[Mapping[str, Any], ...] = field(default=(), repr=False)
@@ -299,6 +303,7 @@ class PreparedConsoleRequest:
             active_tool_loop=self.active_tool_loop,
             active_thinking_groups=self.active_thinking_groups,
             active_continuation_groups=self.active_continuation_groups,
+            reasoning_replay=self.reasoning_replay,
             thinking_policy=self.thinking_policy,
             effective_thinking_policy=self.effective_thinking_policy,
             tools=self.tools,
@@ -308,6 +313,38 @@ class PreparedConsoleRequest:
                 else None
             ),
         )
+
+
+def project_thinking_history(
+    request: PreparedConsoleRequest,
+    reasoning_replay: ReasoningReplayPolicy | None,
+) -> PreparedConsoleRequest:
+    """Filter complete optional owner groups and matching provenance together."""
+    policy = effective_replay_policy(reasoning_replay, request.thinking_policy)
+    mode = policy.mode if policy is not None else "all"
+    keep_old = mode not in {"current", "off"}
+    keep_active = mode != "off"
+    units = tuple(
+        replace(unit, thinking_groups=unit.thinking_groups if keep_old else ())
+        for unit in request.compactable
+    )
+    provenance = request.provenance
+    if provenance is not None:
+        provenance = replace(
+            provenance,
+            compactable=tuple(
+                replace(unit, thinking=unit.thinking if keep_old else ())
+                for unit in provenance.compactable
+            ),
+            active_thinking=provenance.active_thinking if keep_active else (),
+        )
+    return replace(
+        request,
+        compactable=units,
+        active_thinking_groups=request.active_thinking_groups if keep_active else (),
+        provenance=provenance,
+        reasoning_replay=policy,
+    )
 
 
 def attach_thinking_history(
@@ -1085,6 +1122,56 @@ def resolve_request_capacity(
     )
 
 
+def _project_runtime_guidance(
+    semantic: PreparedConsoleRequest,
+    serialized: tuple[Mapping[str, Any], ...] | None = None,
+) -> tuple[list[dict[str, Any]], list[tuple[tuple[int, ...], bool]]]:
+    """Return wire controls and their exact original-row causal index groups."""
+    originals = semantic.flattened_messages()
+    source = serialized if serialized is not None else originals
+    family = (
+        semantic.reasoning_replay.template_family if semantic.reasoning_replay else ""
+    )
+    rows: list[dict[str, Any]] = []
+    origins: list[tuple[tuple[int, ...], bool]] = []
+    for index, (original, value) in enumerate(zip(originals, source, strict=True)):
+        row = dict(value)
+        control = original.get("role") == "user" and (
+            original.get(EXCHANGE_CONTINUATION_KEY) is True
+            or EPHEMERAL_ORIGIN_KEY in original
+        )
+        if (
+            family == "Gemma 4"
+            and control
+            and rows
+            and rows[-1].get("role") == "tool"
+            and isinstance(rows[-1].get("content"), str)
+            and isinstance(row.get("content"), str)
+        ):
+            rows[-1]["content"] += "\n\n[Runtime guidance]\n" + row["content"]
+            indices, _ = origins[-1]
+            origins[-1] = ((*indices, index), True)
+            continue
+        wrap = (
+            family.startswith("Qwen")
+            and original.get("role") == "user"
+            and (
+                control
+                or _is_fenced_tool_result(original)
+                or original.get(LOCAL_TOOL_RESULT_KEY) is True
+            )
+        )
+        if wrap:
+            row["content"] = (
+                "<tool_response>\n"
+                + str(row.get("content") or "")
+                + "\n</tool_response>"
+            )
+        rows.append(row)
+        origins.append(((index,), wrap))
+    return rows, origins
+
+
 def _serialize_messages(
     semantic: PreparedConsoleRequest, wire_style: WireStyle
 ) -> tuple[str | None, tuple[Mapping[str, Any], ...], tuple[Mapping[str, Any], ...]]:
@@ -1111,12 +1198,12 @@ def _serialize_messages(
                 IDLE_REQUEST_OWNER_KEY,
                 PERSISTED_MESSAGE_ID_KEY,
                 PERSISTED_CONVERSATION_ID_KEY,
+                EXCHANGE_CONTINUATION_KEY,
+                LOCAL_TOOL_RESULT_KEY,
             }
         }
         if type(thinking_owner) is str and thinking_owner in thinking_groups:
-            row["content"] = serialize_start_anchored_thinking(
-                row.get("content"), thinking_groups[thinking_owner]
-            )
+            row = serialize_thinking_message(row, thinking_groups[thinking_owner])
         if message.get(MEMORY_OWNER_KEY) == MEMORY_OWNER_VALUE and isinstance(
             row.get("content"), tuple
         ):
@@ -1124,7 +1211,8 @@ def _serialize_messages(
             # Semantic ownership remains "memory" for accounting and safety.
             row["role"] = "user"
         serialized.append(row)
-    all_messages = tuple(serialized)
+    transformed, _origins = _project_runtime_guidance(semantic, tuple(serialized))
+    all_messages = tuple(transformed)
     if wire_style == "distinct_roles":
         return None, all_messages, all_messages
 
@@ -1250,13 +1338,9 @@ def _serialize_provenance(
                 if item is not None
             )
             thinking_group = thinking_groups_by_owner.get(thinking_owner)
-            content_changed = (
-                thinking_group is not None
-                and serialize_start_anchored_thinking(
-                    message.get("content"), thinking_group
-                )
-                != message.get("content")
-            )
+            content_changed = thinking_group is not None and serialize_thinking_message(
+                message, thinking_group
+            ) != dict(message)
             flattened.append(
                 DerivedTraceProvenance(
                     TraceTransformKind.MESSAGE_REWRITE,
@@ -1299,7 +1383,22 @@ def _serialize_provenance(
         continuations=provenance.active_continuations,
     )
     extend_unit(active_unit, active_provenance)
-    flattened_values = tuple(flattened)
+    _transformed, origins = _project_runtime_guidance(semantic)
+    original_tool_indices = set(tool_loop)
+    tool_loop = [
+        i
+        for i, (indices, _changed) in enumerate(origins)
+        if any(index in original_tool_indices for index in indices)
+    ]
+    flattened_values = tuple(
+        DerivedTraceProvenance(
+            TraceTransformKind.RUNTIME_GUIDANCE,
+            tuple(flattened[index] for index in indices),
+        )
+        if changed
+        else flattened[indices[0]]
+        for indices, changed in origins
+    )
     if wire_style == "distinct_roles":
         return ProviderRequestProvenance(
             messages=flattened_values,
@@ -1383,11 +1482,13 @@ def _account_categories(
         empty_active = ({"role": "user", "content": ""},)
         if owner == "system":
             return PreparedConsoleRequest(
+                reasoning_replay=semantic.reasoning_replay,
                 system=semantic.system,
                 active_request=empty_active,
             )
         if owner == "memory":
             return PreparedConsoleRequest(
+                reasoning_replay=semantic.reasoning_replay,
                 system=semantic.system,
                 memory=semantic.memory,
                 active_request=empty_active,
@@ -1397,6 +1498,7 @@ def _account_categories(
             # memory and mandatory, so the schema spend is its own delta
             # instead of masquerading inside mandatory_tokens.
             return PreparedConsoleRequest(
+                reasoning_replay=semantic.reasoning_replay,
                 system=semantic.system,
                 memory=semantic.memory,
                 active_request=empty_active,
@@ -1404,6 +1506,7 @@ def _account_categories(
             )
         if owner == "mandatory":
             return PreparedConsoleRequest(
+                reasoning_replay=semantic.reasoning_replay,
                 system=semantic.system,
                 memory=semantic.memory,
                 mandatory=semantic.mandatory,
@@ -1412,6 +1515,7 @@ def _account_categories(
             )
         if owner == "compactable":
             return PreparedConsoleRequest(
+                reasoning_replay=semantic.reasoning_replay,
                 system=semantic.system,
                 memory=semantic.memory,
                 mandatory=semantic.mandatory,
@@ -1454,9 +1558,7 @@ def _account_categories(
     mandatory = max(0, counts[3] - counts[2])
     compactable = max(0, counts[4] - counts[3])
     total = counts[5]
-    active = max(
-        0, total - system - memory - tool_schema - mandatory - compactable
-    )
+    active = max(0, total - system - memory - tool_schema - mandatory - compactable)
     # TASK-26019: RAG attribution inside mandatory, by the SAME cumulative
     # construction -- only when request provenance labels the rows (capture
     # on); without it the split is unknowable and stays explicitly
@@ -1472,13 +1574,13 @@ def _account_categories(
         rag_rows = tuple(
             row
             for row, descriptor in zip(semantic.mandatory, provenance.mandatory)
-            if getattr(descriptor, "source", None)
-            is TraceProvenanceSource.RAG_CONTEXT
+            if getattr(descriptor, "source", None) is TraceProvenanceSource.RAG_CONTEXT
         )
         rag_attributed = True
         if rag_rows and len(rag_rows) < len(semantic.mandatory):
             through_rag = _count_wire(
                 PreparedConsoleRequest(
+                    reasoning_replay=semantic.reasoning_replay,
                     system=semantic.system,
                     memory=semantic.memory,
                     mandatory=rag_rows,
@@ -1496,9 +1598,7 @@ def _account_categories(
     # TASK-26019: the per-image share of the conversation buckets --
     # deterministic (same rows, same per_image constant the counter
     # charges), bounded by the buckets it lives inside.
-    conversation_rows = [
-        row for unit in semantic.compactable for row in unit.messages
-    ]
+    conversation_rows = [row for unit in semantic.compactable for row in unit.messages]
     conversation_rows.extend(semantic.active_request)
     conversation_rows.extend(semantic.active_tool_loop)
     image_parts = sum(
@@ -1509,9 +1609,7 @@ def _account_categories(
         for part in row["content"]
         if isinstance(part, Mapping) and part.get("type") != "text"
     )
-    attachment_tokens = min(
-        per_image_tokens * image_parts, compactable + active
-    )
+    attachment_tokens = min(per_image_tokens * image_parts, compactable + active)
     return ConsoleRequestTokenAccounting(
         total_input_tokens=total,
         system_tokens=system,
@@ -1537,9 +1635,13 @@ def prepare_provider_request(
     count_fn: Callable[[list[dict[str, Any]], str], int] | None = None,
     apply_safety_window: bool = True,
     response_format: Mapping[str, Any] | None = None,
+    reasoning_replay: ReasoningReplayPolicy | None = None,
 ) -> PreparedProviderRequest:
     """Window, serialize once, and account one exact provider request."""
 
+    semantic = project_thinking_history(
+        semantic, reasoning_replay or semantic.reasoning_replay
+    )
     counter = count_fn or (
         lambda messages, selected_model: count_console_messages_tokens(
             messages,

--- a/tldw_chatbook/Chat/console_prepared_request.py
+++ b/tldw_chatbook/Chat/console_prepared_request.py
@@ -291,7 +291,7 @@ class PreparedConsoleRequest:
             + self.active_request
         )
 
-    def without_oldest_units(self, count: int) -> "PreparedConsoleRequest":
+    def without_oldest_units(self, count: int) -> PreparedConsoleRequest:
         """Return a new request with ``count`` oldest compactable units removed."""
 
         return PreparedConsoleRequest(
@@ -319,7 +319,22 @@ def project_thinking_history(
     request: PreparedConsoleRequest,
     reasoning_replay: ReasoningReplayPolicy | None,
 ) -> PreparedConsoleRequest:
-    """Filter complete optional owner groups and matching provenance together."""
+    """Filter complete optional owner groups and matching provenance together.
+
+    Args:
+        request: Immutable semantic request with canonical owner groups and
+            any aligned capture provenance.
+        reasoning_replay: Frozen local policy to refine conversation Auto.
+            Explicit Include and Exclude retain their authority.
+
+    Returns:
+        A new request with retained thinking groups, matching provenance, and
+        effective replay policy. Required continuation remains unchanged.
+
+    Raises:
+        TraceProvenanceAlignmentError: If reconstructed provenance does not
+            align with the projected semantic request.
+    """
     policy = effective_replay_policy(reasoning_replay, request.thinking_policy)
     mode = policy.mode if policy is not None else "all"
     keep_old = mode not in {"current", "off"}
@@ -1637,7 +1652,35 @@ def prepare_provider_request(
     response_format: Mapping[str, Any] | None = None,
     reasoning_replay: ReasoningReplayPolicy | None = None,
 ) -> PreparedProviderRequest:
-    """Window, serialize once, and account one exact provider request."""
+    """Window, serialize once, and account one exact provider request.
+
+    Args:
+        semantic: Immutable provider-neutral request with semantic ownership.
+        wire_style: Whether system messages remain separate or form a preamble.
+        model: Target model used for serialization and token accounting.
+        provider: Provider identity retained on the prepared artifact.
+        capacity: Resolved context and output limits for the request.
+        per_image_tokens: Token estimate charged for each image part.
+        count_fn: Optional message-token counter; defaults to the Console's
+            multimodal-aware counter.
+        apply_safety_window: Whether to evict complete oldest compactable units
+            when they exceed the effective input ceiling.
+        response_format: Optional structured-response configuration to freeze.
+        reasoning_replay: Frozen local policy applied before serialization and
+            counting; defaults to the policy already attached to ``semantic``.
+
+    Returns:
+        One immutable provider artifact whose serialized messages, ownership,
+        provenance, token totals, and overflow status describe the same request.
+
+    Raises:
+        ThinkingHistorySerializationError: If retained thinking cannot be
+            safely serialized with its visible owner.
+        TraceProvenanceAlignmentError: If provider rewrites do not preserve
+            exact message and sidecar ownership.
+        TypeError: If values to freeze are not JSON-compatible.
+        ValueError: If frozen numeric values are not finite.
+    """
 
     semantic = project_thinking_history(
         semantic, reasoning_replay or semantic.reasoning_replay

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -15,6 +15,7 @@ from contextvars import ContextVar, copy_context
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
+from time import monotonic
 from types import GeneratorType, MappingProxyType
 from typing import Any, AsyncIterator, Callable, Literal, TypeVar, cast
 from urllib.parse import urlparse, urlunparse
@@ -159,6 +160,9 @@ from tldw_chatbook.Utils.tls_trust import build_httpx_async_client
 
 DEFAULT_LLAMACPP_BASE_URL = "http://127.0.0.1:9099"
 PROBE_TIMEOUT_SECONDS = 5.0
+REASONING_METADATA_TTL_SECONDS = 60.0
+REASONING_METADATA_RETRY_SECONDS = 15.0
+REASONING_METADATA_CACHE_SIZE = 32
 """Per-request timeout for readiness probes (``/health``, ``/v1/models``)."""
 GENERATION_CONNECT_TIMEOUT_SECONDS = 10.0
 """Connect timeout for the owned HTTP client used for generation calls."""
@@ -2369,6 +2373,8 @@ class ConsoleProviderGateway:
         self._normalized_writes_enabled = normalized_writes_enabled or (lambda: True)
         self._trace_compatibility_metrics = trace_compatibility_metrics
         self._adapter_admission_issuer = object()
+        self._reasoning_metadata_cache: dict[str, tuple[float, str | None, bool]] = {}
+        self.reasoning_policies: dict[str, ReasoningReplayPolicy] = {}
 
     @property
     def supports_durable_capture(self) -> bool:
@@ -3224,9 +3230,13 @@ class ConsoleProviderGateway:
             endpoint=resolution.base_url,
             model=resolution.model or "",
         )
-        template = None
-        native_tools = False
-        if resolution.ready:
+        key = reasoning_override_key(
+            resolution.provider, resolution.base_url, resolution.model or ""
+        )
+        cached = self._reasoning_metadata_cache.get(key)
+        now = monotonic()
+        template, native_tools = cached[1:] if cached else (None, False)
+        if resolution.ready and (cached is None or now >= cached[0]):
             from .local_reasoning import _LOCAL_FAMILIES
 
             family = _LOCAL_FAMILIES.get(resolution.provider.lower())
@@ -3248,13 +3258,16 @@ class ConsoleProviderGateway:
                         async for chunk in response.aiter_bytes():
                             data.extend(chunk)
                             if len(data) > 262144:
-                                return {}
+                                raise ValueError(
+                                    "Template metadata exceeds size limit."
+                                )
                         payload = json.loads(data)
                         return payload if isinstance(payload, dict) else {}
 
                 try:
                     metadata = await asyncio.wait_for(read_template(), timeout=1.0)
-                    template = metadata.get("chat_template")
+                    raw_template = metadata.get("chat_template")
+                    template = raw_template if isinstance(raw_template, str) else None
                     caps = metadata.get("chat_template_caps", {})
                     native_tools = (
                         family == "llama_cpp"
@@ -3262,24 +3275,30 @@ class ConsoleProviderGateway:
                         and caps.get("supports_tool_calls") is True
                         and caps.get("supports_tools") is True
                     )
+                    ttl = REASONING_METADATA_TTL_SECONDS
                 except (httpx.HTTPError, ValueError, TimeoutError):
-                    pass
-        key = reasoning_override_key(
-            resolution.provider, resolution.base_url, resolution.model or ""
-        )
+                    # Back off missing routes and keep the last successful facts.
+                    # Preferences are reapplied below, never cached with metadata.
+                    ttl = REASONING_METADATA_RETRY_SECONDS
+                self._reasoning_metadata_cache[key] = (
+                    monotonic() + ttl,
+                    template,
+                    native_tools,
+                )
+                while (
+                    len(self._reasoning_metadata_cache) > REASONING_METADATA_CACHE_SIZE
+                ):
+                    self._reasoning_metadata_cache.pop(
+                        next(iter(self._reasoning_metadata_cache))
+                    )
         overrides = console.get("reasoning_native_tool_overrides", {})
         if isinstance(overrides, Mapping) and overrides.get(key) is True:
             native_tools = True
         policy = resolve_reasoning_policy(
             mode, template=template, native_tools=native_tools
         )
-        if not hasattr(self, "reasoning_policies"):
-            self.reasoning_policies = {}
-        key = reasoning_override_key(
-            resolution.provider, resolution.base_url, resolution.model or ""
-        )
         self.reasoning_policies[key] = policy
-        while len(self.reasoning_policies) > 32:
+        while len(self.reasoning_policies) > REASONING_METADATA_CACHE_SIZE:
             self.reasoning_policies.pop(next(iter(self.reasoning_policies)))
         return replace(
             resolution,

--- a/tldw_chatbook/Chat/console_provider_gateway.py
+++ b/tldw_chatbook/Chat/console_provider_gateway.py
@@ -11,7 +11,7 @@ import threading
 import uuid
 import weakref
 from collections.abc import Awaitable, Iterator, Mapping, Sequence
-from contextvars import copy_context
+from contextvars import ContextVar, copy_context
 from copy import deepcopy
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timezone
@@ -97,6 +97,15 @@ from tldw_chatbook.Chat.console_trace_errors import (  # ADR-097 boot ratchet
 
 # ADR-097 boot ratchet: console_trace_settlement (which pulls the semantic-
 # revision stack) is deferred; its two symbols load at their use sites.
+from tldw_chatbook.Chat.local_reasoning import (
+    ReasoningReplayPolicy,
+    effective_replay_policy,
+    reasoning_mode_setting,
+    reasoning_override_key,
+    resolve_reasoning_policy,
+    supports_local_reasoning,
+    reasoning_template_kwargs,
+)
 from tldw_chatbook.Chat.console_thinking_history import (
     ProviderThinkingSidecar,
     ThinkingReplayTarget,
@@ -1385,6 +1394,8 @@ class ConsoleProviderResolution:
     )
     thinking_stream_disposition: ReasoningDisposition = "ignored"
     thinking_round_trip_version: int | None = None
+    reasoning_replay: ReasoningReplayPolicy | None = field(default=None, kw_only=True)
+    local_structured_thinking: bool = field(default=False, kw_only=True)
 
     def __post_init__(self) -> None:
         valid_disposition = self.thinking_stream_disposition in {
@@ -1404,7 +1415,10 @@ class ConsoleProviderResolution:
     @property
     def may_emit_thinking(self) -> bool:
         """Whether this frozen adapter target can emit typed thinking evidence."""
-        return self.thinking_stream_disposition != "ignored"
+        return (
+            self.thinking_stream_disposition != "ignored"
+            or self.local_structured_thinking
+        )
 
 
 def _freeze_auxiliary_value(value: Any) -> Any:
@@ -1840,6 +1854,43 @@ def _unpack_local_completion_result(
     return result, False
 
 
+_local_reasoning_sink: ContextVar[Callable[[Mapping[str, Any]], bool] | None] = (
+    ContextVar("console_local_reasoning_sink", default=None)
+)
+
+
+def _structured_local_thinking(
+    item: Mapping[str, Any], *, provider: str, model: str, protocol: str
+) -> ProviderThinkingDelta | None:
+    if not supports_local_reasoning(provider, model) or "kimi" in model.lower():
+        return None
+    choices = item.get("choices")
+    if (
+        not isinstance(choices, list)
+        or not choices
+        or not isinstance(choices[0], Mapping)
+    ):
+        return None
+    row = choices[0].get("delta") or choices[0].get("message")
+    if not isinstance(row, Mapping):
+        return None
+    key = (
+        "reasoning"
+        if provider.lower() in {"ollama", "local_ollama"}
+        else "reasoning_content"
+    )
+    text = row.get(key)
+    if isinstance(text, str) and text:
+        return ProviderThinkingDelta(
+            text=text,
+            provider=provider,
+            model=model,
+            protocol=protocol,
+            source_format=key,
+        )
+    return None
+
+
 def _local_thinking_delta(
     text: str,
     *,
@@ -2122,6 +2173,7 @@ def build_llamacpp_chat_payload(
     frequency_penalty: float | None = None,
     reasoning_effort: str | None = None,
     thinking_budget_tokens: int | None = None,
+    reasoning_replay: ReasoningReplayPolicy | None = None,
 ) -> dict[str, Any]:
     """Build the OpenAI-compatible llama.cpp chat completion payload.
 
@@ -2202,6 +2254,12 @@ def build_llamacpp_chat_payload(
         template_kwargs = dict(payload.get("chat_template_kwargs") or {})
         template_kwargs["enable_thinking"] = False
         payload["chat_template_kwargs"] = template_kwargs
+    template_options = reasoning_template_kwargs("llama_cpp", reasoning_replay)
+    if template_options:
+        payload["chat_template_kwargs"] = {
+            **payload.get("chat_template_kwargs", {}),
+            **template_options,
+        }
     return payload
 
 
@@ -2379,22 +2437,35 @@ class ConsoleProviderGateway:
         return adapter(*args, **kwargs)
 
     def _bind_trace_preparation(
-        self, signals: ConsoleProviderStreamSignals, owner: object,
-        *, boundary: object | None = None,
+        self,
+        signals: ConsoleProviderStreamSignals,
+        owner: object,
+        *,
+        boundary: object | None = None,
     ) -> None:
         """Bind recovery to the controller's exact frozen accepted continuation."""
-        if boundary is not None and getattr(boundary, "_accepted_preparation", None) is not owner:
+        if (
+            boundary is not None
+            and getattr(boundary, "_accepted_preparation", None) is not owner
+        ):
             raise TraceCallPersistenceError(boundary=boundary)
         signals._trace_preparation = _TraceAcceptedPreparation(
-            self._adapter_admission_issuer, owner, boundary,
+            self._adapter_admission_issuer,
+            owner,
+            boundary,
         )
 
-    def _trace_preparation_scope(self, signals: object) -> _TraceAcceptedPreparation | None:
+    def _trace_preparation_scope(
+        self, signals: object
+    ) -> _TraceAcceptedPreparation | None:
         aggregate = getattr(signals, "_aggregate", signals)
         scope = getattr(aggregate, "_trace_preparation", None)
         if scope is None:
             return None
-        if type(scope) is not _TraceAcceptedPreparation or scope.issuer is not self._adapter_admission_issuer:
+        if (
+            type(scope) is not _TraceAcceptedPreparation
+            or scope.issuer is not self._adapter_admission_issuer
+        ):
             raise TraceCallPersistenceError()
         return scope
 
@@ -2420,9 +2491,14 @@ class ConsoleProviderGateway:
                 # it does not authorize Capture On or a cold/foreign replay.
                 scope.construction_failure = None
                 return
-        if boundary is None or getattr(boundary, "_accepted_preparation", None) is not owner:
+        if (
+            boundary is None
+            or getattr(boundary, "_accepted_preparation", None) is not owner
+        ):
             raise TraceCallPersistenceError(boundary=boundary)
-        verify = getattr(getattr(boundary, "_factory", None), "_verify_owned_recovery", None)
+        verify = getattr(
+            getattr(boundary, "_factory", None), "_verify_owned_recovery", None
+        )
         if not callable(verify):
             raise TraceCallPersistenceError(boundary=boundary)
         verify(boundary, owner)
@@ -2440,11 +2516,19 @@ class ConsoleProviderGateway:
             or request.provenance is None
         ):
             raise TraceCallPersistenceError(boundary=boundary)
-        record = next((item for item in request.provenance.metadata
-                       if type(item) is RequestRouteTraceProvenance), None)
+        record = next(
+            (
+                item
+                for item in request.provenance.metadata
+                if type(item) is RequestRouteTraceProvenance
+            ),
+            None,
+        )
         if (
-            record is None or record.route is not ConsoleRequestRoute.AGENT_FIRST
-            or record.actor_id is None or record.chain_id is None
+            record is None
+            or record.route is not ConsoleRequestRoute.AGENT_FIRST
+            or record.actor_id is None
+            or record.chain_id is None
         ):
             raise TraceCallPersistenceError(boundary=boundary)
         return record.actor_id, record.chain_id
@@ -2454,7 +2538,8 @@ class ConsoleProviderGateway:
         request: PreparedProviderRequest,
         resolution: ConsoleProviderResolution,
         route: ConsoleRequestRoute | None,
-        *, signals: object = None,
+        *,
+        signals: object = None,
     ) -> object:
         """Create and reserve one distinct Capture-On call boundary."""
 
@@ -2478,7 +2563,9 @@ class ConsoleProviderGateway:
             assert self._trace_call_boundary_factory is not None
             if scope is not None and scope.boundary is not None and not scope.claimed:
                 boundary = scope.boundary
-                recover = getattr(getattr(boundary, "_factory", None), "_recover_owned_boundary", None)
+                recover = getattr(
+                    getattr(boundary, "_factory", None), "_recover_owned_boundary", None
+                )
                 if not callable(recover):
                     raise TraceCallPersistenceError(boundary=boundary)
                 scope.claimed = True
@@ -2703,8 +2790,17 @@ class ConsoleProviderGateway:
                         provider=resolution.execution_key or resolution.provider,
                         model=resolution.model or "",
                         protocol=_thinking_protocol(resolution),
-                        disposition=resolution.thinking_stream_disposition,
-                        round_trip_version=resolution.thinking_round_trip_version,
+                        disposition=(
+                            "displayable"
+                            if resolution.local_structured_thinking
+                            else resolution.thinking_stream_disposition
+                        ),
+                        round_trip_version=(
+                            THINKING_ENVELOPE_VERSION
+                            if resolution.local_structured_thinking
+                            else resolution.thinking_round_trip_version
+                        ),
+                        reasoning_replay=resolution.reasoning_replay,
                     ),
                     policy=thinking_policy,
                     sidecars=tuple(
@@ -2762,8 +2858,17 @@ class ConsoleProviderGateway:
                     provider=resolution.execution_key or resolution.provider,
                     model=resolution.model or "",
                     protocol=_thinking_protocol(resolution),
-                    disposition=resolution.thinking_stream_disposition,
-                    round_trip_version=resolution.thinking_round_trip_version,
+                    disposition=(
+                        "displayable"
+                        if resolution.local_structured_thinking
+                        else resolution.thinking_stream_disposition
+                    ),
+                    round_trip_version=(
+                        THINKING_ENVELOPE_VERSION
+                        if resolution.local_structured_thinking
+                        else resolution.thinking_round_trip_version
+                    ),
+                    reasoning_replay=resolution.reasoning_replay,
                 ),
                 policy=thinking_policy,
                 sidecars=tuple(
@@ -2867,6 +2972,7 @@ class ConsoleProviderGateway:
         )
         return prepare_provider_request(
             semantic,
+            reasoning_replay=resolution.reasoning_replay,
             wire_style=wire_style,
             model=resolution.model or "",
             provider=resolution.provider,
@@ -3104,6 +3210,93 @@ class ConsoleProviderGateway:
             **self._resolution_settings(config, model=model),
         )
 
+    async def _resolve_reasoning_history(
+        self, resolution: ConsoleProviderResolution, app_config: Mapping[str, object]
+    ) -> ConsoleProviderResolution:
+        """Read bounded optional template metadata; failure never blocks chat."""
+        if not supports_local_reasoning(resolution.provider, resolution.model or ""):
+            return resolution
+        console = app_config.get("console", {})
+        console = console if isinstance(console, Mapping) else {}
+        mode = reasoning_mode_setting(
+            console,
+            provider=resolution.provider,
+            endpoint=resolution.base_url,
+            model=resolution.model or "",
+        )
+        template = None
+        native_tools = False
+        if resolution.ready:
+            from .local_reasoning import _LOCAL_FAMILIES
+
+            family = _LOCAL_FAMILIES.get(resolution.provider.lower())
+            # Ollama exposes Go templates; until reviewed, use its server default.
+            route = {"llama_cpp": "/props", "vllm": "/tokenizer_info"}.get(family)
+            if route:
+                base = resolution.base_url.rstrip("/").removesuffix("/chat/completions")
+                base = base.removesuffix("/v1")
+
+                async def read_template():
+                    async with self._active_http_client().stream(
+                        "GET",
+                        base + route,
+                        headers=self._authorization_headers(resolution.api_key),
+                        timeout=1.0,
+                    ) as response:
+                        response.raise_for_status()
+                        data = bytearray()
+                        async for chunk in response.aiter_bytes():
+                            data.extend(chunk)
+                            if len(data) > 262144:
+                                return {}
+                        payload = json.loads(data)
+                        return payload if isinstance(payload, dict) else {}
+
+                try:
+                    metadata = await asyncio.wait_for(read_template(), timeout=1.0)
+                    template = metadata.get("chat_template")
+                    caps = metadata.get("chat_template_caps", {})
+                    native_tools = (
+                        family == "llama_cpp"
+                        and isinstance(caps, Mapping)
+                        and caps.get("supports_tool_calls") is True
+                        and caps.get("supports_tools") is True
+                    )
+                except (httpx.HTTPError, ValueError, TimeoutError):
+                    pass
+        key = reasoning_override_key(
+            resolution.provider, resolution.base_url, resolution.model or ""
+        )
+        overrides = console.get("reasoning_native_tool_overrides", {})
+        if isinstance(overrides, Mapping) and overrides.get(key) is True:
+            native_tools = True
+        policy = resolve_reasoning_policy(
+            mode, template=template, native_tools=native_tools
+        )
+        if not hasattr(self, "reasoning_policies"):
+            self.reasoning_policies = {}
+        key = reasoning_override_key(
+            resolution.provider, resolution.base_url, resolution.model or ""
+        )
+        self.reasoning_policies[key] = policy
+        while len(self.reasoning_policies) > 32:
+            self.reasoning_policies.pop(next(iter(self.reasoning_policies)))
+        return replace(
+            resolution,
+            reasoning_replay=policy,
+            local_structured_thinking="kimi" not in (resolution.model or "").lower(),
+            **(
+                {
+                    "thinking_stream_disposition": "displayable",
+                    "thinking_round_trip_version": THINKING_ENVELOPE_VERSION,
+                }
+                if policy.verified
+                and resolution.reasoning_effort != "none"
+                and "kimi" not in (resolution.model or "").lower()
+                else {}
+            ),
+        )
+
     async def resolve_for_send(
         self, selection: ConsoleProviderSelection
     ) -> ConsoleProviderResolution:
@@ -3190,11 +3383,14 @@ class ConsoleProviderGateway:
                     streaming=selection.streaming,
                 )
             )
-            return replace(
-                resolved,
-                provider=identity.execution_key,
-                readiness_key=identity.readiness_key,
-                execution_key=identity.execution_key,
+            return await self._resolve_reasoning_history(
+                replace(
+                    resolved,
+                    provider=identity.execution_key,
+                    readiness_key=identity.readiness_key,
+                    execution_key=identity.execution_key,
+                ),
+                app_config,
             )
 
         if not identity.is_supported:
@@ -3427,7 +3623,7 @@ class ConsoleProviderGateway:
                     execution_key=identity.execution_key,
                 )
 
-        return ConsoleProviderResolution(
+        resolved = ConsoleProviderResolution(
             provider=selection.provider,
             base_url=effective_base_url or "",
             model=model,
@@ -3463,11 +3659,15 @@ class ConsoleProviderGateway:
             ),
         )
 
+        return await self._resolve_reasoning_history(resolved, app_config)
+
     async def stream_llamacpp_chat(
         self,
         *,
         base_url: str,
         model: str,
+        reasoning_replay: ReasoningReplayPolicy | None = None,
+        local_structured_thinking: bool = False,
         messages: list[Mapping[str, Any]],
         temperature: float | None = None,
         top_p: float | None = None,
@@ -3528,6 +3728,7 @@ class ConsoleProviderGateway:
             raise ValueError("invalid llama.cpp base URL")
 
         payload = build_llamacpp_chat_payload(
+            reasoning_replay=reasoning_replay,
             model=model,
             messages=messages,
             stream=True,
@@ -3568,6 +3769,25 @@ class ConsoleProviderGateway:
             async with stream_context as response:
                 response.raise_for_status()
                 async for line in response.aiter_lines():
+                    if (
+                        thinking_stream_disposition == "displayable"
+                        or local_structured_thinking
+                    ) and line.startswith("data:"):
+                        try:
+                            structured_payload = json.loads(line[5:].strip())
+                        except (ValueError, TypeError):
+                            structured_payload = None
+                        if isinstance(structured_payload, Mapping):
+                            event = _structured_local_thinking(
+                                structured_payload,
+                                provider=provider,
+                                model=model,
+                                protocol=protocol,
+                            )
+                            if event is not None:
+                                received_content = True
+                                think_splitter = None
+                                yield event
                     chunk = self._content_from_sse_line(line)
                     if chunk:
                         received_content = True
@@ -3623,6 +3843,7 @@ class ConsoleProviderGateway:
         if on_fallback_transition is not None:
             await on_fallback_transition(stream_error is not None)
         fallback_payload = build_llamacpp_chat_payload(
+            reasoning_replay=reasoning_replay,
             model=model,
             messages=messages,
             stream=False,
@@ -3646,6 +3867,8 @@ class ConsoleProviderGateway:
             fallback_endpoint, fallback_payload
         )
         fallback_result = await self.complete_llamacpp_chat(
+            local_structured_thinking=local_structured_thinking,
+            reasoning_replay=reasoning_replay,
             base_url=normalized_base_url,
             model=model,
             messages=messages,
@@ -3706,6 +3929,8 @@ class ConsoleProviderGateway:
         *,
         base_url: str,
         model: str,
+        reasoning_replay: ReasoningReplayPolicy | None = None,
+        local_structured_thinking: bool = False,
         messages: list[Mapping[str, Any]],
         temperature: float | None = None,
         top_p: float | None = None,
@@ -3766,6 +3991,7 @@ class ConsoleProviderGateway:
 
         request_url = f"{normalized_base_url.rstrip('/')}/v1/chat/completions"
         payload = build_llamacpp_chat_payload(
+            reasoning_replay=reasoning_replay,
             model=model,
             messages=messages,
             stream=False,
@@ -3816,14 +4042,25 @@ class ConsoleProviderGateway:
                 **request_kwargs,
             )
         response.raise_for_status()
+        structured_event = (
+            _structured_local_thinking(
+                response.json(), provider=provider, model=model, protocol=protocol
+            )
+            if thinking_stream_disposition == "displayable" or local_structured_thinking
+            else None
+        )
         content = self._content_from_completion_response(response)
-        if content is None and strict_response:
+        if content is None and strict_response and structured_event is None:
             raise ChatProviderError(
                 "Provider returned an unsupported auxiliary response.",
                 provider="llama_cpp",
             )
         result = (
-            _split_local_completion_items(
+            _LocalCompletionResult(
+                items=(structured_event, *((content,) if content else ()))
+            )
+            if structured_event is not None
+            else _split_local_completion_items(
                 content or "",
                 provider=provider,
                 model=model,
@@ -3904,6 +4141,8 @@ class ConsoleProviderGateway:
                     # thinking settings (documented parity with cloud
                     # providers).
                     text = await self.complete_llamacpp_chat(
+                        local_structured_thinking=resolution.local_structured_thinking,
+                        reasoning_replay=resolution.reasoning_replay,
                         base_url=resolution.base_url,
                         model=model,
                         messages=messages,
@@ -4206,6 +4445,12 @@ class ConsoleProviderGateway:
                     f"{ceiling}). Compaction cannot remove this material.",
                     provider=resolution.provider,
                 )
+            resolution = replace(
+                resolution,
+                reasoning_replay=effective_replay_policy(
+                    resolution.reasoning_replay, prepared.semantic.thinking_policy
+                ),
+            )
             effective_resolution = replace(
                 resolution,
                 max_tokens=(
@@ -4228,7 +4473,10 @@ class ConsoleProviderGateway:
                 )
             else:
                 capture_off_admission = self._capture_off_admission(route)
-            if resolution.provider in {"llama_cpp", "local_llamacpp"}:
+            if (
+                resolution.provider in {"llama_cpp", "local_llamacpp"}
+                and not prepared.tools
+            ):
                 wire_messages = [thaw_json(item) for item in prepared.messages]
 
                 def capture_wire_payload(
@@ -4313,6 +4561,7 @@ class ConsoleProviderGateway:
                 verified_bundle: ProviderRequestShadowBundle | None = None
                 if capture_mode is ConsoleTraceCaptureMode.CAPTURE_ON:
                     verified_wire = build_llamacpp_chat_payload(
+                        reasoning_replay=resolution.reasoning_replay,
                         model=resolution.model,
                         messages=wire_messages,
                         stream=resolution.streaming,
@@ -4372,6 +4621,7 @@ class ConsoleProviderGateway:
                     try:
                         budget = CaptureBudget()
                         wire = verified_wire or build_llamacpp_chat_payload(
+                            reasoning_replay=resolution.reasoning_replay,
                             model=resolution.model,
                             messages=wire_messages,
                             stream=resolution.streaming,
@@ -4428,6 +4678,8 @@ class ConsoleProviderGateway:
                     # close_exchange(status="error") before it re-raises.
                     try:
                         completion_result = await self.complete_llamacpp_chat(
+                            local_structured_thinking=resolution.local_structured_thinking,
+                            reasoning_replay=resolution.reasoning_replay,
                             base_url=resolution.base_url,
                             model=resolution.model,
                             messages=wire_messages,
@@ -4615,6 +4867,8 @@ class ConsoleProviderGateway:
 
                 try:
                     async for chunk in self.stream_llamacpp_chat(
+                        local_structured_thinking=resolution.local_structured_thinking,
+                        reasoning_replay=resolution.reasoning_replay,
                         base_url=resolution.base_url,
                         model=resolution.model,
                         messages=wire_messages,
@@ -4784,7 +5038,28 @@ class ConsoleProviderGateway:
             with contextlib.suppress(RuntimeError):
                 loop.call_soon_threadsafe(queue.put_nowait, item)
 
-        def worker() -> None:
+        structured_seen = False
+
+        def capture_structured(item: Mapping[str, Any]) -> bool:
+            nonlocal structured_seen
+            if not (
+                resolution.local_structured_thinking
+                or resolution.thinking_stream_disposition == "displayable"
+            ):
+                return False
+            event = _structured_local_thinking(
+                item,
+                provider=resolution.execution_key or resolution.provider,
+                model=resolution.model or "",
+                protocol=_thinking_protocol(resolution),
+            )
+            if event is None:
+                return False
+            structured_seen = True
+            enqueue(_QueueItem.thinking(event))
+            return True
+
+        def consume_provider() -> None:
             try:
                 kwargs = self._chat_api_kwargs_from_prepared(resolution, request)
                 kwargs = self._trace_surface_kwargs(trace_call_boundary, kwargs)
@@ -4926,16 +5201,21 @@ class ConsoleProviderGateway:
                 # history, so it is suppressed at GENERATION (not filtered
                 # by string equality — review minor m4: a real answer that
                 # happens to equal the copy text now flows through).
+                normalization_signals = (
+                    signals or ConsoleProviderStreamSignals().new_usage_call()
+                )
                 normalized_response = self.normalize_provider_response(
                     response,
                     suppress_fallback_copy=accumulator is not None,
-                    signals=signals,
+                    signals=normalization_signals,
                 )
                 while not stop_event.is_set():
                     try:
                         text = next(normalized_response)
                     except StopIteration:
                         break
+                    if structured_seen:
+                        think_splitter = None
                     split = think_splitter.feed(text) if think_splitter else None
                     thinking = split.thinking if split is not None else ""
                     visible = split.content if split is not None else text
@@ -4954,10 +5234,12 @@ class ConsoleProviderGateway:
                     if visible:
                         emitted_content = True
                     synthetic = (
-                        signals.take_synthetic_pending()
-                        if signals is not None and visible
+                        normalization_signals.take_synthetic_pending()
+                        if visible
                         else False
                     )
+                    if structured_seen and synthetic:
+                        continue
                     if signals is not None and visible:
                         # M3: the fallback UI copy this loop can receive
                         # from `normalize_provider_response` (NO_PROVIDER_
@@ -5070,6 +5352,13 @@ class ConsoleProviderGateway:
             finally:
                 close_response()
                 enqueue(_QueueItem.done())
+
+        def worker() -> None:
+            token = _local_reasoning_sink.set(capture_structured)
+            try:
+                consume_provider()
+            finally:
+                _local_reasoning_sink.reset(token)
 
         worker_task = asyncio.create_task(asyncio.to_thread(worker))
         try:
@@ -5458,7 +5747,18 @@ class ConsoleProviderGateway:
             ),
             "prompt_caching": resolution.prompt_caching,
         }
-        if resolution.execution_key == "qwencloud":
+        local = supports_local_reasoning(
+            resolution.execution_key or resolution.provider, resolution.model or ""
+        )
+        template_options = reasoning_template_kwargs(
+            resolution.execution_key or resolution.provider, resolution.reasoning_replay
+        )
+        if template_options:
+            kwargs["chat_template_kwargs"] = template_options
+        if local:
+            kwargs["api_base_url"] = resolution.base_url or None
+            kwargs["api_key_resolved"] = True
+        elif resolution.execution_key == "qwencloud":
             kwargs["api_mode"] = resolution.api_mode
             kwargs["api_base_url"] = resolution.base_url or None
         elif resolution.execution_key in {"moonshot", "zai"}:
@@ -5819,6 +6119,8 @@ def _content_from_sse_data(
 
 
 def _content_from_provider_mapping(item: Mapping[str, Any]) -> str | object:
+    sink = _local_reasoning_sink.get()
+    captured_reasoning = sink(item) if sink is not None else False
     choices = item.get("choices")
     if isinstance(choices, list) and choices:
         first = choices[0]
@@ -5829,6 +6131,8 @@ def _content_from_provider_mapping(item: Mapping[str, Any]) -> str | object:
             message = first.get("message")
             if isinstance(message, Mapping) and isinstance(message.get("content"), str):
                 return message["content"]
+            if captured_reasoning:
+                return _EMPTY_RESPONSE
             text = first.get("text")
             if isinstance(text, str):
                 return text

--- a/tldw_chatbook/Chat/console_thinking_capture.py
+++ b/tldw_chatbook/Chat/console_thinking_capture.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import hashlib
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 from uuid import uuid4
 
 from tldw_chatbook.Chat.console_provider_gateway import (
@@ -23,6 +24,36 @@ from tldw_chatbook.Chat.thinking_blocks import (
     ThinkingStatus,
     dump_thinking_blocks_json,
 )
+
+if TYPE_CHECKING:
+    from tldw_chatbook.Chat.console_thinking_history import ProviderThinkingSidecar
+
+CALL_THINKING_KEY = "_tldw_call_thinking"
+
+
+def consume_call_thinking(
+    messages: Sequence[Mapping], *, owner_key: str
+) -> tuple[list[dict], tuple[ProviderThinkingSidecar, ...]]:
+    """Extract ephemeral call envelopes before provider and trace preparation."""
+    from tldw_chatbook.Chat.console_thinking_history import ProviderThinkingSidecar
+
+    rows = []
+    sidecars = []
+    for message in messages:
+        row = dict(message)
+        envelope = row.pop(CALL_THINKING_KEY, None)
+        if envelope is not None:
+            if (
+                not isinstance(envelope, ThinkingEnvelope)
+                or row.get("role") != "assistant"
+            ):
+                raise ValueError("Call thinking must belong to an assistant envelope.")
+            if envelope.blocks:
+                owner = envelope.blocks[0].block_id
+                row[owner_key] = owner
+                sidecars.append(ProviderThinkingSidecar(owner, envelope))
+        rows.append(row)
+    return rows, tuple(sidecars)
 
 
 @dataclass(frozen=True, slots=True)
@@ -158,6 +189,30 @@ class ThinkingCapture:
         """Close the current primary model round at its tool-call seam."""
         self._require_live()
         update = self._mark_boundary()
+        current = self._current_block()
+        if (
+            isinstance(current, DisplayableThinkingBlock)
+            and current.provider
+            in {
+                "llama_cpp",
+                "local_llamacpp",
+                "vllm",
+                "local_vllm",
+                "ollama",
+                "local_ollama",
+            }
+            and current.source_format
+            in {"start_anchored_think", "reasoning_content", "reasoning"}
+        ):
+            self._install(
+                tuple(
+                    replace(block, source_format=block.source_format + ":tool_call")
+                    if block.block_id == current.block_id
+                    else block
+                    for block in self._blocks
+                )
+            )
+            update = replace(update, envelope=self._envelope())
         self._round_ordinal += 1
         self._boundary_reached = False
         return update

--- a/tldw_chatbook/Chat/console_thinking_capture.py
+++ b/tldw_chatbook/Chat/console_thinking_capture.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field, replace
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Any, Literal
 from uuid import uuid4
 
 from tldw_chatbook.Chat.console_provider_gateway import (
@@ -32,13 +32,29 @@ CALL_THINKING_KEY = "_tldw_call_thinking"
 
 
 def consume_call_thinking(
-    messages: Sequence[Mapping], *, owner_key: str
-) -> tuple[list[dict], tuple[ProviderThinkingSidecar, ...]]:
-    """Extract ephemeral call envelopes before provider and trace preparation."""
+    messages: Sequence[Mapping[str, Any]], *, owner_key: str
+) -> tuple[list[dict[str, Any]], tuple[ProviderThinkingSidecar, ...]]:
+    """Extract ephemeral call envelopes before provider and trace preparation.
+
+    Args:
+        messages: Semantic message mappings, optionally carrying a canonical
+            envelope under ``CALL_THINKING_KEY``.
+        owner_key: Temporary row field used to bind each extracted envelope to
+            its assistant owner during subsequent request preparation.
+
+    Returns:
+        Message copies with internal call envelopes removed, together with
+        canonical sidecars for nonempty envelopes. Each sidecar's owner is
+        the envelope's first block identifier; input messages are unchanged.
+
+    Raises:
+        ValueError: If an internal call value is not a ThinkingEnvelope or its
+            message does not have the assistant role.
+    """
     from tldw_chatbook.Chat.console_thinking_history import ProviderThinkingSidecar
 
-    rows = []
-    sidecars = []
+    rows: list[dict[str, Any]] = []
+    sidecars: list[ProviderThinkingSidecar] = []
     for message in messages:
         row = dict(message)
         envelope = row.pop(CALL_THINKING_KEY, None)

--- a/tldw_chatbook/Chat/console_thinking_history.py
+++ b/tldw_chatbook/Chat/console_thinking_history.py
@@ -255,7 +255,22 @@ def serialize_thinking_message(
     message: Mapping[str, Any],
     group: ThinkingOwnerGroup,
 ) -> dict[str, Any]:
-    """Encode complete canonical blocks without changing a structured answer."""
+    """Encode complete canonical blocks without changing a structured answer.
+
+    Args:
+        message: Assistant message whose visible content owns the thinking.
+        group: Compatible complete thinking blocks for that exact owner.
+
+    Returns:
+        A message copy with start-anchored thinking encoded in ``content`` or
+        structured thinking in its declared separate field. Separate-field
+        encoding leaves the visible answer unchanged.
+
+    Raises:
+        ThinkingHistorySerializationError: If the group mixes source encodings,
+            uses an unsupported format, or cannot safely encode start-anchored
+            thinking alongside the supplied answer.
+    """
     row = dict(message)
     formats = {block.source_format for block in group.blocks}
     if formats == {_START_ANCHORED_FORMAT}:

--- a/tldw_chatbook/Chat/console_thinking_history.py
+++ b/tldw_chatbook/Chat/console_thinking_history.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Any, Literal
 
 from tldw_chatbook.Chat.thinking_blocks import (
     THINKING_ENVELOPE_VERSION,
@@ -13,10 +14,10 @@ from tldw_chatbook.Chat.thinking_blocks import (
     normalize_thinking_history_policy,
 )
 
+from .local_reasoning import ReasoningReplayPolicy, supports_local_reasoning
 
 EffectiveThinkingHistoryPolicy = Literal["auto", "include", "exclude", "required"]
 ThinkingReplayDisposition = Literal["displayable", "proprietary", "ignored"]
-_LOCAL_CHAT_TARGETS = frozenset({"llama_cpp", "local_llamacpp", "vllm", "local_vllm"})
 _START_ANCHORED_FORMAT = "start_anchored_think"
 _SERIALIZATION_ERROR = "Thinking history could not be serialized safely."
 
@@ -77,6 +78,7 @@ class ThinkingReplayTarget:
     protocol: str
     disposition: ThinkingReplayDisposition
     round_trip_version: int | None
+    reasoning_replay: ReasoningReplayPolicy | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -112,9 +114,11 @@ def _claims_local_compatibility(
     block: DisplayableThinkingBlock,
     target: ThinkingReplayTarget,
 ) -> bool:
+    ollama = {"ollama", "local_ollama"}
     return (
-        target.provider in _LOCAL_CHAT_TARGETS
-        and block.provider in _LOCAL_CHAT_TARGETS
+        (target.provider.lower() in ollama) == (block.provider.lower() in ollama)
+        and supports_local_reasoning(target.provider, target.model)
+        and supports_local_reasoning(block.provider, block.model)
         and target.model == block.model
         and target.protocol == block.protocol
         and target.disposition == "displayable"
@@ -159,7 +163,11 @@ def resolve_thinking_history(
         saved,
         continuation_required=continuation_required,
     )
-    if saved == "exclude":
+    if saved == "exclude" or (
+        saved == "auto"
+        and target.reasoning_replay is not None
+        and target.reasoning_replay.mode == "off"
+    ):
         return ResolvedThinkingHistory(saved, effective)
 
     groups: list[ThinkingOwnerGroup] = []
@@ -178,10 +186,18 @@ def resolve_thinking_history(
                 block, target
             ):
                 continue
+            # Saved aggregate tool traces have no exact tool-call owner here.
+            if block.source_format.endswith(":tool_call"):
+                continue
+            structured_field = (
+                "reasoning"
+                if target.provider.lower() in {"ollama", "local_ollama"}
+                else "reasoning_content"
+            )
             safely_serializable = (
                 block.source_format == _START_ANCHORED_FORMAT
                 and _safe_start_anchored_text(block.text)
-            )
+            ) or block.source_format == structured_field
             if not safely_serializable:
                 if saved == "include":
                     raise ThinkingHistorySerializationError(_SERIALIZATION_ERROR)
@@ -193,6 +209,10 @@ def resolve_thinking_history(
                     text=block.text,
                 )
             )
+        if len({block.source_format for block in resolved}) > 1:
+            if saved == "include":
+                raise ThinkingHistorySerializationError(_SERIALIZATION_ERROR)
+            continue
         if resolved:
             groups.append(ThinkingOwnerGroup(sidecar.owner_message_id, tuple(resolved)))
     return ResolvedThinkingHistory(saved, effective, tuple(groups))
@@ -229,3 +249,19 @@ def serialize_start_anchored_thinking(
         parts.append(f"<think>{block.text}</think>")
     parts.append(visible_answer)
     return "\n".join(parts)
+
+
+def serialize_thinking_message(
+    message: Mapping[str, Any],
+    group: ThinkingOwnerGroup,
+) -> dict[str, Any]:
+    """Encode complete canonical blocks without changing a structured answer."""
+    row = dict(message)
+    formats = {block.source_format for block in group.blocks}
+    if formats == {_START_ANCHORED_FORMAT}:
+        row["content"] = serialize_start_anchored_thinking(row.get("content"), group)
+    elif len(formats) == 1 and formats <= {"reasoning_content", "reasoning"}:
+        row[next(iter(formats))] = "\n".join(block.text for block in group.blocks)
+    else:
+        raise ThinkingHistorySerializationError(_SERIALIZATION_ERROR)
+    return row

--- a/tldw_chatbook/Chat/console_trace_final_values.py
+++ b/tldw_chatbook/Chat/console_trace_final_values.py
@@ -693,6 +693,7 @@ _DEFAULT_PROVENANCE_KEYS = (
     "verbosity",
     "thinking_effort",
     "thinking_budget_tokens",
+    "chat_template_kwargs",
     "prompt_caching",
 )
 
@@ -729,7 +730,21 @@ def reconstruct_provider_gateway_kwargs(
         "response_format": _thaw(getattr(request, "response_format")),
         "prompt_caching": getattr(resolution, "prompt_caching"),
     }
-    if execution_key == "qwencloud":
+    from tldw_chatbook.Chat.local_reasoning import (
+        reasoning_template_kwargs,
+        supports_local_reasoning,
+    )
+
+    provider = execution_key or resolution.provider
+    template_options = reasoning_template_kwargs(
+        provider, getattr(resolution, "reasoning_replay", None)
+    )
+    if template_options:
+        kwargs["chat_template_kwargs"] = template_options
+    if supports_local_reasoning(provider, resolution.model or ""):
+        kwargs["api_base_url"] = resolution.base_url or None
+        kwargs["api_key_resolved"] = True
+    elif execution_key == "qwencloud":
         kwargs["api_mode"] = getattr(resolution, "api_mode")
         kwargs["api_base_url"] = getattr(resolution, "base_url") or None
     elif execution_key in {"moonshot", "zai"}:

--- a/tldw_chatbook/Chat/console_trace_provenance.py
+++ b/tldw_chatbook/Chat/console_trace_provenance.py
@@ -93,6 +93,7 @@ class TraceTransformKind(str, Enum):
     SYSTEM_FRAMING = "system_framing"
     PROVIDER_OVERLAY = "provider_overlay"
     MESSAGE_REWRITE = "message_rewrite"
+    RUNTIME_GUIDANCE = "runtime_guidance"
     CURRENT_TURN_TEXT = "current_turn_text"
     WINDOWING = "windowing"
 
@@ -598,6 +599,33 @@ def _validate_derived_shape(descriptor: DerivedTraceProvenance) -> None:
 
     transform = descriptor.transform
     artifact = descriptor.artifact
+    if transform is TraceTransformKind.RUNTIME_GUIDANCE:
+        # This encoding preserves a tool-result role while attaching runtime
+        # guidance, or wraps one guidance/result row for a reviewed template.
+        controls = frozenset(
+            {
+                TraceProvenanceSource.ACTIVE_REQUEST,
+                TraceProvenanceSource.PROJECT_INSTRUCTION,
+            }
+        )
+        first_sources = controls | {TraceProvenanceSource.TOOL_RESULT}
+        if (
+            artifact is not None
+            or not descriptor.inputs
+            or not _descriptor_matches_category(
+                descriptor.inputs[0], allow_saved=True, artifact_sources=first_sources
+            )
+            or any(
+                not _descriptor_matches_category(
+                    item, allow_saved=True, artifact_sources=controls
+                )
+                for item in descriptor.inputs[1:]
+            )
+        ):
+            raise TraceProvenanceAlignmentError(
+                "runtime guidance requires its result/control source and exact guidance inputs"
+            )
+        return
     if transform is TraceTransformKind.CURRENT_TURN_TEXT:
         if (
             len(descriptor.inputs) != 1
@@ -747,6 +775,17 @@ def _descriptor_matches_category(
     allow_saved: bool,
     artifact_sources: frozenset[TraceProvenanceSource],
 ) -> bool:
+    if (
+        type(descriptor) is DerivedTraceProvenance
+        and descriptor.transform is TraceTransformKind.RUNTIME_GUIDANCE
+    ):
+        # The wire role is that of the first source; every causal input remains
+        # traversed and admitted by the normal provenance admission walker.
+        return _descriptor_matches_category(
+            descriptor.inputs[0],
+            allow_saved=allow_saved,
+            artifact_sources=artifact_sources,
+        )
     if (
         type(descriptor) is DerivedTraceProvenance
         and descriptor.transform is TraceTransformKind.MESSAGE_REWRITE

--- a/tldw_chatbook/Chat/local_reasoning.py
+++ b/tldw_chatbook/Chat/local_reasoning.py
@@ -62,7 +62,19 @@ _REVIEWED_TEMPLATES = {
 
 @dataclass(frozen=True)
 class ReasoningReplayPolicy:
-    """Immutable optional-reasoning policy pinned to one resolved send."""
+    """Immutable optional-reasoning policy pinned to one resolved send.
+
+    Attributes:
+        mode: Effective history mode, including ``server_default`` for an
+            unreviewed template's automatic behavior.
+        source: User-facing description of where the policy was selected.
+        template_family: Reviewed template family, or an empty string.
+        supports_preserve: Whether the template accepts preservation options;
+            this does not widen the template's own replay eligibility.
+        verified: Whether the template matched an exact reviewed fingerprint.
+        native_tools: Whether the server independently declares native tool
+            support or the user explicitly enabled it for this target.
+    """
 
     mode: str
     source: str
@@ -73,6 +85,11 @@ class ReasoningReplayPolicy:
 
     @property
     def label(self) -> str:
+        """Return a concise description of the resolved mode and template.
+
+        Returns:
+            User-facing policy source, mode, and optional template family.
+        """
         label = {value: label for label, value in REASONING_HISTORY_OPTIONS}.get(
             self.mode, "Server default (unverified template)"
         )
@@ -84,7 +101,19 @@ class ReasoningReplayPolicy:
 def resolve_reasoning_policy(
     mode: str, *, template: object = None, native_tools: bool = False
 ) -> ReasoningReplayPolicy:
-    """Resolve only reviewed templates; unknown text is never executed."""
+    """Resolve only reviewed templates; unknown text is never executed.
+
+    Args:
+        mode: Requested mode: ``auto``, ``current``, ``all``, or ``off``.
+            Unrecognized values use ``auto``.
+        template: Template text to fingerprint, or any non-string value when
+            metadata is unavailable. This function never renders the text.
+        native_tools: Separately established native-tool capability.
+
+    Returns:
+        Frozen effective policy. Automatic mode uses a reviewed template's
+        preference when available and otherwise retains the server default.
+    """
     known = None
     if isinstance(template, str):
         digest = hashlib.sha256(
@@ -105,7 +134,20 @@ def resolve_reasoning_policy(
 
 
 def reasoning_override_key(provider: str, endpoint: str, model: str) -> str:
-    """Stable local target identity, without persisting credentials in the key."""
+    """Build a stable local target key without retaining endpoint credentials.
+
+    Args:
+        provider: Local provider key or supported alias.
+        endpoint: Server URL, optionally ending in ``/v1/chat/completions``.
+        model: Exact selected model identifier.
+
+    Returns:
+        SHA-256 digest of the normalized provider, credential-free endpoint,
+        and model identity.
+
+    Raises:
+        ValueError: If the endpoint cannot be parsed as a URL.
+    """
     parsed = urlsplit(endpoint.strip())
     path = parsed.path.rstrip("/")
     for suffix in ("/chat/completions", "/v1"):
@@ -127,7 +169,22 @@ def reasoning_mode_setting(
     endpoint: str = "",
     model: str = "",
 ) -> str:
-    """Read a scoped override, with explicit legacy-off migration."""
+    """Read a scoped override, with an explicit legacy-off fallback.
+
+    Args:
+        console: Loaded Console settings mapping.
+        provider: Provider key for an optional target-specific lookup.
+        endpoint: Endpoint used with the provider and model to identify an
+            override.
+        model: Exact model identifier; an empty value skips scoped lookup.
+
+    Returns:
+        A supported mode from the scoped override or global preference, or
+        ``off`` for a legacy opt-out and ``auto`` otherwise.
+
+    Raises:
+        ValueError: If an endpoint used for scoped lookup is not parseable.
+    """
     modes = {value for _, value in REASONING_HISTORY_OPTIONS}
     overrides = console.get("reasoning_history_overrides", {})
     if provider and model and isinstance(overrides, Mapping):
@@ -150,7 +207,17 @@ def effective_replay_policy(
     policy: ReasoningReplayPolicy | None,
     conversation_policy: str,
 ) -> ReasoningReplayPolicy | None:
-    """Apply explicit conversation authority before device-local Auto policy."""
+    """Apply explicit conversation authority before device-local Auto policy.
+
+    Args:
+        policy: Frozen device-local policy, or None when no policy was resolved.
+        conversation_policy: Saved conversation preference. ``exclude`` forces
+            Off, ``include`` forces All, and other values retain ``policy``.
+
+    Returns:
+        The effective optional replay policy without mutating the original.
+        Required provider continuation is managed separately.
+    """
     if conversation_policy in {"exclude", "include"}:
         base = policy or ReasoningReplayPolicy("server_default", "Server default")
         return replace(base, mode="off" if conversation_policy == "exclude" else "all")
@@ -158,7 +225,15 @@ def effective_replay_policy(
 
 
 def starts_reasoning_exchange(row: Mapping[str, Any]) -> bool:
-    """Only an actual user request closes the previous reasoning exchange."""
+    """Identify a user request that starts a new reasoning exchange.
+
+    Args:
+        row: Semantic message, including any internal origin annotations.
+
+    Returns:
+        True for an actual user request. Tool results, runtime guidance, and
+        ephemeral project context continue the existing exchange.
+    """
     from tldw_chatbook.Agents.agent_models import FENCE_TOOL_RESULT_PREFIX
     from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
 
@@ -172,7 +247,16 @@ def starts_reasoning_exchange(row: Mapping[str, Any]) -> bool:
 
 
 def supports_local_reasoning(provider: str, model: str) -> bool:
-    """Recognize local transports that accept separate reasoning fields."""
+    """Recognize local transports that accept separate reasoning fields.
+
+    Args:
+        provider: Provider key or supported local alias.
+        model: Selected model identifier.
+
+    Returns:
+        True for a supported local transport with a nonblank model. This does
+        not imply that its template or native-tool behavior is verified.
+    """
     return provider.lower() in _LOCAL_FAMILIES and bool(model.strip())
 
 
@@ -188,6 +272,25 @@ def project_reasoning_history(
 
     This is the agent accounting path; durable history comes from canonical
     sidecars at the gateway. No separate persisted reasoning body is accepted.
+
+    Args:
+        messages: Semantic rows carrying optional ephemeral canonical call
+            envelopes. Input rows and envelopes are not mutated.
+        provider: Target provider key.
+        model: Exact target model identifier.
+        policy: Frozen local replay and template policy, when available.
+        enabled: Whether optional replay is allowed. False applies Exclude
+            independently of the policy's mode.
+
+    Returns:
+        Mutable provider-visible message copies with eligible reasoning and
+        template control encodings. Empty input returns an empty list.
+
+    Raises:
+        ValueError: If a call envelope is invalid, belongs to a non-assistant
+            row, or message ownership cannot form a canonical request.
+        ThinkingHistorySerializationError: If retained reasoning cannot be
+            encoded safely with its visible owner.
     """
     if not messages:
         return []
@@ -245,7 +348,16 @@ def reasoning_template_kwargs(
     provider: str,
     policy: ReasoningReplayPolicy | None,
 ) -> dict[str, bool]:
-    """Expose exact reviewed template options for dispatch and trace admission."""
+    """Expose exact reviewed template options for dispatch and trace admission.
+
+    Args:
+        provider: Target provider key or supported local alias.
+        policy: Frozen replay policy, or None when unavailable.
+
+    Returns:
+        ``preserve_thinking`` with the selected retention value for compatible
+        llama.cpp/vLLM templates, or an empty mapping otherwise.
+    """
     if (
         policy is not None
         and policy.supports_preserve

--- a/tldw_chatbook/Chat/local_reasoning.py
+++ b/tldw_chatbook/Chat/local_reasoning.py
@@ -1,0 +1,255 @@
+"""Device-local replay policy for canonical Console thinking envelopes."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass, replace
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+LOCAL_TOOL_RESULT_KEY = "_tldw_local_tool_result"
+EXCHANGE_CONTINUATION_KEY = "_tldw_exchange_continuation"
+_LOCAL_FAMILIES = {
+    "llama_cpp": "llama_cpp",
+    "local_llamacpp": "llama_cpp",
+    "local-llm": "llama_cpp",
+    "local_llamafile": "llama_cpp",
+    "vllm": "vllm",
+    "local_vllm": "vllm",
+    "ollama": "ollama",
+    "local_ollama": "ollama",
+}
+
+
+REASONING_HISTORY_OPTIONS = (
+    ("Automatic (recommended)", "auto"),
+    ("Current exchange", "current"),
+    ("All available", "all"),
+    ("Off", "off"),
+)
+# Exact reviewed upstream templates; provenance and render tests live in
+# Tests/fixtures/reasoning_templates. Do not infer policy from a model alias.
+_REVIEWED_TEMPLATES = {
+    "6a1015c47ccfcfa67c3b772385bccee357a4d37c3cda37bd202e9047f391ab82": (
+        "Gemma 4",
+        "current",
+        True,
+    ),
+    "1d35a24a2a63cc600c0cab43628a6df4cd3318e959b03307cf5f9f7e29ecf783": (
+        "Gemma 4",
+        "current",
+        False,
+    ),
+    "a4aee8afcf2e0711942cf848899be66016f8d14a889ff9ede07bca099c28f715": (
+        "Qwen3.5",
+        "current",
+        False,
+    ),
+    "e84f32a23fdda27689f868aa4a1a5621f41133e51a48d7f3efcbea2839574259": (
+        "Qwen3.6",
+        "current",
+        True,
+    ),
+    "c3cf9e34abf4f9e36c2d72165aa9c132d3e2a725b6c2586aaa3a8af9d7a81041": (
+        "Qwen3.8",
+        "all",
+        True,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class ReasoningReplayPolicy:
+    """Immutable optional-reasoning policy pinned to one resolved send."""
+
+    mode: str
+    source: str
+    template_family: str = ""
+    supports_preserve: bool = False
+    verified: bool = False
+    native_tools: bool = False
+
+    @property
+    def label(self) -> str:
+        label = {value: label for label, value in REASONING_HISTORY_OPTIONS}.get(
+            self.mode, "Server default (unverified template)"
+        )
+        return f"{self.source} — {label}" + (
+            f" ({self.template_family})" if self.template_family else ""
+        )
+
+
+def resolve_reasoning_policy(
+    mode: str, *, template: object = None, native_tools: bool = False
+) -> ReasoningReplayPolicy:
+    """Resolve only reviewed templates; unknown text is never executed."""
+    known = None
+    if isinstance(template, str):
+        digest = hashlib.sha256(
+            template.replace("\r\n", "\n").strip().encode()
+        ).hexdigest()
+        known = _REVIEWED_TEMPLATES.get(digest)
+    family, automatic, preserve = known or ("", "server_default", False)
+    if mode not in {value for _, value in REASONING_HISTORY_OPTIONS}:
+        mode = "auto"
+    return ReasoningReplayPolicy(
+        automatic if mode == "auto" else mode,
+        "Auto" if mode == "auto" else "User override",
+        family,
+        preserve,
+        known is not None,
+        native_tools,
+    )
+
+
+def reasoning_override_key(provider: str, endpoint: str, model: str) -> str:
+    """Stable local target identity, without persisting credentials in the key."""
+    parsed = urlsplit(endpoint.strip())
+    path = parsed.path.rstrip("/")
+    for suffix in ("/chat/completions", "/v1"):
+        path = path.removesuffix(suffix)
+    netloc = parsed.netloc.rsplit("@", 1)[-1].lower()
+    normalized = urlunsplit((parsed.scheme.lower(), netloc, path, "", ""))
+    identity = [
+        _LOCAL_FAMILIES.get(provider.lower(), provider.lower()),
+        normalized,
+        model,
+    ]
+    return hashlib.sha256(json.dumps(identity).encode()).hexdigest()
+
+
+def reasoning_mode_setting(
+    console: Mapping[str, Any],
+    *,
+    provider: str = "",
+    endpoint: str = "",
+    model: str = "",
+) -> str:
+    """Read a scoped override, with explicit legacy-off migration."""
+    modes = {value for _, value in REASONING_HISTORY_OPTIONS}
+    overrides = console.get("reasoning_history_overrides", {})
+    if provider and model and isinstance(overrides, Mapping):
+        value = overrides.get(reasoning_override_key(provider, endpoint, model))
+        if isinstance(value, str) and value in modes:
+            return value
+    value = console.get("reasoning_history")
+    if isinstance(value, str) and value in modes:
+        return value
+    from tldw_chatbook.config import coerce_bool_setting
+
+    return (
+        "auto"
+        if coerce_bool_setting(console.get("replay_thinking", True), True)
+        else "off"
+    )
+
+
+def effective_replay_policy(
+    policy: ReasoningReplayPolicy | None,
+    conversation_policy: str,
+) -> ReasoningReplayPolicy | None:
+    """Apply explicit conversation authority before device-local Auto policy."""
+    if conversation_policy in {"exclude", "include"}:
+        base = policy or ReasoningReplayPolicy("server_default", "Server default")
+        return replace(base, mode="off" if conversation_policy == "exclude" else "all")
+    return policy
+
+
+def starts_reasoning_exchange(row: Mapping[str, Any]) -> bool:
+    """Only an actual user request closes the previous reasoning exchange."""
+    from tldw_chatbook.Agents.agent_models import FENCE_TOOL_RESULT_PREFIX
+    from tldw_chatbook.Chat.console_project_instructions import EPHEMERAL_ORIGIN_KEY
+
+    return (
+        row.get("role") == "user"
+        and row.get(LOCAL_TOOL_RESULT_KEY) is not True
+        and row.get(EXCHANGE_CONTINUATION_KEY) is not True
+        and EPHEMERAL_ORIGIN_KEY not in row
+        and not str(row.get("content") or "").startswith(FENCE_TOOL_RESULT_PREFIX)
+    )
+
+
+def supports_local_reasoning(provider: str, model: str) -> bool:
+    """Recognize local transports that accept separate reasoning fields."""
+    return provider.lower() in _LOCAL_FAMILIES and bool(model.strip())
+
+
+def project_reasoning_history(
+    messages: Sequence[Mapping[str, Any]],
+    *,
+    provider: str,
+    model: str,
+    policy: ReasoningReplayPolicy | None = None,
+    enabled: bool = True,
+) -> list[dict[str, Any]]:
+    """Project ephemeral per-call canonical envelopes through the wire serializer.
+
+    This is the agent accounting path; durable history comes from canonical
+    sidecars at the gateway. No separate persisted reasoning body is accepted.
+    """
+    if not messages:
+        return []
+    from .console_prepared_request import (
+        THINKING_OWNER_KEY,
+        build_console_request,
+        prepare_provider_request,
+        resolve_request_capacity,
+        thaw_json,
+    )
+    from .console_thinking_capture import consume_call_thinking
+    from .console_thinking_history import ThinkingReplayTarget, resolve_thinking_history
+
+    rows, sidecars = consume_call_thinking(messages, owner_key=THINKING_OWNER_KEY)
+    resolved = resolve_thinking_history(
+        target=ThinkingReplayTarget(
+            provider,
+            model,
+            "chat_completions",
+            "displayable",
+            1,
+            reasoning_replay=policy,
+        ),
+        policy="auto" if enabled else "exclude",
+        sidecars=tuple(sidecars),
+    )
+    eligible = {group.owner_message_id for group in resolved.groups}
+    rows = [
+        {
+            key: value
+            for key, value in row.items()
+            if key != THINKING_OWNER_KEY or value in eligible
+        }
+        for row in rows
+    ]
+    semantic = build_console_request(
+        rows,
+        thinking_groups=resolved.groups,
+        thinking_policy=resolved.saved_policy,
+        effective_thinking_policy=resolved.effective_policy,
+    )
+    prepared = prepare_provider_request(
+        semantic,
+        wire_style="distinct_roles",
+        provider=provider,
+        model=model,
+        reasoning_replay=policy,
+        capacity=resolve_request_capacity(context_window_tokens=None),
+        count_fn=lambda _rows, _model: 0,
+    )
+    return [thaw_json(row) for row in prepared.messages]
+
+
+def reasoning_template_kwargs(
+    provider: str,
+    policy: ReasoningReplayPolicy | None,
+) -> dict[str, bool]:
+    """Expose exact reviewed template options for dispatch and trace admission."""
+    if (
+        policy is not None
+        and policy.supports_preserve
+        and _LOCAL_FAMILIES.get(provider.lower()) in {"llama_cpp", "vllm"}
+    ):
+        return {"preserve_thinking": policy.mode == "all"}
+    return {}

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -555,6 +555,7 @@ def chat_with_local_llm(
     api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     """Chat with a local llamafile/Local-LLM OpenAI-compatible server.
 
@@ -580,6 +581,7 @@ def chat_with_local_llm(
             is the fallback.
         provider_name: Provider key for dynamic config lookup; also
             drives ADR-066 thinking wire composition.
+        chat_template_kwargs: Reviewed template options selected by the caller.
 
     Returns:
         The assistant reply text, or a streaming generator of chunks.
@@ -682,6 +684,7 @@ def chat_with_local_llm(
         reasoning_effort=reasoning_effort,
         thinking_budget_tokens=thinking_budget_tokens,
         thinking_wire_key="local-llm",
+        chat_template_kwargs=chat_template_kwargs,
         # Same pre-existing dict-.capitalize() crash as chat_with_custom_openai.
         provider_name="Local-LLM",
         timeout=timeout,
@@ -755,6 +758,11 @@ def chat_with_llama(
             is the fallback.
         provider_name: Provider key for dynamic config lookup; also
             drives ADR-066 thinking wire composition.
+        chat_template_kwargs: Reviewed template options selected by the caller.
+        api_key_resolved: Whether the caller made the final credential decision,
+            including an explicitly keyless endpoint.
+        tools: OpenAI-format native tool definitions, when the target supports them.
+        tool_choice: Native tool selection policy for this request.
 
     Returns:
         The assistant reply text, or a streaming generator of chunks.
@@ -1492,6 +1500,11 @@ def chat_with_vllm(
             is the fallback.
         provider_name: Provider key for dynamic config lookup; also
             drives ADR-066 thinking wire composition.
+        chat_template_kwargs: Reviewed template options selected by the caller.
+        api_key_resolved: Whether the caller made the final credential decision,
+            including an explicitly keyless endpoint.
+        tools: OpenAI-format native tool definitions, when the target supports them.
+        tool_choice: Native tool selection policy for this request.
 
     Returns:
         The assistant reply text, or a streaming generator of chunks.

--- a/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
+++ b/tldw_chatbook/LLM_Calls/LLM_API_Calls_Local.py
@@ -137,6 +137,7 @@ def _chat_with_openai_compatible_local_server(
     timeout: int = 120,
     api_retries: int = 1,
     api_retry_delay: int = 1,
+    chat_template_kwargs: dict[str, Any] | None = None,
 ):
     start_time = time.time()
     logged_api_base = safe_llm_url_host(api_base_url)
@@ -238,12 +239,20 @@ def _chat_with_openai_compatible_local_server(
             )
         )
 
+    if chat_template_kwargs:
+        payload["chat_template_kwargs"] = {
+            **payload.get("chat_template_kwargs", {}),
+            **chat_template_kwargs,
+        }
+
     # Construct full API URL for chat completions
     base_url = api_base_url.rstrip("/")
     chat_completions_path = "v1/chat/completions"  # Standard OpenAI path
     # full_api_url = api_base_url.rstrip('/') + "/" + chat_completions_path.lstrip('/')
     if base_url.endswith(chat_completions_path):
         full_api_url = base_url
+    elif base_url.endswith("/v1"):
+        full_api_url = base_url + "/chat/completions"
     else:
         # If it doesn't end with the standard path, append it.
         # This handles cases where the config provides just the server root.
@@ -683,7 +692,7 @@ def chat_with_local_llm(
 
 def chat_with_llama(
     input_data: List[Dict[str, Any]],
-    api_key: Optional[str] = None,  # from map
+    api_key: str | None = None,
     custom_prompt: Optional[str] = None,  # from map, Mapped from 'prompt'
     temp: Optional[float] = None,  # from map, generic name is 'temperature'
     system_prompt: Optional[str] = None,  # from map, Mapped from 'system_message'
@@ -717,6 +726,10 @@ def chat_with_llama(
     api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    api_key_resolved: bool | None = None,
 ):
     """Chat with a llama.cpp server (llama_cpp/local_llamacpp/local_llamafile).
 
@@ -776,7 +789,9 @@ def chat_with_llama(
     from ..Chat.console_provider_gateway import normalize_llamacpp_base_url
 
     api_base_url = normalize_llamacpp_base_url(api_base_url)
-    current_api_key = api_key or llama_config.get("api_key")
+    current_api_key = (
+        api_key if api_key_resolved else api_key or llama_config.get("api_key")
+    )
     current_model = model or llama_config.get("model")
     if (
         not current_model
@@ -852,6 +867,9 @@ def chat_with_llama(
 
     # Assuming llama.cpp server uses an OpenAI-compatible endpoint
     return _chat_with_openai_compatible_local_server(
+        tools=tools,
+        tool_choice=tool_choice,
+        chat_template_kwargs=chat_template_kwargs,
         api_base_url=api_base_url,
         model_name=current_model,
         input_data=input_data,
@@ -1411,7 +1429,7 @@ def chat_with_tabbyapi(
 # vLLM (OpenAI compatible)
 def chat_with_vllm(
     input_data: List[Dict[str, Any]],
-    api_key: Optional[str] = None,  # from map
+    api_key: str | None = None,
     custom_prompt_input: Optional[str] = None,  # from map ('prompt')
     # vLLM's map has 'temp':'temperature', 'system_prompt':'system_message' etc.
     # These are the provider-specific names this function receives.
@@ -1445,6 +1463,10 @@ def chat_with_vllm(
     api_base_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     thinking_budget_tokens: Optional[int] = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    api_key_resolved: bool | None = None,
 ):
     """Chat with a vLLM OpenAI-compatible server (vllm/local_vllm).
 
@@ -1489,7 +1511,7 @@ def chat_with_vllm(
             provider=vllm_config_key,
             message="vLLM API URL (api_url) is required and could not be determined from arguments or configuration.",
         )
-    current_api_key = api_key or cfg.get("api_key")
+    current_api_key = api_key if api_key_resolved else api_key or cfg.get("api_key")
     current_model = model or cfg.get("model")
     if not current_model:
         raise ChatConfigurationError(
@@ -1550,6 +1572,9 @@ def chat_with_vllm(
         )
 
     return _chat_with_openai_compatible_local_server(
+        tools=tools,
+        tool_choice=tool_choice,
+        chat_template_kwargs=chat_template_kwargs,
         api_base_url=vllm_api_url,
         model_name=current_model,
         input_data=input_data,
@@ -1707,7 +1732,7 @@ def chat_with_aphrodite(
 # Ollama (with OpenAI compatible endpoint)
 def chat_with_ollama(
     input_data: List[Dict[str, Any]],
-    api_key: Optional[str] = None,  # from map, Ollama doesn't use key but map has it
+    api_key: str | None = None,
     custom_prompt: Optional[str] = None,  # from map ('prompt')
     # Ollama map: 'temp':'temperature', 'system_message':'system_message', 'topp':'top_p', etc.
     temperature: Optional[float] = None,  # from map (mapped from generic 'temp')
@@ -1734,6 +1759,10 @@ def chat_with_ollama(
         str
     ] = None,  # Added to support dynamic configuration loading
     api_base_url: Optional[str] = None,
+    chat_template_kwargs: dict[str, Any] | None = None,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: str | dict[str, Any] | None = None,
+    api_key_resolved: bool | None = None,
 ):
     if model and (model.lower() == "none" or model.strip() == ""):
         model = None
@@ -1757,7 +1786,7 @@ def chat_with_ollama(
 
     # API Key: function argument takes precedence, then config.
     # For Ollama, cfg.get('api_key') will likely be None as it's not standard.
-    current_api_key = api_key or cfg.get("api_key")
+    current_api_key = api_key if api_key_resolved else api_key or cfg.get("api_key")
 
     # Model: function argument takes precedence, then config.
     # config.py's CONFIG_TOML_CONTENT provides a default for [api_settings.ollama].model
@@ -1876,6 +1905,9 @@ def chat_with_ollama(
 
     # Ollama's /v1/chat/completions endpoint is OpenAI compatible
     return _chat_with_openai_compatible_local_server(
+        tools=tools,
+        tool_choice=tool_choice,
+        chat_template_kwargs=chat_template_kwargs,
         api_base_url=current_api_base_url,
         model_name=current_model,
         input_data=input_data,

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -77,10 +77,17 @@ from ...Chat.console_roleplay_identity import (
     normalize_chat_display_name,
 )
 from ...Chat.console_rail_state import normalize_console_rail_layout_scope
+from ...Chat.local_reasoning import (
+    REASONING_HISTORY_OPTIONS,
+    reasoning_mode_setting,
+    reasoning_override_key,
+    supports_local_reasoning,
+)
 from ...Widgets.glyph_fallback import set_ascii_glyph_mode
 from ...Chat.console_provider_endpoints import (
     URL_BASED_PROVIDER_KEYS,
     generic_endpoint_differs,
+    safe_endpoint_display,
     unsaved_endpoint_copy,
 )
 from ...Chat.provider_readiness import get_provider_readiness, provider_config_key
@@ -1173,6 +1180,9 @@ CONSOLE_BEHAVIOR_CONSOLE_KEYS = frozenset(
         "collapse_large_pastes",
         "show_model_thinking",
         "thinking_history_policy_default",
+        "reasoning_history",
+        "reasoning_history_overrides",
+        "reasoning_native_tool_overrides",
         "rail_layout_scope",
         "stack_collapsed_rail_labels",
         "paste_collapse_threshold",
@@ -1248,6 +1258,9 @@ CONSOLE_BEHAVIOR_SAVE_ORDER = (
     "collapse_large_pastes",
     "show_model_thinking",
     "thinking_history_policy_default",
+    "reasoning_history",
+    "reasoning_history_overrides",
+    "reasoning_native_tool_overrides",
     "rail_layout_scope",
     "stack_collapsed_rail_labels",
     "paste_collapse_threshold",
@@ -5526,6 +5539,98 @@ class SettingsScreen(BaseAppScreen):
     def _loaded_thinking_history_policy_default(self) -> str:
         return load_thinking_history_policy_default(self._console_settings())
 
+    def _current_reasoning_target(self) -> tuple[str, str, str] | None:
+        """Snapshot the active local Console endpoint/model identity."""
+
+        runtime = getattr(self.app_instance, "console_runtime", None)
+        controller = getattr(runtime, "chat_controller", None)
+        store = getattr(runtime, "chat_store", None)
+        if controller is None or store is None or store.active_session_id is None:
+            return None
+        snapshot = controller.resolve_turn_configuration_snapshot(
+            store.active_session_id
+        )
+        selection = snapshot.provider_selection
+        model = normalize_console_model_value(
+            selection.explicit_model or selection.configured_model
+        )
+        if model is None or not supports_local_reasoning(selection.provider, model):
+            return None
+
+        from tldw_chatbook.Chat.console_provider_endpoints import (
+            effective_provider_endpoint,
+        )
+
+        provider_key = provider_config_key(selection.provider)
+        provider_settings = provider_settings_for_key(
+            self.app_instance.app_config.get("api_settings", {}),
+            provider_key,
+        )
+        endpoint = (
+            effective_provider_endpoint(
+                provider_key,
+                selection.base_url,
+                provider_settings,
+            )
+            or ""
+        )
+        if selection.provider in {"llama_cpp", "local_llamacpp"}:
+            from tldw_chatbook.Chat.console_session_settings import (
+                normalize_llamacpp_base_url,
+            )
+
+            endpoint = normalize_llamacpp_base_url(selection.base_url)
+        return selection.provider, endpoint, model
+
+    def _reasoning_override_value(self) -> str:
+        target = getattr(self, "_reasoning_override_target", None)
+        overrides = self._console_behavior_value("reasoning_history_overrides") or {}
+        value = (
+            overrides.get(reasoning_override_key(*target), "inherit")
+            if target and isinstance(overrides, Mapping)
+            else "inherit"
+        )
+        allowed = {"inherit", *(value for _, value in REASONING_HISTORY_OPTIONS)}
+        return value if isinstance(value, str) and value in allowed else "inherit"
+
+    def _reasoning_native_override_value(self) -> bool:
+        target = getattr(self, "_reasoning_override_target", None)
+        values = self._console_behavior_value("reasoning_native_tool_overrides") or {}
+        return bool(
+            target
+            and isinstance(values, Mapping)
+            and values.get(reasoning_override_key(*target)) is True
+        )
+
+    def _reasoning_policy_status(self) -> str:
+        target = getattr(self, "_reasoning_override_target", None)
+        mode = self._reasoning_override_value()
+        if mode == "inherit":
+            mode = str(self._console_behavior_value("reasoning_history"))
+        if mode != "auto":
+            label = {value: label for label, value in REASONING_HISTORY_OPTIONS}.get(
+                mode, "Automatic"
+            )
+            return f"Conversation Auto next send: {label}"
+        runtime = getattr(self.app_instance, "console_runtime", None)
+        gateway = getattr(runtime, "provider_gateway", None)
+        known = getattr(gateway, "reasoning_policies", {})
+        policy = (
+            known.get(reasoning_override_key(*target))
+            if target and isinstance(known, Mapping)
+            else None
+        )
+        if policy is not None and policy.source == "Auto":
+            status = f"{policy.label} — checked again on next send"
+            if policy.template_family == "Gemma 4" and not policy.native_tools:
+                status += (
+                    ". Native server tools are needed to retain Gemma thinking "
+                    "across tool rounds; legacy fenced tool results begin a new "
+                    "server-side user turn."
+                )
+            return status
+        return "Conversation Auto: template checked on next send"
+
     def _show_model_thinking_label(self) -> str:
         state = "On" if self._loaded_show_model_thinking() else "Off"
         return f"Show model thinking ({state})"
@@ -5914,6 +6019,22 @@ class SettingsScreen(BaseAppScreen):
             "thinking_history_policy_default": (
                 self._loaded_thinking_history_policy_default()
             ),
+            "reasoning_history": reasoning_mode_setting(self._console_settings()),
+            "reasoning_history_overrides": dict(
+                self._console_settings().get("reasoning_history_overrides")
+            )
+            if isinstance(
+                self._console_settings().get("reasoning_history_overrides"), Mapping
+            )
+            else {},
+            "reasoning_native_tool_overrides": dict(
+                self._console_settings().get("reasoning_native_tool_overrides")
+            )
+            if isinstance(
+                self._console_settings().get("reasoning_native_tool_overrides"),
+                Mapping,
+            )
+            else {},
             "rail_layout_scope": self._loaded_console_rail_layout_scope(),
             "stack_collapsed_rail_labels": self._loaded_stack_collapsed_rail_labels(),
             "paste_collapse_threshold": self._loaded_paste_collapse_threshold(),
@@ -16159,6 +16280,59 @@ class SettingsScreen(BaseAppScreen):
                 id="settings-console-show-model-thinking-help",
                 classes="settings-detail-row",
             )
+            yield Static("Local reasoning history", classes="destination-section")
+            yield Select(
+                REASONING_HISTORY_OPTIONS,
+                value=self._console_behavior_value("reasoning_history"),
+                allow_blank=False,
+                id="settings-console-reasoning-history",
+            )
+            yield Static(
+                "These device-local controls refine Conversation Auto. Conversation "
+                "Include and Exclude override them, and Required continuation remains "
+                "intact. Automatic follows reviewed templates; unknown templates keep "
+                "the server default. All available sends every compatible field, but "
+                "the server template can still omit older reasoning.",
+                id="settings-console-reasoning-history-help",
+                classes="settings-detail-row",
+            )
+            self._reasoning_override_target = self._current_reasoning_target()
+            target = self._reasoning_override_target
+            with Collapsible(title="Override current Console model", collapsed=True):
+                yield Static(
+                    f"{target[0]} / {target[2]} — {safe_endpoint_display(target[1])}"
+                    if target
+                    else "Select a local model in Console to set a remembered override.",
+                    markup=False,
+                    classes="settings-detail-row",
+                )
+                yield Select(
+                    (("Use default", "inherit"), *REASONING_HISTORY_OPTIONS),
+                    value=self._reasoning_override_value(),
+                    allow_blank=False,
+                    disabled=target is None,
+                    id="settings-console-reasoning-override",
+                )
+                yield Checkbox(
+                    "This server is configured for native tool calls",
+                    value=self._reasoning_native_override_value(),
+                    disabled=target is None,
+                    id="settings-console-reasoning-native-tools",
+                    tooltip=(
+                        "Use when the server cannot report support. Configure the "
+                        "server's native tool parser before enabling this preference."
+                    ),
+                )
+                yield Static(
+                    "Remembered for this normalized endpoint and model. Native tool "
+                    "support is configured separately from reasoning replay.",
+                    classes="settings-detail-row",
+                )
+            yield Static(
+                self._reasoning_policy_status(),
+                id="settings-console-reasoning-status",
+                classes="settings-detail-row",
+            )
             yield Button(
                 "Conversation context and memory ↓",
                 id="settings-console-context-memory-jump",
@@ -23794,6 +23968,57 @@ class SettingsScreen(BaseAppScreen):
         self._thinking_visibility_desired_value = next_value
         self._start_thinking_visibility_persist_if_idle()
 
+    @on(Checkbox.Changed, "#settings-console-reasoning-native-tools")
+    def handle_console_reasoning_native_tools_changed(
+        self, event: Checkbox.Changed
+    ) -> None:
+        event.stop()
+        target = getattr(self, "_reasoning_override_target", None)
+        if target is None:
+            return
+        values = dict(
+            self._console_behavior_value("reasoning_native_tool_overrides") or {}
+        )
+        key = reasoning_override_key(*target)
+        if event.value:
+            values[key] = True
+        else:
+            values.pop(key, None)
+        self._stage_console_default_value("reasoning_native_tool_overrides", values)
+        self._mark_console_behavior_settings_staged()
+
+    @on(Select.Changed, "#settings-console-reasoning-history")
+    def handle_console_reasoning_history_changed(self, event: Select.Changed) -> None:
+        event.stop()
+        if event.value not in {value for _, value in REASONING_HISTORY_OPTIONS}:
+            return
+        self._stage_console_default_value("reasoning_history", str(event.value))
+        self._mark_console_behavior_settings_staged()
+        self._set_static_text(
+            "#settings-console-reasoning-status", self._reasoning_policy_status()
+        )
+
+    @on(Select.Changed, "#settings-console-reasoning-override")
+    def handle_console_reasoning_override_changed(self, event: Select.Changed) -> None:
+        event.stop()
+        target = getattr(self, "_reasoning_override_target", None)
+        allowed = {"inherit", *(value for _, value in REASONING_HISTORY_OPTIONS)}
+        if target is None or event.value not in allowed:
+            return
+        overrides = dict(
+            self._console_behavior_value("reasoning_history_overrides") or {}
+        )
+        key = reasoning_override_key(*target)
+        if event.value == "inherit":
+            overrides.pop(key, None)
+        else:
+            overrides[key] = str(event.value)
+        self._stage_console_default_value("reasoning_history_overrides", overrides)
+        self._mark_console_behavior_settings_staged()
+        self._set_static_text(
+            "#settings-console-reasoning-status", self._reasoning_policy_status()
+        )
+
     @on(Checkbox.Changed, "#settings-console-stack-collapsed-rail-labels")
     def handle_console_rail_label_style_changed(self, event: Checkbox.Changed) -> None:
         """Stage the collapsed Console rail presentation preference."""
@@ -28611,6 +28836,30 @@ class SettingsScreen(BaseAppScreen):
         self._set_static_text(
             "#settings-console-exchange-capture-status",
             self._console_capture_status,
+        )
+        try:
+            native = self.query_one(
+                "#settings-console-reasoning-native-tools", Checkbox
+            )
+            with native.prevent(Checkbox.Changed):
+                native.value = self._reasoning_native_override_value()
+        except QueryError:
+            pass
+        for selector, value in (
+            (
+                "#settings-console-reasoning-history",
+                self._console_behavior_value("reasoning_history"),
+            ),
+            ("#settings-console-reasoning-override", self._reasoning_override_value()),
+        ):
+            try:
+                widget = self.query_one(selector, Select)
+                with widget.prevent(Select.Changed):
+                    widget.value = value
+            except QueryError:
+                pass
+        self._set_static_text(
+            "#settings-console-reasoning-status", self._reasoning_policy_status()
         )
         try:
             checkbox = self.query_one("#settings-console-show-model-thinking", Checkbox)

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -201,6 +201,7 @@ from ...Utils.input_validation import (
     sanitize_string,
     validate_bounded_integer,
     validate_number_range,
+    validate_reasoning_history_selector,
     validate_text_input,
     validate_url,
 )
@@ -23972,6 +23973,12 @@ class SettingsScreen(BaseAppScreen):
     def handle_console_reasoning_native_tools_changed(
         self, event: Checkbox.Changed
     ) -> None:
+        """Stage explicit native-tool support for the active local target.
+
+        Args:
+            event: Checkbox event carrying the requested support state.
+        """
+
         event.stop()
         target = getattr(self, "_reasoning_override_target", None)
         if target is None:
@@ -23989,10 +23996,18 @@ class SettingsScreen(BaseAppScreen):
 
     @on(Select.Changed, "#settings-console-reasoning-history")
     def handle_console_reasoning_history_changed(self, event: Select.Changed) -> None:
+        """Validate and stage the default local reasoning replay mode.
+
+        Args:
+            event: Selector event carrying the requested default mode.
+        """
+
         event.stop()
-        if event.value not in {value for _, value in REASONING_HISTORY_OPTIONS}:
+        try:
+            value = validate_reasoning_history_selector(event.value)
+        except ValueError:
             return
-        self._stage_console_default_value("reasoning_history", str(event.value))
+        self._stage_console_default_value("reasoning_history", value)
         self._mark_console_behavior_settings_staged()
         self._set_static_text(
             "#settings-console-reasoning-status", self._reasoning_policy_status()
@@ -24000,19 +24015,31 @@ class SettingsScreen(BaseAppScreen):
 
     @on(Select.Changed, "#settings-console-reasoning-override")
     def handle_console_reasoning_override_changed(self, event: Select.Changed) -> None:
+        """Validate and stage the active target's remembered replay override.
+
+        Args:
+            event: Selector event carrying a replay mode or ``inherit``.
+        """
+
         event.stop()
         target = getattr(self, "_reasoning_override_target", None)
-        allowed = {"inherit", *(value for _, value in REASONING_HISTORY_OPTIONS)}
-        if target is None or event.value not in allowed:
+        if target is None:
+            return
+        try:
+            value = validate_reasoning_history_selector(
+                event.value,
+                allow_inherit=True,
+            )
+        except ValueError:
             return
         overrides = dict(
             self._console_behavior_value("reasoning_history_overrides") or {}
         )
         key = reasoning_override_key(*target)
-        if event.value == "inherit":
+        if value == "inherit":
             overrides.pop(key, None)
         else:
-            overrides[key] = str(event.value)
+            overrides[key] = value
         self._stage_console_default_value("reasoning_history_overrides", overrides)
         self._mark_console_behavior_settings_staged()
         self._set_static_text(

--- a/tldw_chatbook/Utils/input_validation.py
+++ b/tldw_chatbook/Utils/input_validation.py
@@ -25,6 +25,7 @@ from pydantic import (
 )
 
 from ..Metrics.metrics_logger import log_counter, log_histogram
+from .reasoning_config import REASONING_HISTORY_MODES
 
 PROVIDER_API_KEY_MAX_LENGTH = 4096
 CONSOLE_DRAFT_MAX_LENGTH = 100_000
@@ -49,6 +50,56 @@ TERMINAL_SESSION_NAME_MIN_DISPLAY_CHARACTERS = 1
 TERMINAL_SESSION_NAME_MAX_DISPLAY_CHARACTERS = 64
 TERMINAL_SESSION_NAME_MAX_CODEPOINTS = 1_024
 _EXTENDED_GRAPHEME_PATTERN = regex.compile(r"\X", regex.VERSION1)
+
+
+class ReasoningHistorySelectorInput(BaseModel):
+    """Strict boundary for a Console reasoning-history selector event.
+
+    Attributes:
+        allow_inherit: Whether the per-target reset choice is accepted.
+        value: Exact selector value received from the UI event.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    allow_inherit: bool = False
+    value: str
+
+    @field_validator("value")
+    @classmethod
+    def _validate_value(cls, value: str, info: ValidationInfo) -> str:
+        allowed = set(REASONING_HISTORY_MODES)
+        if info.data.get("allow_inherit") is True:
+            allowed.add("inherit")
+        if value not in allowed:
+            raise ValueError("invalid reasoning history selector value")
+        return value
+
+
+def validate_reasoning_history_selector(
+    value: object,
+    *,
+    allow_inherit: bool = False,
+) -> str:
+    """Validate one reasoning-history selector value without coercion.
+
+    Args:
+        value: Candidate Textual selector value.
+        allow_inherit: Whether the per-target ``inherit`` choice is accepted.
+
+    Returns:
+        The exact validated selector value.
+
+    Raises:
+        ValueError: If the value has the wrong type or is not an allowed choice.
+    """
+
+    try:
+        return ReasoningHistorySelectorInput.model_validate(
+            {"value": value, "allow_inherit": allow_inherit}
+        ).value
+    except PydanticValidationError:
+        raise ValueError("reasoning history selector value is invalid") from None
 
 
 class VllmDraftInputEvent(BaseModel):

--- a/tldw_chatbook/Utils/reasoning_config.py
+++ b/tldw_chatbook/Utils/reasoning_config.py
@@ -1,0 +1,162 @@
+"""Validated configuration boundary for device-local reasoning replay."""
+
+from __future__ import annotations
+
+import json
+import os
+from collections.abc import Mapping, MutableMapping
+from dataclasses import dataclass
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError, field_validator
+
+REASONING_HISTORY_ENV = "TLDW_CONSOLE_REASONING_HISTORY"
+REASONING_HISTORY_OVERRIDES_ENV = "TLDW_CONSOLE_REASONING_HISTORY_OVERRIDES"
+REASONING_NATIVE_TOOL_OVERRIDES_ENV = (
+    "TLDW_CONSOLE_REASONING_NATIVE_TOOL_OVERRIDES"
+)
+REASONING_HISTORY_MODES = frozenset({"auto", "current", "all", "off"})
+
+
+class ConsoleReasoningConfig(BaseModel):
+    """Strict effective configuration for local reasoning replay.
+
+    Attributes:
+        replay_thinking: Legacy global replay preference.
+        reasoning_history: Default local replay mode for Conversation Auto.
+        reasoning_history_overrides: Replay modes keyed by normalized target digest.
+        reasoning_native_tool_overrides: Native-tool support keyed by target digest.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True, strict=True)
+
+    replay_thinking: bool = True
+    reasoning_history: str = "auto"
+    reasoning_history_overrides: dict[str, str] = Field(default_factory=dict)
+    reasoning_native_tool_overrides: dict[str, bool] = Field(default_factory=dict)
+
+    @field_validator("reasoning_history")
+    @classmethod
+    def _validate_mode(cls, value: str) -> str:
+        if value not in REASONING_HISTORY_MODES:
+            raise ValueError("unsupported reasoning history mode")
+        return value
+
+    @field_validator("reasoning_history_overrides")
+    @classmethod
+    def _validate_modes(cls, values: dict[str, str]) -> dict[str, str]:
+        if any(value not in REASONING_HISTORY_MODES for value in values.values()):
+            raise ValueError("unsupported reasoning history override")
+        return values
+
+
+@dataclass(frozen=True, slots=True)
+class ConsoleReasoningConfigResolution:
+    """Validated effective settings and value-free fallback diagnostics.
+
+    Attributes:
+        settings: Strict effective reasoning configuration.
+        diagnostics: Safe messages naming fields that used fallback defaults.
+    """
+
+    settings: ConsoleReasoningConfig
+    diagnostics: tuple[str, ...] = ()
+
+
+def migrate_legacy_reasoning_history(
+    config: MutableMapping[str, object],
+) -> None:
+    """Preserve an explicit legacy replay opt-out before defaults are merged.
+
+    Args:
+        config: Raw user configuration, before programmatic defaults are merged.
+    """
+
+    console = config.get("console")
+    if not isinstance(console, MutableMapping):
+        return
+    if (
+        "reasoning_history" not in console
+        and console.get("replay_thinking") is False
+    ):
+        console["reasoning_history"] = "off"
+
+
+def _environment_json_value(raw: str) -> object:
+    """Decode one non-empty JSON environment value for model validation."""
+
+    try:
+        return json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return raw
+
+
+def resolve_console_reasoning_config(
+    console: object,
+    *,
+    environ: Mapping[str, str] | None = None,
+) -> ConsoleReasoningConfigResolution:
+    """Resolve environment-first replay settings through the strict model.
+
+    Args:
+        console: Merged Console configuration mapping.
+        environ: Optional environment mapping. Defaults to ``os.environ``.
+
+    Returns:
+        Validated settings plus sanitized diagnostics for rejected fields.
+    """
+
+    values = console if isinstance(console, Mapping) else {}
+    environment = os.environ if environ is None else environ
+    candidate: dict[str, object] = {
+        "replay_thinking": values.get("replay_thinking", True),
+        "reasoning_history": values.get("reasoning_history", "auto"),
+        "reasoning_history_overrides": values.get(
+            "reasoning_history_overrides", {}
+        ),
+        "reasoning_native_tool_overrides": values.get(
+            "reasoning_native_tool_overrides", {}
+        ),
+    }
+    environment_fields = {
+        "reasoning_history": REASONING_HISTORY_ENV,
+        "reasoning_history_overrides": REASONING_HISTORY_OVERRIDES_ENV,
+        "reasoning_native_tool_overrides": REASONING_NATIVE_TOOL_OVERRIDES_ENV,
+    }
+    for field_name, environment_name in environment_fields.items():
+        override = environment.get(environment_name)
+        if override in (None, ""):
+            continue
+        candidate[field_name] = (
+            override
+            if field_name == "reasoning_history"
+            else _environment_json_value(override)
+        )
+
+    try:
+        settings = ConsoleReasoningConfig.model_validate(candidate)
+        return ConsoleReasoningConfigResolution(settings)
+    except ValidationError as exc:
+        invalid_fields = {
+            str(error["loc"][0])
+            for error in exc.errors(
+                include_url=False,
+                include_context=False,
+                include_input=False,
+            )
+            if error.get("loc")
+        }
+
+    safe_defaults: dict[str, object] = {
+        "replay_thinking": True,
+        "reasoning_history": "auto",
+        "reasoning_history_overrides": {},
+        "reasoning_native_tool_overrides": {},
+    }
+    for field_name in invalid_fields:
+        candidate[field_name] = safe_defaults[field_name]
+    settings = ConsoleReasoningConfig.model_validate(candidate)
+    diagnostics = tuple(
+        f"console.{field_name} is invalid; using its safe default"
+        for field_name in sorted(invalid_fields)
+    )
+    return ConsoleReasoningConfigResolution(settings, diagnostics)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -1935,21 +1935,14 @@ def _load_settings_uncached(
         final_console_settings_cli.get("stack_collapsed_rail_labels", False),
         False,
     )
-    from tldw_chatbook.Chat.local_reasoning import reasoning_mode_setting
+    from tldw_chatbook.Utils.reasoning_config import resolve_console_reasoning_config
 
-    final_console_settings_cli["replay_thinking"] = coerce_bool_setting(
-        final_console_settings_cli.get("replay_thinking", True),
-        True,
-    )
-    final_console_settings_cli["reasoning_history"] = reasoning_mode_setting(
+    reasoning_resolution = resolve_console_reasoning_config(
         final_console_settings_cli
     )
-    for key in (
-        "reasoning_history_overrides",
-        "reasoning_native_tool_overrides",
-    ):
-        if not isinstance(final_console_settings_cli.get(key), dict):
-            final_console_settings_cli[key] = {}
+    for diagnostic in reasoning_resolution.diagnostics:
+        logger.warning("Invalid Console reasoning configuration: {}", diagnostic)
+    final_console_settings_cli.update(reasoning_resolution.settings.model_dump())
     _rail_layout_scope = final_console_settings_cli.get("rail_layout_scope")
     final_console_settings_cli["rail_layout_scope"] = (
         _rail_layout_scope.strip().lower()
@@ -3571,6 +3564,8 @@ shutdown_grace_seconds = 120.0
 collapse_large_pastes = true  # Display large pasted chunks compactly in Console composer
 show_model_thinking = true  # Presentation only; capture and replay are unchanged
 thinking_history_policy_default = "auto"  # auto, include, exclude for new conversations
+# Environment overrides: TLDW_CONSOLE_REASONING_HISTORY (mode), and JSON maps in
+# TLDW_CONSOLE_REASONING_HISTORY_OVERRIDES / TLDW_CONSOLE_REASONING_NATIVE_TOOL_OVERRIDES.
 reasoning_history = "auto"  # local replay when a conversation uses Auto: auto, current, all, off
 reasoning_history_overrides = {}  # normalized endpoint/model digest -> replay mode
 reasoning_native_tool_overrides = {}  # normalized endpoint/model digest -> true
@@ -6062,6 +6057,11 @@ def _load_cli_config_bootstrap_unlocked(
         user_config_from_file, _schema_changed, _schema_conflict = (
             migrate_config_forward(user_config_from_file)
         )
+        from tldw_chatbook.Utils.reasoning_config import (
+            migrate_legacy_reasoning_history,
+        )
+
+        migrate_legacy_reasoning_history(user_config_from_file)
         _CONFIG_SCHEMA_CONFLICT = _schema_conflict
         if _schema_conflict is not None:
             logger.warning(_schema_conflict)

--- a/tldw_chatbook/config.py
+++ b/tldw_chatbook/config.py
@@ -1935,6 +1935,21 @@ def _load_settings_uncached(
         final_console_settings_cli.get("stack_collapsed_rail_labels", False),
         False,
     )
+    from tldw_chatbook.Chat.local_reasoning import reasoning_mode_setting
+
+    final_console_settings_cli["replay_thinking"] = coerce_bool_setting(
+        final_console_settings_cli.get("replay_thinking", True),
+        True,
+    )
+    final_console_settings_cli["reasoning_history"] = reasoning_mode_setting(
+        final_console_settings_cli
+    )
+    for key in (
+        "reasoning_history_overrides",
+        "reasoning_native_tool_overrides",
+    ):
+        if not isinstance(final_console_settings_cli.get(key), dict):
+            final_console_settings_cli[key] = {}
     _rail_layout_scope = final_console_settings_cli.get("rail_layout_scope")
     final_console_settings_cli["rail_layout_scope"] = (
         _rail_layout_scope.strip().lower()
@@ -3556,6 +3571,9 @@ shutdown_grace_seconds = 120.0
 collapse_large_pastes = true  # Display large pasted chunks compactly in Console composer
 show_model_thinking = true  # Presentation only; capture and replay are unchanged
 thinking_history_policy_default = "auto"  # auto, include, exclude for new conversations
+reasoning_history = "auto"  # local replay when a conversation uses Auto: auto, current, all, off
+reasoning_history_overrides = {}  # normalized endpoint/model digest -> replay mode
+reasoning_native_tool_overrides = {}  # normalized endpoint/model digest -> true
 stack_collapsed_rail_labels = false  # Use compact stacked labels on collapsed Console rails
 rail_layout_scope = "global"  # Share Console rail disclosure across workspaces; use "workspace" for per-workspace layouts
 assistant_library_access_default = false  # New Console sessions block assistant Library access
@@ -5677,6 +5695,8 @@ _FREEFORM_CONFIG_PREFIXES: tuple[tuple[str, ...], ...] = (
                                 # Agents/agent_service.py (two-homes drift),
                                 # so documented overrides here would all flag
                                 # as unknown (Qodo #13, PR #2301)
+    ("console", "reasoning_history_overrides"),
+    ("console", "reasoning_native_tool_overrides"),
     ("api_settings",),          # provider configs incl. user-added custom providers
     ("providers",),             # provider display sections + model lists
     ("model_capabilities", "models"),    # arbitrary model names


### PR DESCRIPTION
Console now keeps provider-reported thinking visible by default and preserves it in the canonical transcript, while local replay follows the active server template. This rebases the original draft onto current `dev` and integrates with ADR-090 instead of introducing a second thinking store.

- Add Automatic / Current exchange / All available / Off local replay, with endpoint/model overrides in canonical Settings. Conversation Include/Exclude and required provider continuation keep their authority.
- Recognize reviewed Gemma 4 and Qwen3.5/3.6/3.8 templates by exact fingerprint. Unknown templates keep server defaults. Native-tool capability is discovered or explicitly configured independently of replay.
- Capture declared llama.cpp/vLLM/Ollama reasoning fields as typed events. Preserve exact per-call thinking through native tools, child continuation, accounting and trace admission; avoid replaying aggregate tool traces as final-answer thinking.
- Keep endpoint/model policy and keyless credentials pinned to their resolved target. Model overrides and fallback candidates cannot inherit another target's native-tool approval.

`All available` controls request fields; the server template may still omit older thoughts. Gemma's older-final and fenced-tool limitations are covered by exact-template render tests and explained in Settings. Saved thinking is unaffected by replay preferences.

Validation: targeted gateway, history, agent, trace, persistence and mounted Settings tests; reviewed Jinja render fixtures. Live localhost:9099 Gemma 4 verified four-turn Auto/All/Off capture and replay plus a native calculator call whose thinking survived `/apply-template` and whose answer was 221. vLLM/Ollama and Qwen behavior are covered by controlled adapter/template tests; no live server claim for those targets.

Governance: ADR-090 amendment and the Console local reasoning integration plan.

Local validation notes: the required fast-lane selection passed 778 tests; six process-lease tests cannot initialize macOS semaphores on this host (`SemLock: [Errno 28] No space left on device`), including outside the sandbox. Three untouched broader regression failures (stop state, deletion sidecar expectations, narrow disclosure height) were independently reproduced from unchanged `dev` source. GitHub checks remain the merge gate.
