### PR TITLE
fix(tests): repair stale controller/reconcile fixtures (7 red on dev)

### DIFF
--- a/Tests/UI/test_console_workspace_controller.py
+++ b/Tests/UI/test_console_workspace_controller.py
@@ -101,6 +101,16 @@ class _NoMountScreen:
         self.size = SimpleNamespace(width=120, height=40)
         self.app = SimpleNamespace(push_screen=lambda _modal: None)
 
+    def _build_console_provider_selection(self, _session_id):
+        # The resume flow's token-preparation step reads (and re-reads, for
+        # its change guard) the screen's provider selection; a stable,
+        # equal-to-itself snapshot is all the unmounted fixture needs.
+        return SimpleNamespace(
+            explicit_model=None,
+            configured_model=None,
+            provider="fixture",
+        )
+
     def call_after_refresh(self, callback) -> None:
         self.after_refresh.append(callback)
 

--- a/Tests/Workspaces/test_console_workspace_reconcile.py
+++ b/Tests/Workspaces/test_console_workspace_reconcile.py
@@ -225,6 +225,16 @@ class _RealActivateStub(_Stub):
     def _default_console_session_settings(self):
         return None
 
+    def _blank_console_session_settings(self):
+        # The real activation path creates the workspace blank chat from
+        # config-owned defaults (formerly `_default_console_session_settings`);
+        # an unmounted stub has no config, so a plain None matches this
+        # stub's historical settings shape.
+        return None
+
+    def _console_new_chat_default_generation(self):
+        return 0
+
 
 class _RealStoreCoreStub(_RealActivateStub):
     """Make core sync exercise the real store's active-session invariant."""

--- a/backlog/tasks/task-32313 - Fix-stale-controller-and-reconcile-test-fixtures-drift.md
+++ b/backlog/tasks/task-32313 - Fix-stale-controller-and-reconcile-test-fixtures-drift.md
@@ -1,0 +1,65 @@
+---
+id: TASK-32313
+title: 'Fix stale controller and reconcile test fixtures (drift)'
+status: Done
+assignee:
+  - '@zcode'
+created_date: '2026-09-10 12:00'
+labels:
+  - tests
+  - console
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Seven tests were red on dev (verified on a pristine worktree): four resume
+tests in `Tests/UI/test_console_workspace_controller.py` plus its
+constructor-docstring test, and two in
+`Tests/Workspaces/test_console_workspace_reconcile.py`. All fixture drift,
+not product bugs: the resume flow gained a token-preparation step that reads
+`screen._build_console_provider_selection` (missing from `_NoMountScreen`),
+the workspace activation path renamed its defaults accessor to
+`_blank_console_session_settings` and added
+`_console_new_chat_default_generation` (missing from the reconcile stubs),
+and the controller constructor gained an undocumented
+`notify_character_navigation` dependency. Notably, the atomic-rollback
+resume test was passing VACUOUSLY through the wrong except path because the
+drift exception fired before every injected failure boundary.
+
+ADR required: no — test-only fixture repair plus one docstring line.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Both suites fully green on dev: 115 controller tests, 9 reconcile tests
+- [x] #2 The cancellation/rollback resume test exercises its injected failure boundaries (no longer short-circuited by fixture drift)
+- [x] #3 No production behavior changes (docstring addition only)
+<!-- AC:END -->
+
+## Implementation Plan
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce on pristine dev; capture the actual drift exception
+   (`AttributeError: '_NoMountScreen' object has no attribute
+   '_build_console_provider_selection'`) by spying the resume steps.
+2. Teach `_NoMountScreen` a stable provider-selection snapshot; teach the
+   reconcile stubs the renamed/added accessors; document the constructor
+   dependency.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- `Tests/UI/test_console_workspace_controller.py`: `_NoMountScreen` gains
+  `_build_console_provider_selection` returning a stable SimpleNamespace
+  (equal-to-itself for the token-prep change guard).
+- `Tests/Workspaces/test_console_workspace_reconcile.py`:
+  `_RealActivateStub` gains `_blank_console_session_settings` (None,
+  matching its historical settings shape) and
+  `_console_new_chat_default_generation` (0).
+- `tldw_chatbook/UI/Console_Modules/workspace.py`: docstring-only — the
+  `notify_character_navigation:` Args entry.
+- Evidence: controller suite 115 passed, reconcile suite 9 passed (were
+  5 and 2 failures respectively).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -562,6 +562,9 @@ class ConsoleWorkspaceController:
                 terminal lines (or ``None`` before layout) so the browser's
                 per-section/group visible-row cap can adapt to fill the
                 available space.
+            notify_character_navigation: Report a character-conversation
+                activation result to the user; defaults to the app-level
+                ``notify`` when not supplied.
         """
         self._screen = screen
         self._notify_character_navigation = notify_character_navigation


### PR DESCRIPTION
## What

Seven tests red on `dev` (verified on a pristine worktree before touching anything) — all **fixture drift**, no product bugs:

| Suite | Failure | Cause |
|---|---|---|
| `test_console_workspace_controller.py` | 4 resume tests (cancellation, id-only opener, teardown, retry) | `_NoMountScreen` lacks `_build_console_provider_selection`, which the resume flow's token-preparation step reads |
| `test_console_workspace_controller.py` | constructor-docstring test | `notify_character_navigation` param added without its Args entry |
| `test_console_workspace_reconcile.py` | 2 tests | stubs predate the `_blank_console_session_settings` rename and the `_console_new_chat_default_generation` call |

The nastiest part: the atomic-rollback resume test was passing **vacuously** — the drift exception fired before every injected failure boundary, so the assertions held through the wrong except path, while the cancellation sibling (same fixture, `CancelledError`) lost the propagation it was pinning. Fixing the stub restores the tests' actual contracts.

## Changes

- `Tests/UI/test_console_workspace_controller.py`: `_NoMountScreen._build_console_provider_selection` → stable `SimpleNamespace` (equal-to-itself for the token-prep change guard)
- `Tests/Workspaces/test_console_workspace_reconcile.py`: stub gains `_blank_console_session_settings` (None) and `_console_new_chat_default_generation` (0)
- `UI/Console_Modules/workspace.py`: **docstring-only** `notify_character_navigation:` entry

## Evidence

- Controller suite: 115 passed (was 5 failures). Reconcile suite: 9 passed (was 2).
- Diagnosed by spying the resume steps directly (the load/hydrate/token-prep chain), not by guessing from the DID-NOT-RAISE symptom.
- TASK-32313 on the board, ADR not required (test-only + docstring).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes seven red tests on `dev` caused by stale fixtures, so the resume and reconcile tests now exercise their intended failure paths instead of short-circuiting.

- Adds a stable `_build_console_provider_selection` to `_NoMountScreen` to satisfy the resume flow's token-preparation step.
- Updates reconcile stubs with missing `_blank_console_session_settings` and `_console_new_chat_default_generation`.
- Adds a missing docstring entry for `notify_character_navigation` in `workspace.py`.
- Records the diagnosis and acceptance criteria in `backlog/tasks/task-32313`.

<sup>Written for commit 1744d805eb02c4d1d8025c50fe5e266893d9afad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

