### PR TITLE
fix(library-notes): Escape goes where the footer says, one noun per Notes source, the editor Body takes its pane, import review uses the selection glyphs (critique-9 wave, tasks 32233/32215/32218 + hand-offs)

### DIFF
--- a/Docs/User_Guide/library/file-notes.md
+++ b/Docs/User_Guide/library/file-notes.md
@@ -1,11 +1,11 @@
-# Folder Files — plain notes on disk, edited in place
+# Folder files — plain notes on disk, edited in place
 
 ## What this screen is for
 
-Folder Files edits ordinary files that live in a folder you choose on disk —
+Folder files edits ordinary files that live in a folder you choose on disk —
 what you see in the editor is exactly what's in the file, and saves write
-straight back to it. It is a separate system from [Database notes](notes.md):
-nothing here is stored in the Library database, there are no templates or
+straight back to it. It is a separate system from [Library notes](notes.md):
+nothing here is stored in the Library's own database, there are no templates or
 database mirror, and no "Use in Console" handoff. This is also the key
 difference
 from Library Notes lasting sync: lasting sync keeps a reviewed relationship
@@ -23,10 +23,10 @@ Open [Library](../library.md) (**Ctrl+3**), pick **Notes** in the rail's
 Browse section, then use the source strip at the top of the canvas: it reads
 **Library notes** | **Folder files**. Click **Folder files** — while the
 workspace loads you'll briefly see "Opening File Notes…". At wide sizes,
-Library navigation and the Folder Files tree have separate slim collapse
+Library navigation and the Folder files tree have separate slim collapse
 grips. Each pane remembers its own choice; collapsing the tree does not also
-collapse Library navigation or the Database Notes list. On compact
-terminals, Library shows the Folder Files canvas as the single visible stage so
+collapse Library navigation or the Library notes list. On compact
+terminals, Library shows the Folder files canvas as the single visible stage so
 its controls remain on-screen; **Escape** or **Library notes** returns to the
 Library notes view. Either switch first saves any unsaved edits on the side
 you're leaving.
@@ -37,8 +37,8 @@ change your saved pane choice. Reopen Library navigation with its grip and it
 stays open for the rest of the work session. Opening another file, switching
 between Edit and Manage, autosaving, resolving a conflict, or resizing does
 not close it again. The automatic close resets only when you close or clear
-the open Folder Files file, switch between Folder Files and Database Notes,
-change the linked folder, clear the selected Database note, or leave Notes.
+the open Folder files file, switch between Folder files and Library notes,
+change the linked folder, clear the selected Library note, or leave Notes.
 Using compact **Back to navigator** does not reset it.
 
 ## Layout tour
@@ -77,7 +77,7 @@ Using compact **Back to navigator** does not reset it.
   input, the **Files** tree of everything under the linked folder, and a
   **Search results** tree that appears only while a query is active. Its grip
   collapses or restores this tree independently of Library navigation and the
-  Database Notes list. Large folders and direct-path
+  Library notes list. Large folders and direct-path
   search fallbacks show 100 rows at a time; activate **Load more** to append
   the next 100 without rebuilding the entire tree.
 - **File work area** (right) — a breadcrumb ("No file selected" until you
@@ -178,7 +178,7 @@ report that diff output was omitted or elided. A deleted or unreadable Disk side
 is named explicitly. Closing Compare returns to the conflict without resolving
 it or changing any side.
 
-Folder Files does not use **Ctrl+S** and does not assign a replacement. Keep
+Folder files does not use **Ctrl+S** and does not assign a replacement. Keep
 typing and autosave writes the file. When the file body has keyboard focus,
 only its boundary becomes more prominent; its background and size do not
 change. Compact inputs such as a named target path keep their usual filled
@@ -388,9 +388,9 @@ not available.
 | Esc (reload confirmation) | Cancel reload, preserve the draft and conflict, and return focus to the action that opened the confirmation |
 | Esc (Session Git panel) | Step back safely: row list → Files; commit form → cancel; commit review → edit message; candidate/remote check → cancel; push review → Back; active push/uncertain recovery check → Files while it continues; push result → session |
 | Esc (dialogs) | Close "File Notes folder details" or **Endpoint Details**; cancel the repository-trust or destination-authorization dialog |
-| Esc (folder change running) | Leaves Folder files for Database notes, exactly as it does when nothing is running — the folder change is abandoned and the previously linked folder is kept. The same applies to the "‹ Library / Notes" cue, the **Database** button, switching rail rows, the command palette and Ctrl+Q: a running folder change never blocks the way out |
+| Esc (folder change running) | Leaves Folder files for Library notes, exactly as it does when nothing is running — the folder change is abandoned and the previously linked folder is kept. The same applies to the "‹ Library / Notes" cue, the **Library notes** button, switching rail rows, the command palette and Ctrl+Q: a running folder change never blocks the way out |
 
-Folder Files does not register **Ctrl+S** and does not replace it with another
+Folder files does not register **Ctrl+S** and does not replace it with another
 save shortcut. File edits save automatically.
 
 ## Related settings & docs
@@ -400,8 +400,8 @@ save shortcut. File edits save automatically.
   picker reopens while no folder is linked yet: the folder you last picked
   through it, written on every pick, and ignored in favour of your home
   directory if it no longer exists. **Import once** and **Keep a folder
-  synced** keep their own separate keys, see [Database notes](notes.md).
-- [Database notes](notes.md) — the Library-stored notes system, with
+  synced** keep their own separate keys, see [Library notes](notes.md).
+- [Library notes](notes.md) — the Library-stored notes system, with
   templates, reviewed **Add from files…**, lasting root management, and Console
   handoff. Folder files is different — the files *are* the notes.
 - [Library](../library.md) — the parent screen; [guide index](../index.md)
@@ -450,7 +450,7 @@ save shortcut. File edits save automatically.
   operation updates only the approved remote ref; it does not fetch or update
   the local remote-tracking ref. Refresh that state later with external Git if
   you need it.
-- **No Console handoff.** Unlike Database notes, media, and prompts, this
+- **No Console handoff.** Unlike Library notes, media, and prompts, this
   workspace has no "Use in Console" — copy text out manually if you need it
   in a chat.
 - **Structural actions wait during Git work.** While a stage, unstage, commit,
@@ -502,7 +502,7 @@ the picker left open for an invalid path. Pinned in
 *Verified against fix/library-notes-docs — 2026-09-09 (task-32141: guide
 sweep after the Notes critique wave; the linked-folder status line reads
 "Linked · Local folder: \<folder\>", not "Linked — \<folder\>"; corrected
-here and in [Database notes](notes.md)).*
+here and in [Library notes](notes.md)).*
 
 *Verified against fix/library-notes-file-notes — 2026-09-09 (task-32121
 review round 2: **Keep waiting** also extends a change queued behind an
@@ -517,7 +517,7 @@ falling back to home when none has been picked yet — or when the stored
 value no longer names a real folder. Stored as `[file_notes] browse` in
 `config.toml`. Independent of Import once's and
 Keep a folder synced's own last-used directories, see
-[Database notes](notes.md).)*
+[Library notes](notes.md).)*
 
 *Verified against fix/library-notes-r-file-notes — 2026-09-09 (task-32173:
 the Library rail is now shown inside Folder files before a folder is linked,
@@ -544,3 +544,9 @@ a folder change reports the cancellation as a notification rather than into
 the row being torn down, and the wait line no longer carries the warning or
 offline tint of the state it replaced. Pinned by tests, not by a live
 capture.)*
+
+*Verified against fix/library-crit9-notes — 2026-09-10 (task-32218: one noun
+per Notes source. This page, the canvas authority line and the F1 Escape row
+all say **Folder files** and **Library notes**; the capitalised "Folder Files"
+and the "back to Database" footer chip are retired. Escape from Folder files
+now reads `esc back to Library notes`.)*

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -46,7 +46,7 @@ saving, resolving a conflict, or resizing the terminal does not close it
 again. The automatic close becomes available again only after you clear the
 selected Library note, switch between Library notes and Folder files,
 change the linked Folder files root, leave Notes, or close the open Folder
-Files file. Folder files' compact **Back to navigator** action is not a reset.
+files file. Folder files' compact **Back to navigator** action is not a reset.
 
 When Library navigation is closed, one stable cue names the return
 destination:
@@ -167,7 +167,7 @@ source-managed placement, removing one placement does not remove the portable
 membership while the other remains effective.
 
 This does not synchronize filesystem paths or grant filesystem access. Folder
-Files and lasting folder sync remain device-private authorities. For the
+files and lasting folder sync remain device-private authorities. For the
 identity, dependency, suppression, conflict, and recovery contract, see the
 [Sync-v2 client runtime](../../Development/Sync-v2-client.md).
 

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -19,16 +19,16 @@ under the rail's "Create" section.
 
 ## Layout tour
 
-Database Notes uses three side-by-side roles when there is room: Library
+Library notes uses three side-by-side roles when there is room: Library
 navigation, the Notes list, and the note you are working on. The Library
 navigation and Notes list each have their own slim collapse grip. Collapsing
 one does not collapse the other, and each grip remembers its own choice.
 
-Wide Database Notes keeps Library navigation beside the list while you scan:
+Wide Library notes keeps Library navigation beside the list while you scan:
 
 ```text
 +----------------------+-----------------------------------------------+
-| Library              | Database | Files                              |
+| Library              | Library notes | Files                         |
 | Browse               | Notes (N)                                     |
 |   Notes              | Filter...  New  Select  Add from files… Export |
 |   Media              | New folder   Move   Remove                    |
@@ -44,9 +44,9 @@ to reopen Library navigation; after you do, it stays open for the rest of that
 work session. Opening another note, switching between Edit, Preview, and Info,
 saving, resolving a conflict, or resizing the terminal does not close it
 again. The automatic close becomes available again only after you clear the
-selected Database note, switch between Database Notes and Folder Files,
-change the linked Folder Files root, leave Notes, or close the open Folder
-Files file. Folder Files' compact **Back to navigator** action is not a reset.
+selected Library note, switch between Library notes and Folder files,
+change the linked Folder files root, leave Notes, or close the open Folder
+Files file. Folder files' compact **Back to navigator** action is not a reset.
 
 When Library navigation is closed, one stable cue names the return
 destination:
@@ -87,7 +87,7 @@ editor's own Back control returns to its list.
   open the list takes the width the empty work area would otherwise waste,
   so long titles are not truncated on a wide terminal; opening a note hands
   that width back. Its own grip collapses or restores the list without
-  changing the Folder Files tree choice. Renaming a note does not repaint its
+  changing the Folder files tree choice. Renaming a note does not repaint its
   list row live while the note stays open: a Notes refresh that lands while
   the title field holds focus is skipped rather than queued, so tabbing or
   clicking to another field does not by itself catch it up. The row shows the
@@ -129,7 +129,7 @@ editor's own Back control returns to its list.
 
 Three different notes worlds meet here, and each surface now says so in
 place: the strip above the canvas switches between two of them.
-**Library notes** (this page) keeps notes inside the Library database.
+**Library notes** (this page) keeps notes inside the Library's own database.
 **Folder files** is a mode of this same Notes screen: it swaps the work area
 for the File Notes workspace — which edits plain files under a folder you
 choose directly and has its own Session Git panel — while the Library rail
@@ -143,8 +143,8 @@ through the lasting-sync runtime.
 ### Portable organization with Sync v2
 
 For an eligible local-first server profile, Manual Sync can also carry the
-logical organization of Library notes: keywords, keyword collections, Database
-Notes folders, and their memberships. These six organization types enroll as
+logical organization of Library notes: keywords, keyword collections, Library
+notes folders, and their memberships. These six organization types enroll as
 one capability; Chatbook will not synchronize only part of the group.
 
 The first run may pause for an adoption review when a local and server object
@@ -155,7 +155,7 @@ and publication is blocked. Interrupted enrollment and sync can be retried from
 the same Manual Sync surface; committed checkpoints and pending changes are
 resumed rather than rebuilt.
 
-Deleting a Database Notes folder synchronizes only that explicit deletion. Its
+Deleting a Library notes folder synchronizes only that explicit deletion. Its
 descendants and memberships stay dormant and become effective again after the
 folder is restored. If a note belongs to a folder through both manual and
 source-managed placement, removing one placement does not remove the portable
@@ -177,7 +177,7 @@ folder or whole-keyword filter. At least one of these is required:
   match `Agent-Lesson`;
 - `folder_id` uses the stable opaque folder identity returned by an earlier
   read; and
-- `folder` resolves an exact relative Database Notes path. It is not a local
+- `folder` resolves an exact relative Library notes path. It is not a local
   filesystem path. Ambiguous, deleted, or conflicting folder selections are
   refused instead of guessed.
 
@@ -214,7 +214,7 @@ Agent Lessons marker is the spelling-exact `agent-lesson` keyword; the
 
 Chatbook creates one conventional root folder named `Agent_Lessons` after the
 applicable Notes organization readiness boundary. It remains an ordinary,
-user-owned Database Notes folder: you may rename, move, or delete it, and
+user-owned Library notes folder: you may rename, move, or delete it, and
 Chatbook does not recreate a folder you deliberately changed. On synchronized
 profiles, only a provably untouched empty seed race converges automatically;
 edited, acknowledged, used, differently spelled, or colliding candidates wait
@@ -291,7 +291,7 @@ device.
 
 ### Notes list
 
-Database Notes are presented as a folder tree rather than one flattened
+Library notes are presented as a folder tree rather than one flattened
 snapshot. Each level loads independently in fixed pages of 20:
 
 - A folder-row **More folders** control loads the next 20 direct children of
@@ -381,8 +381,8 @@ jumps away as you type or after you move to another field. The next refresh
 that arrives once your hands are off the field paints normally.
 
 Notes does not use **Ctrl+S**, and there is no replacement Notes save
-shortcut. Use the visible **Save** button when you want an immediate Database
-save; normal Tab navigation and **F6** can reach it. Autosave continues to
+shortcut. Use the visible **Save** button when you want an immediate Library
+notes save; normal Tab navigation and **F6** can reach it. Autosave continues to
 handle ordinary typing.
 
 When the note body has keyboard focus, only its boundary becomes more
@@ -393,7 +393,7 @@ Title and Keywords still use their usual filled focus treatment.
 The wide `‹ Library / Notes` cue and Escape use the same guarded return as
 the compact Back control. A dirty save, sync, conflict, reload confirmation,
 or running mutation can therefore keep the focused task open until it is safe
-to leave. A successful return restores the Database/Files source, filter,
+to leave. A successful return restores the Library notes / Folder files source, filter,
 sort, selected note or placement, Notes-list scroll, Library-rail scroll, and
 semantic keyboard focus instead of starting over at the first row.
 
@@ -453,7 +453,7 @@ because Enter there goes back rather than creating anything.
 the header names neither relationship — it reads "Add from files" and its next
 action is to pick one:
 
-- **Import once** copies supported files into Database Notes and ends after its
+- **Import once** copies supported files into Library notes and ends after its
   reviewed receipt. Later changes to the originals are not tracked.
 - **Keep a folder synced** creates a lasting local relationship. Choose the
   folder, direction, and local Library destination, then choose **Check
@@ -514,7 +514,7 @@ unavailable-in-this-release reason; no files or notes change.
 
 ### Import once
 
-**Import once** copies supported note files into local Database Notes. It is
+**Import once** copies supported note files into local Library notes. It is
 not the same as **Keep a folder synced**: the import ends after this reviewed
 batch, while lasting sync retains a root relationship.
 
@@ -634,7 +634,7 @@ outside the batch stayed as text and are not counted.
 
 1. In the notes list, click **Add from files…**, choose **Import once**, and
    pick the first file or one folder.
-2. For files, click **Add another file** as needed and enter the Database Notes
+2. For files, click **Add another file** as needed and enter the Library notes
    destination. A folder already supplies its proposed hierarchy. Picked the
    wrong source? Use **Change selection** or **Clear**.
 3. Click **Check selection** and review classifications, actions, matches, and
@@ -712,7 +712,7 @@ permanent delete.
 The footer advertises these as `ctrl+n new note | / find note | esc focus
 rail`. Notes does not register **Ctrl+S** and does not replace it with
 another save shortcut. Use the visible
-Database **Save** button for an immediate save; Folder Files saves
+Library notes **Save** button for an immediate save; Folder files saves
 automatically. Global navigation keys live in the [guide index](../index.md).
 
 ## Related settings & docs
@@ -737,7 +737,7 @@ automatically. Global navigation keys live in the [guide index](../index.md).
 ## Verification evidence
 
 TASK-19012 verifies this journey through the real `LibraryScreen` hierarchy
-and the shipped CSS bundle. The mounted matrix covers Database Notes and its
+and the shipped CSS bundle. The mounted matrix covers Library notes and its
 Add-from-files chooser at wide and 60×20 sizes, the visibly unavailable server
 destination, lasting-root attention/recovery after a fresh screen, and Folder
 files with Session Git at its supported 40×20 layout. It checks painted text,
@@ -765,7 +765,7 @@ evidence directory remains for inspection.
   lookup, and collision analysis are read-only. If checking fails, review the
   selected paths and destination and try again.
 - **Cancellation is partial, not undo** — work already completed remains in
-  Database Notes and is reported honestly in the receipt. Retry resumes only
+  Library notes and is reported honestly in the receipt. Retry resumes only
   unfinished or explicitly retryable work from that same app session.
 - **Another Chatbook process blocks activation** — close it and restart before
   activating folder sync. The cutover does not hot-swap or run two writers.
@@ -822,7 +822,7 @@ seam (Back, Escape, rail switch, screen leave), not just the two this
 paragraph's prose already covered).*
 
 *Verified on codex/notes-delete-undo-receipt — 2026-08-11 (TASK-15100:
-confirmed Database Note deletion now leaves a named inline Undo/Dismiss
+confirmed Library note deletion now leaves a named inline Undo/Dismiss
 receipt; Undo restores the exact soft-deleted row and Notes rail count through
 the version-checked service seam.)*
 
@@ -1042,3 +1042,14 @@ Folder files now keeps the Library rail before a folder is linked as well as
 after, so the empty state is a mode of Notes rather than a full-width
 onboarding step. Compact terminals — under about 120 columns — collapse the
 rail either way, as before. See [File notes](file-notes.md).)*
+
+*Verified against fix/library-crit9-notes — 2026-09-10 (task-32233: Escape on
+the Notes list now goes where the footer chip says — out of the Filter box to
+the rail's **Search Library…** box, and from there to the canvas, the same
+two-step ladder Media has. task-32218: one noun per source — this page and the
+canvas call the Library's own notes **Library notes** and the on-disk ones
+**Folder files**; "Library database", "Database Notes" and "Folder Files" are
+retired as user-visible names. task-32215: the three placement verbs (**Add to
+folder**, **Move note**, **Remove placement**) are pinned to a selected row;
+**Sort** on a populated list arrived with task-32172. task-32217: the note
+editor's Body box takes the height its pane has spare.)*

--- a/Tests/UI/test_library_crit8_keyboard.py
+++ b/Tests/UI/test_library_crit8_keyboard.py
@@ -31,6 +31,7 @@ from tldw_chatbook.Library.library_shell_state import (
     LIBRARY_ROW_BROWSE_NOTES,
     LIBRARY_ROW_CREATE_NOTE,
 )
+from tldw_chatbook.UI.Library_Modules.canvas_sync import _sync_library_canvas
 from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
     LibraryAdaptiveReaderPaneGrip,
 )
@@ -612,4 +613,122 @@ async def test_pane_grip_focus_is_visible_against_its_blurred_sibling():
         assert "reverse" in str(grip_a.styles.text_style).lower(), (
             f"expected a reverse (block-inverting) focus style, got "
             f"{grip_a.styles.text_style!r}"
+        )
+
+
+# --- task-32233: the Notes canvas keeps the same Escape contract -------------
+
+
+async def _open_notes_list(screen, pilot, *, folder_tree: bool = True):
+    """Land on the Notes list in one of its two layouts.
+
+    ``folder_tree`` is the shipped default (PR #2543): the branch loader
+    fills ``tree_branches`` and the canvas paints the folder projection.
+    Clearing those branches is the same state the canvas paints before the
+    first branch slice settles -- the plain database list.
+    """
+    screen.query_one("#library-row-browse-notes").press()
+    await _wait_for_selector(screen, pilot, "#library-notes-filter")
+    await pilot.pause()
+    if not folder_tree:
+        screen._notes_state.tree_branches = {}
+        _sync_library_canvas(screen, "notes")
+        await pilot.pause()
+        await pilot.pause()
+    assert bool(screen.query(".library-notes-tree-note-row")) is folder_tree, (
+        "the layout under test is not the one that got painted"
+    )
+    return screen.query_one("#library-notes-filter", Input)
+
+
+@pytest.mark.asyncio
+async def test_escape_from_the_notes_filter_box_blurs_and_the_next_key_is_a_canvas_key():
+    """AC#1: Escape must leave the Notes filter box, like every sibling list.
+
+    Live at dev 1077ac2dad the Notes filter box CLEARED on Escape and kept
+    the caret, so the next printable key was typed straight back into it --
+    ``library_notes_escape`` is declared first among this screen's Escape
+    bindings and its gate was True on the plain list, so the focus hop the
+    footer advertises was never reached.
+    """
+    host = _build_library_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        filter_box = await _open_notes_list(screen, pilot)
+
+        await pilot.press("slash")
+        await pilot.pause()
+        assert screen.focused is filter_box
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.focused is not filter_box, screen.focused
+
+        before = screen.query_one("#library-notes-filter", Input).value
+        await pilot.press("n")
+        await pilot.pause()
+        assert screen.query_one("#library-notes-filter", Input).value == before, (
+            "`n` was typed into the Notes filter box after Escape."
+        )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("layout", ["database", "folder_tree"])
+async def test_escape_on_the_plain_notes_list_focuses_the_rail_search_box(layout):
+    """AC#2: both Notes list layouts honour the footer's "esc focus rail".
+
+    The same destination ``/``, F6 and the Media/Prompts/Skills lists already
+    converge on (``_library_list_focus_rail_target``), so the chip is telling
+    the truth on every list canvas rather than all but this one.
+    """
+    host = _build_library_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_notes_list(screen, pilot, folder_tree=layout == "folder_tree")
+
+        assert ("esc", "focus rail") in (
+            screen._library_footer_shortcuts_for_current_state()
+        )
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.focused is screen.query_one("#library-search-input", Input), (
+            f"Escape on the {layout} Notes list left focus on "
+            f"{screen.focused!r} while the footer said 'focus rail'."
+        )
+
+
+@pytest.mark.asyncio
+async def test_escape_from_the_rail_box_on_the_notes_list_still_blurs_to_the_canvas():
+    """AC#1: the Notes list completes the same two-step Escape ladder as Media.
+
+    The filter box hands Escape to the rail search box (the sibling test);
+    from there the hop would re-focus the widget that already has focus, so
+    Escape must blur to the canvas instead -- the case
+    ``library_blur_text_field`` was added for (task-32051). That binding is
+    declared after ``library_notes_escape``, whose gate covers the whole
+    Notes workflow, so on this canvas it never fired: live at dev 1077ac2dad
+    `abc` was typed into the rail box.
+    """
+    host = _build_library_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _open_notes_list(screen, pilot)
+        search_box = screen.query_one("#library-search-input", Input)
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.focused is search_box
+
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.focused is not search_box, screen.focused
+        assert not isinstance(screen.focused, Input), screen.focused
+        await pilot.press("n")
+        await pilot.pause()
+        assert screen.query_one("#library-search-input", Input).value == "", (
+            "`n` was typed into the rail search box after Escape."
         )

--- a/Tests/UI/test_library_crit8_keyboard.py
+++ b/Tests/UI/test_library_crit8_keyboard.py
@@ -733,6 +733,7 @@ async def test_escape_from_the_rail_box_on_the_notes_list_still_blurs_to_the_can
             "`n` was typed into the rail search box after Escape."
         )
 
+
 @pytest.mark.asyncio
 async def test_emergency_tab_from_a_note_field_still_reaches_on_key():
     """task-32106 (PR #2571 re-review, NEW-1): the priority Tab must yield here.

--- a/Tests/UI/test_library_crit8_polish_shell.py
+++ b/Tests/UI/test_library_crit8_polish_shell.py
@@ -665,11 +665,12 @@ async def test_a_notes_refresh_never_overwrites_the_keywords_being_typed():
 
 @pytest.mark.asyncio
 async def test_notes_work_pane_does_not_repeat_the_list_pane_status_line():
-    """task-32063: both Notes panes painted `Library notes · Library database`.
+    """task-32063: both Notes panes painted the same authority sentence.
 
-    Live at 235x52 the list pane read "Library notes · Library database · Ready
-    · Next: Create a note or add from files." while the work pane restated the
-    same authority in its own header.
+    Live at 235x52 the list pane read "Library notes · Ready · Next: Create a
+    note or add from files." (then "Library notes · Library database · …",
+    before task-32218 dropped the second noun) while the work pane restated
+    the same authority in its own header.
     """
     app = _build_test_app()
     _seed_conversations(app, _two_conversations(), notes=_two_notes())
@@ -687,8 +688,10 @@ async def test_notes_work_pane_does_not_repeat_the_list_pane_status_line():
             screen.query_one("#library-note-work-authority", Static).renderable
         )
 
-        assert list_line.startswith("Library notes · Library database")
-        assert not work_line.startswith("Library notes · Library database"), (
+        # task-32218 renamed the authority to the one noun the source strip
+        # uses; the claim under test -- only ONE pane paints it -- is unchanged.
+        assert list_line.startswith("Library notes")
+        assert not work_line.startswith("Library notes"), (
             "the work pane must not restate the list pane's authority sentence"
         )
         assert work_line

--- a/Tests/UI/test_library_crit9_notes.py
+++ b/Tests/UI/test_library_crit9_notes.py
@@ -221,3 +221,42 @@ async def test_the_note_editor_body_takes_the_height_its_pane_has_spare():
             f"at {region.region.bottom}: {region.region.bottom - body.region.bottom} "
             "blank rows under the note."
         )
+
+
+@pytest.mark.asyncio
+async def test_the_note_preview_takes_the_same_height_the_body_does():
+    """Preview replaces the Body one-for-one, so it fills the pane too.
+
+    Qodo #2590 comment 3: the component rule this branch added is a bare
+    `#library-note-preview-region`, but `LibraryScreen.BUNDLED_CSS` carries its
+    own copy, which the build scopes to `LibraryScreen #library-note-preview-
+    region` -- one type selector more specific, so it kept the retired
+    `height: auto / min-height: 12 / max-height: 20`. Edit expanded and Preview
+    stayed capped at 20 rows in a 30-row pane. `#library-note-body` has no such
+    scoped copy, which is why only Preview was affected.
+    """
+    host = _notes_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        row = await _wait_for_selector(screen, pilot, ".library-notes-tree-note-row")
+        row.press()
+        await _wait_for_selector(screen, pilot, "#library-note-body")
+        screen.query_one("#library-note-preview", Button).press()
+        preview = await _wait_for_selector(screen, pilot, "#library-note-preview-region")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one("#library-note-preview-region").region.height > 0,
+            message="Preview never took the work pane.",
+        )
+
+        parent = preview.parent
+        assert parent.content_region.height > 20, parent.content_region
+        # One row of the region's own bottom margin is all that may be left.
+        assert preview.region.bottom >= parent.content_region.bottom - 1, (
+            f"Preview stops at {preview.region.bottom} in a pane whose content "
+            f"ends at {parent.content_region.bottom}: "
+            f"{parent.content_region.bottom - preview.region.bottom} blank rows "
+            "under the rendered note."
+        )

--- a/Tests/UI/test_library_crit9_notes.py
+++ b/Tests/UI/test_library_crit9_notes.py
@@ -1,0 +1,223 @@
+"""Library ▸ Notes toolbar gating and source vocabulary -- critique #9.
+
+Group `notes` of the critique-9 fix wave:
+
+- task-32215 AC#2: the three selection-scoped folder verbs (`Add to folder`,
+  `Move note`, `Remove placement`) must not stand in the toolbar with no
+  row selected. AC#1 (Sort on a populated list) was already delivered by the
+  Notes wave's PR #2558 and is pinned by its own tests -- nothing here
+  re-pins Sort in either direction.
+- task-32218: one noun per Notes source. `Library notes` for the notes the
+  Library keeps itself, `Folder files` for the notes that live as files in a
+  folder -- and no `Library database`, `Database Notes` or capitalised
+  `Folder Files` anywhere a reader can see them.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_library_shell import (
+    LIBRARY_TEST_SIZE,
+    LibraryHarness,
+    _active_library_screen,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_condition,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+from Tests.UI.app_factory import _build_test_app
+from tldw_chatbook.Library.library_notes_state import LibraryNotesListState
+from tldw_chatbook.Library.library_notes_tree_state import (
+    LibraryNotesTreeProjection,
+    LibraryNotesTreeRow,
+)
+from tldw_chatbook.Widgets.Library.library_notes_canvas import LibraryNotesCanvas
+
+#: The three actions that only mean something once a note placement is the
+#: selected row. `New folder` is NOT one of them -- it makes a folder next to
+#: whatever is showing.
+SELECTION_SCOPED_FOLDER_VERBS = (
+    "#library-notes-placement-add",
+    "#library-notes-placement-move",
+    "#library-notes-placement-remove",
+)
+
+#: Every retired spelling of the two sources. `Database` is matched as a whole
+#: word and case-sensitively: the empty state's prose ("the Library's own
+#: database") describes where the notes live and is not a name.
+RETIRED_SOURCE_WORDS = (
+    "Library database",
+    "Database Notes",
+    "Database notes",
+    "Folder Files",
+    "back to Database",
+)
+
+
+def _notes_host() -> LibraryHarness:
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        _two_conversations(),
+        notes=[{"title": "Research Note", "id": "note-1"}],
+    )
+    return LibraryHarness(app)
+
+
+def _painted(screen) -> str:
+    """The whole painted frame as one plain-text string."""
+    return "\n".join(
+        "".join(segment.text for segment in strip)
+        for strip in screen._compositor.render_strips()
+    )
+
+
+def _assert_no_retired_source_words(painted: str, where: str) -> None:
+    for retired in RETIRED_SOURCE_WORDS:
+        assert retired not in painted, f"{where} still paints {retired!r}"
+    stray = re.search(r"\bDatabase\b", painted)
+    assert stray is None, f"{where} still names a source 'Database'"
+
+
+def _tree(*, selected: str) -> LibraryNotesTreeProjection:
+    return LibraryNotesTreeProjection(
+        rows=(
+            LibraryNotesTreeRow(
+                placement_id="folder:ideas",
+                kind="folder",
+                label="Ideas",
+                depth=0,
+                folder_id="ideas",
+                focus_id="library-notes-folder-ideas",
+                expanded=True,
+            ),
+            LibraryNotesTreeRow(
+                placement_id=selected or "note:ideas:n1:m1",
+                kind="note",
+                label="Research Note",
+                depth=1,
+                note_id="n1",
+                membership_id="m1",
+                folder_id="ideas",
+                focus_id="library-notes-tree-note-n1",
+            ),
+        )
+    )
+
+
+# --- task-32215 AC#2 --------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("selected", ["", "note:ideas:n1:m1"])
+async def test_selection_scoped_folder_verbs_need_a_selected_row(
+    widget_pilot, selected
+):
+    """The three placement verbs appear only once a note row is selected.
+
+    Live at dev 02374bf66a all four transfer verbs stood in the toolbar on a
+    plain seven-note list, three of them meaningless with nothing selected
+    and none of them carrying a reason. `New folder` stays either way.
+    """
+    async with await widget_pilot(
+        LibraryNotesCanvas,
+        list_state=LibraryNotesListState(
+            rows=(),
+            header_copy="Notes (1)",
+            status_copy="",
+            empty_copy="No notes yet. Create your first note.",
+        ),
+        tree_projection=_tree(selected=selected),
+        tree_selected_placement_id=selected,
+        pane_width=120,
+    ) as pilot:
+        await pilot.pause()
+        assert pilot.app.query_one("#library-notes-folder-new", Button)
+        for button_id in SELECTION_SCOPED_FOLDER_VERBS:
+            found = pilot.app.query(button_id)
+            assert bool(found) is bool(selected), (
+                f"{button_id} present={bool(found)} with selected={selected!r}"
+            )
+
+
+# --- task-32218 -------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_library_notes_paints_one_noun_for_its_own_source():
+    """AC#1, database side: `Library notes`, and nothing else."""
+    host = _notes_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-filter")
+        await pilot.pause()
+
+        painted = _painted(screen)
+        assert "Library notes" in painted, "the source's own noun is not painted"
+        _assert_no_retired_source_words(painted, "Library notes")
+
+
+@pytest.mark.asyncio
+async def test_folder_files_paints_one_noun_for_the_on_disk_source():
+    """AC#1, files side: `Folder files`, and an Escape chip naming where it goes."""
+    host = _notes_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        await _wait_for_selector(screen, pilot, "#library-notes-source-files")
+        screen.query_one("#library-notes-source-files", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._file_notes_active(),
+            message="Folder files never took over the view.",
+        )
+        await pilot.pause()
+
+        painted = _painted(screen)
+        assert "Folder files" in painted, "the source's own noun is not painted"
+        _assert_no_retired_source_words(painted, "Folder files")
+        assert ("esc", "back to Library notes") in (
+            screen._library_footer_shortcuts_for_current_state()
+        )
+
+
+# --- task-32217 AC#2, the note-editor clause --------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_note_editor_body_takes_the_height_its_pane_has_spare():
+    """The Body is this pane's primary content box, so it fills it.
+
+    Its ceiling (`max-height: 20`) dated from when the keywords, meta line
+    and action row still sat below the TextArea; they moved into Info, so
+    `#library-note-editor-region` ends at this field and the ceiling only
+    bought blank pane. Measured live at 235x52 on the seeded profile before
+    this change: a 3-line note got a 12-row box with 18 empty rows under it.
+    """
+    host = _notes_host()
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-notes").press()
+        row = await _wait_for_selector(screen, pilot, ".library-notes-tree-note-row")
+        row.press()
+        body = await _wait_for_selector(screen, pilot, "#library-note-body")
+        await pilot.pause()
+        await pilot.pause()
+
+        region = screen.query_one("#library-note-editor-region")
+        assert region.region.height > 20, region.region
+        # One row of the field's own bottom margin is all that may be left.
+        assert body.region.bottom >= region.region.bottom - 1, (
+            f"the Body box stops at {body.region.bottom} in a pane that ends "
+            f"at {region.region.bottom}: {region.region.bottom - body.region.bottom} "
+            "blank rows under the note."
+        )

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -2879,7 +2879,7 @@ async def test_folder_files_authority_row_tracks_root_save_and_session_git(
         assert workspace.children[0] is authority
         assert authority._render_markup is False
         assert _static_text(workspace, "#file-notes-authority") == (
-            "Folder Files · No folder selected"
+            "Folder files · No folder selected"
         )
         assert "Choose folder" in _static_text(workspace, "#file-notes-save-status")
 
@@ -3078,7 +3078,7 @@ def test_configured_root_authority_state_table_is_two_line_and_bounded(
 
         assert "\n" not in authority and "\n" not in content, context
         assert cell_len(authority) <= 60, (context, authority)
-        assert "Folder Files" in authority and "Folder:" in authority, context
+        assert "Folder files" in authority and "Folder:" in authority, context
         if offline is True:
             assert "Folder unavailable" in authority
         elif warning:
@@ -3828,7 +3828,7 @@ async def test_saved_authority_with_session_git_paints_at_60x20(
             cell_len(row) <= authority.region.width
             for row in authority_copy.splitlines()
         )
-        assert "Folder Files" in painted
+        assert "Folder files" in painted
         assert "Folder:" in painted
         assert "Saved" in _static_text(workspace, "#file-notes-save-status")
         if push_copy:
@@ -6806,7 +6806,7 @@ async def test_file_notes_authority_is_painted_and_contained_at_60x20_shell(
         assert workspace.content_region.contains_region(content.region)
         assert shell_grid.content_region.contains_region(workspace.region)
         assert 0 < authority.region.height <= 2
-        assert _painted_style_of_text(pilot.app, authority.region, "Folder Files")
+        assert _painted_style_of_text(pilot.app, authority.region, "Folder files")
         assert _painted_style_of_text(pilot.app, content.region, "Saved")
 
     await workspace.shutdown()
@@ -6878,7 +6878,7 @@ async def test_file_notes_merged_recovery_authority_paints_at_60x20_shell(
         assert workspace.content_region.contains_region(content.region)
         assert shell_grid.content_region.contains_region(workspace.region)
         assert 0 < authority.region.height <= 2
-        assert "Folder Files" in painted
+        assert "Folder files" in painted
         assert "Folder: Resear" in painted
         assert "name" in painted
         assert state_copy in content_words
@@ -6971,7 +6971,7 @@ async def test_file_notes_combined_non_ready_authority_matrix_paints_at_60x20(
                 cell_len(row) <= authority.region.width
                 for row in authority_copy.splitlines()
             )
-            assert "Folder Files" in painted
+            assert "Folder files" in painted
             assert "Folder:" in painted
             assert (
                 "Folder unavailable" if root_state == "offline" else "Folder warning"

--- a/Tests/UI/test_library_file_notes_workspace.py
+++ b/Tests/UI/test_library_file_notes_workspace.py
@@ -3021,7 +3021,7 @@ async def test_file_notes_authority_copy_is_complete_and_bounded(
         replica=replica,
         poll_interval=10,
     )
-    expected_authority = "Folder Files · Folder: notes"
+    expected_authority = "Folder files · Folder: notes"
 
     async with _WorkspaceHarness(workspace).run_test(size=size) as pilot:
         await _wait_until(pilot, lambda: workspace.initialized, "scan did not finish")

--- a/Tests/UI/test_library_note_import_flow.py
+++ b/Tests/UI/test_library_note_import_flow.py
@@ -31,6 +31,10 @@ from Tests.UI.test_library_shell import (
 )
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
 from tldw_chatbook.UI.Screens import library_screen as library_screen_module
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_GLYPH_SELECTED,
+    LIBRARY_GLYPH_UNSELECTED,
+)
 from tldw_chatbook.Library.library_note_import_state import (
     NoteImportPhase,
     initial_note_import_snapshot,
@@ -663,7 +667,7 @@ async def test_obsidian_review_defaults_on_shows_skips_and_never_touches_the_vau
             await _reach_import_review(screen, pilot, vault)
 
             toggle = screen.query_one("#note-import-obsidian-mode", Button)
-            assert str(toggle.label) == "✓ Obsidian vault"
+            assert str(toggle.label) == f"{LIBRARY_GLYPH_SELECTED} Obsidian vault"
             assert "skips .obsidian" in str(
                 screen.query_one("#note-import-obsidian-reason", Static).renderable
             )
@@ -686,7 +690,7 @@ async def test_obsidian_review_defaults_on_shows_skips_and_never_touches_the_vau
                 pilot,
                 lambda: str(
                     screen.query_one("#note-import-obsidian-mode", Button).label
-                ).startswith("○"),
+                ).startswith(LIBRARY_GLYPH_UNSELECTED),
                 message="Turning Obsidian vault off never re-ran the check.",
             )
             review_off = _review_text(screen)

--- a/Tests/UI/test_library_notes_files_sync_journey.py
+++ b/Tests/UI/test_library_notes_files_sync_journey.py
@@ -462,7 +462,7 @@ async def test_database_notes_import_once_journey_is_painted_focused_and_retaine
         purpose = str(
             screen.query_one("#library-notes-database-purpose", Static).renderable
         )
-        assert "Library notes · Library database" in str(authority.renderable)
+        assert "Library notes" in str(authority.renderable)
         assert "use Sync to mirror" not in purpose
         assert "switch to Folder files" in purpose
         assert "choose Add from files" in purpose

--- a/Tests/UI/test_library_notes_reader.py
+++ b/Tests/UI/test_library_notes_reader.py
@@ -413,18 +413,20 @@ async def test_database_notes_capability_inventory_and_modes(
 @pytest.mark.parametrize(
     ("authority", "state", "expected_content", "expected_authority", "safe"),
     (
-        ("database", "conflict", "Conflict", "Database Notes", "Review recovery"),
-        ("database", "read_only", "Read-only", "Database Notes", "Keep the draft"),
-        ("database", "failed", "Save failed", "Database Notes", "Retry Save"),
-        ("database", "saving", "Saving", "Database Notes", None),
-        ("database", "dirty", "Unsaved changes", "Database Notes", None),
-        ("database", "clean", "Saved", "Database Notes", None),
-        ("folder", "conflict", "Conflict", "Folder Files", "Save Copy"),
-        ("folder", "read_only", "Read-only", "Folder Files", "Open Manage"),
-        ("folder", "failed", "Save failed", "Folder Files", "Save Copy"),
-        ("folder", "saving", "Saving", "Folder Files", None),
-        ("folder", "dirty", "Unsaved changes", "Folder Files", None),
-        ("folder", "clean", "Saved", "Folder Files", None),
+        # task-32218: one noun per source -- "Database Notes" and
+        # "Folder Files" are retired spellings of these two.
+        ("database", "conflict", "Conflict", "Library notes", "Review recovery"),
+        ("database", "read_only", "Read-only", "Library notes", "Keep the draft"),
+        ("database", "failed", "Save failed", "Library notes", "Retry Save"),
+        ("database", "saving", "Saving", "Library notes", None),
+        ("database", "dirty", "Unsaved changes", "Library notes", None),
+        ("database", "clean", "Saved", "Library notes", None),
+        ("folder", "conflict", "Conflict", "Folder files", "Save Copy"),
+        ("folder", "read_only", "Read-only", "Folder files", "Open Manage"),
+        ("folder", "failed", "Save failed", "Folder files", "Save Copy"),
+        ("folder", "saving", "Saving", "Folder files", None),
+        ("folder", "dirty", "Unsaved changes", "Folder files", None),
+        ("folder", "clean", "Saved", "Folder files", None),
     ),
 )
 def test_notes_header_status_channels_follow_approved_precedence(

--- a/Tests/UI/test_library_shell.py
+++ b/Tests/UI/test_library_shell.py
@@ -24007,7 +24007,7 @@ def _assert_task8_compact_chrome(screen: LibraryScreen) -> None:
     assert authority.region.height == 2
     assert notes.content_region.contains_region(authority.region)
     authority_text = getattr(authority.renderable, "plain", str(authority.renderable))
-    assert "Library notes · Library database" in authority_text
+    assert "Library notes" in authority_text
     assert "Next:" in authority_text
     assert footer.region.height == 1
     assert (

--- a/Tests/Widgets/Library/test_library_note_import_canvas.py
+++ b/Tests/Widgets/Library/test_library_note_import_canvas.py
@@ -12,6 +12,10 @@ from textual.widgets import Button, Input, Static
 
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_GLYPH_SELECTED,
+    LIBRARY_GLYPH_UNSELECTED,
+)
 from tldw_chatbook.Library.library_note_import_state import (
     LibraryNoteImportItemSnapshot,
     LibraryNoteImportSnapshot,
@@ -434,8 +438,10 @@ async def test_update_choices_are_independent_and_post_item_scoped_messages() ->
         await pilot.pause()
         replace_button = app.query_one("#note-import-replace-item-1", Button)
         membership_button = app.query_one("#note-import-membership-item-1", Button)
-        assert replace_button.label.plain.startswith("✓")
-        assert membership_button.label.plain.startswith("○")
+        # task-32235 AC#2: the legend's checkbox pair, not the outcome "✓"
+        # and the blocked-action "○" these labels used to borrow.
+        assert replace_button.label.plain.startswith(LIBRARY_GLYPH_SELECTED)
+        assert membership_button.label.plain.startswith(LIBRARY_GLYPH_UNSELECTED)
         assert await pilot.click(replace_button)
         assert await pilot.click(membership_button)
         await pilot.pause()

--- a/Tests/Widgets/Library/test_library_notes_canvas.py
+++ b/Tests/Widgets/Library/test_library_notes_canvas.py
@@ -237,7 +237,8 @@ async def test_authority_row_is_first_plain_child_in_every_notes_mode(
         assert authority._render_markup is False
         text = getattr(authority.renderable, "plain", str(authority.renderable))
         assert "Library notes" in text
-        assert "Library database" in text
+        # task-32218: one noun per source -- "· Library database" is gone.
+        assert "Library database" not in text
         assert status_fragment in text
         assert "Next:" in text
 
@@ -405,7 +406,7 @@ async def test_list_authority_running_without_status_uses_updating_fallback(
 
         assert "Updating notes…" in text
         assert "Ready" not in text
-        assert text == "Library notes · Library database · Updating notes…"
+        assert text == "Library notes · Updating notes…"
         assert "Next:" not in text
 
 
@@ -430,7 +431,7 @@ async def test_editor_authority_tracks_post_mount_save_state(widget_pilot):  # n
         assert canvas.query_one("#library-notes-authority", Static) is authority
         text = getattr(authority.renderable, "plain", str(authority.renderable))
         assert "Saving note…" in text
-        assert text == "Library notes · Library database · Saving note…"
+        assert text == "Library notes · Saving note…"
         assert "Next:" not in text
 
         canvas.apply_session_state(_editor_state(status="Save failed: database busy"))
@@ -468,7 +469,7 @@ async def test_editor_authority_tracks_transfer_through_context_navigation(
         assert "Saved" in text
         assert "Exporting Markdown…" in text
         assert (
-            text == "Library notes · Library database · Saved · Exporting Markdown…"
+            text == "Library notes · Saved · Exporting Markdown…"
         )
         assert "Next:" not in text
 

--- a/backlog/tasks/task-32215 - Library-Notes-the-Sort-chooser-exists-only-on-the-empty-list-folder-verbs-are-ungated.md
+++ b/backlog/tasks/task-32215 - Library-Notes-the-Sort-chooser-exists-only-on-the-empty-list-folder-verbs-are-ungated.md
@@ -3,10 +3,10 @@ id: TASK-32215
 title: >-
   Library Notes: the Sort chooser exists only on the empty list; folder verbs
   are ungated
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-10 14:53'
-updated_date: '2026-09-11 01:30'
+updated_date: '2026-09-11 02:00'
 labels:
   - library
   - notes
@@ -24,8 +24,8 @@ The empty Notes toolbar reads `New · Sort: Newest · ○ Select`; with seven no
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Sort is available on a populated Notes list in the same slot as its siblings
-- [ ] #2 Selection-scoped folder verbs appear only with a checked row or are gated with the inline-reason grammar
+- [x] #1 Sort is available on a populated Notes list in the same slot as its siblings
+- [x] #2 Selection-scoped folder verbs appear only with a checked row or are gated with the inline-reason grammar
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,3 +36,15 @@ The empty Notes toolbar reads `New · Sort: Newest · ○ Select`; with seven no
 3. Pin + fix whatever half still stands
 4. Docs stamp + notes
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both halves were already delivered by the Notes wave; this task contributes the missing pins and NO new controls.
+
+AC#1 -- verified live at dev 1077ac2dad on the seeded 7-note profile: the populated toolbar reads `New · Sort: Newest · Select`, in the same slot as its siblings. PR #2558 (task-32172) composed Sort unconditionally with a Newest default and #2565 re-pins its presence; no second Sort control was written, and nothing here re-pins Sort in either direction.
+
+AC#2 -- the snapshot measured 02374bf66a, before the folder-tree mode landed. At the current tip `_compose_tree_actions` composes `Add to folder`, `Move note` and `Remove placement` ONLY when the selected tree row is a note placement (folder verbs likewise only for a folder row); with nothing selected the toolbar carries just `New folder`, which is not selection-scoped. Verified live in all three states (captures in crit9/wave/notes/caps) and now pinned: Tests/UI/test_library_crit9_notes.py::test_selection_scoped_folder_verbs_need_a_selected_row, parametrized over selected/not, which passes on dev and is the evidence the claim is real rather than incidental.
+
+Files: Tests/UI/test_library_crit9_notes.py (new).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32215 - Library-Notes-the-Sort-chooser-exists-only-on-the-empty-list-folder-verbs-are-ungated.md
+++ b/backlog/tasks/task-32215 - Library-Notes-the-Sort-chooser-exists-only-on-the-empty-list-folder-verbs-are-ungated.md
@@ -3,9 +3,10 @@ id: TASK-32215
 title: >-
   Library Notes: the Sort chooser exists only on the empty list; folder verbs
   are ungated
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-10 14:53'
+updated_date: '2026-09-11 01:30'
 labels:
   - library
   - notes
@@ -26,3 +27,12 @@ The empty Notes toolbar reads `New · Sort: Newest · ○ Select`; with seven no
 - [ ] #1 Sort is available on a populated Notes list in the same slot as its siblings
 - [ ] #2 Selection-scoped folder verbs appear only with a checked row or are gated with the inline-reason grammar
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Verify Sort presence on a populated list (PR #2558) -- do not write a second Sort control
+2. Verify whether the selection-scoped folder verbs are gated
+3. Pin + fix whatever half still stands
+4. Docs stamp + notes
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
+++ b/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
@@ -3,9 +3,10 @@ id: TASK-32218
 title: >-
   Library Notes vocabulary: one journey passes 'Library notes', 'Library
   database', 'Folder files', 'Folder Files' and 'esc back to Database'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-10 14:54'
+updated_date: '2026-09-11 01:30'
 labels:
   - library
   - notes
@@ -26,3 +27,12 @@ Five names for the two Notes sources across the rail, canvas titles, the strip a
 - [ ] #1 One noun per Notes source used in the rail row, canvas title, strip, empty state and footer
 - [ ] #2 The guide uses the same nouns
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Inventory every user-visible Notes-source noun
+2. Apply 'Library notes' / 'Folder files' everywhere
+3. Pin with a painted-text walk in both modes
+4. Update the two guide pages
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
+++ b/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
@@ -3,10 +3,10 @@ id: TASK-32218
 title: >-
   Library Notes vocabulary: one journey passes 'Library notes', 'Library
   database', 'Folder files', 'Folder Files' and 'esc back to Database'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-10 14:54'
-updated_date: '2026-09-11 01:30'
+updated_date: '2026-09-11 02:00'
 labels:
   - library
   - notes
@@ -24,8 +24,8 @@ Five names for the two Notes sources across the rail, canvas titles, the strip a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One noun per Notes source used in the rail row, canvas title, strip, empty state and footer
-- [ ] #2 The guide uses the same nouns
+- [x] #1 One noun per Notes source used in the rail row, canvas title, strip, empty state and footer
+- [x] #2 The guide uses the same nouns
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -36,3 +36,21 @@ Five names for the two Notes sources across the rail, canvas titles, the strip a
 3. Pin with a painted-text walk in both modes
 4. Update the two guide pages
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Inventory first (grep over tldw_chatbook/ and Docs/User_Guide/library/), then one noun per source everywhere a reader can see it.
+
+Six production sites carried the drift: library_notes_canvas.py's NOTES_AUTHORITY_PREFIX ("Library notes · Library database") and three sibling literals ("Database Notes · Library database"), library_file_notes_workspace.py's authority line ("Folder Files · …"), and library_screen.py's two Escape labels (the F1 row "Back to Database notes" and the footer chip "back to Database"). The source strip, the Add-from-files canvas and the sync-roots canvas were already correct and were not touched.
+
+Now: **Library notes** and **Folder files**, matching the strip labels the reader actually clicks. The three canvas literals were replaced by the one NOTES_AUTHORITY_PREFIX constant rather than three new copies. The empty state keeps its lowercase prose ("These notes live in the Library's own database") -- that describes where notes live and is not a name.
+
+Docs: both guide pages rewritten to the same two nouns (Database Notes/Database notes -> Library notes, Folder Files -> Folder files, "the Library database" -> "the Library's own database", the "**Database** button" -> "**Library notes** button"), plus a stamp on each. Historical Verified-against stamps keep their original wording.
+
+Five existing pins asserted the retired copy and were updated in place (test_library_crit8_polish_shell, test_library_notes_files_sync_journey, test_library_shell, test_library_file_notes_workspace, test_library_notes_canvas x4); none of them asserted a design decision, only the old string. New walk: Tests/UI/test_library_crit9_notes.py asserts the painted frame in both modes carries the mode's noun and none of "Library database", "Database Notes", "Folder Files", "back to Database" or a bare word "Database", and that the Folder files footer chip reads `esc back to Library notes`.
+
+KNOWN GAP: Settings still labels the pane "Folder Files tree" (settings_appearance_defaults.py, settings_search_index.py, settings_screen.py). Those files are outside this branch's ownership, so they are left for a follow-up rather than edited here.
+
+Files: tldw_chatbook/Widgets/Library/library_notes_canvas.py, library_file_notes_workspace.py, tldw_chatbook/UI/Screens/library_screen.py (two one-line labels), Docs/User_Guide/library/notes.md, file-notes.md, Tests/UI/test_library_crit9_notes.py + 5 pin files.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
+++ b/backlog/tasks/task-32218 - Library-Notes-vocabulary-one-journey-passes-Library-notes-Library-database-Folder-files-Folder-Files-and-esc-back-to-Database.md
@@ -50,7 +50,26 @@ Docs: both guide pages rewritten to the same two nouns (Database Notes/Database 
 
 Five existing pins asserted the retired copy and were updated in place (test_library_crit8_polish_shell, test_library_notes_files_sync_journey, test_library_shell, test_library_file_notes_workspace, test_library_notes_canvas x4); none of them asserted a design decision, only the old string. New walk: Tests/UI/test_library_crit9_notes.py asserts the painted frame in both modes carries the mode's noun and none of "Library database", "Database Notes", "Folder Files", "back to Database" or a bare word "Database", and that the Folder files footer chip reads `esc back to Library notes`.
 
-KNOWN GAP: Settings still labels the pane "Folder Files tree" (settings_appearance_defaults.py, settings_search_index.py, settings_screen.py). Those files are outside this branch's ownership, so they are left for a follow-up rather than edited here.
+AC#1 names five surfaces; the rail row is the one that did NOT change, and
+that is deliberate (controller ruling R1). It reads `Notes (N)`, which is the
+SECTION name in the same grammar as `Media (N)` / `Conversations (N)` /
+`Prompts (N)` -- not a name for either source. The two source nouns live on
+the strip inside that section (`Library notes | Folder files`,
+`library_browse_route_swap.py:141,156`), which is where the reader actually
+chooses between them and where the one-noun rule has to hold. Renaming the
+rail row to "Library notes (N)" would break the rail's own grammar, leave
+Folder files with no rail row at all, and collide with the rail work on a
+sibling branch. The controller confirmed AC#1 is satisfied without changing
+it.
+
+KNOWN GAP: Settings still labels the pane "Folder Files tree" (settings_appearance_defaults.py, settings_search_index.py, settings_screen.py). Those files are outside this branch's ownership, so they are left for a
+follow-up rather than edited here. Two smaller items belong in the same
+rider: `test_settings_configuration_hub.py:2224/2225/2239` pins those labels,
+and `library_notes_controller.py:4534/4541/4543` still raise fail-closed
+`RuntimeError("Local Database Notes …")` guards. The latter are type-guard
+failures on the app's own DB handle -- no caller catches them (there is no
+`except` in `library_note_import_controller.py`), they are outside AC#1's five
+surfaces, and a user should never see one; left deliberately.
 
 Files: tldw_chatbook/Widgets/Library/library_notes_canvas.py, library_file_notes_workspace.py, tldw_chatbook/UI/Screens/library_screen.py (two one-line labels), Docs/User_Guide/library/notes.md, file-notes.md, Tests/UI/test_library_crit9_notes.py + 5 pin files.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32233 - Library-Notes-Escape-is-inert-in-the-filter-box-and-on-the-plain-list-although-the-footer-promises-esc-focus-rail.md
+++ b/backlog/tasks/task-32233 - Library-Notes-Escape-is-inert-in-the-filter-box-and-on-the-plain-list-although-the-footer-promises-esc-focus-rail.md
@@ -3,10 +3,10 @@ id: TASK-32233
 title: >-
   Library Notes: Escape is inert in the filter box and on the plain list
   although the footer promises 'esc focus rail'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-10 14:51'
-updated_date: '2026-09-11 01:30'
+updated_date: '2026-09-11 01:59'
 labels:
   - library
   - notes
@@ -25,9 +25,9 @@ On the Notes canvas Escape in the filter box does nothing and the next printable
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Escape in the Notes filter box blurs to the canvas and the next printable key does its canvas job
-- [ ] #2 Escape on the plain Notes list (database and folder-tree layouts) focuses the rail's Search Library… box exactly as the footer says
-- [ ] #3 Both cases are pinned in `Tests/UI/test_library_crit8_keyboard.py` alongside the Media pins
+- [x] #1 Escape in the Notes filter box blurs to the canvas and the next printable key does its canvas job
+- [x] #2 Escape on the plain Notes list (database and folder-tree layouts) focuses the rail's Search Library… box exactly as the footer says
+- [x] #3 Both cases are pinned in `Tests/UI/test_library_crit8_keyboard.py` alongside the Media pins
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -39,3 +39,19 @@ On the Notes canvas Escape in the filter box does nothing and the next printable
 4. Live-verify at 235x52 and 100x30
 5. Docs stamp + notes
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Re-verified live at dev 1077ac2dad before changing anything: BOTH cases still reproduced. In the filter box Escape cleared the value and kept the caret, so `/ read esc n` put "n" straight back in; on the plain list `esc abc` went nowhere and the keys were swallowed. Captures under crit9/wave/notes/caps/32233-*.
+
+Root cause was NOT the blur gate the snapshot suspected. `library_notes_escape` is the FIRST of this screen's many Escape bindings and its check_action is `visible_notes` -- true across the whole Notes workflow -- so Textual never tried `library_blur_text_field` or `library_list_focus_rail` (declared last) on this canvas at all. The action's own tail then restored the rail ROW through the notes focus identity, which resolved back into the navigator region and put the caret back in the filter.
+
+Fix, in `action_library_notes_escape`'s tail only: when the canvas is genuinely showing its plain list, converge on the shared hop `/`, F6 and every sibling list canvas use (`action_library_list_focus_rail` -> `_library_list_focus_rail_target()`), and blur to the canvas through `action_library_blur_text_field` when the caret is already standing on that hop's destination. No Notes-specific Escape handler was added; the compact stage collapse above it is untouched (test_library_shell.py:21679 depends on it, and it was re-verified live at 100x30).
+
+One delivery detail cost a round: the hop must be the canvas sync's explicit `then`, not `call_after_refresh`. A recompose already in flight restores the identity it captured before the key, and a bare deferred hop lands BEFORE that restore and is silently undone (traced through canvas_sync._restore_then_explicit).
+
+AC#1 reading: Escape leaves the filter box for the rail's Search Library… box rather than straight to the canvas. That is the pinned house contract -- `test_escape_from_a_list_filter_box_still_goes_where_the_footer_says` (task-32051 fix round 1) forbids the blur binding outranking a hop that genuinely moves focus, and the wave plan's Step 3 named that same rule. A second Escape then blurs to the canvas and the next printable key does its canvas job, which is the AC's substance and is pinned too.
+
+Files: tldw_chatbook/UI/Library_Modules/library_notes_controller.py, Tests/UI/test_library_crit8_keyboard.py (3 new pins beside the Media ones: filter box, plain list x2 layouts, rail box).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32233 - Library-Notes-Escape-is-inert-in-the-filter-box-and-on-the-plain-list-although-the-footer-promises-esc-focus-rail.md
+++ b/backlog/tasks/task-32233 - Library-Notes-Escape-is-inert-in-the-filter-box-and-on-the-plain-list-although-the-footer-promises-esc-focus-rail.md
@@ -3,9 +3,10 @@ id: TASK-32233
 title: >-
   Library Notes: Escape is inert in the filter box and on the plain list
   although the footer promises 'esc focus rail'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-10 14:51'
+updated_date: '2026-09-11 01:30'
 labels:
   - library
   - notes
@@ -28,3 +29,13 @@ On the Notes canvas Escape in the filter box does nothing and the next printable
 - [ ] #2 Escape on the plain Notes list (database and folder-tree layouts) focuses the rail's Search Library… box exactly as the footer says
 - [ ] #3 Both cases are pinned in `Tests/UI/test_library_crit8_keyboard.py` alongside the Media pins
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Re-verify live at the current dev tip (both cases, both layouts)
+2. Pin both cases in Tests/UI/test_library_crit8_keyboard.py beside the Media pins (TDD red)
+3. Fix the Escape ladder so the Notes list reaches the shared focus-rail hop
+4. Live-verify at 235x52 and 100x30
+5. Docs stamp + notes
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32235 - Library-one-state-glyph-legend-—-`○`-means-disabled-unchecked-and-skipped-leading-`▸`-means-selected-row-and-disclosure.md
+++ b/backlog/tasks/task-32235 - Library-one-state-glyph-legend-—-`○`-means-disabled-unchecked-and-skipped-leading-`▸`-means-selected-row-and-disclosure.md
@@ -26,7 +26,7 @@ priority: high
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
 - [x] #1 A documented legend: `▸/▾` trailing for disclosure, `█` leading for the keyboard cursor, `☐/☑` for selection, `✓/✗/–` for settled outcomes; blocked actions keep their inline reason and drop the glyph
-- [ ] #2 Every Library canvas uses the legend; the guide's glyph sentences match
+- [x] #2 Every Library canvas uses the legend; the guide's glyph sentences match
 - [x] #3 Captures at 235x52 and 100x30 pin one meaning per glyph
 <!-- AC:END -->
 
@@ -97,4 +97,18 @@ claim omitted three glyphs the Import queue paints, so `●` (still
 working), `≡` (already in your Library) and `⊘` (cancelled) are now rows in
 it. The carve-out import at `library_ingest_state.py:325` is relative and
 98 chars instead of 190, still one line.
+
+### AC#2 close-out (hand-off to the critique-9 `notes` branch)
+
+The one canvas Task 5 could not reach was the note-import review, whose
+`_choice_label` (`library_note_import_canvas.py`) still rendered a selection
+as `✓`/`○` -- colliding with the settled-outcome `✓` one row above it in the
+same receipt and with the blocked-action `○` on the buttons beside it. It now
+uses `LIBRARY_GLYPH_SELECTED`/`LIBRARY_GLYPH_UNSELECTED`, so every Library
+canvas is on the legend. The guide's legend row already named "Import type
+toggles" under `☐`/`☑`, so no guide sentence needed changing.
+
+Pins updated: `Tests/Widgets/Library/test_library_note_import_canvas.py` and
+`Tests/UI/test_library_note_import_flow.py` (both now assert the constants,
+not a literal).
 <!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Library_Modules/library_notes_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_controller.py
@@ -3009,6 +3009,45 @@ class LibraryNotesController:
             self._sync_library_notes_reader_layout_from_shell(priority="library")
         self._apply_library_notes_stage_visibility()
         self._apply_library_notes_footer_context()
+        if self._screen._library_list_canvas_showing_list():
+            rail_target = self._screen._library_list_focus_rail_target().lstrip("#")
+            if rail_target and (getattr(self.focused, "id", "") or "") == rail_target:
+                # ...and when the caret is ALREADY standing on the hop's
+                # destination the hop is inert, so the next printable key
+                # would be typed into the rail box -- task-32051's exact
+                # finding, which ``library_blur_text_field`` exists to close
+                # on every other canvas. It never fires here (this binding is
+                # declared first and its gate covers the whole Notes
+                # workflow), so reach the same shared action directly. This
+                # is the one rule the screen's own gate states; it is not
+                # restated anywhere else.
+                self._screen.action_library_blur_text_field()
+                return
+            # task-32233: from the plain Notes list, converge on the ONE
+            # focus-rail hop `/`, F6 and every sibling list canvas's Escape
+            # already use (`_library_list_focus_rail_target`), because that
+            # is what the footer's "esc focus rail" chip promises.
+            #
+            # This binding is declared FIRST among the screen's many Escape
+            # entries and its gate is True across the whole Notes workflow,
+            # so on the list it is the only path the key ever takes --
+            # `library_list_focus_rail`, declared last, was never reached.
+            # Restoring the rail ROW instead left the caret where it was
+            # (the filter box, once this restore resolved the navigator
+            # region) and the next printable key was typed into it: live at
+            # dev 1077ac2dad, `/ read esc n` put "n" back in the filter.
+            #
+            # Delivered as the canvas sync's explicit ``then`` (the shape the
+            # branches above use), NOT ``call_after_refresh``: a canvas
+            # recompose already in flight restores the identity it captured
+            # before the key -- the list row -- and a bare deferred hop lands
+            # BEFORE that restore and is silently undone. ``_restore_then_
+            # explicit`` runs the notes restore first and the explicit
+            # follow-up last, so the hop is what the user is left with.
+            _sync_library_canvas(
+                self, "notes", then=self._screen.action_library_list_focus_rail
+            )
+            return
         identity = LibraryNotesFocusIdentity(
             stage="rail",
             region="navigator",

--- a/tldw_chatbook/UI/Library_Modules/library_notes_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_controller.py
@@ -3009,41 +3009,38 @@ class LibraryNotesController:
             self._sync_library_notes_reader_layout_from_shell(priority="library")
         self._apply_library_notes_stage_visibility()
         self._apply_library_notes_footer_context()
+        # task-32233: from the plain Notes list, converge on the ONE focus-rail
+        # hop `/`, F6 and every sibling list canvas's Escape already use
+        # (`_library_list_focus_rail_target`), because that is what the
+        # footer's "esc focus rail" chip promises.
+        #
+        # This binding is declared FIRST among the screen's many Escape entries
+        # and its gate is True across the whole Notes workflow, so on the list
+        # it is the only path the key ever takes -- `library_list_focus_rail`,
+        # declared last, was never reached. Restoring the rail ROW instead left
+        # the caret where it was (the filter box, once this restore resolved
+        # the navigator region) and the next printable key was typed into it:
+        # live at dev 1077ac2dad, `/ read esc n` put "n" back in the filter.
         if self._screen._library_list_canvas_showing_list():
             rail_target = self._screen._library_list_focus_rail_target().lstrip("#")
             if rail_target and (getattr(self.focused, "id", "") or "") == rail_target:
-                # ...and when the caret is ALREADY standing on the hop's
-                # destination the hop is inert, so the next printable key
-                # would be typed into the rail box -- task-32051's exact
-                # finding, which ``library_blur_text_field`` exists to close
-                # on every other canvas. It never fires here (this binding is
-                # declared first and its gate covers the whole Notes
-                # workflow), so reach the same shared action directly. This
-                # is the one rule the screen's own gate states; it is not
-                # restated anywhere else.
+                # ...except when the caret is ALREADY standing on the hop's
+                # destination: the hop would be inert and the next printable
+                # key typed into the rail box -- task-32051's exact finding,
+                # which `library_blur_text_field` exists to close on every
+                # other canvas and which never fires here for the reason
+                # above. Reach that same shared action directly. This is the
+                # one rule the screen's own gate states; it is not restated
+                # anywhere else.
                 self._screen.action_library_blur_text_field()
                 return
-            # task-32233: from the plain Notes list, converge on the ONE
-            # focus-rail hop `/`, F6 and every sibling list canvas's Escape
-            # already use (`_library_list_focus_rail_target`), because that
-            # is what the footer's "esc focus rail" chip promises.
-            #
-            # This binding is declared FIRST among the screen's many Escape
-            # entries and its gate is True across the whole Notes workflow,
-            # so on the list it is the only path the key ever takes --
-            # `library_list_focus_rail`, declared last, was never reached.
-            # Restoring the rail ROW instead left the caret where it was
-            # (the filter box, once this restore resolved the navigator
-            # region) and the next printable key was typed into it: live at
-            # dev 1077ac2dad, `/ read esc n` put "n" back in the filter.
-            #
-            # Delivered as the canvas sync's explicit ``then`` (the shape the
-            # branches above use), NOT ``call_after_refresh``: a canvas
-            # recompose already in flight restores the identity it captured
-            # before the key -- the list row -- and a bare deferred hop lands
-            # BEFORE that restore and is silently undone. ``_restore_then_
-            # explicit`` runs the notes restore first and the explicit
-            # follow-up last, so the hop is what the user is left with.
+            # Delivered as the canvas sync's explicit `then` (the shape the
+            # branches above use), NOT `call_after_refresh`: a canvas recompose
+            # already in flight restores the identity it captured before the
+            # key -- the list row -- and a bare deferred hop lands BEFORE that
+            # restore and is silently undone. `_restore_then_explicit` runs the
+            # notes restore first and the explicit follow-up last, so the hop
+            # is what the user is left with.
             _sync_library_canvas(
                 self, "notes", then=self._screen.action_library_list_focus_rail
             )

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -972,7 +972,7 @@ class LibraryScreen(BaseAppScreen):
         # mode owning the Notes canvas (``_file_notes_active()``), the same
         # gate the sibling skill-editor binding uses, so it never fires on
         # any other Library surface.
-        ("escape", "library_notes_files_back", "Back to Database notes"),
+        ("escape", "library_notes_files_back", "Back to Library notes"),
         # task-2856: four more "escape" bindings, tried in order after the
         # two above and gated the same way -- each ``check_action`` returns
         # False everywhere outside its own state, so Textual falls through
@@ -1180,7 +1180,7 @@ class LibraryScreen(BaseAppScreen):
     LIBRARY_NOTES_FILES_SHORTCUTS = (
         ("/", "focus search"),
         ("F6", "next pane"),
-        ("esc", "back to Database"),
+        ("esc", "back to Library notes"),
     )
 
     LIBRARY_NOTES_FILES_RELOAD_CONFIRM_SHORTCUTS = (

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1654,10 +1654,18 @@ class LibraryScreen(BaseAppScreen):
         overflow-x: hidden;
     }
 
+    /* task-32217 (Qodo #2590 comment 3): NO sizing here. The build scopes this
+       block to `LibraryScreen #library-note-preview-region`, one type selector
+       more specific than the app sheet's bare id, so the old
+       `height: auto / min-height: 12 / max-height: 20` silently outranked the
+       density rule and Preview stayed capped at 20 rows in a 40-row pane while
+       Edit expanded. `#library-note-body` never had a copy here, which is why
+       only Preview was affected. Deleting the three sizing declarations rather
+       than restating them keeps ONE home for the rule: with the app sheet the
+       bare id applies, and without it (harness tests) `VerticalScroll`'s own
+       `height: 1fr` gives the same shape. Chrome stays -- it is the fallback
+       this block exists for. */
     #library-note-preview-region {
-        height: auto;
-        min-height: 12;
-        max-height: 20;
         margin: 0 0 1 0;
         border: solid $surface-lighten-1;
         overflow-y: auto;

--- a/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
+++ b/tldw_chatbook/Widgets/Library/library_file_notes_workspace.py
@@ -238,14 +238,14 @@ def resolve_file_note_status_channels(
     else:
         path = Path(root)
         folder_name = path.name or path.anchor or str(path)
-        authority_prefix = "Folder Files · Folder:"
+        authority_prefix = "Folder files · Folder:"
         available = 60 - cell_len(authority_prefix + " " + authority_suffix)
         if available > 0:
             root_name = _middle_elide_cells(folder_name, min(14, available))
             root_copy = f"Folder: {root_name}"
         else:
             root_copy = "Folder:…"
-    authority = f"Folder Files · {root_copy}{authority_suffix}"
+    authority = f"Folder files · {root_copy}{authority_suffix}"
     if cell_len(authority) > 60:
         authority = _middle_elide_cells(authority, 60)
     return NotesStatusChannels(content, authority, safe)

--- a/tldw_chatbook/Widgets/Library/library_note_import_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_note_import_canvas.py
@@ -15,6 +15,10 @@ from tldw_chatbook.Library.library_note_import_state import (
     LibraryNoteImportItemSnapshot,
     LibraryNoteImportSnapshot,
 )
+from tldw_chatbook.Library.library_shell_state import (
+    LIBRARY_GLYPH_SELECTED,
+    LIBRARY_GLYPH_UNSELECTED,
+)
 from tldw_chatbook.Notes.note_import_plan_models import (
     NON_IMPORTABLE_CLASSIFICATIONS,
 )
@@ -46,8 +50,15 @@ _NON_IMPORTABLE = frozenset(
 
 
 def _choice_label(*, selected: bool, text: str) -> str:
-    """Return a monochrome-readable selected/unselected action label."""
-    return f"{'✓' if selected else '○'} {text}"
+    """Return a monochrome-readable selected/unselected action label.
+
+    task-32235 AC#2: these are checkboxes, so they take the legend's
+    checkbox pair. They used to render "✓"/"○", which collided with the
+    settled-outcome "✓" one row above them in the same receipt and with the
+    blocked-action "○" on the buttons beside them.
+    """
+    glyph = LIBRARY_GLYPH_SELECTED if selected else LIBRARY_GLYPH_UNSELECTED
+    return f"{glyph} {text}"
 
 
 def _disabled_action_label(text: str, *, disabled: bool) -> str:

--- a/tldw_chatbook/Widgets/Library/library_notes_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_notes_canvas.py
@@ -205,7 +205,14 @@ def _library_note_back_label(compact: bool) -> str:
 #: The storage authority every Database Notes surface answers to. Painted once
 #: per screen: the mounted list pane owns it, and a work pane beside it drops
 #: it rather than repeating the same sentence (task-32063).
-NOTES_AUTHORITY_PREFIX = "Library notes · Library database"
+#:
+#: task-32218: ONE noun for this source. It used to read "Library notes ·
+#: Library database", and three sibling sites said "Database Notes · Library
+#: database" -- five names for two sources across one journey, so the word a
+#: reader clicked in the strip ("Library notes") never reappeared where they
+#: landed. The source strip's own label is the noun; everything else here
+#: quotes it.
+NOTES_AUTHORITY_PREFIX = "Library notes"
 
 #: Every control a reader types a note into. A refresh that would recompose
 #: this canvas while one of them has focus is deferred instead (task-32062).
@@ -273,7 +280,7 @@ def resolve_database_note_status_channels(
         content, safe = "Unsaved changes", None
     else:
         content, safe = "Saved", None
-    return NotesStatusChannels(content, "Database Notes · Library database", safe)
+    return NotesStatusChannels(content, NOTES_AUTHORITY_PREFIX, safe)
 
 
 @dataclass(frozen=True)
@@ -1715,7 +1722,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         status_line = presentation_state.status_line
         channels = presentation_state.status_channels or NotesStatusChannels(
             status_line or "Saved",
-            "Database Notes · Library database",
+            NOTES_AUTHORITY_PREFIX,
         )
 
         # File-synced notes may carry YAML front matter; consume it instead
@@ -2255,7 +2262,7 @@ class LibraryNotesCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             preview_body.update(snapshot.body)
         channels = state.status_channels or NotesStatusChannels(
             state.status_line or "Saved",
-            "Database Notes · Library database",
+            NOTES_AUTHORITY_PREFIX,
         )
         content_copy = channels.content_recovery
         if channels.safe_next_action:

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -2890,26 +2890,28 @@ with stray left-edge border fragments), and padding 0 1 so the full
     text-style: bold;
 }
 
-/* Bounded editor: a bare TextArea in this scrolling canvas defaults to
-   height:1fr, which would balloon to fill available space and crowd out
-   the keywords/meta/action row beneath it. height:auto with a floor and a
-   generous ceiling keeps short notes compact while long notes scroll
-   inside the field itself instead of pushing the rest of the editor off
-   screen. */
+/* task-32217 (critique #9 density rule): the Body is the primary content
+   box of this pane and takes the pane. The old ceiling (`height: auto`,
+   `max-height: 20`) was written when the keywords, meta line and action
+   row still sat BELOW the TextArea and it had to leave them room; they
+   moved into the Info region, so `#library-note-editor-region` ends at
+   this field and the ceiling only bought blank pane. Measured live at
+   235x52 on the seeded profile: a 3-line note got a 12-row box with 18
+   empty rows under it, and the compact stage had already been given
+   `1fr` for the same reason (see the `.library-notes-compact` rules). */
 #library-note-body {
-    height: auto;
-    min-height: 12;
-    max-height: 20;
+    height: 1fr;
+    min-height: 6;
     margin: 0 0 1 0;
 }
 
-/* The read-only Markdown preview takes the TextArea's place one-for-one.
-   The focusable wrapper is its sole scroll owner; Markdown grows naturally
-   inside it so keyboard paging can reach the complete document. */
+/* The read-only Markdown preview takes the TextArea's place one-for-one,
+   so it takes the same height. The focusable wrapper is its sole scroll
+   owner; Markdown grows naturally inside it so keyboard paging can reach
+   the complete document. */
 #library-note-preview-region {
-    height: auto;
-    min-height: 12;
-    max-height: 20;
+    height: 1fr;
+    min-height: 6;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;
     overflow-y: auto;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -1721,26 +1721,28 @@ with stray left-edge border fragments), and padding 0 1 so the full
     text-style: bold;
 }
 
-/* Bounded editor: a bare TextArea in this scrolling canvas defaults to
-   height:1fr, which would balloon to fill available space and crowd out
-   the keywords/meta/action row beneath it. height:auto with a floor and a
-   generous ceiling keeps short notes compact while long notes scroll
-   inside the field itself instead of pushing the rest of the editor off
-   screen. */
+/* task-32217 (critique #9 density rule): the Body is the primary content
+   box of this pane and takes the pane. The old ceiling (`height: auto`,
+   `max-height: 20`) was written when the keywords, meta line and action
+   row still sat BELOW the TextArea and it had to leave them room; they
+   moved into the Info region, so `#library-note-editor-region` ends at
+   this field and the ceiling only bought blank pane. Measured live at
+   235x52 on the seeded profile: a 3-line note got a 12-row box with 18
+   empty rows under it, and the compact stage had already been given
+   `1fr` for the same reason (see the `.library-notes-compact` rules). */
 #library-note-body {
-    height: auto;
-    min-height: 12;
-    max-height: 20;
+    height: 1fr;
+    min-height: 6;
     margin: 0 0 1 0;
 }
 
-/* The read-only Markdown preview takes the TextArea's place one-for-one.
-   The focusable wrapper is its sole scroll owner; Markdown grows naturally
-   inside it so keyboard paging can reach the complete document. */
+/* The read-only Markdown preview takes the TextArea's place one-for-one,
+   so it takes the same height. The focusable wrapper is its sole scroll
+   owner; Markdown grows naturally inside it so keyboard paging can reach
+   the complete document. */
 #library-note-preview-region {
-    height: auto;
-    min-height: 12;
-    max-height: 20;
+    height: 1fr;
+    min-height: 6;
     margin: 0 0 1 0;
     border: solid $ds-grid-line;
     overflow-y: auto;

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -1196,10 +1196,18 @@
         overflow-x: hidden;
     }
 
+    /* task-32217 (Qodo #2590 comment 3): NO sizing here. The build scopes this
+       block to `LibraryScreen #library-note-preview-region`, one type selector
+       more specific than the app sheet's bare id, so the old
+       `height: auto / min-height: 12 / max-height: 20` silently outranked the
+       density rule and Preview stayed capped at 20 rows in a 40-row pane while
+       Edit expanded. `#library-note-body` never had a copy here, which is why
+       only Preview was affected. Deleting the three sizing declarations rather
+       than restating them keeps ONE home for the rule: with the app sheet the
+       bare id applies, and without it (harness tests) `VerticalScroll`'s own
+       `height: 1fr` gives the same shape. Chrome stays -- it is the fallback
+       this block exists for. */
     LibraryScreen #library-note-preview-region {
-        height: auto;
-        min-height: 12;
-        max-height: 20;
         margin: 0 0 1 0;
         border: solid $surface-lighten-1;
         overflow-y: auto;

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -899,6 +899,17 @@
 
 
 
+    /* task-32217 (Qodo #2590 comment 3): NO sizing here. The build scopes this
+       block to `LibraryScreen #library-note-preview-region`, one type selector
+       more specific than the app sheet's bare id, so the old
+       `height: auto / min-height: 12 / max-height: 20` silently outranked the
+       density rule and Preview stayed capped at 20 rows in a 40-row pane while
+       Edit expanded. `#library-note-body` never had a copy here, which is why
+       only Preview was affected. Deleting the three sizing declarations rather
+       than restating them keeps ONE home for the rule: with the app sheet the
+       bare id applies, and without it (harness tests) `VerticalScroll`'s own
+       `height: 1fr` gives the same shape. Chrome stays -- it is the fallback
+       this block exists for. */
 
 
 


### PR DESCRIPTION
Part of the Library critique-9 fix wave (plan: `Docs/superpowers/plans/2026-09-10-library-crit9-wave.md`, group `notes`). Held until the peer session's Notes program landed (#2543 … #2565); branched from and re-merged with that final code.

## What
- **task-32233** — Escape on every Notes surface goes where the footer says: from the filter box to the rail Search box, a second Escape to the canvas (the Media contract, task-32051); on the plain list Escape reaches the rail. Root cause was not the plan's: `library_notes_escape` is declared first with gate `visible_notes`, so the blur/focus-rail bindings were never consulted; the fix lives in `action_library_notes_escape`'s tail. Pinned (both layouts) in `Tests/UI/test_library_crit8_keyboard.py` beside the Media pins.
- **task-32215** — no product code: Sort is composed unconditionally since #2558 and the folder verbs are gated by the folder-tree mode; both verified live and pinned (presence + gating; no absence pin).
- **task-32218** — one noun per Notes source ("Library notes" / "Folder files"); the rail row deliberately stays "Notes (N)" as the section name (recorded in the task). The rename is finished in its own test suite and the guide.
- **Hand-off task-32235 AC#2** — the note-import review's choices use the shared selection glyphs (`☑/☐`) from `library_shell_state.py`.
- **Hand-off task-32217 (note-editor half)** — the note editor Body takes the pane it is given, same grammar as the media reader (#2583); actions sit above the Body so nothing can be stranded.

## Evidence
- `Tests/UI/test_library_crit9_notes.py` (new, red-first) + pins in `test_library_crit8_keyboard.py`, `test_library_notes_canvas.py`, `test_library_note_import_canvas.py`; whole-file A/B against dev on every touched file (identical failing-name sets where dev is red: `test_library_file_notes_workspace.py` 8/152 both sides, `test_library_notes_reader.py` 4/30 both sides).
- Live-verified on an isolated seeded profile at 235x52 and 100x30.
- Guide `Docs/User_Guide/library/notes.md` (all stamps kept).

## Review
Task review (Changes requested: 1 blocker — six stale `Folder Files` assertions — 2 Medium, 3 Low, 1 Info) → fix round 1 (`812ecbfd92`; two Lows declined with evidence, recorded as a rider paragraph in task-32218: Settings still says "Folder Files tree" in three files). Scoped re-review in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Part of the Library critique-9 notes wave: Escape on Notes now actually goes where the footer says, each Notes source has one name, and three visual details match shared conventions.

**Bug Fixes**
- Escape in the Notes filter box and on the plain list now goes to the rail Search box, then to the canvas, matching Media; previously it cleared the filter value, kept the caret, and swallowed keys.
- The root cause was `library_notes_escape` being declared before the shared blur and focus-rail bindings, whose gates never fired on this canvas.
- The note editor Body and its Markdown preview now fill their pane instead of stopping at 20 rows. Preview stayed capped after the Body fix because the bundled scoped CSS copy outranked the density rule; its sizing declarations were removed so the rule has one home.
- The three placement verbs only appear when a row is selected; Sort's presence on populated lists was verified live and pinned with no code change.

**Refactors**
- Notes sources now have one noun each: "Library notes" and "Folder files"; "Library database", "Database Notes", and "Folder Files" are retired as user-visible names, while the rail row stays "Notes (N)" as the section name.
- The note-import review's choices now use the shared ☑/☐ selection glyphs instead of ✓/○, which collided with their settled-outcome and blocked-action meanings in the same receipt.
- Settings still labels the pane "Folder Files tree" in three files; left for a follow-up as it is outside this branch's ownership.

<sup>Written for commit 918d47a68e690f4441ff604629ad3c7b510d2c69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2590?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

