### PR TITLE
feat(console): edit displayable thinking block text in place (TASK-32312)

### DIFF
--- a/Docs/User_Guide/console/chat-basics.md
+++ b/Docs/User_Guide/console/chat-basics.md
@@ -304,6 +304,13 @@ to hidden chain-of-thought.
   by the adapter. Proprietary evidence is text-free and appears as
   **Thinking · unavailable**; expanding it shows exactly
   `Proprietary thinking obfuscated - not available`.
+- Select a displayable Thinking row and press **e** to edit its text in place.
+  The answer, block identity, provenance, and replay encoding stay intact.
+  Blank edits are rejected, and text containing `<think>`/`</think>` tags is
+  rejected for start-anchored blocks so replay serialization stays safe.
+  Edited thinking stays replay-eligible under the same replay policy.
+  Proprietary (**unavailable**) rows cannot be edited, and editing the answer
+  itself still clears the turn's thinking.
 - A new live disclosure opens when its first evidence arrives, then
   auto-collapses once at the first visible answer or tool event. If neither
   occurs, the terminal state is the fallback boundary. Expanding or collapsing
@@ -390,7 +397,7 @@ also appears there when an original attempt can be shown safely.
 |---|---|---|
 | Copy | Copies the message body to the clipboard. | All messages |
 | 🔊 / ⏹ | Speaks the reply aloud; playback starts automatically, and while it plays the button becomes ⏹ to stop ("Stopped speaking."). Text-to-speech provider setup lives in Settings. | Completed assistant replies |
-| Edit | Opens the "Edit Message" editor; editing one of your own messages can also fork and resend — see [branching & rewind](branching-and-rewind.md). | All messages |
+| Edit | Opens the "Edit Message" editor; editing one of your own messages can also fork and resend — see [branching & rewind](branching-and-rewind.md). On a selected displayable **Thinking** row, **e** opens the "Edit Thinking" editor for that block's text — see [model thinking disclosures](#model-thinking-disclosures). | All messages |
 | < > | Step between regenerated variants — see [branching & rewind](branching-and-rewind.md). | Messages with variants |
 | Fork | Opens a focused naming dialog, then creates a new independent chat containing the active conversation path through this message, inclusive. Press **f** for the same action — see [branching & rewind](branching-and-rewind.md). | Stable User and Assistant messages |
 | ♻ | Regenerate — fork another assistant variant for this turn; the old answer is kept, not overwritten — see [branching & rewind](branching-and-rewind.md). | Assistant replies |

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -344,8 +344,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 86,
-      "diagnostic_digest": "47ce61f1133ed06c9ece",
+      "call_count": 87,
+      "diagnostic_digest": "b01c4cdca44176b29894",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -11518,7 +11518,7 @@
     "path_privacy_candidate_calls": 709,
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
-    "task_492_calls": 1385,
+    "task_492_calls": 1386,
     "task_494_calls": 7700
   }
 }

--- a/Tests/Chat/test_console_edit_message_modal.py
+++ b/Tests/Chat/test_console_edit_message_modal.py
@@ -17,6 +17,8 @@ from textual.widgets import Button, Static, TextArea
 from tldw_chatbook.Widgets.Console.console_edit_message_modal import (
     ConsoleEditMessageModal,
     ConsoleEditResult,
+    ConsoleEditThinkingModal,
+    ConsoleThinkingEditResult,
 )
 
 
@@ -666,3 +668,87 @@ async def test_context_copy_mentions_resend_only_when_can_resend():
         )
         assert "Edit & resend" not in context_plain
         assert "will not create a new prompt" in context_plain
+
+
+# --- ConsoleEditThinkingModal (TASK-32312): block-scoped thinking text edit ---
+
+
+def test_thinking_edit_result_dataclass_shape():
+    r = ConsoleThinkingEditResult(text="cleaned")
+    assert r.text == "cleaned"
+
+
+def test_thinking_edit_result_is_frozen():
+    r = ConsoleThinkingEditResult(text="cleaned")
+    with pytest.raises(Exception):
+        r.text = "changed"  # type: ignore[misc]
+
+
+@pytest.mark.asyncio
+async def test_thinking_modal_prefills_text_and_names_the_block_scope():
+    app = _ModalHost()
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditThinkingModal(text="original reasoning")
+        app.push_screen(modal)
+        await pilot.pause()
+        editor = modal.query_one("#console-edit-thinking-body", TextArea)
+        assert editor.text == "original reasoning"
+        context = _static_plain_text(
+            modal.query_one("#console-edit-thinking-context", Static)
+        )
+        assert "thinking" in context.lower()
+        assert len(modal.query("#console-edit-thinking-resend")) == 0
+
+
+@pytest.mark.asyncio
+async def test_thinking_modal_save_dismisses_result_with_text():
+    app = _ModalHost()
+    result: list[ConsoleThinkingEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditThinkingModal(text="orig")
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-thinking-body", TextArea)
+        editor.text = "cleaned reasoning"
+        await pilot.click("#console-edit-thinking-save")
+        await pilot.pause()
+
+    assert result == [ConsoleThinkingEditResult(text="cleaned reasoning")]
+
+
+@pytest.mark.asyncio
+async def test_thinking_modal_blank_save_blocked_inline():
+    app = _ModalHost()
+    result: list[ConsoleThinkingEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditThinkingModal(text="orig")
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-thinking-body", TextArea)
+        editor.text = "   "
+        await pilot.click("#console-edit-thinking-save")
+        await pilot.pause()
+
+        assert result == []
+        error = modal.query_one("#console-edit-thinking-error", Static)
+        assert "cannot be blank" in _static_plain_text(error).lower()
+
+
+@pytest.mark.asyncio
+async def test_thinking_modal_cancel_dismisses_none():
+    app = _ModalHost()
+    result: list[ConsoleThinkingEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditThinkingModal(text="orig")
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        await pilot.click("#console-edit-thinking-cancel")
+        await pilot.pause()
+
+    assert result == [None]

--- a/Tests/Chat/test_console_edit_message_modal.py
+++ b/Tests/Chat/test_console_edit_message_modal.py
@@ -752,3 +752,25 @@ async def test_thinking_modal_cancel_dismisses_none():
         await pilot.pause()
 
     assert result == [None]
+
+
+@pytest.mark.asyncio
+async def test_thinking_modal_oversized_save_blocked_inline():
+    from tldw_chatbook.Chat.thinking_blocks import MAX_THINKING_TEXT_BYTES
+
+    app = _ModalHost()
+    result: list[ConsoleThinkingEditResult | None] = []
+
+    async with app.run_test(size=(120, 40)) as pilot:
+        modal = ConsoleEditThinkingModal(text="orig")
+        await app.push_screen(modal, callback=result.append)
+        await pilot.pause()
+
+        editor = modal.query_one("#console-edit-thinking-body", TextArea)
+        editor.text = "x" * (MAX_THINKING_TEXT_BYTES + 1)
+        await pilot.click("#console-edit-thinking-save")
+        await pilot.pause()
+
+        assert result == []
+        error = modal.query_one("#console-edit-thinking-error", Static)
+        assert "too large" in _static_plain_text(error).lower()

--- a/Tests/Chat/test_console_thinking_history.py
+++ b/Tests/Chat/test_console_thinking_history.py
@@ -409,3 +409,31 @@ async def test_gateway_shared_raw_owner_marker_attaches_continuation_and_thinkin
     assert repr(prepared.messages_payload).count("SHARED-OWNER-CANARY") == 1
     assert [item async for item in gateway.stream_chat(resolution, prepared)] == ["ok"]
     assert repr(dispatched[0]["messages_payload"]).count("SHARED-OWNER-CANARY") == 1
+
+
+def test_user_edited_block_text_replays_in_original_encoding() -> None:
+    # ADR-090 amendment (TASK-32312): editing a displayable block's text keeps
+    # it replay-eligible, serialized in its original source encoding.
+    resolved = resolve_thinking_history(
+        target=_target(),
+        policy="include",
+        sidecars=(_sidecar(_displayable("USER-CLEANED-REASONING")),),
+    )
+
+    assert [block.text for block in resolved.groups[0].blocks] == [
+        "USER-CLEANED-REASONING"
+    ]
+    assert resolved.groups[0].blocks[0].source_format == "start_anchored_think"
+
+
+def test_user_edited_block_text_with_think_tags_is_skipped_under_auto() -> None:
+    # Edited text that is unsafe for the block's encoding is skipped under
+    # Auto exactly like unsafe captured text (the store rejects this edit
+    # shape up front; this pins the resolution-side guard).
+    resolved = resolve_thinking_history(
+        target=_target(),
+        policy=None,
+        sidecars=(_sidecar(_displayable("cleaned <think>bad</think>")),),
+    )
+
+    assert resolved.groups == ()

--- a/Tests/Chat/test_console_thinking_persistence.py
+++ b/Tests/Chat/test_console_thinking_persistence.py
@@ -1295,3 +1295,63 @@ def test_edit_thinking_block_rejects_oversized_text() -> None:
         store.update_message_thinking_block(
             message_id, "reasoning-1", "x" * (MAX_THINKING_TEXT_BYTES + 1)
         )
+
+
+def test_edit_thinking_block_rejects_stale_expected_text() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+
+    with pytest.raises(ValueError, match="changed while editing"):
+        store.update_message_thinking_block(
+            message_id,
+            "reasoning-1",
+            "cleaned reasoning",
+            expected_text="stale prefill text",
+        )
+
+    unchanged = store.get_message(message_id)
+    assert unchanged.thinking is not None
+    assert unchanged.thinking.blocks[0].text == "reasoning"
+
+
+def test_edit_thinking_block_accepts_matching_expected_text() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+
+    edited = store.update_message_thinking_block(
+        message_id,
+        "reasoning-1",
+        "cleaned reasoning",
+        expected_text="reasoning",
+    )
+
+    assert edited.thinking is not None
+    assert edited.thinking.blocks[0].text == "cleaned reasoning"
+
+
+def test_thinking_edit_reconcile_records_sync_version_hash(tmp_path: Path) -> None:
+    db, conversation_id, repository = _database(tmp_path / "edit-sync-hash.sqlite")
+    _insert(db, repository, _acceptance(conversation_id))
+    canonical = dump_thinking_blocks_json(_thinking("old reasoning"))
+    _raw_semantic_corruption(
+        db,
+        "UPDATE messages SET content = 'old answer', thinking_blocks_json = ?, "
+        "assistant_generation_state = 'complete' WHERE id = 'assistant-1'",
+        (canonical,),
+    )
+    store, _session_id = _restored_store(db, conversation_id)
+
+    class _ReconcileProducer:
+        source = db
+
+        def reconcile_chat_message_intent(self, **_kwargs: object) -> dict[str, object]:
+            return {
+                "status": "enqueued",
+                "outbox_entry": {"envelope": {"payload_hash": "hash-after-edit"}},
+            }
+
+    store.sync_v2_server_profile_id = "server-a"
+    store.sync_v2_chat_producer = _ReconcileProducer()
+
+    store.update_message_thinking_block("assistant-1", "reasoning-1", "cleaned")
+
+    stable_key = f"{conversation_id}:assistant-1"
+    assert store._sync_v2_message_versions.get(stable_key) == "hash-after-edit"

--- a/Tests/Chat/test_console_thinking_persistence.py
+++ b/Tests/Chat/test_console_thinking_persistence.py
@@ -23,8 +23,11 @@ from tldw_chatbook.Chat.console_chat_store import (
 )
 from tldw_chatbook.Chat.message_metadata import MessageMetadata
 from tldw_chatbook.Chat.thinking_blocks import (
+    MAX_THINKING_TEXT_BYTES,
     DisplayableThinkingBlock,
+    ProprietaryThinkingBlock,
     ThinkingEnvelope,
+    ThinkingEnvelopeValidationError,
     dump_thinking_blocks_json,
     parse_thinking_blocks_json,
 )
@@ -1105,3 +1108,190 @@ def test_configured_sync_without_committed_source_fails_before_non_db_write(
     assert persistence.projections == []
     after = store._generation_variant(store._message_or_raise("assistant-1"))
     assert replace(after, id=before.id) == before
+
+
+def _memory_thinking_store(
+    envelope: ThinkingEnvelope | None = None,
+) -> tuple[ConsoleChatStore, str]:
+    store = ConsoleChatStore()
+    session = store.create_session(title="thinking-edit")
+    message = store.append_message(
+        session.id, role=ConsoleMessageRole.ASSISTANT, content="the answer"
+    )
+    if envelope is not None:
+        store.replace_message_thinking(message.id, envelope)
+    return store, message.id
+
+
+def test_edit_thinking_block_updates_text_and_persists_projection(
+    tmp_path: Path,
+) -> None:
+    db, conversation_id, repository = _database(tmp_path / "edit-thinking.sqlite")
+    _insert(db, repository, _acceptance(conversation_id))
+    canonical = dump_thinking_blocks_json(_thinking("old reasoning"))
+    _raw_semantic_corruption(
+        db,
+        "UPDATE messages SET content = 'old answer', thinking_blocks_json = ?, "
+        "assistant_generation_state = 'complete' WHERE id = 'assistant-1'",
+        (canonical,),
+    )
+    store, _session_id = _restored_store(db, conversation_id)
+
+    edited = store.update_message_thinking_block(
+        "assistant-1", "reasoning-1", "cleaned reasoning"
+    )
+    row = db.get_message_by_id("assistant-1")
+
+    assert edited.content == "old answer"
+    assert edited.thinking is not None
+    assert edited.thinking.blocks[0].text == "cleaned reasoning"
+    assert edited.thinking.blocks[0].block_id == "reasoning-1"
+    assert edited.thinking.blocks[0].source_format == "think_tag"
+    assert row["content"] == "old answer"
+    assert row["thinking_blocks_json"] == dump_thinking_blocks_json(edited.thinking)
+
+
+def test_edit_thinking_block_updates_selected_variant_envelope(tmp_path: Path) -> None:
+    db, conversation_id, repository = _database(tmp_path / "edit-variant.sqlite")
+    _insert(db, repository, _acceptance(conversation_id))
+    store, _session_id = _restored_store(db, conversation_id)
+    live = _install_thinking_variant(store)
+    assert live.variants is not None
+    content_before = live.content
+
+    edited = store.update_message_thinking_block(
+        "assistant-1", "reasoning-1", "cleaned reasoning"
+    )
+    message = store.get_message("assistant-1")
+
+    assert message.variants is not None
+    assert message.variants.selected_index == 0
+    selected = message.variants.variants[0]
+    assert selected.thinking is not None
+    assert selected.thinking.blocks[0].text == "cleaned reasoning"
+    other = message.variants.variants[1]
+    assert other.thinking is not None
+    assert other.thinking.blocks[0].text == "non-database reasoning"
+    assert edited.thinking is not None
+    assert edited.thinking.blocks[0].text == "cleaned reasoning"
+    assert message.content == content_before
+
+
+def test_edit_thinking_block_rejects_blank_text() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+
+    with pytest.raises(ValueError, match="blank"):
+        store.update_message_thinking_block(message_id, "reasoning-1", "   ")
+
+
+def test_edit_thinking_block_rejects_unknown_block() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+
+    with pytest.raises(ValueError, match="Unknown thinking block"):
+        store.update_message_thinking_block(message_id, "missing-1", "new text")
+
+    unchanged = store.get_message(message_id)
+    assert unchanged.thinking is not None
+    assert unchanged.thinking.blocks[0].text == "reasoning"
+
+
+def test_edit_thinking_block_rejects_owner_without_thinking() -> None:
+    store, message_id = _memory_thinking_store(None)
+
+    with pytest.raises(ValueError, match="no thinking"):
+        store.update_message_thinking_block(message_id, "reasoning-1", "new text")
+
+
+def test_edit_thinking_block_rejects_proprietary_block() -> None:
+    envelope = ThinkingEnvelope(
+        (
+            DisplayableThinkingBlock(
+                block_id="reasoning-1",
+                round_ordinal=0,
+                provider="llama_cpp",
+                model="test-model",
+                protocol="chat_completions",
+                source_format="think_tag",
+                status="complete",
+                text="visible reasoning",
+            ),
+            ProprietaryThinkingBlock(
+                block_id="private-1",
+                round_ordinal=1,
+                provider="moonshot",
+                model="kimi-k3",
+                protocol="chat_completions",
+                source_format="preserved_reasoning",
+                status="complete",
+            ),
+        )
+    )
+    store, message_id = _memory_thinking_store(envelope)
+
+    with pytest.raises(ValueError, match="Proprietary thinking"):
+        store.update_message_thinking_block(message_id, "private-1", "leaked text")
+
+    unchanged = store.get_message(message_id)
+    assert isinstance(unchanged.thinking.blocks[1], ProprietaryThinkingBlock)
+
+
+def test_edit_thinking_block_rejects_start_anchored_token_injection() -> None:
+    envelope = ThinkingEnvelope(
+        (
+            DisplayableThinkingBlock(
+                block_id="reasoning-1",
+                round_ordinal=0,
+                provider="llama_cpp",
+                model="test-model",
+                protocol="chat_completions",
+                source_format="start_anchored_think",
+                status="complete",
+                text="honest reasoning",
+            ),
+        )
+    )
+    store, message_id = _memory_thinking_store(envelope)
+
+    with pytest.raises(ValueError, match="think"):
+        store.update_message_thinking_block(
+            message_id, "reasoning-1", "cleaned <think>injected</think>"
+        )
+
+    unchanged = store.get_message(message_id)
+    assert unchanged.thinking.blocks[0].text == "honest reasoning"
+
+
+def test_edit_thinking_block_rejects_streaming_owner() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+    store._message_or_raise(message_id).status = "streaming"
+
+    with pytest.raises(ValueError, match="finish"):
+        store.update_message_thinking_block(message_id, "reasoning-1", "new text")
+
+
+def test_edit_thinking_block_rejects_disabled_generation_actions() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+    store._message_or_raise(message_id).thinking_actions_enabled = False
+
+    with pytest.raises(ConsoleThinkingCompatibilityError):
+        store.update_message_thinking_block(message_id, "reasoning-1", "new text")
+
+
+def test_edit_thinking_block_rejects_non_assistant_owner() -> None:
+    store = ConsoleChatStore()
+    session = store.create_session(title="user-row")
+    user = store.append_message(
+        session.id, role=ConsoleMessageRole.USER, content="hello"
+    )
+
+    with pytest.raises(ValueError, match="assistant"):
+        store.update_message_thinking_block(user.id, "reasoning-1", "new text")
+
+
+def test_edit_thinking_block_rejects_oversized_text() -> None:
+    store, message_id = _memory_thinking_store(_thinking("reasoning"))
+
+    with pytest.raises(ThinkingEnvelopeValidationError):
+        store.update_message_thinking_block(
+            message_id, "reasoning-1", "x" * (MAX_THINKING_TEXT_BYTES + 1)
+        )

--- a/Tests/UI/test_console_native_transcript.py
+++ b/Tests/UI/test_console_native_transcript.py
@@ -16,6 +16,7 @@ from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     _visible_text,
 )
 from tldw_chatbook.Chat.console_chat_models import (
+    PROPRIETARY_THINKING_NOTICE,
     ConsoleActivityPresentation,
     ConsoleChatMessage,
     ConsoleCitationNoticeCode,
@@ -4283,3 +4284,33 @@ def test_console_transcript_empty_state_is_centered_in_stylesheets():
         assert "align: center middle" in panel_rule, css_path
         body_rule = css.split(".console-transcript-empty-body {", 1)[1].split("}", 1)[0]
         assert "text-align: center" in body_rule, css_path
+
+
+def test_console_thinking_row_edit_action_gated_by_displayability():
+    service = ConsoleMessageActionService()
+    displayable_row = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content="visible reasoning",
+        id="thinking-displayable",
+        activity_presentation=ConsoleActivityPresentation(
+            "thinking", "Thinking", "done"
+        ),
+    )
+    proprietary_row = ConsoleChatMessage(
+        role=ConsoleMessageRole.TOOL,
+        content=PROPRIETARY_THINKING_NOTICE,
+        id="thinking-proprietary",
+        activity_presentation=ConsoleActivityPresentation(
+            "thinking", "Thinking", "unavailable"
+        ),
+    )
+
+    displayable_ids = [
+        action.action_id for action in service.available_actions(displayable_row)
+    ]
+    proprietary_ids = [
+        action.action_id for action in service.available_actions(proprietary_row)
+    ]
+
+    assert "edit" in displayable_ids
+    assert "edit" not in proprietary_ids

--- a/Tests/UI/test_console_thinking_disclosures.py
+++ b/Tests/UI/test_console_thinking_disclosures.py
@@ -665,3 +665,24 @@ async def test_editable_block_returns_none_for_proprietary() -> None:
         disclosure = _disclosure(transcript, proprietary_owner)
 
         assert transcript.thinking_editable_block(disclosure.activity_message_id) is None
+
+
+@pytest.mark.asyncio
+async def test_editable_block_refuses_streaming_owner() -> None:
+    app = ThinkingTranscriptHarness()
+    streaming = _assistant(
+        content="",
+        status="streaming",
+        blocks=(_displayable("partial live thinking"),),
+    )
+
+    async with app.run_test(size=(100, 28)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([streaming], session_id="session-a")
+        await transcript.refresh_messages()
+        disclosure = _disclosure(transcript, streaming)
+
+        # A live disclosure must not open the edit modal with partial text
+        # (TASK-32312 review: saving a stale live prefill after completion
+        # would truncate the finished reasoning).
+        assert transcript.thinking_editable_block(disclosure.activity_message_id) is None

--- a/Tests/UI/test_console_thinking_disclosures.py
+++ b/Tests/UI/test_console_thinking_disclosures.py
@@ -623,3 +623,45 @@ def test_session_switch_prunes_thinking_owner_state_and_tool_expansion_survives_
     assert thinking_id not in transcript._thinking_activity_refs
     assert not transcript._pending_thinking_auto_collapse
     assert not transcript._manual_thinking_disclosures
+
+
+@pytest.mark.asyncio
+async def test_editable_block_resolves_owner_block_and_text() -> None:
+    app = ThinkingTranscriptHarness()
+    historical = _assistant(
+        content="Answer",
+        status="complete",
+        blocks=(_displayable("full historical thinking"),),
+    )
+
+    async with app.run_test(size=(100, 28)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([historical], session_id="session-a")
+        await transcript.refresh_messages()
+        disclosure = _disclosure(transcript, historical)
+
+        resolved = transcript.thinking_editable_block(disclosure.activity_message_id)
+
+        assert resolved == (
+            historical.id,
+            "thinking-block-0",
+            "full historical thinking",
+        )
+
+
+@pytest.mark.asyncio
+async def test_editable_block_returns_none_for_proprietary() -> None:
+    app = ThinkingTranscriptHarness()
+    proprietary_owner = _assistant(
+        content="Answer",
+        status="complete",
+        blocks=(_proprietary(),),
+    )
+
+    async with app.run_test(size=(100, 28)) as pilot:
+        transcript = app.query_one(ConsoleTranscript)
+        transcript.set_messages([proprietary_owner], session_id="session-a")
+        await transcript.refresh_messages()
+        disclosure = _disclosure(transcript, proprietary_owner)
+
+        assert transcript.thinking_editable_block(disclosure.activity_message_id) is None

--- a/Tests/UI/test_console_thinking_edit_wiring.py
+++ b/Tests/UI/test_console_thinking_edit_wiring.py
@@ -7,6 +7,8 @@ saving must route through ``store.update_message_thinking_block`` so the
 answer content and the generation envelope stay one owner group.
 """
 
+from types import SimpleNamespace
+
 import pytest
 from textual.widgets import TextArea
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
@@ -143,4 +145,80 @@ async def test_thinking_only_edit_changes_transcript_fingerprint():
         assert (
             console._native_console_transcript_fingerprint([after])
             != fingerprint_before
+        )
+
+
+@pytest.mark.asyncio
+async def test_saved_thinking_edit_repaints_mounted_disclosure_row():
+    """End-to-end repaint check (Qodo #3): after saving a block-text edit,
+    the mounted disclosure row's rendered text must show the edited text."""
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        assistant = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="the answer"
+        )
+        store.replace_message_thinking(
+            assistant.id, _reasoning_envelope("original reasoning")
+        )
+        await console._sync_native_console_chat_ui()
+
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        activity_id = next(iter(transcript._thinking_activity_refs))
+        assert transcript.thinking_detail_text(activity_id) == "original reasoning"
+
+        # The production path: modal -> save -> controller schedules the
+        # same console-sync worker the screen uses after an edit.
+        await console._message._open_console_thinking_edit_modal(
+            owner_message_id=assistant.id,
+            block_id="reasoning-1",
+            text="original reasoning",
+        )
+        await _wait_until(
+            lambda: any(
+                isinstance(s, ConsoleEditThinkingModal)
+                for s in console.app.screen_stack
+            ),
+            pilot,
+        )
+        modal = next(
+            s
+            for s in reversed(console.app.screen_stack)
+            if isinstance(s, ConsoleEditThinkingModal)
+        )
+        from textual.widgets import TextArea
+
+        editor = modal.query_one("#console-edit-thinking-body", TextArea)
+        editor.text = "cleaned reasoning"
+        await pilot.pause()
+        await pilot.click("#console-edit-thinking-save")
+        await pilot.pause()
+
+        await _wait_until(
+            lambda: transcript.thinking_detail_text(activity_id)
+            == "cleaned reasoning",
+            pilot,
+        )
+        # The MOUNTED row's visible text (not just the display model):
+        from tldw_chatbook.Widgets.Console.console_assistant_turn import (
+            ConsoleActivityDisclosure,
+        )
+
+        disclosure = transcript.query_one(
+            f"#console-activity-disclosure-{activity_id}",
+            ConsoleActivityDisclosure,
+        )
+        disclosure.header.on_click(SimpleNamespace(stop=lambda: None))
+        await pilot.pause()
+        await _wait_until(
+            lambda: any(
+                "cleaned reasoning" in (w.renderable if isinstance(w.renderable, str) else str(getattr(w.renderable, "plain", "")))
+                for w in disclosure.detail_stack.children
+            ),
+            pilot,
         )

--- a/Tests/UI/test_console_thinking_edit_wiring.py
+++ b/Tests/UI/test_console_thinking_edit_wiring.py
@@ -9,12 +9,10 @@ answer content and the generation envelope stay one owner group.
 
 import pytest
 from textual.widgets import TextArea
-
 from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
 from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
     ConsoleHarness,
 )
-
 from tldw_chatbook.Chat.console_chat_models import (
     PROPRIETARY_THINKING_NOTICE,
     ConsoleMessageRole,
@@ -115,3 +113,34 @@ async def test_thinking_row_edit_opens_modal_and_saves_block_text():
         assert edited.content == "the answer"
         assert edited.thinking is not None
         assert edited.thinking.blocks[0].block_id == "reasoning-1"
+
+
+@pytest.mark.asyncio
+async def test_thinking_only_edit_changes_transcript_fingerprint():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        assistant = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="the answer"
+        )
+        store.replace_message_thinking(
+            assistant.id, _reasoning_envelope("original reasoning")
+        )
+
+        before = store.get_message(assistant.id)
+        fingerprint_before = console._native_console_transcript_fingerprint([before])
+
+        store.update_message_thinking_block(
+            assistant.id, "reasoning-1", "cleaned reasoning"
+        )
+        after = store.get_message(assistant.id)
+
+        assert (
+            console._native_console_transcript_fingerprint([after])
+            != fingerprint_before
+        )

--- a/Tests/UI/test_console_thinking_edit_wiring.py
+++ b/Tests/UI/test_console_thinking_edit_wiring.py
@@ -1,0 +1,117 @@
+"""Screen wiring for editing displayable thinking block text (TASK-32312).
+
+The thinking disclosure row's Edit action must open the block-scoped
+``ConsoleEditThinkingModal`` (not the message edit modal, and not the dead
+store lookup that treated the display-only activity id as a tree node), and
+saving must route through ``store.update_message_thinking_block`` so the
+answer content and the generation envelope stay one owner group.
+"""
+
+import pytest
+from textual.widgets import TextArea
+
+from Tests.UI.test_destination_shells import _build_test_app, _wait_for_selector
+from Tests.UI.test_product_maturity_gate1_core_loop_screen_adaptation import (
+    ConsoleHarness,
+)
+
+from tldw_chatbook.Chat.console_chat_models import (
+    PROPRIETARY_THINKING_NOTICE,
+    ConsoleMessageRole,
+)
+from tldw_chatbook.Chat.thinking_blocks import (
+    DisplayableThinkingBlock,
+    ThinkingEnvelope,
+)
+from tldw_chatbook.Widgets.Console import ConsoleTranscript
+from tldw_chatbook.Widgets.Console.console_edit_message_modal import (
+    ConsoleEditThinkingModal,
+)
+
+
+async def _wait_until(predicate, pilot, *, attempts: int = 80) -> None:
+    for _ in range(attempts):
+        if predicate():
+            return
+        await pilot.pause(0.02)
+    raise AssertionError("Condition never became true.")
+
+
+def _reasoning_envelope(text: str) -> ThinkingEnvelope:
+    return ThinkingEnvelope(
+        (
+            DisplayableThinkingBlock(
+                block_id="reasoning-1",
+                round_ordinal=0,
+                provider="llama_cpp",
+                model="test-model",
+                protocol="chat_completions",
+                source_format="think_tag",
+                status="complete",
+                text=text,
+            ),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_thinking_row_edit_opens_modal_and_saves_block_text():
+    app = _build_test_app()
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        store = console._ensure_console_chat_store()
+        session = store.ensure_session()
+        assistant = store.append_message(
+            session.id, role=ConsoleMessageRole.ASSISTANT, content="the answer"
+        )
+        store.replace_message_thinking(
+            assistant.id, _reasoning_envelope("original reasoning")
+        )
+        await console._sync_native_console_chat_ui()
+
+        transcript = console.query_one("#console-native-transcript", ConsoleTranscript)
+        activity_id = next(iter(transcript._thinking_activity_refs))
+        transcript.select_message(activity_id)
+        await console._sync_native_console_chat_ui()
+
+        # Thinking disclosures carry no action buttons (copy-style keyboard
+        # seam): the `e` shortcut routes through the transcript action and
+        # bubbles ConsoleThinkingEditRequested to the screen.
+        transcript.action_invoke_selected_action("edit")
+        await _wait_until(
+            lambda: any(
+                isinstance(s, ConsoleEditThinkingModal)
+                for s in console.app.screen_stack
+            ),
+            pilot,
+        )
+        modal_screen = next(
+            s
+            for s in reversed(console.app.screen_stack)
+            if isinstance(s, ConsoleEditThinkingModal)
+        )
+        await pilot.pause()
+        editor = modal_screen.query_one("#console-edit-thinking-body", TextArea)
+        assert editor.text == "original reasoning"
+
+        editor.text = "cleaned reasoning"
+        await pilot.pause()
+        await pilot.click("#console-edit-thinking-save")
+        await pilot.pause()
+        await _wait_until(
+            lambda: (
+                store.get_message(assistant.id).thinking is not None
+                and store.get_message(assistant.id).thinking.blocks[0].text
+                == "cleaned reasoning"
+            ),
+            pilot,
+            attempts=150,
+        )
+
+        edited = store.get_message(assistant.id)
+        assert edited.content == "the answer"
+        assert edited.thinking is not None
+        assert edited.thinking.blocks[0].block_id == "reasoning-1"

--- a/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
+++ b/backlog/decisions/090-console-thinking-block-ownership-and-replay.md
@@ -161,3 +161,36 @@ Automatic recognizes exact reviewed templates, not aliases. Reviewed Gemma 4 and
 Projection occurs before serialization, token accounting and provider admission. Whole owner groups and their matching provenance are filtered together. Runtime guidance and tool results continue the active exchange; any provider-visible row rewrite must preserve causal trace provenance. Children inherit policy but never a parent's thinking owner. Capture, default-on display, canonical persistence and importable transcript export are unaffected by replay preferences.
 
 Reviewed local runtime-control encoding uses the typed `RUNTIME_GUIDANCE` provenance transform. It retains the tool-result/control source and every appended guidance input; ordinary `MESSAGE_REWRITE` continues to accept only exact thinking/continuation attachments.
+
+## Amendment: user editing of displayable thinking block text (2026-09-11, TASK-32312)
+
+Displayable thinking block text is user-editable in place through a block-scoped
+Console edit action. This amends the accepted edit boundary above ("Assistant edit
+remains edit-in-place but explicitly clears thinking and continuation for the
+selected generation"): content edits continue to clear the generation envelope
+unchanged, while the new block-scoped action edits only one displayable block's text
+and leaves answer content, rounds, block identity, provenance, source encoding, and
+provider continuation intact.
+
+Boundary and semantics:
+
+1. Only `DisplayableThinkingBlock`s are editable. Proprietary evidence blocks remain
+   content-free and offer no edit affordance.
+2. An edited block keeps its block id, round ordinal, provenance, and source format.
+   Those fields describe the block's origin, not byte-exactness of its text — the
+   same convention as assistant content edits, which carry no edited marker and no
+   stored original copy.
+3. Edits re-validate the whole envelope (canonical JSON, block-count/text-size
+   bounds, non-empty block text) and persist through the atomic selected-generation
+   projection together with the unchanged answer, so memory, database, and Sync v2
+   observe one owner group. Blank edits are rejected; thinking-block deletion is not
+   part of this amendment (content edit already clears the whole envelope).
+4. Edited blocks remain replay-eligible. Replay continues to serialize a block in its
+   original source encoding and to apply the existing serialization safety checks:
+   edited text that is unsafe for the block's encoding (for example `<think`/
+   `</think` under start-anchored encoding) is rejected at edit time, would be
+   skipped under Auto, and fails before send under Include. No cross-provider
+   translation is introduced.
+5. Block-text editing is refused for streaming/pending owners, opaque or quarantined
+   generations (`thinking_actions_enabled=False`), and non-assistant owners — the
+   same generation-mutation gates as variant selection.

--- a/backlog/docs/lessons-textual.md
+++ b/backlog/docs/lessons-textual.md
@@ -890,3 +890,27 @@ through the whole hazard, because the row it presses (`.library-media-row`) was
 NOT one of the migrated handlers. A guard's pin only covers the handlers that
 route through the guard; migrating a handler out from under one silently
 narrows what the pin proves without changing the pin's result.
+
+## `@on` handlers must live on the ChatScreen — `Console_Modules/message.py` is a controller, not a mixin (TASK-32312, 2026-09-10)
+
+**TASK-32312.** Wiring a `ConsoleThinkingEditRequested` event handler for the
+thinking-block edit feature, I added `@on(ConsoleThinkingEditRequested)` to a method
+in `UI/Console_Modules/message.py` — and the handler silently never ran (no modal, no
+toast, test timeout). That module's methods are not screen methods:
+`ChatScreen` constructs exactly one `ConsoleMessageController` in `__init__` (kept at
+`self._message`) and delegates specific methods into it. A plain controller object is
+not a Textual message pump, so `@on` tags on it are inert, and the controller has no
+`query_one` — `self.query_one(...)` inside it raises `AttributeError`, which a broad
+`except Exception` then swallowed into a misleading `None` return. The second trap:
+my first fix probed `hasattr(console, 'on_console_thinking_edit_requested')` via an
+**instance-attribute spy**, which stayed empty — Textual dispatch walks
+`type(self).__mro__`, so instance-attr replacement is invisible to delivery and
+"handler not called" conclusions from it are unreliable.
+
+**What to do.** Put `@on(...)` handlers on `ChatScreen` itself
+(`UI/Screens/chat_screen.py`) and delegate one line into
+`self._message.<controller_method>(event)`. Inside the controller, reach the DOM and
+screen through `self._screen` (`self._screen.query_one(...)`), never `self.` — the
+module's own header says "never a back-door through `self.screen`". When probing
+message delivery in tests, replace the handler on a subclass or count side effects
+(posted modals, store writes), not via instance attributes.

--- a/backlog/tasks/task-32312 - Console-edit-displayable-thinking-block-text-in-place.md
+++ b/backlog/tasks/task-32312 - Console-edit-displayable-thinking-block-text-in-place.md
@@ -1,0 +1,50 @@
+---
+id: TASK-32312
+title: 'Console: edit displayable thinking block text in place'
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-09-11'
+updated_date: '2026-09-11 03:46'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Users need to correct or clean up a model's visible thinking text (typos, sensitive fragments, export hygiene) without discarding the whole generation. ADR-090 currently clears thinking entirely when the answer content is edited; this task adds a block-scoped in-place edit for displayable thinking blocks. Amends ADR-090: edited blocks keep identity/provenance, stay replay-eligible in their original encoding under existing serialization safety checks, and content-edit-clears-thinking behavior is unchanged.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Edit action appears on selected displayable thinking rows (never proprietary) and opens a modal prefilled with the block text
+- [x] #2 Save persists edited text via the atomic generation projection: content untouched, no descendant purge, variant envelope and message envelope both updated
+- [x] #3 Blank edits and unsafe start-anchored text (`<think`/`</think`) rejected with clear messages; envelope bounds re-validated (256 KiB block, 1 MiB envelope)
+- [x] #4 Edits refused while streaming/pending, for opaque or quarantined generations, and for non-assistant owners
+- [x] #5 Edited blocks remain replay-eligible under existing policy with existing safety checks (auto skips unsafe, include fails before send)
+- [x] #6 Existing content-edit-clears-thinking behavior unchanged (its test stays green)
+- [x] #7 ADR-090 amendment records user-editable block text semantics
+- [x] #8 User docs updated
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Baseline targeted tests (thinking persistence/blocks/history/presentation, edit modal, message actions) — 272 passed
+2. Write ADR-090 amendment
+3. TDD store method: update_message_thinking_block with envelope revalidation, dual-home write, atomic persist, guards
+4. TDD ConsoleEditThinkingModal + transcript thinking-row edit action + screen wiring
+5. Extend thinking-history tests with edited-text serialization cases
+6. Update user docs; run targeted tests; task close-out
+
+ADR required: yes
+ADR path: backlog/decisions/090-console-thinking-block-ownership-and-replay.md (amendment)
+Reason: amends ADR-090's accepted "assistant edit clears thinking" boundary by adding block-scoped user edits of displayable thinking text with replay-eligibility semantics.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implemented block-scoped displayable thinking edit per the ADR-090 amendment: store update_message_thinking_block (guards + envelope revalidation + atomic generation projection + variant dual-home), ConsoleEditThinkingModal, keyboard e seam on thinking rows via ConsoleThinkingEditRequested event (ChatScreen handler -> ConsoleMessageController), proprietary rows gated. +23 targeted tests, zero regressions vs clean dev (35 failures pre-exist on this machine).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -246,6 +246,7 @@ from tldw_chatbook.Chat.provider_continuation import (
 from tldw_chatbook.Chat.provider_usage import ProviderUsage
 from tldw_chatbook.Chat.rag_scope import RagScope, SessionScopeHolder, serialize_scope
 from tldw_chatbook.Chat.thinking_blocks import (
+    ProprietaryThinkingBlock,
     ThinkingEnvelope,
     ThinkingHistoryPolicy,
     ThinkingStatus,
@@ -17478,6 +17479,102 @@ class ConsoleChatStore:
         if durably_committed and committed_version is not None:
             message.provider_continuation_message_version = committed_version
             message.provider_continuation_remote = False
+        return self._snapshot(message)
+
+    def update_message_thinking_block(
+        self, message_id: str, block_id: str, text: str
+    ) -> ConsoleChatMessage:
+        """Edit one displayable thinking block's text in place.
+
+        ADR-090 amendment (TASK-32312): block identity, provenance, source
+        encoding, and the answer stay intact; only the block's text changes.
+        """
+        with self._generation_owner_scope(message_id):
+            self._reject_quarantined_generation_mutation(
+                self._message_or_raise(message_id)
+            )
+            return self._run_commit_aware_generation_mutation(
+                message_id,
+                lambda: self._update_message_thinking_block(
+                    message_id, block_id, text
+                ),
+            )
+
+    def _update_message_thinking_block(
+        self, message_id: str, block_id: str, text: str
+    ) -> ConsoleChatMessage:
+        message = self._message_or_raise(message_id)
+        if message.role is not ConsoleMessageRole.ASSISTANT:
+            raise ValueError("Only assistant messages can own thinking.")
+        if message.status in {"pending", "streaming"}:
+            raise ValueError("Wait for response to finish before editing thinking.")
+        if not message.thinking_actions_enabled:
+            raise ConsoleThinkingCompatibilityError(
+                "This conversation contains a newer thinking format; "
+                "upgrade before editing it."
+            )
+        envelope = message.thinking
+        if envelope is None:
+            raise ValueError("This message has no thinking blocks to edit.")
+        block = next(
+            (
+                candidate
+                for candidate in envelope.blocks
+                if candidate.block_id == block_id
+            ),
+            None,
+        )
+        if block is None:
+            raise ValueError(f"Unknown thinking block id: {block_id!r}.")
+        if isinstance(block, ProprietaryThinkingBlock):
+            raise ValueError("Proprietary thinking cannot be edited.")
+        if not text.strip():
+            raise ValueError("Thinking text cannot be blank.")
+        if block.source_format == "start_anchored_think":
+            lowered = text.lower()
+            if "<think" in lowered or "</think" in lowered:
+                raise ValueError(
+                    "Edited thinking cannot contain <think> or </think> tags "
+                    "for a start-anchored thinking block."
+                )
+        edited_envelope = ThinkingEnvelope(
+            tuple(
+                replace(block, text=text)
+                if candidate.block_id == block_id
+                else candidate
+                for candidate in envelope.blocks
+            )
+        )
+        # The dumper is the shared strict boundary (canonical JSON plus all
+        # envelope bounds) for every durable thinking write.
+        dump_thinking_blocks_json(edited_envelope)
+        current = self._generation_variant(message)
+        target = replace(
+            current,
+            thinking=edited_envelope,
+            opaque_thinking_json=None,
+            thinking_warning=None,
+        )
+        durably_committed, committed_version = self._persist_generation_variant(
+            message,
+            target,
+            current=current,
+        )
+        if message.variants is not None:
+            selected_index = message.variants.selected_index
+            message.variants.variants[selected_index] = replace(
+                message.variants.variants[selected_index],
+                thinking=edited_envelope,
+                opaque_thinking_json=None,
+                thinking_warning=None,
+            )
+        self._apply_generation_variant(message, target)
+        if durably_committed and committed_version is not None:
+            message.provider_continuation_message_version = committed_version
+            message.provider_continuation_remote = False
+        # Edited thinking can ride a local replay payload, so invalidate any
+        # cached prepared request without touching the conversation epoch.
+        self._bump_payload_revision(self._message_session_index[message.id])
         return self._snapshot(message)
 
     def begin_variant_stream(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -17482,12 +17482,40 @@ class ConsoleChatStore:
         return self._snapshot(message)
 
     def update_message_thinking_block(
-        self, message_id: str, block_id: str, text: str
+        self,
+        message_id: str,
+        block_id: str,
+        text: str,
+        *,
+        expected_text: str | None = None,
     ) -> ConsoleChatMessage:
         """Edit one displayable thinking block's text in place.
 
         ADR-090 amendment (TASK-32312): block identity, provenance, source
         encoding, and the answer stay intact; only the block's text changes.
+
+        Args:
+            message_id: Native Console id of the assistant owner.
+            block_id: Envelope block id whose text is being replaced.
+            text: Replacement text. Must be non-blank, bounded by the
+                envelope limits, and safe for the block's source encoding.
+            expected_text: The text the editor prefilled from. When supplied
+                and the block's current text differs, the edit is refused --
+                an optimistic guard against saving a stale modal over a
+                newer generation (a stream that settled, or a variant swap,
+                while the editor was open).
+
+        Returns:
+            A snapshot of the updated message.
+
+        Raises:
+            KeyError: Unknown message id.
+            ValueError: Non-assistant owner, streaming/pending owner,
+                disabled generation actions, missing envelope or block,
+                proprietary block, blank text, unsafe start-anchored text,
+                stale ``expected_text``, or envelope bound violations.
+            ConsoleThinkingCompatibilityError: The generation's thinking
+                data is unreadable (opaque future envelope or quarantine).
         """
         with self._generation_owner_scope(message_id):
             self._reject_quarantined_generation_mutation(
@@ -17496,12 +17524,20 @@ class ConsoleChatStore:
             return self._run_commit_aware_generation_mutation(
                 message_id,
                 lambda: self._update_message_thinking_block(
-                    message_id, block_id, text
+                    message_id,
+                    block_id,
+                    text,
+                    expected_text=expected_text,
                 ),
             )
 
     def _update_message_thinking_block(
-        self, message_id: str, block_id: str, text: str
+        self,
+        message_id: str,
+        block_id: str,
+        text: str,
+        *,
+        expected_text: str | None = None,
     ) -> ConsoleChatMessage:
         message = self._message_or_raise(message_id)
         if message.role is not ConsoleMessageRole.ASSISTANT:
@@ -17528,6 +17564,11 @@ class ConsoleChatStore:
             raise ValueError(f"Unknown thinking block id: {block_id!r}.")
         if isinstance(block, ProprietaryThinkingBlock):
             raise ValueError("Proprietary thinking cannot be edited.")
+        if expected_text is not None and block.text != expected_text:
+            raise ValueError(
+                "Thinking changed while editing; reopen the block and edit "
+                "the current text."
+            )
         if not text.strip():
             raise ValueError("Thinking text cannot be blank.")
         if block.source_format == "start_anchored_think":
@@ -20229,7 +20270,7 @@ class ConsoleChatStore:
                 thinking.envelope
             )
         try:
-            reconcile(
+            result = reconcile(
                 server_profile_id=profile_id,
                 authenticated_principal_id=self.sync_v2_authenticated_principal_id,
                 workspace_scope=self.sync_v2_workspace_scope,
@@ -20240,6 +20281,27 @@ class ConsoleChatStore:
         except Exception:
             logger.warning(
                 "Failed to project Sync v2 continuation owner after local mutation"
+            )
+            return
+        # The reconciled envelope is now the newest projected payload for
+        # this row. Record its hash so the next ordinary enqueue (for
+        # example a later content edit) chains from it as base_version
+        # instead of the stale pre-generation-mutation hash.
+        try:
+            session = self._sessions.get(
+                self._message_session_index.get(message.id, "")
+            )
+            conversation_id = (
+                session.persisted_conversation_id if session is not None else None
+            )
+            if conversation_id is not None:
+                self._record_sync_v2_message_version(
+                    f"{conversation_id}:{persisted_id}", result
+                )
+        except Exception:
+            logger.warning(
+                "Failed to record Sync v2 version hash after generation "
+                "reconciliation"
             )
 
     def _persist_pending_message_if_ready(

--- a/tldw_chatbook/Chat/console_message_actions.py
+++ b/tldw_chatbook/Chat/console_message_actions.py
@@ -11,6 +11,7 @@ from markdown_it import MarkdownIt
 
 from tldw_chatbook.Chat.console_chat_fork import ConsoleForkEligibility
 from tldw_chatbook.Chat.console_chat_models import (
+    ConsoleActivityPresentation,
     ConsoleChatMessage,
     ConsoleMessageRole,
 )
@@ -631,6 +632,19 @@ class ConsoleMessageActionService:
                 if action_id == "speak"
                 else (action_id, label)
                 for action_id, label in completed_actions
+            ]
+        presentation = message.activity_presentation
+        if (
+            isinstance(presentation, ConsoleActivityPresentation)
+            and presentation.kind == "thinking"
+            and presentation.status == "unavailable"
+        ):
+            # TASK-32312: content-free proprietary evidence has no editable
+            # text; only displayable thinking blocks offer the edit action.
+            completed_actions = [
+                (action_id, label)
+                for action_id, label in completed_actions
+                if action_id != "edit"
             ]
         if message.status == "failed" and self._is_assistant_message(message):
             # Retry regenerates a failed ASSISTANT response. A failed USER row —

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -128,7 +128,10 @@ from ...Chat.console_chat_models import (
     ConsoleVariantSet,
     MessageAttachment,
 )
-from ...Chat.console_chat_store import ConsoleChatStore
+from ...Chat.console_chat_store import (
+    ConsoleChatStore,
+    ConsoleThinkingCompatibilityError,
+)
 from ...Chat.console_chat_fork import ConsoleForkEligibility
 from ...Chat.console_conversation_hydration import (
     console_messages_from_conversation_tree,
@@ -161,11 +164,14 @@ from ...Notes.notes_scope_service import ScopeType
 from ...Widgets.Console import (
     ConsoleEditMessageModal,
     ConsoleEditResult,
+    ConsoleEditThinkingModal,
     ConsoleSaveAsModal,
+    ConsoleThinkingEditResult,
 )
 
 if TYPE_CHECKING:
     from ..Screens.chat_screen import ChatScreen
+    from ...Widgets.Console.console_transcript import ConsoleThinkingEditRequested
 
 logger = logger.bind(module="ChatScreen")
 
@@ -2541,6 +2547,97 @@ class ConsoleMessageController:
                 can_resend=can_resend,
                 clears_generation_provenance=clears_generation_provenance,
             ),
+            callback=_apply_edit,
+        )
+
+    def _console_thinking_edit_target(
+        self, activity_id: str
+    ) -> tuple[str, str, str] | None:
+        """Resolve a thinking row's editable displayable block.
+
+        Returns ``None`` when ``activity_id`` is not a projected thinking row
+        or carries no displayable block; the caller decides how to respond.
+        """
+        from ...Widgets.Console.console_transcript import ConsoleTranscript
+
+        try:
+            transcript = self._screen.query_one(
+                "#console-native-transcript", ConsoleTranscript
+            )
+        except Exception:
+            return None
+        if transcript.thinking_owner_message_id(activity_id) is None:
+            return None
+        return transcript.thinking_editable_block(activity_id)
+
+    async def handle_console_thinking_edit_requested(
+        self, event: "ConsoleThinkingEditRequested"
+    ) -> None:
+        """Open the block-scoped thinking edit modal (TASK-32312).
+
+        Called by ``ChatScreen``'s ``@on(ConsoleThinkingEditRequested)``
+        handler: the transcript posts the event from the thinking row's
+        keyboard edit seam (mirroring copy, which has no action buttons
+        either), and the screen resolves the displayable block from the
+        display model because the display-only activity id can never
+        resolve in the store.
+        """
+        editable = self._console_thinking_edit_target(event.activity_id)
+        if editable is None:
+            self.app_instance.notify(
+                "This thinking block cannot be edited.", severity="warning"
+            )
+            return
+        owner_message_id, block_id, text = editable
+        await self._open_console_thinking_edit_modal(
+            owner_message_id=owner_message_id,
+            block_id=block_id,
+            text=text,
+        )
+
+    async def _open_console_thinking_edit_modal(
+        self, *, owner_message_id: str, block_id: str, text: str
+    ) -> None:
+        """Open the block-scoped thinking edit modal for one displayable block."""
+        store = self._ensure_console_chat_store()
+
+        def _apply_edit(result: ConsoleThinkingEditResult | None) -> None:
+            if result is None:
+                return
+            try:
+                store.update_message_thinking_block(
+                    owner_message_id, block_id, result.text
+                )
+            except ValueError as exc:
+                self.app_instance.notify(str(exc), severity="warning")
+                return
+            except ConsoleThinkingCompatibilityError as exc:
+                self.app_instance.notify(str(exc), severity="warning")
+                return
+            except KeyError:
+                self.app_instance.notify(
+                    "Console message action target no longer exists.",
+                    severity="error",
+                )
+                return
+            self._last_console_action = ConsoleActionResult(
+                action_id="edit",
+                status="completed",
+                visible_copy="Edited thinking block.",
+                target_message_id=owner_message_id,
+                target_content=result.text,
+            )
+            self.run_worker(
+                self._sync_native_console_chat_ui(),
+                exclusive=True,
+                group="console-sync",
+            )
+            self.app_instance.notify(
+                "Edited thinking block.", severity="information"
+            )
+
+        await self.push_screen(
+            ConsoleEditThinkingModal(text=text),
             callback=_apply_edit,
         )
 

--- a/tldw_chatbook/UI/Console_Modules/message.py
+++ b/tldw_chatbook/UI/Console_Modules/message.py
@@ -2581,6 +2581,10 @@ class ConsoleMessageController:
         either), and the screen resolves the displayable block from the
         display model because the display-only activity id can never
         resolve in the store.
+
+        Args:
+            event: Thinking-row edit request carrying the projected
+                activity id of the selected disclosure row.
         """
         editable = self._console_thinking_edit_target(event.activity_id)
         if editable is None:
@@ -2606,7 +2610,10 @@ class ConsoleMessageController:
                 return
             try:
                 store.update_message_thinking_block(
-                    owner_message_id, block_id, result.text
+                    owner_message_id,
+                    block_id,
+                    result.text,
+                    expected_text=text,
                 )
             except ValueError as exc:
                 self.app_instance.notify(str(exc), severity="warning")

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -17514,6 +17514,24 @@ class ChatScreen(BaseAppScreen):
             presentation_context.transcript_style.value,
             presentation_context.revision,
         )
+
+        def _thinking_signature(envelope: Any) -> Any:
+            # A block-text edit changes nothing else in this fingerprint, so
+            # the disclosure's projected text must join the signature or a
+            # thinking-only edit is skipped as a no-op refresh (TASK-32312).
+            return (
+                None
+                if envelope is None
+                else tuple(
+                    (
+                        block.block_id,
+                        block.status,
+                        getattr(block, "text", None),
+                    )
+                    for block in getattr(envelope, "blocks", ())
+                )
+            )
+
         message_signatures = []
         for message in messages:
             variants = getattr(message, "variants", None)
@@ -17525,6 +17543,9 @@ class ChatScreen(BaseAppScreen):
                         (
                             getattr(variant, "id", None),
                             getattr(variant, "content", ""),
+                            _thinking_signature(
+                                getattr(variant, "thinking", None)
+                            ),
                         )
                         for variant in (getattr(variants, "variants", None) or ())
                     ),
@@ -17542,6 +17563,7 @@ class ChatScreen(BaseAppScreen):
                     getattr(message, "turn_id", None),
                     getattr(message, "persisted_message_id", None),
                     terminal_receipt_id_for_message(message),
+                    _thinking_signature(getattr(message, "thinking", None)),
                     variant_signature,
                     getattr(message, "citation_presentation", None),
                 )
@@ -21995,6 +22017,10 @@ class ChatScreen(BaseAppScreen):
         The transcript posts this from the thinking row's keyboard edit seam
         (mirroring copy, which has no action buttons either);
         ``event.stop()`` because nothing above this screen subscribes.
+
+        Args:
+            event: Thinking-row edit request carrying the projected
+                activity id of the selected disclosure row.
         """
         event.stop()
         await self._message.handle_console_thinking_edit_requested(event)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -594,6 +594,7 @@ from ...Widgets.Console.console_inspector_section import (
 from ...Widgets.Console.console_command_popup import ConsoleCommandPopup
 from ...Widgets.Console.console_transcript import (
     ConsoleReviewNotesRequested,
+    ConsoleThinkingEditRequested,
     console_transcripts_on_screen,
 )
 from ...Widgets.Console.console_selection_menu import (
@@ -21984,6 +21985,19 @@ class ChatScreen(BaseAppScreen):
         self._review_selection.request_selection_feedback(
             event.action, event.quote, event.anchor_message_id
         )
+
+    @on(ConsoleThinkingEditRequested)
+    async def on_console_thinking_edit_requested(
+        self, event: ConsoleThinkingEditRequested
+    ) -> None:
+        """Open the block-scoped thinking edit modal (TASK-32312).
+
+        The transcript posts this from the thinking row's keyboard edit seam
+        (mirroring copy, which has no action buttons either);
+        ``event.stop()`` because nothing above this screen subscribes.
+        """
+        event.stop()
+        await self._message.handle_console_thinking_edit_requested(event)
 
     @on(ConsoleReviewNotesRequested)
     def on_console_review_notes_requested(

--- a/tldw_chatbook/Widgets/Console/__init__.py
+++ b/tldw_chatbook/Widgets/Console/__init__.py
@@ -30,7 +30,12 @@ from .console_citation_sources_modal import (
     ConsoleCitationSourcesModal,
     build_console_citation_source_rows,
 )
-from .console_edit_message_modal import ConsoleEditMessageModal, ConsoleEditResult
+from .console_edit_message_modal import (
+    ConsoleEditMessageModal,
+    ConsoleEditResult,
+    ConsoleEditThinkingModal,
+    ConsoleThinkingEditResult,
+)
 from .console_fork_chat_modal import (
     ConsoleForkChatModal,
     ConsoleForkDialogSummary,
@@ -69,7 +74,7 @@ from .console_terminal_messages import (
     ConsoleTerminalActionRequested,
     ConsoleTerminalInputRequested,
 )
-from .console_transcript import ConsoleTranscript
+from .console_transcript import ConsoleThinkingEditRequested, ConsoleTranscript
 from .console_workbench_state import build_console_workbench_state
 from .console_workspace_context import ConsoleWorkspaceContextTray
 from .console_workspace_tree import (
@@ -144,6 +149,8 @@ __all__ = [
     "ConsoleContextControlState",
     "ConsoleEditMessageModal",
     "ConsoleEditResult",
+    "ConsoleEditThinkingModal",
+    "ConsoleThinkingEditResult",
     "ConsoleForkChatModal",
     "ConsoleForkDialogSummary",
     "ConsoleForkSubmitResult",
@@ -174,6 +181,7 @@ __all__ = [
     "ConsoleTerminalWorkspace",
     "TerminalSessionFormResult",
     "TerminalViewport",
+    "ConsoleThinkingEditRequested",
     "ConsoleTranscript",
     "ConsoleTranscriptSurface",
     "ConsoleVoicePreview",

--- a/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
@@ -188,3 +188,115 @@ class ConsoleEditMessageModal(
             )
             return
         self.dismiss(ConsoleEditResult(text=edited_content, resend=True))
+
+
+@dataclass(frozen=True)
+class ConsoleThinkingEditResult:
+    """Outcome of the thinking-block edit modal: the block's edited text.
+
+    ADR-090 amendment (TASK-32312): only the displayable block's text
+    changes; the answer, provenance, and replay encoding stay intact.
+    """
+
+    text: str
+
+
+class ConsoleEditThinkingModal(
+    SafeModalDismissMixin, ModalScreen[ConsoleThinkingEditResult | None]
+):
+    """Edit one displayable thinking block's text without touching the answer."""
+
+    DEFAULT_CSS = """
+    ConsoleEditThinkingModal {
+        align: center middle;
+    }
+
+    #console-edit-thinking-modal {
+        width: 92;
+        height: 28;
+        border: tall gray;
+        background: black;
+        padding: 1 2;
+    }
+
+    #console-edit-thinking-context {
+        height: auto;
+        margin: 1 0 1 0;
+    }
+
+    #console-edit-thinking-body {
+        width: 100%;
+        height: 1fr;
+        min-height: 8;
+    }
+
+    #console-edit-thinking-error {
+        height: auto;
+        min-height: 1;
+        color: red;
+    }
+
+    #console-edit-thinking-actions {
+        height: 3;
+        min-height: 3;
+        margin: 1 0 0 0;
+        align-horizontal: right;
+    }
+
+    #console-edit-thinking-cancel,
+    #console-edit-thinking-save {
+        width: 10;
+        min-width: 10;
+        height: 3;
+        min-height: 3;
+    }
+    """
+
+    SAFE_MODAL_CONTENT = "#console-edit-thinking-modal"
+    BINDINGS = [("escape", "request_safe_cancel", "Cancel")]
+
+    def __init__(self, *, text: str) -> None:
+        super().__init__()
+        self._text = text
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-edit-thinking-modal"):
+            yield Static("Edit Thinking", classes="console-modal-header")
+            yield Static(
+                "Editing this thinking block. The answer, its provenance, "
+                "and replay encoding stay intact.",
+                id="console-edit-thinking-context",
+                markup=False,
+            )
+            yield _EditMessageTextArea(self._text, id="console-edit-thinking-body")
+            yield Static("", id="console-edit-thinking-error", markup=False)
+            with Horizontal(id="console-edit-thinking-actions"):
+                yield Button("Cancel", id="console-edit-thinking-cancel")
+                yield Button(
+                    "Save", id="console-edit-thinking-save", variant="primary"
+                )
+
+    def on_mount(self, event: events.Mount) -> None:  # type: ignore[override]
+        # Same stale-key clock domain guard as the message edit modal
+        # (TASK-360): keys pressed before this modal appeared never reach
+        # the textarea.
+        self._opened_at = event.time
+        area = self.query_one("#console-edit-thinking-body", _EditMessageTextArea)
+        area.opened_at = event.time
+        area.focus()
+
+    @on(Button.Pressed, "#console-edit-thinking-cancel")
+    async def _cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="button")
+
+    @on(Button.Pressed, "#console-edit-thinking-save")
+    def _save(self, event: Button.Pressed) -> None:
+        event.stop()
+        edited_text = self.query_one("#console-edit-thinking-body", TextArea).text
+        if not edited_text.strip():
+            self.query_one("#console-edit-thinking-error", Static).update(
+                "Thinking text cannot be blank."
+            )
+            return
+        self.dismiss(ConsoleThinkingEditResult(text=edited_text))

--- a/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_edit_message_modal.py
@@ -10,6 +10,7 @@ from textual.containers import Horizontal, Vertical
 from textual.screen import ModalScreen
 from textual.widgets import Button, Static, TextArea
 
+from tldw_chatbook.Chat.thinking_blocks import MAX_THINKING_TEXT_BYTES
 from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
 
 
@@ -204,7 +205,13 @@ class ConsoleThinkingEditResult:
 class ConsoleEditThinkingModal(
     SafeModalDismissMixin, ModalScreen[ConsoleThinkingEditResult | None]
 ):
-    """Edit one displayable thinking block's text without touching the answer."""
+    """Edit one displayable thinking block's text without touching the answer.
+
+    Args:
+        text: The block's current text, used as the editor prefill; the
+            caller also keeps this value as the optimistic-concurrency
+            baseline for the store's save-time ``expected_text`` guard.
+    """
 
     DEFAULT_CSS = """
     ConsoleEditThinkingModal {
@@ -260,6 +267,7 @@ class ConsoleEditThinkingModal(
         self._text = text
 
     def compose(self) -> ComposeResult:
+        """Yield the modal's context line, editor, error line, and actions."""
         with Vertical(id="console-edit-thinking-modal"):
             yield Static("Edit Thinking", classes="console-modal-header")
             yield Static(
@@ -277,9 +285,12 @@ class ConsoleEditThinkingModal(
                 )
 
     def on_mount(self, event: events.Mount) -> None:  # type: ignore[override]
-        # Same stale-key clock domain guard as the message edit modal
-        # (TASK-360): keys pressed before this modal appeared never reach
-        # the textarea.
+        """Arm the TASK-360 stale-key guard and focus the editor.
+
+        Args:
+            event: Mount event supplying the clock domain shared with
+                ``Key.time`` for the pre-modal keystroke guard.
+        """
         self._opened_at = event.time
         area = self.query_one("#console-edit-thinking-body", _EditMessageTextArea)
         area.opened_at = event.time
@@ -297,6 +308,11 @@ class ConsoleEditThinkingModal(
         if not edited_text.strip():
             self.query_one("#console-edit-thinking-error", Static).update(
                 "Thinking text cannot be blank."
+            )
+            return
+        if len(edited_text.encode("utf-8")) > MAX_THINKING_TEXT_BYTES:
+            self.query_one("#console-edit-thinking-error", Static).update(
+                "Edited thinking is too large for one block."
             )
             return
         self.dismiss(ConsoleThinkingEditResult(text=edited_text))

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2637,6 +2637,21 @@ class ConsoleTranscriptJumpPill(Static):
                 transcript.focus()
 
 
+class ConsoleThinkingEditRequested(Message):
+    """Bubbled when the user asks to edit a thinking block's text.
+
+    TASK-32312: posted by ``ConsoleTranscript.action_invoke_selected_action``
+    for a selected thinking disclosure row (the keyboard mirror of the
+    thinking-row copy seam). Anchored by projected activity id -- the owning
+    screen resolves the displayable block from the transcript's display
+    model and owns the block-scoped edit modal.
+    """
+
+    def __init__(self, activity_id: str) -> None:
+        super().__init__()
+        self.activity_id = activity_id
+
+
 class ConsoleReviewNotesRequested(Message):
     """Bubbled when the user asks to see a message's review notes.
 
@@ -5109,6 +5124,34 @@ class ConsoleTranscript(VerticalScroll):
         ref = self._thinking_activity_refs.get(activity_id)
         return ref.assistant_message_id if ref is not None else None
 
+    def thinking_editable_block(self, activity_id: str) -> tuple[str, str, str] | None:
+        """Resolve one displayable block for the block-scoped edit seam.
+
+        Returns ``(assistant_message_id, block_id, text)``, or ``None`` for
+        unknown rows and content-free proprietary evidence (TASK-32312).
+        """
+        ref = self._thinking_activity_refs.get(activity_id)
+        if ref is None:
+            return None
+        assistant = next(
+            (
+                message
+                for message in self._messages
+                if message.id == ref.assistant_message_id
+            ),
+            None,
+        )
+        envelope = assistant.thinking if assistant is not None else None
+        if not isinstance(envelope, ThinkingEnvelope):
+            return None
+        block = next(
+            (block for block in envelope.blocks if block.block_id == ref.block_id),
+            None,
+        )
+        if not isinstance(block, DisplayableThinkingBlock):
+            return None
+        return ref.assistant_message_id, ref.block_id, block.text
+
     def _thinking_display_message(self, activity_id: str) -> ConsoleChatMessage | None:
         """Build a bounded display-only row for selection/copy/Inspector seams."""
         ref = self._thinking_activity_refs.get(activity_id)
@@ -5630,6 +5673,14 @@ class ConsoleTranscript(VerticalScroll):
                 if callable(copy_to_clipboard):
                     copy_to_clipboard(thinking_detail)
                 return
+        if action_id == "edit" and (
+            self.thinking_owner_message_id(message_id) is not None
+        ):
+            # TASK-32312: thinking disclosures carry no action buttons
+            # (``action_widgets=()``); like copy, edit is a keyboard seam
+            # here and the owning screen opens the block-scoped modal.
+            self.post_message(ConsoleThinkingEditRequested(message_id))
+            return
         if action_id == "tool-output" and self._activity_can_expand(message_id):
             self.toggle_tool_output(message_id)
             return

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -2645,6 +2645,10 @@ class ConsoleThinkingEditRequested(Message):
     thinking-row copy seam). Anchored by projected activity id -- the owning
     screen resolves the displayable block from the transcript's display
     model and owns the block-scoped edit modal.
+
+    Args:
+        activity_id: Projected thinking activity row identifier (the
+            deterministic uuid5 of the owner message and block ids).
     """
 
     def __init__(self, activity_id: str) -> None:
@@ -5127,8 +5131,14 @@ class ConsoleTranscript(VerticalScroll):
     def thinking_editable_block(self, activity_id: str) -> tuple[str, str, str] | None:
         """Resolve one displayable block for the block-scoped edit seam.
 
-        Returns ``(assistant_message_id, block_id, text)``, or ``None`` for
-        unknown rows and content-free proprietary evidence (TASK-32312).
+        Args:
+            activity_id: Projected thinking activity row identifier.
+
+        Returns:
+            A ``(assistant_message_id, block_id, text)`` tuple for a
+            displayable block on a terminal (non-streaming) assistant owner,
+            or ``None`` for unknown rows, content-free proprietary evidence,
+            and live rows whose partial text must never prefill an editor.
         """
         ref = self._thinking_activity_refs.get(activity_id)
         if ref is None:
@@ -5141,7 +5151,9 @@ class ConsoleTranscript(VerticalScroll):
             ),
             None,
         )
-        envelope = assistant.thinking if assistant is not None else None
+        if assistant is None or assistant.status in {"pending", "streaming"}:
+            return None
+        envelope = assistant.thinking
         if not isinstance(envelope, ThinkingEnvelope):
             return None
         block = next(


### PR DESCRIPTION
## What

Block-scoped in-place editing of one displayable thinking block's text. Select a **Thinking** row in the Console and press **e** — the new "Edit Thinking" modal opens prefilled with that block's text; saving edits only the text. Per the recorded ADR-090 amendment: block identity, provenance, source encoding, the answer, and provider continuation stay intact; edited blocks remain replay-eligible in their original encoding under the existing serialization safety checks (Auto skips unsafe text, Include fails before send). Content-edit-clears-thinking is unchanged, and proprietary (unavailable) rows offer no edit.

## How

- **Store**: `ConsoleChatStore.update_message_thinking_block` — assistant-only, terminal status only, refuses opaque/quarantined generations, blank text, and `<think`/`</think>` injection for start-anchored blocks; re-validates the envelope through `ThinkingEnvelope` + `dump_thinking_blocks_json` and persists atomically via the selected-generation projection (variant envelope and message envelope both updated; payload-revision bump, no descendant purge).
- **UI**: `ConsoleEditThinkingModal` (same safe-dismiss/stale-key patterns as the message edit modal); thinking rows carry no action buttons by design, so `e` intercepts in `ConsoleTranscript.action_invoke_selected_action` and posts `ConsoleThinkingEditRequested`; `ChatScreen` handles it and delegates into `ConsoleMessageController`.
- **Gating**: `ConsoleMessageActionService` drops the edit action for thinking/unavailable presentations; stray requests get a refusal toast.

## Evidence

- +23 targeted tests, all RED→GREEN (store, modal, transcript helper, action gating, end-to-end wiring, replay pins).
- Targeted sweep (10 files): 448 passed / 35 failed; git-stash differential against clean `origin/dev` shows the **same 35 failures** (425 passed) — pre-existing compositor/paint-width and 2 integration failures on the dev machine, not introduced here.
- ADR-090 amendment: `backlog/decisions/090-console-thinking-block-ownership-and-replay.md`; task: TASK-32312; docs: `Docs/User_Guide/console/chat-basics.md`; new lesson in `backlog/docs/lessons-textual.md`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Selecting a displayable Thinking row and pressing `e` now opens a block-scoped editor for that block's text without discarding the answer. Unlike answer edits, which still clear the turn's thinking, this preserves block identity, provenance, source encoding, provider continuation, and replay eligibility; proprietary rows offer no edit.

- Persists atomically through the selected-generation projection, updating message and variant envelopes, bumping the payload revision, and retaining descendants.
- Rejects blank, oversized, unsafe, unknown, proprietary, live, non-assistant, opaque, quarantined, and stale edits; a freshness guard refuses saving over a newer generation.
- Keeps replay behavior unchanged: Auto skips unsafe text, while Include fails before sending.
- Refreshes mounted transcript disclosures after thinking-only edits and records the reconciled Sync v2 hash so later mutations chain from it.

<sup>Written for commit a830acf8bf639f740e1156927966c79ea40e5be8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

