### PR TITLE
Fix Console portrait scaling and stabilize rail refresh

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -43,6 +43,15 @@ task...".
   Mic and Attach have their own page:
   [attachments, images & voice](attachments-images-voice.md).
 
+### Character portrait sizing
+
+The selected character's portrait scales up or down to fit the available
+Character image area, keeping the whole image visible without stretching or
+cropping. Space may remain beside or beneath the image when its proportions
+differ from the area. The Character section grows with the terminal height and reserves space
+for the name and controls. Resizing smaller fits the portrait back into the
+reduced area. Click the portrait to open the larger image viewer.
+
 ### What the next send will cost
 
 When there is something to send, Send reads **Send | $** (or **Queue | $**

--- a/Tests/UI/test_console_character_avatar.py
+++ b/Tests/UI/test_console_character_avatar.py
@@ -1756,18 +1756,20 @@ async def test_successful_actor_replacement_clears_old_actor_override(
 @pytest.mark.parametrize(
     ("source_size", "available_box", "expected_box"),
     (
-        ((8, 8), (40, 30), (8, 4)),
+        ((8, 8), (40, 30), (40, 20)),
+        ((8, 32), (40, 30), (15, 30)),
+        ((32, 8), (40, 30), (40, 5)),
         ((1200, 300), (30, 30), (30, 4)),
         ((300, 1200), (30, 30), (15, 30)),
         ((600, 600), (30, 30), (30, 15)),
     ),
 )
-def test_character_avatar_fit_is_scale_down_only_and_aspect_preserving(
+def test_character_avatar_fit_expands_or_shrinks_preserving_aspect(
     source_size,
     available_box,
     expected_box,
 ):
-    """Character art may shrink to contain, but never grows to fill 35 rows."""
+    """Character art uses the available box regardless of source resolution."""
 
     from tldw_chatbook.UI.Console_Modules.character_avatar_layout import (
         fit_character_avatar_cell_box,
@@ -1833,11 +1835,12 @@ def test_character_avatar_fit_omits_the_image_when_no_cell_box_remains():
         ((1200, 300), "graphics"),
         ((600, 600), "pixels"),
         ((8, 8), "graphics"),
+        ((8, 8), "pixels"),
         ((2400, 2400), "pixels"),
     ),
 )
 @pytest.mark.asyncio
-async def test_character_shapes_and_controls_settle_inside_35_rows(
+async def test_character_shapes_and_controls_settle_inside_current_budget(
     console_screen_with_db_and_pilot,
     source_size,
     mode,
@@ -1883,10 +1886,13 @@ async def test_character_shapes_and_controls_settle_inside_35_rows(
 
     assert left_rail.character_avatar_box is not None
     fitted_width, fitted_height = left_rail.character_avatar_box
-    assert fitted_width <= source_size[0]
-    assert fitted_height <= (source_size[1] + 1) // 2
-    assert body.virtual_region_with_margin.height <= 35
-    assert bounded.desired_content_lines <= 35
+    assert 0 < fitted_width <= body.content_region.width
+    assert 0 < fitted_height <= bounded.max_content_lines
+    if source_size == (8, 8):
+        assert fitted_width > source_size[0]
+        assert fitted_height > source_size[1] // 2
+    assert body.virtual_region_with_margin.height <= bounded.max_content_lines
+    assert bounded.desired_content_lines <= bounded.max_content_lines
     assert not bounded.hint.display
     assert reaction_button.virtual_region_with_margin.bottom <= (
         body.virtual_region_with_margin.bottom
@@ -1916,13 +1922,13 @@ async def test_character_shapes_and_controls_settle_inside_35_rows(
         left_rail.request_allocation_reconcile()
         await pilot.pause(0.05)
         if (
-            body.virtual_region_with_margin.height <= 35
-            and bounded.desired_content_lines <= 35
+            body.virtual_region_with_margin.height <= bounded.max_content_lines
+            and bounded.desired_content_lines <= bounded.max_content_lines
         ):
             break
     assert len(screen.query(".console-character-search-row")) == 8
-    assert body.virtual_region_with_margin.height <= 35
-    assert bounded.desired_content_lines <= 35
+    assert body.virtual_region_with_margin.height <= bounded.max_content_lines
+    assert bounded.desired_content_lines <= bounded.max_content_lines
     assert screen.query_one("#console-character-reaction-open") is reaction_button
 
 
@@ -1930,7 +1936,7 @@ async def test_character_shapes_and_controls_settle_inside_35_rows(
 async def test_oversized_character_controls_use_local_scroll_and_keep_offset(
     console_screen_with_db_and_pilot,
 ):
-    """Controls beyond 35 rows stay reachable and retain their local offset."""
+    """Controls beyond the current budget retain scrolling and their offset."""
 
     from tldw_chatbook.UI.Console_Modules.left_rail import ConsoleLeftRail
     from tldw_chatbook.Widgets.Console.console_bounded_section import (
@@ -1953,14 +1959,14 @@ async def test_oversized_character_controls_use_local_scroll_and_keep_offset(
     # Navigation owns the visible identity; the legacy painter caption is hidden.
     name = screen.query_one("#console-character-identity", Static)
     reaction_button = screen.query_one("#console-character-reaction-open")
-    name.styles.height = 36
+    name.styles.height = bounded.max_content_lines + 1
     left_rail.apply_section_open("character", True)
     left_rail.request_allocation_reconcile()
     await pilot.pause()
     await pilot.pause()
 
     assert left_rail.character_avatar_box == (0, 0)
-    assert bounded.desired_content_lines > 35
+    assert bounded.desired_content_lines > bounded.max_content_lines
     assert bounded.hint.display
     assert bounded.viewport.max_scroll_y > 0
 
@@ -2521,10 +2527,10 @@ async def test_pixels_avatar_paints_nonzero_region_in_auto_holder():
 
 @pytest.mark.parametrize("initial_box", (None, (30, 30)))
 @pytest.mark.asyncio
-async def test_initial_tiny_avatar_uses_intrinsic_size_before_rail_reconciliation(
+async def test_initial_tiny_avatar_fills_box_before_rail_reconciliation(
     initial_box,
 ):
-    """Neither a missing nor a stale large box may upscale the first paint."""
+    """The first paint also enlarges small artwork to its current box."""
 
     screen = _bare_console_screen(ConsoleChatStore())
     spec = {
@@ -2538,8 +2544,8 @@ async def test_initial_tiny_avatar_uses_intrinsic_size_before_rail_reconciliatio
 
     async with app.run_test(size=(60, 30)):
         widget = app.query_one("#console-character-avatar-image", Static)
-        assert widget.styles.width.value == 8
-        assert widget.styles.height.value == 4
+        expected = (16, 8) if initial_box is None else (30, 15)
+        assert (widget.region.width, widget.region.height) == expected
 
 
 @pytest.mark.asyncio
@@ -2682,3 +2688,41 @@ async def test_animated_character_uses_mounted_playback_and_same_asset_mode_chan
         )
     assert db.get_character_card_by_id(character_id)["image"] == data
     assert await asyncio.to_thread(export_bytes) == original_export
+
+
+@pytest.mark.asyncio
+async def test_character_portrait_grows_and_shrinks_with_terminal(
+    console_screen_with_db_and_pilot,
+):
+    """A tall small portrait fills new rows, then returns to its original size."""
+    from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+    from tldw_chatbook.UI.Console_Modules.left_rail import ConsoleLeftRail
+
+    _app, screen, db, pilot = console_screen_with_db_and_pilot
+    _configure_native_ready_console(_app)
+    await screen._sync_native_console_chat_ui()
+    assert not screen._console_setup_modal_blocking()
+    output = BytesIO()
+    PILImage.new("RGB", (8, 64), (20, 100, 160)).save(output, format="PNG")
+    character_id = db.add_character_card(
+        {"name": "Tall portrait", "image": output.getvalue()}
+    )
+    _set_active_console_character(screen, character_id, "Tall portrait")
+    await screen._character._refresh_active_character_avatar_if_scope_changed()
+    rail = screen.query_one(ConsoleLeftRail)
+    sizes = []
+    for height in (72, 144, 72):
+        await pilot.resize_terminal(180, height)
+        for _ in range(12):
+            await pilot.pause()
+        portrait = screen.query_one("#console-character-avatar-image")
+        body = screen.query_one("#console-rail-section-body-character")
+        bounded = screen.query_one("#console-bounded-section-character")
+        sizes.append(portrait.region.size)
+        assert portrait.region.width > 0
+        assert body.virtual_region_with_margin.height <= bounded.max_content_lines
+        assert abs(portrait.region.width * 4 - portrait.region.height) <= 4
+        assert rail.character_avatar_box is not None
+    assert sizes[1].height > sizes[0].height
+    assert sizes[1].width > sizes[0].width
+    assert sizes[2] == sizes[0]

--- a/Tests/UI/test_console_rail_reconciliation.py
+++ b/Tests/UI/test_console_rail_reconciliation.py
@@ -3151,3 +3151,31 @@ async def test_scroll_cost_probe_still_detects_pre_split_routing(
         assert burst > 0, (
             "the probe no longer observes the pre-split coalesced layout cost"
         )
+
+
+@pytest.mark.asyncio
+async def test_character_header_missing_during_prepare_does_not_latch_reconciliation():
+    host = ConsoleHarness(_build_test_app())
+    async with host.run_test(size=(180, 72)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-left-rail")
+        rail = console.query_one(ConsoleLeftRail)
+        await pilot.pause()
+        header = rail.query_one("#console-rail-section-header-character")
+        parent = header.parent
+        bounded = rail.query_one("#console-bounded-section-character")
+        await header.remove()
+        # The body remains while its header is temporarily absent.
+        rail._allocation_reconcile_scheduled = True
+        rail._prepare_allocation_reconcile()
+        for _ in range(3):
+            await pilot.pause()
+        assert not rail._allocation_reconcile_scheduled
+        await parent.mount(header, before=bounded)
+        await pilot.resize_terminal(180, 100)
+        for _ in range(4):
+            await pilot.pause()
+        assert bounded.max_content_lines == max(
+            35, rail._snapshot_outer_viewport_height() - header.outer_size.height
+        )
+        assert not rail._allocation_reconcile_scheduled

--- a/Tests/UI/test_console_rail_reconciliation.py
+++ b/Tests/UI/test_console_rail_reconciliation.py
@@ -58,10 +58,10 @@ from tldw_chatbook.Workspaces.workspace_tree_state import (
 SECTION_IDS = (
     "workspace",
     "conversations",
+    "character",
     "model",
     "agent",
     "details",
-    "character",
 )
 LOCAL_HINT = "▼ more — scroll"
 #: TASK-23195 made the outer hint name the sections below the fold instead
@@ -455,14 +455,27 @@ async def test_all_open_context_sections_keep_their_own_complete_ceiling_and_out
         initial_state = rail._rail_state
         # The two peer list sections' ceilings grow to fill the rail (half
         # the measured viewport each, floored at the historical 20-line
-        # ceiling); every other section keeps its fixed ceiling.
+        # ceiling); Character gets the viewport minus its header.
         adaptive_budget = console_rail_section_height_budget(
             rail._snapshot_outer_viewport_height()
         )
         ceilings = dict(
             zip(
                 SECTION_IDS,
-                (adaptive_budget, adaptive_budget, 15, 15, 15, 35),
+                (
+                    adaptive_budget,
+                    adaptive_budget,
+                    max(
+                        35,
+                        rail._snapshot_outer_viewport_height()
+                        - rail.query_one(
+                            "#console-rail-section-header-character"
+                        ).outer_size.height,
+                    ),
+                    15,
+                    15,
+                    15,
+                ),
                 strict=True,
             )
         )
@@ -1901,7 +1914,7 @@ async def test_focus_and_pointer_activation_are_transient_and_open_close_falls_b
         await pilot.pause()
         assert await pilot.click(conversations_toggle)
         await _settle(pilot)
-        assert rail._active_section_id == "model"
+        assert rail._active_section_id == "character"
 
 
 @pytest.mark.parametrize("owner_name", ("sources", "settings", "run"))
@@ -2232,7 +2245,7 @@ async def test_canceled_header_press_releases_pointer_activation_latch(
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("removed_section", "expected_fallback"),
-    (("character", "details"), ("agent", "model")),
+    (("character", "conversations"), ("agent", "model")),
 )
 async def test_absent_active_section_falls_back_in_stable_descriptor_order(
     monkeypatch: pytest.MonkeyPatch,

--- a/Tests/UI/test_console_tick_gating.py
+++ b/Tests/UI/test_console_tick_gating.py
@@ -30,6 +30,7 @@ regardless of visibility. The hidden-skip was not implemented; see
 for a regression test protecting that deliberate choice.
 """
 
+import asyncio
 from dataclasses import replace
 from unittest.mock import patch
 
@@ -538,3 +539,89 @@ async def test_console_workspace_context_fresh_tray_still_synced_mid_run():
                 "a fresh (post-recompose) context projection must heal the "
                 "Workspaces and Conversations trays together"
             )
+
+
+@pytest.mark.asyncio
+async def test_mounted_conversation_rows_stay_stable_during_cache_refresh():
+    from Tests.UI.test_console_native_chat_flow import _configure_native_ready_console
+
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    class DelayedConversationService:
+        refreshing = False
+
+        async def list_conversations(self, **kwargs):
+            if kwargs.get("scope_type") != "global":
+                return {"items": [], "pagination": {"total": 0}}
+            if self.refreshing:
+                started.set()
+                await release.wait()
+            return {
+                "items": [
+                    {
+                        "id": "saved-stable",
+                        "title": "Updated saved chat"
+                        if self.refreshing
+                        else "Original saved chat",
+                        "scope_type": "global",
+                    }
+                ],
+                "pagination": {"total": 1},
+            }
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    service = DelayedConversationService()
+    app.local_chat_conversation_service = service
+    app.chat_conversation_scope_service = None
+    host = ConsoleHarness(app)
+    async with host.run_test(size=(180, 72)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-workspace-context")
+        await console._sync_native_console_chat_ui()
+        assert not console._console_setup_modal_blocking()
+        for _ in range(12):
+            await pilot.pause()
+        rows = tuple(console.query(".console-workspace-conversation-row"))
+        saved = next(row for row in rows if row.conversation_id == "saved-stable")
+        assert "Original saved chat" in " ".join(str(saved.label).split())
+        outer = console.query_one("#console-left-rail-body")
+        bounded = console.query_one("#console-bounded-section-conversations")
+        character_header = console.query_one("#console-rail-section-header-character")
+        assert outer.content_region.contains_region(saved.region)
+        geometry = (bounded.region, character_header.region, outer.scroll_y)
+        service.refreshing = True
+        console._workspace._console_persisted_rows_cache_at -= (
+            CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS + 1
+        )
+        try:
+            await console._sync_native_console_chat_ui()
+            await asyncio.wait_for(started.wait(), timeout=3)
+            for _ in range(4):
+                await pilot.pause()
+                assert (
+                    tuple(console.query(".console-workspace-conversation-row")) == rows
+                )
+                assert (
+                    bounded.region,
+                    character_header.region,
+                    outer.scroll_y,
+                ) == geometry
+                assert "Original saved chat" in " ".join(str(saved.label).split())
+        finally:
+            release.set()
+        for _ in range(20):
+            await pilot.pause()
+            if console._workspace._console_persisted_rows_refresh_key is None:
+                break
+        assert console._workspace._console_persisted_rows_refresh_key is None
+        for _ in range(4):
+            await pilot.pause()
+        updated = next(
+            row
+            for row in console.query(".console-workspace-conversation-row")
+            if row.conversation_id == "saved-stable"
+        )
+        assert "Updated saved chat" in " ".join(str(updated.label).split())
+        assert (bounded.region, character_header.region, outer.scroll_y) == geometry

--- a/Tests/UI/test_console_workspace_controller.py
+++ b/Tests/UI/test_console_workspace_controller.py
@@ -4551,3 +4551,28 @@ def test_console_appearance_map_caches_within_ttl_and_refetches_new_ids():
     # An id outside the cached map must refetch (once), not serve a stale miss.
     controller._console_conversation_appearance_map(["conv-1", "conv-9"])
     assert len(service.calls) == 2
+
+
+@pytest.mark.parametrize(
+    "requested_key", [("", None), ("new search", None), ("", "other-chat")]
+)
+def test_expired_browser_cache_retains_only_matching_rows_during_refresh(requested_key):
+    screen = _NoMountScreen()
+    controller = _workspace_controller(screen=screen)
+    cached = ([_rich_row()], 1, "")
+    controller._console_persisted_rows_cache = cached
+    controller._console_persisted_rows_cache_key = ("", None)
+    controller._console_persisted_rows_cache_at = 0.0
+
+    for _ in range(3):
+        result = controller._sync_persisted_console_browser_rows(*requested_key)
+        assert result == (cached if requested_key == ("", None) else ([], None, ""))
+    assert len(screen.workers) == 1
+
+    controller._invalidate_console_persisted_rows_cache()
+    assert controller._sync_persisted_console_browser_rows(*requested_key) == (
+        [],
+        None,
+        "",
+    )
+    assert len(screen.workers) == 2

--- a/backlog/decisions/083-console-edge-rails-and-workspace-tree-ownership.md
+++ b/backlog/decisions/083-console-edge-rails-and-workspace-tree-ownership.md
@@ -239,3 +239,25 @@ custom Tree or generalized private rendering layer remains rejected.
 - [ADR-043: Console rail compact collapse yields to explicit toggles](043-console-rail-compact-collapse-yields-to-explicit-toggle.md)
 - [ADR-077: Bound Console rail sections and expose hidden overflow](077-console-bounded-rail-section-scrolling.md)
 - [TASK-20937](../tasks/task-20937%20-%20Make-Console-rails-edge-native-and-organize-conversations-by-workspace.md)
+
+## Amendment (2026-09-10): Character portraits expand with the viewport
+
+TASK-32311 replaces the fixed 35-row Character maximum with a body ceiling
+of the measured Context viewport minus the Character header, with 35 rows
+retained as the compact/unmeasured fallback. This follows the user's request
+for portraits to grow with the terminal. The body still hugs its content;
+its ceiling is not a minimum height. Other sections remain reachable through
+the existing outer scroll owner.
+
+Both graphics and mosaic portraits use an aspect-preserving contain fit,
+allowing enlargement as well as reduction. The portrait receives only the
+rows left after measuring the Character controls. Geometry reconciliation
+uses the same current ceiling as the bounded section and the existing
+resize epoch/follow-up guards. A change in measured non-image control geometry
+starts a new epoch so async search-result expansion cannot strand a portrait
+at an oversized earlier fit. Image-only size changes do not reset that guard.
+Oversized controls retain local scrolling.
+
+Keeping a fixed maximum leaves unused space in tall terminals; stretching
+or cover-cropping would distort or hide artwork. Neither meets the requested
+whole-portrait fit. No new setting, renderer, or scroll owner is introduced.

--- a/backlog/docs/lessons-live-verification.md
+++ b/backlog/docs/lessons-live-verification.md
@@ -2495,3 +2495,15 @@ and legacy fenced tool results looked like new user turns and discarded active
 thinking. A live native calculator exchange on port 9099 retained its exact
 thinking in `/apply-template` and returned 221. Keep wire-field, rendered-prompt,
 and transcript-retention assertions separate; only claim the layer verified.
+
+
+## Observe populated rails across cache expiry, not just initial layout
+
+**TASK-32311, 2026-09-10.** Portrait resize tests settled, but the user saw the
+actual served Console rail repeatedly move. Tracing the populated local profile
+showed the Conversations body alternating between 53 and 13 rows every two
+seconds: TTL expiry returned an empty list while its background query ran.
+Retaining the same-key cached rows during refresh stopped the motion. Actual
+browser screenshots taken 23 seconds apart then had identical left-rail pixels.
+Use a populated profile and observe across refresh intervals; a single screenshot
+or an empty harness cannot establish that a layout stays still.

--- a/backlog/tasks/task-32311 - Allow-Console-portraits-to-expand-within-the-Character-area.md
+++ b/backlog/tasks/task-32311 - Allow-Console-portraits-to-expand-within-the-Character-area.md
@@ -5,7 +5,7 @@ status: Done
 assignee:
   - '@codex'
 created_date: '2026-09-11 02:15'
-updated_date: '2026-09-11 03:21'
+updated_date: '2026-09-11 03:36'
 labels: []
 dependencies: []
 ---
@@ -24,6 +24,7 @@ Selected character portraits stop growing before filling the available image are
 - [x] #4 Character body grows with a taller terminal and shrinks back on resize, reserving measured control rows
 - [x] #5 After portrait and control updates settle, the left rail remains stationary without repeated fitting or scrolling
 - [x] #6 Saved-conversation background refresh uses a 10-second cache interval while explicit invalidation remains immediate
+- [x] #7 Mounted cache-refresh coverage proves stable rows through worker completion and rail reconciliation recovers from a missing Character header
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,6 +40,7 @@ Reason: user requested viewport-responsive Character section sizing, replacing i
 4. Add grow/shrink mounted regression and update fixed-ceiling assertions. Run targeted avatar and rail tests and static checks; document behavior.
 5. Investigate live rail motion. Keep the last matching persisted conversation rows visible during TTL refresh, verify query/invalidation boundaries, and confirm stability in the actual textual-serve app. Routine cache-display fix: no additional ADR required.
 6. Raise the saved-conversation cache TTL to 10 seconds as requested; retain explicit invalidation and verify existing cache-expiry tests. No additional ADR required for this polling-interval adjustment.
+7. Address Qodo review: add a mounted cache-expiry/worker-completion regression, guard Character header lookup during partial recomposition with a recovery test, and correct stale interval documentation. Routine fixes within ADR-083; no new ADR.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -59,6 +61,8 @@ Live verification follow-up: ran the actual application through its built-in tex
 Added three cache-expiry/query/selection regressions. Red: same-key expiry returned an empty list. Green: 131 targeted controller, tray guard, and tick tests passed; five unrelated failures reproduced on untouched dev ed6fd5db0a (constructor dependency documentation and four saved-chat opener cases). Changed-line Ruff formatting, Ruff lint, and diff checks pass. Two actual served browser captures 22.9 seconds apart have identical pixels across the full left rail, with Samira's portrait visible. Evidence: /private/tmp/rail-stable-first.png and /private/tmp/rail-stable-second.png. Removed temporary diagnostics. Added the populated-profile/cache-expiry verification lesson.
 
 Requested refresh-rate follow-up: raised the persisted conversation cache TTL from 2 to 10 seconds. The screen now re-exports the controller constant instead of retaining a duplicate 2-second value. Explicit invalidation, streaming, portrait geometry, and the separate appearance cache retain their behavior. Seven targeted cache/expiry/invalidation tests pass; Ruff lint, changed-line formatting, and diff checks pass. The running browser session will use the new interval after its next app restart.
+
+Qodo review follow-up: added a mounted ready-Console integration regression covering cache expiry, stable row identity/visible bounds/rail geometry while a real refresh worker is blocked, and publication of changed data after completion. Removing the stale-row fallback reproduced disappearing rows. Guarded the Character header lookup during prepare alongside the bounded-section lookup; the new partial-recomposition regression reproduced NoMatches before the fix and verifies flag recovery plus subsequent resizing. Removed the stale numeric TTL claim from transcript-timer documentation. Twelve targeted tick, recompose, and portrait tests pass; Ruff lint/format and diff checks pass.
 <!-- SECTION:NOTES:END -->
 
 ## Renumbering provenance

--- a/backlog/tasks/task-32311 - Allow-Console-portraits-to-expand-within-the-Character-area.md
+++ b/backlog/tasks/task-32311 - Allow-Console-portraits-to-expand-within-the-Character-area.md
@@ -1,0 +1,66 @@
+---
+id: TASK-32311
+title: Allow Console portraits to expand within the Character area
+status: Done
+assignee:
+  - '@codex'
+created_date: '2026-09-11 02:15'
+updated_date: '2026-09-11 03:21'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Selected character portraits stop growing before filling the available image area. Scale the complete portrait up or down without distortion while keeping Character controls visible.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Small and large portraits use the available image box with preserved proportions and no cropping
+- [x] #2 Graphics and mosaic rendering agree and resize without clipping or hiding controls
+- [x] #3 Targeted avatar tests and static checks pass
+- [x] #4 Character body grows with a taller terminal and shrinks back on resize, reserving measured control rows
+- [x] #5 After portrait and control updates settle, the left rail remains stationary without repeated fitting or scrolling
+- [x] #6 Saved-conversation background refresh uses a 10-second cache interval while explicit invalidation remains immediate
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: yes (amend existing decision)
+ADR path: backlog/decisions/083-console-edge-rails-and-workspace-tree-ownership.md
+Reason: user requested viewport-responsive Character section sizing, replacing its fixed maximum while preserving existing ownership.
+
+1. Reproduce source-size cap with failing tests.
+2. Remove source-pixel caps from Character contain geometry.
+3. Amend ADR-083 and make the Character body ceiling follow the measured outer viewport, minus its header, with the existing 35 rows as a compact fallback. Use that same budget for portrait fitting after subtracting controls.
+4. Add grow/shrink mounted regression and update fixed-ceiling assertions. Run targeted avatar and rail tests and static checks; document behavior.
+5. Investigate live rail motion. Keep the last matching persisted conversation rows visible during TTL refresh, verify query/invalidation boundaries, and confirm stability in the actual textual-serve app. Routine cache-display fix: no additional ADR required.
+6. Raise the saved-conversation cache TTL to 10 seconds as requested; retain explicit invalidation and verify existing cache-expiry tests. No additional ADR required for this polling-interval adjustment.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented on codex/console-portrait-fit from freshly fetched origin/dev ed6fd5db0a.
+
+Character portraits now enlarge or shrink with an aspect-preserving contain fit. The Character body follows the measured Context viewport minus its header (35-row compact fallback), and the image uses only rows left after controls. Changes to measured control geometry start a fresh fit epoch so asynchronous search expansion cannot leave an oversized stale portrait. Graphics and mosaic continue to share the same box and off-loop rendering.
+
+Amended existing ADR-083: backlog/decisions/083-console-edge-rails-and-workspace-tree-ownership.md. Updated the Console user guide, portrait regression tests, and the rail tests to the existing production section order. No dependencies or storage changes.
+
+Validation: initial new small-portrait tests failed at 8x4 vs expected 40x20 cells; the resize regression failed at unchanged 24-row height. With the fix, all 92 avatar/off-loop tests passed, and the ready-Console resize regression passed separately. Visual captures at 180x72 and 180x144 show the complete bordered test image at 11x44 and 25x100 cells, preserving circular markers. Ruff lint/format, diff whitespace, and Backlog ID checks pass.
+
+The broader rail run exposed stale order expectations (corrected to the shipped Character placement) and the unrelated test_bounded_rail_shell_regions_are_compositor_contained[160x45] Inspector Sources hint hit-test failure. That same hit-test failure and old order expectations were reproduced on an untouched archive of ed6fd5db0a. Final rail verification: 49 passed / 2 compositor cases deselected; the larger compositor case passed in the combined run, and the smaller case is the reproduced baseline failure. Tests used NO_COLOR unset with TERM=xterm-256color and COLORTERM=truecolor so the existing color-paint assertion could exercise color output. Full repository suite was not run.
+
+Live verification follow-up: ran the actual application through its built-in textual-serve path using an isolated copy of the local profile and selected the existing Samira conversation. The user reported repeated left-rail movement. Tracing proved the persisted conversation cache returned no rows at its two-second TTL boundary, making Conversations alternate between 53 and 13 rows while portrait geometry stayed constant. The sync accessor now retains the last matching query/selection result while its existing worker refreshes; explicit invalidation and different keys still clear the display. No additional ADR is required for this routine display bug fix.
+
+Added three cache-expiry/query/selection regressions. Red: same-key expiry returned an empty list. Green: 131 targeted controller, tray guard, and tick tests passed; five unrelated failures reproduced on untouched dev ed6fd5db0a (constructor dependency documentation and four saved-chat opener cases). Changed-line Ruff formatting, Ruff lint, and diff checks pass. Two actual served browser captures 22.9 seconds apart have identical pixels across the full left rail, with Samira's portrait visible. Evidence: /private/tmp/rail-stable-first.png and /private/tmp/rail-stable-second.png. Removed temporary diagnostics. Added the populated-profile/cache-expiry verification lesson.
+
+Requested refresh-rate follow-up: raised the persisted conversation cache TTL from 2 to 10 seconds. The screen now re-exports the controller constant instead of retaining a duplicate 2-second value. Explicit invalidation, streaming, portrait geometry, and the separate appearance cache retain their behavior. Seven targeted cache/expiry/invalidation tests pass; Ruff lint, changed-line formatting, and diff checks pass. The running browser session will use the new interval after its next app restart.
+<!-- SECTION:NOTES:END -->
+
+## Renumbering provenance
+
+Renumbered from TASK-32301 after rebasing onto dev 0fcb79e596. The Library list-entry focus task was created on 2026-09-10 at 21:30; this task was created on 2026-09-11 at 02:15. The older task retains TASK-32301 under the TASK-19601 owner rule. Portrait task references in ADR-083 and the live-verification lesson now use TASK-32311.

--- a/tldw_chatbook/UI/Console_Modules/character_avatar_layout.py
+++ b/tldw_chatbook/UI/Console_Modules/character_avatar_layout.py
@@ -6,10 +6,7 @@ from dataclasses import dataclass
 from functools import partial
 from typing import Any, Callable
 
-from ...Chat.console_image_view import (
-    fit_image_cell_size,
-    scale_image_pixel_size_for_cell_box,
-)
+from ...Chat.console_image_view import fit_image_cell_size
 from ...Utils.mosaic_render import mosaic_contain_cell_size
 
 
@@ -18,25 +15,17 @@ def fit_character_avatar_cell_box(
     available_cols: int,
     available_lines: int,
 ) -> tuple[int, int]:
-    """Return a scale-down-only contain box for ``image``.
+    """Return the largest aspect-preserving contain box for ``image``.
 
-    The shared image scaler's ``thumbnail`` operation never enlarges its
-    source. Its dimensions cap the intrinsic terminal footprint; the shared
-    cell fitter still receives the original dimensions so thumbnail rounding
-    cannot change the source aspect ratio by a row or column. The shared mosaic
-    contain-grid helper canonicalizes the result to the exact fallback grid;
-    graphics then uses that same box.
-
-    TASK-22221: those capping dimensions come from
-    ``scale_image_pixel_size_for_cell_box`` -- arithmetic identical to what
-    ``thumbnail`` would produce -- rather than from an actual LANCZOS resample
-    whose pixels were discarded. The rail runs this once per distinct viewport
-    size during a resize drag, on the event loop.
+    Fit to the available terminal area, allowing both enlargement and
+    reduction. Source pixels describe proportions, not a display-size cap.
+    Geometry stays arithmetic-only; the mosaic helper canonicalizes the
+    result to the fallback grid shared with graphics rendering.
 
     Args:
         image: Decoded PIL-compatible image. The source is never modified.
         available_cols: Measured Character-body columns available to the image.
-        available_lines: Rows left beneath the 35-row complete-body ceiling.
+        available_lines: Rows left beneath the current complete-body ceiling.
 
     Returns:
         ``(width_cells, height_cells)``. ``(0, 0)`` means no image cell fits.
@@ -47,19 +36,11 @@ def fit_character_avatar_cell_box(
     if box_cols == 0 or box_lines == 0:
         return 0, 0
 
-    scaled_width, scaled_height = scale_image_pixel_size_for_cell_box(
-        image.width,
-        image.height,
-        box_cols,
-        box_lines,
-    )
-    intrinsic_cols = min(box_cols, max(1, int(scaled_width)))
-    intrinsic_lines = min(box_lines, max(1, (max(1, int(scaled_height)) + 1) // 2))
     fitted_cols, fitted_lines = fit_image_cell_size(
         max(1, int(image.width)),
         max(1, int(image.height)),
-        intrinsic_cols,
-        intrinsic_lines,
+        box_cols,
+        box_lines,
     )
     return mosaic_contain_cell_size(
         image.width,

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -121,8 +121,8 @@ CONSOLE_REFRESH_RUNNING_APP_ID = "console-refresh-running-app"
 CONSOLE_DISMISS_DEFAULT_REFRESH_ID = "console-dismiss-default-refresh"
 #: The two peer list sections whose bounded-section ceilings grow to fill
 #: the rail (half the measured viewport each, via
-#: `console_rail_section_height_budget`). Every other section keeps the
-#: historical fixed ceiling.
+#: `console_rail_section_height_budget`). Character uses the full viewport
+#: minus its header; the remaining sections keep their fixed ceilings.
 _ADAPTIVE_BUDGET_SECTION_IDS = frozenset({"workspace", "conversations"})
 
 CharacterAvatarBox = tuple[int, int]
@@ -292,8 +292,7 @@ class ConsoleLeftRail(Vertical):
                 continue
             self.post_message(
                 self.SectionToggled(section_id=descriptor.section_id, opened=opened)
-                )
-
+            )
 
     class SectionToggled(Message):
         """A rail section's toggle button was pressed by the user.
@@ -462,6 +461,7 @@ class ConsoleLeftRail(Vertical):
         self._character_avatar_box: CharacterAvatarBox | None = None
         self._character_avatar_fit_generation = 0
         self._character_avatar_geometry_epoch = 0
+        self._character_avatar_controls_geometry: tuple[int, int] | None = None
         self._character_avatar_viewport_size: tuple[int, int] | None = None
         self._character_avatar_fit_signature: tuple[int, int, int] | None = None
         self._character_avatar_fit_result: CharacterAvatarBox | None = None
@@ -474,9 +474,7 @@ class ConsoleLeftRail(Vertical):
         )
         self._manual_reaction_label = str(manual_reaction_label or "").strip()
         self._settings_session_id = settings_session_id
-        self._settings_persistence_failures = dict(
-            settings_persistence_failures or {}
-        )
+        self._settings_persistence_failures = dict(settings_persistence_failures or {})
         self._default_durability_state = (
             default_durability_state or ConsoleDefaultDurabilityState()
         )
@@ -508,7 +506,9 @@ class ConsoleLeftRail(Vertical):
         """Synchronize body content and the collapsed Character summary."""
 
         try:
-            widget = self.query_one("#console-character-context", ConsoleCharacterContext)
+            widget = self.query_one(
+                "#console-character-context", ConsoleCharacterContext
+            )
             header = self.query_one(
                 "#console-rail-section-header-character",
                 DestinationRailSectionHeader,
@@ -674,7 +674,9 @@ class ConsoleLeftRail(Vertical):
         generation = failures.get(ConsoleSettingsComponent.GENERATION_SETTINGS)
         context = failures.get(ConsoleSettingsComponent.CONTEXT_POLICY)
         default_copy = self._default_recovery_copy(default_state)
-        has_warning = generation is not None or context is not None or bool(default_copy)
+        has_warning = (
+            generation is not None or context is not None or bool(default_copy)
+        )
 
         try:
             title = self.query_one("#console-rail-section-title-model", Static)
@@ -688,9 +690,7 @@ class ConsoleLeftRail(Vertical):
             context_button = self.query_one(
                 f"#{CONSOLE_RETRY_CONTEXT_SETTINGS_ID}", Button
             )
-            retry_default = self.query_one(
-                f"#{CONSOLE_RETRY_DEFAULT_SAVE_ID}", Button
-            )
+            retry_default = self.query_one(f"#{CONSOLE_RETRY_DEFAULT_SAVE_ID}", Button)
             discard_default = self.query_one(
                 f"#{CONSOLE_DISCARD_DEFAULT_RETRY_ID}", Button
             )
@@ -1248,6 +1248,12 @@ class ConsoleLeftRail(Vertical):
                 and section.max_content_lines != adaptive_budget
             ):
                 section.max_content_lines = adaptive_budget
+            if descriptor.section_id == "character" and viewport_height > 0:
+                header = self.query_one("#console-rail-section-header-character")
+                section.max_content_lines = max(
+                    descriptor.max_content_lines,
+                    viewport_height - header.outer_size.height,
+                )
             section.set_allocation(None)
             if section.native_scroll_owner is None:
                 section.styles.height = "auto"
@@ -1358,6 +1364,9 @@ class ConsoleLeftRail(Vertical):
             body = self.query_one("#console-rail-section-body-character", Vertical)
             frame = self.query_one("#console-character-avatar-frame", Horizontal)
             holder = self.query_one("#console-character-avatar", ClickableAvatarBox)
+            section = self.query_one(
+                "#console-bounded-section-character", ConsoleBoundedSection
+            )
         except (NoMatches, QueryError):
             return
         if not body.display or not body.is_mounted or not holder.is_mounted:
@@ -1366,8 +1375,12 @@ class ConsoleLeftRail(Vertical):
         complete_rows = max(0, body.virtual_region_with_margin.height)
         image_rows = max(0, frame.virtual_region_with_margin.height)
         measured_non_image_rows = max(0, complete_rows - image_rows)
-        available_rows = max(0, 35 - measured_non_image_rows)
+        available_rows = max(0, section.max_content_lines - measured_non_image_rows)
         available_cols = max(0, body.content_region.width)
+        controls_geometry = (available_cols, measured_non_image_rows)
+        if controls_geometry != self._character_avatar_controls_geometry:
+            self._character_avatar_controls_geometry = controls_geometry
+            self.invalidate_character_avatar_geometry()
         is_followup = self._character_avatar_followup_pending
         self._character_avatar_followup_pending = False
         fit_signature = (
@@ -2123,7 +2136,9 @@ class ConsoleLeftRail(Vertical):
             )
             avatar_holder.styles.width = "auto"
             avatar_holder.styles.height = "auto"
-            avatar_frame = Horizontal(avatar_holder, id="console-character-avatar-frame")
+            avatar_frame = Horizontal(
+                avatar_holder, id="console-character-avatar-frame"
+            )
             avatar_frame.styles.width = "100%"
             avatar_frame.styles.height = "auto"
             avatar_frame.styles.align_horizontal = "center"

--- a/tldw_chatbook/UI/Console_Modules/left_rail.py
+++ b/tldw_chatbook/UI/Console_Modules/left_rail.py
@@ -1240,6 +1240,12 @@ class ConsoleLeftRail(Vertical):
                     f"#console-bounded-section-{descriptor.section_id}",
                     ConsoleBoundedSection,
                 )
+                if descriptor.section_id == "character" and viewport_height > 0:
+                    header = self.query_one("#console-rail-section-header-character")
+                    section.max_content_lines = max(
+                        descriptor.max_content_lines,
+                        viewport_height - header.outer_size.height,
+                    )
             except (NoMatches, QueryError):
                 continue
             if (
@@ -1248,12 +1254,6 @@ class ConsoleLeftRail(Vertical):
                 and section.max_content_lines != adaptive_budget
             ):
                 section.max_content_lines = adaptive_budget
-            if descriptor.section_id == "character" and viewport_height > 0:
-                header = self.query_one("#console-rail-section-header-character")
-                section.max_content_lines = max(
-                    descriptor.max_content_lines,
-                    viewport_height - header.outer_size.height,
-                )
             section.set_allocation(None)
             if section.native_scroll_owner is None:
                 section.styles.height = "auto"

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -139,11 +139,10 @@ if TYPE_CHECKING:
 
 logger = logger.bind(module="ChatScreen")
 
-CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
-# PR #2480 review (#7): the batched appearance map is cached on the same
-# order as the persisted-rows cache -- short enough that an appearance
-# change made elsewhere shows up promptly, long enough that the several
-# merges inside one state build share one read.
+CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 10.0
+# PR #2480 review (#7): keep the appearance map cache short so changes
+# made elsewhere show up promptly, while the several merges inside one
+# state build share one read.
 CONSOLE_APPEARANCE_MAP_CACHE_TTL_SECONDS = 2.0
 CONSOLE_SAVED_CONVERSATION_RESUME_FAILURE_COPY = (
     "Couldn't resume this saved conversation: it was deleted or couldn't be read.\n"
@@ -3366,6 +3365,16 @@ class ConsoleWorkspaceController:
                     group="console-persisted-browser-cache",
                     exclusive=True,
                 )
+        # TTL expiry schedules a refresh; it does not mean the rows vanished.
+        # Keep the same query/selection visible while that worker runs so the
+        # rail does not collapse and restore its scroll position on every refresh.
+        # Explicit invalidation clears this entry; another key never reuses it.
+        if (
+            self._console_persisted_rows_cache is not None
+            and self._console_persisted_rows_cache_key
+            == (query, current_conversation_id)
+        ):
+            return self._console_persisted_rows_cache
         return [], None, ""
 
     async def _refresh_console_persisted_rows_cache(

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -145,6 +145,9 @@ from ..Console_Modules.left_rail import (
     CONSOLE_RETRY_GENERATION_SETTINGS_ID,
     ConsoleLeftRail,
 )
+from ..Console_Modules.workspace import (
+    CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS as CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS,
+)
 from ..Console_Modules.message import ConsoleMessageController
 from ..Console_Modules.right_rail import ConsoleInspectorRail
 from ..Console_Modules.provider_continuation_recovery import (
@@ -775,13 +778,6 @@ CONSOLE_ACTIVE_RUN_STATUSES: tuple[ConsoleRunStatus, ...] = tuple(
 # is actively streaming (e.g. a sub-agent finished in a *different*
 # Console session/tab).
 CONSOLE_SUBAGENT_COUNTS_CACHE_TTL_SECONDS = 2.0
-# TASK-251 (audit P1 B1): the persisted conversation-browser rows behind
-# `_refresh_console_persisted_rows_cache` queries the DB per scope (global +
-# every workspace) on every 0.2s poll tick -- measured 11-70ms/tick. Modeled
-# directly on the sub-agent badge-count TTL cache above (same staleness
-# bound, same "explicit invalidation is a nice-to-have, the TTL is the
-# correctness backstop" philosophy).
-CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS = 2.0
 # Cost-ticker PR3 (task-5): the 0.2s transcript tick stops once a run leaves
 # an active status (`_start_console_transcript_sync_timer`), so a WARM
 # prompt cache that later goes EXPIRED on its own -- with no further sync

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17982,9 +17982,9 @@ class ChatScreen(BaseAppScreen):
             # stays coupled to the SAME combined condition as the stop
             # (not a bare "viewed session idle") so a long-running
             # background session cannot reintroduce the per-tick DB query
-            # TASK-251's TTL cache exists to prevent; the resulting bound
-            # on staleness is `CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS`
-            # (2s), the documented backstop for exactly this gap.
+            # TASK-251's TTL cache exists to prevent. The refresh interval
+            # is `CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS`; matching rows
+            # stay visible until the background refresh publishes its result.
             # task-15862: a wake delivery scheduled but not yet busy (the
             # coordinator's `_delivering` is set synchronously BEFORE its
             # asyncio task first runs) must not let a poll beat in that gap


### PR DESCRIPTION
## Summary
Small Console character portraits stopped enlarging at their source-size limit. Portraits now scale up or down to fit the available area without cropping or changing proportions, and the Character section grows with terminal height while reserving room for its controls.

The saved-conversation list also stays visible during background cache refreshes, preventing the left rail from collapsing and expanding on each refresh. Its cache interval is now 10 seconds, with explicit invalidation retained and one shared interval constant.

Updates ADR-083, the Console guide, regression coverage, and Backlog task TASK-32311.

## Validation
- After rebasing onto dev `0fcb79e596`: 16 targeted portrait sizing, terminal resize, cache expiry, and invalidation tests passed.
- Earlier focused verification: all 92 avatar/off-loop tests passed; 49 rail tests passed with two compositor cases excluded; 131 controller/tray/tick tests passed.
- Actual application verified through textual-serve using an isolated copy of the local profile and an existing Samira conversation. Two screenshots 22.9 seconds apart had identical pixels across the entire left rail.
- Ruff lint, formatting of changed Python regions, diff whitespace, and Backlog ID checks passed. No full-suite run.

Known baseline failures were reproduced on untouched dev `ed6fd5db0a`: the 160x45 Inspector Sources compositor hit-test, workspace constructor dependency documentation, and four saved-conversation opener cases. These are outside this change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Console character portraits so they scale up or down to fill the available Character area without cropping or distortion, and stops the saved-conversation rail from collapsing and expanding during background cache refreshes.

Implements TASK-32311: the Character section now grows with terminal height (35 rows remains the compact fallback) instead of using a fixed 35-row cap. Portrait fitting also invalidates when measured Character controls change, so async search expansion can't leave an oversized stale portrait, and reconciliation now recovers when the Character header is temporarily missing during recomposition. Saved-conversation rows are kept visible while their TTL refresh worker runs, and `CONSOLE_PERSISTED_ROWS_CACHE_TTL_SECONDS` goes from 2 to 10 seconds with explicit invalidation retained.

**Migration**
- The running browser session picks up the new 10-second cache interval after its next app restart.

<sup>Written for commit 3d96f08160ae6a43f8f8c907636ba73f36fe524e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2589?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

