### PR TITLE
fix(library-export): full fidelity by default, the bundle stated before it is written, every blocked Export and Reader control carries its reason (critique-10 wave, tasks 32353 + 32362)

### DIFF
--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -160,10 +160,12 @@ When the submit button is off, its reason is on the line directly beneath
 it — "Choose a destination before exporting.", "Nothing to export in this
 scope.", "Waiting for item counts before exporting.", or "An export is
 already running." (task-32362). It is the same sentence the tooltip shows,
-so a keyboard-first reader never has to hover to find out why. A "Cancel" button appears while an export is running. Once an
-export finishes, a receipt line appears above the submit button and stays
-there — it updates in place after each further export and survives
-switching to another rail row and back, for the rest of the session.
+so a keyboard-first reader never has to hover to find out why.
+
+A "Cancel" button appears while an export is running. Once an export
+finishes, a receipt line appears above the submit button and stays there —
+it updates in place after each further export and survives switching to
+another rail row and back, for the rest of the session.
 
 The receipt is read back out of the bundle that was written, not out of
 what you asked for: "✓ exported · 12 items · 348 KB · /path/to/out.zip"

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -146,10 +146,15 @@ only loses content when you ask it to (task-32353).
 
 Directly above the submit button, two quiet lines say what pressing it
 will write, before you press it (task-32353): a **bundle line** —
-"Bundle: 2 media items · full files · about 4 KB before compression" —
-naming the item count, the fidelity the chooser is set to, and how much
-content is going in (the written `.zip` is smaller; the receipt after the
-run reports that file's own size); and a
+"Bundle: 2 media items · text only · about 4 KB before compression" —
+naming how many items are going in, what the archive holds for each of
+them, and how much content that is (the written `.zip` is smaller; the
+receipt after the run reports that file's own size). "text only" is not a
+summary of the quality chooser: whatever that control is set to, a bundle
+holds each item's stored text plus its details, never the original media
+file — the Library does not keep a path to one. The line is absent when
+the scope is empty, where "Nothing to export in this scope." is the only
+thing worth saying. And a
 **contents list** naming the items themselves, up to 20 of them, then
 "+ N more". Where the size cannot be known up front (an "Everything"
 export spans four sources, only one of which can be measured beforehand)
@@ -276,7 +281,7 @@ destination, or leaving the Import canvas cancels pending consent.
 |---|---|
 | "Export name" | Pre-filled "Library export 2026-07-31" (today's date); becomes the bundle's display name. |
 | "quality: original" | Opens on "original" (full fidelity, task-32353). Press to open a one-row strip of thumbnail / compressed / original (✓ on the active one) right under the button; pick one directly, or press the button again / Escape to close without changing. The helper line underneath always describes the option currently showing. Only "original" copies full media files into the zip; the others keep the package small. |
-| "Bundle: N media items · full files · about X KB before compression" | What pressing Export will actually write: the item count, the fidelity the quality chooser is set to, and how much content is going in. The archive itself is smaller — the receipt after the run stats the written `.zip`. Reads "size known once it runs" when the scope's size cannot be measured up front. Appears once counting finishes. |
+| "Bundle: N media items · text only · about X KB before compression" | What pressing Export will actually write: how many items go in, what the archive holds for each (stored text and details — never the original media file, whatever the quality chooser says), and how much content that is. The archive itself is smaller — the receipt after the run stats the written `.zip`. Reads "size known once it runs" when the scope's size cannot be measured up front. The count is the items still exportable, so a selection whose item was trashed underneath reports what will really be written. Absent for an empty scope. Appears once counting finishes. |
 | The contents list | The titles of the items going into the bundle, up to 20, then "+ N more". Absent when the scope's items cannot be enumerated before the run. |
 | "Choose destination…" | Opens "Choose Export Destination". Whatever you pick is normalized to end in `.zip`; if that file already exists, an "Overwrites <name>" note appears (informational — exporting proceeds and replaces it). |
 | "Export bundle (.zip)" | Enabled once counting has finished, the scope is non-empty, and a destination is chosen. "Nothing to export in this scope." appears when the scope is empty; either way, the reason is printed on the line directly below the button AND repeated in its tooltip (or "Write the bundle to the chosen destination." once it's ready) — a disabled press can never look like it silently did nothing. |
@@ -956,3 +961,11 @@ the export will write — count, fidelity, estimated size, and the item titles
 cannot be read as contradicting the receipt's smaller written-archive figure;
 task-32362: a blocked "Export bundle (.zip)"
 prints its reason on the line below it, not only in a tooltip.)*
+
+*Verified against fix/library-crit10-export — 2026-09-11, review round 2
+(Qodo on PR #2601: the bundle line no longer names the quality chooser's
+value — the exporter writes the same stored text for all three options, so
+"previews only"/"compressed files"/"full files" described an archive that is
+never produced; an empty scope shows no bundle line rather than "0 items …
+about 1 KB"; and the count is the items still exportable, not the raw size
+of a selection that may have gone stale.)*

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -146,8 +146,10 @@ only loses content when you ask it to (task-32353).
 
 Directly above the submit button, two quiet lines say what pressing it
 will write, before you press it (task-32353): a **bundle line** —
-"Bundle: 2 media items · full files · about 4 KB" — naming the item count,
-the fidelity the chooser is set to, and the estimated size; and a
+"Bundle: 2 media items · full files · about 4 KB before compression" —
+naming the item count, the fidelity the chooser is set to, and how much
+content is going in (the written `.zip` is smaller; the receipt after the
+run reports that file's own size); and a
 **contents list** naming the items themselves, up to 20 of them, then
 "+ N more". Where the size cannot be known up front (an "Everything"
 export spans four sources, only one of which can be measured beforehand)
@@ -272,7 +274,7 @@ destination, or leaving the Import canvas cancels pending consent.
 |---|---|
 | "Export name" | Pre-filled "Library export 2026-07-31" (today's date); becomes the bundle's display name. |
 | "quality: original" | Opens on "original" (full fidelity, task-32353). Press to open a one-row strip of thumbnail / compressed / original (✓ on the active one) right under the button; pick one directly, or press the button again / Escape to close without changing. The helper line underneath always describes the option currently showing. Only "original" copies full media files into the zip; the others keep the package small. |
-| "Bundle: N media items · full files · about X KB" | What pressing Export will actually write: the item count, the fidelity the quality chooser is set to, and the estimated size. Reads "size known once it runs" when the scope's size cannot be measured up front. Appears once counting finishes. |
+| "Bundle: N media items · full files · about X KB before compression" | What pressing Export will actually write: the item count, the fidelity the quality chooser is set to, and how much content is going in. The archive itself is smaller — the receipt after the run stats the written `.zip`. Reads "size known once it runs" when the scope's size cannot be measured up front. Appears once counting finishes. |
 | The contents list | The titles of the items going into the bundle, up to 20, then "+ N more". Absent when the scope's items cannot be enumerated before the run. |
 | "Choose destination…" | Opens "Choose Export Destination". Whatever you pick is normalized to end in `.zip`; if that file already exists, an "Overwrites <name>" note appears (informational — exporting proceeds and replaces it). |
 | "Export bundle (.zip)" | Enabled once counting has finished, the scope is non-empty, and a destination is chosen. "Nothing to export in this scope." appears when the scope is empty; either way, the reason is printed on the line directly below the button AND repeated in its tooltip (or "Write the bundle to the chosen destination." once it's ready) — a disabled press can never look like it silently did nothing. |
@@ -948,5 +950,7 @@ path, jumping the listing to it, with Ctrl+A selecting the field.)*
 quality chooser opens on "original" instead of "thumbnail", so a bundle only
 loses content when asked, and a bundle line plus a contents list state what
 the export will write — count, fidelity, estimated size, and the item titles
-— before the button is pressed; task-32362: a blocked "Export bundle (.zip)"
+— before the button is pressed, the size qualified "before compression" so it
+cannot be read as contradicting the receipt's smaller written-archive figure;
+task-32362: a blocked "Export bundle (.zip)"
 prints its reason on the line below it, not only in a tooltip.)*

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -141,7 +141,24 @@ respectively — a single fixed "original copies full media files…" caption
 used to show regardless of the selected option) (shown only when media is
 in scope), "Choose destination…"
 above "No destination chosen", and the "Export bundle (.zip)" submit
-button. A "Cancel" button appears while an export is running. Once an
+button. The chooser opens on **original** — full fidelity — so a bundle
+only loses content when you ask it to (task-32353).
+
+Directly above the submit button, two quiet lines say what pressing it
+will write, before you press it (task-32353): a **bundle line** —
+"Bundle: 2 media items · full files · about 4 KB" — naming the item count,
+the fidelity the chooser is set to, and the estimated size; and a
+**contents list** naming the items themselves, up to 20 of them, then
+"+ N more". Where the size cannot be known up front (an "Everything"
+export spans four sources, only one of which can be measured beforehand)
+the line says "size known once it runs" rather than guessing, and the
+contents list is absent. Both appear once counting finishes.
+
+When the submit button is off, its reason is on the line directly beneath
+it — "Choose a destination before exporting.", "Nothing to export in this
+scope.", "Waiting for item counts before exporting.", or "An export is
+already running." (task-32362). It is the same sentence the tooltip shows,
+so a keyboard-first reader never has to hover to find out why. A "Cancel" button appears while an export is running. Once an
 export finishes, a receipt line appears above the submit button and stays
 there — it updates in place after each further export and survives
 switching to another rail row and back, for the rest of the session.
@@ -254,9 +271,11 @@ destination, or leaving the Import canvas cancels pending consent.
 | Export control | What it does |
 |---|---|
 | "Export name" | Pre-filled "Library export 2026-07-31" (today's date); becomes the bundle's display name. |
-| "quality: thumbnail" | Press to open a one-row strip of thumbnail / compressed / original (✓ on the active one) right under the button; pick one directly, or press the button again / Escape to close without changing. The helper line underneath always describes the option currently showing. Only "original" copies full media files into the zip; the others keep the package small. |
+| "quality: original" | Opens on "original" (full fidelity, task-32353). Press to open a one-row strip of thumbnail / compressed / original (✓ on the active one) right under the button; pick one directly, or press the button again / Escape to close without changing. The helper line underneath always describes the option currently showing. Only "original" copies full media files into the zip; the others keep the package small. |
+| "Bundle: N media items · full files · about X KB" | What pressing Export will actually write: the item count, the fidelity the quality chooser is set to, and the estimated size. Reads "size known once it runs" when the scope's size cannot be measured up front. Appears once counting finishes. |
+| The contents list | The titles of the items going into the bundle, up to 20, then "+ N more". Absent when the scope's items cannot be enumerated before the run. |
 | "Choose destination…" | Opens "Choose Export Destination". Whatever you pick is normalized to end in `.zip`; if that file already exists, an "Overwrites <name>" note appears (informational — exporting proceeds and replaces it). |
-| "Export bundle (.zip)" | Enabled once counting has finished, the scope is non-empty, and a destination is chosen. "Nothing to export in this scope." appears when the scope is empty; either way, hovering the button always shows a tooltip naming the same reason it's disabled (or "Write the bundle to the chosen destination." once it's ready) — a disabled press can never look like it silently did nothing. |
+| "Export bundle (.zip)" | Enabled once counting has finished, the scope is non-empty, and a destination is chosen. "Nothing to export in this scope." appears when the scope is empty; either way, the reason is printed on the line directly below the button AND repeated in its tooltip (or "Write the bundle to the chosen destination." once it's ready) — a disabled press can never look like it silently did nothing. |
 | "Cancel" | Visible only while an export is running; stops it. The quiet line above keeps reporting progress throughout ("Exporting (N items)…" at first, then the phase it's on — "Collecting notes…  3/12", "Packaging archive…  5/9 files"), and once the write has run for about three seconds that same line gains " · still working · Cancel" pointing at this button. Pressing it leaves "Cancelling…" until the run reports back. |
 | "✓ exported · N items · X KB · path" | Appears after the first successful export this session; the count and size are read back from the written archive's own manifest, so they report what actually landed rather than what was selected. Stays until the next successful export replaces it. (A receipt restored from an earlier session, before those facts were recorded, still shows as "Last export: <path> · <relative time>".) |
 | "✗ export produced no content · N items were selected" | The run collected none of the N items you selected, so no bundle was written at all — nothing on disk to mistake for a real export. The submit button becomes "Retry export". (A single-item selection reads "· 1 item was selected".) |
@@ -924,3 +943,10 @@ and the file dialogs' "File name" box takes a typed or pasted absolute/"~"
 path, jumping the listing to it, with Ctrl+A selecting the field.)*
 
 *Verified against fix/library-crit9-import — 2026-09-10 (task-32216: "Show details" leaves focus on the row action it toggled instead of the Keywords field 25 rows up; task-32231: a run of identical settled outcomes collapses into one "✗ failed · N files · reason" row with "Show the N files", "Retry all" and "Dismiss all"; a group whose members need a different transcription model offers no bare "Retry all", matching those rows' own actions; a group never spans two imports.)*
+
+*Verified against fix/library-crit10-export — 2026-09-11 (task-32353: the
+quality chooser opens on "original" instead of "thumbnail", so a bundle only
+loses content when asked, and a bundle line plus a contents list state what
+the export will write — count, fidelity, estimated size, and the item titles
+— before the button is pressed; task-32362: a blocked "Export bundle (.zip)"
+prints its reason on the line below it, not only in a tooltip.)*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -526,7 +526,7 @@ still spans the pane.
 
 | Button | What it does |
 |---|---|
-| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. When there is nothing on the current tab to search, it reads "○ Find" and the reason is printed on the line directly under the toolbar — "No analysis to search yet.", "Analysis is still generating." or "Finish editing the analysis first." — not only in a tooltip (task-32362). |
+| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. When the tab you are on has nothing to search, it reads "○ Find" and prints that tab's own reason on the line directly under the toolbar, not only in a tooltip (task-32362). |
 | "Use in Console" | Stages this item as context for your next Console message. |
 | "Read later" ↔ "Remove later" | Toggles the loaded item's persisted reading-list state. |
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. Opening it adds one toolbar row directly beneath this one — the tab row and the reading body shift down a single line (two on a Reader too narrow to fit all four actions side by side), never off the fold — the button reads "More ▴" while the row is open, and focus stays on it so a second press closes the row. |

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -526,7 +526,7 @@ still spans the pane.
 
 | Button | What it does |
 |---|---|
-| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. |
+| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. When there is nothing on the current tab to search, it reads "○ Find" and the reason is printed on the line directly under the toolbar — "No analysis to search yet.", "Analysis is still generating." or "Finish editing the analysis first." — not only in a tooltip (task-32362). |
 | "Use in Console" | Stages this item as context for your next Console message. |
 | "Read later" ↔ "Remove later" | Toggles the loaded item's persisted reading-list state. |
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. Opening it adds one toolbar row directly beneath this one — the tab row and the reading body shift down a single line (two on a Reader too narrow to fit all four actions side by side), never off the fold — the button reads "More ▴" while the row is open, and focus stays on it so a second press closes the row. |
@@ -1176,3 +1176,7 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-export — 2026-09-11 (task-32362: a
+blocked "○ Find" prints why on the line below the Reader toolbar, matching
+the blocked Generate action's own inline reason one pane over.)*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -11505,6 +11505,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1384,
-    "task_494_calls": 7688
+    "task_494_calls": 7689
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2703,8 +2703,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 6,
-      "diagnostic_digest": "4a1765bcd05c2792e06d",
+      "call_count": 7,
+      "diagnostic_digest": "c386b717698c71d3eb24",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/library_export_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11505,6 +11505,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1384,
-    "task_494_calls": 7687
+    "task_494_calls": 7688
   }
 }

--- a/Tests/Architecture/test_library_export_wiring.py
+++ b/Tests/Architecture/test_library_export_wiring.py
@@ -73,6 +73,9 @@ _EXPORT_CLUSTER_METHOD_NAMES: tuple[str, ...] = (
     "_library_export_is_server_mode",
     "_resolve_library_export_chachanotes_db",
     "_compute_library_export_counts",
+    # task-32353 AC#2: the counts helper's sibling -- same staticmethod
+    # shape, same quiet-degrade-with-a-log contract, one query over.
+    "_compute_library_export_preview",
     "handle_library_export_submit",
     "_build_library_export_payload",
     "_run_library_export_via_service",
@@ -109,7 +112,7 @@ _EXPORT_CLUSTER_SCREEN_DELEGATOR_PRUNED: frozenset[str] = frozenset(
     }
 )
 
-#: The 5 names above that are `@staticmethod`s on `LibraryScreen`. Their
+#: The 6 names above that are `@staticmethod`s on `LibraryScreen`. Their
 #: delegators forward straight to the module-level `LibraryExportController`
 #: CLASS (per task-8-report.md's "static-method delegator pattern"
 #: correction, cited in the conversations wiring test), not through
@@ -118,6 +121,7 @@ _EXPORT_CLUSTER_STATICMETHOD_NAMES: frozenset[str] = frozenset(
     {
         "_default_library_export_form",
         "_compute_library_export_counts",
+        "_compute_library_export_preview",
         "_build_library_export_payload",
         "_run_library_export_via_service",
         "_build_library_export_success_message",
@@ -127,7 +131,7 @@ _EXPORT_CLUSTER_STATICMETHOD_NAMES: frozenset[str] = frozenset(
 
 @pytest.mark.unit
 def test_export_controller_owns_its_cluster() -> None:
-    """Every one of the 22 moved names is a callable on the controller.
+    """Every one of the 23 moved names is a callable on the controller.
 
     Covers the whole cluster, not a hand-picked sample -- mirrors
     `test_browse_controller_owns_its_cluster` in the conversations wiring
@@ -147,7 +151,7 @@ def test_export_controller_owns_its_cluster() -> None:
 
 @pytest.mark.unit
 def test_screen_delegates_export_handlers() -> None:
-    """Every one of the 22 moved names is a one-line screen delegator that
+    """Every one of the 23 moved names is a one-line screen delegator that
     forwards to the SAME-NAMED controller method (or, for the 5
     static/classmethods, to the module-level controller CLASS).
 
@@ -190,7 +194,7 @@ def test_screen_delegates_export_handlers() -> None:
 
 @pytest.mark.unit
 def test_export_cluster_staticmethods_forward_to_the_controller_class() -> None:
-    """The 5 staticmethod names in the cluster forward to the CLASS, not an instance."""
+    """The 6 staticmethod names in the cluster forward to the CLASS, not an instance."""
     from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
 
     not_class_forwarding = []

--- a/Tests/Library/test_library_export_execution.py
+++ b/Tests/Library/test_library_export_execution.py
@@ -24,7 +24,7 @@ from loguru import logger
 
 
 from tldw_chatbook.Chatbooks.chatbook_models import ContentType
-from tldw_chatbook.Library.library_export_scope import ExportScope
+from tldw_chatbook.Library.library_export_scope import ExportPreview, ExportScope
 from tldw_chatbook.UI.Screens.library_screen import (
     LibraryEntryReconcileResult,
     LibraryScreen,
@@ -194,7 +194,15 @@ def test_prompt_memory_database_forces_inline_count_resolution():
         (
             scope,
             {"media": 0, "conversations": 0, "notes": 0, "prompts": 2},
-            {"generation": 7, "route_key": route_key, "request_id": 1},
+            {
+                "generation": 7,
+                "route_key": route_key,
+                "request_id": 1,
+                # task-32353: a Prompts scope has no media to size, so the
+                # sibling preview read lands empty -- and never touches the
+                # poison media source to find that out.
+                "preview": ExportPreview(),
+            },
         )
     ]
 

--- a/Tests/Library/test_library_export_execution.py
+++ b/Tests/Library/test_library_export_execution.py
@@ -182,6 +182,9 @@ def test_prompt_memory_database_forces_inline_count_resolution():
             "notes": 0,
             "prompts": 2,
         },
+        # task-32353: the counts helper's sibling, which the worker calls
+        # for the contents/size preview beside the counts.
+        _compute_library_export_preview=lambda *_args: ExportPreview(),
         _apply_library_export_counts=apply_counts,
         _run_library_export_counts_worker=lambda *_args: pytest.fail(
             "memory-backed Prompt counts must stay on the owner thread"

--- a/Tests/Library/test_library_export_scope.py
+++ b/Tests/Library/test_library_export_scope.py
@@ -543,3 +543,80 @@ def test_preview_raises_so_its_wrapper_can_log_the_failure():
     assert any("category=RuntimeError" in line for line in warnings), warnings
     # A missing seam is not an error -- there is simply nothing to read.
     assert preview_export_scope(ExportScope(kind="media"), None).approx_bytes is None
+
+
+# --- Qodo review on PR #2601 -------------------------------------------------
+
+
+def test_preview_reports_how_many_active_rows_it_actually_found(media_db):
+    """Qodo #7: a selection counted by ``len(scope.ids)`` promised items the
+    archive would not hold. The preview resolves the selection against the
+    same active-row filter the collector applies and reports that count."""
+    kept, _, _ = media_db.add_media_with_keywords(
+        title="Kept", content="k" * 1024, media_type="article"
+    )
+    trashed, _, _ = media_db.add_media_with_keywords(
+        title="Trashed", content="t" * 2048, media_type="article"
+    )
+    media_db.mark_as_trash(trashed)
+
+    preview = preview_export_scope(
+        ExportScope(kind="media", ids=(str(kept), str(trashed))), media_db
+    )
+
+    # Two selected, one still exportable.
+    assert preview.item_count == 1
+    assert preview.titles == ("Kept",)
+    assert preview.approx_bytes == 1024
+
+
+def test_preview_counts_past_the_render_cap(media_db):
+    """The item count covers every matching row, not just the fetched page."""
+    for index in range(25):
+        media_db.add_media_with_keywords(
+            title=f"Item {index:02d}",
+            content=f"{index:02d}" + "x" * 1022,
+            media_type="article",
+        )
+
+    preview = preview_export_scope(ExportScope(kind="media"), media_db)
+
+    assert preview.item_count == 25
+    assert len(preview.titles) == 21
+
+
+def test_preview_reads_the_whole_estimate_in_one_statement(media_db):
+    """Qodo #2/#3: titles, count and bytes came from two statements, so a
+    write landing between them could mix snapshots, and two cursors were
+    left to garbage collection. One windowed statement, one closed cursor."""
+    media_db.add_media_with_keywords(
+        title="Only", content="o" * 1024, media_type="article"
+    )
+    seen: list[str] = []
+    real = media_db.execute_query
+
+    def record(query, params=None, **kwargs):
+        seen.append(query)
+        return real(query, params, **kwargs)
+
+    media_db.execute_query = record
+    try:
+        preview = preview_export_scope(ExportScope(kind="media"), media_db)
+    finally:
+        media_db.execute_query = real
+
+    assert len(seen) == 1, seen
+    assert preview.item_count == 1
+    assert preview.approx_bytes == 1024
+
+
+def test_preview_of_an_empty_scope_reports_zero_not_none(media_db):
+    """Zero bytes is a known fact; ``None`` means "could not find out". The
+    canvas renders them differently, so the query must not conflate them."""
+    preview = preview_export_scope(
+        ExportScope(kind="media", media_type="video"), media_db
+    )
+
+    assert preview.item_count == 0
+    assert preview.approx_bytes == 0
+    assert preview.titles == ()

--- a/Tests/Library/test_library_export_scope.py
+++ b/Tests/Library/test_library_export_scope.py
@@ -17,6 +17,7 @@ snapshot instead of a fresh query would silently drop rows past the cap.
 from __future__ import annotations
 
 import pytest
+from loguru import logger as loguru_logger
 
 from tldw_chatbook.Chatbooks.chatbook_models import ContentType
 from tldw_chatbook.DB.ChaChaNotes_DB import CharactersRAGDB
@@ -25,6 +26,7 @@ from tldw_chatbook.DB.Prompts_DB import PromptsDatabase
 from tldw_chatbook.Library.library_export_scope import (
     ExportScope,
     count_export_scope,
+    ExportPreview,
     export_scope_label,
     preview_export_scope,
     resolve_export_selections,
@@ -465,7 +467,7 @@ def test_preview_honours_the_media_type_filter_for_a_whole_source_scope(media_db
 
 
 def test_preview_skips_deleted_and_trashed_items(media_db):
-    kept, _, _ = media_db.add_media_with_keywords(
+    media_db.add_media_with_keywords(
         title="Kept", content="k" * 1024, media_type="article"
     )
     trashed, _, _ = media_db.add_media_with_keywords(
@@ -475,9 +477,30 @@ def test_preview_skips_deleted_and_trashed_items(media_db):
 
     preview = preview_export_scope(ExportScope(kind="media"), media_db)
 
+    # The trashed item contributes neither a title nor its 1024 bytes.
     assert preview.titles == ("Kept",)
     assert preview.approx_bytes == 1024
-    assert kept
+
+
+def test_preview_caps_the_title_query_instead_of_reading_every_row(media_db):
+    """task-32353 review (Low 3): the SUM must visit every row, but the
+    canvas renders 20 titles -- so the title query is LIMITed and never
+    materialises one string per item in a whole-source scope."""
+    for index in range(25):
+        # Distinct content per item: identical content dedups into one row.
+        media_db.add_media_with_keywords(
+            title=f"Item {index:02d}",
+            content=f"{index:02d}" + "x" * 1022,
+            media_type="article",
+        )
+
+    preview = preview_export_scope(ExportScope(kind="media"), media_db)
+
+    # One row past the render limit -- enough to know it was truncated.
+    assert len(preview.titles) == 21
+    assert preview.titles[0] == "Item 00"
+    # The byte total still covers all 25, not just the 21 fetched.
+    assert preview.approx_bytes == 25 * 1024
 
 
 def test_preview_is_empty_for_a_scope_whose_items_it_cannot_size(media_db):
@@ -491,13 +514,32 @@ def test_preview_is_empty_for_a_scope_whose_items_it_cannot_size(media_db):
     assert preview.approx_bytes is None
 
 
-def test_preview_degrades_quietly_instead_of_raising_out_of_the_worker():
+def test_preview_raises_so_its_wrapper_can_log_the_failure():
+    """task-32353 review (Medium 2): the quiet-degrade AND its log line
+    live in the controller wrapper, exactly like the sibling counts
+    helper -- the pure query raises rather than failing invisibly."""
+    from tldw_chatbook.UI.Library_Modules.library_export_controller import (
+        LibraryExportController,
+    )
+
     class _Broken:
         def execute_query(self, query, params=()):
             raise RuntimeError("no such table: Media")
 
-    preview = preview_export_scope(ExportScope(kind="media"), _Broken())
+    with pytest.raises(RuntimeError):
+        preview_export_scope(ExportScope(kind="media"), _Broken())
 
-    assert preview.titles == ()
-    assert preview.approx_bytes is None
+    # loguru does not route through pytest's caplog -- attach a real sink.
+    warnings: list[str] = []
+    handle = loguru_logger.add(warnings.append, level="WARNING")
+    try:
+        degraded = LibraryExportController._compute_library_export_preview(
+            ExportScope(kind="media"), _Broken()
+        )
+    finally:
+        loguru_logger.remove(handle)
+    assert degraded == ExportPreview()
+    assert any("Library export preview failed" in line for line in warnings), warnings
+    assert any("category=RuntimeError" in line for line in warnings), warnings
+    # A missing seam is not an error -- there is simply nothing to read.
     assert preview_export_scope(ExportScope(kind="media"), None).approx_bytes is None

--- a/Tests/Library/test_library_export_scope.py
+++ b/Tests/Library/test_library_export_scope.py
@@ -26,6 +26,7 @@ from tldw_chatbook.Library.library_export_scope import (
     ExportScope,
     count_export_scope,
     export_scope_label,
+    preview_export_scope,
     resolve_export_selections,
 )
 
@@ -408,3 +409,95 @@ def test_export_scope_label_media_type_filter_pluralises_too():
 def test_export_scope_label_explicit_selection_pluralises():
     scope = ExportScope(kind="notes", ids=("note-1",))
     assert export_scope_label(scope, {"notes": 1}) == "Selected notes · 1 item"
+
+
+# --- preview_export_scope (task-32353 AC#2) ---------------------------------
+# The canvas asked for a destination and a name and then wrote a bundle
+# nobody had seen the contents of. This is the pre-write read that lets it
+# say what it is about to write -- run on the counts worker, never the UI
+# thread, and never raising out of it.
+
+
+def test_preview_reports_the_selected_items_titles_and_their_stored_bytes(media_db):
+    first, _, _ = media_db.add_media_with_keywords(
+        title="Attention Is All You Need", content="a" * 2048, media_type="article"
+    )
+    second, _, _ = media_db.add_media_with_keywords(
+        title="Deep Residual Learning", content="b" * 2048, media_type="article"
+    )
+    scope = ExportScope(
+        kind="media", ids=(f"local:media:{first}", f"local:media:{second}")
+    )
+
+    preview = preview_export_scope(scope, media_db)
+
+    assert preview.titles == (
+        "Attention Is All You Need",
+        "Deep Residual Learning",
+    )
+    assert preview.approx_bytes == 4096
+
+
+def test_preview_counts_utf8_bytes_not_characters(media_db):
+    # A bare LENGTH() on TEXT counts characters and would under-report any
+    # non-ASCII library by up to 4x.
+    media_id, _, _ = media_db.add_media_with_keywords(
+        title="Ω", content="Ω" * 100, media_type="article"
+    )
+
+    preview = preview_export_scope(
+        ExportScope(kind="media", ids=(str(media_id),)), media_db
+    )
+
+    assert preview.approx_bytes == 200
+
+
+def test_preview_honours_the_media_type_filter_for_a_whole_source_scope(media_db):
+    media_db.add_media_with_keywords(title="V1", content="x" * 1024, media_type="video")
+    media_db.add_media_with_keywords(title="A1", content="y" * 1024, media_type="article")
+
+    preview = preview_export_scope(
+        ExportScope(kind="media", media_type="video"), media_db
+    )
+
+    assert preview.titles == ("V1",)
+    assert preview.approx_bytes == 1024
+
+
+def test_preview_skips_deleted_and_trashed_items(media_db):
+    kept, _, _ = media_db.add_media_with_keywords(
+        title="Kept", content="k" * 1024, media_type="article"
+    )
+    trashed, _, _ = media_db.add_media_with_keywords(
+        title="Trashed", content="t" * 1024, media_type="article"
+    )
+    media_db.mark_as_trash(trashed)
+
+    preview = preview_export_scope(ExportScope(kind="media"), media_db)
+
+    assert preview.titles == ("Kept",)
+    assert preview.approx_bytes == 1024
+    assert kept
+
+
+def test_preview_is_empty_for_a_scope_whose_items_it_cannot_size(media_db):
+    """An "everything" export spans four sources; only one is sizeable here,
+    so the canvas says "size known once it runs" rather than guessing."""
+    media_db.add_media_with_keywords(title="M", content="m" * 1024, media_type="article")
+
+    preview = preview_export_scope(ExportScope(kind="everything"), media_db)
+
+    assert preview.titles == ()
+    assert preview.approx_bytes is None
+
+
+def test_preview_degrades_quietly_instead_of_raising_out_of_the_worker():
+    class _Broken:
+        def execute_query(self, query, params=()):
+            raise RuntimeError("no such table: Media")
+
+    preview = preview_export_scope(ExportScope(kind="media"), _Broken())
+
+    assert preview.titles == ()
+    assert preview.approx_bytes is None
+    assert preview_export_scope(ExportScope(kind="media"), None).approx_bytes is None

--- a/Tests/Library/test_library_export_state.py
+++ b/Tests/Library/test_library_export_state.py
@@ -272,7 +272,13 @@ def test_running_status_and_error_lines_pass_through_unchanged():
 
 def test_media_quality_options_are_the_three_known_values_in_order():
     assert MEDIA_QUALITY_OPTIONS == ("thumbnail", "compressed", "original")
-    assert DEFAULT_MEDIA_QUALITY == "thumbnail"
+
+
+def test_export_defaults_to_full_fidelity():
+    """task-32353 AC#1 (critique #10): the default used to be "thumbnail" --
+    a silent data reduction chosen for someone whose reason for exporting is
+    usually to keep the files. A lossy bundle is now something you ask for."""
+    assert DEFAULT_MEDIA_QUALITY == "original"
 
 
 def test_export_form_state_carries_quality_choices_visible_flag():

--- a/Tests/UI/test_library_choice_strips.py
+++ b/Tests/UI/test_library_choice_strips.py
@@ -438,7 +438,8 @@ async def test_export_quality_strip_opens_picks_and_second_press_closes():
         screen = await _open_media_export(host, pilot)
 
         opener = screen.query_one("#library-export-quality", Button)
-        assert str(opener.label) == "quality: thumbnail"
+        # task-32353 AC#1: the form opens at full fidelity now, not "thumbnail".
+        assert str(opener.label) == "quality: original"
 
         opener.press()
         await _wait_for_selector(screen, pilot, "#library-export-quality-choices")
@@ -446,37 +447,37 @@ async def test_export_quality_strip_opens_picks_and_second_press_closes():
             str(button.label)
             for button in screen.query(".library-export-quality-choice")
         ]
-        assert labels == ["✓ thumbnail", "compressed", "original"]
+        assert labels == ["thumbnail", "compressed", "✓ original"]
 
         # Second press on the still-visible opener closes without change.
         screen.query_one("#library-export-quality", Button).press()
         await pilot.pause()
         await pilot.pause()
         assert not screen.query("#library-export-quality-choices")
-        assert screen._export_state.form.get("quality", "thumbnail") == "thumbnail"
+        assert screen._export_state.form.get("quality", "original") == "original"
 
         # Reopen and pick directly: value + helper line update, strip closes.
         screen.query_one("#library-export-quality", Button).press()
         await _wait_for_selector(screen, pilot, "#library-export-quality-choices")
-        original = next(
+        thumbnail = next(
             button
             for button in screen.query(".library-export-quality-choice")
-            if str(button.label) == "original"
+            if str(button.label) == "thumbnail"
         )
-        original.press()
+        thumbnail.press()
         await pilot.pause()
         await pilot.pause()
 
-        assert screen._export_state.form["quality"] == "original"
+        assert screen._export_state.form["quality"] == "thumbnail"
         assert not screen.query("#library-export-quality-choices")
         assert (
             str(screen.query_one("#library-export-quality", Button).label)
-            == "quality: original"
+            == "quality: thumbnail"
         )
         helper = str(
             screen.query_one("#library-export-quality-helper", Static).renderable
         )
-        assert "original" in helper.lower() or "full" in helper.lower()
+        assert "preview" in helper.lower()
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_crit10_export.py
+++ b/Tests/UI/test_library_crit10_export.py
@@ -45,6 +45,7 @@ def _state(**overrides):
         destination="/tmp/out.zip",
         titles=("Attention Is All You Need", "Deep Residual Learning"),
         approx_bytes=4096,
+        item_count=2,
     )
     base.update(overrides)
     return build_library_export_form_state(**base)
@@ -70,23 +71,13 @@ async def test_the_export_canvas_says_what_the_bundle_will_contain():
     async with app.run_test(size=(235, 52)) as pilot:
         line = pilot.app.query_one("#library-export-consequence-line", Static)
         assert (
-            str(line.renderable) == "Bundle: 2 media items · full files · about 4 KB before compression"
+            str(line.renderable) == "Bundle: 2 media items · text only · about 4 KB before compression"
         ), str(line.renderable)
         assert line.display is True
         contents = pilot.app.query_one("#library-export-contents", Static)
         assert "Attention Is All You Need" in str(contents.renderable)
         assert "Deep Residual Learning" in str(contents.renderable)
         assert contents.display is True
-
-
-@pytest.mark.asyncio
-async def test_the_consequence_line_names_the_chosen_fidelity():
-    """The fidelity is the knob's consequence, not its label -- a lossy
-    bundle says so where the user is about to press."""
-    app = _ExportHost(_state(media_quality="thumbnail"))
-    async with app.run_test(size=(235, 52)) as pilot:
-        line = pilot.app.query_one("#library-export-consequence-line", Static)
-        assert "previews only" in str(line.renderable)
 
 
 def test_an_unsizeable_scope_says_so_instead_of_guessing():
@@ -96,9 +87,10 @@ def test_an_unsizeable_scope_says_so_instead_of_guessing():
         counts={"media": 11, "conversations": 6, "notes": 7, "prompts": 5},
         titles=(),
         approx_bytes=None,
+        item_count=None,
     )
     assert state.consequence_line == (
-        "Bundle: 29 items · full files · size known once it runs"
+        "Bundle: 29 items · text only · size known once it runs"
     )
     assert state.contents_lines == ()
 
@@ -110,6 +102,7 @@ def test_a_long_contents_list_is_capped_and_says_how_many_it_hid():
         scope=ExportScope(kind="media"),
         counts={"media": 250, "conversations": 0, "notes": 0, "prompts": 0},
         titles=tuple(f"Item {n}" for n in range(21)),
+        item_count=250,
     )
     assert len(state.contents_lines) == 21
     assert state.contents_lines[:20] == tuple(f"Item {n}" for n in range(20))
@@ -121,6 +114,7 @@ def test_a_contents_list_that_exactly_fills_the_cap_hides_nothing():
         scope=ExportScope(kind="media"),
         counts={"media": 20, "conversations": 0, "notes": 0, "prompts": 0},
         titles=tuple(f"Item {n}" for n in range(20)),
+        item_count=20,
     )
     assert len(state.contents_lines) == 20
     assert not any(line.startswith("+ ") for line in state.contents_lines)
@@ -246,3 +240,91 @@ async def test_an_available_find_mounts_no_reason_line():
     async with app.run_test(size=(235, 52)) as pilot:
         assert pilot.app.query_one("#library-media-reader-find", Button).disabled is False
         assert not pilot.app.query("#library-media-reader-find-reason")
+
+
+# --- Qodo review on PR #2601 -------------------------------------------------
+
+
+def test_the_bundle_phrase_never_claims_a_fidelity_the_writer_does_not_apply():
+    """Qodo #1 (High): ``ChatbookCreator._collect_media`` reads ``quality``
+    exactly once -- to stamp it into the manifest -- and otherwise writes the
+    same text payload for every option. A line saying "previews only" or
+    "compressed files" described an artifact that is never written, so the
+    phrase states what the archive actually holds and does not vary."""
+    phrases = {
+        _state(media_quality=quality).consequence_line
+        for quality in ("thumbnail", "compressed", "original")
+    }
+    assert len(phrases) == 1, phrases
+    assert "text only" in phrases.pop()
+    for absent in ("previews only", "compressed files", "full files"):
+        assert absent not in _state(media_quality="thumbnail").consequence_line
+
+
+def test_an_empty_scope_states_no_bundle_at_all():
+    """Qodo #6 (Bug): ``format_export_bytes`` floors at 1 KB, so an empty
+    media scope rendered "Bundle: 0 media items · … · about 1 KB" directly
+    above "Nothing to export in this scope." One of those was a lie."""
+    state = _state(
+        counts={"media": 0, "conversations": 0, "notes": 0, "prompts": 0},
+        titles=(),
+        approx_bytes=0,
+        item_count=0,
+    )
+    assert state.consequence_line == ""
+    assert state.contents_lines == ()
+    assert state.empty_scope_line == "Nothing to export in this scope."
+
+
+def test_the_bundle_counts_the_items_the_preview_actually_found():
+    """Qodo #7 (Bug): ``count_export_scope`` returns ``len(scope.ids)`` for an
+    explicit selection without checking the rows are still active, so a
+    selection whose item was trashed underneath promised more than the
+    archive would hold. The bundle line counts what the preview resolved."""
+    state = _state(
+        scope=ExportScope(kind="media", ids=("1", "2")),
+        counts={"media": 2, "conversations": 0, "notes": 0, "prompts": 0},
+        titles=("Attention Is All You Need",),
+        item_count=1,
+        approx_bytes=2048,
+    )
+    assert state.consequence_line.startswith("Bundle: 1 media item ·")
+    assert state.contents_lines == ("Attention Is All You Need",)
+
+
+def test_the_remainder_counts_from_the_preview_not_the_selection():
+    state = _state(
+        scope=ExportScope(kind="media"),
+        counts={"media": 250, "conversations": 0, "notes": 0, "prompts": 0},
+        titles=tuple(f"Item {n}" for n in range(21)),
+        item_count=200,
+        approx_bytes=4096,
+    )
+    assert state.consequence_line.startswith("Bundle: 200 media items ·")
+    assert state.contents_lines[-1] == "+ 180 more"
+
+
+def test_starting_generation_is_not_an_unchanged_viewer_sync():
+    """Qodo #8 (Bug): ``_sync_library_media_viewer_state``'s unchanged
+    comparison omitted ``generating_analysis``, although the else-branch
+    assigns it. A generation that started with nothing else changing took
+    the unchanged path, so the Reader kept saying "No analysis to search
+    yet." while one was generating -- and, before this branch made the
+    reason visible, kept a stale ``○`` label and tooltip too."""
+    import inspect
+
+    from tldw_chatbook.UI.Library_Modules.library_media_controller import (
+        LibraryMediaController,
+    )
+
+    source = inspect.getsource(
+        LibraryMediaController._sync_library_media_viewer_state
+    )
+    unchanged = source[source.index("unchanged = ("):source.index("if unchanged:")]
+    assert (
+        "viewer.generating_analysis == self._library_media_generating_analysis"
+        in unchanged
+    ), (
+        "generating_analysis is assigned on the changed path but not compared "
+        "on the unchanged one, so a generation transition never recomposes"
+    )

--- a/Tests/UI/test_library_crit10_export.py
+++ b/Tests/UI/test_library_crit10_export.py
@@ -7,9 +7,9 @@ count, fidelity, estimated size) and a contents list now sit directly above
 the button.
 
 task-32362 -- "Export bundle (.zip)" carried no inline reason ("No
-destination chosen" sat three rows up). It now renders the reason on the
-line below the button, in the ``library-media-action-reason`` grammar
-task-31981 established.
+destination chosen" sat three rows up), and the Reader's "○ Find" had one
+only on hover. Both now render the reason on the line below the control, in
+the ``library-media-action-reason`` grammar task-31981 established.
 
 Widget-render and geometry assertions use a real Textual ``Pilot``
 (``App.run_test()``) against the consolidated widget CSS the real app loads;
@@ -28,7 +28,11 @@ from tldw_chatbook.Library.library_export_state import (
     EXPORT_BUTTON_NO_DESTINATION_TOOLTIP,
     build_library_export_form_state,
 )
+from tldw_chatbook.Library.library_media_viewer_state import (
+    build_library_media_viewer_state,
+)
 from tldw_chatbook.Widgets.Library.library_export_canvas import LibraryExportCanvas
+from tldw_chatbook.Widgets.Library.library_media_viewer import LibraryMediaViewer
 
 
 def _state(**overrides):
@@ -166,3 +170,53 @@ def test_the_inline_reason_and_the_tooltip_cannot_drift():
     ):
         assert state.submit_blocked_reason == export_button_tooltip(state)
     assert _state().submit_blocked_reason == ""
+
+
+# --- task-32362: the Reader's "○ Find" ---------------------------------------
+
+
+class _ReaderHost(ConsolidatedCSSApp):
+    def __init__(self, viewer: LibraryMediaViewer):
+        super().__init__()
+        self._viewer = viewer
+
+    def compose(self):
+        yield self._viewer
+
+
+def _reader(**kwargs) -> LibraryMediaViewer:
+    """A Reader on a real item with content but no analysis yet."""
+    return LibraryMediaViewer(
+        build_library_media_viewer_state(
+            {
+                "id": 1,
+                "title": "Attention Is All You Need",
+                "type": "article",
+                "content": "body text",
+                "analysis_content": "",
+            }
+        ),
+        id="library-media-viewer",
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_blocked_find_carries_its_reason_under_the_toolbar():
+    viewer = _reader(reader_mode="analysis")
+    app = _ReaderHost(viewer)
+    async with app.run_test(size=(235, 52)) as pilot:
+        find = pilot.app.query_one("#library-media-reader-find", Button)
+        reason = pilot.app.query_one("#library-media-reader-find-reason", Static)
+        assert find.disabled
+        assert str(find.label).startswith("○ ")
+        assert str(reason.renderable) == find.tooltip
+        assert reason.region.y >= find.region.y + find.region.height
+
+
+@pytest.mark.asyncio
+async def test_an_available_find_mounts_no_reason_line():
+    app = _ReaderHost(_reader(reader_mode="read"))
+    async with app.run_test(size=(235, 52)) as pilot:
+        assert pilot.app.query_one("#library-media-reader-find", Button).disabled is False
+        assert not pilot.app.query("#library-media-reader-find-reason")

--- a/Tests/UI/test_library_crit10_export.py
+++ b/Tests/UI/test_library_crit10_export.py
@@ -1,0 +1,168 @@
+"""Library critique #10: the Export canvas states its consequence, and every
+blocked control carries its reason on the next line.
+
+task-32353 AC#2 -- the canvas asked for a destination and a name and then
+wrote a bundle nobody had seen the contents of. A consequence line (item
+count, fidelity, estimated size) and a contents list now sit directly above
+the button.
+
+task-32362 -- "Export bundle (.zip)" carried no inline reason ("No
+destination chosen" sat three rows up). It now renders the reason on the
+line below the button, in the ``library-media-action-reason`` grammar
+task-31981 established.
+
+Widget-render and geometry assertions use a real Textual ``Pilot``
+(``App.run_test()``) against the consolidated widget CSS the real app loads;
+the DB read that feeds the consequence line is exercised against a real
+in-memory ``MediaDatabase`` in ``Tests/Library/test_library_export_scope.py``.
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button, Static
+
+from Tests.UI.consolidated_css import ConsolidatedCSSApp
+from tldw_chatbook.Library.library_export_scope import ExportScope
+from tldw_chatbook.Library.library_export_state import (
+    EXPORT_BUTTON_NO_DESTINATION_TOOLTIP,
+    build_library_export_form_state,
+)
+from tldw_chatbook.Widgets.Library.library_export_canvas import LibraryExportCanvas
+
+
+def _state(**overrides):
+    base = dict(
+        scope=ExportScope(kind="media", ids=("1", "2")),
+        counts={"media": 2, "conversations": 0, "notes": 0, "prompts": 0},
+        name="Library export 2026-09-11",
+        description="",
+        media_quality="original",
+        destination="/tmp/out.zip",
+        titles=("Attention Is All You Need", "Deep Residual Learning"),
+        approx_bytes=4096,
+    )
+    base.update(overrides)
+    return build_library_export_form_state(**base)
+
+
+class _ExportHost(ConsolidatedCSSApp):
+    """Minimal host: one export canvas, nothing else."""
+
+    def __init__(self, state):
+        super().__init__()
+        self._state = state
+
+    def compose(self):
+        yield LibraryExportCanvas(self._state, id="library-export-canvas")
+
+
+# --- task-32353 AC#2: the bundle is stated before it is written -------------
+
+
+@pytest.mark.asyncio
+async def test_the_export_canvas_says_what_the_bundle_will_contain():
+    app = _ExportHost(_state())
+    async with app.run_test(size=(235, 52)) as pilot:
+        line = pilot.app.query_one("#library-export-consequence-line", Static)
+        assert (
+            str(line.renderable) == "Bundle: 2 media items · full files · about 4 KB"
+        ), str(line.renderable)
+        assert line.display is True
+        contents = pilot.app.query_one("#library-export-contents", Static)
+        assert "Attention Is All You Need" in str(contents.renderable)
+        assert "Deep Residual Learning" in str(contents.renderable)
+        assert contents.display is True
+
+
+@pytest.mark.asyncio
+async def test_the_consequence_line_names_the_chosen_fidelity():
+    """The fidelity is the knob's consequence, not its label -- a lossy
+    bundle says so where the user is about to press."""
+    app = _ExportHost(_state(media_quality="thumbnail"))
+    async with app.run_test(size=(235, 52)) as pilot:
+        line = pilot.app.query_one("#library-export-consequence-line", Static)
+        assert "previews only" in str(line.renderable)
+
+
+def test_an_unsizeable_scope_says_so_instead_of_guessing():
+    """task-32353 AC#2: ``None`` bytes is honest copy, never a zero."""
+    state = _state(
+        scope=ExportScope(kind="everything"),
+        counts={"media": 11, "conversations": 6, "notes": 7, "prompts": 5},
+        titles=(),
+        approx_bytes=None,
+    )
+    assert state.consequence_line == (
+        "Bundle: 29 items · full files · size known once it runs"
+    )
+    assert state.contents_lines == ()
+
+
+def test_a_long_contents_list_is_capped_and_says_how_many_it_hid():
+    state = _state(titles=tuple(f"Item {n}" for n in range(25)))
+    assert len(state.contents_lines) == 21
+    assert state.contents_lines[-1] == "+ 5 more"
+
+
+def test_the_consequence_line_is_empty_until_the_counts_land():
+    state = _state(counts=None)
+    assert state.counts_loading is True
+    assert state.consequence_line == ""
+
+
+@pytest.mark.asyncio
+async def test_both_lines_stay_mounted_while_counting_so_the_patcher_finds_them():
+    """The counts-landing patcher updates in place, never by recompose --
+    so both lines must already exist, display-toggled off."""
+    app = _ExportHost(_state(counts=None))
+    async with app.run_test(size=(235, 52)) as pilot:
+        assert (
+            pilot.app.query_one("#library-export-consequence-line", Static).display
+            is False
+        )
+        assert pilot.app.query_one("#library-export-contents", Static).display is False
+
+
+# --- task-32362: a blocked control's reason sits beside it ------------------
+
+
+@pytest.mark.asyncio
+async def test_the_blocked_export_button_carries_its_reason_on_the_next_line():
+    app = _ExportHost(_state(destination=""))
+    async with app.run_test(size=(235, 52)) as pilot:
+        button = pilot.app.query_one("#library-export-submit", Button)
+        reason = pilot.app.query_one("#library-export-submit-reason", Static)
+        assert button.disabled
+        assert str(button.label).startswith("○ ")
+        # One source, not a second sentence: the inline line IS the tooltip.
+        assert str(reason.renderable) == button.tooltip
+        assert str(reason.renderable) == EXPORT_BUTTON_NO_DESTINATION_TOOLTIP
+        assert reason.display is True
+        assert reason.region.y == button.region.y + button.region.height
+
+
+@pytest.mark.asyncio
+async def test_a_ready_export_button_shows_no_reason_line():
+    app = _ExportHost(_state())
+    async with app.run_test(size=(235, 52)) as pilot:
+        button = pilot.app.query_one("#library-export-submit", Button)
+        assert button.disabled is False
+        assert (
+            pilot.app.query_one("#library-export-submit-reason", Static).display
+            is False
+        )
+
+
+def test_the_inline_reason_and_the_tooltip_cannot_drift():
+    """Every blocked predicate the tooltip knows, the inline line knows."""
+    from tldw_chatbook.Library.library_export_state import export_button_tooltip
+
+    for state in (
+        _state(destination=""),
+        _state(counts={"media": 0, "conversations": 0, "notes": 0, "prompts": 0}),
+        _state(counts=None),
+        _state(running=True),
+    ):
+        assert state.submit_blocked_reason == export_button_tooltip(state)
+    assert _state().submit_blocked_reason == ""

--- a/Tests/UI/test_library_crit10_export.py
+++ b/Tests/UI/test_library_crit10_export.py
@@ -104,9 +104,26 @@ def test_an_unsizeable_scope_says_so_instead_of_guessing():
 
 
 def test_a_long_contents_list_is_capped_and_says_how_many_it_hid():
-    state = _state(titles=tuple(f"Item {n}" for n in range(25)))
+    """The query fetches 21 titles at most, so the remainder is derived from
+    the counts -- the only place the true total lives (review Low 3)."""
+    state = _state(
+        scope=ExportScope(kind="media"),
+        counts={"media": 250, "conversations": 0, "notes": 0, "prompts": 0},
+        titles=tuple(f"Item {n}" for n in range(21)),
+    )
     assert len(state.contents_lines) == 21
-    assert state.contents_lines[-1] == "+ 5 more"
+    assert state.contents_lines[:20] == tuple(f"Item {n}" for n in range(20))
+    assert state.contents_lines[-1] == "+ 230 more"
+
+
+def test_a_contents_list_that_exactly_fills_the_cap_hides_nothing():
+    state = _state(
+        scope=ExportScope(kind="media"),
+        counts={"media": 20, "conversations": 0, "notes": 0, "prompts": 0},
+        titles=tuple(f"Item {n}" for n in range(20)),
+    )
+    assert len(state.contents_lines) == 20
+    assert not any(line.startswith("+ ") for line in state.contents_lines)
 
 
 def test_the_consequence_line_is_empty_until_the_counts_land():
@@ -211,6 +228,15 @@ async def test_the_blocked_find_carries_its_reason_under_the_toolbar():
         assert find.disabled
         assert str(find.label).startswith("○ ")
         assert str(reason.renderable) == find.tooltip
+        # The reason is the toolbar's immediate next sibling and paints
+        # below the button. Asserted as DOM adjacency rather than an exact
+        # row delta (the Export twin's shape): this host mounts the viewer
+        # without its usual container, so the ds-toolbar Horizontal takes
+        # more rows here than in the app. Live at 235x52 the reason renders
+        # on the row directly under the toolbar -- capture 04.
+        toolbar = pilot.app.query_one("#library-media-reader-primary-toolbar")
+        siblings = list(toolbar.parent.children)
+        assert siblings[siblings.index(toolbar) + 1] is reason
         assert reason.region.y >= find.region.y + find.region.height
 
 

--- a/Tests/UI/test_library_crit10_export.py
+++ b/Tests/UI/test_library_crit10_export.py
@@ -70,7 +70,7 @@ async def test_the_export_canvas_says_what_the_bundle_will_contain():
     async with app.run_test(size=(235, 52)) as pilot:
         line = pilot.app.query_one("#library-export-consequence-line", Static)
         assert (
-            str(line.renderable) == "Bundle: 2 media items · full files · about 4 KB"
+            str(line.renderable) == "Bundle: 2 media items · full files · about 4 KB before compression"
         ), str(line.renderable)
         assert line.display is True
         contents = pilot.app.query_one("#library-export-contents", Static)

--- a/Tests/UI/test_library_export_receipt.py
+++ b/Tests/UI/test_library_export_receipt.py
@@ -240,6 +240,7 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
                 last_bytes=None,
             ),
             query_one=pilot.app.query_one,
+            query=pilot.app.query,
         )
         fake._library_entry_route_key = lambda: (LIBRARY_ROW_INGEST_EXPORT,)
         fake._library_entry_reconcile_is_current = lambda *_args: True
@@ -325,6 +326,7 @@ async def test_update_library_export_canvas_after_run_patches_receipt_and_toolti
                 last_bytes=3072,
             ),
             query_one=pilot.app.query_one,
+            query=pilot.app.query,
         )
         fake._library_structural_waits = {}
         fake._library_export_status_line = (

--- a/Tests/UI/test_library_export_receipt.py
+++ b/Tests/UI/test_library_export_receipt.py
@@ -30,7 +30,7 @@ from textual.app import App
 from Tests.UI.consolidated_css import ConsolidatedCSSApp
 from textual.widgets import Button, Static
 
-from tldw_chatbook.Library.library_export_scope import ExportScope
+from tldw_chatbook.Library.library_export_scope import ExportPreview, ExportScope
 from tldw_chatbook.Library.library_export_state import (
     EXPORT_BUTTON_COUNTING_TOOLTIP,
     EXPORT_RETRY_BUTTON_COPY,
@@ -217,6 +217,8 @@ async def test_apply_library_export_counts_patches_tooltip_alongside_disabled():
             # fake-self" retarget precedent).
             _export_state=SimpleNamespace(
                 scope=scope,
+                # task-32353: the counts worker's sibling preview read.
+                preview=ExportPreview(),
                 counts=None,
                 counts_request_id=1,
                 form={
@@ -298,6 +300,8 @@ async def test_update_library_export_canvas_after_run_patches_receipt_and_toolti
             # `_library_export_<field>` shim is gone.
             _export_state=SimpleNamespace(
                 scope=scope,
+                # task-32353: the counts worker's sibling preview read.
+                preview=ExportPreview(),
                 counts={"media": 1, "conversations": 0, "notes": 0},
                 form={
                     "name": "x",

--- a/backlog/tasks/task-32353 - Library-Export-the-default-quality-thumbnail-silently-ships-previews-and-the-bundle-is-never-listed-before-writing.md
+++ b/backlog/tasks/task-32353 - Library-Export-the-default-quality-thumbnail-silently-ships-previews-and-the-bundle-is-never-listed-before-writing.md
@@ -3,9 +3,10 @@ id: TASK-32353
 title: >-
   Library Export: the default 'quality: thumbnail' silently ships previews, and
   the bundle is never listed before writing
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:16'
+updated_date: '2026-09-11 07:49'
 labels:
   - library
   - export
@@ -22,7 +23,33 @@ The export canvas defaults to 'quality: thumbnail — keeps a small preview imag
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Export defaults to full fidelity
-- [ ] #2 The canvas shows what the bundle will contain (item count, fidelity, estimated size) before the button is pressed
-- [ ] #3 Pinned
+- [x] #1 Export defaults to full fidelity
+- [x] #2 The canvas shows what the bundle will contain (item count, fidelity, estimated size) before the button is pressed
+- [x] #3 Pinned
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Flip DEFAULT_MEDIA_QUALITY to 'original'; update the two default pins.
+2. Extend the export counts worker with a media title + byte preview query (parameterised, same connection, never raises).
+3. Add consequence_line + contents_lines to LibraryExportFormState and its builder; reuse _count_phrase and lift format_last_export_line's KB rounding into one shared formatter.
+4. Yield both lines in library_export_canvas.compose, display-toggled, above the submit button.
+5. Docs + live verify.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+DEFAULT_MEDIA_QUALITY is now "original": the form opens at full fidelity, so a bundle only loses content when asked. The two pins asserting the old default were updated (Tests/Library/test_library_export_state.py, Tests/UI/test_library_choice_strips.py, whose direct-pick half now targets "thumbnail" so it still exercises a real change). Chatbooks' own defaults (chatbook_models.py:546, chatbook_creator.py:268) were checked and deliberately left alone -- different surface, own callers, and ChatbookCreationWizard.py:944 passes an explicit value.
+
+AC#2: preview_export_scope() (library_export_scope.py) reads the in-scope media items' titles and their stored content's UTF-8 byte total -- one parameterised query on the same connection, run on the counts worker beside count_export_scope, and it never raises out of that worker (a missing seam, a missing table or a too-large selection all degrade to the empty preview). It lands through _apply_library_export_counts under the same staleness guards as the counts, into a new LibraryExportState.preview field that resets with them. build_library_export_form_state gained consequence_line + contents_lines; the canvas yields both display-toggled above the submit button, and the counts-landing patcher owns them (recompose discipline).
+
+Deviation from the plan's pinned string, with evidence: live on the seeded profile a selection estimated at "about 9 KB" wrote a 3,606-byte archive whose receipt read "4 KB". The estimate now says "about N KB before compression" -- it counts content going in, the receipt stats the zip coming out, and without the qualifier the two read as a contradiction.
+
+Formatters: format_export_bytes() lifts format_last_export_line's own KB rounding into one function both call, so the estimate and the receipt can never round differently; the count phrase reuses _count_phrase from library_export_scope.
+
+Files: tldw_chatbook/Library/library_export_scope.py, library_export_state.py; tldw_chatbook/UI/Library_Modules/library_export_state.py, library_export_controller.py; tldw_chatbook/UI/Screens/library_screen.py (counts worker + apply + builder); tldw_chatbook/Widgets/Library/library_export_canvas.py; Tests/UI/test_library_crit10_export.py (new), Tests/Library/test_library_export_scope.py, test_library_export_state.py, test_library_export_execution.py, Tests/UI/test_library_choice_strips.py, test_library_export_receipt.py; Docs/User_Guide/library/import-and-export.md.
+
+Known limitation (honest, not silent): an "everything" scope spans four sources and only media is sizeable up front, so it renders "size known once it runs" and no contents list. The media-only scopes -- selection or whole-source, with or without a type filter -- get both.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32362 - Library-two-disabled-controls-without-an-adjacent-reason-Export-bundle-○-Find-on-the-Analysis-tab.md
+++ b/backlog/tasks/task-32362 - Library-two-disabled-controls-without-an-adjacent-reason-Export-bundle-○-Find-on-the-Analysis-tab.md
@@ -3,9 +3,10 @@ id: TASK-32362
 title: >-
   Library: two disabled controls without an adjacent reason (Export bundle; '○
   Find' on the Analysis tab)
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:19'
+updated_date: '2026-09-11 07:49'
 labels:
   - library
   - copy
@@ -22,5 +23,28 @@ priority: low
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Every disabled control on the Export canvas and in the Media viewer carries its reason on the same line
+- [x] #1 Every disabled control on the Export canvas and in the Media viewer carries its reason on the same line
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Expose submit_blocked_reason on the export state from the same source export_button_tooltip uses.
+2. Yield an inline reason Static under the Export submit button (library-media-action-reason class).
+3. Yield the Find reason inline under the Reader primary toolbar, matching the task-31981 Analysis precedent.
+4. Docs + live verify.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Both blocked controls now print their reason on the line below them, in the library-media-action-reason grammar task-31981 established for the Reader's blocked Generate.
+
+Export button: LibraryExportFormState gained a submit_blocked_reason property that returns export_button_tooltip(self) when the gate is closed and "" when it is open -- one source, so the inline line and the tooltip are literally the same string and cannot drift. apply_library_export_submit_gate (the single helper the compose path and both in-place patchers already shared for disabled/label/tooltip) now flips the Static too, so counts landing cannot leave a stale reason. A test parametrises all four blocked predicates against export_button_tooltip, and a Pilot test asserts the line sits at button.region.y + height.
+
+Reader "○ Find": _compose_primary_toolbar yields the Static AFTER the ds-toolbar Horizontal closes, not inside it -- mixing a Static in with that toolbar's Buttons is this canvas's documented non-rendering failure mode, and the Generate precedent in the same file yields outside for the same reason. The string still comes from analysis_find_unavailable_reason, so it tracks whatever that function returns.
+
+Live (tmux 235x52, seeded profile): Analysis tab with no analysis renders "○ Find" over "No analysis to search yet.", directly above the existing "○ Generate" / "No analysis provider is configured · ..." pair. Confirmed at the same time that the Info tab's Find is still ENABLED today (analysis_find_unavailable_reason returns "" for mode != "analysis"); Task 1 owns that function, and once it lands the Info case renders through this same branch with no further change here.
+
+Files: tldw_chatbook/Library/library_export_state.py, tldw_chatbook/Widgets/Library/library_export_canvas.py, tldw_chatbook/Widgets/Library/library_media_viewer.py (_compose_primary_toolbar only -- _compose_active_body untouched, it belongs to Task 1); Tests/UI/test_library_crit10_export.py; Docs/User_Guide/library/import-and-export.md, Docs/User_Guide/library/media-and-conversations.md.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_export_scope.py
+++ b/tldw_chatbook/Library/library_export_scope.py
@@ -19,7 +19,7 @@ handles are passed in by the caller and never constructed here.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Mapping, Protocol
+from typing import Any, Mapping, NamedTuple, Protocol
 
 from tldw_chatbook.Chatbooks.chatbook_models import ContentType
 from tldw_chatbook.Library.library_media_state import library_media_int_backing_id
@@ -161,6 +161,87 @@ def count_export_scope(
     if prompts_db is not None and scope.kind in ("everything", "prompts"):
         counts["prompts"] = len(prompts_db.get_all_active_prompt_ids())
     return counts
+
+
+class MediaContentSource(Protocol):
+    """The read seam ``preview_export_scope`` needs off ``MediaDatabase``."""
+
+    def execute_query(self, query: str, params: tuple = ...) -> Any: ...
+
+
+class ExportPreview(NamedTuple):
+    """What the bundle will hold, as far as one pre-write query can say.
+
+    task-32353 AC#2: the export canvas asked for a destination and a name
+    and then wrote a bundle nobody had seen the contents of. This is the
+    "before you press it" half -- read on the counts worker, beside the
+    counts, never on the UI thread.
+
+    Attributes:
+        titles: The in-scope media items' titles, in export (id) order.
+        approx_bytes: Those items' stored content in bytes, or ``None``
+            when the scope's media set is not enumerable up front (an
+            ``everything`` export spans four sources, only one of which
+            this query can size) or the query failed. ``None`` is what
+            drives the canvas's honest "size known once it runs" copy --
+            never a zero standing in for "unknown".
+    """
+
+    titles: tuple[str, ...] = ()
+    approx_bytes: int | None = None
+
+
+def preview_export_scope(
+    scope: ExportScope, media_db: MediaContentSource | None
+) -> ExportPreview:
+    """Read the in-scope media items' titles and total stored size.
+
+    Only a ``kind="media"`` scope has an enumerable, sizeable item set --
+    every other kind returns the empty preview so the canvas says "size
+    known once it runs" rather than guessing. ``ChatbookCreator.
+    _collect_media`` writes each item's ``content`` column into the zip
+    (plus a small metadata JSON), so that column's byte length is the
+    honest estimate for what lands on disk.
+
+    Never raises: a missing seam, a missing table, or a selection too
+    large for SQLite's bound-parameter limit all degrade to the empty
+    preview, exactly like ``_compute_library_export_counts``'s
+    quiet-degrade contract for the sibling counts query.
+
+    Args:
+        scope: What this export will include.
+        media_db: The media database read seam, or ``None``.
+
+    Returns:
+        The titles + byte total, or ``ExportPreview()`` when unavailable.
+    """
+    if scope.kind != "media" or media_db is None:
+        return ExportPreview()
+    where = ["deleted = 0", "is_trash = 0"]
+    params: list[Any] = []
+    if scope.ids:
+        selected = [_media_selection_id(value) for value in scope.ids]
+        where.append(f"id IN ({','.join('?' * len(selected))})")
+        params.extend(selected)
+    else:
+        media_type = _effective_media_type(scope)
+        if media_type is not None:
+            where.append("type = ?")
+            params.append(media_type)
+    # LENGTH(CAST(... AS BLOB)) is the UTF-8 BYTE count; a bare LENGTH()
+    # on TEXT counts characters and under-reports any non-ASCII library.
+    query = (
+        "SELECT title, LENGTH(CAST(content AS BLOB)) AS size FROM Media "
+        f"WHERE {' AND '.join(where)} ORDER BY id ASC"
+    )
+    try:
+        rows = media_db.execute_query(query, tuple(params)).fetchall()
+    except Exception:
+        return ExportPreview()
+    return ExportPreview(
+        tuple(str(row["title"] or "Untitled") for row in rows),
+        sum(int(row["size"] or 0) for row in rows),
+    )
 
 
 def resolve_export_selections(

--- a/tldw_chatbook/Library/library_export_scope.py
+++ b/tldw_chatbook/Library/library_export_scope.py
@@ -163,6 +163,12 @@ def count_export_scope(
     return counts
 
 
+# How many titles the export canvas lists before it summarises the rest.
+# Owned here, beside the query that applies it as a LIMIT, and imported by
+# ``library_export_state`` -- one number, not two that can drift.
+_CONTENTS_PREVIEW_LIMIT = 20
+
+
 class MediaContentSource(Protocol):
     """The read seam ``preview_export_scope`` needs off ``MediaDatabase``."""
 
@@ -198,22 +204,44 @@ def preview_export_scope(
 
     Only a ``kind="media"`` scope has an enumerable, sizeable item set --
     every other kind returns the empty preview so the canvas says "size
-    known once it runs" rather than guessing. ``ChatbookCreator.
-    _collect_media`` writes each item's ``content`` column into the zip
-    (plus a small metadata JSON), so that column's byte length is the
-    honest estimate for what lands on disk.
+    known once it runs" rather than guessing.
 
-    Never raises: a missing seam, a missing table, or a selection too
-    large for SQLite's bound-parameter limit all degrade to the empty
-    preview, exactly like ``_compute_library_export_counts``'s
-    quiet-degrade contract for the sibling counts query.
+    What the byte total means: ``ChatbookCreator._collect_media`` writes
+    each item's ``content`` column TWICE before compression -- once as
+    ``media_<id>.txt`` and again inside a metadata JSON that embeds the
+    same column under a ``"content"`` key, alongside summary/prompt/
+    provenance. This counts that column ONCE, so it is a deliberate lower
+    bound on the pre-compression payload, not the pre-compression total.
+    That is why the canvas says "about". Do not "correct" it against the
+    doubled figure: the archive is then zipped, and the user's own
+    reference point is how much of their library is going in.
+
+    Two statements, not one: the ``SUM`` has to visit every matching row,
+    but the canvas renders at most ``_CONTENTS_PREVIEW_LIMIT`` titles, so
+    the title query is capped rather than materialising one string per
+    item in a whole-source scope. The caller derives "+ N more" from the
+    counts it already has.
+
+    Raises rather than degrading: the quiet-degrade AND its log line live
+    in ``LibraryExportController._compute_library_export_preview``,
+    exactly where ``count_export_scope``'s live
+    (``_compute_library_export_counts``). A silent ``except`` here would
+    make the one path in this feature that can fail in production fail
+    invisibly -- a canvas stuck on "size known once it runs" with no
+    trace in the log.
 
     Args:
         scope: What this export will include.
         media_db: The media database read seam, or ``None``.
 
     Returns:
-        The titles + byte total, or ``ExportPreview()`` when unavailable.
+        The byte total plus at most ``_CONTENTS_PREVIEW_LIMIT + 1``
+        titles, or ``ExportPreview()`` when the scope is not sizeable.
+
+    Raises:
+        Exception: Whatever the media seam raises -- a missing table, a
+            selection past SQLite's bound-parameter limit, a changed
+            seam. The controller wrapper logs and degrades.
     """
     if scope.kind != "media" or media_db is None:
         return ExportPreview()
@@ -228,19 +256,23 @@ def preview_export_scope(
         if media_type is not None:
             where.append("type = ?")
             params.append(media_type)
+    clause = " AND ".join(where)
     # LENGTH(CAST(... AS BLOB)) is the UTF-8 BYTE count; a bare LENGTH()
     # on TEXT counts characters and under-reports any non-ASCII library.
-    query = (
-        "SELECT title, LENGTH(CAST(content AS BLOB)) AS size FROM Media "
-        f"WHERE {' AND '.join(where)} ORDER BY id ASC"
-    )
-    try:
-        rows = media_db.execute_query(query, tuple(params)).fetchall()
-    except Exception:
-        return ExportPreview()
+    total = media_db.execute_query(
+        "SELECT COALESCE(SUM(LENGTH(CAST(content AS BLOB))), 0) AS size "
+        f"FROM Media WHERE {clause}",
+        tuple(params),
+    ).fetchone()
+    # One row past the render limit is all the caller needs to know the
+    # list was truncated; the true remainder comes from the counts.
+    titles = media_db.execute_query(
+        f"SELECT title FROM Media WHERE {clause} ORDER BY id ASC LIMIT ?",
+        (*params, _CONTENTS_PREVIEW_LIMIT + 1),
+    ).fetchall()
     return ExportPreview(
-        tuple(str(row["title"] or "Untitled") for row in rows),
-        sum(int(row["size"] or 0) for row in rows),
+        tuple(str(row["title"] or "Untitled") for row in titles),
+        int(total["size"] or 0) if total is not None else 0,
     )
 
 

--- a/tldw_chatbook/Library/library_export_scope.py
+++ b/tldw_chatbook/Library/library_export_scope.py
@@ -18,6 +18,7 @@ handles are passed in by the caller and never constructed here.
 
 from __future__ import annotations
 
+from contextlib import closing
 from dataclasses import dataclass
 from typing import Any, Mapping, NamedTuple, Protocol
 
@@ -172,7 +173,24 @@ _CONTENTS_PREVIEW_LIMIT = 20
 class MediaContentSource(Protocol):
     """The read seam ``preview_export_scope`` needs off ``MediaDatabase``."""
 
-    def execute_query(self, query: str, params: tuple = ...) -> Any: ...
+    def execute_query(self, query: str, params: tuple = ...) -> Any:
+        """Execute one parameterised read and return its cursor.
+
+        Args:
+            query: A single SQL statement with ``?`` placeholders.
+            params: The values to bind, positionally.
+
+        Returns:
+            The ``sqlite3.Cursor`` the statement produced. The caller owns
+            it and must close it (``preview_export_scope`` does, via
+            ``contextlib.closing``).
+
+        Raises:
+            Exception: Whatever the implementation raises for a bad
+                statement, a missing table, or a closed connection --
+                ``MediaDatabase`` raises its own ``DatabaseError``.
+        """
+        ...
 
 
 class ExportPreview(NamedTuple):
@@ -188,13 +206,22 @@ class ExportPreview(NamedTuple):
         approx_bytes: Those items' stored content in bytes, or ``None``
             when the scope's media set is not enumerable up front (an
             ``everything`` export spans four sources, only one of which
-            this query can size) or the query failed. ``None`` is what
-            drives the canvas's honest "size known once it runs" copy --
-            never a zero standing in for "unknown".
+            this query can size). ``None`` is what drives the canvas's
+            honest "size known once it runs" copy -- never a zero
+            standing in for "unknown", and a real zero (an empty scope)
+            is reported as ``0``.
+        item_count: How many ACTIVE rows the scope resolved to, or
+            ``None`` when it was not enumerable. Not the same number as
+            ``count_export_scope``'s: that one trusts ``len(scope.ids)``
+            for an explicit selection, while this one applies the
+            deleted/trashed filter the collector will apply, so a
+            selection whose item was trashed underneath counts here as
+            what the archive will actually hold.
     """
 
     titles: tuple[str, ...] = ()
     approx_bytes: int | None = None
+    item_count: int | None = None
 
 
 def preview_export_scope(
@@ -216,11 +243,14 @@ def preview_export_scope(
     doubled figure: the archive is then zipped, and the user's own
     reference point is how much of their library is going in.
 
-    Two statements, not one: the ``SUM`` has to visit every matching row,
-    but the canvas renders at most ``_CONTENTS_PREVIEW_LIMIT`` titles, so
-    the title query is capped rather than materialising one string per
-    item in a whole-source scope. The caller derives "+ N more" from the
-    counts it already has.
+    One statement, not three: ``COUNT(*) OVER ()`` and ``SUM(...) OVER
+    ()`` are evaluated over every row the ``WHERE`` matched, BEFORE the
+    ``LIMIT`` trims the rows returned -- so a single cursor yields the
+    true count, the true byte total, and just the handful of titles the
+    canvas renders. That also means the three facts come from one
+    snapshot (a concurrent write cannot land between them) and there is
+    one cursor to close, deterministically, rather than two left to the
+    garbage collector (Qodo #2/#3 on PR #2601).
 
     Raises rather than degrading: the quiet-degrade AND its log line live
     in ``LibraryExportController._compute_library_export_preview``,
@@ -235,8 +265,9 @@ def preview_export_scope(
         media_db: The media database read seam, or ``None``.
 
     Returns:
-        The byte total plus at most ``_CONTENTS_PREVIEW_LIMIT + 1``
-        titles, or ``ExportPreview()`` when the scope is not sizeable.
+        The active-row count and byte total plus at most
+        ``_CONTENTS_PREVIEW_LIMIT + 1`` titles, or ``ExportPreview()``
+        when the scope is not sizeable.
 
     Raises:
         Exception: Whatever the media seam raises -- a missing table, a
@@ -256,23 +287,33 @@ def preview_export_scope(
         if media_type is not None:
             where.append("type = ?")
             params.append(media_type)
-    clause = " AND ".join(where)
     # LENGTH(CAST(... AS BLOB)) is the UTF-8 BYTE count; a bare LENGTH()
     # on TEXT counts characters and under-reports any non-ASCII library.
-    total = media_db.execute_query(
-        "SELECT COALESCE(SUM(LENGTH(CAST(content AS BLOB))), 0) AS size "
-        f"FROM Media WHERE {clause}",
-        tuple(params),
-    ).fetchone()
     # One row past the render limit is all the caller needs to know the
-    # list was truncated; the true remainder comes from the counts.
-    titles = media_db.execute_query(
-        f"SELECT title FROM Media WHERE {clause} ORDER BY id ASC LIMIT ?",
-        (*params, _CONTENTS_PREVIEW_LIMIT + 1),
-    ).fetchall()
+    # list was truncated; the true remainder comes from ``item_count``.
+    query = (
+        # No COALESCE around the SUM: SQLite rejects it in window
+        # position. SUM skips NULL content (it contributes no bytes), and
+        # an all-NULL scope yields NULL, which the `or 0` below floors.
+        "SELECT title, COUNT(*) OVER () AS items, "
+        "SUM(LENGTH(CAST(content AS BLOB))) OVER () AS size "
+        f"FROM Media WHERE {' AND '.join(where)} "
+        "ORDER BY id ASC LIMIT ?"
+    )
+    with closing(
+        media_db.execute_query(
+            query, (*params, _CONTENTS_PREVIEW_LIMIT + 1)
+        )
+    ) as cursor:
+        rows = cursor.fetchall()
+    if not rows:
+        # An empty scope is a KNOWN zero, not an unknown -- the canvas
+        # renders the two differently.
+        return ExportPreview((), 0, 0)
     return ExportPreview(
-        tuple(str(row["title"] or "Untitled") for row in titles),
-        int(total["size"] or 0) if total is not None else 0,
+        tuple(str(row["title"] or "Untitled") for row in rows),
+        int(rows[0]["size"] or 0),
+        int(rows[0]["items"] or 0),
     )
 
 

--- a/tldw_chatbook/Library/library_export_state.py
+++ b/tldw_chatbook/Library/library_export_state.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Mapping
 
 from tldw_chatbook.Library.library_export_scope import (
+    _CONTENTS_PREVIEW_LIMIT,
     ExportScope,
     _count_phrase,
     export_scope_label,
@@ -89,9 +90,6 @@ _MEDIA_QUALITY_BUNDLE_COPY: dict[str, str] = {
     "original": "full files",
 }
 
-# How many titles the contents disclosure lists before it summarises the rest.
-_CONTENTS_PREVIEW_LIMIT = 20
-
 
 def format_export_bytes(size_bytes: int) -> str:
     """Return a byte count in the Export canvas's own "N KB" spelling.
@@ -108,6 +106,13 @@ def format_export_bytes(size_bytes: int) -> str:
         e.g. ``"4 KB"`` -- never "0 KB" for a non-empty bundle (anything
         under 1 KB rounds up to 1).
     """
+    # ponytail: KB only, inherited from the receipt's own rounding -- a
+    # multi-GB media library's ESTIMATE reads "about 1048576 KB before
+    # compression" (the receipt never saw numbers that large). Switch both
+    # halves to a unit-stepping formatter (``library_ingest_state.
+    # _human_size`` already steps) and re-pin the critique-9 receipt string
+    # in the SAME change; splitting them would let estimate and receipt
+    # round differently, which is the drift this function exists to prevent.
     return f"{max(1, round(size_bytes / 1024))} KB"
 
 
@@ -341,12 +346,19 @@ def build_library_export_form_state(
         else f"Bundle: {_count_phrase(total, noun)}{fidelity}{size}"
     )
     # The preview lands with the counts, so neither line renders before them.
-    extra = len(titles) - _CONTENTS_PREVIEW_LIMIT
+    # ``titles`` is capped at the limit + 1 by the query, so its length only
+    # says WHETHER the list was truncated -- the remainder comes from the
+    # counts, which is the only place the true total lives.
+    extra = total - _CONTENTS_PREVIEW_LIMIT
     contents_lines = (
         ()
         if counts_loading
         else tuple(titles[:_CONTENTS_PREVIEW_LIMIT])
-        + ((f"+ {extra} more",) if extra > 0 else ())
+        + (
+            (f"+ {extra} more",)
+            if len(titles) > _CONTENTS_PREVIEW_LIMIT and extra > 0
+            else ()
+        )
     )
     return LibraryExportFormState(
         scope=scope,

--- a/tldw_chatbook/Library/library_export_state.py
+++ b/tldw_chatbook/Library/library_export_state.py
@@ -79,16 +79,22 @@ _MEDIA_QUALITY_HELPER_COPY: dict[str, str] = {
 }
 
 
-# task-32353 AC#2: the consequence line's fidelity phrase -- the same three
-# options ``_MEDIA_QUALITY_HELPER_COPY`` captions, said in the two words the
-# bundle summary has room for. Unknown values degrade to "full files" for the
-# same reason the helper copy degrades to "original": it is the conservative
-# (most-content) description.
-_MEDIA_QUALITY_BUNDLE_COPY: dict[str, str] = {
-    "thumbnail": "previews only",
-    "compressed": "compressed files",
-    "original": "full files",
-}
+# task-32353 AC#2, corrected by Qodo #1 on PR #2601: this phrase used to name
+# the quality chooser's value ("previews only" / "compressed files" / "full
+# files"). It cannot. ``ChatbookCreator._collect_media`` reads ``quality``
+# exactly ONCE -- to stamp it into the manifest -- and otherwise writes the
+# same payload for every option: each item's stored ``content`` as a .txt plus
+# a metadata JSON. The original media file is never in the archive at all (the
+# Media table holds no file path; see that method's own comment). So the line
+# states what the archive actually holds, and says it the same way whichever
+# option is selected -- a bundle summary must not describe an artifact the
+# writer never produces.
+# ponytail: quality-invariant because the knob is inert downstream. If
+# ``_collect_media`` ever implements thumbnail/compressed for real, this goes
+# back to varying by option -- and the chooser's own helper captions
+# (``_MEDIA_QUALITY_HELPER_COPY`` above), which describe the same absent
+# behaviour, must be corrected in the SAME change.
+_BUNDLE_PAYLOAD_COPY = "text only"
 
 
 def format_export_bytes(size_bytes: int) -> str:
@@ -270,6 +276,7 @@ def build_library_export_form_state(
     quality_choices_visible: bool = False,
     titles: tuple[str, ...] = (),
     approx_bytes: int | None = None,
+    item_count: int | None = None,
 ) -> LibraryExportFormState:
     """Build the export canvas's full display state.
 
@@ -299,6 +306,11 @@ def build_library_export_form_state(
         approx_bytes: Their total stored size in bytes
             (``ExportPreview.approx_bytes``), or ``None`` when unknown --
             ``None`` is rendered as honest copy, never as a zero.
+        item_count: How many ACTIVE rows the preview resolved
+            (``ExportPreview.item_count``), or ``None`` where no preview
+            ran. Where present it, not ``counts``, is the bundle's count:
+            ``count_export_scope`` trusts an explicit selection's length
+            without re-checking the rows still exist.
 
     Returns:
         The canvas's full display state.
@@ -324,11 +336,7 @@ def build_library_export_form_state(
     # a name and then wrote a bundle nobody had seen the contents of, at a
     # fidelity chosen by a control rendered at the same weight as "sort".
     # This states the consequence in one line, above the button.
-    fidelity = (
-        f" · {_MEDIA_QUALITY_BUNDLE_COPY.get(media_quality, 'full files')}"
-        if show_media_fields
-        else ""
-    )
+    payload = f" · {_BUNDLE_PAYLOAD_COPY}" if show_media_fields else ""
     # "before compression" is load-bearing, not padding: this counts the
     # content going IN, while the receipt after the run stats the zip that
     # came OUT (live check: a 9 KB estimate wrote a 4 KB archive). Without
@@ -340,16 +348,27 @@ def build_library_export_form_state(
     )
     # A media-only scope counts media items; a mixed scope counts items.
     noun = "media item" if scope.kind == "media" else "item"
+    # Qodo #7: ``count_export_scope`` trusts ``len(scope.ids)`` for an
+    # explicit selection without checking those rows are still active, so a
+    # selection whose item was trashed underneath promised more than the
+    # archive would hold. The preview applies the collector's own
+    # deleted/trashed filter, so where it ran, IT is the bundle's count.
+    bundle_total = total if item_count is None else item_count
     consequence_line = (
         ""
-        if counts_loading
-        else f"Bundle: {_count_phrase(total, noun)}{fidelity}{size}"
+        # Qodo #6: an empty scope has no bundle to describe, and
+        # ``format_export_bytes`` floors at 1 KB -- "Bundle: 0 media items
+        # ... about 1 KB" used to sit directly above "Nothing to export in
+        # this scope." ``empty_scope_line`` is the only line that case needs.
+        if counts_loading or bundle_total <= 0
+        else f"Bundle: {_count_phrase(bundle_total, noun)}{payload}{size}"
     )
     # The preview lands with the counts, so neither line renders before them.
     # ``titles`` is capped at the limit + 1 by the query, so its length only
     # says WHETHER the list was truncated -- the remainder comes from the
-    # counts, which is the only place the true total lives.
-    extra = total - _CONTENTS_PREVIEW_LIMIT
+    # preview's own active-row count (Qodo #7), falling back to the counts
+    # where no preview ran.
+    extra = bundle_total - _CONTENTS_PREVIEW_LIMIT
     contents_lines = (
         ()
         if counts_loading

--- a/tldw_chatbook/Library/library_export_state.py
+++ b/tldw_chatbook/Library/library_export_state.py
@@ -23,7 +23,11 @@ from datetime import date
 from pathlib import Path
 from typing import Mapping
 
-from tldw_chatbook.Library.library_export_scope import ExportScope, export_scope_label
+from tldw_chatbook.Library.library_export_scope import (
+    ExportScope,
+    _count_phrase,
+    export_scope_label,
+)
 
 # Exact copy values. The F4 plan's Global Constraints originally pinned
 # EXPORT_HEADER_COPY/EXPORT_BUTTON_COPY to "Export chatbook" -- task-2857
@@ -55,10 +59,12 @@ EXPORT_BUTTON_RUNNING_TOOLTIP = "An export is already running."
 EXPORT_BUTTON_COUNTING_TOOLTIP = "Waiting for item counts before exporting."
 EXPORT_BUTTON_NO_DESTINATION_TOOLTIP = "Choose a destination before exporting."
 
-# The creator's own quality options (thumbnail/compressed/original); default
-# is the cheapest one, matching the design spec.
 MEDIA_QUALITY_OPTIONS = ("thumbnail", "compressed", "original")
-DEFAULT_MEDIA_QUALITY = "thumbnail"
+# task-32353 AC#1 (critique #10): the default used to be "thumbnail", which
+# "keeps a small preview image instead of the full file" -- a silent data
+# reduction chosen for someone whose reason for exporting is usually to keep
+# the files. A lossy bundle is now something you ask for.
+DEFAULT_MEDIA_QUALITY = "original"
 
 # task-2859 item 3: the helper line used to be one FIXED sentence describing
 # "original" quality ("original copies full media files into the zip"),
@@ -70,6 +76,39 @@ _MEDIA_QUALITY_HELPER_COPY: dict[str, str] = {
     "compressed": "shrinks media files before adding them to the zip",
     "original": "copies full media files into the zip",
 }
+
+
+# task-32353 AC#2: the consequence line's fidelity phrase -- the same three
+# options ``_MEDIA_QUALITY_HELPER_COPY`` captions, said in the two words the
+# bundle summary has room for. Unknown values degrade to "full files" for the
+# same reason the helper copy degrades to "original": it is the conservative
+# (most-content) description.
+_MEDIA_QUALITY_BUNDLE_COPY: dict[str, str] = {
+    "thumbnail": "previews only",
+    "compressed": "compressed files",
+    "original": "full files",
+}
+
+# How many titles the contents disclosure lists before it summarises the rest.
+_CONTENTS_PREVIEW_LIMIT = 20
+
+
+def format_export_bytes(size_bytes: int) -> str:
+    """Return a byte count in the Export canvas's own "N KB" spelling.
+
+    One formatter for both halves of the same promise: the pre-write
+    estimate on ``consequence_line`` and the post-write receipt in
+    ``format_last_export_line``. They round identically so "about 4 KB"
+    is never followed by a receipt saying "4.1 KB" for the same bundle.
+
+    Args:
+        size_bytes: A non-negative byte count.
+
+    Returns:
+        e.g. ``"4 KB"`` -- never "0 KB" for a non-empty bundle (anything
+        under 1 KB rounds up to 1).
+    """
+    return f"{max(1, round(size_bytes / 1024))} KB"
 
 
 def media_quality_helper_copy(media_quality: str) -> str:
@@ -167,6 +206,13 @@ class LibraryExportFormState:
             ``_reset_library_export_transient_state`` -- unlike every
             other field above, this is NOT derived from the current
             scope/form.
+        consequence_line: task-32353 AC#2: what pressing Export will
+            actually write -- item count, fidelity and estimated size in
+            one line above the button; ``""`` while counts are loading.
+        contents_lines: task-32353 AC#2: the in-scope items' titles (at
+            most ``_CONTENTS_PREVIEW_LIMIT``, then a ``"+ N more"``
+            summary), or ``()`` when the scope's items are not
+            enumerable up front.
     """
 
     scope: ExportScope
@@ -187,6 +233,20 @@ class LibraryExportFormState:
     # task-14902: True while the quality chooser's direct-pick strip
     # renders below its (still-visible) opener button.
     quality_choices_visible: bool = False
+    consequence_line: str = ""
+    contents_lines: tuple[str, ...] = ()
+
+    @property
+    def submit_blocked_reason(self) -> str:
+        """Why the Export button is off right now, or ``""`` when it is on.
+
+        task-32362: the blocked button's reason had to reach a mouse
+        tooltip to be read at all -- ``"No destination chosen"`` sat
+        three rows up. The inline reason under the button and the
+        tooltip are THE SAME STRING because both come from
+        ``export_button_tooltip``; there is no second sentence to drift.
+        """
+        return "" if self.export_enabled else export_button_tooltip(self)
 
 
 def build_library_export_form_state(
@@ -203,6 +263,8 @@ def build_library_export_form_state(
     error_line: str = "",
     last_export_line: str = "",
     quality_choices_visible: bool = False,
+    titles: tuple[str, ...] = (),
+    approx_bytes: int | None = None,
 ) -> LibraryExportFormState:
     """Build the export canvas's full display state.
 
@@ -226,6 +288,12 @@ def build_library_export_form_state(
         last_export_line: The durable receipt line (task-2858 AC#3,
             LIB-12), already formatted by ``format_last_export_line`` --
             this function only passes it through.
+        titles: The in-scope items' titles (``ExportPreview.titles``),
+            already observed by the counts worker; ``()`` when the
+            scope's items are not enumerable up front.
+        approx_bytes: Their total stored size in bytes
+            (``ExportPreview.approx_bytes``), or ``None`` when unknown --
+            ``None`` is rendered as honest copy, never as a zero.
 
     Returns:
         The canvas's full display state.
@@ -247,6 +315,35 @@ def build_library_export_form_state(
     export_enabled = (
         not running and not counts_loading and total > 0 and bool(destination_clean)
     )
+    # task-32353 AC#2 (critique #10): the canvas asked for a destination and
+    # a name and then wrote a bundle nobody had seen the contents of, at a
+    # fidelity chosen by a control rendered at the same weight as "sort".
+    # This states the consequence in one line, above the button.
+    fidelity = (
+        f" · {_MEDIA_QUALITY_BUNDLE_COPY.get(media_quality, 'full files')}"
+        if show_media_fields
+        else ""
+    )
+    size = (
+        f" · about {format_export_bytes(approx_bytes)}"
+        if approx_bytes is not None
+        else " · size known once it runs"
+    )
+    # A media-only scope counts media items; a mixed scope counts items.
+    noun = "media item" if scope.kind == "media" else "item"
+    consequence_line = (
+        ""
+        if counts_loading
+        else f"Bundle: {_count_phrase(total, noun)}{fidelity}{size}"
+    )
+    # The preview lands with the counts, so neither line renders before them.
+    extra = len(titles) - _CONTENTS_PREVIEW_LIMIT
+    contents_lines = (
+        ()
+        if counts_loading
+        else tuple(titles[:_CONTENTS_PREVIEW_LIMIT])
+        + ((f"+ {extra} more",) if extra > 0 else ())
+    )
     return LibraryExportFormState(
         scope=scope,
         scope_line=scope_line,
@@ -264,6 +361,8 @@ def build_library_export_form_state(
         overwrite_line=overwrite_line,
         last_export_line=last_export_line,
         quality_choices_visible=quality_choices_visible,
+        consequence_line=consequence_line,
+        contents_lines=contents_lines,
     )
 
 
@@ -368,9 +467,9 @@ def format_last_export_line(
         return ""
     if item_count is not None and size_bytes is not None:
         item_word = "item" if item_count == 1 else "items"
-        kilobytes = max(1, round(size_bytes / 1024))
         return (
-            f"✓ exported · {item_count} {item_word} · {kilobytes} KB · {clean_path}"
+            f"✓ exported · {item_count} {item_word} · "
+            f"{format_export_bytes(size_bytes)} · {clean_path}"
         )
     current = time.time() if now is None else now
     elapsed = max(0.0, current - exported_at)

--- a/tldw_chatbook/Library/library_export_state.py
+++ b/tldw_chatbook/Library/library_export_state.py
@@ -324,8 +324,12 @@ def build_library_export_form_state(
         if show_media_fields
         else ""
     )
+    # "before compression" is load-bearing, not padding: this counts the
+    # content going IN, while the receipt after the run stats the zip that
+    # came OUT (live check: a 9 KB estimate wrote a 4 KB archive). Without
+    # the qualifier the two numbers read as a contradiction.
     size = (
-        f" · about {format_export_bytes(approx_bytes)}"
+        f" · about {format_export_bytes(approx_bytes)} before compression"
         if approx_bytes is not None
         else " · size known once it runs"
     )

--- a/tldw_chatbook/UI/Library_Modules/library_export_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_export_controller.py
@@ -233,7 +233,11 @@ from textual.css.query import NoMatches, QueryError
 from textual.widgets import Button, Input, Static
 
 from ...Chatbooks.chatbook_models import ContentType
-from ...Library.library_export_scope import ExportScope, count_export_scope
+from ...Library.library_export_scope import (
+    ExportPreview,
+    ExportScope,
+    count_export_scope,
+)
 from ...Library.library_export_state import (
     DEFAULT_MEDIA_QUALITY,
     MEDIA_QUALITY_OPTIONS,
@@ -714,6 +718,9 @@ class LibraryExportController:
         """
         self._library_export_scope = scope or ExportScope(kind="everything")
         self._library_export_counts = None
+        # task-32353 AC#2: the preview lands and clears with the counts --
+        # a fresh visit must never show the previous scope's contents list.
+        self._library_export_preview = ExportPreview()
         self._library_export_form = self._default_library_export_form()
         # task-14902: a fresh visit never inherits a half-open quality strip.
         self._library_export_quality_choices_visible = False

--- a/tldw_chatbook/UI/Library_Modules/library_export_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_export_controller.py
@@ -237,6 +237,7 @@ from ...Library.library_export_scope import (
     ExportPreview,
     ExportScope,
     count_export_scope,
+    preview_export_scope,
 )
 from ...Library.library_export_state import (
     DEFAULT_MEDIA_QUALITY,
@@ -829,6 +830,38 @@ class LibraryExportController:
                 type(exc).__name__,
             )
             return {"media": 0, "conversations": 0, "notes": 0, "prompts": 0}
+
+    @staticmethod
+    def _compute_library_export_preview(
+        scope: ExportScope, media_db: Any
+    ) -> ExportPreview:
+        """Read what the bundle will contain, beside the counts (task-32353 AC#2).
+
+        The sibling of ``_compute_library_export_counts`` above, and
+        deliberately the same shape: the pure query lives in
+        ``library_export_scope`` and raises honestly, this wrapper owns
+        the quiet-degrade AND the log line. Without the log, a canvas
+        permanently stuck on "size known once it runs" (a missing table,
+        a selection past SQLite's bound-parameter limit, a changed seam)
+        would be undiagnosable -- the one path in this feature that can
+        fail in production must not fail invisibly.
+
+        Args:
+            scope: What this export will include.
+            media_db: The media database read seam, or ``None``.
+
+        Returns:
+            The titles + byte total, or ``ExportPreview()`` on any failure.
+        """
+        try:
+            return preview_export_scope(scope, media_db)
+        except Exception as exc:
+            logger.warning(
+                "Library export preview failed scope_kind={} category={}",
+                scope.kind,
+                type(exc).__name__,
+            )
+            return ExportPreview()
 
     # ----- Export canvas: execution (Task 3) ------------------------------
 

--- a/tldw_chatbook/UI/Library_Modules/library_export_state.py
+++ b/tldw_chatbook/UI/Library_Modules/library_export_state.py
@@ -61,7 +61,7 @@ import threading
 from dataclasses import dataclass, field
 from typing import Any
 
-from ...Library.library_export_scope import ExportScope
+from ...Library.library_export_scope import ExportPreview, ExportScope
 
 
 @dataclass
@@ -78,6 +78,11 @@ class LibraryExportState:
     # plan's screen-attrs contract.
     scope: ExportScope = ExportScope(kind="everything")
     counts: dict[str, int] | None = None
+    # task-32353 AC#2: the counts worker's sibling read -- WHAT the bundle
+    # will contain (titles + estimated bytes), landed and reset in lockstep
+    # with ``counts`` so the consequence line can never describe a scope the
+    # count no longer belongs to.
+    preview: ExportPreview = ExportPreview()
     # Monotonic ownership for the counts request, separate from the export
     # execution token below.  Scope/route/generation can all repeat after a
     # leave -> return ABA visit, so none of them can identify the newest

--- a/tldw_chatbook/UI/Library_Modules/library_media_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_controller.py
@@ -3863,6 +3863,12 @@ class LibraryMediaController:
             and viewer.confirming_delete == self._library_media_confirming_delete
             and tuple(viewer.highlights) == highlights
             and viewer.editing_analysis == self._library_media_editing_analysis
+            # Qodo #8 on PR #2601: assigned on the changed path below but
+            # never compared here, so a generation that started with nothing
+            # else changing took the unchanged path and the Reader kept
+            # rendering the PREVIOUS reason -- "No analysis to search yet."
+            # while one was generating, plus a stale "○" label and tooltip.
+            and viewer.generating_analysis == self._library_media_generating_analysis
             and viewer.analysis_provider_reason == analysis_provider_reason
             and viewer.content_query == self._library_media_content_query
             and viewer.content_match_index == self._library_media_content_match_index

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -124,7 +124,9 @@ from ...Library.library_conversation_reader_state import (
     project_conversation_multiselect,
 )
 from ...Library.library_export_scope import (
+    ExportPreview,
     ExportScope,
+    preview_export_scope,
     resolve_export_selections,
 )
 from ...Library.library_export_state import (
@@ -18428,12 +18430,14 @@ class LibraryScreen(BaseAppScreen):
             counts = self._compute_library_export_counts(
                 scope, media_db, chachanotes_db, prompts_db
             )
+            preview = preview_export_scope(scope, media_db)
             result = self._apply_library_export_counts(
                 scope,
                 counts,
                 generation=generation,
                 route_key=route_key,
                 request_id=request_id,
+                preview=preview,
             )
             if (
                 result is not LibraryEntryReconcileResult.APPLIED
@@ -18451,6 +18455,7 @@ class LibraryScreen(BaseAppScreen):
                     generation=generation,
                     route_key=route_key,
                     request_id=request_id,
+                    preview=preview,
                 )
             return
         self._run_library_export_counts_worker(
@@ -18477,6 +18482,10 @@ class LibraryScreen(BaseAppScreen):
         counts = self._compute_library_export_counts(
             scope, media_db, chachanotes_db, prompts_db
         )
+        # task-32353 AC#2: the same worker, the same connection -- the
+        # contents/size read never happens on the UI thread, and it degrades
+        # to an empty preview rather than raising out of here.
+        preview = preview_export_scope(scope, media_db)
         # ``self.app`` (Textual's own running-App property), not
         # ``self.app_instance`` -- ``call_from_thread`` needs the App whose
         # event loop is actually running this screen (see
@@ -18491,6 +18500,7 @@ class LibraryScreen(BaseAppScreen):
                 generation=generation,
                 route_key=route_key,
                 request_id=request_id,
+                preview=preview,
             )
         except Exception:
             # A shutdown/detach mid-marshal can raise RuntimeError OR
@@ -18506,6 +18516,7 @@ class LibraryScreen(BaseAppScreen):
         generation: int | None = None,
         route_key: tuple[object, ...] | None = None,
         request_id: int,
+        preview: ExportPreview | None = None,
     ) -> LibraryEntryReconcileResult:
         """Marshal a landed counts result onto the export form (UI thread).
 
@@ -18536,6 +18547,8 @@ class LibraryScreen(BaseAppScreen):
             counts: The landed counts (keys "media"/"conversations"/"notes"/
                 "prompts").
             request_id: Monotonic identity of the Export visit/count request.
+            preview: The sibling contents/size read (task-32353 AC#2),
+                landed under the same staleness guards as ``counts``.
         """
         if request_id != self._export_state.counts_request_id:
             return LibraryEntryReconcileResult.SUPERSEDED
@@ -18568,6 +18581,7 @@ class LibraryScreen(BaseAppScreen):
         if not self._library_entry_reconcile_is_current(generation, active_route_key):
             return LibraryEntryReconcileResult.SUPERSEDED
         self._export_state.counts = counts
+        self._export_state.preview = preview or ExportPreview()
         state = self._build_library_export_state()
         try:
             canvas = self.query_one("#library-export-canvas", LibraryExportCanvas)
@@ -18586,6 +18600,17 @@ class LibraryScreen(BaseAppScreen):
             empty_line = self.query_one("#library-export-empty-line", Static)
             empty_line.update(state.empty_scope_line)
             empty_line.display = bool(state.empty_scope_line)
+            # task-32353 AC#2: both new lines are empty until counts land,
+            # so this patcher owns them too (recompose discipline -- the
+            # in-place updater owns every conditional compose owns).
+            consequence = self.query_one(
+                "#library-export-consequence-line", Static
+            )
+            consequence.update(state.consequence_line)
+            consequence.display = bool(state.consequence_line)
+            contents = self.query_one("#library-export-contents", Static)
+            contents.update("\n".join(state.contents_lines))
+            contents.display = bool(state.contents_lines)
             # task-2858 AC#3 (LIB-11): the tooltip flips in place with
             # `disabled`, same F-018 discipline as the select-mode
             # toolbar's export/delete buttons -- otherwise the compose-
@@ -18626,6 +18651,8 @@ class LibraryScreen(BaseAppScreen):
             error_line=self._export_state.error,
             last_export_line=last_export_line,
             quality_choices_visible=self._export_state.quality_choices_visible,
+            titles=self._export_state.preview.titles,
+            approx_bytes=self._export_state.preview.approx_bytes,
         )
 
     # ----- Export canvas: execution (Task 3) ------------------------------

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -18666,6 +18666,7 @@ class LibraryScreen(BaseAppScreen):
             quality_choices_visible=self._export_state.quality_choices_visible,
             titles=self._export_state.preview.titles,
             approx_bytes=self._export_state.preview.approx_bytes,
+            item_count=self._export_state.preview.item_count,
         )
 
     # ----- Export canvas: execution (Task 3) ------------------------------

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -126,7 +126,6 @@ from ...Library.library_conversation_reader_state import (
 from ...Library.library_export_scope import (
     ExportPreview,
     ExportScope,
-    preview_export_scope,
     resolve_export_selections,
 )
 from ...Library.library_export_state import (
@@ -18402,6 +18401,10 @@ class LibraryScreen(BaseAppScreen):
     def _compute_library_export_counts(scope: ExportScope, media_db: Any, chachanotes_db: Any, prompts_db: Any) -> dict[str, int]:
         return LibraryExportController._compute_library_export_counts(scope, media_db, chachanotes_db, prompts_db)
 
+    @staticmethod
+    def _compute_library_export_preview(scope: ExportScope, media_db: Any) -> ExportPreview:
+        return LibraryExportController._compute_library_export_preview(scope, media_db)
+
     def _start_library_export_counts_worker(self) -> None:
         """Kick off the export scope's full-query counts (Task 1's resolver).
 
@@ -18430,7 +18433,7 @@ class LibraryScreen(BaseAppScreen):
             counts = self._compute_library_export_counts(
                 scope, media_db, chachanotes_db, prompts_db
             )
-            preview = preview_export_scope(scope, media_db)
+            preview = self._compute_library_export_preview(scope, media_db)
             result = self._apply_library_export_counts(
                 scope,
                 counts,
@@ -18483,9 +18486,9 @@ class LibraryScreen(BaseAppScreen):
             scope, media_db, chachanotes_db, prompts_db
         )
         # task-32353 AC#2: the same worker, the same connection -- the
-        # contents/size read never happens on the UI thread, and it degrades
-        # to an empty preview rather than raising out of here.
-        preview = preview_export_scope(scope, media_db)
+        # contents/size read never happens on the UI thread, and its wrapper
+        # logs then degrades rather than letting a failure escape here.
+        preview = self._compute_library_export_preview(scope, media_db)
         # ``self.app`` (Textual's own running-App property), not
         # ``self.app_instance`` -- ``call_from_thread`` needs the App whose
         # event loop is actually running this screen (see
@@ -18600,17 +18603,6 @@ class LibraryScreen(BaseAppScreen):
             empty_line = self.query_one("#library-export-empty-line", Static)
             empty_line.update(state.empty_scope_line)
             empty_line.display = bool(state.empty_scope_line)
-            # task-32353 AC#2: both new lines are empty until counts land,
-            # so this patcher owns them too (recompose discipline -- the
-            # in-place updater owns every conditional compose owns).
-            consequence = self.query_one(
-                "#library-export-consequence-line", Static
-            )
-            consequence.update(state.consequence_line)
-            consequence.display = bool(state.consequence_line)
-            contents = self.query_one("#library-export-contents", Static)
-            contents.update("\n".join(state.contents_lines))
-            contents.display = bool(state.contents_lines)
             # task-2858 AC#3 (LIB-11): the tooltip flips in place with
             # `disabled`, same F-018 discipline as the select-mode
             # toolbar's export/delete buttons -- otherwise the compose-
@@ -18622,6 +18614,27 @@ class LibraryScreen(BaseAppScreen):
             apply_library_export_submit_gate(submit_button, state)
         except (NoMatches, QueryError):
             return LibraryEntryReconcileResult.FAILED
+        # task-32353 AC#2: both new lines are empty until counts land, so
+        # this patcher owns them too (recompose discipline -- the in-place
+        # updater owns every conditional compose owns). Deliberately AFTER
+        # the gate, in its own guard: the Export button's disabled/label/
+        # tooltip must never be left stale by a quiet line failing to
+        # resolve, which is what sharing the `try` above would have done.
+        for selector, text, shown in (
+            (
+                "#library-export-consequence-line",
+                state.consequence_line,
+                bool(state.consequence_line),
+            ),
+            (
+                "#library-export-contents",
+                "\n".join(state.contents_lines),
+                bool(state.contents_lines),
+            ),
+        ):
+            for line in self.query(selector):
+                line.update(text)
+                line.display = shown
         return LibraryEntryReconcileResult.APPLIED
 
     def _build_library_export_state(self) -> LibraryExportFormState:

--- a/tldw_chatbook/Widgets/Library/library_export_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_export_canvas.py
@@ -65,6 +65,15 @@ def apply_library_export_submit_gate(
     # what pressing Export will do or the SAME blocker ``disabled``
     # reflects.
     submit_button.tooltip = export_button_tooltip(state)
+    # task-32362: the inline reason under the button is a fourth thing that
+    # flips with ``disabled``, so it flips here too -- otherwise the
+    # counts-landing patcher (which never recomposes) leaves it stale.
+    # ``parent`` is None during ``compose``, where the caller sets it
+    # directly; once mounted, ``query`` finds it without raising.
+    if submit_button.parent is not None:
+        for reason in submit_button.parent.query("#library-export-submit-reason"):
+            reason.update(state.submit_blocked_reason)
+            reason.display = bool(state.submit_blocked_reason)
 
 class LibraryExportCanvas(PostRecomposeCallback, VerticalScroll):
     """Render the Library export canvas: scope summary + chatbook export form.
@@ -223,6 +232,26 @@ class LibraryExportCanvas(PostRecomposeCallback, VerticalScroll):
         )
         last_export_line.display = bool(state.last_export_line)
         yield last_export_line
+        # task-32353 AC#2: what the button will actually write, stated
+        # directly above it. Display-toggled rather than conditionally
+        # yielded for the same reason as the quiet lines above -- the
+        # counts-landing patcher updates it in place, never by recompose.
+        consequence_line = Static(
+            state.consequence_line,
+            id="library-export-consequence-line",
+            classes="library-export-quiet-line",
+            markup=False,
+        )
+        consequence_line.display = bool(state.consequence_line)
+        yield consequence_line
+        contents = Static(
+            "\n".join(state.contents_lines),
+            id="library-export-contents",
+            classes="library-export-quiet-line",
+            markup=False,
+        )
+        contents.display = bool(state.contents_lines)
+        yield contents
         submit_button = Button(
             EXPORT_BUTTON_COPY,
             id="library-export-submit",
@@ -234,6 +263,18 @@ class LibraryExportCanvas(PostRecomposeCallback, VerticalScroll):
         # ``apply_library_export_submit_gate``).
         apply_library_export_submit_gate(submit_button, state)
         yield submit_button
+        # task-32362: the reason reaches a keyboard-first user on the next
+        # line, not only a hover tooltip -- the same inline-reason grammar
+        # task-31981 gave the Reader's blocked Generate. Always mounted, so
+        # the in-place gate patchers can toggle it alongside `disabled`.
+        submit_reason = Static(
+            state.submit_blocked_reason,
+            id="library-export-submit-reason",
+            classes="library-media-action-reason",
+            markup=False,
+        )
+        submit_reason.display = bool(state.submit_blocked_reason)
+        yield submit_reason
         cancel_button = Button(
             "Cancel",
             id="library-export-cancel",

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -417,6 +417,19 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                     id="library-media-reader-more",
                     compact=True,
                 )
+        if find_reason:
+            # task-32362 (critique #10, A cap 42): the "\u25cb" said blocked and
+            # nothing said why unless you hovered -- the same gap task-31981
+            # closed for Generate, one toolbar over. Yielded AFTER the
+            # ``ds-toolbar`` Horizontal closes, not inside it: mixing a
+            # Static in with the toolbar's Buttons is this canvas's known
+            # non-rendering failure mode (see ``compose``).
+            yield Static(
+                find_reason,
+                id="library-media-reader-find-reason",
+                classes="library-media-action-reason",
+                markup=False,
+            )
         # The same condition the More button above is composed under: a stale
         # ``more_open`` carried onto a server-only detail would otherwise paint
         # an empty actions row under a button that is no longer there.


### PR DESCRIPTION
Part of the Library critique-10 fix wave (plan: `Docs/superpowers/plans/2026-09-11-library-crit10-wave.md`, group `export`). Lands after the `viewer` branch (it carries a one-method carve-out in `library_media_viewer.py`).

## What
- **task-32353** — Export defaults to full fidelity (`DEFAULT_MEDIA_QUALITY = "original"`); before the button the canvas states what the bundle will contain: item count, fidelity, a titles list on media scopes and "about N KB before compression" (the estimate counts content in; the receipt stats the file out — the qualifier removes a real 9 KB / 4 KB contradiction seen live); the `everything` scope shows count and fidelity with an honest "size known once it runs".
- **task-32362** — the Export canvas's only disabled control and the Reader's two carry their reason on the next line (the inline line is the tooltip by construction); the Reader half renders whatever `analysis_find_unavailable_reason` returns, so the viewer branch's Find changes flow through with no copy here.

## Evidence
- `Tests/UI/test_library_crit10_export.py` (12 tests, red-first) + updated export state/scope/execution/receipt suites; the critique-9 P0 pins (receipt read from the written artifact; empty-export error) hold; 160 passed across the 12 export files post-merge.
- Live export to the profile's `exports/` with the written zip listed.
- Guides: `library/import-and-export.md`, `library/media-and-conversations.md` with refreshed stamps; the diagnostic inventory regenerated for one new export-preview warning.

## Review
Task review (approved; 2 Medium, 5 Low, 3 nits → fix round 1 `8912cb3ff8` + `bdf46e89d0`, none declined). Riders noted by the reviewer and implementer: `ChatbookCreator._collect_media` ignores `quality` entirely (the knob is a no-op; the default is now the least-wrong option), and the KB-only size formatter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes Library exports full-fidelity by default and states what a bundle will contain before it is written; blocked Export and Reader controls now carry their reason on the next line instead of only in a hover tooltip.

- The quality chooser opens on "original" instead of "thumbnail", so a bundle only loses content when asked.
- The Export canvas shows a bundle line (item count, what the archive holds, estimated size) and a contents list (up to 20 titles, then "+ N more") above the submit button, once counting finishes. The line reads "text only" for every quality option since the writer never varies by option, and it counts the items the preview found active, so a selection with a trashed item no longer over-promises.
- Size estimates are labeled "before compression" because the receipt reports the written archive's size; scopes that can't be measured up front read "size known once it runs" with no estimate or contents list, and an empty scope shows no bundle line at all.
- The blocked Export submit button and the Reader's "○ Find" print their reason on the next line; the inline text and the tooltip come from one source, and the Find reason no longer goes stale when a generation starts.
- User guides for import/export and media/conversations document both behaviors.

<sup>Written for commit 3a907d844d572cc41451e1303574fc61f75afbe8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2601?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

