### PR TITLE
docs(irc): reassess pydle plan and prepare PTO handoff

### DIFF
--- a/Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+++ b/Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
@@ -1,0 +1,571 @@
+# tldw-pydle 1.1.0.post1 implementation plan
+
+Status: Foundational task ready; behavioral amendments under PR review
+Reassessed: 2026-09-10
+Start here: [PTO handoff](2026-09-10-network-chat-pto-handoff.md)
+Amendment: [ADR-149](../../../backlog/decisions/149-network-chat-handoff-reliability-amendments.md)
+Date: 2026-08-23
+Design: [Network Chat IRCv3 and tldw-pydle design](../specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md)
+Decision: [ADR-148](../../../backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md)
+Scope: Dedicated fork and first release artifact only; no Chatbook runtime integration or screen
+
+> **For agentic workers:** Use superpowers:executing-plans to execute one claimed task at a time. This PR delivers planning only.
+
+**Goal:** Deliver an independently tested IRC client fork before Chatbook adopts it.
+
+**Architecture:** One connection owns transport, ordered reduction and bounded delivery; Chatbook owns application lifecycle and UI behind an adapter.
+
+**Tech Stack:** Python 3.11+ fork; Python 3.12+ and Textual 8.x for later Chatbook integration.
+
+**Spec:** [Design](../specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md).
+
+## Global constraints
+
+- Canonical Codeberg base remains `4efcc3b5096536668dfe772461f19a17f1ddd84e`; never silently track develop.
+- Separate distribution `tldw-pydle`, import `tldw_pydle`; no vendored source.
+- Direct verified TLS; PLAIN only over verified TLS; no implicit reconnect.
+- Memory-only transcripts; no raw wire or payload-bearing diagnostics.
+- Fork Python 3.11–3.14 Linux gates; Windows/macOS transport and packaging coverage on 3.12.
+- Behavioral changes require the corresponding ADR-149 amendments accepted first.
+
+## ADR check
+
+ADR required: yes
+
+ADR path: `backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md` (approved boundary); `backlog/decisions/149-network-chat-handoff-reliability-amendments.md` (proposed corrections)
+
+Reason: The work creates a maintained runtime dependency and defines transport,
+authentication, privacy, lifecycle, protocol, packaging, and cross-repository
+interfaces shared by Chatbook and approved tldw client roles.
+
+## Objective
+
+Publish `tldw-pydle==1.1.0.post1` as a provenance-preserving, independently
+installable Python 3.11+ fork of canonical Codeberg pydle. The release must
+apply IRC protocol state in wire order, keep content and credentials out of
+diagnostics, provide verified TLS and TLS-gated SASL PLAIN, own its async
+lifecycle honestly, stream LIST within bounds, preserve the first modern IRCv3
+semantics, and pass deterministic, AgentIRC, and pinned-Ergo artifact gates.
+
+## Task sequence
+
+| Order | Task | Outcome | Depends on |
+| --- | --- | --- | --- |
+| 1 | [TASK-21601](../../../backlog/tasks/task-21601%20-%20Establish-tldw-pydle-fork-provenance-and-isolated-package.md) | Full-history fork, isolated namespace, buildable wheel/sdist | None |
+| 2 | [TASK-21602](../../../backlog/tasks/task-21602%20-%20Remove-IRC-content-from-diagnostics-and-harden-outbound-transport.md) | Content-free diagnostics and one ordered bounded writer | 21601 |
+| 3 | [TASK-21603](../../../backlog/tasks/task-21603%20-%20Own-tldw-pydle-connection-lifecycle-and-secure-TLS.md) | Explicit lifecycle, honest close and verified direct TLS | 21602 |
+| 4 | [TASK-21604](../../../backlog/tasks/task-21604%20-%20Implement-ordered-IRC-protocol-reduction-and-correlated-replies.md) | Wire-ordered state and publish-before-send correlation | 21603 |
+| 5 | [TASK-21605](../../../backlog/tasks/task-21605%20-%20Implement-CAP-302-and-TLS-gated-SASL-PLAIN.md) | CAP 302 state machine and dependency-free PLAIN | 21604 |
+| 6 | [TASK-21606](../../../backlog/tasks/task-21606%20-%20Add-bounded-streaming-IRC-LIST-sessions.md) | Incremental bounded LIST with honest local cancellation | 21604 |
+| 7 | [TASK-21607](../../../backlog/tasks/task-21607%20-%20Add-bounded-IRCv3-message-and-history-semantics.md) | Tags, time, echo, BATCH and draft history semantics | 21605 |
+| 8 | [TASK-21608](../../../backlog/tasks/task-21608%20-%20Gate-and-publish-tldw-pydle-1-1-0-post1.md) | Reproducible compatibility-gated release | 21601–21607 |
+
+TASK-21605 and TASK-21606 are code-independent after TASK-21604, but they
+should still be executed serially unless the user explicitly requests parallel
+agent work. TASK-21608 does not begin until both branches have landed with
+TASK-21607.
+
+## Repository and branch boundaries
+
+Use a dedicated checkout of `rmusser01/tldw-pydle` outside Chatbook source. Choose an authorized local path; the original author's Windows directory is not required. A sibling path may require filesystem approval in an agent session. Do not place the fork under Chatbook as a
+vendored directory, submodule, or long-lived temporary checkout.
+
+Remote roles:
+
+```text
+origin    https://github.com/rmusser01/tldw-pydle.git
+upstream  https://codeberg.org/shiz/pydle.git
+```
+
+The default branch is `develop`. Feature branches use the repository's normal
+`codex/` prefix. Each Backlog task maps to one reviewable fork PR. Chatbook task
+records, ADR links, and plan notes are updated in a separate Chatbook docs
+commit without copying fork source into this repository.
+
+Before every task:
+
+- [ ] Re-read its Backlog file and ADR-148.
+- [ ] Confirm no existing branch, worktree, or PR already owns the task.
+- [ ] Move only that task to In Progress and add its implementation plan before
+   changing fork behavior.
+- [ ] Rebase or update from the accepted prior task tag/branch.
+- [ ] Derive the focused test list from the files and public behavior being
+   changed.
+- [ ] For an ad-hoc full local sweep, ask and obtain explicit opt-in. This does
+   not suspend the reviewed unattended fork CI workflow.
+
+## TASK-21601 — fork provenance and isolated package
+
+### Target files in the fork
+
+```text
+UPSTREAM_BASE
+NOTICE
+FORK_GOVERNANCE.md
+pyproject.toml
+README.md
+LICENSE.md
+tldw_pydle/**
+tests/**
+scripts/check_namespace.py
+tests/test_distribution_artifacts.py
+```
+
+Exact upstream filenames may differ. Preserve canonical files rather than
+creating duplicates when a file already has the same responsibility.
+
+### Steps
+
+- [ ] Verify the approved SHA and v1.1.0 ancestor exist, then branch explicitly from `4efcc3b5096536668dfe772461f19a17f1ddd84e`. Develop moved to `e27b6a2138c81061c2e6a937526fceaedb94d31a` by 2026-09-10; this does not block starting from the pin. Audit the eight-commit delta separately before changing the base.
+- [ ] Check for an existing fork first. If absent, an authorized owner creates GitHub empty, without a template. Clone full Codeberg history, retain Codeberg as `upstream`, add GitHub as `origin`, and create fork develop at the approved SHA. Push only that branch and explicitly reviewed provenance tags; never mirror-push unrelated refs.
+- [ ] Make `develop` the GitHub default branch and protect it according to the
+   available repository policy. Do not enable workflows until their permissions
+   and action pins are reviewed.
+- [ ] Add `UPSTREAM_BASE` containing the exact SHA, plus NOTICE and governance
+   documentation. Preserve upstream `LICENSE.md` verbatim even if its text has
+   an unusual placeholder.
+- [ ] Commit the provenance/governance boundary before renaming any package.
+- [ ] In a second mechanical commit, rename `pydle/` to `tldw_pydle/` and rewrite
+   internal imports, tests, console scripts, examples, README commands, source
+   URLs, issue URLs, and build metadata.
+- [ ] Set distribution `tldw-pydle`, version `1.1.0.post1`, Python floor 3.11, and
+   classifiers matching the tested range. Preserve existing SASL dependency metadata in this mechanical task; TASK-21605 removes pure-sasl and obsolete mechanisms when the replacement passes tests. Do not publish this intermediate package as production-ready.
+- [ ] Add a namespace guard that inspects both source and built artifact. Explicit
+   upstream attribution strings are allowlisted; runtime `import pydle`, a
+   top-level `pydle/`, and upstream console-script names fail.
+- [ ] Build wheel and sdist, inspect their members, install each into its own clean
+   environment, co-install upstream pydle, and prove both import identities are
+   distinct.
+- [ ] Compare the namespace commit against the pinned upstream tree after
+    reversing only path/import/metadata substitutions; any protocol behavior
+    delta is removed or moved to a later task.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_distribution_artifacts.py -q
+python scripts/check_namespace.py
+python -m build
+python -m ruff check tldw_pydle tests scripts
+python -m ruff format --check tldw_pydle tests scripts
+```
+
+Artifact tests must open the wheel and sdist directly. Reading only
+`pyproject.toml` is not packaging evidence.
+
+### Commit boundaries
+
+- [ ] `chore(fork): record canonical upstream provenance`
+- [ ] `refactor(package): isolate tldw_pydle namespace`
+- [ ] `test(package): verify built distribution identity`
+
+## TASK-21602 — diagnostics and outbound transport
+
+### Target files
+
+```text
+tldw_pydle/client.py
+tldw_pydle/connection.py
+tldw_pydle/protocol.py
+tldw_pydle/diagnostics.py          # only if a narrow new owner is warranted
+tests/test_diagnostics_privacy.py
+tests/test_outbound_transport.py
+tests/support/scripted_server.py
+```
+
+### Steps
+
+- [ ] Inventory every logger call, warning, exception wrapper, repr, and test
+   artifact reachable from send, receive, parse failure, authentication,
+   timeout, and disconnect. Record which currently carries raw content.
+- [ ] Replace raw-frame logging with a helper or fixed call pattern that accepts
+   only opaque connection ID, command/capability name, numeric/reply code,
+   encoded size, duration, and reason category. Never redact a fully formatted
+   raw frame after the fact.
+- [ ] Remove invalid-message warnings that interpolate `message._raw`. Convert
+   exception logging to fixed exception type/category where the original
+   message may contain transport data.
+- [ ] Build synthetic fixtures containing a plaintext secret, its exact base64
+   representation, channel key, private endpoint, nick/channel/target, topic,
+   and message body. Capture every field and rendered logger output.
+- [ ] Introduce one writer with a queue bounded by entries and encoded bytes. Keep FIFO order for admitted application commands and reserve protocol-control capacity for PONG/negotiation. Reject admission on exhaustion, without an unbounded waiter backlog; the reducer never waits for application queue capacity.
+- [ ] Validate structured command parts and encoded bytes before acquiring the
+   writer. Reject CR/LF/NUL and unsafe targets. Enforce protocol/tag budgets
+   after encoding, not by character count.
+- [ ] Review upstream commit `7c7f5c73bf14b8207a551a6cbf38627984cb7f4e` (PR 196 is now merged) and adapt its stalled-write fix with provenance to the pinned base, namespace and disconnect result. Add a deterministic
+   writer/drain double that stalls without sleeping the whole test.
+- [ ] Prove a timeout publishes exactly one failure/disconnect outcome and leaves
+   no second writer or unobserved drain task.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_diagnostics_privacy.py tests/test_outbound_transport.py -q
+python -m ruff check tldw_pydle tests/test_diagnostics_privacy.py tests/test_outbound_transport.py
+```
+
+Mutation checks:
+
+- restore either raw debug call and see the privacy test fail;
+- remove the outbound lock/queue and see concurrent ordering fail;
+- remove the drain bound and see the stalled-writer test fail.
+
+## TASK-21603 — lifecycle and secure TLS
+
+### Target files
+
+```text
+tldw_pydle/client.py
+tldw_pydle/connection.py
+tldw_pydle/features/tls.py
+tldw_pydle/lifecycle.py
+tests/test_client_lifecycle.py
+tests/integration/test_tls_transport.py
+tests/support/certificates/**
+```
+
+Prefer generated test certificates from a deterministic test helper over
+committing private-key material unless the repository has a reviewed fixture
+policy. Any committed fixture key is synthetic, conspicuously named, and
+excluded from secret scanners through a narrow documented rule.
+
+### Steps
+
+- [ ] Define and review exact typed lifecycle signatures, connection states and
+   terminal close/failure results before dependent work starts. Keep state
+   transitions monotonic and reject new work after closing begins.
+- [ ] Replace implicit `RECONNECT_ON_ERROR` and delayed reconnect timers with
+   emitted unexpected-disconnect state. Preserve an explicit compatibility
+   note instead of silently reconnecting old subclasses.
+- [ ] Own the reader, writer, timers, callbacks, and pending queries in one client
+   lifecycle registry. Every creation site registers before scheduling.
+- [ ] Implement connect cancellation and one-generation readiness storage.
+   `wait_ready()` supports multiple awaiters observing one terminal result.
+- [ ] Implement idempotent `aclose()` with cleanup owned independently of its
+   waiters; cancelling one waiter cannot cancel shared cleanup. Block new work, fail/settle queries,
+   best-effort bounded QUIT, close the writer, await `wait_closed()`, observe
+   tasks with bounded `asyncio.wait`, cancel, observe again, and drain done
+   exceptions.
+- [ ] Add force-abort for a broken transport after graceful bounds. Do not use
+   `wait_for(gather(...))` as the sole shutdown bound.
+- [ ] For callbacks ignoring cancellation but still yielding, return typed incomplete close with opaque retained-task identity. Revoke public command/publication authority and use a fresh Client for a replacement connection. Callbacks are trusted Python, not a sandbox: code blocking the loop cannot have an in-loop time guarantee.
+- [ ] Make the effective client-level TLS default verified. Use
+   `ssl.PROTOCOL_TLS_CLIENT`, hostname verification, certificate-chain
+   verification, SNI, and a typed caller-provided trust context.
+- [ ] Build loopback TLS fixtures for matching trusted, hostname mismatch,
+   untrusted chain, required-TLS/no-plaintext-fallback, cancellation, and
+   writer close.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_client_lifecycle.py tests/integration/test_tls_transport.py -q
+python -m ruff check tldw_pydle tests/test_client_lifecycle.py tests/integration/test_tls_transport.py
+```
+
+Mutation checks restore implicit reconnect, omit `wait_closed`, accept an
+untrusted cert, allow plaintext fallback, and let an old callback publish after
+close. Each mutation must make a named test fail.
+
+## TASK-21604 — ordered reduction and correlation
+
+### Target files
+
+```text
+tldw_pydle/client.py
+tldw_pydle/features/**
+tldw_pydle/reducer.py
+tldw_pydle/correlation.py
+tldw_pydle/events.py
+tests/test_protocol_ordering.py
+tests/test_query_correlation.py
+tests/test_callback_delivery.py
+tests/support/scripted_server.py
+```
+
+New modules are justified only if they create narrow ownership. Do not create
+a generic framework that obscures pydle's existing feature composition.
+
+### Steps
+
+- [ ] Inventory every `on_raw_*`, `_sync_*`, user/channel mutation, query future,
+   and public callback. Classify each as parser, ordered reducer, correlation
+   completion, or post-commit application callback. Add a ratchet so new raw
+   handlers cannot bypass classification.
+- [ ] Replace one-detached-task-per-message dispatch with monotonic inbound
+   envelopes and one ordered reduction path.
+- [ ] Split reducer-safe internal state work from public/user callbacks. Complete
+   state commit and correlation resolution before enqueueing the immutable
+   event view.
+- [ ] Ensure capability-selection hooks used during negotiation are configured
+   synchronously before connection. Arbitrary async application work is not
+   invoked from the reducer.
+- [ ] Implement a bounded ordered callback/event queue. Define exact coalescing
+   identity for presence/state events. Never coalesce chat messages or query
+   terminal results.
+- [ ] Full non-coalescible callback queues initiate one typed slow-consumer close; the independent lifecycle result settles queries. Never await callback capacity from the reducer: a callback may be awaiting WHOIS. Test that cycle at capacity. Coalescing removes the old event and appends the new state at its latest receive sequence.
+- [ ] Add a correlation registry whose `prepare` step creates result storage and
+   future before the writer can send. Convert WHOIS first and then every query
+   included in the release.
+- [ ] Reject ambiguous duplicate same-target/same-command operations where IRC
+   replies cannot be distinguished. Do not claim labeled-response concurrency
+   before it is implemented.
+- [ ] Settle callers exactly once, but retain a bounded tombstone for abandoned unlabelled queries until their terminal wire reply or teardown. Reject correlation-key reuse during that interval. Use ISUPPORT CASEMAPPING for target keys, never generic Unicode casefold. Late replies cannot resolve replacement operations.
+- [ ] Script back-to-back JOIN/NICK/WHOIS/BATCH-like frames while callbacks block
+    or fail. Assert state and events exactly match receive order.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_protocol_ordering.py tests/test_query_correlation.py tests/test_callback_delivery.py -q
+python -m ruff check tldw_pydle tests/test_protocol_ordering.py tests/test_query_correlation.py tests/test_callback_delivery.py
+```
+
+Mutation checks restore detached dispatch, move future creation after send,
+resolve after callback, remove the queue bound, and permit an ambiguous
+duplicate query.
+
+## TASK-21605 — CAP 302 and SASL PLAIN
+
+### Target files
+
+```text
+tldw_pydle/features/ircv3/cap.py
+tldw_pydle/features/ircv3/sasl.py
+tldw_pydle/features/ircv3/readiness.py
+tests/test_cap302.py
+tests/test_sasl_plain.py
+tests/test_registration_readiness.py
+tests/support/scripted_server.py
+```
+
+### Steps
+
+- [ ] Replace the current capability dictionaries/sets with explicit offered,
+   supported-policy, requested, pending, negotiated, and semantic states.
+- [ ] Parse CAP 302 continuation form and capability values without lowercasing or
+   otherwise changing opaque capability names.
+- [ ] Accumulate every LS row before computing requests. Use a stable feature
+   registration order and split REQ chunks by encoded line budget.
+- [ ] Associate ACK/NAK with pending request chunks. Each REQ is accepted or
+   rejected atomically; distinguish outcomes across separately sent chunks,
+   not partial acceptance within one REQ. Process NEW/DEL after registration
+   without re-running CAP END.
+- [ ] Make CAP END an idempotent registration action that can occur exactly once
+   after required capability/SASL policy resolves.
+- [ ] Emit ready once on `001` only after mandatory SASL/capabilities succeed; refuse premature welcome otherwise. Allow legacy no-CAP registration when none is mandatory. MOTD never gates readiness; cancelling one waiter must not cancel the shared result.
+- [ ] Implement PLAIN with standard-library base64 over
+   `authzid NUL authcid NUL password`. Chunk encoded bytes into 400-byte
+   AUTHENTICATE parameters and send `+` after an empty or exact-multiple final
+   response.
+- [ ] Gate PLAIN on the actual SSL transport and validated trust context, not a caller boolean. Reject embedded credential NULs and nonempty/malformed PLAIN challenges. Remove pure-sasl metadata/imports with passing replacement tests.
+- [ ] Replace all SASL timers with lifecycle-owned handles/tasks, including the
+   continuation path that currently passes a coroutine object to `call_later`.
+- [ ] Minimize retained secret references and prove all negotiation terminal
+    paths release them from client state and exclude them from diagnostics.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_cap302.py tests/test_sasl_plain.py tests/test_registration_readiness.py -q
+python -m ruff check tldw_pydle tests/test_cap302.py tests/test_sasl_plain.py tests/test_registration_readiness.py
+```
+
+Tests include multiline LS/LIST form, values, trailing space, split requests,
+ACK/NAK, NEW/DEL, one END, multiple readiness waiters, exact 400-byte boundary,
+multiple chunks, malformed challenge, success/rejection/abort/timeout, missing
+required SASL, and TLS refusal.
+
+## TASK-21606 — bounded streaming LIST
+
+### Target files
+
+```text
+tldw_pydle/features/rfc1459/list.py
+tldw_pydle/models.py
+tests/test_channel_list_stream.py
+tests/support/scripted_server.py
+```
+
+Use the existing feature layout if it already has a clearer LIST owner. Do not
+copy Codeberg PR 172's shared arrays or send-before-future ordering.
+
+### Steps
+
+- [ ] Define immutable `ListEntry` and `ListResult` models plus an async LIST
+   session/iterator. Keep raw numerics private.
+- [ ] Register the session and bounded queue before sending LIST. Reject a second
+   session while the first response remains ambiguous.
+- [ ] Parse `321`, `322`, `323`, documented error numerics, standard replies, and
+   TRYAGAIN into exact session transitions.
+- [ ] Count received, delivered, and dropped rows independently. Validate user
+   counts and preserve bounded topic content for the caller without logging it.
+- [ ] On local limit or cancellation, stop caller delivery and enter drain mode.
+   Continue reducing unrelated frames while discarding LIST rows through 323.
+- [ ] Bound drain duration. Missing 323 settles the caller and releases buffered rows but retains one bounded LIST tombstone. Reject another LIST until 323 or teardown; unrelated chat remains usable. Terminal counters snapshot caller settlement, not later discarded rows.
+- [ ] Accept server-side ELIST filters only when supported; document that the
+   iterator is local flow control, not universal IRC pagination.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_channel_list_stream.py -q
+python -m ruff check tldw_pydle tests/test_channel_list_stream.py
+```
+
+Mutation checks make the queue unbounded, create state after send, stop
+reducing unrelated chat during drain, and omit the drain deadline.
+
+## TASK-21607 — IRCv3 messages and history
+
+### Target files
+
+```text
+tldw_pydle/features/ircv3/tags.py
+tldw_pydle/features/ircv3/server_time.py
+tldw_pydle/features/ircv3/batch.py
+tldw_pydle/features/ircv3/chathistory.py
+tldw_pydle/models.py
+tests/test_message_tags.py
+tests/test_server_time_and_echo.py
+tests/test_batch.py
+tests/test_chathistory.py
+```
+
+### Steps
+
+- [ ] Implement tag escaping/unescaping and the IRCv3 byte budgets, including the
+   separate tag and unchanged message portions. Reject or classify oversized
+   input before it reaches semantic handlers.
+- [ ] Retain bounded unknown tags as untrusted protocol metadata. Provide
+   immutable views and prevent them from becoming log fields automatically.
+- [ ] Parse server-time into a validated timezone-aware value. Preserve receive
+   time separately for ordering and fallback.
+- [ ] Preserve authoritative server echoes and actual correlation metadata. A write is not delivery acknowledgement. Without labels/usable identity, never merge by text or time: identical legitimate messages remain distinct. Local optimistic-send state stays explicitly unconfirmed.
+- [ ] Implement bounded BATCH state with ID, type, parameters, parent, open/close order and member sequence. History cannot mutate live membership/topic state. Do not negotiate event-playback without separate semantics/tests. Support unknown batch types and honest
+   incomplete termination.
+- [ ] Implement negotiated `draft/chathistory` commands and correlated `chathistory`
+   batches. Honor the server's CHATHISTORY/MSGREFTYPES declarations where
+   present and preserve timestamp/msgid anchors.
+- [ ] Validate server over-return, mismatched batch type/target, empty batch,
+   standard replies, error numerics, cancellation, timeout, and disconnect.
+- [ ] Return immutable history results. Leave paging policy, cross-page
+   deduplication, transcript retention, unread state, and persistence to the
+   embedding adapter/application.
+
+### Focused verification
+
+```text
+python -m pytest tests/test_message_tags.py tests/test_server_time_and_echo.py tests/test_batch.py tests/test_chathistory.py -q
+python -m ruff check tldw_pydle tests/test_message_tags.py tests/test_server_time_and_echo.py tests/test_batch.py tests/test_chathistory.py
+```
+
+Mutation checks remove a tag bound, scramble batch member order, accept a
+mismatched history batch, and merge receive-time with server-time authority.
+
+## TASK-21608 — compatibility gate and release
+
+### Target files
+
+```text
+.github/workflows/ci.yml
+.github/workflows/compatibility.yml
+.github/workflows/release.yml
+tests/integration/test_deterministic_oracle.py
+tests/integration/test_agentirc.py
+tests/integration/test_ergo.py
+tests/integration/test_release_artifact.py
+scripts/download_pinned_ergo.py
+scripts/check_release_artifacts.py
+CHANGELOG.md
+```
+
+### Steps
+
+- [ ] Run Python 3.11–3.14 on Linux, plus 3.12 transport/TLS/packaging on Windows/macOS. Verify installer availability before patch-pinning interpreters. Pin every third-party action by full commit
+   SHA with a nearby version comment. Use minimal top-level and job-level
+   permissions.
+- [ ] Ensure pull-request workflows use neither publishing credentials nor
+   `pull_request_target` execution of untrusted code.
+- [ ] Build wheel/sdist once in the release-artifact job. Downstream jobs download
+   that artifact rather than rebuilding or editable-installing the checkout.
+- [ ] Port the deterministic scripted oracle to the final public API and assert
+   registration, CAP, SASL, PING/PONG, JOIN/channel/DM, WHOIS, LIST, tags,
+   history, disconnect, and lifecycle outcomes.
+- [ ] Pin an exact AgentIRC release or commit and an exact Ergo release. Verify the
+   Ergo archive checksum before execution. Run two-client chat and cleanup
+   against both using only synthetic fixture content.
+- [ ] Prove normal/cooperative zero-task shutdown on every target and the explicit
+   incomplete outcome for a cancellation-resistant application callback.
+- [ ] Inspect and independently install wheel and sdist on every supported Python.
+   Assert namespace, metadata, Python floor, license/notice, upstream base, and
+   patch inventory from the artifacts themselves.
+- [ ] Generate SHA-256 checksums and a supported provenance/SBOM artifact. Release
+   notes include exact upstream base and per-commit patch classification.
+- [ ] Configure PyPI Trusted Publishing without storing a long-lived PyPI token.
+   Publish only from a reviewed `v1.1.0.post1` tag and approved environment.
+- [ ] Add a non-release-blocking scheduled job for latest stable upstream and
+    Ergo. It files or reports drift; it does not alter the pinned release gate.
+- [ ] Execute fork CI gates through the reviewed workflow, without requiring an absent author's interactive prompt. Agents ask before ad-hoc full local sweeps. Never run the full Chatbook suite for fork-only changes.
+- [ ] If external publishing is unavailable, preserve verified local artifacts
+    and record the exact blocker. Do not mark publication AC complete or call
+    the task Done.
+
+### Required release evidence
+
+```text
+Python 3.11–3.14 CI result
+deterministic oracle result against built wheel
+loopback TLS matrix result
+AgentIRC exact version/commit and two-client result
+Ergo version, download URL, SHA-256 and two-client result
+wheel and sdist filenames plus SHA-256
+artifact member/metadata report
+owned task/timer shutdown report
+privacy-log synthetic-secret report
+SBOM/provenance locator
+GitHub release and PyPI project/version locators
+```
+
+## Cross-task test-support rules
+
+- The scripted server is test-only and implements only the exact frames needed
+  by each case. It is not a second IRC server implementation.
+- Test events/barriers establish ordering; fixed sleeps are not race evidence.
+- Timeouts distinguish operation deadlines from shutdown observation bounds.
+- Cancellation tests trigger cancellation after the named lifecycle state is
+  observed, not before the response or callback begins.
+- Privacy tests inspect every default logger/sink and rendered field, not just
+  captured wire bytes.
+- Async test helpers store content-only exception type/category rather than a
+  traceback retaining live transports.
+- Packaging assertions read wheel/sdist members and installed metadata.
+- Live target fixtures use synthetic identities/content and bind loopback only.
+- Every temporary server/process/path is recorded and cleaned after exact-path
+  verification; failed cleanup is reported.
+
+## Documentation and closeout per task
+
+Before a task is marked Done:
+
+- [ ] Check every acceptance criterion only when its evidence exists.
+- [ ] Add concise Implementation Notes naming approach, trade-offs, files, tests,
+   artifact/commit IDs, and deviations.
+- [ ] Record ADR required/path/reason in the task's implementation plan and notes.
+- [ ] Run targeted tests and Ruff for touched modules; record exact commands and
+   results.
+- [ ] Self-review the task diff and compare behavior-sensitive tests against the
+   prior task base where useful.
+- [ ] Update fork README/governance/changelog when the public contract changes.
+- [ ] Add a lessons entry only when an incident reveals reusable evidence not
+   already captured by the existing testing/live/backlog lessons.
+- [ ] Re-scan task and ADR IDs against current refs/worktrees before merging
+   Chatbook governance changes.
+
+## Definition of the first release boundary
+
+The programme is complete only when TASK-21608 publishes externally retrievable artifacts matching the tested hashes. A publication blocker leaves the programme incomplete even when local artifacts pass. Completion does **not** add the dependency to
+Chatbook. The next separately designed Chatbook tranche may then file tasks for
+typed models/fake adapter, application session manager, private profiles and
+credentials, the Network Chat vertical slice, and the real `tldw-pydle`
+adapter pinned to the released artifact.

--- a/Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+++ b/Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
@@ -1,0 +1,180 @@
+# Network Chat / tldw-pydle — PTO handoff
+
+Date: 2026-09-10
+Reviewed Chatbook base: `3afa68f1b99103ec8b5b5f19921ac480ad9344ac` (`origin/dev`)
+Scope: Plan reassessment and contributor handoff only; no runtime implementation.
+
+## Start here
+
+The fork remains the selected direction. Maintaining it is a core reliability
+project, not a small dependency bump. Start with **TASK-21601**, then take one
+task at a time from the [eight-task execution plan](2026-08-23-tldw-pydle-first-release.md#task-sequence).
+All eight tasks remain **To Do**, unassigned, with unchecked acceptance criteria.
+No fork release, Chatbook IRC adapter, Network Chat screen, or tldw_server IRC
+service is delivered by this PR.
+
+Read in this order:
+
+1. This handoff: current facts, blockers and first actions.
+2. [ADR-148](../../../backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md): approved product and fork boundary.
+3. [ADR-149](../../../backlog/decisions/149-network-chat-handoff-reliability-amendments.md): proposed corrections for PR review, not silently accepted policy.
+4. [Design](../specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md): full ownership and feature contracts.
+5. Your task and its section in the [execution plan](2026-08-23-tldw-pydle-first-release.md).
+
+ADR required: yes
+
+ADR path: `backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md`;
+`backlog/decisions/149-network-chat-handoff-reliability-amendments.md`
+
+Reason: Preserve the approved dependency/runtime boundary and separately review
+corrections to async ownership, correlation, security and release contracts.
+
+## What the reassessment found
+
+| Finding | Change in this handoff |
+| --- | --- |
+| Callback backpressure could deadlock a callback awaiting WHOIS | Reducer never waits for callback capacity; overload closes visibly. |
+| A timed-out query's late replies could resolve a new query | Bounded tombstones quarantine correlation keys until terminal replies or teardown. |
+| A lock alone does not bound queued outbound work | Bound admission bytes/entries and reserve control capacity for PONG. |
+| Arbitrary callbacks cannot be forcibly stopped inside asyncio | Bound yielding stragglers honestly; fresh client per connection; no sandbox claim. |
+| CAP draft assigned continuation/value grammar to ACK/NAK | Correct LS/LIST and LS/NEW grammar; authenticate before ready. |
+| Identical messages could be mistaken for duplicate echoes | Do not correlate by text/time; history cannot change live presence. |
+| Current dev reuses some screens and now requires Python 3.12 | Explicit suspend/resume tests; keep the fork's independent 3.11 floor. |
+| Mechanical packaging prematurely removed SASL dependencies | Defer dependency removal to the tested PLAIN replacement. |
+| Recording a publishing blocker could count as programme completion | Publication remains unchecked and unfinished until retrievable artifacts exist. |
+| ADR-084 was claimed by other work while this draft was unlanded | Preserve the decision as ADR-148; proposed changes are ADR-149. |
+
+## Verified upstream state and limits of the evidence
+
+Canonical upstream is **Codeberg**, not the GitHub mirror. Read-only ref checks
+and the Codeberg comparison API on 2026-09-10 established:
+
+- Approved fork point: `4efcc3b5096536668dfe772461f19a17f1ddd84e`.
+- Upstream v1.1.0 tag: `cbc18112e141d357abfb5828262cd98d65628096` (unchanged).
+- Current develop: `e27b6a2138c81061c2e6a937526fceaedb94d31a`.
+- Eight commits after the approved point include a stalled-write fix,
+  fixture cleanup, formatting/lint/workflow/link changes and a commit titled
+  `Version 1.2.0`. That title alone is not evidence of a published artifact.
+- The stalled-write fix is commit `7c7f5c73bf14b8207a551a6cbf38627984cb7f4e`;
+  do not tell contributors PR 196 is still merely an open proposal.
+
+The [exact comparison](https://codeberg.org/shiz/pydle/compare/4efcc3b5096536668dfe772461f19a17f1ddd84e...e27b6a2138c81061c2e6a937526fceaedb94d31a)
+is inventory evidence, **not** a fresh behavioral audit. This PR does not claim
+that the new develop tip passes the old spike or fixes every known problem.
+Begin at the approved SHA; propose a base bump separately if the audit warrants it.
+
+The August draft reports 53 upstream tests, 9 selection passes/2 skipped live
+cases, and 2 Ergo passes. Those were historical editable-checkout feasibility
+results; they have not been rerun here. Their unpublished spike files are not
+required to follow this plan. Rebuild deterministic cases in the fork from the
+listed scenarios and prove them against the actual release artifact. Do not
+use old task IDs 15700/15701 or ADRs 057/058: current dev assigns them elsewhere.
+
+## Prerequisites and ownership during PTO
+
+| Item | Current evidence | Owner/action |
+| --- | --- | --- |
+| GitHub fork `rmusser01/tldw-pydle` | Authenticated lookup could not resolve it on 2026-09-10 | Repository owner checks again, creates it if absent, grants maintainers access and configures develop protection. |
+| Behavioral amendments | ADR-149 proposed | Reviewer accepts or records changes before the affected implementation task starts. |
+| PyPI project/environment | Not inspected or configured by this PR | Release maintainer obtains project access and configures Trusted Publishing before TASK-21608. Never paste a token into a task. |
+| Artifact compatibility fixtures | Historical prototypes only | Task owners implement deterministic/TLS fixtures and pin exact AgentIRC/Ergo versions and hashes. |
+| tldw_server IRC endpoint | No implemented contract verified here | Server owner designs service/auth contract later; not a blocker for public IRC or fork work. |
+
+Assignees are intentionally not invented. Claim a task in Backlog and link the
+fork PR in that task; check for an existing claim/PR first. At handoff, record
+branch, commit, exact failing/passing commands and the next uncompleted step.
+Do not depend on the original author's checkout, credentials, stash or memory.
+
+## First contributor session
+
+- [ ] Confirm the handoff PR and applicable ADR decisions have been reviewed.
+- [ ] Check the task's status, assignee and existing fork PRs before taking it.
+- [ ] Have an authorized owner establish the remote/access if needed. Check
+      before creating anything; never replace a repository another contributor
+      has already initialized.
+- [ ] Clone canonical Codeberg with full history outside Chatbook source. Keep
+      Codeberg as upstream and add the GitHub fork as origin.
+- [ ] Verify the pinned SHA and branch fork develop explicitly from it, not
+      from moving upstream develop. Do not mirror-push every branch/tag.
+- [ ] Disable/review copied automation before enabling workflows on the fork.
+- [ ] Mark only TASK-21601 In Progress and add its task-local Implementation
+      Plan, including ADR required/path/reason, before implementation.
+- [ ] Preserve LICENSE, record UPSTREAM_BASE and NOTICE, make the namespace
+      migration separately, then build/inspect/install both distributions.
+- [ ] Open one fork PR for the task and update this repository's task with its
+      evidence. Never mark later tasks Done based on a predecessor's tests.
+
+Backlog tasks are the source of truth in Chatbook; code and fork CI live in the
+fork repository. Do not copy the fork into Chatbook or duplicate competing task
+boards. The [Backlog tooling lessons](../../../backlog/docs/lessons-backlog-hygiene.md)
+document a five-digit task editing bug: verify the printed path and resulting
+diff after CLI edits, and use the documented direct-file fallback if affected.
+
+## Required regression scenarios added by this review
+
+Use explicit events/barriers rather than arbitrary sleeps. Each task retains
+the focused test commands and file owners in the execution plan.
+
+| Task | Deterministic setup | Required observation |
+| --- | --- | --- |
+| 21602 | Fill application outbound admission; inject server PING | Capacity stays bounded; PONG/control processing succeeds or a typed terminal failure occurs, never a hidden indefinite wait. |
+| 21603 | Two callers await close; cancel one during cleanup | Cleanup remains owned; the other receives the truthful final result; no detached protocol work. |
+| 21603 | Callback suppresses cancellation but yields; separately attempt a public command after close | Close reports retained callback; command is refused; replacement Client remains untouched. |
+| 21604 | Callback awaits WHOIS; fill callback queue before delivering 318 | Query succeeds before overflow or fails via explicit slow-consumer close; never deadlocks. |
+| 21604 | Timeout WHOIS A; attempt A again; deliver old 311/318 | Second A is refused until the old terminal, and old results never reach a new caller. |
+| 21604 | Coalesce presence at sequences 1 and 3 with a message at 2 | New state at 3 does not appear ahead of message 2. |
+| 21605 | Send 001 before mandatory SASL completes; repeat without mandatory capabilities on a no-CAP server | First attempt fails closed; legacy attempt can become ready; readiness emits once. |
+| 21605 | Cancel one of two wait_ready callers | Other caller still receives readiness or the same terminal failure. |
+| 21606 | Cancel LIST; omit 323 past drain deadline; interleave chat and request another LIST | Caller settles; chat works; second LIST refused; eventual 323 clears the tombstone. |
+| 21607 | Send identical messages twice and receive two echoes; deliver historical membership frames | Both legitimate messages survive; history does not rewrite live membership. |
+| 21608 | Build once, distribute wheel to clean target environments | Recorded hashes identify the exact tested/published bytes; no editable-import leakage. |
+
+Tag budgets follow the [IRCv3 specification](https://ircv3.net/specs/extensions/message-tags.html):
+incoming tag section is at most 8191 bytes including `@` and its trailing space;
+client-sent tag data is at most 4094 bytes excluding those delimiters. The
+non-tag message keeps its independent 512-byte budget including CRLF. Test
+encoded boundaries and fragmented input before semantic processing.
+
+## Scope checkpoints and next work
+
+After TASK-21604, review the real diff and deterministic evidence against
+ADR-148's reconsideration triggers. If ordering requires pervasive feature
+rewrites, record the concrete cost and reconsider the core before investing in
+history. Do not promise a release date before this checkpoint. The first
+release still includes the approved IRCv3 semantics; an intermediate wheel is
+not permission to integrate an unstable client into Chatbook.
+
+The next **separately filed and reviewed** Chatbook tranche is:
+
+1. Protocol-neutral models and fake adapter; no fork imports in UI or models.
+2. App-owned session manager, generation fencing, bounded buffers, reconnect
+   policy and shutdown through the existing composition root.
+3. Private non-secret profiles/favorites and credential references; follow
+   current local-private-data rules rather than placing secrets in TOML.
+4. Fake-adapter Network Chat route, transcript/composer, channel/direct buffers,
+   members, browse/join/favorite; mounted navigation and suspend/resume tests.
+5. Exact released fork adapter and two-client live verification, then history.
+6. Explicit tldw_server service descriptor and IRC-scoped credential exchange,
+   coordinated with the server owner. Never reuse an HTTP token implicitly.
+
+These are scope boundaries, **not nonexistent future task IDs**. File atomic
+tasks before starting them. Public IRC is the first integration target; the
+client fork does not supply an IRC server.
+
+Current Chatbook seams to read before that tranche:
+
+- [screen_registry.py](../../../tldw_chatbook/UI/Navigation/screen_registry.py),
+  [shell_destinations.py](../../../tldw_chatbook/UI/Navigation/shell_destinations.py)
+  and [route_inventory.py](../../../tldw_chatbook/UI/Workbench/route_inventory.py).
+- [app.py](../../../tldw_chatbook/app.py) and
+  [ADR-036](../../../backlog/decisions/036-application-service-composition-lifecycle.md).
+- [settings_screen.py](../../../tldw_chatbook/UI/Screens/settings_screen.py),
+  [optional_deps.py](../../../tldw_chatbook/Utils/optional_deps.py) and
+  [pyproject.toml](../../../pyproject.toml).
+
+## Documentation PR verification
+
+Run the Backlog ID/Windows-path guard, check all new relative links and task
+dependencies, check whitespace, and inspect the staged diff for docs-only scope.
+No application/fork test run is claimed. All implementation acceptance criteria
+remain open, and PR creation does not create a fork repository or publish a package.

--- a/Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+++ b/Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
@@ -1,0 +1,865 @@
+# Network Chat IRCv3 and tldw-pydle design
+
+Status: Approved baseline; ADR-149 amendments proposed for review
+Reassessed: 2026-09-10
+Start here: [PTO handoff](../plans/2026-09-10-network-chat-pto-handoff.md)
+Amendment: [ADR-149](../../../backlog/decisions/149-network-chat-handoff-reliability-amendments.md)
+Date: 2026-08-23
+Decision: [ADR-148](../../../backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md)
+Implementation: [First-release plan](../plans/2026-08-23-tldw-pydle-first-release.md); TASK-21601 through TASK-21608 are filed and remain To Do
+
+## Summary
+
+Chatbook will gain a lightweight, keyboard-first **Network Chat** screen for
+ordinary IRC networks, AgentIRC, and a future IRC service explicitly advertised
+by tldw_server. The screen supports connection profiles, channels, direct
+messages, channel browsing, favorites, presence, unread and mention state,
+common commands, and capability-gated modern IRCv3 behavior.
+
+The IRC client core will be a separately released, tldw-maintained fork of
+pydle. The fork remains behind a protocol-neutral Chatbook adapter. It is not
+vendored into Chatbook, does not expose mutable pydle state to Textual, and does
+not make the Network Chat screen responsible for socket lifetime.
+
+The critical review changed the fork from a bounded collection of feature
+patches into a small reliability refactor. Canonical pydle currently logs raw
+frames, dispatches inbound messages concurrently, owns reconnect implicitly,
+does not fully close its transport, and has incomplete CAP, correlation, SASL,
+LIST, and resource-bound semantics. Those defects must be corrected coherently
+before the client can be called a stable shared dependency.
+
+## Design outcomes already resolved
+
+- Primary fork repository: `github.com/rmusser01/tldw-pydle`.
+- Canonical upstream: `https://codeberg.org/shiz/pydle`.
+- Upstream fork point: `develop` commit
+  `4efcc3b5096536668dfe772461f19a17f1ddd84e`, verified unchanged on
+  2026-08-23.
+- Upstream release ancestor: pydle v1.1.0 tag
+  `cbc18112e141d357abfb5828262cd98d65628096`.
+- Distribution: `tldw-pydle`.
+- Import package: `tldw_pydle`.
+- Initial version: `1.1.0.post1`.
+- Default branch: `develop`.
+- Fork Python floor: 3.11; current Chatbook independently requires 3.12+.
+- Full upstream Git history and BSD-3-Clause text are preserved.
+- Reconnect is owned by Chatbook or another embedding application, not the
+  library.
+- SASL PLAIN is standard-library code and requires verified TLS; `pure-sasl`
+  is not required.
+- The first release does not expose SASL EXTERNAL or a certificate credential
+  profile.
+- Local transcripts remain memory-only by default.
+
+## Goals
+
+- Produce a stable IRCv3 client artifact that can be shared by Chatbook and
+  tldw components with client roles.
+- Preserve protocol state in server wire order.
+- Make every internal task, timer, query, write, and transport close observable
+  and bounded.
+- Keep authentication material and message content out of ordinary logs.
+- Support direct verified TLS, CAP 302, SASL PLAIN, core IRC, message tags,
+  server-time, echo-message, BATCH, CHATHISTORY, and channel LIST.
+- Offer incremental channel browsing without unbounded accumulation.
+- Keep Chatbook's UI, persistence, reconnect, and service-discovery decisions
+  outside the fork.
+- Make upstream synchronization and downstream patch provenance routine rather
+  than archaeological.
+- Gate releases on the built artifact, not only an editable checkout.
+
+## Non-goals for the first fork release
+
+- Implementing an IRC server.
+- Becoming an IRC bouncer.
+- DCC chat or file transfer.
+- STARTTLS negotiation or opportunistic plaintext-to-TLS upgrade.
+- SASL mechanisms other than PLAIN.
+- Client-certificate profile UX.
+- Automatic reconnection.
+- A scripting or plugin runtime.
+- Chatbook profiles, favorites, unread state, transcript persistence, or UI.
+- AgentIRC-specific semantics in the generic core.
+- Guessing a tldw_server IRC endpoint from an HTTP URL.
+- Supporting Python 3.10.
+
+## System ownership
+
+| Concern | Owner | Lifetime | Persistence |
+| --- | --- | --- | --- |
+| Socket, TLS stream, parser, protocol state, internal tasks and timers | `tldw_pydle` client | One connection | None |
+| Ordered protocol event and callback delivery | `tldw_pydle` client | One connection | None |
+| Connection generation, reconnect policy and backoff | Chatbook `IrcSessionManager` | Application | None |
+| Stable typed events and command results | Chatbook IRC adapter | Application contract | None |
+| Bounded recent messages, presence, unread and mentions | Chatbook `IrcBufferStore` | Application session | Memory only |
+| Non-secret profiles, favorites and autojoin choices | Chatbook profile repository | Application | Private local store |
+| Passwords, tokens, channel keys and certificate material | Chatbook credential provider | Lookup scoped | Environment or credential store |
+| Selected network/buffer, rail state and scroll anchor | Network Chat screen | Screen visit | Existing memory-only screen snapshot |
+| tldw_server endpoint and authentication metadata | Advertised service descriptor | Active server binding | Existing server authority |
+
+Neither a `tldw_pydle.Client`, its callback object, a mutable users/channels
+mapping, nor a raw IRC message crosses the Chatbook adapter boundary.
+
+## Runtime architecture
+
+```text
+TCP/TLS reader
+    -> bounded byte framing and parsing
+    -> ordered protocol reducer
+         -> internal state commit
+         -> resolve correlated futures
+         -> emit immutable internal event
+    -> bounded ordered callback/event delivery
+
+application command
+    -> validate and encode within byte budget
+    -> register correlation before send when required
+    -> serialized outbound writer
+    -> bounded drain
+```
+
+### Why the split is required
+
+Canonical pydle currently creates one task per parsed message. Those tasks can
+interleave JOIN, NICK, CAP, WHOIS, BATCH, and history mutations contrary to wire
+order. Keeping the task handles would make shutdown more visible but would not
+make state deterministic.
+
+Awaiting each existing handler in full is also unsafe. Some handlers issue and
+await WHOIS or WHOX while later inbound numerics are responsible for completing
+those futures. A globally sequential callback pipeline would wait for a reply
+that it has prevented itself from processing.
+
+The reducer therefore performs only bounded protocol work. It may create or
+resolve correlation state, update client state, and produce an internal event.
+It may not await a future that depends on later wire input or run arbitrary
+application code.
+
+## Ordered inbound processing
+
+The connection owns one reader task and one ordered reducer task. An
+implementation may combine them when doing so preserves the same ownership and
+test seams. Every complete frame receives a monotonic receive sequence.
+
+The reducer applies valid frames in sequence order. Core state changes and
+correlated-result updates are complete before an event is offered to callbacks.
+Malformed frames produce classified protocol events. A malformed optional
+message does not silently corrupt state, and a fatal framing condition closes
+the connection with an observable reason.
+
+Feature modules register synchronous capability and reducer hooks. Capability
+selection is configured before connection and cannot depend on arbitrary async
+application callbacks during CAP negotiation. A reducer hook that needs later
+wire input creates correlation state and returns; it never waits inline.
+
+### Callback delivery
+
+Upstream-style async callbacks remain available for compatibility inside the
+fork namespace, but they run after state commit through one owned ordered
+delivery queue. Chatbook uses the adapter rather than treating those callbacks
+as its stable API.
+
+Callback exceptions are captured as content-free diagnostics and exposed
+through a defined callback-error event or close result. They do not kill the
+reader task, disappear as “Task exception was never retrieved,” or roll back
+already committed protocol state.
+
+The queue is bounded. Coalescible presence/state events may replace an older
+unconsumed event for the same identity. Message and query-result events are
+never silently discarded. If a consumer remains too slow for the bounded
+queue, the client closes with a visible slow-consumer outcome without awaiting callback capacity from the reducer. Otherwise a callback awaiting a query can block its own reply. Coalescing removes the old event and appends new state at the latest receive sequence.
+
+## Correlated protocol operations
+
+Every query has an explicit correlation owner and terminal states. Pending
+state is published before its outbound command can be observed by the server.
+The reducer resolves or fails it on the corresponding terminal numeric,
+standard reply, disconnect, timeout, or cancellation.
+
+First-release correlated operations include:
+
+- WHOIS;
+- channel LIST;
+- capability requests;
+- SASL negotiation;
+- registration readiness;
+- CHATHISTORY BATCH assembly.
+
+Only one operation is allowed when IRC cannot reliably disambiguate concurrent
+responses, including LIST and same-target WHOIS where labels are unavailable.
+Labeled-response support may permit broader concurrency later, but it is not
+assumed.
+
+Timeout/cancellation settles the caller but retains a bounded tombstone for an unlabelled operation until its terminal reply or teardown. Same-key reuse is refused; negotiated IRC CASEMAPPING defines identity. All correlation futures are failed before connection state is discarded.
+Cancellation remains distinguishable from server rejection, disconnect,
+timeout, truncation, and malformed response.
+
+## Outbound transport
+
+One connection owns one writer and a queue bounded by entries and encoded bytes. Admitted application commands are FIFO; protocol-control traffic has reserved capacity so user pressure cannot starve PONG. Queue admission cannot create unbounded waiters. Registration, CAP, SASL,
+queries, PONG, and application messages cannot call `write()`/`drain()`
+concurrently.
+
+The writer:
+
+- accepts structured commands rather than raw untrusted line strings at its
+  public seam;
+- rejects CR, LF, NUL, and invalid target/control input without silent repair;
+- budgets encoded bytes after applying tags and encoding;
+- splits only operations whose protocol semantics define safe splitting;
+- refuses messages that cannot be represented safely;
+- uses a configurable bounded `drain()` timeout;
+- turns stalled writes into one unexpected-disconnect outcome;
+- never logs the encoded frame.
+
+QUIT is best-effort within the close budget. Failure to send QUIT does not
+prevent transport teardown.
+
+## Lifecycle contract
+
+The preferred lifecycle is usable directly and as an async context manager:
+
+```text
+client = Client(...)
+await client.connect(host, port, tls=...)
+ready = await client.wait_ready()
+...
+result = await client.aclose(reason="application shutdown")
+```
+
+TASK-21603 must deliver and review the exact typed lifecycle signatures and
+result models before dependent work starts. The following behaviors are stable:
+
+- `connect()` establishes one connection generation and returns only after the
+  transport is established or fails.
+- `wait_ready()` is idempotent within one generation: all awaiters observe the
+  same readiness or terminal negotiation result, while the readiness event and
+  state transition occur exactly once after numeric `001`.
+- `aclose()` is idempotent and safe from connected, connecting, negotiating,
+  failed, or already closed states.
+- close prevents new commands, settles pending operations, attempts QUIT when
+  appropriate, closes the writer, awaits `wait_closed()`, cancels/drains all
+  owned tasks and timers, and returns a structured outcome.
+- an explicit force-abort path exists for an uncooperative or broken transport
+  after the graceful budget expires.
+- the library never schedules reconnect.
+
+### Close bounds
+
+Shutdown cannot rely on `asyncio.wait_for(gather(...))` as its only bound,
+because a task that swallows cancellation can keep `wait_for` suspended. The
+close algorithm first requests cooperative shutdown, observes tasks with
+`asyncio.wait()` for bounded intervals, cancels remaining tasks, observes again,
+and reports any retained stragglers before aborting the transport. Every done
+task has its exception drained.
+
+Python cannot forcibly terminate arbitrary async application code that catches
+`CancelledError` and continues forever. A normal or cooperative close therefore
+proves zero client-owned tasks. If callback code remains uncooperative after the
+close budget while still yielding to the loop, `aclose()` returns a bounded `incomplete` outcome identifying the
+retained callback task; all reader, reducer, writer, query and timer work is
+settled, the transport is aborted, and the retained callback has no authority
+to publish further protocol state. The client retains observability until that
+task actually exits and never reports a clean close prematurely.
+
+Callbacks are trusted Python code, not a sandbox. No in-process guarantee can stop code blocking the event loop. Only public command/publication authority is fenced; replacement connections use fresh Client objects.
+
+Release tests include deliberately cancellation-resistant callback work so
+both the time bound and the honest incomplete outcome are measured rather than
+inferred.
+
+## Connection states
+
+| State | Meaning | Permitted next actions |
+| --- | --- | --- |
+| `idle` | No generation has started | Connect, close |
+| `connecting` | TCP/TLS establishment | Cancel, close |
+| `negotiating` | CAP, SASL and registration | Cancel, close |
+| `ready` | Numeric `001` received | IRC commands, close |
+| `closing` | New work refused; drain underway | Await close |
+| `closed` | Transport and owned work settled | Inspect result, create a new generation through the embedding owner |
+| `failed` | Generation ended unexpectedly | Inspect failure, close/settle |
+
+Readiness is emitted once per generation. MOTD `376`/`422` may enrich startup
+state but does not gate ready, because valid servers such as AgentIRC may not
+send either numeric.
+
+## Privacy-safe diagnostics
+
+Raw inbound and outbound frame logging is removed from the default and debug
+paths. Log records are created from fixed fields rather than by redacting a
+previously formatted frame.
+
+Allowed examples:
+
+- connection ID and generation;
+- direction and IRC command name;
+- capability name and transition;
+- numeric or standard-reply code;
+- encoded byte count;
+- elapsed duration and timeout category;
+- task name and content-free exception type;
+- close reason category.
+
+Forbidden examples:
+
+- raw lines or message tags as received;
+- hostnames, endpoints, nicknames, accounts, channel names or targets;
+- PRIVMSG, NOTICE, topic, real-name, or CTCP bodies;
+- PASS and AUTHENTICATE parameters;
+- plaintext or base64-encoded synthetic secrets;
+- channel keys, OAuth or server tokens;
+- certificate private-key bytes or passwords;
+- exception messages containing server or transport payload text.
+
+Tests attach a real in-memory handler to every library logger and inspect every
+record field, rendered string, exception representation, close result, and
+artifact emitted by default test/release paths. Synthetic secrets include
+plain and encoded variants. The release also scans built artifacts and example
+configuration for insecure or real-looking credentials.
+
+An explicit protocol trace, if added later, requires a separate ephemeral
+diagnostic design. It cannot be implemented by turning raw debug logging back
+on.
+
+## TLS and authentication
+
+### TLS
+
+First release supports direct TLS and explicit plaintext connections. Chatbook
+profiles default to direct TLS and do not expose certificate-verification
+disablement as an ordinary recovery action.
+
+The client uses `ssl.PROTOCOL_TLS_CLIENT`, certificate-chain verification,
+hostname verification, and server-name indication. It accepts a caller-provided
+CA context/reference through a typed boundary. Certificate failure is terminal
+for that attempt and never triggers a plaintext retry.
+
+Loopback integration tests use generated test certificates and cover:
+
+- trusted certificate plus matching hostname succeeds;
+- trusted certificate plus hostname mismatch fails;
+- untrusted certificate fails;
+- TLS-required never falls back to plaintext;
+- close awaits or aborts the TLS writer within its bound.
+
+### SASL PLAIN
+
+SASL PLAIN is implemented directly:
+
+```text
+base64(authzid NUL authcid NUL password)
+```
+
+The encoded response follows IRC's 400-byte AUTHENTICATE chunks and sends the
+required `+` terminator when the encoded length is an exact multiple of 400.
+The implementation accepts bytes at the narrowest possible boundary, avoids
+copying secrets into exception or repr output, and releases credential
+references after negotiation finishes.
+
+PLAIN is refused unless the current transport is verified TLS. Any future
+diagnostic override belongs outside ordinary profile configuration and is not
+part of this release.
+
+All SASL timers are owned handles or tasks. The existing upstream continuation
+timer bug—passing an already-created coroutine into `call_later()`—is replaced
+and regression-tested with a multi-frame challenge and timeout path.
+
+## CAP 302 state machine
+
+The capability model tracks:
+
+- offered capabilities and values;
+- application-supported capability policy;
+- requested capability names (values belong only to LS/NEW);
+- pending request chunks;
+- negotiated enabled capabilities;
+- semantically supported capabilities exposed by the adapter.
+
+Registration behavior:
+
+1. Send CAP LS 302.
+2. Accumulate every continuation row.
+3. Compute a deterministic request order from registered feature policy.
+4. Split CAP REQ into encoded-line-safe chunks.
+5. Process ACK/NAK per request chunk; continuation grammar belongs only to LS/LIST, and values only to LS/NEW.
+6. Complete mandatory SASL where configured.
+7. Send CAP END exactly once.
+8. Emit ready once on `001` after required authentication/capabilities succeed. Allow legacy registration without CAP if none is mandatory. One cancelled waiter cannot cancel the shared result.
+
+After registration, CAP NEW and DEL update offered and enabled state without
+sending another registration CAP END. Capability loss cancels or disables only
+dependent operations and produces a typed capability-change event.
+
+Capability hooks do not execute arbitrary async application work inside the
+ordered reducer. Application policy is registered before connection.
+
+## Message tags, server-time, BATCH and history
+
+Tag parsing follows IRCv3 escaping rules and rejects control or size violations
+at the parser boundary. Unknown tags are retained internally within resource
+bounds but are not interpreted as trusted application metadata.
+
+`server-time` is parsed into a timezone-aware timestamp. The original raw value
+may remain in the bounded internal message model for diagnostics-free protocol
+semantics, but ordinary logs never include it with the message body.
+
+BATCH tracks batch ID, type, parameters, parent relation, open/close sequence,
+and bounded member identity. Unknown batch types remain representable. Closing
+or disconnecting fails incomplete correlated batches honestly.
+
+CHATHISTORY preserves:
+
+- target;
+- request anchor and limit;
+- BATCH identity;
+- server time;
+- message ID when present;
+- sender, target and message type;
+- live-versus-history origin.
+
+History must not mutate live membership/topic state; event-playback support is not implied. Echoes remain authoritative server events, but text/time similarity is not identity and cannot collapse legitimate repeats. A write is not a delivery receipt.
+
+The fork assembles one correlated history result. Chatbook owns display
+pagination, buffer retention, cross-page deduplication, and transcript anchors.
+
+## Streaming channel LIST
+
+IRC LIST usually has no true server-side cancellation or universal pagination.
+The API therefore models what the client can guarantee rather than pretending
+that cancelling a Python future stops the server.
+
+One connection may own one LIST session. The session exposes an asynchronous
+stream of:
+
+```text
+ListEntry(channel, user_count, topic)
+```
+
+and a terminal result containing:
+
+```text
+received_count
+delivered_count
+dropped_count
+truncated
+cancelled
+completion_numeric
+error
+```
+
+Entries pass through a bounded queue. A caller may set a local delivery limit.
+When the consumer cancels or reaches that limit, the client stops delivering
+rows and drains/discards remaining LIST replies through numeric `323` while
+continuing to process unrelated protocol frames. A drain deadline prevents a
+malicious or broken server from holding the caller forever. One bounded LIST tombstone remains until 323 or teardown; another LIST is refused while unrelated chat continues. Terminal counters snapshot caller settlement.
+
+Where ISUPPORT advertises compatible ELIST filters, the adapter may submit a
+server-side filter. The API does not claim universal pagination.
+
+LIST tests cover `321`, `322`, `323`, empty results, malformed counts, error
+numerics, `TRYAGAIN`, local cancellation, consumer backpressure, disconnect,
+and a server that never sends `323`.
+
+## Resource bounds
+
+The fork defines and tests explicit bounds for:
+
+- total inbound framed line bytes;
+- IRCv3 tag-section bytes;
+- incomplete receive-buffer bytes;
+- outbound encoded command bytes;
+- SASL challenge/response bytes;
+- open BATCH count and members;
+- pending correlation count and per-query results;
+- LIST queue and total delivered rows;
+- callback/event queue;
+- close and write-drain duration;
+- content-free diagnostic collection.
+
+Protocol limits are counted after encoding, not as Python characters. Defaults
+are standards-compatible and have documented absolute safety ceilings. The
+implementation plan will pin the exact constants after tests against Ergo and
+AgentIRC; the design does not authorize an unbounded “server decides” mode.
+
+An over-limit condition is either a refused outbound operation, a truncated
+query with an explicit result, a skipped non-critical message with a visible
+gap, or a fatal protocol failure. It is never silent truncation of credentials,
+targets, or chat text.
+
+## Fork public compatibility surface
+
+The namespace change makes `tldw-pydle` a distinct distribution, so byte-for-
+byte upstream import compatibility is not promised. Within `tldw_pydle`, the
+fork retains familiar high-level commands and callback names where they do not
+conflict with the reliability architecture.
+
+The stable first-release surface consists of:
+
+- client construction and feature policy;
+- explicit lifecycle methods and result types;
+- core IRC send/join/part/nick/topic/away commands;
+- correlated WHOIS, LIST, and CHATHISTORY operations;
+- immutable internal message/event views exposed to adapters;
+- capability and connection snapshots;
+- typed error, timeout, cancellation, truncation and close outcomes.
+
+Mutable `users`, `channels`, pending dictionaries, raw messages, task sets, and
+transport writers are implementation details. Chatbook does not depend on
+them even if compatibility access remains available to fork subclasses.
+
+## Namespace migration and upstream synchronization
+
+The fork is created by cloning Codeberg with full history and adding GitHub as
+the primary remote while retaining a read-only `upstream` remote. The initial
+history is not squashed.
+
+The first downstream commits are deliberately mechanical:
+
+1. Record `UPSTREAM_BASE` and add fork notice/governance files.
+2. Rename the package and rewrite imports, entry points, examples, metadata,
+   and tests from `pydle` to `tldw_pydle`.
+3. Add guards proving the built wheel has no top-level `pydle` package and no
+   stale import or script surface.
+
+Behavioral changes begin only after the namespace commit. Generic fixes are
+kept separate from tldw lifecycle policy and feature work.
+
+For upstream contribution, a generic fix may be prepared on a clean branch
+against the upstream namespace and then represented by a provenance-linked
+downstream commit. Downstream release notes map every patch to one of:
+
+- upstream correctness/security;
+- adopted open-PR provenance;
+- tldw lifecycle policy;
+- tldw IRCv3 feature semantics;
+- packaging/release infrastructure.
+
+An upstream synchronization records old base, new base, conflicts, retained
+patches, dropped patches already absorbed upstream, and the complete gate
+result. Opaque squash replacement is prohibited.
+
+## License and notices
+
+The upstream BSD-3-Clause license is retained verbatim, including any unusual
+placeholder text in the canonical source. The fork does not silently “repair”
+upstream's license wording. A separate NOTICE identifies tldw modifications,
+the exact upstream repository and base, and adopted pull-request provenance.
+
+Wheel and sdist tests inspect the actual artifacts for LICENSE, NOTICE,
+upstream-base metadata, package namespace, and source URLs.
+
+## CI and release design
+
+### Pull-request CI
+
+- Python 3.11–3.14 on Linux; Python 3.12 transport/TLS/packaging on Windows/macOS.
+- Unit and deterministic protocol-oracle tests.
+- Real loopback TLS tests.
+- Namespace, license, notice, secret-log, resource-bound, and task-leak guards.
+- Ruff format and lint checks.
+- Wheel and sdist build plus member inspection.
+- Clean-environment install and import from each artifact.
+- No publishing credentials or privileged workflow trigger.
+
+### Compatibility CI
+
+- AgentIRC pinned to an exact release or commit.
+- Ergo pinned to an exact release and checksum.
+- Two-client registration, channel chat, direct chat, PING/PONG, tags,
+  disconnect and server cleanup.
+- CAP/SASL/history coverage where the target supports it.
+- The tested artifact is the built wheel, not an editable working tree.
+
+### Scheduled compatibility
+
+- Latest stable Codeberg pydle audit.
+- Latest stable Ergo compatibility.
+- Dependency and security-advisory review.
+- Results create maintenance work but do not rewrite the historical result of
+  a pinned release gate.
+
+### Release job
+
+- Build once from a reviewed tag.
+- Verify wheel/sdist contents and install both independently.
+- Generate SHA-256 checksums and provenance/SBOM data.
+- Publish a GitHub release with upstream base and patch inventory.
+- Publish to PyPI through Trusted Publishing when configured.
+- Use minimal job permissions and actions pinned by full commit SHA.
+
+Chatbook consumes an exact released version in an optional IRC dependency
+group only after the artifact passes deterministic, TLS, AgentIRC, and pinned-
+Ergo gates.
+
+## Verification matrix
+
+| Area | Required evidence |
+| --- | --- |
+| Ordering | Scripted server sends state-dependent frames back-to-back; reducer state and emitted events match wire order under delayed/failing callbacks. |
+| Correlation | Reply can arrive immediately after command write; future/result existed first and resolves once. Parallel unsupported queries are rejected. |
+| Lifecycle | Connect cancel, negotiation cancel, graceful close, transport reset, stalled write and callback failure settle within bounds with zero owned work. A cancellation-resistant callback returns a bounded incomplete outcome naming the retained callback while protocol work reaches zero and late state publication is rejected. |
+| Privacy | Plain and encoded SASL secrets, PASS, channel key, chat body and topic are absent from every captured log field, exception representation and default artifact. |
+| TLS | Matching trusted cert passes; hostname mismatch and untrusted cert fail; no plaintext fallback. |
+| SASL | Success, rejection, timeout, exact-400 chunk terminator, multiple chunks, malformed base64 and disconnect. |
+| CAP | Multiline LS, values, deterministic split REQ, ACK/NAK, NEW/DEL, CAP END once, ready on 001 once. |
+| LIST | Incremental rows, local limit, cancellation/drain, pressure, no 323, error numerics and disconnect. |
+| BATCH/history | Nested/unknown batches, valid history, empty history, incomplete close, time/msgid preservation and bounds. |
+| Parser bounds | Oversized line/tag/buffer and malformed escape paths produce classified outcomes without growth or content logs. |
+| Packaging | Built wheel/sdist contain only `tldw_pydle`, required license/notice/provenance, and install cleanly on every supported Python. |
+| Compatibility | The same built artifact passes deterministic server, AgentIRC and pinned Ergo targets. |
+
+Earlier unpublished spike evidence remains useful as feasibility evidence: the
+canonical Codeberg checkout reported 53 upstream tests passing; the isolated
+selection suite reported 9 passing with 2 opt-in live skips; and the explicit
+Ergo 2.19.0 run reported 2 passing. Those editable-checkout results do not
+satisfy the release gate. The release work must reproduce them against the
+built artifact.
+
+Per repository policy, implementation will use targeted verification while
+work is in progress. A full Chatbook suite is not part of fork work and will be
+run only if the user explicitly requests it before a Chatbook integration PR.
+
+## Chatbook adapter boundary
+
+The Chatbook adapter exposes behavior such as:
+
+```text
+connect(profile_id)
+disconnect(network_id, reason)
+join(network_id, channel, key_ref=None)
+part(network_id, channel, reason=None)
+send_message(network_id, target, text)
+send_notice(network_id, target, text)
+send_action(network_id, target, text)
+set_nick(network_id, nick)
+set_away(network_id, message=None)
+set_topic(network_id, channel, topic)
+request_whois(network_id, nick)
+stream_channels(network_id, filter=None, limit=None)
+request_history(network_id, target, anchor, limit)
+capability_snapshot(network_id)
+shutdown()
+```
+
+Every operation returns or emits typed Chatbook models. Errors preserve a
+stable reason category, user-safe recovery copy, and an optional numeric or
+standard-reply code. Raw IRC frames and fork exception messages do not cross
+into persistent UI diagnostics.
+
+Connection events carry a monotonic generation. An event from an old
+generation cannot mutate a replacement connection after explicit disconnect
+or reconnect.
+
+## Chatbook session manager
+
+One application-owned manager is composed by `TldwCli` after its dependencies
+are ready and closed during application shutdown. Navigating away from Network Chat detaches or pauses view subscriptions; connections continue. Current routes can be reusable: treat resume/suspend and final unmount separately, resubscribe once with a fresh snapshot, and test both reuse and fresh-screen lifecycles. Initially use the default non-reusable route unless a reuse audit passes.
+
+The manager owns:
+
+- selected profiles and active adapter instances;
+- connection generation;
+- capped reconnect backoff and jitter;
+- explicit-disconnect suppression;
+- blocked-versus-retryable failure classification;
+- bounded recent buffer and presence state;
+- unread, mention and visible history-gap state;
+- subscription pressure and screen snapshot delivery;
+- complete application shutdown of every adapter.
+
+Authentication rejection, certificate failure, invalid profile and missing
+credential enter a blocked state rather than retrying indefinitely. The
+Network Chat UI always identifies the problem owner and recovery action.
+
+## Network profiles and credentials
+
+A non-secret profile contains:
+
+- stable ID and display name;
+- host, port and direct-TLS requirement;
+- verification requirement and optional CA reference;
+- nickname, alternate nicknames, username and real name;
+- SASL mechanism and credential reference;
+- favorite and ordered autojoin channels;
+- channel-key credential references;
+- reconnect preference;
+- UTF-8 encoding policy;
+- source authority: manual, server-advertised or built-in example.
+
+Resolved passwords, tokens and keys never enter the profile record, events,
+screen snapshots, logs or exception messages. Removing a live profile requires
+disconnect confirmation. Parting a channel does not remove its favorite, and
+removing a favorite does not part the channel.
+
+## Network Chat screen
+
+Network Chat is a canonical `irc` route associated with the Console
+destination. A visible mode strip navigates between Agent Console and Network
+Chat; it is real routing, not an in-place widget swap.
+
+The screen follows the Workbench decomposition:
+
+```text
+tldw_chatbook/
+  IRC/
+    models.py
+    events.py
+    adapter.py
+    session_manager.py
+    buffer_store.py
+    profile_repository.py
+    credential_provider.py
+    adapters/tldw_pydle_adapter.py
+  UI/Screens/irc_screen.py
+  UI/IRC_Modules/
+    network_rail.py
+    transcript_region.py
+    member_inspector.py
+    channel_browser.py
+    composer.py
+    controller.py
+    wiring.py
+  Widgets/IRC/
+```
+
+### First-release regions
+
+1. Network and buffer rail with saved networks, joined channels, direct
+   messages, favorites, unread, mentions, mute and connection state.
+2. Active buffer with identity, topic, modes, bounded transcript, history
+   boundary, composer and delivery feedback.
+3. Optional member inspector with privileges, account/away state and WHOIS.
+4. Channel browser consuming the incremental LIST stream with progress,
+   filters, join and favorite actions.
+
+Wide layout shows all three primary columns. Medium layout turns the member
+inspector into an explicit overlay/secondary region. Compact layout preserves
+the active buffer and provides collapsed rail handles. The inspector disappears
+before the network rail.
+
+Screen bindings follow the current keybinding ADR. It does not shadow terminal
+convention keys or global `ctrl+p`, `ctrl+q`, `f1`, and `f6`. Footer hints are
+generated only for actions that work in the current state and focus context.
+
+No settings are added to deprecated settings surfaces. Global IRC defaults and
+profile management eventually live in the canonical F9 Settings screen;
+immediate connect, join, favorite and mute actions remain on Network Chat.
+
+## tldw_server discovery
+
+A future active tldw_server capability response advertises an explicit service
+descriptor such as:
+
+```json
+{
+  "service": "irc",
+  "protocol": "ircv3",
+  "host": "chat.example.internal",
+  "port": 6697,
+  "tls": "required",
+  "auth": {
+    "mechanisms": ["PLAIN"],
+    "credential_scope": "active-server"
+  },
+  "capabilities": ["server-time", "batch", "draft/chathistory"]
+}
+```
+
+The coordinated server contract is a later decision. The descriptor does not
+authorize persisting the active server token in an IRC profile. The credential
+provider resolves the active credential at connect time. If the descriptor
+changes or disappears, the derived profile becomes visibly stale or
+unavailable and never falls back to guessed coordinates.
+
+## Implementation workstreams after approval
+
+These are dependency-ordered workstreams, not reserved task IDs. Each becomes
+one or more atomic Backlog tasks with its own acceptance criteria and targeted
+tests.
+
+1. **Fork provenance and packaging**: create the repository from full Codeberg
+   history, pin `UPSTREAM_BASE`, preserve notices, perform the namespace-only
+   migration, and establish artifact guards.
+2. **Transport privacy and lifecycle**: remove raw logging, serialize writes,
+   adopt stalled-write provenance, await transport close, remove implicit
+   reconnect, and own tasks/timers.
+3. **Ordered reducer and correlation**: separate state commits from callbacks,
+   fix send-before-future races, define query outcomes, and prove close under
+   callback failure and cancellation resistance.
+4. **CAP, TLS and SASL**: implement the CAP 302 state machine, verified TLS
+   gates, standard-library PLAIN, owned negotiation timeouts and one-time
+   readiness.
+5. **Streaming LIST**: structured bounded iterator/session, local cancellation
+   and drain behavior, errors and pressure tests.
+6. **IRCv3 semantics**: tags, server-time, echo-message, BATCH and CHATHISTORY
+   models plus resource bounds.
+7. **Compatibility and release**: deterministic oracle, TLS, AgentIRC, pinned
+   Ergo, artifact install, supply-chain controls and `1.1.0.post1` publication.
+8. **Chatbook model and fake-adapter foundation**: stable typed profiles,
+   commands, events and fake adapter with no production fork dependency.
+9. **Chatbook session lifecycle**: application composition, generation fencing,
+   reconnect, bounded buffers and shutdown.
+10. **Private profiles and credentials**: non-secret persistence, favorites,
+    autojoin and credential lookup.
+11. **Network Chat vertical slice**: route, regions, one network/channel,
+    transcript, composer, topic and members through the fake adapter.
+12. **Real adapter and browsing**: exact fork artifact, channel/direct chat,
+    LIST browser, common commands, unread and favorites.
+13. **History and tldw_server integration**: capability-driven history followed
+    by a separately approved server descriptor contract.
+
+The fork release is completed before Chatbook adds the real dependency. The
+Chatbook fake-adapter and model work may proceed without fork objects, but the
+real adapter cannot pin an editable branch or an unpublished artifact.
+
+## First fork release acceptance gates
+
+- Canonical upstream base and complete downstream patch inventory recorded.
+- Built wheel and sdist contain `tldw_pydle`, not a top-level `pydle` package.
+- LICENSE, NOTICE, source URLs and upstream base are present in both artifacts.
+- Python 3.11–3.14 unit and deterministic suites pass.
+- Protocol state and callback events preserve scripted wire order.
+- Immediate WHOIS replies cannot beat pending-state publication.
+- No raw frame, secret, encoded secret or message body appears in default logs
+  or failure objects.
+- Verified TLS success/failure and no-downgrade tests pass.
+- SASL PLAIN success, rejection, chunking, timeout and cleanup tests pass.
+- CAP multiline, values, split requests, ACK/NAK, NEW/DEL and one-time END/ready
+  tests pass.
+- LIST is incremental, bounded and truthful under local cancellation and a
+  missing terminal numeric.
+- Write stall, read failure, connect cancellation and callback failure finish
+  within their declared bounds.
+- Normal and cooperative failed close leave zero client-owned tasks and timers.
+  A cancellation-resistant callback instead returns a bounded incomplete
+  outcome naming the retained callback, with zero protocol tasks/timers and no
+  authority for late state publication.
+- Tags, server-time, BATCH and CHATHISTORY preserve required identity and obey
+  bounds.
+- The same built artifact passes two-client AgentIRC and pinned Ergo runs.
+- Actions are pinned, permissions are minimal, and release artifacts include
+  checksums plus provenance/SBOM data.
+
+## Changes from the earlier draft
+
+The critical review made these deliberate corrections:
+
+- raw frame redaction became content-free structured logging;
+- detached handler ownership became ordered state reduction plus post-commit
+  callbacks;
+- a task registry became complete task/timer/query/transport lifecycle;
+- a simple CAP continuation patch became a CAP 302 state machine;
+- `pure-sasl` became a dependency-free PLAIN implementation;
+- TLS default testing became real certificate and no-downgrade integration
+  testing;
+- `channel_list() -> list` became a bounded streaming LIST session;
+- implicit receive limits became explicit byte/resource contracts;
+- the fork floor is 3.11; Chatbook's current floor is independently 3.12;
+- “current Ergo” became pinned release CI plus a scheduled latest-stable job;
+- namespace isolation gained mechanical-commit and built-artifact guards;
+- editable-checkout feasibility evidence no longer counts as release evidence.
+
+The selected library, repository direction, adapter boundary, screen ownership,
+memory-only transcript default, and explicit tldw_server discovery seam remain
+unchanged.

--- a/backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+++ b/backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
@@ -1,0 +1,255 @@
+# ADR-148: Network Chat IRCv3 and tldw-pydle boundary
+
+Status: Accepted
+Date: 2026-08-23
+Renumbered: 2026-09-10 from the unlanded ADR-084 draft; that number is now occupied on dev.
+Review amendment: [ADR-149](149-network-chat-handoff-reliability-amendments.md) (Proposed; original decision text retained below).
+Related Tasks: TASK-21601 through TASK-21608
+Supersedes: N/A; consolidates the IRC design and client-selection drafts that
+did not land on the current `dev` history
+
+## Decision
+
+Chatbook will add **Network Chat** as a distinct IRCv3 screen under the existing
+Console destination. It is a sibling route to the agent Console rather than a
+mode inside the agent transcript. Fresh screen instances own only view state.
+An application-scoped IRC session manager owns live connections, bounded
+in-memory buffers, unread state, reconnect policy, and application shutdown.
+
+Chatbook will use a separately packaged, tldw-maintained fork of pydle behind a
+protocol-neutral adapter. The primary repository is intended to be
+`rmusser01/tldw-pydle`; the canonical upstream remains
+`https://codeberg.org/shiz/pydle`. The fork begins from upstream `develop`
+commit `4efcc3b5096536668dfe772461f19a17f1ddd84e`, verified again on
+2026-08-23, which descends from the pydle 1.1.0 tag
+`cbc18112e141d357abfb5828262cd98d65628096`.
+
+The distribution name is `tldw-pydle`, the import package is `tldw_pydle`, and
+the first release line is `1.1.0.postN`. The fork preserves full upstream
+history, copyrights, and BSD-3-Clause license text. It adds a notice describing
+the fork and exact upstream base; it does not publish or install a top-level
+`pydle` package.
+
+The fork requires Python 3.11 or newer. Chatbook already has that floor, and
+the reliable lifecycle design benefits from structured concurrency and modern
+exception handling. Python 3.10 compatibility is not an initial release goal.
+
+The fork owns transport, parsing, registration, CAP and SASL state machines,
+ordered protocol-state application, correlated protocol queries, and every
+internal task or timer. Chatbook owns the top-level adapter scope, connection
+generation, reconnect decisions, typed application events, profiles,
+credential references, message-buffer policy, persistence, and UI.
+
+Incoming frames are parsed and applied to protocol state in wire order. A
+state reducer must never await a future whose completion requires later
+inbound frames. Correlated operations publish their pending state before their
+command is written. User callbacks run only after the corresponding state
+commit, through owned bounded delivery machinery; callback failure is
+observable but cannot reorder or stall protocol state.
+
+Outbound writes are serialized. Encoded byte limits and a bounded drain
+timeout are enforced at the transport boundary. The client has explicit,
+idempotent `connect`, `wait_ready`, and asynchronous close behavior. It does
+not reconnect implicitly. Close cancels or drains every cooperative owned
+reader, dispatcher, callback, timer, and request task, awaits
+`writer.wait_closed()` within a bound, and exposes any forced-abort outcome.
+Arbitrary callback code that ignores cancellation produces a bounded,
+explicitly incomplete close result naming the retained callback; protocol work
+still settles and that callback loses authority to publish protocol state.
+
+Persistent and ordinary debug logs are content-free. They may record opaque
+network and operation identifiers, command names, capability names, numeric or
+standard-reply codes, byte counts, timings, and reason categories. They never
+record raw IRC frames, endpoints, nicknames, account or channel names, targets,
+message bodies, topics, real names, passwords, channel keys, tokens, SASL
+payloads, certificate-key material, or exception messages that may contain
+those values. Raw wire capture is not a production logging mode.
+
+Direct TLS is the first-release secure transport. Certificate-chain and
+hostname verification are enabled by default, certificate failure never
+downgrades to plaintext, and an ordinary Chatbook profile cannot disable
+verification. SASL PLAIN is implemented directly using the Python standard
+library, including IRC's 400-byte AUTHENTICATE chunking, and is refused unless
+verified TLS succeeded. `pure-sasl` is not a required dependency. SASL
+EXTERNAL and certificate credential profiles remain unavailable until an
+end-to-end implementation and real TLS tests prove them.
+
+CAP 302 uses an explicit registration state machine. Offered, requested,
+pending, negotiated, and semantically supported capabilities remain distinct.
+The client accumulates continuation rows, handles values plus ACK/NAK/NEW/DEL,
+splits deterministic requests within encoded line limits, and sends `CAP END`
+exactly once during registration. Registration readiness is emitted exactly
+once on numeric `001`; MOTD completion may enrich state but is not the ready
+boundary.
+
+The first modern semantic baseline is message tags, server-time,
+echo-message, BATCH, and `draft/chathistory`. BATCH membership, timestamps,
+message IDs, and history boundaries are preserved internally. Chatbook still
+defines stable public event types, history pagination policy, buffer bounds,
+and cross-reconnect deduplication.
+
+Channel browsing uses one LIST session per connection and exposes a bounded
+asynchronous stream of structured entries rather than accumulating an
+unbounded list. Local cancellation stops delivery to the caller and drains or
+discards server replies until numeric `323`; it does not claim to cancel the
+server's transmission. The terminal result reports completion, truncation,
+dropped rows, cancellation, and protocol failure explicitly.
+
+The parser and transport enforce explicit inbound line, tag, receive-buffer,
+outbound line, query-result, callback-queue, and shutdown bounds in encoded
+bytes. Limits are configurable within a documented safe range. Oversized or
+malformed input produces a classified protocol outcome rather than unbounded
+allocation or accidental content logging.
+
+The fork has its own CI and release process. Deterministic tests run on every
+supported Python version. Release artifacts are built, installed into clean
+environments, and inspected to prove the namespace, license/notice files, and
+metadata. AgentIRC and a pinned Ergo release are compatibility gates before
+Chatbook updates its exact dependency pin. A separate scheduled job may test
+the latest stable Ergo, but an unpinned moving target does not define release
+reproducibility.
+
+Release automation pins third-party actions by full commit, uses minimal
+permissions, does not expose publishing credentials to pull-request jobs, and
+publishes checksums plus provenance or an SBOM. PyPI publication uses Trusted
+Publishing when configured. The exact upstream base and downstream patch
+inventory are present in release metadata and notes.
+
+Generic correctness and security fixes are prepared so they can be offered to
+upstream independently. Namespace migration is a separate mechanical commit,
+and automated guards detect stale `import pydle`, accidental upstream console
+scripts, or a built top-level `pydle` package. Upstream review occurs at least
+quarterly, on each upstream release, and on relevant transport, TLS, SASL, or
+parser security disclosures.
+
+A future tldw_server integration advertises an explicit IRC service
+descriptor containing endpoint, TLS, authentication, and capability metadata.
+The client never derives an IRC endpoint by rewriting a REST URL or guessing a
+port. Public networks, AgentIRC, and a tldw_server-provided endpoint all use
+the same standards-first adapter contract; server-specific extensions remain
+optional capability modules.
+
+## Context
+
+Network Chat has a different lifecycle from an agent conversation. It has
+long-lived sockets, multiple networks and buffers, presence, capability
+negotiation, unread and mention state, channel browsing, reconnection, and
+potential server-backed history. Mounting those concerns inside the Console
+transcript or letting each screen own a socket would conflict with Chatbook's
+fresh-screen navigation and narrow state-owner decisions.
+
+Executable spikes against pydle, AgentIRC, and Ergo showed that canonical
+Codeberg pydle is the smallest complete-client base once maintaining a fork is
+accepted. The pinned source already contains some fixes absent from its 1.1.0
+wheel, but its remaining behavior is not release-ready for Chatbook:
+
+- complete inbound and outbound IRC frames are logged at debug level;
+- each inbound message is dispatched through an independent detached task,
+  permitting protocol state to change out of wire order;
+- implicit reconnect is enabled and transport shutdown does not await the
+  writer's close;
+- outbound writes are not serialized;
+- WHOIS publishes pending correlation state after sending its command;
+- CAP state is incomplete for multiline CAP 302 and post-registration NEW/DEL;
+- one SASL continuation timeout constructs `call_later` with a coroutine
+  object instead of a callback;
+- the effective TLS-verification default is unsafe at the client feature seam;
+- LIST prior art accumulates shared results and does not model bounded local
+  cancellation;
+- receive, line, tag, query, callback, and shutdown resource bounds are not a
+  coherent public contract.
+
+Keeping only task handles around the existing concurrent handlers would make
+shutdown more observable but would not restore deterministic state ordering.
+Making every current handler sequential would deadlock handlers that wait for
+later WHOIS or WHOX replies. The ordered reducer and post-commit callback
+boundary are therefore required architecture rather than optional cleanup.
+
+The earlier SASL prototype used `pure-sasl`. Its latest PyPI release is from
+2019. SASL PLAIN's initial response and IRC chunking are small enough to own
+and test directly, avoiding a mandatory stale dependency while leaving future
+mechanisms to a separate decision.
+
+These decisions cover a long-lived network service, authentication, private
+content, dependency ownership, packaging, a cross-module adapter, and durable
+screen placement. They require a canonical ADR before implementation tasks
+begin.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Use unmodified pydle from PyPI | The wheel predates relevant Codeberg fixes and retains insecure defaults, broken CAP behavior, detached lifecycle, and missing modern semantics. |
+| Patch pydle only inside Chatbook | The client is intended for Chatbook and tldw_server consumers. A hidden application patch cannot provide a stable shared artifact, independent CI, or upstream provenance. |
+| Keep the upstream `pydle` import namespace | It reduces sync churn but makes co-installation ambiguous and lets the fork silently shadow upstream. Isolation is worth the mechanical migration cost. |
+| Use `pure-sasl` for PLAIN | It adds a required dependency whose latest release is from 2019 for a small mechanism the fork can implement and verify directly. |
+| Await every existing pydle handler sequentially | Some handlers wait on replies processed by later inbound frames, producing protocol deadlocks. |
+| Retain concurrent handlers and add locks | Locks do not define wire-order state commits and can deadlock correlated query paths. |
+| Let the library reconnect automatically | Chatbook owns user intent, recovery UI, backoff, credential refresh, and connection generations; hidden reconnect races all of those owners. |
+| Return LIST as one Python list | Large networks can exhaust memory and provide no incremental progress or truthful cancellation semantics. |
+| Make “latest Ergo” the release gate | A moving dependency makes a previously reproducible release fail without a source change. Pinned release CI plus a scheduled latest-compatibility job separates those concerns. |
+| Build a new sans-I/O client around irctokens/ircstates | It provides maximum control but requires building transport, registration, CAP, SASL, correlation, state, feature semantics, and lifecycle. The audited fork remains the smaller complete-client path. |
+| Use AgentIRC's client as the universal client | AgentIRC is principally a server and agent-collaboration target. Ordinary IRCv3 interoperability must not depend on its extensions. |
+| Persist all received messages by default | That creates a new private transcript store with retention, deletion, search, export, and sync obligations. First release remains memory-only unless server history is available. |
+
+## Consequences
+
+### Benefits
+
+- Chatbook receives a complete, independently testable IRC client artifact
+  without exposing fork internals to UI or persistence code.
+- Protocol state has deterministic ordering even when application callbacks
+  are slow or fail.
+- Authentication and chat content stay out of ordinary diagnostics.
+- Application-owned reconnect and generation fencing remain truthful.
+- Channel browsing, history, and shutdown have explicit resource bounds.
+- Public IRC, AgentIRC, and future tldw_server installations share one
+  standards-first path.
+
+### Accepted trade-offs
+
+- tldw assumes long-term fork maintenance, release engineering, security
+  response, and upstream synchronization.
+- The reliable dispatcher is a core refactor rather than a short patch queue.
+- Namespace isolation increases mechanical conflict during upstream sync.
+- Python 3.10 consumers cannot use the first fork release.
+- Memory-only messages are lost at application exit when the server provides
+  no history.
+- SASL mechanisms other than PLAIN remain unavailable until separately
+  implemented and release-gated.
+- Local LIST cancellation cannot force an IRC server to stop sending; it can
+  only bound local delivery and memory while draining the protocol response.
+
+## Reconsideration triggers
+
+Reconsider the selected core if any of the following remains true after the
+first release tranche:
+
+- fork objects or callbacks leak through the Chatbook adapter;
+- ordered state application requires invasive rewrites across most feature
+  modules rather than the defined dispatch and correlation seams;
+- an upstream sync requires repeatedly rebuilding multiple core subsystems;
+- a relevant high-severity transport, parser, TLS, or SASL issue cannot be
+  fixed or mitigated promptly;
+- the artifact cannot pass deterministic, AgentIRC, and pinned-Ergo gates on
+  supported Python versions;
+- cooperative shutdown cannot prove zero library-internal tasks;
+- an incomplete close cannot identify retained uncooperative callback tasks or
+  prevent them from publishing late protocol state.
+
+## Links
+
+- [Network Chat and tldw-pydle design](../../Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md)
+- [tldw-pydle first-release implementation plan](../../Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md)
+- [ADR-011: Chatbook Workbench UI System](011-chatbook-workbench-ui-system.md)
+- [ADR-029: Local Private Data Boundary](029-local-private-data-boundary.md)
+- [ADR-031: TUI keybinding and footer-hint conventions](031-tui-keybinding-and-footer-hint-conventions.md)
+- [ADR-032: Immutable installed distribution assets](032-immutable-installed-distribution-assets.md)
+- [ADR-033: Application session state ownership](033-application-session-state-ownership.md)
+- [ADR-036: Application service composition lifecycle](036-application-service-composition-lifecycle.md)
+- [Canonical pydle source](https://codeberg.org/shiz/pydle)
+- [pydle PR 172: LIST support](https://codeberg.org/shiz/pydle/pulls/172)
+- [pydle PR 196: stalled-write timeout](https://codeberg.org/shiz/pydle/pulls/196)
+- [IRCv3 specifications](https://ircv3.net/irc/)
+- [AgentIRC](https://github.com/agentculture/agentirc)
+- [Ergo](https://github.com/ergochat/ergo)

--- a/backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+++ b/backlog/decisions/149-network-chat-handoff-reliability-amendments.md
@@ -1,0 +1,98 @@
+# ADR-149: Network Chat handoff reliability amendments
+
+Status: Proposed
+Date: 2026-09-10
+Amends upon acceptance: [ADR-148](148-network-chat-ircv3-and-tldw-pydle-boundary.md)
+Related Tasks: TASK-21601 through TASK-21608
+
+## Context
+
+The owner requested a fresh plan assessment and a PR against dev for PTO handoff.
+The approved August draft never landed. Its provisional ADR-084 number now
+collides, so its decision text is preserved as ADR-148. This separate amendment
+records behavioral corrections without silently rewriting an accepted ADR.
+Acceptance of this amendment is a reviewer decision; packaging from the original
+pinned base does not require waiting for the behavioral decisions below.
+
+Current Chatbook requires Python >=3.12 and its route registry supports retained
+screens with resume/suspend. The fork's independently approved >=3.11 floor is
+unchanged. Upstream develop advanced eight commits to
+`e27b6a2138c81061c2e6a937526fceaedb94d31a`, including the stalled-write fix.
+These observations do not establish new fork test results or authorize a base bump.
+
+## Decision proposed
+
+1. Keep `4efcc3b5096536668dfe772461f19a17f1ddd84e` as the audited fork point.
+   Audit later upstream changes separately. Adopt the stalled-write change from
+   `7c7f5c73bf14b8207a551a6cbf38627984cb7f4e` with provenance, not as an
+   unreviewed wholesale base update. Preserve pure-sasl metadata during the
+   namespace-only task; remove it with the tested replacement in TASK-21605.
+2. A full callback queue must not suspend the protocol reducer. Fail closed with
+   a typed slow-consumer result, delivered through independent lifecycle state.
+   Otherwise a callback awaiting WHOIS can deadlock while its own reply waits
+   behind queue backpressure. Coalesced state is re-enqueued at its new receive
+   sequence, preserving ordering relative to intervening message events.
+3. Bound outbound queue bytes, entries and admission work, not merely individual
+   drain calls. Reserve protocol-control capacity, preserve FIFO application
+   admission order, and never await application queue space from the reducer.
+   Exhausted control capacity is terminal; no silent PONG loss.
+4. Timeout/cancellation settles callers but does not erase wire ambiguity.
+   Unlabelled queries retain bounded tombstones until their terminal reply or
+   disconnect; reject reuse of the correlation key meanwhile. LIST keeps one
+   tombstone after its drain deadline while unrelated chat remains usable.
+   Query keys use negotiated IRC CASEMAPPING. Tombstones count against pending
+   operation limits; exhaustion rejects new queries rather than growing memory.
+5. Bounded incomplete callback shutdown assumes the callback still yields to
+   the event loop. Python cannot forcibly stop arbitrary blocking application
+   code. Fence public commands/publication and create a fresh client per new
+   connection; do not claim Python private attributes sandbox hostile callbacks.
+   The close operation owns cleanup independently of any individual awaiter.
+6. CAP continuation syntax belongs to LS/LIST, values to LS/NEW. ACK/NAK settles
+   each request chunk. Ready requires numeric 001 plus successful mandatory
+   authentication; a no-CAP server can register when no capability is mandatory.
+   One cancelled readiness waiter cannot cancel everyone else's result.
+7. Gate PLAIN on the actual verified SSL transport and approved context, not a
+   caller-provided verified flag. Reject credential NULs and invalid PLAIN
+   challenges. No HTTP API credential is implicitly an IRC credential.
+8. Preserve server echoes without deduplicating by text/time or promising a
+   receipt from a socket write. History does not mutate live membership/topic
+   state. Do not request event-playback capabilities without explicit support.
+9. Navigation does not own connections, whether a screen is destroyed or
+   suspended. Later Chatbook work must test both visit lifecycles, detach view
+   subscriptions, and reconcile once from a current snapshot on return.
+10. Release completion requires published, retrievable artifacts matching tested
+    hashes. A publishing blocker leaves the task unfinished. CI is unattended;
+    local full-suite consent does not make CI wait for the absent author.
+    Add Windows/macOS Python 3.12 transport, TLS and packaging evidence to the
+    Linux Python 3.11–3.14 matrix.
+
+## Alternatives and consequences
+
+- Blocking callback delivery preserves all events only until it deadlocks;
+  explicit disconnect is preferable to an apparently healthy frozen session.
+- Releasing query keys on timeout permits stale responses to corrupt new
+  operations. Tombstones trade temporary query availability for correctness;
+  reconnect remains an explicit embedding-application action.
+- Changing the baseline to current upstream immediately would invalidate the
+  prior audit. A reviewed base update remains possible without blocking the
+  mechanical fork task.
+- Forcible callback termination requires a process boundary and serialization
+  contract, disproportionate for trusted embedding callbacks; no such boundary
+  is promised by this fork.
+- The first fork version remains `1.1.0.post1` as previously approved. That is a
+  downstream distribution version, not a claim of upstream API compatibility.
+  Review its release naming before publication; a version change must update
+  package metadata, task criteria and release workflow together.
+
+No IRC implementation, server endpoint, credentials, publication configuration,
+or new persistence schema is introduced by this decision.
+
+## References
+
+- [PTO handoff and validation scenarios](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md)
+- [Updated execution plan](../../Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md)
+- [Current route registry](../../tldw_chatbook/UI/Navigation/screen_registry.py)
+- [Current Python requirement](../../pyproject.toml)
+- [Codeberg change set](https://codeberg.org/shiz/pydle/compare/4efcc3b5096536668dfe772461f19a17f1ddd84e...e27b6a2138c81061c2e6a937526fceaedb94d31a)
+- [IRCv3 CAP specification](https://ircv3.net/specs/extensions/capability-negotiation.html)
+- [IRCv3 message tags](https://ircv3.net/specs/extensions/message-tags.html)

--- a/backlog/decisions/README.md
+++ b/backlog/decisions/README.md
@@ -112,6 +112,8 @@ ADRs explain why significant architectural decisions were made. Backlog tasks, S
 | [ADR-145](145-reviewed-petdex-import-and-pinned-https.md) | Accepted; destination partially superseded by ADR-146 | Import reviewed Petdex artwork with pinned HTTPS and preserved native notices. |
 | [ADR-146](146-independent-buddy-petdex-publication-and-character-creation.md) | Accepted | Publish reviewed Petdex artwork to an independent Buddy and create durable characters through guarded management entry points. |
 | [ADR-147](147-conversation-archive-and-exact-resume.md) | Accepted | Preserve saved chat identity through reversible archive, scoped search, transcript review and exact Console resume. |
+| [ADR-148](148-network-chat-ircv3-and-tldw-pydle-boundary.md) | Accepted; ADR-149 amendments proposed | Preserve the approved Network Chat ownership and separately maintained Codeberg pydle fork boundary. |
+| [ADR-149](149-network-chat-handoff-reliability-amendments.md) | Proposed | Clarify bounded callback/transport delivery, late-reply isolation, current screen lifecycle and truthful release completion for the PTO handoff. |
 
 ## Historical Decision Material
 

--- a/backlog/tasks/task-21601 - Establish-tldw-pydle-fork-provenance-and-isolated-package.md
+++ b/backlog/tasks/task-21601 - Establish-tldw-pydle-fork-provenance-and-isolated-package.md
@@ -1,0 +1,46 @@
+---
+id: TASK-21601
+title: Establish tldw-pydle fork provenance and isolated package
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - network-chat
+  - dependency
+  - packaging
+dependencies: []
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Create a provenance-preserving, separately installable tldw-pydle foundation so
+later reliability work has one stable repository, namespace, license boundary,
+and reproducible package artifact shared by approved tldw client roles.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The fork retains the complete canonical Codeberg history through upstream commit `4efcc3b5096536668dfe772461f19a17f1ddd84e`, records that exact base in a machine-readable location, and retains an `upstream` remote plus a `develop` default branch.
+- [ ] #2 Built metadata identifies distribution `tldw-pydle`, import package `tldw_pydle`, version `1.1.0.post1`, and Python 3.11 or newer without installing or shadowing a top-level `pydle` package.
+- [ ] #3 The upstream BSD-3-Clause license text is preserved verbatim and both wheel and sdist contain a fork NOTICE identifying the canonical source, base commit, and tldw modification boundary.
+- [ ] #4 The namespace migration covers code, tests, entry points, examples, and project metadata, and automated guards detect stale runtime `import pydle` references or upstream console-script names outside explicit provenance material.
+- [ ] #5 Wheel and sdist build reproducibly, their members are inspected directly, and each artifact installs and imports successfully in a clean Python 3.11 environment alongside upstream pydle without collision.
+- [ ] #6 The initial downstream commit series separates provenance/notice work from the mechanical namespace migration and contains no protocol-behavior change.
+- [ ] #7 Fork governance documents the patch taxonomy, upstream synchronization procedure, release blocking policy, and quarterly/release/security review triggers from ADR-148.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21602 - Remove-IRC-content-from-diagnostics-and-harden-outbound-transport.md
+++ b/backlog/tasks/task-21602 - Remove-IRC-content-from-diagnostics-and-harden-outbound-transport.md
@@ -1,0 +1,47 @@
+---
+id: TASK-21602
+title: Remove IRC content from diagnostics and harden outbound transport
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - security
+  - privacy
+  - transport
+dependencies:
+  - TASK-21601
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make the fork safe to operate around private conversations and authentication
+by replacing raw-frame diagnostics with content-free metadata and by giving
+outbound IRC traffic one validated, byte-bounded, stall-bounded ordering seam.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Default and debug diagnostics never contain raw IRC frames, endpoints, nicknames, account/channel names, targets, message/topic bodies, PASS data, channel keys, tokens, SASL payloads, certificate material, or payload-bearing exception messages.
+- [ ] #2 Diagnostic records use fixed content-free fields for opaque connection identity, command/capability name, numeric or standard-reply code, encoded size, timing, and reason category.
+- [ ] #3 Synthetic plaintext and encoded secrets plus representative private chat content are absent from every captured log field, rendered record, exception representation, and default test artifact on send, receive, parse-error, timeout, and disconnect paths.
+- [ ] #4 Outbound application operations preserve FIFO admission order through one writer; queue bytes and entries are bounded, protocol-control capacity prevents PONG starvation, and `write()`/`drain()` calls never interleave.
+- [ ] #5 Outbound commands enforce encoded byte budgets and reject CR, LF, NUL, invalid targets, and unsafe unsplittable content without silently truncating credentials, targets, or message text.
+- [ ] #6 A configurable bounded drain timeout produces one classified unexpected-disconnect outcome and does not leave a second writer, pending drain, or unobserved task.
+- [ ] #7 Deterministic tests prove concurrent ordering, size/control validation, stalled-write behavior, and the complete content-free diagnostic contract.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21603 - Own-tldw-pydle-connection-lifecycle-and-secure-TLS.md
+++ b/backlog/tasks/task-21603 - Own-tldw-pydle-connection-lifecycle-and-secure-TLS.md
@@ -1,0 +1,47 @@
+---
+id: TASK-21603
+title: Own tldw-pydle connection lifecycle and secure TLS
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - lifecycle
+  - tls
+  - security
+dependencies:
+  - TASK-21602
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give embedding applications deterministic authority over connection lifetime
+and verified transport security so close, cancellation, failure, and TLS
+posture are explicit outcomes rather than detached side effects.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 The client exposes reviewed typed connect, generation-idempotent wait-ready, asynchronous close, and force-abort signatures/results from idle, connecting, negotiating, ready, failed, closing, and closed states; cancelling one close waiter does not cancel shared cleanup or another waiter's outcome.
+- [ ] #2 The library performs no implicit reconnect or delayed reconnect scheduling after unexpected disconnect, authentication failure, explicit close, or cancellation.
+- [ ] #3 Cooperative close refuses new commands, settles pending operations, attempts bounded QUIT where appropriate, closes and awaits the writer, cancels/drains all owned work, drains completed exceptions, and finishes with zero owned tasks and timers.
+- [ ] #4 Callback code that ignores cancellation but keeps yielding yields a bounded explicitly incomplete close outcome naming the retained callback while all protocol tasks/timers reach zero and public late commands/publication are rejected; no bound is claimed for code blocking the event loop.
+- [ ] #5 Direct TLS enables certificate-chain and hostname verification by default, supplies SNI, accepts a typed custom trust context, and never downgrades a failed TLS-required connection to plaintext.
+- [ ] #6 Loopback certificate tests prove matching trusted success, hostname mismatch failure, untrusted-chain failure, no plaintext fallback, and bounded TLS writer closure.
+- [ ] #7 Connection cancellation, read reset, failed negotiation, repeated close, stalled close, and normal close have deterministic tests with no unobserved exception or falsely clean shutdown result.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21604 - Implement-ordered-IRC-protocol-reduction-and-correlated-replies.md
+++ b/backlog/tasks/task-21604 - Implement-ordered-IRC-protocol-reduction-and-correlated-replies.md
@@ -1,0 +1,48 @@
+---
+id: TASK-21604
+title: Implement ordered IRC protocol reduction and correlated replies
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - asyncio
+  - reliability
+  - architecture
+dependencies:
+  - TASK-21603
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Make protocol state deterministic by applying inbound IRC frames in wire order,
+separating state commits from application callbacks, and publishing query
+correlation before a fast server can reply.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Every complete inbound frame has monotonic receive order and valid frames mutate core protocol state in that order even when callbacks are delayed, fail, or issue additional IRC commands.
+- [ ] #2 Protocol reducers perform only bounded state/correlation work and never await a future whose completion requires a later inbound frame; JOIN/WHOX and WHOIS flows cannot self-deadlock.
+- [ ] #3 WHOIS and each other included query publish pending future/result state before their command can reach the writer, and immediate scripted replies resolve exactly once without being lost.
+- [ ] #4 Correlated operations have distinct success, rejection, timeout, cancellation, malformed-response, and disconnect outcomes, and every pending operation terminates before connection state is discarded.
+- [ ] #5 Application callbacks run after the corresponding state commit through owned bounded ordered delivery; callback failure is observable and cannot roll back, reorder, or directly mutate committed protocol state.
+- [ ] #6 Presence/state events may coalesce only under the documented identity rule, message and query-result events are never silently dropped, and full callback queues trigger a classified slow-consumer close without making the reducer wait for callback capacity or query completion.
+- [ ] #7 Unsupported ambiguous concurrent queries are rejected deterministically; cancelled/timed-out unlabelled queries retain bounded tombstones until their wire terminal or disconnect, preventing late replies from resolving a replacement query, using negotiated IRC casemapping for target identity.
+- [ ] #8 Deterministic race, ordering, slow-callback, callback-failure, immediate-reply, query-cancellation, and shutdown tests prove the new reducer/correlation boundary.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21605 - Implement-CAP-302-and-TLS-gated-SASL-PLAIN.md
+++ b/backlog/tasks/task-21605 - Implement-CAP-302-and-TLS-gated-SASL-PLAIN.md
@@ -1,0 +1,47 @@
+---
+id: TASK-21605
+title: Implement CAP 302 and TLS-gated SASL PLAIN
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - ircv3
+  - sasl
+  - security
+dependencies:
+  - TASK-21604
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Provide deterministic modern registration and dependency-free authentication
+so capabilities, readiness, and SASL state remain correct across multiline,
+failure, timeout, and post-registration changes.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 CAP LS 302 accumulates every continuation row and preserves opaque case-sensitive capability names plus allowed values before computing requests.
+- [ ] #2 Capability state distinguishes offered, supported, requested, pending, negotiated, and semantically supported, with deterministic encoded-line-safe CAP REQ chunks and correct ACK/NAK handling per request chunk; continuation syntax applies only to LS/LIST and values only to LS/NEW.
+- [ ] #3 CAP END is sent exactly once during registration, CAP NEW/DEL update post-registration state without another registration END, and readiness transitions/emits exactly once on numeric `001` for all waiters only after required authentication succeeds; a legacy server without CAP remains usable when no mandatory capability is configured.
+- [ ] #4 SASL PLAIN is implemented without `pure-sasl`, produces the correct base64 payload, uses 400-byte AUTHENTICATE chunks, and sends the required `+` terminator for empty or exact-multiple responses.
+- [ ] #5 SASL PLAIN is refused unless the active transport completed certificate and hostname verification; required-SASL unavailability or rejection has a typed terminal outcome and never falls through as authenticated.
+- [ ] #6 SASL timeouts are owned and cancellable, the upstream continuation-timer callback defect is regression-tested, and secret references are released after success, rejection, cancellation, timeout, or disconnect.
+- [ ] #7 Multiline CAP, values, split requests, ACK/NAK, NEW/DEL, required/optional SASL, chunking, malformed challenge, timeout, immediate reply, and one-time readiness are covered by deterministic tests with content-free logs.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21606 - Add-bounded-streaming-IRC-LIST-sessions.md
+++ b/backlog/tasks/task-21606 - Add-bounded-streaming-IRC-LIST-sessions.md
@@ -1,0 +1,47 @@
+---
+id: TASK-21606
+title: Add bounded streaming IRC LIST sessions
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - channel-browser
+  - streaming
+  - reliability
+dependencies:
+  - TASK-21604
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Give channel browsers incremental, memory-bounded and cancellation-honest LIST
+results without pretending a local consumer can stop an IRC server's reply
+stream.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One LIST session per connection exposes an asynchronous stream of structured channel, user-count, and topic entries plus a typed terminal result.
+- [ ] #2 Pending session state exists before LIST is sent, rows flow through a bounded queue, and caller delivery limits do not require accumulating the complete server list.
+- [ ] #3 The terminal result distinguishes normal completion, empty completion, local cancellation, truncation, dropped rows, protocol error, timeout, and disconnect and reports received/delivered/dropped counts.
+- [ ] #4 Local cancellation or delivery-limit completion stops caller delivery and drains/discards LIST numerics through `323` while unrelated protocol frames continue to be reduced.
+- [ ] #5 A bounded drain deadline settles the caller when a server never sends `323`, retaining one bounded LIST tombstone until the terminal numeric or connection teardown; another LIST is rejected while ambiguous but unrelated chat remains usable.
+- [ ] #6 Compatible advertised ELIST filters may be sent, but the API and documentation do not claim universal server-side pagination or cancellation.
+- [ ] #7 Deterministic tests cover `321`/`322`/`323`, empty results, malformed counts, error numerics, TRYAGAIN, pressure, local limit, cancellation, disconnect, interleaved chat, and missing terminal numeric.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21607 - Add-bounded-IRCv3-message-and-history-semantics.md
+++ b/backlog/tasks/task-21607 - Add-bounded-IRCv3-message-and-history-semantics.md
@@ -1,0 +1,47 @@
+---
+id: TASK-21607
+title: Add bounded IRCv3 message and history semantics
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - ircv3
+  - history
+  - protocol
+dependencies:
+  - TASK-21605
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Add the bounded modern message semantics needed by a useful IRCv3 client while
+keeping draft history behavior capability-gated and keeping Chatbook's stable
+events, paging, and retention policy outside the fork.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Message-tag parsing implements IRCv3 escaping and byte limits, retains bounded unknown tags without trusting them, and classifies malformed or oversized input without logging content.
+- [ ] #2 `server-time` produces a validated timezone-aware timestamp, and echo-message preserves authoritative server echoes without collapsing identical legitimate messages or treating socket writes as delivery receipts; absent correlation identity yields an explicit unconfirmed local-send state.
+- [ ] #3 BATCH state preserves ID, type, parameters, parent relation, ordered membership, and open/close lifecycle within explicit open-batch and member bounds, including unknown batch types and incomplete disconnect; historical events cannot mutate live membership/topic state, and unsupported event-playback capabilities are not requested.
+- [ ] #4 Negotiated `draft/chathistory` requests preserve target, anchor/reference type, limit, batch identity, message ID, server time, sender/target, message type, and live-versus-history origin.
+- [ ] #5 Empty history, standard-reply/numeric failure, unsupported references, malformed or mismatched batches, server over-return, cancellation, timeout, and disconnect all terminate the correlated history operation truthfully.
+- [ ] #6 Fork models remain immutable adapter-facing views and do not take ownership of Chatbook display pagination, cross-page deduplication, transcript retention, unread state, or persistence.
+- [ ] #7 Deterministic resource-bound and semantic tests cover escaped/unknown/oversized tags, live echo, nested and unknown batches, valid/empty/incomplete history, timestamp/msgid anchors, over-return, failure, cancellation, and disconnect.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.

--- a/backlog/tasks/task-21608 - Gate-and-publish-tldw-pydle-1-1-0-post1.md
+++ b/backlog/tasks/task-21608 - Gate-and-publish-tldw-pydle-1-1-0-post1.md
@@ -1,0 +1,55 @@
+---
+id: TASK-21608
+title: Gate and publish tldw-pydle 1.1.0.post1
+status: To Do
+assignee: []
+created_date: '2026-08-23 23:23'
+updated_date: '2026-09-10 12:00'
+labels:
+  - irc
+  - release
+  - ci
+  - supply-chain
+dependencies:
+  - TASK-21601
+  - TASK-21602
+  - TASK-21603
+  - TASK-21604
+  - TASK-21605
+  - TASK-21606
+  - TASK-21607
+references:
+  - backlog/decisions/148-network-chat-ircv3-and-tldw-pydle-boundary.md
+  - backlog/decisions/149-network-chat-handoff-reliability-amendments.md
+documentation:
+  - Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md
+  - Docs/superpowers/plans/2026-08-23-tldw-pydle-first-release.md
+  - Docs/superpowers/specs/2026-08-23-network-chat-ircv3-and-tldw-pydle-design.md
+priority: high
+type: task
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Turn the completed fork changes into a reproducible, independently installable
+release proven against deterministic protocol, TLS, AgentIRC, and Ergo targets
+before any Chatbook task is allowed to pin the real dependency.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Pull-request CI runs targeted unit, deterministic protocol, TLS, privacy, resource-bound, lifecycle, namespace, license, wheel, and sdist gates on Python 3.11, 3.12, 3.13, and 3.14.
+- [ ] #2 The exact built wheel—not an editable checkout—passes the deterministic oracle and two-client compatibility runs against an exact AgentIRC version and an exact Ergo release whose archive checksum is verified.
+- [ ] #3 Normal/cooperative shutdown leaves zero owned work across every compatibility target, while the cancellation-resistant callback case returns the required bounded incomplete outcome with no remaining protocol authority.
+- [ ] #4 Release CI builds once from a reviewed tag, independently inspects and installs wheel and sdist, and proves package namespace, Python floor, LICENSE, NOTICE, upstream base, source URLs, and patch inventory.
+- [ ] #5 Third-party actions are pinned by full commit SHA, workflow permissions are minimal, pull-request jobs receive no publishing credentials, and no `pull_request_target` path can execute untrusted release code.
+- [ ] #6 The release publishes SHA-256 checksums plus provenance or an SBOM, and its notes map every downstream commit to the ADR-148 patch taxonomy and exact Codeberg base.
+- [ ] #7 Version `1.1.0.post1` is published through an approved GitHub release and PyPI Trusted Publishing configuration, with externally retrievable artifacts matching the tested hashes. An external blocker is recorded with verified local artifacts but leaves this criterion unchecked and the task unfinished.
+- [ ] #8 A separate scheduled compatibility job checks latest stable upstream and Ergo without making those moving targets rewrite the pinned release result.
+- [ ] #9 No Chatbook runtime dependency, screen, profile schema, credential store, or transcript persistence is introduced by this fork release task.
+<!-- AC:END -->
+
+## Handoff
+
+Read the [PTO entry point](../../Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md) before claiming this task. Implementation lives in the separate fork; this record stays in Chatbook. ADR-148 records the approved boundary; ADR-149 contains the proposed review corrections. Add an Implementation Plan only after moving this task to In Progress. No implementation or release evidence is claimed by this documentation PR.


### PR DESCRIPTION
## Purpose

Reassess the approved Network Chat / tldw-pydle plan and make it executable by other contributors during the owner's PTO. Documentation only: no IRC implementation, dependency change, server deployment or package publication.

**Start here:** [PTO handoff](https://github.com/rmusser01/tldw_chatbook/blob/codex/network-chat-pto-handoff/Docs/superpowers/plans/2026-09-10-network-chat-pto-handoff.md)

## Contents

- Land the previously uncommitted design, first-release plan and eight To Do tasks (TASK-21601–21608).
- Preserve the approved architecture as ADR-148; the original provisional ADR-084 number now collides with unrelated dev work.
- Put behavioral corrections in proposed ADR-149 for explicit review, without rewriting the accepted decision.
- Add task claiming, prerequisite ownership, first-session steps, exact regression scenarios, evidence limits and subsequent Chatbook/server work boundaries.

## Reassessment

- Prevent callback-queue/WHOIS deadlocks and bound outbound admission with protocol-control capacity.
- Retain bounded late-reply tombstones after query/LIST cancellation and timeout.
- Make yielding-callback shutdown guarantees honest and cleanup independent of individual waiters.
- Correct CAP grammar, authentication-before-ready, echo identity and history/live-state separation.
- Account for current Chatbook Python 3.12 and reusable screen suspend/resume behavior while retaining the fork's separate Python 3.11 floor.
- Keep publication blockers from counting as completed releases; defer pure-sasl removal until the tested replacement.

Canonical Codeberg was checked again: develop has advanced eight commits to e27b6a2138c81061c2e6a937526fceaedb94d31a, including the merged stalled-write fix. The plan retains the approved 4efcc3b5096536668dfe772461f19a17f1ddd84e base pending a separate behavioral audit; historical spike results are explicitly not fresh release evidence.

## Contributor starting point / prerequisites

Start with TASK-21601. The authenticated lookup could not resolve rmusser01/tldw-pydle; an authorized repository owner should verify/create it and grant access. PyPI publishing setup is not verified. Review ADR-149 before affected behavioral implementation. All eight tasks remain open/unassigned. Later Chatbook UI and tldw_server work require separately filed, reviewed tasks.

## Verification

- Backlog ID/frontmatter/Windows-path guard: passed across 3,701 task records after rebasing onto current dev.
- 53 relative links across 13 new documents, task frontmatter paths, open-task state and whitespace: passed.
- Final diff whitespace check: passed; exactly 14 documentation files in PR scope.
- Remote-ref and worktree ADR/task collision checks completed.
- No full application suite or fork tests run: this PR changes only planning documents and does not claim implementation acceptance.

Please review the handoff and ADR-149 first; the larger design preserves the prior approved context. Do not mark implementation tasks Done when merging this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reassesses the approved Network Chat / `tldw-pydle` plan and lands it as a PTO handoff so other contributors can execute it during the owner's absence. Documentation only; no IRC implementation, dependency change, server deployment, or package publication.

**Handoff contents**
- Commits the previously uncommitted design, first-release plan, and eight To Do tasks (TASK-21601–21608).
- Renumbers the approved architecture to ADR-148; the original ADR-084 number now collides with dev work.
- Adds proposed ADR-149 with behavioral corrections, leaving the accepted ADR-148 text untouched.
- Adds task claiming, prerequisite ownership, first-session steps, regression scenarios, and evidence limits.

**Review focus**
- Review ADR-149 and the handoff doc first.
- The fork repo and PyPI publishing are unverified; an authorized owner must create/grant access.
- All eight tasks remain open and unassigned.
- Do not mark implementation tasks Done when merging.

<sup>Written for commit a576d4df19f006cc484b35cd5d4402f95caa0429. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

