### PR TITLE
fix(library): one pager rule for Skills, Collections and Trash; Collections gets one name and a true empty state; the trust banner says why (critique-10 wave, tasks 32352/32354/32363 + decision 32057)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -321,6 +321,13 @@ selection controls with a useful next step. The exact total remains visible in
 the title, but there is no meaningless “page 1 of 1” or “nothing to select”
 mechanic.
 
+The paging half of that rule is Library-wide: **Skills, Collections and the
+media Trash** drop “page 1 of 1”, the boundary reason and both **Previous** /
+**Next** controls too whenever everything fits on one page, keeping only the
+item range. Every part comes back the moment a second page exists. Paging that
+is *paused* rather than absent — a stale page whose totals are withheld — keeps
+its controls, disabled and carrying the reason.
+
 ```text
 source really has no items          active filter has no matches
 --------------------------          ----------------------------
@@ -884,3 +891,7 @@ list, and the landing hub is capped at 96 cells).*
 (task-32225: the return chip stands down wherever a canvas owns Escape itself,
 so the footer never names a return the key would not perform; task-32228:
 Conversations arrives with its first row focused like every other browse list).*
+
+*Verified against fix/library-crit10-pagers — 2026-09-11 (task-32354: the
+single-page pager rule this page documents now holds for Skills, Collections
+and the media Trash as well as Media, Conversations and Prompts).*

--- a/Docs/User_Guide/library/collections.md
+++ b/Docs/User_Guide/library/collections.md
@@ -18,10 +18,13 @@ folders ([Notes](notes.md)) and Prompt collections
 > create/rename/delete Collections manager. That surface no longer ships:
 > the generic Collections tables are read-only recovery data (see
 > [Legacy Collections data](#legacy-collections-data) below), and the row
-> opens the captures reading list documented here. Whether the row keeps
-> the name "Collections" or becomes "Captures" is an open product
-> decision (task-32057 AC#1) — the name may change; the surface described
-> here is what ships.
+> opens the captures reading list documented here. The name question is
+> now settled (task-32057 AC#1, 2026-09-11): the feature is called
+> **Collections** in the rail and on the canvas, and **Quick Capture** is
+> the name of one action on it — the button that saves a URL — not of the
+> screen. The local Collections service stays **read-only**: there is no
+> schema migration, no membership model and no "Add to collection"
+> affordance anywhere in the app.
 
 ## Getting there
 
@@ -57,6 +60,7 @@ right.
 
 **Capture list (middle):**
 
+- **Collections** — the canvas heading, the same name the rail row carries.
 - **Quick Capture** — opens the save form (see
   [Common tasks](#common-tasks)). Disabled with its reason in the tooltip
   when the active authority cannot capture.
@@ -73,11 +77,21 @@ right.
   The row you have loaded in the reader is prefixed `Loaded in Reader`; a
   row you just clicked whose detail is still arriving reads `Selected ·
   loading`.
-- **Range line** — `1–20 of 57`, or `0–0 of 0` when the scope is empty, or
-  `Page N · total unavailable` when a refresh failed.
-- **Previous** / **Next** — 20 captures per page. Each carries its reason
-  as a tooltip when it is not pressable ("No current next page is
-  available.").
+- **Empty state**, one of two sentences — never both, and never the wrong
+  one. With no filter set: "No saved captures yet · press Quick Capture
+  above to save a page by URL." With a filter (search text, domain, tags or
+  a date bound): "No captures match these filters · clear them to see
+  everything saved."
+- **Range line** — `1–20 of 57 · Page 1 of 3`, or `0–0 of 0` when the scope
+  is empty, or `Page N · total unavailable` when a refresh failed.
+- **Previous** / **Next** — 20 captures per page. They are drawn **only
+  when a second page exists**: a scope that fits on one page has nowhere to
+  page to, so the page number, the boundary reason and both controls are
+  suppressed, exactly as on every other Library list. A disabled control
+  carries a leading **○** and its reason as a tooltip ("Already on the
+  first page.", "No more results."). Paging is **paused**, not absent,
+  while a page is stale — the controls stay, disabled, reading "No current
+  next page is available.".
 
 **Reader (right):** empty until you select a capture ("Select a capture to
 read it here."), then:
@@ -110,7 +124,7 @@ read it here."), then:
 | Sort: … | Cycles the sort order in place; the label always names the order in force. |
 | Filter captures | Free-text search inside the current scope. |
 | Scope sub-rows | All Captures, Saved, Reading, Read, Archived, Favorites, then your saved searches. The selected scope carries the count. |
-| Previous / Next | Move by exact 20-capture pages. |
+| Previous / Next | Move by exact 20-capture pages. Drawn only when a second page exists. |
 | Mark Read / Favorite / Move to Archive | Status actions on the loaded capture. Archiving leaves a `Moved to Archive · was <status>.` receipt with **Undo**. |
 | Open Original | Opens the capture's original URL in your browser. |
 | Read / Highlights / Notes / Info | Reader modes over the one loaded capture. |
@@ -239,3 +253,10 @@ so the rail borrowed the unfiltered total for one load window. The
 unfiltered prefetch now answers only for the unfiltered scope, a page whose
 authority has gone is never painted, and a count read that fails or runs out
 of deadline shows "(—)" with a Details sentence instead of vanishing.)*
+
+*Verified against fix/library-crit10-pagers — 2026-09-11 (task-32057 AC#1
+decided and task-32352: one name — the canvas heading is "Collections" and
+"Quick Capture" is only the save-a-URL button; the empty state no longer
+tells a profile that never captured anything to clear filters it never set;
+the pager at `0–0 of 0` draws no controls at all, per task-32354's shared
+single-page rule. Live at 235x52, 100x30 and 60x24 on a seeded profile.)*

--- a/Docs/User_Guide/library/collections.md
+++ b/Docs/User_Guide/library/collections.md
@@ -77,11 +77,20 @@ right.
   The row you have loaded in the reader is prefixed `Loaded in Reader`; a
   row you just clicked whose detail is still arriving reads `Selected ·
   loading`.
-- **Empty state**, one of two sentences — never both, and never the wrong
-  one. With no filter set: "No saved captures yet · press Quick Capture
-  above to save a page by URL." With a filter (search text, domain, tags or
-  a date bound): "No captures match these filters · clear them to see
-  everything saved."
+- **Empty state**, one of three sentences — never more than one, and never
+  the wrong one. Each names the control that narrowed the list and the way
+  back out of it.
+  - A filter is set (search text, domain, tags or a date bound — the things
+    **Clear** undoes): "No captures match these filters · clear them to see
+    everything saved."
+  - A rail scope is selected (Saved, Reading, Read, Archived, Favorites):
+    "Nothing in this scope yet · choose All Captures in the rail to see
+    everything saved."
+  - Neither: "No saved captures yet · press Quick Capture above to save a
+    page by URL."
+
+  A filter set *inside* a scope takes the filter sentence: it is the
+  narrowing the reader can undo from the canvas.
 - **Range line** — `1–20 of 57 · Page 1 of 3`, or `0–0 of 0` when the scope
   is empty, or `Page N · total unavailable` when a refresh failed.
 - **Previous** / **Next** — 20 captures per page. They are drawn **only
@@ -259,4 +268,6 @@ decided and task-32352: one name — the canvas heading is "Collections" and
 "Quick Capture" is only the save-a-URL button; the empty state no longer
 tells a profile that never captured anything to clear filters it never set;
 the pager at `0–0 of 0` draws no controls at all, per task-32354's shared
-single-page rule. Live at 235x52, 100x30 and 60x24 on a seeded profile.)*
+single-page rule. Live at 235x52, 100x30 and 60x24 on a seeded profile. Fix
+round 1: the empty state gained a third sentence for an empty rail scope,
+which the first cut mis-read as a never-used profile.)*

--- a/Docs/User_Guide/library/collections.md
+++ b/Docs/User_Guide/library/collections.md
@@ -83,14 +83,20 @@ right.
   - A filter is set (search text, domain, tags or a date bound — the things
     **Clear** undoes): "No captures match these filters · clear them to see
     everything saved."
-  - A rail scope is selected (Saved, Reading, Read, Archived, Favorites):
-    "Nothing in this scope yet · choose All Captures in the rail to see
-    everything saved."
+  - A rail scope is selected (Saved, Reading, Read, Archived, Favorites, or a
+    saved search carrying its own status / favourite predicate): "Nothing in
+    this scope yet · choose All Captures in the rail to see everything
+    saved."
   - Neither: "No saved captures yet · press Quick Capture above to save a
     page by URL."
 
   A filter set *inside* a scope takes the filter sentence: it is the
-  narrowing the reader can undo from the canvas.
+  narrowing the reader can undo from the canvas. None of the three appears
+  until a page has actually come back — while the first load is running, or
+  after it failed, the "Loading captures…" line or the error and its
+  **Retry** are the only message, because "no captures" is a claim about a
+  result. If a page is left on screen while a new scope loads, the sentence
+  describes the page you can see, not the scope being fetched.
 - **Range line** — `1–20 of 57 · Page 1 of 3`, or `0–0 of 0` when the scope
   is empty, or `Page N · total unavailable` when a refresh failed.
 - **Previous** / **Next** — 20 captures per page. They are drawn **only
@@ -270,4 +276,7 @@ tells a profile that never captured anything to clear filters it never set;
 the pager at `0–0 of 0` draws no controls at all, per task-32354's shared
 single-page rule. Live at 235x52, 100x30 and 60x24 on a seeded profile. Fix
 round 1: the empty state gained a third sentence for an empty rail scope,
-which the first cut mis-read as a never-used profile.)*
+which the first cut mis-read as a never-used profile. Bot review round: it no
+longer speaks at all before a page has come back, it describes the page on
+screen rather than the scope being fetched, and a saved search's
+`favorite=False` predicate counts as a scope.)*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -296,7 +296,11 @@ Escape returns to the list.
 Notes on the edges: with nothing deleted the view says "Trash is empty.
 Items you delete from Media land here." and "Restore" reads "○ Restore"
 with a reason tooltip; if the trash holds more items than one fetch page,
-a status line says "showing X of N" honestly. Entering Trash clears any
+a status line says "showing X of N" honestly. The pager under the list is
+drawn **only when a second page exists**: a trash that fits on one page keeps
+the item range ("1-1 of 1") and drops "Page 1 of 1" along with both
+**Previous** / **Next**, the same rule the rest of the Library follows (see
+[Library](../library.md)), so Restore sits directly under the last row. Entering Trash clears any
 "✓ deleted…" receipt still showing on the list — the Trash view is the
 durable path that receipt pointed at. Trashed items are **excluded from
 search** (Library search and RAG keyword retrieval both skip them) until
@@ -1176,3 +1180,8 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-pagers — 2026-09-11 (task-32354: a
+single-page Trash draws no "Page 1 of 1" and no Previous/Next, and its pager
+block is one row instead of two. Live at 235x52 on a seeded profile with one
+trashed item and with the list filtered to none.)*

--- a/Docs/User_Guide/library/skills.md
+++ b/Docs/User_Guide/library/skills.md
@@ -72,7 +72,7 @@ the canvas scrolls, so the trust panel may sit below the fold.
 
 | Line | Action button |
 |---|---|
-| "Skill trust isn't set up — set it up to review and use skills." | **Set up skill trust** |
+| "Skill trust isn't set up, so every skill reads \"needs review\" — set it up to review and use skills." | **Set up skill trust** |
 | "Skill trust needs to be set up again after an update." | **Set up skill trust** |
 | "Skill trust is temporarily unavailable — try again." | **Retry** |
 | "Skill trust is locked for this session." | **Unlock** |
@@ -84,6 +84,13 @@ A standalone **Reset skill trust…** button appears next to the header for
 the locked and set-up-again states. It two-step confirms with "Reset skill
 trust? Every skill will need re-approval. Your skills are not deleted."
 (**Reset** / **Cancel**).
+
+### Pager
+
+The pager under the list shows the item range, and — only when a second page
+exists — the page number, the boundary reason, and the **Previous** / **Next**
+controls. A list that fits on one page has nowhere to page to, so none of that
+chrome is drawn; this matches every other Library list.
 
 ### Importing
 
@@ -454,3 +461,9 @@ check.)*
 row carries its trust state as a word, so an approved and an unapproved skill
 no longer paint alike; task-32217: with no skill open the list takes the
 columns the "Select a skill to inspect it here." pane was holding).*
+
+*Verified against fix/library-crit10-pagers — 2026-09-11 (task-32363: the
+trust banner says that with no trust store every skill reads "needs review",
+so an approval made earlier is unverifiable rather than lost; task-32354: the
+Skills pager drops "Page 1 of 1", its boundary reasons and the two dead
+controls when everything fits on one page).*

--- a/Docs/User_Guide/library/skills.md
+++ b/Docs/User_Guide/library/skills.md
@@ -72,7 +72,7 @@ the canvas scrolls, so the trust panel may sit below the fold.
 
 | Line | Action button |
 |---|---|
-| "Skill trust isn't set up, so every skill reads \"needs review\" — set it up to review and use skills." | **Set up skill trust** |
+| "Skill trust isn't set up, so every skill reads “needs review” — set it up to review and use skills." | **Set up skill trust** |
 | "Skill trust needs to be set up again after an update." | **Set up skill trust** |
 | "Skill trust is temporarily unavailable — try again." | **Retry** |
 | "Skill trust is locked for this session." | **Unlock** |

--- a/Tests/Library/test_library_pager_state.py
+++ b/Tests/Library/test_library_pager_state.py
@@ -5,6 +5,8 @@ import pytest
 from tldw_chatbook.Library.library_pager_state import (
     LibraryPagerDisplay,
     build_library_pager_display,
+    library_pager_layout,
+    simple_library_pager_display,
 )
 
 
@@ -423,3 +425,72 @@ def test_stale_state_rejects_error_copy_even_with_meaningful_stale_copy():
             error_copy="Couldn't refresh page.",
             stale_copy="List may be out of date",
         )
+
+
+# ---------------------------------------------------------------------------
+# ``simple_library_pager_display`` (task-32354): the factory for a source
+# that pages itself and cannot satisfy ``build_library_pager_display``'s
+# row-count invariants.
+# ---------------------------------------------------------------------------
+
+
+def test_simple_display_on_one_page_is_single_page_with_both_reasons():
+    display = simple_library_pager_display(
+        range_copy="0–0 of 0",
+        page=1,
+        total_pages=1,
+        has_previous=False,
+        has_next=False,
+    )
+
+    assert display == LibraryPagerDisplay(
+        title_count=None,
+        range_copy="0–0 of 0",
+        page_copy="Page 1 of 1",
+        status_copy="",
+        previous_disabled=True,
+        next_disabled=True,
+        previous_reason="Already on the first page.",
+        next_reason="No more results.",
+        retry_visible=False,
+        single_page=True,
+    )
+    layout = library_pager_layout(display)
+    assert layout.status_parts == ("0–0 of 0",)
+    assert layout.boundary_reasons == ()
+    assert layout.controls_hidden is True
+
+
+def test_simple_display_with_a_next_page_keeps_every_part_of_the_pager():
+    display = simple_library_pager_display(
+        range_copy="1–20 of 21",
+        page=1,
+        total_pages=2,
+        has_previous=False,
+        has_next=True,
+    )
+
+    assert display.single_page is False
+    assert display.next_reason == ""
+    layout = library_pager_layout(display)
+    assert layout.status_parts == ("1–20 of 21", "Page 1 of 2")
+    assert layout.boundary_reasons == ("Already on the first page.",)
+    assert layout.controls_hidden is False
+
+
+def test_simple_display_drops_page_copy_when_the_page_count_is_unknown():
+    """A service that cannot give an exact total still gets a usable pager:
+    no "Page x of 0", and the controls stay because a next page may exist."""
+    display = simple_library_pager_display(
+        range_copy="Page 2 · total unavailable",
+        page=2,
+        total_pages=0,
+        has_previous=True,
+        has_next=True,
+    )
+
+    assert display.page_copy == ""
+    assert display.single_page is False
+    layout = library_pager_layout(display)
+    assert layout.status_parts == ("Page 2 · total unavailable",)
+    assert layout.controls_hidden is False

--- a/Tests/Library/test_library_skills_state.py
+++ b/Tests/Library/test_library_skills_state.py
@@ -487,7 +487,14 @@ def test_skill_trust_header_line_maps_postures():
     from tldw_chatbook.Library.library_skills_state import skill_trust_header_line
 
     assert skill_trust_header_line("needs_setup", 0)[1] == "setup"
-    assert "isn't set up" in skill_trust_header_line("needs_setup", 0)[0]
+    # task-32363: the banner states the precedence -- with no trust store
+    # there is nothing to verify an approval against, so an approved skill
+    # reads "needs review" beside an unapproved one and the list looks
+    # wrong rather than unverifiable.
+    assert skill_trust_header_line("needs_setup", 0)[0] == (
+        'Skill trust isn\'t set up, so every skill reads "needs review" — '
+        "set it up to review and use skills."
+    )
     assert skill_trust_header_line("needs_resetup", 0)[1] == "resetup"
     assert "again after an update" in skill_trust_header_line("needs_resetup", 0)[0]
     assert skill_trust_header_line("unavailable", 0)[1] == "retry"

--- a/Tests/UI/test_library_crit10_pagers.py
+++ b/Tests/UI/test_library_crit10_pagers.py
@@ -36,12 +36,26 @@ from tldw_chatbook.UI.Library_Modules.library_collections_capture_controller imp
 from tldw_chatbook.Widgets.Library.library_collections_capture_reader import (
     CollectionsCaptureReaderPresentation,
     LibraryCollectionsItemsPane,
+    collections_empty_state_copy,
 )
 
 
 # ---------------------------------------------------------------------------
 # Collections
 # ---------------------------------------------------------------------------
+
+# The three empty-state sentences, written out here rather than imported, so
+# the wording itself is pinned and not just the branch that produces it.
+_EMPTY_NOTHING_SAVED = (
+    "No saved captures yet · press Quick Capture above to save a page by URL."
+)
+_EMPTY_FILTERED = (
+    "No captures match these filters · clear them to see everything saved."
+)
+_EMPTY_SCOPED = (
+    "Nothing in this scope yet · choose All Captures in the rail to see "
+    "everything saved."
+)
 
 
 class _ItemsApp(ConsolidatedCSSApp):
@@ -72,23 +86,41 @@ def _capture(index: int) -> CaptureSummary:
     )
 
 
-def _collections_app(
-    *, total: int, rows: int = 0, stale: bool = False, **scope
-) -> _ItemsApp:
-    """Build an Items pane over a page of ``rows`` items out of ``total``."""
-    request = CapturePageRequest(AUTHORITY, **scope)
-    page = CapturePage(request, tuple(_capture(index) for index in range(rows)), total)
-    state = CollectionsCaptureControllerState(
-        authority_key=AUTHORITY,
-        requested_scope=request,
-        applied_scope=request,
-        page=page,
-        page_stale=stale,
-    )
+def _pane(state: CollectionsCaptureControllerState) -> _ItemsApp:
     return _ItemsApp(
         CollectionsCaptureReaderPresentation(
             state=state,
             capabilities=_capabilities("browse", "capture"),
+        )
+    )
+
+
+def _collections_app(*, total: int, rows: int = 0, stale: bool = False, **scope):
+    """Build an Items pane over a page of ``rows`` items out of ``total``."""
+    request = CapturePageRequest(AUTHORITY, **scope)
+    page = CapturePage(request, tuple(_capture(index) for index in range(rows)), total)
+    return _pane(
+        CollectionsCaptureControllerState(
+            authority_key=AUTHORITY,
+            requested_scope=request,
+            applied_scope=request,
+            page=page,
+            page_stale=stale,
+        )
+    )
+
+
+def _collections_app_without_a_page(
+    *, loading: bool = False, error: str | None = None, **scope
+):
+    """An Items pane whose requested scope has produced no page yet."""
+    return _pane(
+        CollectionsCaptureControllerState(
+            authority_key=AUTHORITY,
+            requested_scope=CapturePageRequest(AUTHORITY, **scope),
+            page=None,
+            page_loading=loading,
+            page_error=error,
         )
     )
 
@@ -130,9 +162,7 @@ async def test_collections_empty_state_never_blames_an_unset_filter():
     async with app.run_test(size=(235, 52)) as pilot:
         await pilot.pause()
         empty = app.query_one("#library-collections-items-empty", Static)
-        assert str(empty.renderable) == (
-            "No saved captures yet · press Quick Capture above to save a page by URL."
-        )
+        assert str(empty.renderable) == _EMPTY_NOTHING_SAVED
 
 
 @pytest.mark.asyncio
@@ -142,9 +172,7 @@ async def test_collections_empty_state_names_filters_only_when_one_is_set():
     async with app.run_test(size=(235, 52)) as pilot:
         await pilot.pause()
         empty = app.query_one("#library-collections-items-empty", Static)
-        assert str(empty.renderable) == (
-            "No captures match these filters · clear them to see everything saved."
-        )
+        assert str(empty.renderable) == _EMPTY_FILTERED
 
 
 @pytest.mark.parametrize(
@@ -165,10 +193,7 @@ async def test_collections_empty_state_names_an_empty_rail_scope(scope):
     async with app.run_test(size=(235, 52)) as pilot:
         await pilot.pause()
         empty = app.query_one("#library-collections-items-empty", Static)
-        assert str(empty.renderable) == (
-            "Nothing in this scope yet · choose All Captures in the rail to see "
-            "everything saved."
-        )
+        assert str(empty.renderable) == _EMPTY_SCOPED
 
 
 @pytest.mark.asyncio
@@ -178,9 +203,97 @@ async def test_collections_empty_state_prefers_the_filter_copy_inside_a_scope():
     async with app.run_test(size=(235, 52)) as pilot:
         await pilot.pause()
         empty = app.query_one("#library-collections-items-empty", Static)
-        assert str(empty.renderable) == (
-            "No captures match these filters · clear them to see everything saved."
+        assert str(empty.renderable) == _EMPTY_FILTERED
+
+
+# --- the empty-state rule itself, without mounting anything ----------------
+# Qodo review of PR #2599 (item 3): the branch precedence and the field
+# classification are a rule, not a rendering detail, and were reachable only
+# through a mounted Textual app.
+
+
+@pytest.mark.parametrize(
+    ("scope", "expected"),
+    (
+        ({}, _EMPTY_NOTHING_SAVED),
+        ({"search": "anything"}, _EMPTY_FILTERED),
+        ({"tags": ("research",)}, _EMPTY_FILTERED),
+        ({"domain": "example.com"}, _EMPTY_FILTERED),
+        ({"date_from": "2026-01-01"}, _EMPTY_FILTERED),
+        ({"date_to": "2026-01-01"}, _EMPTY_FILTERED),
+        ({"statuses": ("archived",)}, _EMPTY_SCOPED),
+        ({"favorite": True}, _EMPTY_SCOPED),
+        # Qodo item 4: "not favourite" is a real saved-search predicate, and
+        # `False` is not "no scope".
+        ({"favorite": False}, _EMPTY_SCOPED),
+        # Precedence: a filter inside a scope is the narrowing this canvas
+        # can undo, so it wins.
+        ({"favorite": True, "search": "anything"}, _EMPTY_FILTERED),
+        ({"statuses": ("read",), "domain": "example.com"}, _EMPTY_FILTERED),
+    ),
+)
+def test_collections_empty_state_copy_rule(scope, expected):
+    assert collections_empty_state_copy(CapturePageRequest(AUTHORITY, **scope)) == (
+        expected
+    )
+
+
+@pytest.mark.asyncio
+async def test_collections_empty_state_names_a_non_favourite_saved_search():
+    """Qodo item 4, at the UI boundary: `favorite=False` is an active scope."""
+    app = _collections_app(total=0, favorite=False)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == _EMPTY_SCOPED
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    ({"loading": True}, {"error": "refresh_failed"}, {}),
+    ids=("loading", "failed", "never-requested"),
+)
+@pytest.mark.asyncio
+async def test_collections_says_nothing_definitive_before_a_page_arrives(kwargs):
+    """Qodo item 1: an absent page is not an authoritative empty result.
+
+    "No saved captures yet" beside a "Loading captures…" callout or a Retry
+    is a claim the canvas cannot support — no request for this scope has
+    succeeded yet.
+    """
+    app = _collections_app_without_a_page(**kwargs)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        assert not app.query("#library-collections-items-empty")
+        if kwargs.get("loading"):
+            assert app.query_one("#library-collections-page-loading", Static)
+        if kwargs.get("error"):
+            assert app.query_one("#library-collections-page-error", Static)
+
+
+@pytest.mark.asyncio
+async def test_collections_empty_state_follows_the_page_it_describes():
+    """Qodo item 1, second half: a retained stale page keeps its own scope.
+
+    A scope change leaves the last good page on screen while the new request
+    runs, so copy derived from `requested_scope` would describe a page that
+    is not the one being shown.
+    """
+    applied = CapturePageRequest(AUTHORITY, statuses=("archived",))
+    requested = CapturePageRequest(AUTHORITY, search="something else")
+    app = _pane(
+        CollectionsCaptureControllerState(
+            authority_key=AUTHORITY,
+            requested_scope=requested,
+            applied_scope=applied,
+            page=CapturePage(applied, (), 0),
+            page_stale=True,
         )
+    )
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == _EMPTY_SCOPED
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_crit10_pagers.py
+++ b/Tests/UI/test_library_crit10_pagers.py
@@ -1,0 +1,258 @@
+"""Critique #10: the Collections and Trash pagers, name and empty state.
+
+Covers task-32352 (one name, a true empty state, a disabled pager at
+``0–0 of 0``) and the Collections/Trash half of task-32354 (every Library
+pager goes through ``library_pager_layout``'s single-page rule).
+
+The Skills half of task-32354 lives in ``test_library_skills_canvas.py``
+beside the pin it reverses.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from Tests.UI.test_library_collections_capture_reader import (
+    AUTHORITY,
+    _capabilities,
+)
+from tldw_chatbook.Library.collections_capture_models import (
+    CAPTURE_PAGE_SIZE,
+    CaptureIdentity,
+    CapturePage,
+    CapturePageRequest,
+    CaptureSummary,
+)
+from tldw_chatbook.UI.Library_Modules.library_collections_capture_controller import (
+    CollectionsCaptureControllerState,
+)
+from tldw_chatbook.Widgets.Library.library_collections_capture_reader import (
+    CollectionsCaptureReaderPresentation,
+    LibraryCollectionsItemsPane,
+)
+from Tests.UI.test_library_media_trash import (
+    _TrashCanvasApp,
+    _fresh_trash_pager,
+    _trash_state,
+)
+
+
+# ---------------------------------------------------------------------------
+# Collections
+# ---------------------------------------------------------------------------
+
+
+class _ItemsApp(ConsolidatedCSSApp):
+    """Mounts the Collections Items pane alone -- the surface under test."""
+
+    def __init__(self, presentation: CollectionsCaptureReaderPresentation) -> None:
+        super().__init__()
+        self.presentation = presentation
+
+    def compose(self):
+        yield LibraryCollectionsItemsPane(self.presentation, id="items")
+
+
+def _capture(index: int) -> CaptureSummary:
+    return CaptureSummary(
+        identity=CaptureIdentity(AUTHORITY, f"capture-{index:03d}"),
+        canonical_url=f"https://example.com/{index}",
+        title=f"Capture {index}",
+        domain="example.com",
+        summary="A compact summary.",
+        published_at="2026-08-30T12:00:00Z",
+        status="reading",
+        favorite=False,
+        tags=(),
+        processing_state="ready",
+        created_at="2026-08-31T12:00:00Z",
+        updated_at="2026-08-31T12:00:00Z",
+    )
+
+
+def _collections_app(
+    *, total: int, rows: int = 0, stale: bool = False, **scope
+) -> _ItemsApp:
+    """Build an Items pane over a page of ``rows`` items out of ``total``."""
+    request = CapturePageRequest(AUTHORITY, **scope)
+    page = CapturePage(request, tuple(_capture(index) for index in range(rows)), total)
+    state = CollectionsCaptureControllerState(
+        authority_key=AUTHORITY,
+        requested_scope=request,
+        applied_scope=request,
+        page=page,
+        page_stale=stale,
+    )
+    return _ItemsApp(
+        CollectionsCaptureReaderPresentation(
+            state=state,
+            capabilities=_capabilities("browse", "capture"),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_collections_canvas_is_named_collections_not_quick_capture():
+    """task-32352 AC#1: one name in the rail and on the canvas.
+
+    The rail row says "Collections (N)"; the canvas led with the Quick
+    Capture button and no heading at all, so the first painted line read
+    as the canvas title. "Quick Capture" survives only on the button that
+    saves a URL -- it is a verb, not a place.
+    """
+    app = _collections_app(total=0)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        heading = app.query_one("#library-collections-header", Static)
+        assert str(heading.renderable) == "Collections"
+        titled = [
+            widget
+            for widget in app.query(Static)
+            if str(getattr(widget, "renderable", "")).strip() == "Quick Capture"
+        ]
+        assert not titled, "Quick Capture is a button label, not a title"
+        assert "Quick Capture" in str(
+            app.query_one("#library-collections-quick-capture", Button).label
+        )
+
+
+@pytest.mark.asyncio
+async def test_collections_empty_state_never_blames_an_unset_filter():
+    """task-32352 AC#2: a profile that never captured anything.
+
+    One sentence used to cover both cases, so an empty profile was told
+    to clear filters it had never set and pointed at Quick Capture as if
+    it were somewhere else on the screen.
+    """
+    app = _collections_app(total=0)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == (
+            "No saved captures yet · press Quick Capture above to save a page by URL."
+        )
+
+
+@pytest.mark.asyncio
+async def test_collections_empty_state_names_filters_only_when_one_is_set():
+    """task-32352 AC#2, the other half: a filter IS set, so say so."""
+    app = _collections_app(total=0, search="nothing matches this")
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == (
+            "No captures match these filters · clear them to see everything saved."
+        )
+
+
+@pytest.mark.asyncio
+async def test_collections_shows_no_pager_chrome_at_zero_of_zero():
+    """task-32352 AC#3 + task-32354 AC#1 for this canvas.
+
+    Previous/Next rendered enabled-looking at "0–0 of 0" while the
+    identical Trash pager rendered disabled (B D6 cap 52). There is
+    nowhere to page to, so the shared rule drops the controls entirely.
+    """
+    app = _collections_app(total=0)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        assert not app.query("#library-collections-page-toolbar")
+        assert str(
+            app.query_one("#library-collections-page-range", Static).renderable
+        ) == "0–0 of 0"
+
+
+@pytest.mark.asyncio
+async def test_collections_keeps_paused_controls_when_the_page_is_stale():
+    """The suppression's precondition: nowhere to page to, not paging paused.
+
+    A stale page withholds totals, so both directions are unavailable --
+    but that is "we cannot page right now", not "this is the only page".
+    The controls stay, disabled, with the reason the old pager gave
+    (pinned by ``test_items_keep_capture_controls_rows_and_stale_recovery_
+    reachable``).
+    """
+    app = _collections_app(total=40, rows=CAPTURE_PAGE_SIZE, stale=True)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        previous = app.query_one("#library-collections-page-previous", Button)
+        assert previous.disabled
+        assert previous.tooltip == "No current previous page is available."
+        assert str(
+            app.query_one("#library-collections-page-range", Static).renderable
+        ) == "Page 1 · total unavailable"
+
+
+@pytest.mark.asyncio
+async def test_collections_keeps_the_pager_when_a_second_page_exists():
+    """The suppression is the one-page case only -- two pages keep both
+    controls, the page copy, and the ``○`` marker every other Library
+    pager uses for a disabled one."""
+    app = _collections_app(total=CAPTURE_PAGE_SIZE + 1, rows=CAPTURE_PAGE_SIZE)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        assert app.query("#library-collections-page-toolbar")
+        assert str(
+            app.query_one("#library-collections-page-range", Static).renderable
+        ) == f"1–{CAPTURE_PAGE_SIZE} of {CAPTURE_PAGE_SIZE + 1} · Page 1 of 2"
+        previous = app.query_one("#library-collections-page-previous", Button)
+        assert previous.disabled
+        assert str(previous.label).startswith("○ ")
+        assert not app.query_one(
+            "#library-collections-page-next", Button
+        ).disabled
+
+
+# ---------------------------------------------------------------------------
+# Trash
+# ---------------------------------------------------------------------------
+
+
+def _trash_app(*, total: int, rows: int) -> _TrashCanvasApp:
+    """Reuse the Trash suite's own canvas host and record shape."""
+    records = [
+        {
+            "id": str(index),
+            "title": f"Trashed {index}",
+            "type": "audio",
+            "trash_date": "2026-09-01T00:00:00+00:00",
+        }
+        for index in range(rows)
+    ]
+    return _TrashCanvasApp(
+        _trash_state(records=records, total=total, selected_id=""),
+        pager=_fresh_trash_pager(total=total, rows=rows),
+    )
+
+
+@pytest.mark.asyncio
+async def test_trash_shows_no_pager_controls_on_a_single_page():
+    """task-32354 AC#1 for Trash, at the width where the rows matter."""
+    app = _trash_app(total=1, rows=1)
+    async with app.run_test(size=(60, 24)) as pilot:
+        await pilot.pause()
+        assert not app.query("#library-media-trash-pager-controls")
+        assert not app.query("#library-media-trash-page")
+        assert str(
+            app.query_one("#library-media-trash-range", Static).renderable
+        ) == "1-1 of 1"
+        pager = app.query_one("#library-media-trash-pager")
+        assert pager.styles.height.value == 1
+
+
+@pytest.mark.asyncio
+async def test_trash_keeps_its_two_row_pager_when_a_second_page_exists():
+    app = _trash_app(total=45, rows=20)
+    async with app.run_test(size=(60, 24)) as pilot:
+        await pilot.pause()
+        assert app.query("#library-media-trash-pager-controls")
+        assert str(
+            app.query_one("#library-media-trash-range", Static).renderable
+        ) == "1-20 of 45"
+        assert str(
+            app.query_one("#library-media-trash-page", Static).renderable
+        ) == "Page 1 of 3"
+        pager = app.query_one("#library-media-trash-pager")
+        assert pager.styles.height.value == 2

--- a/Tests/UI/test_library_crit10_pagers.py
+++ b/Tests/UI/test_library_crit10_pagers.py
@@ -18,6 +18,11 @@ from Tests.UI.test_library_collections_capture_reader import (
     AUTHORITY,
     _capabilities,
 )
+from Tests.UI.test_library_media_trash import (
+    _TrashCanvasApp,
+    _fresh_trash_pager,
+    _trash_state,
+)
 from tldw_chatbook.Library.collections_capture_models import (
     CAPTURE_PAGE_SIZE,
     CaptureIdentity,
@@ -31,11 +36,6 @@ from tldw_chatbook.UI.Library_Modules.library_collections_capture_controller imp
 from tldw_chatbook.Widgets.Library.library_collections_capture_reader import (
     CollectionsCaptureReaderPresentation,
     LibraryCollectionsItemsPane,
-)
-from Tests.UI.test_library_media_trash import (
-    _TrashCanvasApp,
-    _fresh_trash_pager,
-    _trash_state,
 )
 
 
@@ -139,6 +139,42 @@ async def test_collections_empty_state_never_blames_an_unset_filter():
 async def test_collections_empty_state_names_filters_only_when_one_is_set():
     """task-32352 AC#2, the other half: a filter IS set, so say so."""
     app = _collections_app(total=0, search="nothing matches this")
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == (
+            "No captures match these filters · clear them to see everything saved."
+        )
+
+
+@pytest.mark.parametrize(
+    "scope",
+    ({"favorite": True}, {"statuses": ("archived",)}),
+    ids=("favorites", "archived"),
+)
+@pytest.mark.asyncio
+async def test_collections_empty_state_names_an_empty_rail_scope(scope):
+    """task-32352 AC#2, the third case: the rail's own scope narrowed it.
+
+    The rail's scope rows set ``statuses``/``favorite`` rather than any of
+    the filter-form fields, so an empty Favorites beside a rail reading
+    "Collections (57)" would otherwise claim nothing was ever saved and
+    point at an action that does not leave the scope.
+    """
+    app = _collections_app(total=0, **scope)
+    async with app.run_test(size=(235, 52)) as pilot:
+        await pilot.pause()
+        empty = app.query_one("#library-collections-items-empty", Static)
+        assert str(empty.renderable) == (
+            "Nothing in this scope yet · choose All Captures in the rail to see "
+            "everything saved."
+        )
+
+
+@pytest.mark.asyncio
+async def test_collections_empty_state_prefers_the_filter_copy_inside_a_scope():
+    """A filter set inside a scope is the thing the reader can clear."""
+    app = _collections_app(total=0, favorite=True, search="nothing matches this")
     async with app.run_test(size=(235, 52)) as pilot:
         await pilot.pause()
         empty = app.query_one("#library-collections-items-empty", Static)

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -321,6 +321,12 @@ async def test_skills_canvas_renders_the_full_pager_when_a_second_page_exists():
     state = dataclasses.replace(_two_row_state(), pager=pager)
     app = _CanvasHost(state, trust_posture="ready")
     async with app.run_test() as pilot:
+        # The header counts the SOURCE (``state.pager.title_count``), not the
+        # rows mounted on this page -- 21 against 2 mounted rows is what makes
+        # the two distinguishable, and the single-page companion cannot say so.
+        assert str(pilot.app.query_one("#library-skills-header").renderable) == (
+            f"Skills ({DEFAULT_SKILL_BROWSE_PAGE_SIZE + 1})"
+        )
         status = str(pilot.app.query_one("#library-skills-range").renderable)
         assert status.endswith("· Page 1 of 2"), status
         assert pilot.app.query(f"#{LIBRARY_SKILLS_PAGE_PREVIOUS_ID}")

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -38,6 +38,7 @@ from tldw_chatbook.Library.library_shell_state import (
 )
 from tldw_chatbook.Library.library_pager_state import build_library_pager_display
 from tldw_chatbook.Library.library_skills_state import (
+    DEFAULT_SKILL_BROWSE_PAGE_SIZE,
     SkillBrowseScope,
     SkillEditorState,
     SkillEditorSupportingFile,
@@ -55,6 +56,8 @@ from tldw_chatbook.UI.Screens import library_screen as library_screen_module
 from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Widgets.Library.library_skills_canvas import (
     _TRUST_SETUP_EXPLANATION_COPY,
+    LIBRARY_SKILLS_PAGE_NEXT_ID,
+    LIBRARY_SKILLS_PAGE_PREVIOUS_ID,
     LibrarySkillsListCanvas,
     skill_context_toggle_label,
     skill_disable_model_label,
@@ -252,13 +255,23 @@ async def test_skills_canvas_sort_label_reflects_sort_mode():
 
 
 @pytest.mark.asyncio
-async def test_skills_canvas_renders_exact_pager_and_source_wide_trust_count():
+async def test_skills_canvas_suppresses_single_page_chrome_and_keeps_the_trust_count():
+    """One page of skills renders the range and nothing else (task-32354).
+
+    This REVERSES the pin that
+    ``test_skills_canvas_renders_exact_pager_and_source_wide_trust_count``
+    carried: this canvas composed its own pager and so never got the
+    single-page suppression task-28016/31237 gave every other Library list.
+    The source-wide trust count (``blocked_total``, which counts blocked
+    skills across the whole source and not just this page) stays asserted
+    here; the paged shape moved to the companion test below.
+    """
     pager = build_library_pager_display(
-        applied_page=2,
-        requested_page=2,
-        page_size=20,
+        applied_page=1,
+        requested_page=1,
+        page_size=DEFAULT_SKILL_BROWSE_PAGE_SIZE,
         row_count=2,
-        total=22,
+        total=2,
         freshness="fresh",
     )
     state = dataclasses.replace(
@@ -269,17 +282,55 @@ async def test_skills_canvas_renders_exact_pager_and_source_wide_trust_count():
     )
     app = _CanvasHost(state, trust_posture="ready")
     async with app.run_test() as pilot:
-        assert "22" in str(pilot.app.query_one("#library-skills-header").renderable)
+        assert str(pilot.app.query_one("#library-skills-header").renderable) == (
+            "Skills (2)"
+        )
         assert "7 skills" in str(
             pilot.app.query_one("#library-skills-trust-header").renderable
         )
-        assert "21-22 of 22" in str(
-            pilot.app.query_one("#library-skills-range").renderable
+        assert str(pilot.app.query_one("#library-skills-range").renderable) == (
+            "1-2 of 2"
         )
-        assert "Page 2 of 2" in str(
-            pilot.app.query_one("#library-skills-page").renderable
+        assert not pilot.app.query(
+            "#library-skills-page"
+        ), "Page 1 of 1 has nowhere to page to"
+        assert not pilot.app.query("#library-skills-pager-status")
+        assert not pilot.app.query(
+            f"#{LIBRARY_SKILLS_PAGE_PREVIOUS_ID}"
+        ), "no dead Previous/Next"
+        assert not pilot.app.query(f"#{LIBRARY_SKILLS_PAGE_NEXT_ID}")
+
+
+@pytest.mark.asyncio
+async def test_skills_canvas_renders_the_full_pager_when_a_second_page_exists():
+    """A second page brings back every part of the pager (task-32354).
+
+    One skill more than the browse page size (``21``) is what makes a
+    second page exist; the mounted row list stays the two-row fixture,
+    since the canvas renders ``state.rows`` and ``state.pager`` from
+    independent controller reads.
+    """
+    pager = build_library_pager_display(
+        applied_page=1,
+        requested_page=1,
+        page_size=DEFAULT_SKILL_BROWSE_PAGE_SIZE,
+        row_count=DEFAULT_SKILL_BROWSE_PAGE_SIZE,
+        total=DEFAULT_SKILL_BROWSE_PAGE_SIZE + 1,
+        freshness="fresh",
+    )
+    state = dataclasses.replace(_two_row_state(), pager=pager)
+    app = _CanvasHost(state, trust_posture="ready")
+    async with app.run_test() as pilot:
+        status = str(pilot.app.query_one("#library-skills-range").renderable)
+        assert status.endswith("· Page 1 of 2"), status
+        assert pilot.app.query(f"#{LIBRARY_SKILLS_PAGE_PREVIOUS_ID}")
+        assert (
+            str(pilot.app.query_one("#library-skills-pager-status").renderable)
+            == "Already on the first page."
         )
-        assert pilot.app.query_one("#library-skills-page-next", Button).disabled
+        assert not pilot.app.query_one(
+            f"#{LIBRARY_SKILLS_PAGE_NEXT_ID}", Button
+        ).disabled
 
 
 @pytest.mark.asyncio
@@ -1451,7 +1502,7 @@ async def test_library_skills_45_item_pager_is_visible_and_reaches_middle_page(
         for _ in range(12):
             await pilot.pause()
             if "Page 2 of 3" in str(
-                screen.query_one("#library-skills-page", Static).renderable
+                screen.query_one("#library-skills-range", Static).renderable
             ):
                 break
         assert screen.query_one("#library-skill-row-skill-020", Button)
@@ -1464,7 +1515,7 @@ async def test_library_skills_45_item_pager_is_visible_and_reaches_middle_page(
         for _ in range(12):
             await pilot.pause()
             if "Page 3 of 3" in str(
-                screen.query_one("#library-skills-page", Static).renderable
+                screen.query_one("#library-skills-range", Static).renderable
             ):
                 break
         assert screen.query_one("#library-skill-row-skill-040", Button)
@@ -1516,7 +1567,7 @@ async def test_library_skills_page_previous_returns_to_the_prior_exact_page():
         for _ in range(12):
             await pilot.pause()
             if "Page 2 of 3" in str(
-                screen.query_one("#library-skills-page", Static).renderable
+                screen.query_one("#library-skills-range", Static).renderable
             ):
                 break
         assert "21-40 of 45" in str(
@@ -1527,7 +1578,7 @@ async def test_library_skills_page_previous_returns_to_the_prior_exact_page():
         for _ in range(12):
             await pilot.pause()
             if "Page 1 of 3" in str(
-                screen.query_one("#library-skills-page", Static).renderable
+                screen.query_one("#library-skills-range", Static).renderable
             ):
                 break
         assert screen.query_one("#library-skill-row-skill-000", Button)

--- a/Tests/UI/test_library_skills_canvas.py
+++ b/Tests/UI/test_library_skills_canvas.py
@@ -405,7 +405,14 @@ async def test_skills_list_renders_trust_header_setup():
     app = _CanvasHost(_two_row_state(), trust_posture="needs_setup")
     async with app.run_test() as pilot:
         header = pilot.app.query_one("#library-skills-trust-header", Static)
-        assert "isn't set up" in str(header.renderable)
+        # task-32363: the whole sentence, at the UI boundary. A substring
+        # check on "isn't set up" survived reverting the explanation, so the
+        # thing the task added had no integration coverage at all (Qodo
+        # review of PR #2599, item 2).
+        assert str(header.renderable) == (
+            'Skill trust isn\'t set up, so every skill reads "needs review" — '
+            "set it up to review and use skills."
+        )
         action = pilot.app.query_one("#library-skills-trust-action", Button)
         assert action.trust_action == "setup"
 

--- a/backlog/tasks/task-32057 - Library-Collections-row-undocumented-captures-browser-legacy_read_only-service-and-rail-side-effects.md
+++ b/backlog/tasks/task-32057 - Library-Collections-row-undocumented-captures-browser-legacy_read_only-service-and-rail-side-effects.md
@@ -25,16 +25,33 @@ The 'Collections' row opens a 'Quick Capture' captures browser ('Sort: saved des
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A recorded decision states what the Collections row is today and the user guide matches it
+- [x] #1 A recorded decision states what the Collections row is today and the user guide matches it
 - [x] #2 The row shows a count before it is visited
 - [x] #3 Selecting the row never changes another rail section's disclosure state
 - [x] #4 If writes are refused, the canvas says so with the recovery path the service names
 <!-- AC:END -->
 
+## Decision
+
+Decided by the user, 2026-09-11 (critique-10 fix wave, branch `fix/library-crit10-pagers`).
+
+Neither Option A nor Option B. **The rail row stays, and the feature has one
+name everywhere: "Collections".** The canvas heading "Quick Capture" is
+retired in favour of "Collections"; "Quick Capture" survives only as the
+label of the button that saves a URL, because that is a verb and not a
+place. The canvas gets a true empty state that does not mention filters
+unless one is set and does not point at an action that is not on screen.
+The local service stays read-only — no schema migration, no membership
+model, no "Add to collection" affordance this wave — and the guide says so.
+
+Implemented on the crit10 `pagers` branch alongside task-32352.
+
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
 Three of the four ACs are done in code and docs; AC#1 (what the Collections row IS) is a product decision and is deliberately left unticked -- both options are costed below.
+
+**AC#1 was decided on 2026-09-11 -- see the `## Decision` section above.** The two options costed at the bottom of these notes are kept for the record; neither was taken. Implemented on `fix/library-crit10-pagers` alongside task-32352.
 
 ## What shipped
 

--- a/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
+++ b/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
@@ -4,9 +4,10 @@ title: >-
   Library Collections: the rail row opens 'Quick Capture', its empty state
   blames unset filters and names an absent action, and its pager is not disabled
   at 0 of 0
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:16'
+updated_date: '2026-09-11 07:43'
 labels:
   - library
   - collections
@@ -23,7 +24,39 @@ The rail row 'Collections (0)' opens a canvas titled Quick Capture whose only me
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 One name for the feature in the rail and on the canvas
-- [ ] #2 A true empty state that does not mention filters unless one is set and does not cite an action absent from the screen
-- [ ] #3 The pager is disabled at 0 of 0 like Trash's
+- [x] #1 One name for the feature in the rail and on the canvas
+- [x] #2 A true empty state that does not mention filters unless one is set and does not cite an action absent from the screen
+- [x] #3 The pager is disabled at 0 of 0 like Trash's
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Give the Collections items canvas a 'Collections' heading; keep 'Quick Capture' as the save-a-URL button label only.
+2. Split the empty state: filtered vs never-captured; filtered branch reachable only when a filter field is set.
+3. Route the pager through simple_library_pager_display + library_pager_layout so 0 of 0 shows no controls.
+4. Tests in Tests/UI/test_library_crit10_pagers.py; update collections.md + stamp.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+All three ACs, implementing the user's task-32057 AC#1 decision (recorded under `## Decision` in that task file).
+
+**AC#1 — one name.** The canvas had no heading at all, so its first painted line — the **Quick Capture** button — read as the title while the rail row said "Collections (0)". The pane now leads with a `Collections` heading (`#library-collections-header`, the same `destination-section` class the Skills canvas uses). "Quick Capture" survives only as the label of the button that saves a URL: it is a verb, not a place. The rail row is untouched.
+
+**AC#2 — a true empty state.** One sentence covered both an empty collection and a filtered-to-nothing one, so a profile that had never saved anything was told to clear filters it had never set and pointed at Quick Capture as if it were elsewhere on the screen. Split in two, keyed on the real filter-bearing fields of `CapturePageRequest` (`search`, `tags`, `domain`, `date_from`, `date_to` — the five the Filters form and the search box set, and the five **Clear** clears). `statuses`/`favorite` are deliberately excluded: they carry the rail's scope selection, which Clear does not touch.
+
+- no filter: "No saved captures yet · press Quick Capture above to save a page by URL."
+- a filter: "No captures match these filters · clear them to see everything saved."
+
+**AC#3 — the pager is disabled at 0 of 0.** Previous/Next were plain `disabled=` Buttons with no `○` marker, so at `0–0 of 0` they read as enabled where the structurally identical Trash pager read as disabled. The canvas now goes through `simple_library_pager_display` + `library_pager_layout` (task-32354), which at one page drops the page copy, the boundary reasons and both controls; on two pages the controls come back with `library_disabled_action_label`'s `○` and the shared reasons.
+
+Live at 235x52, 100x30 and 60x24 on the seeded profile: heading `Collections`, the never-captured sentence, `0–0 of 0` with no controls (`crit10/wave/pagers/caps/02`, `07`, `08`).
+
+## Files
+
+- `tldw_chatbook/Widgets/Library/library_collections_capture_reader.py`.
+- `Tests/UI/test_library_crit10_pagers.py` (new).
+- `Docs/User_Guide/library/collections.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
+++ b/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
@@ -50,6 +50,28 @@ All three ACs, implementing the user's task-32057 AC#1 decision (recorded under 
 - no filter: "No saved captures yet · press Quick Capture above to save a page by URL."
 - a filter: "No captures match these filters · clear them to see everything saved."
 
+## Fix round 1 (task review, 2026-09-11)
+
+**P2 — the first cut's empty state was false for a rail scope.** `filtered`
+tested only the filter-form fields, but the rail's scope rows set `statuses`
+/ `favorite` (`library_collections_controller.py:491-508`), so an empty
+**Favorites** beside a rail reading `Collections (57)` claimed nothing had
+ever been saved and pointed at an action that does not leave the scope — the
+same class of defect AC#2 exists to fix. The empty state is now three
+branches, narrowest first, because the two narrowings come from different
+controls and have different ways out: a filter is undone by **Clear**, a
+scope by choosing **All Captures**. A filter set inside a scope takes the
+filter sentence. Pinned red-first by
+`test_collections_empty_state_names_an_empty_rail_scope[favorites|archived]`
+and `test_collections_empty_state_prefers_the_filter_copy_inside_a_scope`.
+
+**P3 — the Collections/Trash boundary-reason asymmetry is a decision, not an
+accident.** Collections gained a `#library-collections-page-reason` line (the
+brief's Step 3 asks for it, and it matches Media/Conversations/Prompts);
+Trash did not, because its pager is a pinned fixed-height container and the
+line would cost a row at exactly the width task-32354's finding is about.
+Collections' pager has no fixed height, so it can afford one.
+
 **AC#3 — the pager is disabled at 0 of 0.** Previous/Next were plain `disabled=` Buttons with no `○` marker, so at `0–0 of 0` they read as enabled where the structurally identical Trash pager read as disabled. The canvas now goes through `simple_library_pager_display` + `library_pager_layout` (task-32354), which at one page drops the page copy, the boundary reasons and both controls; on two pages the controls come back with `library_disabled_action_label`'s `○` and the shared reasons.
 
 Live at 235x52, 100x30 and 60x24 on the seeded profile: heading `Collections`, the never-captured sentence, `0–0 of 0` with no controls (`crit10/wave/pagers/caps/02`, `07`, `08`).

--- a/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
+++ b/backlog/tasks/task-32352 - Library-Collections-the-rail-row-opens-Quick-Capture-its-empty-state-blames-unset-filters-and-names-an-absent-action-and-its-pager-is-not-disabled-at-0-of-0.md
@@ -65,6 +65,32 @@ filter sentence. Pinned red-first by
 `test_collections_empty_state_names_an_empty_rail_scope[favorites|archived]`
 and `test_collections_empty_state_prefers_the_filter_copy_inside_a_scope`.
 
+## Bot review round (Qodo on PR #2599, 2026-09-11)
+
+Two real correctness bugs in the fix-round-1 empty state, both fixed
+red-first, plus the testability rule the second one exposed.
+
+- **The empty state spoke before it had a result.** It rendered whenever
+  `page` was `None` *or* empty, and `page is None` is also initial loading
+  and initial failure — so "No saved captures yet" painted beside
+  "Loading captures…" and beside the error's **Retry**. It now renders only
+  for a page that actually came back. This was pre-existing (the old
+  one-size sentence did it too), but splitting the copy made the claim
+  sharper and therefore more wrong.
+- **The copy described the wrong scope.** It read `state.requested_scope`,
+  while a retained stale page outlives the request that replaced it. It now
+  reads `page.applied` — the scope that produced the page on screen.
+- **`favorite=False` is a scope, not "no scope".** `favorite` is tri-state;
+  a saved search for non-favourites carries `False`, which a truthiness test
+  read as unset, so an empty non-favourites search claimed nothing had ever
+  been saved.
+- The rule moved out of `compose` into `collections_empty_state_copy`, a
+  pure function in the same module, so the precedence and the field
+  classification are testable without mounting Textual — the same shape the
+  Library's other copy rules already use (`skill_trust_header_line`,
+  `library_pager_layout`). 11 parameterized unit rows plus the mounted tests
+  as integration coverage.
+
 **P3 — the Collections/Trash boundary-reason asymmetry is a decision, not an
 accident.** Collections gained a `#library-collections-page-reason` line (the
 brief's Step 3 asks for it, and it matches Media/Conversations/Prompts);

--- a/backlog/tasks/task-32354 - Library-route-the-Skills-Collections-and-Trash-pagers-through-the-shared-single-page-rule.md
+++ b/backlog/tasks/task-32354 - Library-route-the-Skills-Collections-and-Trash-pagers-through-the-shared-single-page-rule.md
@@ -57,6 +57,20 @@ Skills, Collections and the media Trash now render their pagers through `library
 1. **Collections suppresses only when `bounded`** (paging enabled AND an exact total). Neither direction moving because paging is PAUSED — a stale page withholds totals — is not "this is the only page", and `test_items_keep_capture_controls_rows_and_stale_recovery_reachable` pins the paused controls. They stay, disabled, with their old reason. Pinned from this side too by `test_collections_keeps_paused_controls_when_the_page_is_stale`.
 2. **Trash keeps `#library-media-trash-page` (empty) whenever the controls render**, because the initial-error posture pins an empty page Static in `test_media_trash_geometry_four_sizes_paints_all_fixed_controls`. No new boundary-reason row was added to Trash either: that would ADD a line at 60x24, the opposite of the finding, and no AC asks for it.
 
+## Fix round 1 (task review, 2026-09-11)
+
+- The pin split had lost the assertion that the Skills header counts the
+  SOURCE (`state.pager.title_count`) rather than the mounted rows: the
+  single-page test's `total` and row count are both 2, so a regression to
+  `len(rows)` would have passed. The two-page test (21 total, 2 mounted
+  rows) now asserts `"Skills (21)"`, which only `title_count` can produce.
+- `Docs/User_Guide/library/media-and-conversations.md` — the Trash's own
+  page — now documents the single-page pager too, not just `library.md`.
+- `Docs/User_Guide/library/skills.md`'s trust-header row had the Python
+  string's `\"` escapes copied into the Markdown table, where they render as
+  visible backslashes; it now uses curly quotes. The product string is
+  unchanged.
+
 ## Files
 
 - `tldw_chatbook/Library/library_pager_state.py` — `simple_library_pager_display`.

--- a/backlog/tasks/task-32354 - Library-route-the-Skills-Collections-and-Trash-pagers-through-the-shared-single-page-rule.md
+++ b/backlog/tasks/task-32354 - Library-route-the-Skills-Collections-and-Trash-pagers-through-the-shared-single-page-rule.md
@@ -3,9 +3,10 @@ id: TASK-32354
 title: >-
   Library: route the Skills, Collections and Trash pagers through the shared
   single-page rule
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:17'
+updated_date: '2026-09-11 07:42'
 labels:
   - library
   - ux
@@ -22,6 +23,44 @@ At 100x30 the Skills canvas spends four lines on '1-2 of 2 / Page 1 of 1 / Alrea
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Skills, Collections and Trash render no pager chrome when everything fits on one page, like Media/Conversations/Prompts
-- [ ] #2 The existing pin is updated to the shared rule
+- [x] #1 Skills, Collections and Trash render no pager chrome when everything fits on one page, like Media/Conversations/Prompts
+- [x] #2 The existing pin is updated to the shared rule
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Split the Skills pager pin into a suppressed-single-page test and a full-two-page test (deliberate reversal).
+2. Route library_skills_canvas._compose_pager through library_pager_layout.
+3. Add simple_library_pager_display to library_pager_state; route the Collections pager through it.
+4. Route the Trash pager through library_pager_layout (height 1 when suppressed).
+5. Live-verify at 235x52 / 100x30 / 60x24; docs + stamps.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Skills, Collections and the media Trash now render their pagers through `library_pager_layout`, so the single-page rule (task-28016/31237/32104) finally holds for every Library list.
+
+**Skills** (`library_skills_canvas.py::_compose_pager`) hand-rolled its boundary reasons and yielded the range, the page copy and both controls unconditionally. It now renders what the layout returns: the range Static carries the joined `status_parts`, so the separate `#library-skills-page` Static is gone and the page copy rides the range line on two pages. Live at 60x24 this gives back 3 of 18 usable rows and the second of two skills keeps its description line (compare assessor A's cap 61 with `crit10/wave/pagers/caps/09-skills-60x24.txt`).
+
+**Collections** could not use `build_library_pager_display` — it raises when `row_count` disagrees with `applied_page`/`total`, and this canvas's service can return a short page — so `simple_library_pager_display` was added to `library_pager_state.py` for a source that pages itself. It carries the same copy and the same boundary reasons, so such a source still goes through the one shared rule. `CAPTURE_PAGE_SIZE` (already in `collections_capture_models`) replaced the three hand-written `20`s.
+
+**Trash** keeps its fixed-height pager block, at 1 row instead of 2 when the controls are suppressed.
+
+## The pin this reverses (AC#2)
+
+`test_skills_canvas_renders_exact_pager_and_source_wide_trust_count` pinned the four-line Skills pager verbatim. It is split, not deleted or loosened, into `test_skills_canvas_suppresses_single_page_chrome_and_keeps_the_trust_count` (the suppressed shape, keeping the source-wide `blocked_total` assertions) and `test_skills_canvas_renders_the_full_pager_when_a_second_page_exists` (every part back at 21 skills, one more than `DEFAULT_SKILL_BROWSE_PAGE_SIZE`). Four settle loops that polled `#library-skills-page` for "Page N of 3" now poll `#library-skills-range`, which carries that copy.
+
+## Two deliberate narrowings
+
+1. **Collections suppresses only when `bounded`** (paging enabled AND an exact total). Neither direction moving because paging is PAUSED — a stale page withholds totals — is not "this is the only page", and `test_items_keep_capture_controls_rows_and_stale_recovery_reachable` pins the paused controls. They stay, disabled, with their old reason. Pinned from this side too by `test_collections_keeps_paused_controls_when_the_page_is_stale`.
+2. **Trash keeps `#library-media-trash-page` (empty) whenever the controls render**, because the initial-error posture pins an empty page Static in `test_media_trash_geometry_four_sizes_paints_all_fixed_controls`. No new boundary-reason row was added to Trash either: that would ADD a line at 60x24, the opposite of the finding, and no AC asks for it.
+
+## Files
+
+- `tldw_chatbook/Library/library_pager_state.py` — `simple_library_pager_display`.
+- `tldw_chatbook/Widgets/Library/library_skills_canvas.py`, `library_collections_capture_reader.py`, `library_media_trash_canvas.py`.
+- `Tests/Library/test_library_pager_state.py` (+3), `Tests/UI/test_library_skills_canvas.py` (pin split), `Tests/UI/test_library_crit10_pagers.py` (new, 8 tests).
+- `Docs/User_Guide/library.md`, `library/collections.md`, `library/skills.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32363 - Library-Skills-a-trust-approved-skill-reads-needs-review-when-the-trust-store-is-not-set-up-with-no-explanation.md
+++ b/backlog/tasks/task-32363 - Library-Skills-a-trust-approved-skill-reads-needs-review-when-the-trust-store-is-not-set-up-with-no-explanation.md
@@ -3,9 +3,10 @@ id: TASK-32363
 title: >-
   Library Skills: a trust-approved skill reads 'needs review' when the trust
   store is not set up, with no explanation
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:19'
+updated_date: '2026-09-11 07:43'
 labels:
   - library
   - skills
@@ -23,5 +24,31 @@ The seeded trust-approved skill renders '⚠ needs review' beside the unapproved
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The list distinguishes an approved skill from an unapproved one, or the banner states that approvals apply once trust is set up
+- [x] #1 The list distinguishes an approved skill from an unapproved one, or the banner states that approvals apply once trust is set up
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reword skill_trust_header_line's needs_setup branch to state the precedence (no trust store => every skill reads needs review).
+2. Update the pin in Tests/Library/test_library_skills_state.py to the exact string.
+3. Update Docs/User_Guide/library/skills.md + stamp.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Took AC#1's second branch: the banner states the precedence.
+
+The list genuinely cannot distinguish an approved skill from an unapproved one under the `needs_setup` posture — with no trust store there is nothing to verify an approval against, so both render `⚠ needs review` and the list looked wrong rather than unverifiable. `skill_trust_header_line`'s `needs_setup` branch now returns:
+
+> Skill trust isn't set up, so every skill reads "needs review" — set it up to review and use skills.
+
+The action id is unchanged (`setup`), so the **Set up skill trust** button and every posture around it are untouched. `grep -rn "Skill trust isn't set up"` found one product occurrence, one pin (`test_skill_trust_header_line_maps_postures`, tightened from a substring to the exact string) and one guide row (`Docs/User_Guide/library/skills.md`); the two `Docs/superpowers/` hits are the historical plan and design record and were left as written.
+
+One cost worth naming: at 60 columns the sentence wraps to 4 lines instead of 2. It fits because task-32354 gave the same canvas 3 rows back from the pager on the same branch (`crit10/wave/pagers/caps/09-skills-60x24.txt` — both skills still visible).
+
+## Files
+
+- `tldw_chatbook/Library/library_skills_state.py`, `Tests/Library/test_library_skills_state.py`, `Docs/User_Guide/library/skills.md`.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32363 - Library-Skills-a-trust-approved-skill-reads-needs-review-when-the-trust-store-is-not-set-up-with-no-explanation.md
+++ b/backlog/tasks/task-32363 - Library-Skills-a-trust-approved-skill-reads-needs-review-when-the-trust-store-is-not-set-up-with-no-explanation.md
@@ -48,6 +48,14 @@ The action id is unchanged (`setup`), so the **Set up skill trust** button and e
 
 One cost worth naming: at 60 columns the sentence wraps to 4 lines instead of 2. It fits because task-32354 gave the same canvas 3 rows back from the pager on the same branch (`crit10/wave/pagers/caps/09-skills-60x24.txt` — both skills still visible).
 
+## Bot review round (Qodo on PR #2599, 2026-09-11)
+
+The new banner had an exact unit assertion but only a substring one
+(`"isn't set up"`) at the UI boundary, so reverting the explanation would
+have left the mounted Skills suite green.
+`test_skills_list_renders_trust_header_setup` now asserts the whole
+sentence.
+
 ## Files
 
 - `tldw_chatbook/Library/library_skills_state.py`, `Tests/Library/test_library_skills_state.py`, `Docs/User_Guide/library/skills.md`.

--- a/tldw_chatbook/Library/library_pager_state.py
+++ b/tldw_chatbook/Library/library_pager_state.py
@@ -101,6 +101,46 @@ def library_pager_layout(
     )
 
 
+def simple_library_pager_display(
+    *,
+    range_copy: str,
+    page: int,
+    total_pages: int,
+    has_previous: bool,
+    has_next: bool,
+) -> LibraryPagerDisplay:
+    """Build a pager display for a source that pages itself (task-32354).
+
+    ``build_library_pager_display`` validates row counts against an exact
+    total and raises when they disagree -- correct for the sources that own
+    their paging end to end, fatal for one whose service may return a short
+    page. This carries the same copy and the same boundary reasons so those
+    sources can still go through ``library_pager_layout``.
+
+    Args:
+        range_copy: The already-formatted item range line.
+        page: The applied page number.
+        total_pages: Known page count, or 0 when it is unknown.
+        has_previous: Whether a previous page can be loaded.
+        has_next: Whether a next page can be loaded.
+
+    Returns:
+        A display whose ``single_page`` is True when neither direction can move.
+    """
+    return LibraryPagerDisplay(
+        title_count=None,
+        range_copy=range_copy,
+        page_copy=f"Page {page} of {total_pages}" if total_pages else "",
+        status_copy="",
+        previous_disabled=not has_previous,
+        next_disabled=not has_next,
+        previous_reason="" if has_previous else _FIRST_PAGE_REASON,
+        next_reason="" if has_next else _FINAL_PAGE_REASON,
+        retry_visible=False,
+        single_page=not has_previous and not has_next,
+    )
+
+
 def build_library_pager_display(
     *,
     applied_page: int | None,

--- a/tldw_chatbook/Library/library_skills_state.py
+++ b/tldw_chatbook/Library/library_skills_state.py
@@ -809,8 +809,13 @@ def skill_trust_header_line(posture: str, blocked_count: int) -> tuple[str, str]
         action), or ``None`` to hide the header entirely.
     """
     if posture == "needs_setup":
+        # task-32363 (critique #10, B D5): with no trust store every skill
+        # reads "needs review", including ones approved earlier -- the list
+        # looked wrong rather than unverifiable. The banner now states the
+        # precedence instead of leaving the reader to infer it.
         return (
-            "Skill trust isn't set up — set it up to review and use skills.",
+            "Skill trust isn't set up, so every skill reads \"needs review\" — "
+            "set it up to review and use skills.",
             "setup",
         )
     if posture == "needs_resetup":

--- a/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
@@ -439,6 +439,15 @@ class LibraryCollectionsItemsPane(Vertical):
             # that had never saved anything was told to clear filters it had
             # never set, and pointed at an action ("Quick Capture") as if it
             # were somewhere else on the screen.
+            #
+            # Three cases, narrowest first. The two narrowings come from
+            # different controls and have different ways out, so they cannot
+            # share a sentence: the filter form and the search box set
+            # ``search``/``tags``/``domain``/``date_from``/``date_to`` and are
+            # undone by Clear, while the rail's scope rows set
+            # ``statuses``/``favorite`` and are undone by choosing All
+            # Captures. Only when neither is set has the profile really
+            # never saved anything.
             scope = state.requested_scope
             filtered = scope is not None and bool(
                 scope.search
@@ -447,11 +456,22 @@ class LibraryCollectionsItemsPane(Vertical):
                 or scope.date_from
                 or scope.date_to
             )
-            empty_copy = (
-                "No captures match these filters · clear them to see everything saved."
-                if filtered
-                else "No saved captures yet · press Quick Capture above to save a page by URL."
-            )
+            scoped = scope is not None and bool(scope.statuses or scope.favorite)
+            if filtered:
+                empty_copy = (
+                    "No captures match these filters · clear them to see "
+                    "everything saved."
+                )
+            elif scoped:
+                empty_copy = (
+                    "Nothing in this scope yet · choose All Captures in the rail "
+                    "to see everything saved."
+                )
+            else:
+                empty_copy = (
+                    "No saved captures yet · press Quick Capture above to save "
+                    "a page by URL."
+                )
             yield Static(
                 empty_copy,
                 id="library-collections-items-empty",

--- a/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
@@ -21,6 +21,7 @@ from textual.content import Content
 from textual.widgets import Button, Input, Static, TextArea
 
 from tldw_chatbook.Library.collections_capture_models import (
+    CAPTURE_PAGE_SIZE,
     CapabilityState,
     CaptureCapabilities,
     CaptureHighlight,
@@ -30,6 +31,10 @@ from tldw_chatbook.Library.collections_capture_models import (
 )
 from tldw_chatbook.Library.library_collections_service import (
     LegacyCollectionsReadOnlyError,
+)
+from tldw_chatbook.Library.library_pager_state import (
+    library_pager_layout,
+    simple_library_pager_display,
 )
 from tldw_chatbook.Library.library_shell_state import library_disabled_action_label
 from tldw_chatbook.UI.Library_Modules.library_collections_capture_controller import (
@@ -262,6 +267,18 @@ class LibraryCollectionsItemsPane(Vertical):
         """Render the reading-list surface without exposing URL queries."""
         state = self.presentation.state
         capture_enabled, capture_reason = self.presentation.capability("capture")
+        # task-32352 AC#1 / task-32057 (critique #10): the rail row says
+        # "Collections (N)" and this canvas had no heading at all, so its
+        # first painted line -- the Quick Capture button -- read as the
+        # title and the feature appeared to have two names. One name
+        # everywhere; "Quick Capture" survives only on the button below,
+        # because it is a verb (save this URL) and not a place.
+        yield Static(
+            "Collections",
+            id="library-collections-header",
+            classes="destination-section",
+            markup=False,
+        )
         with Horizontal(classes="ds-toolbar", id="library-collections-items-toolbar"):
             yield Button(
                 library_disabled_action_label("Quick Capture", not capture_enabled),
@@ -417,8 +434,26 @@ class LibraryCollectionsItemsPane(Vertical):
 
         page = state.page
         if page is None or not page.items:
+            # task-32352 AC#2 (critique #10): one sentence covered both an
+            # empty collection and a filtered-to-nothing one, so a profile
+            # that had never saved anything was told to clear filters it had
+            # never set, and pointed at an action ("Quick Capture") as if it
+            # were somewhere else on the screen.
+            scope = state.requested_scope
+            filtered = scope is not None and bool(
+                scope.search
+                or scope.tags
+                or scope.domain
+                or scope.date_from
+                or scope.date_to
+            )
+            empty_copy = (
+                "No captures match these filters · clear them to see everything saved."
+                if filtered
+                else "No saved captures yet · press Quick Capture above to save a page by URL."
+            )
             yield Static(
-                "No captures match this scope. Clear filters or save a URL with Quick Capture.",
+                empty_copy,
                 id="library-collections-items-empty",
                 classes="destination-purpose",
                 markup=False,
@@ -460,44 +495,87 @@ class LibraryCollectionsItemsPane(Vertical):
         )
         if state.exact_total is None:
             range_copy = f"Page {current_page} · total unavailable"
+            total_pages = 0
         else:
-            start = 0 if state.exact_total == 0 else (current_page - 1) * 20 + 1
-            stop = min(current_page * 20, state.exact_total)
+            start = (
+                0
+                if state.exact_total == 0
+                else (current_page - 1) * CAPTURE_PAGE_SIZE + 1
+            )
+            stop = min(current_page * CAPTURE_PAGE_SIZE, state.exact_total)
             range_copy = f"{start}–{stop} of {state.exact_total}"
-        yield Static(
-            range_copy,
-            id="library-collections-page-range",
-            markup=False,
-        )
+            total_pages = max(
+                1,
+                (state.exact_total + CAPTURE_PAGE_SIZE - 1) // CAPTURE_PAGE_SIZE,
+            )
         has_previous = state.paging_enabled and current_page > 1
         has_next = (
             state.paging_enabled
             and state.exact_total is not None
-            and current_page * 20 < state.exact_total
+            and current_page * CAPTURE_PAGE_SIZE < state.exact_total
         )
-        with Horizontal(classes="ds-toolbar", id="library-collections-page-toolbar"):
-            yield Button(
-                "Previous",
-                id="library-collections-page-previous",
-                compact=True,
-                disabled=not has_previous,
-                tooltip=(
-                    "Load the previous page."
-                    if has_previous
-                    else "No current previous page is available."
-                ),
+        # task-32352 AC#3 / task-32354 (critique #10): this pager was hand
+        # rolled -- enabled-looking Previous/Next at "0–0 of 0", and no "○"
+        # marker on a disabled one, unlike every other Library pager. It now
+        # goes through the same rule, via a display the shared builder can't
+        # produce (its row-count invariants assume a source that owns its
+        # paging end to end; this one's service can return a short page).
+        #
+        # ``bounded`` is the rule's precondition: neither direction moving
+        # because this IS the only page is the case the rule suppresses;
+        # neither direction moving because paging is PAUSED (a stale or
+        # loading page, totals withheld) is not -- the controls stay, still
+        # disabled, with the reason the old pager gave.
+        bounded = state.paging_enabled and state.exact_total is not None
+        pager = simple_library_pager_display(
+            range_copy=range_copy,
+            page=current_page,
+            total_pages=total_pages,
+            has_previous=has_previous,
+            has_next=has_next,
+        )
+        layout = library_pager_layout(pager)
+        controls_hidden = bounded and layout.controls_hidden
+        yield Static(
+            " · ".join(layout.status_parts),
+            id="library-collections-page-range",
+            markup=False,
+        )
+        if layout.boundary_reasons:
+            yield Static(
+                " · ".join(layout.boundary_reasons),
+                id="library-collections-page-reason",
+                classes="destination-purpose",
+                markup=False,
             )
-            yield Button(
-                "Next",
-                id="library-collections-page-next",
-                compact=True,
-                disabled=not has_next,
-                tooltip=(
-                    "Load the next page."
-                    if has_next
-                    else "No current next page is available."
-                ),
+        if not controls_hidden:
+            previous_reason = (
+                pager.previous_reason
+                if bounded
+                else "No current previous page is available."
             )
+            next_reason = (
+                pager.next_reason
+                if bounded
+                else "No current next page is available."
+            )
+            with Horizontal(
+                classes="ds-toolbar", id="library-collections-page-toolbar"
+            ):
+                yield Button(
+                    library_disabled_action_label("Previous", not has_previous),
+                    id="library-collections-page-previous",
+                    compact=True,
+                    disabled=not has_previous,
+                    tooltip=previous_reason or "Load the previous page.",
+                )
+                yield Button(
+                    library_disabled_action_label("Next", not has_next),
+                    id="library-collections-page-next",
+                    compact=True,
+                    disabled=not has_next,
+                    tooltip=next_reason or "Load the next page.",
+                )
 
 
 def _action_button(

--- a/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_collections_capture_reader.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Library.collections_capture_models import (
     CaptureCapabilities,
     CaptureHighlight,
     CaptureIdentity,
+    CapturePageRequest,
     CaptureSummary,
     SavedCaptureSearch,
 )
@@ -220,6 +221,49 @@ class LibraryCollectionsScopeRows(Vertical):
                 id="library-collections-more-saved-searches",
                 compact=True,
             )
+
+
+def collections_empty_state_copy(scope: CapturePageRequest) -> str:
+    """Name what narrowed an empty capture page, and the way back out of it.
+
+    task-32352 AC#2 (critique #10): one sentence covered both an empty
+    collection and a filtered-to-nothing one, so a profile that had never
+    saved anything was told to clear filters it had never set and pointed at
+    an action ("Quick Capture") as if it were elsewhere on the screen.
+
+    Three cases, narrowest first, because the two narrowings come from
+    different controls and have different ways out: the filter form and the
+    search box set ``search``/``tags``/``domain``/``date_from``/``date_to``
+    and are undone by **Clear**, while the rail's scope rows (and saved
+    searches) set ``statuses``/``favorite`` and are undone by choosing **All
+    Captures**. A filter set inside a scope takes the filter sentence -- it
+    is the narrowing this canvas can undo. Only when neither is set has the
+    profile really never saved anything.
+
+    Args:
+        scope: The request that produced the empty page -- ``page.applied``,
+            never the requested scope, which a retained stale page outlives.
+
+    Returns:
+        One sentence, already in "reason · next step" form.
+    """
+    if (
+        scope.search
+        or scope.tags
+        or scope.domain
+        or scope.date_from
+        or scope.date_to
+    ):
+        return "No captures match these filters · clear them to see everything saved."
+    # ``favorite`` is tri-state: ``False`` is the saved-search predicate "not
+    # a favourite", an active narrowing, so truthiness is the wrong test
+    # (Qodo review of PR #2599, item 4).
+    if scope.statuses or scope.favorite is not None:
+        return (
+            "Nothing in this scope yet · choose All Captures in the rail to see "
+            "everything saved."
+        )
+    return "No saved captures yet · press Quick Capture above to save a page by URL."
 
 
 def _capture_row_label(
@@ -433,52 +477,21 @@ class LibraryCollectionsItemsPane(Vertical):
             )
 
         page = state.page
-        if page is None or not page.items:
-            # task-32352 AC#2 (critique #10): one sentence covered both an
-            # empty collection and a filtered-to-nothing one, so a profile
-            # that had never saved anything was told to clear filters it had
-            # never set, and pointed at an action ("Quick Capture") as if it
-            # were somewhere else on the screen.
-            #
-            # Three cases, narrowest first. The two narrowings come from
-            # different controls and have different ways out, so they cannot
-            # share a sentence: the filter form and the search box set
-            # ``search``/``tags``/``domain``/``date_from``/``date_to`` and are
-            # undone by Clear, while the rail's scope rows set
-            # ``statuses``/``favorite`` and are undone by choosing All
-            # Captures. Only when neither is set has the profile really
-            # never saved anything.
-            scope = state.requested_scope
-            filtered = scope is not None and bool(
-                scope.search
-                or scope.tags
-                or scope.domain
-                or scope.date_from
-                or scope.date_to
-            )
-            scoped = scope is not None and bool(scope.statuses or scope.favorite)
-            if filtered:
-                empty_copy = (
-                    "No captures match these filters · clear them to see "
-                    "everything saved."
-                )
-            elif scoped:
-                empty_copy = (
-                    "Nothing in this scope yet · choose All Captures in the rail "
-                    "to see everything saved."
-                )
-            else:
-                empty_copy = (
-                    "No saved captures yet · press Quick Capture above to save "
-                    "a page by URL."
-                )
+        if page is not None and not page.items:
+            # task-32352 AC#2 (critique #10) + Qodo review of PR #2599 (item
+            # 1): "no captures" is a claim about a page that actually came
+            # back. An absent page means loading, an initial failure, or a
+            # scope never requested -- the callout above is the only honest
+            # message then. And the copy describes ``page.applied``, the scope
+            # that produced THIS page, never ``requested_scope``: a retained
+            # stale page outlives the request that replaced it.
             yield Static(
-                empty_copy,
+                collections_empty_state_copy(page.applied),
                 id="library-collections-items-empty",
                 classes="destination-purpose",
                 markup=False,
             )
-        else:
+        elif page is not None:
             loaded_identity = (
                 state.loaded_detail.capture.identity
                 if state.loaded_detail is not None
@@ -1048,6 +1061,7 @@ class LibraryCollectionsWorkPane(VerticalScroll):
 
 
 __all__ = [
+    "collections_empty_state_copy",
     "CollectionsCaptureReaderPresentation",
     "CollectionsReaderMode",
     "LibraryCollectionsHighlightButton",

--- a/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_trash_canvas.py
@@ -28,7 +28,10 @@ from tldw_chatbook.Library.library_media_state import (
     MediaTrashMutationTarget,
     media_trash_age_copy,
 )
-from tldw_chatbook.Library.library_pager_state import LibraryPagerDisplay
+from tldw_chatbook.Library.library_pager_state import (
+    LibraryPagerDisplay,
+    library_pager_layout,
+)
 from tldw_chatbook.Library.library_shell_state import (
     library_disabled_action_label,
 )
@@ -450,9 +453,17 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                 yield button
 
         if bounded and self.pager is not None:
+            # task-32354 (critique #10): Trash rendered range + "Page 1 of 1"
+            # + two dead controls for a one-item page. The single-page rule
+            # (task-28016/31237/32104) is ``library_pager_layout``'s; when it
+            # hides the controls this block is one row, not two.
+            layout = library_pager_layout(
+                self.pager, retry_visible=self.retry_visible
+            )
+            pager_rows = 1 if layout.controls_hidden else 2
             pager = Vertical(id="library-media-trash-pager")
-            pager.styles.height = 2
-            pager.styles.min_height = 2
+            pager.styles.height = pager_rows
+            pager.styles.min_height = pager_rows
             pager.styles.overflow = ("hidden", "hidden")
             with pager:
                 copy = Horizontal(id="library-media-trash-pager-copy")
@@ -465,68 +476,74 @@ class LibraryMediaTrashCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vert
                         id="library-media-trash-range",
                         markup=False,
                     )
-                    yield Static(
-                        self.pager.page_copy,
-                        id="library-media-trash-page",
-                        markup=False,
+                    # Kept whenever the controls are, even empty: the
+                    # initial-error posture pins an empty page Static
+                    # (``test_media_trash_geometry_four_sizes...``), and
+                    # only the single-page case is this task's subject.
+                    if not layout.controls_hidden:
+                        yield Static(
+                            self.pager.page_copy,
+                            id="library-media-trash-page",
+                            markup=False,
+                        )
+                if not layout.controls_hidden:
+                    controls = Horizontal(
+                        classes="ds-toolbar", id="library-media-trash-pager-controls"
                     )
-                controls = Horizontal(
-                    classes="ds-toolbar", id="library-media-trash-pager-controls"
-                )
-                controls.styles.height = 1
-                controls.styles.min_height = 1
-                controls.styles.overflow = ("hidden", "hidden")
-                with controls:
-                    controls_disabled = bool(self.controls_disabled_reason)
-                    previous_disabled = (
-                        self.pager.previous_disabled or controls_disabled
-                    )
-                    previous = Button(
-                        library_disabled_action_label("Previous", previous_disabled),
-                        id="library-media-trash-previous",
-                        classes="library-canvas-action",
-                        compact=True,
-                        disabled=previous_disabled,
-                        tooltip=(
-                            self.controls_disabled_reason
-                            or self.pager.previous_reason
-                            or None
-                        ),
-                    )
-                    previous.styles.min_width = 0
-                    previous.styles.padding = 0
-                    yield previous
-                    if self.retry_visible:
-                        retry = Button(
-                            library_disabled_action_label("Retry", controls_disabled),
-                            id="library-media-trash-retry",
+                    controls.styles.height = 1
+                    controls.styles.min_height = 1
+                    controls.styles.overflow = ("hidden", "hidden")
+                    with controls:
+                        controls_disabled = bool(self.controls_disabled_reason)
+                        previous_disabled = (
+                            self.pager.previous_disabled or controls_disabled
+                        )
+                        previous = Button(
+                            library_disabled_action_label("Previous", previous_disabled),
+                            id="library-media-trash-previous",
                             classes="library-canvas-action",
                             compact=True,
-                            disabled=controls_disabled,
+                            disabled=previous_disabled,
                             tooltip=(
                                 self.controls_disabled_reason
-                                or "Retry the failed Trash request."
+                                or self.pager.previous_reason
+                                or None
                             ),
                         )
-                        retry.styles.min_width = 0
-                        retry.styles.padding = 0
-                        yield retry
-                    next_disabled = self.pager.next_disabled or controls_disabled
-                    next_button = Button(
-                        library_disabled_action_label("Next", next_disabled),
-                        id="library-media-trash-next",
-                        classes="library-canvas-action",
-                        compact=True,
-                        disabled=next_disabled,
-                        tooltip=(
-                            self.controls_disabled_reason
-                            or self.pager.next_reason
-                            or None
-                        ),
-                    )
-                    next_button.styles.min_width = 0
-                    next_button.styles.padding = 0
-                    yield next_button
+                        previous.styles.min_width = 0
+                        previous.styles.padding = 0
+                        yield previous
+                        if self.retry_visible:
+                            retry = Button(
+                                library_disabled_action_label("Retry", controls_disabled),
+                                id="library-media-trash-retry",
+                                classes="library-canvas-action",
+                                compact=True,
+                                disabled=controls_disabled,
+                                tooltip=(
+                                    self.controls_disabled_reason
+                                    or "Retry the failed Trash request."
+                                ),
+                            )
+                            retry.styles.min_width = 0
+                            retry.styles.padding = 0
+                            yield retry
+                        next_disabled = self.pager.next_disabled or controls_disabled
+                        next_button = Button(
+                            library_disabled_action_label("Next", next_disabled),
+                            id="library-media-trash-next",
+                            classes="library-canvas-action",
+                            compact=True,
+                            disabled=next_disabled,
+                            tooltip=(
+                                self.controls_disabled_reason
+                                or self.pager.next_reason
+                                or None
+                            ),
+                        )
+                        next_button.styles.min_width = 0
+                        next_button.styles.padding = 0
+                        yield next_button
 
         if self.confirmation_target is not None:
             confirmation = Vertical(id="library-media-trash-delete-confirmation")

--- a/tldw_chatbook/Widgets/Library/library_skills_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_skills_canvas.py
@@ -42,7 +42,10 @@ from tldw_chatbook.Library.library_shell_state import (
     library_disabled_action_label,
     library_toggle_label,
 )
-from tldw_chatbook.Library.library_pager_state import LibraryPagerDisplay
+from tldw_chatbook.Library.library_pager_state import (
+    LibraryPagerDisplay,
+    library_pager_layout,
+)
 from tldw_chatbook.Widgets.Library.library_choice_strip import (
     compose_library_choice_strip,
 )
@@ -1318,32 +1321,27 @@ class LibrarySkillsListCanvas(PostRecomposeCallback, VerticalScroll):
             yield from self._compose_pager(state.pager)
 
     def _compose_pager(self, pager: LibraryPagerDisplay) -> ComposeResult:
-        """Render the controller-derived Skills pager without recalculation."""
-        reasons = tuple(
-            dict.fromkeys(
-                reason
-                for disabled, reason in (
-                    (pager.previous_disabled, pager.previous_reason),
-                    (pager.next_disabled, pager.next_reason),
-                )
-                if disabled and reason
-            )
-        )
+        """Render the controller-derived Skills pager through the shared rule.
+
+        task-32354 (critique #10): this canvas composed the pager itself and
+        so never got the single-page suppression task-28016/31237 gave every
+        other Library list -- four lines of "Page 1 of 1 / Already on the
+        first page. / ○ Previous ○ Next" for two skills, 4 of 18 usable rows
+        at 60x24 (A caps 60/61). The rule is ``library_pager_layout``'s; this
+        method only renders what it returns.
+        """
+        layout = library_pager_layout(pager)
         with Vertical(id="library-skills-pager", classes="library-source-pager"):
             yield Static(
-                pager.range_copy,
+                " · ".join(layout.status_parts),
                 id="library-skills-range",
                 classes="library-source-pager-status",
                 markup=False,
             )
-            yield Static(
-                pager.page_copy,
-                id="library-skills-page",
-                classes="library-source-pager-status",
-                markup=False,
-            )
             status_copy = " · ".join(
-                copy for copy in (pager.status_copy, *reasons) if copy
+                copy
+                for copy in (pager.status_copy, *layout.boundary_reasons)
+                if copy
             )
             if status_copy:
                 yield Static(
@@ -1352,6 +1350,8 @@ class LibrarySkillsListCanvas(PostRecomposeCallback, VerticalScroll):
                     classes="library-source-pager-status",
                     markup=False,
                 )
+            if layout.controls_hidden:
+                return
             with Horizontal(classes="library-source-pager-controls"):
                 yield Button(
                     library_disabled_action_label("Previous", pager.previous_disabled),


### PR DESCRIPTION
Part of the Library critique-10 fix wave (plan: `Docs/superpowers/plans/2026-09-11-library-crit10-wave.md`, group `pagers`). No `library_screen.py` or TCSS changes.

## What
- **task-32354** — Skills, Collections and Trash render through the shared `library_pager_layout` single-page rule: no "1-2 of 2 / Page 1 of 1 / ○ Previous ○ Next" chrome when everything fits (at 60x24 that was 4 of 18 rows). Deliberately reverses the pinned Skills pager (`test_skills_canvas_renders_exact_pager_and_source_wide_trust_count`, split into a suppressed one-page and a full two-page pin; page size 20). Collections suppresses only when `bounded` (a stale page keeps its paused controls); Trash keeps its page Static in the initial-error posture, as its geometry pin requires.
- **task-32352 + decision task-32057** — Collections keeps its rail row and one name everywhere ("Quick Capture" only on the button); the empty state distinguishes a filter (undone by Clear), an empty rail scope such as Favorites/Archived (undone by All Captures) and a never-captured source, and never cites an absent action; the pager is disabled at 0 of 0. The user's decision is recorded verbatim under `## Decision` in task-32057.
- **task-32363** — the Skills trust banner states why every skill reads "needs review" while the trust store is not set up.

## Evidence
- `Tests/UI/test_library_crit10_pagers.py` (11 tests, red-first, incl. one at 60x24) + `Tests/Library/test_library_pager_state.py` (+3) + the split Skills pin; failing-name sets on the touched suites are byte-identical to the base.
- Live-verified at 235x52, 100x30 and 60x24 on an isolated seeded profile.
- Guides: `library.md`, `library/collections.md`, `library/skills.md`, `library/media-and-conversations.md` with refreshed stamps.

## Review
Task review (Changes requested: 1 P2 — the empty state ignored the rail scope — 4 P3, 1 P4) → fix round 1 (`40860feb05`, all six addressed, none declined). Scoped re-review in progress. Rider noted: a Trash filtered to zero matches still says "Trash is empty".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes the Skills, Collections, and Trash pagers through the shared single-page rule, so a list that fits on one page no longer draws "Page 1 of 1" or dead Previous/Next controls. Collections also gets a single name and a true empty state, and the Skills trust banner now explains why every skill reads "needs review" when the trust store is not set up.

- Skills, Collections, and Trash now render pagers via `library_pager_layout`; single-page lists drop the page copy, boundary reasons, and both controls.
- Collections gains a "Collections" heading; "Quick Capture" remains only as the save-a-URL button.
- The Collections empty state distinguishes a set filter, an empty rail scope, and a never-captured profile, each with the right way out; it renders only for a page that came back and describes the scope on screen.
- The Skills trust banner states that without a trust store every skill reads "needs review" because approvals can't be verified.

<sup>Written for commit cf3eb83391c83c98cda66a4ddd82c67b1037b307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

