### PR TITLE
fix(console): transcript presses dismiss the rail row action menus (TASK-32311)

### DIFF
--- a/Tests/UI/test_console_conversation_action_menu.py
+++ b/Tests/UI/test_console_conversation_action_menu.py
@@ -554,3 +554,52 @@ async def test_transcript_click_folds_the_menu(monkeypatch) -> None:
         assert not screen.query(ConsoleConversationActionMenu), (
             "a transcript press left the row action menu mounted"
         )
+
+
+@pytest.mark.asyncio
+async def test_fold_helper_dismisses_both_registries_without_focus_restore() -> None:
+    """Unit seam for _fold_row_action_menus_for_pointer (PR #2593 review).
+
+    Mounts one menu of EACH registry directly (no UI open path), parks
+    focus somewhere deliberate, calls the transcript helper, and asserts
+    every registered menu was dismissed with restore_focus=False -- i.e.
+    both gone and focus untouched (no yank back to the rail opener).
+    """
+    from tldw_chatbook.Chat.console_conversation_actions import (
+        ConversationMenuTarget,
+    )
+    from tldw_chatbook.Chat.console_workspace_actions import WorkspaceMenuTarget
+    from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+        ConsoleWorkspaceActionMenu,
+    )
+
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        transcript = screen.query_one("#console-native-transcript")
+        await screen.mount(
+            ConsoleConversationActionMenu(
+                target=ConversationMenuTarget(conversation_id="c1"),
+                opener_id="console-conversation-actions-0",
+                screen_x=4,
+                screen_y=6,
+            ),
+            ConsoleWorkspaceActionMenu(
+                target=WorkspaceMenuTarget(workspace_id="w1"),
+                opener_id="console-workspace-tree",
+                screen_x=4,
+                screen_y=14,
+            ),
+        )
+        await pilot.pause(0.3)
+        composer = screen.query_one("#console-native-composer")
+        screen.set_focus(composer)
+        await pilot.pause()
+
+        transcript._fold_row_action_menus_for_pointer()
+        await pilot.pause(0.3)
+
+        assert not screen.query(ConsoleConversationActionMenu)
+        assert not screen.query(ConsoleWorkspaceActionMenu)
+        assert pilot.app.focused is composer, (
+            "fold restored opener focus instead of honouring the press"
+        )

--- a/Tests/UI/test_console_conversation_action_menu.py
+++ b/Tests/UI/test_console_conversation_action_menu.py
@@ -531,3 +531,26 @@ async def test_copy_follows_the_active_branch_not_every_sibling(
         assert "question" in copied[0]
         assert "first attempt" in copied[0]
         assert copied[0].count("## Assistant") == 1
+
+
+@pytest.mark.asyncio
+async def test_transcript_click_folds_the_menu(monkeypatch) -> None:
+    """ADR-068 completion: transcript presses own the biggest screen area.
+
+    The screen-level outside-click dismissal returns early for transcript
+    targets (the transcript owns its in-area interaction), and the
+    transcript's own cleanup only knew its selection UI -- so a click on
+    the transcript left a row action menu floating. The transcript's
+    pointer press now folds the row menus itself.
+    """
+    async with make_console_pilot(size=(160, 48), production_styles=True) as pilot:
+        screen = pilot.app.screen
+        _opener(screen).press()
+        await pilot.pause(0.3)
+        assert screen.query(ConsoleConversationActionMenu)
+
+        assert await pilot.click("#console-native-transcript")
+        await pilot.pause(0.3)
+        assert not screen.query(ConsoleConversationActionMenu), (
+            "a transcript press left the row action menu mounted"
+        )

--- a/Tests/UI/test_console_workspace_action_menu.py
+++ b/Tests/UI/test_console_workspace_action_menu.py
@@ -723,3 +723,21 @@ async def test_contextual_star_button_and_selection_line_are_retired() -> None:
         assert not console.query("#console-workspace-tree-star")
         assert not console.query("#console-workspace-tree-selection-context")
         assert not console.query("#console-workspace-context-action-row")
+
+
+@pytest.mark.asyncio
+async def test_transcript_press_folds_the_workspace_menu() -> None:
+    """ADR-068 parity: transcript presses fold the workspace menu too."""
+    async with make_console_pilot(size=(160, 44), production_styles=True) as pilot:
+        console = pilot.app.screen
+        console.app_instance.workspace_registry_service = _stub_registry()
+
+        _request_menu(console, kind="workspace")
+        await pilot.pause(0.4)
+        assert console.query(ConsoleWorkspaceActionMenu)
+
+        assert await pilot.click("#console-native-transcript")
+        await pilot.pause(0.3)
+        assert not console.query(ConsoleWorkspaceActionMenu), (
+            "a transcript press left the workspace menu mounted"
+        )

--- a/backlog/tasks/task-32311 - Row-action-menus-transcript-clicks-must-dismiss-them.md
+++ b/backlog/tasks/task-32311 - Row-action-menus-transcript-clicks-must-dismiss-them.md
@@ -1,0 +1,41 @@
+---
+id: TASK-32311
+title: 'Row action menus: transcript clicks must dismiss them'
+status: Done
+assignee:
+  - '@Robert'
+created_date: '2026-09-11 04:12'
+updated_date: '2026-09-11 04:13'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Clicking the transcript (most of the screen) left the conversation/workspace action menu mounted: the screen-level outside-click dismissal returns early for transcript targets, and the transcript's own pointer cleanup only knew its selection UI. The transcript's pointer press now folds both row-menu registries.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 A transcript press folds an open conversation action menu
+- [x] #2 A transcript press folds an open workspace action menu
+- [x] #3 Composer and rail outside-clicks keep folding the menus (regression)
+- [x] #4 Menu-internal clicks (border/padding/buttons) still never fold it (regression)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Red tests in both menu suites: transcript press (pilot.click on #console-native-transcript) folds the open menu.
+2. ConsoleTranscript.on_mouse_down folds the conversation + workspace action-menu registries (restore_focus=False; function-local imports per ADR-097).
+3. Suites, lint, PR.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause: the screen's outside-click dismissal (`_dismiss_console_selection_menus_outside_transcript`) returns early for any transcript-ancestor target -- "the transcript owns its in-area interaction" -- but the transcript's own pointer cleanup only knew its text-selection UI and the More menu, so presses on the transcript (the largest region of the Console) left the rail row-action menus floating. The transcript's `on_mouse_down` (the same earliest-seam precedent the More menu's press dismissal uses) now folds both row-menu registries with no opener focus-restore; menu-internal clicks are unaffected because the action menus mount on the screen, never inside the transcript.
+
+Verification: new red-then-green tests in both menu suites (19 and 20 green); the compositor-tint and four More-menu transcript-suite failures are pre-existing on clean origin/dev (verified by stash-baseline: 7/7 fail without this change). Live-driver note: the PTY synthetic driver can no longer OPEN the rail menus on current dev (rail pointer machinery eats synthetic press pairs) and the seeded workspace tree listing is transient after re-sync, so the transcript-click dismissal is mounted-verified; composer-click dismissal of the same seam was live-verified in earlier UATs.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32450 - Row-action-menus-transcript-clicks-must-dismiss-them.md
+++ b/backlog/tasks/task-32450 - Row-action-menus-transcript-clicks-must-dismiss-them.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-32311
+id: TASK-32450
 title: 'Row action menus: transcript clicks must dismiss them'
 status: Done
 assignee:
@@ -23,6 +23,15 @@ Clicking the transcript (most of the screen) left the conversation/workspace act
 - [x] #3 Composer and rail outside-clicks keep folding the menus (regression)
 - [x] #4 Menu-internal clicks (border/padding/buttons) still never fold it (regression)
 <!-- AC:END -->
+
+## Renumbering
+
+TASK-19601 owner rule: this task originally took id 32311, which collided
+with the older arrival ``task-32311 - Allow-Console-portraits-to-expand-
+within-the-Character-area.md`` already on dev. Renumbered to TASK-32450
+(dev max + headroom) with this provenance section; doc comments and test
+references were updated with it. Earlier commit messages on this branch
+still name TASK-32311.
 
 ## Implementation Plan
 

--- a/tldw_chatbook/Widgets/Console/console_transcript.py
+++ b/tldw_chatbook/Widgets/Console/console_transcript.py
@@ -5805,6 +5805,34 @@ class ConsoleTranscript(VerticalScroll):
             return None
         return widget
 
+    def _fold_row_action_menus_for_pointer(self) -> None:
+        """Fold rail row-action menus on a transcript press (ADR-068).
+
+        The screen-level outside-click dismissal returns early for
+        transcript targets -- this widget owns its in-area interaction --
+        and this widget's own cleanup only knew its selection UI, so a
+        press on the transcript (most of the screen) left a conversation or
+        workspace action menu floating. Fold both registries here with no
+        opener focus-restore: the press already expresses the user's focus
+        intent. Imports stay function-local per ADR-097 (this module is on
+        the boot path; the menu modules must not be).
+        """
+        try:
+            screen = self.screen
+        except Exception:
+            return
+        from tldw_chatbook.Widgets.Console.console_conversation_action_menu import (
+            conversation_action_menus_on_screen,
+        )
+        from tldw_chatbook.Widgets.Console.console_workspace_action_menu import (
+            workspace_action_menus_on_screen,
+        )
+
+        for menu in conversation_action_menus_on_screen(screen):
+            menu.dismiss_menu(restore_focus=False)
+        for menu in workspace_action_menus_on_screen(screen):
+            menu.dismiss_menu(restore_focus=False)
+
     async def on_mouse_down(self, event: MouseDown) -> None:
         """Dismiss More, then arm a drag on a left press over selectable text."""
         if self._kb_selection_row is not None:
@@ -5821,6 +5849,7 @@ class ConsoleTranscript(VerticalScroll):
         # proceeds; the active opener is exempt so its Button.Pressed can
         # keep owning the menu's open/reopen lifecycle.
         await self._dismiss_message_more_for_pointer(press_control)
+        self._fold_row_action_menus_for_pointer()
         # Click-outside dismissal, row-body half (final review): rows stop
         # their own Clicks (the message-selection toggle), so with a menu
         # open a press on another row's body never reaches this


### PR DESCRIPTION
## Summary

Clicking the transcript — most of the Console screen — left the chat/workspace action menu (Favourite / Change status / Archive / Rename… / Copy as…) floating. Root cause: the screen's outside-click dismissal returns early for transcript targets ("the transcript owns its in-area interaction"), but the transcript's own pointer cleanup only knew its text-selection UI and the More menu — nobody folded the row action menus.

Fix: `ConsoleTranscript.on_mouse_down` (the same earliest-seam precedent the More menu's press dismissal already uses) now folds both row-menu registries — conversation and workspace — with `restore_focus=False` (the press already expresses the user's focus intent) and function-local imports so the ADR-097 boot ratchet is untouched. Composer and rail clicks already folded the menus (unchanged); menu-internal clicks are unaffected because the action menus mount on the screen, never inside the transcript.

## Testing

- Red-then-green pins in both menu suites: `test_transcript_click_folds_the_menu` (conversation) and `test_transcript_press_folds_the_workspace_menu` — 19 + 20 green, including the existing composer-click dismissal and chrome-click regression tests.
- Adjacent suites: selection-dismissal perf and workspace context rail green; the compositor-tint and four More-menu transcript-suite failures are pre-existing on clean origin/dev (stash-baselined: 7/7 fail without this change).
- Ruff clean on the touched file.

TASK-32311 · ADR-068 (dismiss contract) · ADR-097 (boot ratchet)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clicking the transcript — most of the Console screen — now dismisses open conversation and workspace action menus, so they no longer float over the screen. Previously a transcript press only handled its selection UI; `ConsoleTranscript.on_mouse_down` now folds both row-menu registries with `restore_focus=False`, since the press already expresses the user's focus intent. Composer and rail outside-clicks still fold the menus, and menu-internal clicks stay unaffected because the menus mount on the screen, not inside the transcript. A unit seam verifies both registries fold without focus restore. The task was renumbered from TASK-32311 to TASK-32450 because 32311 collided with an existing task on dev; tests and doc comments now reference 32450.

<sup>Written for commit 2250175dbc8aab95cca60ee88e61aa7a595ddd47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

