### PR TITLE
fix(library-media): the footer keeps its canvas verbs while typing, Find opens from the keyboard and refuses the tabs it cannot search, a Markdown analysis renders (critique-10 wave, tasks 32346/32348/32365)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -268,8 +268,12 @@ readable measure rather than stretched across the whole canvas.
   "key action" pair — the Notes editor, for example, shows "ctrl+s save
   note | esc back to notes".
   While a text field has focus the footer leads with `typing in field`,
-  names `esc leave field`, and keeps the canvas verbs after `after esc:` —
-  they are not live until you leave the field.
+  names the Escape chip for that surface (`esc leave field` where nothing
+  else owns the key — a list canvas keeps its own `esc focus rail`), and
+  carries the canvas verbs after `after esc:` — they are not live until you
+  leave the field. On a terminal under 64 columns the return chip
+  (`esc back to Library`) comes first instead, because that is the one
+  action the narrow footer must never drop.
 
 One special case: selecting **Notes** adds a
 **Library notes | Folder files** strip above the workbench. **Folder files**

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -271,9 +271,8 @@ readable measure rather than stretched across the whole canvas.
   names the Escape chip for that surface (`esc leave field` where nothing
   else owns the key — a list canvas keeps its own `esc focus rail`), and
   carries the canvas verbs after `after esc:` — they are not live until you
-  leave the field. On a terminal under 64 columns the return chip
-  (`esc back to Library`) comes first instead, because that is the one
-  action the narrow footer must never drop.
+  leave the field. Under 64 columns there is room for a single chip, so the
+  footer names only what Escape does there and the verbs are not listed.
 
 One special case: selecting **Notes** adds a
 **Library notes | Folder files** strip above the workbench. **Folder files**

--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -258,7 +258,8 @@ readable measure rather than stretched across the whole canvas.
   landing adds "i import content"
   and "n new note" (single-letter accelerators for the hub actions);
   the Search / RAG canvas adds "u use Library
-  context in Console", "enter select evidence", and "o open evidence";
+  context in Console", "o open evidence", and an "enter" hint that names
+  whatever Enter does on the control you are focused on;
   a Media/Notes/Prompts/Skills/Collections list adds "esc focus rail";
   that list's item viewer/editor (or the media viewer) adds "esc back to
   list" instead; the Export canvas adds "esc back to Media" (or whichever
@@ -266,6 +267,9 @@ readable measure rather than stretched across the whole canvas.
   staging canvas adds "esc back to hub". Every hint is a per-key
   "key action" pair — the Notes editor, for example, shows "ctrl+s save
   note | esc back to notes".
+  While a text field has focus the footer leads with `typing in field`,
+  names `esc leave field`, and keeps the canvas verbs after `after esc:` —
+  they are not live until you leave the field.
 
 One special case: selecting **Notes** adds a
 **Library notes | Folder files** strip above the workbench. **Folder files**
@@ -884,3 +888,10 @@ list, and the landing hub is capped at 96 cells).*
 (task-32225: the return chip stands down wherever a canvas owns Escape itself,
 so the footer never names a return the key would not perform; task-32228:
 Conversations arrives with its first row focused like every other browse list).*
+
+*Verified against fix/library-crit10-viewer — 2026-09-11 (task-32346: with the
+caret in the Search/RAG query box the footer reads "typing in field | esc leave
+field | after esc: u use Library context in Console · o open evidence | enter
+run search | F6 next pane"; the same shape on the Media list keeps "s select"
+behind the same gesture, and "F6 next pane" is last so a narrow footer drops it
+before any verb).*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -501,6 +501,8 @@ still spans the pane.
   a two-line analysis puts them on the next line, not at the bottom of the
   pane. A long analysis scrolls the tab, carrying its actions to the end of
   the text rather than clipping them.
+  A Markdown analysis renders like the Read tab, with the same
+  Rendered/Raw toggle.
   Analysis is produced at import time (the "Analyze after import" option),
   written by hand here, or generated in place: **"Generate"** (**"Regenerate"**
   once one exists) calls the configured analysis provider without leaving
@@ -526,7 +528,7 @@ still spans the pane.
 
 | Button | What it does |
 |---|---|
-| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. |
+| "Find" | Opens the search bar for the tab you are reading — the transcript on Read, the analysis on Analysis — focused and ready to type; a second press or Escape closes it. Walking with `]`/`[` keeps an active query but never moves your cursor into the field. This never filters Items. `Ctrl+F` opens it from the keyboard. On Highlights and Info it is disabled and says so — those tabs have no text to search. |
 | "Use in Console" | Stages this item as context for your next Console message. |
 | "Read later" ↔ "Remove later" | Toggles the loaded item's persisted reading-list state. |
 | "More" | Keeps secondary actions reachable: Edit metadata, Open original when available, Open manager, and Move to trash. Narrow layouts retain these actions here rather than hiding them. Opening it adds one toolbar row directly beneath this one — the tab row and the reading body shift down a single line (two on a Reader too narrow to fit all four actions side by side), never off the fold — the button reads "More ▴" while the row is open, and focus stays on it so a second press closes the row. |
@@ -1176,3 +1178,11 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-viewer — 2026-09-11 (task-32348: Ctrl+F
+opens the Reader's Find bar and the footer names it, the Highlights and Info
+tabs refuse it with "This tab has no text to search · switch to Read or
+Analysis.", and "t" cannot arm the delete confirmation while Find is open;
+task-32365: a stored analysis beginning "## Key contributions" paints as a
+heading with a Rendered|Raw toggle above it, and a plain-prose analysis is
+offered no toggle).*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -502,7 +502,11 @@ still spans the pane.
   pane. A long analysis scrolls the tab, carrying its actions to the end of
   the text rather than clipping them.
   A Markdown analysis renders like the Read tab, with the same
-  Rendered/Raw toggle.
+  Rendered/Raw toggle. While a Find query is active the analysis shows its
+  stored text instead — only that view can mark the matches — and the strip
+  says so ("Showing the stored text so matches can be marked · clear the
+  search to read it rendered."); clearing the search hands the rendered view
+  straight back.
   Analysis is produced at import time (the "Analyze after import" option),
   written by hand here, or generated in place: **"Generate"** (**"Regenerate"**
   once one exists) calls the configured analysis provider without leaving
@@ -1186,3 +1190,9 @@ Analysis.", and "t" cannot arm the delete confirmation while Find is open;
 task-32365: a stored analysis beginning "## Key contributions" paints as a
 heading with a Rendered|Raw toggle above it, and a plain-prose analysis is
 offered no toggle).*
+
+*Verified against fix/library-crit10-viewer — 2026-09-11, fix round 1
+(task-32365 review finding 1: submitting a Find query over a rendered
+analysis now shows the stored text, where the matches are actually marked,
+with "○ Rendered" refused and its reason on the line beneath; clearing the
+query restores the rendered view).*

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -8,7 +8,7 @@ opens from the keyboard and refuses the tabs it cannot search) and 32365
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Button, Static
+from textual.widgets import Button, Input, Static
 
 from Tests.UI.test_library_crit9_shell import (
     _library_host,
@@ -317,3 +317,34 @@ async def test_below_64_columns_a_focused_input_leaves_the_single_chip_alone():
             message="The media filter box never took focus.",
         )
         assert screen._library_footer_shortcuts_for_current_state() == blurred
+
+
+@pytest.mark.asyncio
+async def test_below_64_columns_the_viewer_names_escape_not_a_bare_status_word():
+    """Task 6's re-review, applied to the surface its own gate stands down on.
+
+    ``_library_narrow_stage_return_active`` yields whenever an earlier Escape
+    action owns the key, and its docstring names the 60x24 Media viewer as
+    exactly that case -- so the stand-down above does NOT cover the viewer,
+    and the wide form ran there. At 60 columns only the first chip is
+    painted, so it led with the bare status word "typing in field": true, and
+    useless, where the blurred footer had at least named a key.
+
+    The single slot now carries the Escape chip, which is the one thing that
+    works from inside the field -- the same "recovery outranks navigation
+    below 64 columns" order Task 6's block uses, so the two read as one
+    grammar at that width.
+    """
+    host = _media_host()
+    async with host.run_test(size=(60, 24)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        assert not screen._library_narrow_stage_return_active()
+        await pilot.press("ctrl+f")
+        await _wait_for_condition(
+            pilot,
+            lambda: isinstance(screen.focused, Input),
+            message="ctrl+f never focused the Find input.",
+        )
+        chips = screen._library_footer_shortcuts_for_current_state()
+        assert chips[0][0] == "esc", chips
+        assert chips[1] == ("", "typing in field"), chips

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -28,6 +28,7 @@ from tldw_chatbook.Widgets.Library.library_media_content import (
 )
 from tldw_chatbook.Widgets.Library.library_media_viewer import (
     ANALYSIS_RENDERED_BLOCKED_BY_SEARCH,
+    LibraryMediaViewer,
 )
 from Tests.UI.test_library_shell import (
     LibraryProductionCSSHarness,
@@ -348,3 +349,103 @@ async def test_below_64_columns_the_viewer_names_escape_not_a_bare_status_word()
         chips = screen._library_footer_shortcuts_for_current_state()
         assert chips[0][0] == "esc", chips
         assert chips[1] == ("", "typing in field"), chips
+
+
+# --------------------------------------------------------------------------
+# Qodo review round
+# --------------------------------------------------------------------------
+
+
+def test_find_follows_the_analysis_the_reader_actually_shows():
+    """Qodo 1: ``detail_analysis_text`` read only the newest version, while
+    ``build_library_media_viewer_state`` prefers a top-level
+    ``analysis_content`` -- so on a detail carrying one with no versions the
+    Analysis tab displayed text while the Find gate reported none. Both
+    callers want "the analysis the Reader shows", and one of them says so in
+    its own docstring, so the precedence is fixed at the shared seam."""
+    from tldw_chatbook.Library.library_media_viewer_state import (
+        build_library_media_viewer_state,
+        detail_analysis_text,
+    )
+
+    top_level_only = {
+        "media_id": "1",
+        "title": "T",
+        "type": "article",
+        "analysis_content": "Top-level analysis",
+    }
+    assert detail_analysis_text(top_level_only) == "Top-level analysis"
+    assert (
+        build_library_media_viewer_state(top_level_only).analysis
+        == detail_analysis_text(top_level_only)
+    )
+
+    # Top level still wins over versions, and versions still answer alone.
+    both = dict(top_level_only, versions=[{"version_number": 1, "analysis_content": "V"}])
+    assert detail_analysis_text(both) == "Top-level analysis"
+    versions_only = {
+        "media_id": "1",
+        "title": "T",
+        "type": "article",
+        "versions": [{"version_number": 1, "analysis_content": "V"}],
+    }
+    assert detail_analysis_text(versions_only) == "V"
+
+
+def test_an_external_detail_is_searchable_whatever_mode_it_inherited():
+    """Qodo 4: ``_compose_active_body`` composes the Read body for EVERY
+    external detail (``external_detail or reader_mode == "read"``), so it
+    always has a bar to mount. The mode-only refusal treated one opened
+    after Info/Highlights as unsearchable -- a regression this round
+    introduced, since the gate used to return "" for every non-analysis
+    mode."""
+    from tldw_chatbook.Library.library_media_viewer_state import (
+        analysis_find_unavailable_reason,
+    )
+
+    for mode in ("info", "highlights", "read", "analysis"):
+        assert analysis_find_unavailable_reason(
+            mode=mode,
+            analysis="",
+            generating=False,
+            editing=False,
+            external=True,
+        ) == "", mode
+    # Local details keep the refusal.
+    assert analysis_find_unavailable_reason(
+        mode="info", analysis="x", generating=False, editing=False
+    ) == "This tab has no text to search · switch to Read or Analysis."
+
+
+@pytest.mark.asyncio
+async def test_pressing_raw_during_a_search_does_not_outlive_the_search():
+    """Qodo 3: the toggle strip's press handler wrote analysis_content_mode
+    unconditionally, so pressing the already-selected Raw during a search
+    made the mode stick and the inline promise ("clear the search to read it
+    rendered") false. Both controls are inert while the query forces Raw."""
+    host = _analysis_host(_MARKDOWN_ANALYSIS)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        await _switch_to_analysis(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        await _submit_content_search_query(screen, pilot, "point")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).active_mode == "raw",
+            message="The query never forced the Raw view.",
+        )
+        raw = screen.query_one("#library-media-analysis-content-mode-raw", Button)
+        assert raw.disabled is True, "Raw must not be pressable while it is forced"
+        viewer = screen.query_one(LibraryMediaViewer)
+        assert viewer.analysis_content_mode == "rendered"
+
+        await _submit_content_search_query(screen, pilot, "")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).active_mode == "rendered",
+            message="Clearing the query never restored the Rendered view.",
+        )

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -14,7 +14,6 @@ from Tests.UI.test_library_crit9_shell import (
     _library_host,
 )
 from Tests.UI.test_library_media_render_fixes import (
-    _analysis_flow_host,
     _open_first_reader_row,
     _painted,
     _switch_to_analysis,
@@ -88,3 +87,77 @@ async def test_the_media_filter_box_keeps_the_list_verbs_the_same_way():
         joined = " ".join(label for _key, label in chips)
         assert "after esc: " in joined and "s select" in joined, chips
         assert chips[-1] == ("F6", "next pane"), chips
+
+
+# --------------------------------------------------------------------------
+# task-32348: Find
+# --------------------------------------------------------------------------
+
+
+def test_find_is_refused_on_the_tabs_that_have_no_search_bar():
+    from tldw_chatbook.Library.library_media_viewer_state import (
+        analysis_find_unavailable_reason,
+    )
+
+    for mode in ("info", "highlights"):
+        assert analysis_find_unavailable_reason(
+            mode=mode, analysis="anything", generating=False, editing=False
+        ) == "This tab has no text to search · switch to Read or Analysis.", mode
+    assert analysis_find_unavailable_reason(
+        mode="read", analysis="", generating=False, editing=False
+    ) == ""
+    assert analysis_find_unavailable_reason(
+        mode="analysis", analysis="", generating=False, editing=False
+    ) == "No analysis to search yet."
+
+
+async def _open_first_media_reader(host, pilot):
+    """Open the first media item's Reader and return the settled screen."""
+    screen = await _open_media_list(host, pilot)
+    await _open_first_reader_row(screen, pilot)
+    return screen
+
+
+@pytest.mark.asyncio
+async def test_ctrl_f_opens_the_reader_find_bar_and_the_footer_names_it():
+    host = _media_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        assert ("ctrl+f", "find") in screen._library_footer_shortcuts_for_current_state()
+        await pilot.press("ctrl+f")
+        await pilot.pause()
+        assert screen.query("#library-media-content-search-controls")
+        assert screen._media_state.find_open is True
+
+
+@pytest.mark.asyncio
+async def test_t_never_arms_the_trash_while_find_is_open():
+    host = _media_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        await pilot.press("ctrl+f")
+        await pilot.pause()
+        assert screen.check_action("library_media_move_to_trash", ()) is False
+        assert ("t", "trash") not in screen._library_footer_shortcuts_for_current_state()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert screen.check_action("library_media_move_to_trash", ()) is True
+
+
+@pytest.mark.asyncio
+async def test_find_is_refused_on_the_info_tab_and_t_stays_a_plain_character():
+    """task-32348 AC#2, B D4/D4a: the Info tab has no bar to mount."""
+    host = _media_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        screen.query_one("#library-media-reader-select-info", Button).press()
+        await _wait_for_selector(screen, pilot, "#library-media-reader-mode-info")
+        await pilot.pause()
+        assert screen.check_action("library_media_reader_find", ()) is False
+        assert ("ctrl+f", "find") not in (
+            screen._library_footer_shortcuts_for_current_state()
+        )
+        await pilot.press("ctrl+f")
+        await pilot.pause()
+        assert screen._media_state.find_open is False
+        assert not screen.query("#library-media-content-search-controls")

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -124,6 +124,14 @@ async def test_ctrl_f_opens_the_reader_find_bar_and_the_footer_names_it():
     async with host.run_test(size=(235, 52)) as pilot:
         screen = await _open_first_media_reader(host, pilot)
         assert ("ctrl+f", "find") in screen._library_footer_shortcuts_for_current_state()
+        # The critique's "Find is not in the Tab order" reading is wrong: the
+        # button is an ordinary focusable Button in the Reader's focus chain.
+        # What was missing was a KEY, which is what this test pins.
+        find_button = screen.query_one("#library-media-reader-find", Button)
+        assert find_button.focusable, find_button
+        assert find_button in screen.focus_chain, [
+            w.id for w in screen.focus_chain
+        ]
         await pilot.press("ctrl+f")
         await pilot.pause()
         assert screen.query("#library-media-content-search-controls")

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -1,0 +1,90 @@
+"""Critique-10 Reader group: the typing footer, Find, and a rendered analysis.
+
+Covers tasks 32346 (the canvas verbs survive a focused Input), 32348 (Find
+opens from the keyboard and refuses the tabs it cannot search) and 32365
+(a Markdown analysis renders).
+"""
+
+from __future__ import annotations
+
+import pytest
+from textual.widgets import Button
+
+from Tests.UI.test_library_crit9_shell import (
+    _library_host,
+)
+from Tests.UI.test_library_media_render_fixes import (
+    _analysis_flow_host,
+    _open_first_reader_row,
+    _painted,
+    _switch_to_analysis,
+)
+from Tests.UI.test_library_media_side_by_side import (
+    _build_media_test_app,
+    _open_media_list,
+    _two_media_items,
+)
+from Tests.UI.test_library_shell import (
+    LibraryProductionCSSHarness,
+    _active_library_screen,
+    _seed_conversations,
+    _two_conversations,
+    _wait_for_condition,
+    _wait_for_library_shell,
+    _wait_for_selector,
+)
+
+
+def _media_host() -> LibraryProductionCSSHarness:
+    """The Library with two local media items, list and Reader both usable."""
+    app = _build_media_test_app()
+    _seed_conversations(app, _two_conversations(), media=_two_media_items())
+    return LibraryProductionCSSHarness(app)
+
+
+# --------------------------------------------------------------------------
+# task-32346: the footer under a focused Input
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_focused_search_box_keeps_the_canvas_verbs_behind_one_named_key():
+    host = _library_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-search").press()
+        query = await _wait_for_selector(screen, pilot, "#library-rag-query-input")
+        query.focus()
+        await pilot.pause()
+        chips = screen._library_footer_shortcuts_for_current_state()
+        labels = [label for _key, label in chips]
+        assert labels[0] == "typing in field", chips
+        assert ("esc", "leave field") in chips, chips
+        joined = " ".join(labels)
+        assert "after esc: u use Library context in Console · o open evidence" in joined, chips
+        # AC#2: "F6 next pane" is LAST, so the responsive footer drops it
+        # before any canvas verb.
+        assert chips[-1] == ("F6", "next pane"), chips
+        # AC#1's honesty half: no single printable key is advertised as live.
+        assert not [key for key, _label in chips if len(key) == 1 and key.isprintable()], chips
+
+
+@pytest.mark.asyncio
+async def test_the_media_filter_box_keeps_the_list_verbs_the_same_way():
+    host = _media_host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        box = await _wait_for_selector(screen, pilot, "#library-media-filter")
+        box.focus()
+        # The list settles asynchronously and re-seats focus; wait for the
+        # caret to actually land in the filter box rather than assume it.
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.focused is screen.query_one("#library-media-filter"),
+            message="The media filter box never took focus.",
+        )
+        chips = screen._library_footer_shortcuts_for_current_state()
+        joined = " ".join(label for _key, label in chips)
+        assert "after esc: " in joined and "s select" in joined, chips
+        assert chips[-1] == ("F6", "next pane"), chips

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -161,3 +161,53 @@ async def test_find_is_refused_on_the_info_tab_and_t_stays_a_plain_character():
         await pilot.pause()
         assert screen._media_state.find_open is False
         assert not screen.query("#library-media-content-search-controls")
+# --------------------------------------------------------------------------
+# task-32365: a Markdown analysis renders
+# --------------------------------------------------------------------------
+
+
+_MARKDOWN_ANALYSIS = "## Key contributions\n\nA first point, and a second."
+
+
+def _analysis_host(analysis: str) -> LibraryProductionCSSHarness:
+    """Media whose stored analysis is ``analysis``.
+
+    Local media detail never carries ``analysis_content`` at the top level;
+    the viewer reads the newest ``versions`` entry.
+    """
+    app = _build_media_test_app()
+    items = _two_media_items()
+    for item in items:
+        item["versions"] = [{"version_number": 1, "analysis_content": analysis}]
+    _seed_conversations(app, _two_conversations(), media=items)
+    return LibraryProductionCSSHarness(app)
+
+
+@pytest.mark.asyncio
+async def test_a_stored_analysis_renders_its_markdown_with_a_raw_toggle():
+    host = _analysis_host(_MARKDOWN_ANALYSIS)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        await _switch_to_analysis(screen, pilot)
+        body = await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        painted = _painted(host, body.region)
+        assert "Key contributions" in painted, painted
+        assert "## Key" not in painted, painted
+        toggle = screen.query_one("#library-media-analysis-content-mode-raw", Button)
+        toggle.press()
+        await pilot.pause()
+        await pilot.pause()
+        assert "## Key contributions" in _painted(
+            host, screen.query_one("#library-media-viewer-content").region
+        )
+
+
+@pytest.mark.asyncio
+async def test_a_plain_text_analysis_is_offered_no_toggle():
+    """Nothing to render, so no affordance for it (the Read tab's rule)."""
+    host = _analysis_host("A flat paragraph of prose, with no markup at all.")
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        await _switch_to_analysis(screen, pilot)
+        await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        assert not screen.query("#library-media-analysis-content-mode-raw")

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -281,3 +281,39 @@ async def test_an_active_find_query_drops_the_rendered_analysis_to_the_view_that
             ).active_mode == "rendered",
             message="Clearing the query never restored the Rendered view.",
         )
+
+
+@pytest.mark.asyncio
+async def test_below_64_columns_a_focused_input_leaves_the_single_chip_alone():
+    """Coordinator ruling (Task 6 measurement): below 64 columns the footer
+    paints exactly ONE ~24-char context chip, and there Escape returns to
+    Library rather than leaving the field. Emitting the wide
+    ``typing in field · after esc: …`` form as well makes AppFooterStatus
+    elide the whole context to "…", so the Input-focus transform stands down
+    on that stage and the narrow block's chip is the entire context.
+
+    The expected set is READ from the blurred state rather than written out,
+    so this pins "focusing an Input changes nothing here" without duplicating
+    the literal Task 6 owns.
+    """
+    host = _media_host()
+    async with host.run_test(size=(60, 24)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _wait_for_condition(
+            pilot,
+            lambda: screen._library_narrow_stage_return_active(),
+            message="The Library pane never closed at 60 columns.",
+        )
+        blurred = screen._library_footer_shortcuts_for_current_state()
+        # AppFooterStatus paints a PREFIX of the registered set, and Task 6's
+        # block puts its Escape chip first so that prefix is that chip.
+        assert blurred[0][0] == "esc", blurred
+
+        box = await _wait_for_selector(screen, pilot, "#library-media-filter")
+        box.focus()
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.focused is screen.query_one("#library-media-filter"),
+            message="The media filter box never took focus.",
+        )
+        assert screen._library_footer_shortcuts_for_current_state() == blurred

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -449,3 +449,37 @@ async def test_pressing_raw_during_a_search_does_not_outlive_the_search():
             ).active_mode == "rendered",
             message="Clearing the query never restored the Rendered view.",
         )
+
+
+@pytest.mark.asyncio
+async def test_the_find_button_matches_the_key_on_an_external_document():
+    """Coordinator ruling after Qodo 4: the button's own gate call had not
+    learned ``external``, so for a server document opened while the session
+    carried "info"/"highlights" the KEY worked and the BUTTON stayed
+    disabled -- the exact key/control divergence
+    ``_toggle_library_media_find`` exists to prevent. Both read one call now.
+
+    Composed directly: an external detail is a server round trip the Library
+    harness has no fixture for, and the divergence is entirely in what the
+    toolbar passes to the gate.
+    """
+    from tldw_chatbook.Library.library_media_viewer_state import (
+        build_library_media_viewer_state,
+    )
+
+    viewer = LibraryMediaViewer(
+        build_library_media_viewer_state(
+            {
+                "media_id": "server:1",
+                "title": "Server document",
+                "type": "article",
+                "content": "Searchable body text.",
+            }
+        ),
+        reader_mode="info",
+        external_detail=True,
+    )
+    async with _media_host().run_test(size=(235, 52)) as pilot:
+        await pilot.app.screen.mount(viewer)
+        await pilot.pause()
+        assert viewer.query_one("#library-media-reader-find", Button).disabled is False

--- a/Tests/UI/test_library_crit10_viewer.py
+++ b/Tests/UI/test_library_crit10_viewer.py
@@ -8,7 +8,7 @@ opens from the keyboard and refuses the tabs it cannot search) and 32365
 from __future__ import annotations
 
 import pytest
-from textual.widgets import Button
+from textual.widgets import Button, Static
 
 from Tests.UI.test_library_crit9_shell import (
     _library_host,
@@ -23,9 +23,16 @@ from Tests.UI.test_library_media_side_by_side import (
     _open_media_list,
     _two_media_items,
 )
+from tldw_chatbook.Widgets.Library.library_media_content import (
+    LibraryMediaContentBody,
+)
+from tldw_chatbook.Widgets.Library.library_media_viewer import (
+    ANALYSIS_RENDERED_BLOCKED_BY_SEARCH,
+)
 from Tests.UI.test_library_shell import (
     LibraryProductionCSSHarness,
     _active_library_screen,
+    _submit_content_search_query,
     _seed_conversations,
     _two_conversations,
     _wait_for_condition,
@@ -153,8 +160,15 @@ async def test_t_never_arms_the_trash_while_find_is_open():
 
 
 @pytest.mark.asyncio
-async def test_find_is_refused_on_the_info_tab_and_t_stays_a_plain_character():
-    """task-32348 AC#2, B D4/D4a: the Info tab has no bar to mount."""
+async def test_find_is_refused_on_the_info_tab():
+    """task-32348, B D4: the Info tab has no bar to mount, so Find refuses it.
+
+    Review finding 2: this deliberately says nothing about "t". With Find
+    CLOSED on Info, ``library_media_move_to_trash`` is still live (its gate
+    reads view/substate/pending, never the reader mode), so "t" does arm the
+    confirmation there -- the AC#2 guarantee is about a PENDING Find gesture
+    and is pinned by ``test_t_never_arms_the_trash_while_find_is_open``.
+    """
     host = _media_host()
     async with host.run_test(size=(235, 52)) as pilot:
         screen = await _open_first_media_reader(host, pilot)
@@ -169,6 +183,8 @@ async def test_find_is_refused_on_the_info_tab_and_t_stays_a_plain_character():
         await pilot.pause()
         assert screen._media_state.find_open is False
         assert not screen.query("#library-media-content-search-controls")
+
+
 # --------------------------------------------------------------------------
 # task-32365: a Markdown analysis renders
 # --------------------------------------------------------------------------
@@ -219,3 +235,49 @@ async def test_a_plain_text_analysis_is_offered_no_toggle():
         await _switch_to_analysis(screen, pilot)
         await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
         assert not screen.query("#library-media-analysis-content-mode-raw")
+
+
+@pytest.mark.asyncio
+async def test_an_active_find_query_drops_the_rendered_analysis_to_the_view_that_marks():
+    """Review finding 1: rendered mode mounts only the Markdown widget, whose
+    ``sync_search`` no-ops (there is no raw view to restyle) and whose
+    scroll-to-match is a source-line index applied to a rendered scroller. So
+    a Find over a rendered analysis counted matches and marked none. An active
+    query now shows the view that can mark, and the toggle says so."""
+    host = _analysis_host(_MARKDOWN_ANALYSIS)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_media_reader(host, pilot)
+        await _switch_to_analysis(screen, pilot)
+        body = await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        assert body.active_mode == "rendered", body.active_mode
+
+        await _submit_content_search_query(screen, pilot, "point")
+        body = await _wait_for_selector(screen, pilot, "#library-media-viewer-content")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).active_mode == "raw",
+            message="An active analysis query never dropped to the Raw view.",
+        )
+        raw_button = screen.query_one("#library-media-analysis-content-mode-raw", Button)
+        assert "Raw (selected)" in str(raw_button.label), raw_button.label
+        # ...and Rendered is refused with its reason, never a pressable
+        # control that repaints the same body.
+        rendered = screen.query_one(
+            "#library-media-analysis-content-mode-rendered", Button
+        )
+        assert rendered.disabled is True
+        assert rendered.tooltip == ANALYSIS_RENDERED_BLOCKED_BY_SEARCH
+        reason = screen.query_one("#library-media-analysis-content-mode-reason", Static)
+        assert str(reason.renderable) == ANALYSIS_RENDERED_BLOCKED_BY_SEARCH
+
+        # Clearing the query hands the rendered view back.
+        await _submit_content_search_query(screen, pilot, "")
+        await _wait_for_condition(
+            pilot,
+            lambda: screen.query_one(
+                "#library-media-viewer-content", LibraryMediaContentBody
+            ).active_mode == "rendered",
+            message="Clearing the query never restored the Rendered view.",
+        )

--- a/Tests/UI/test_library_media_reader_flow.py
+++ b/Tests/UI/test_library_media_reader_flow.py
@@ -1974,6 +1974,11 @@ def test_find_from_analysis_opens_the_bar_on_the_analysis_tab():
     fake._library_media_find_unavailable_reason = MethodType(
         LibraryScreen._library_media_find_unavailable_reason, fake
     )
+    # task-32348: the button handler and the ctrl+f action share one
+    # implementation, so the fake binds that too.
+    fake._toggle_library_media_find = MethodType(
+        LibraryScreen._toggle_library_media_find, fake
+    )
     LibraryScreen.handle_library_media_reader_find(
         fake, SimpleNamespace(stop=lambda: None)
     )
@@ -2164,7 +2169,9 @@ async def test_unmount_drains_pending_and_ambiguous_inflight_progress_writes():
 # ---------------------------------------------------------------------------
 
 
-def _reader_key_fake(*, view="viewer", external=False, substate=False, pending=False):
+def _reader_key_fake(
+    *, view="viewer", external=False, substate=False, pending=False, find_open=False
+):
     """A minimal screen fake for the Reader action-key check_action gates."""
     from tldw_chatbook.Library.library_shell_state import LIBRARY_ROW_BROWSE_MEDIA
 
@@ -2174,6 +2181,9 @@ def _reader_key_fake(*, view="viewer", external=False, substate=False, pending=F
         _media_state=SimpleNamespace(
             view=view,
             selected_media_id=media_id,
+            # task-32348: the trash gate reads this -- with the Find bar
+            # open the user is typing a query, not arming a delete.
+            find_open=find_open,
             reader_session=SimpleNamespace(
                 external_detail=external,
                 pending_request=object() if pending else None,
@@ -2218,6 +2228,12 @@ def test_reader_action_keys_gated_to_plain_local_viewer():
         "library_media_move_to_trash",
     ):
         assert LibraryScreen.check_action(listing, action, ()) is False, action
+
+    # task-32348 AC#2: with the Find bar open the caret is in a query field,
+    # so the one destructive single key stands down; the other two do not.
+    finding = _reader_key_fake(find_open=True)
+    assert LibraryScreen.check_action(finding, "library_media_move_to_trash", ()) is False
+    assert LibraryScreen.check_action(finding, "library_media_read_later", ()) is True
 
     # Qodo #2317: while a detail request is pending (mid-load/traversal), the
     # displayed detail is not yet the selected item -> all off.

--- a/backlog/tasks/task-32346 - Library-footer-canvas-key-hints-vanish-whenever-an-Input-has-focus.md
+++ b/backlog/tasks/task-32346 - Library-footer-canvas-key-hints-vanish-whenever-an-Input-has-focus.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32346
 title: 'Library footer: canvas key hints vanish whenever an Input has focus'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:14'
+updated_date: '2026-09-11 07:34'
 labels:
   - library
   - ux
@@ -21,7 +22,29 @@ After submitting a search (or typing in any Library Input) the footer reads 'typ
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The canvas verbs stay visible while an Input has focus, prefixed by the field state (e.g. 'typing in field · esc leaves field | u … | o …')
-- [ ] #2 When width is short, 'F6 next pane' is dropped before any canvas verb
-- [ ] #3 Pinned on Search/RAG and the Media list
+- [x] #1 The canvas verbs stay visible while an Input has focus, prefixed by the field state (e.g. 'typing in field · esc leaves field | u … | o …')
+- [x] #2 When width is short, 'F6 next pane' is dropped before any canvas verb
+- [x] #3 Pinned on Search/RAG and the Media list
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing test: footer chips while an Input has focus (Search/RAG + Media list)
+2. Rewrite the isinstance(focused, (Input, TextArea)) block in _library_footer_shortcuts_for_current_state: lead with 'typing in field', name 'esc leave field' (gated on check_action), keep the swallowed verbs behind 'after esc: ', push 'F6 next pane' last
+3. Green + footer suites, docs stamp
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The snapshot's premise is wrong and the fix keeps the correction: u, o and / are non-priority Bindings, so a focused Input consumes the printable key before any Screen binding sees it -- re-advertising them as live would be the dead-key lie task-31272 removed, and task-31223's suppression stays. What was missing was the way back.
+
+_library_footer_shortcuts_for_current_state's isinstance(focused, (Input, TextArea)) block now splits the route set into swallowed single printable keys and kept multi-char ones, and rebuilds it as:
+  typing in field | esc <label> | after esc: <swallowed verbs> | <other kept> | F6 next pane
+'esc leave field' is synthesised only where the route set carries no Escape chip of its own, gated through check_action('library_blur_text_field') so it can never advertise a refusal; where the surface already owns Escape (the Media list's 'esc focus rail', the Reader's 'esc close') that chip speaks for itself. '/' is dropped from the swallowed list by the same _library_slash_would_land predicate that already drops the live chip. 'F6 next pane' moves LAST so AppFooterStatus's retain-the-prefix degradation drops it before any canvas verb (AC#2).
+
+Live (tmux, seeded profile): Search/RAG query box at 235 cols reads 'typing in field | esc leave field | after esc: u use Library context in Console · o open evidence · / focus search | enter run search | F6 next pane'; the Media filter box reads '... | esc focus rail | after esc: / focus search · s select | F6 next pane'; the Reader Find bar at 160 cols keeps the verbs and drops F6 to the reserved cluster.
+
+Files: tldw_chatbook/UI/Screens/library_screen.py (that one block only), Tests/UI/test_library_crit10_viewer.py (new), Docs/User_Guide/library.md (footer paragraph + the retired 'enter select evidence' claim, stamped).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32348 - Library-Media-viewer-Find-is-unreachable-by-keyboard-and-inert-to-the-click-and-a-failed-attempt-leaves-t-trash-armed.md
+++ b/backlog/tasks/task-32348 - Library-Media-viewer-Find-is-unreachable-by-keyboard-and-inert-to-the-click-and-a-failed-attempt-leaves-t-trash-armed.md
@@ -3,9 +3,10 @@ id: TASK-32348
 title: >-
   Library Media viewer: Find is unreachable by keyboard and inert to the click,
   and a failed attempt leaves 't trash' armed
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:15'
+updated_date: '2026-09-11 07:34'
 labels:
   - library
   - media
@@ -23,7 +24,33 @@ Find is neither in the Tab order (10 Tabs each way) nor opened by the same SGR c
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Find opens from the keyboard (a binding with a footer chip) and is in the viewer's Tab order
-- [ ] #2 No single-key destructive accelerator fires while the viewer's Find gesture is pending
-- [ ] #3 Pinned
+- [x] #1 Find opens from the keyboard (a binding with a footer chip) and is in the viewer's Tab order
+- [x] #2 No single-key destructive accelerator fires while the viewer's Find gesture is pending
+- [x] #3 Pinned
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Unit test: analysis_find_unavailable_reason refuses info/highlights
+2. Implement the refusal in library_media_viewer_state
+3. Extract the Find handler body, add ctrl+f binding + action + check_action gate + footer chip
+4. Gate 't' (trash) off while find_open
+5. UI tests + docs
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+One cause behind both halves of D4/D4a. analysis_find_unavailable_reason only ever considered the Analysis tab and returned '' for every other mode, but _compose_active_body mounts a Find bar on Read and Analysis ONLY. So on Info/Highlights the button was enabled, armed find_open, mounted nothing, and the focus call found no input -- focus stayed outside any Input, where the 't' of a typed 'token' reached the screen accelerator and armed 'Delete this media?'.
+
+- library_media_viewer_state.py: the gate refuses info/highlights with 'This tab has no text to search · switch to Read or Analysis.' (renamed nothing -- 12 call sites reference the name). The disabled button carries that reason on screen and in its tooltip; the key drops from the footer with it.
+- library_screen.py: the handler body is extracted to _toggle_library_media_find, so the new ctrl+f Binding -> action_library_media_reader_find and the Button press run ONE implementation and can never diverge. check_action gates the action on the same reason string, so the ('ctrl+f','find') footer chip can never advertise a refusal. ctrl+f is not printable, so it survives the focused-Input footer transform and still works from inside the Find field itself.
+- AC#2: check_action refuses library_media_move_to_trash while find_open, and the 't trash' chip drops with it.
+
+AC#1's Tab-order half was DISPROVED, not implemented: #library-media-reader-find is an ordinary focusable Button and is in screen.focus_chain -- the test now pins that. What it lacked was a key. No Tab-order change was made. (B's '10 Tabs each way' most likely walked the Items pane's own rows.)
+
+Live (tmux, seeded profile, 235x52): Reader footer shows 'ctrl+f find'; ctrl+f mounts 'Search content…' focused and the footer becomes 'typing in field | esc close | after esc: / focus search · ] next item · l read later · c use in Console | ctrl+f find | F6 next pane' -- 't trash' absent. Typing 'token' filled the query, no delete confirmation. On Info and Highlights the button reads '○ Find', the chip is gone, and ctrl+f is inert.
+
+Files: tldw_chatbook/Library/library_media_viewer_state.py, tldw_chatbook/UI/Screens/library_screen.py (BINDINGS, Reader route branch, check_action branch, Find handler), Tests/UI/test_library_crit10_viewer.py (new), Tests/UI/test_library_media_reader_flow.py (two test doubles updated for the new gate read and the extracted method, plus one new assertion), Docs/User_Guide/library/media-and-conversations.md (Find row, stamped).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32365 - Library-Media-viewer-stored-analysis-renders-as-raw-Markdown.md
+++ b/backlog/tasks/task-32365 - Library-Media-viewer-stored-analysis-renders-as-raw-Markdown.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32365
 title: 'Library Media viewer: stored analysis renders as raw Markdown'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:20'
+updated_date: '2026-09-11 07:34'
 labels:
   - library
   - media
@@ -20,5 +21,28 @@ A stored analysis shows '## Key contributions' as source text inside its box on 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The Analysis tab renders Markdown like the Read tab does, with a Raw toggle
+- [x] #1 The Analysis tab renders Markdown like the Read tab does, with a Raw toggle
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing test: a markdown analysis paints rendered with a Raw toggle
+2. _compose_analysis sniffs the analysis with looks_like_markdown_content and passes the viewer's analysis_content_mode
+3. Reuse _compose_content_mode_toggle with an id prefix; handle the presses in the viewer widget
+4. Green + reader suites, docs
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The Analysis body pinned is_markdown=False, mode='raw' with the comment 'Analysis is plain text -> raw mode, not Markdown'. That assumption is false in practice -- a generated analysis is Markdown -- so '## Key contributions' painted as source. _compose_analysis now runs looks_like_markdown_content (the same content sniff task-32234 made the Read tab's sole authority) and passes it, plus the tab's own view mode, to the same LibraryMediaContentBody. _compose_content_mode_toggle grew is_markdown / mode / prefix arguments defaulting to the Read tab's values, so there is still ONE toggle renderer; the Analysis instance yields #library-media-analysis-content-mode-rendered / -raw. A plain-prose analysis gets no toggle, exactly as a plain item gets none on Read. The Find bar's placeholder also now reflects the analysis's markdown-ness ('Search content (raw text)…').
+
+Deviation from the plan's step, deliberate: the plan said to thread analysis_content_mode from the screen the way content_mode is threaded (a new _media_state field, three edits in library_media_controller.py, two controller handlers and two forwarders in library_screen.py -- the last outside this task's ownership ranges). The mode is the widget's own view state: the screen has nothing to keep in step with it, and the Read tab's in-place sync_mode patch exists only to avoid re-parsing a full document on every traversal keystroke, which a deliberate toggle press is not. So the press is handled in the widget and answered with refresh(recompose=True). ~15 lines in one file instead of ~40 across four, and library_screen.py stayed inside its assigned ranges. Consequence: a Raw choice on Analysis persists for the session instead of being reseeded per item.
+
+The strip and separator ids stay UNPREFIXED: only one Reader body composes at a time so they are still unique, and they carry the width rules (#library-media-content-mode-strip in _agentic_terminal.tcss, plus this class's DEFAULT_CSS for the separator) that keep the row out of Textual's bare-1fr non-rendering trap. No CSS change, no bundle regeneration.
+
+Live (tmux, seeded profile, 235x52): 'Andrej Karpathy — Intro to Large Language Models' opens its Analysis tab with 'Rendered (selected) | Raw' and paints 'Summary' as a heading with bulleted list items; pressing Raw paints '## Summary' and '- Pretraining …' as source. Items with a plain analysis show no toggle.
+
+Files: tldw_chatbook/Widgets/Library/library_media_viewer.py, Tests/UI/test_library_crit10_viewer.py (new), Docs/User_Guide/library/media-and-conversations.md (Analysis section, stamped).
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/Library/library_media_viewer_state.py
+++ b/tldw_chatbook/Library/library_media_viewer_state.py
@@ -514,12 +514,30 @@ def build_library_media_highlight_rows(
 
 
 def detail_analysis_text(detail: Mapping[str, Any]) -> str:
-    """Public read of the newest version's analysis text (see the private helper)."""
-    return _latest_version_analysis_text(detail)
+    """Public read of the analysis the Reader would DISPLAY for ``detail``.
+
+    Qodo on #2602: this returned only the newest version's text, while
+    ``build_library_media_viewer_state`` prefers a top-level
+    ``analysis_content`` and falls back to versions -- so a detail carrying
+    the top-level form with no versions displayed an analysis while both
+    callers here reported none (Find refused it, and the bulk Analyze gate
+    counted the item as un-analyzed). Both want "the analysis the Reader
+    shows", and ``_library_media_unanalyzed_ids`` says exactly that in its
+    own docstring, so the precedence is fixed once, here.
+
+    Args:
+        detail: A ``get_media_item`` detail mapping.
+
+    Returns:
+        The displayed analysis text, or "" when there is none.
+    """
+    return _text(detail.get("analysis_content")) or _latest_version_analysis_text(
+        detail
+    )
 
 
 def analysis_find_unavailable_reason(
-    *, mode: str, analysis: str, generating: bool, editing: bool
+    *, mode: str, analysis: str, generating: bool, editing: bool, external: bool = False
 ) -> str:
     """Why Find cannot open on the Reader tab being read, or "" when it can.
 
@@ -534,6 +552,11 @@ def analysis_find_unavailable_reason(
         analysis: The current analysis text, or "".
         generating: Whether an analysis is being generated.
         editing: Whether the analysis edit form is open.
+        external: Whether this is a server ("external") detail. Those
+            compose the READ body whatever mode was retained
+            (``_compose_active_body``'s first branch is
+            ``external_detail or reader_mode == "read"``), so they always
+            have a bar to mount and are always searchable.
 
     Returns:
         The user-facing reason, or "" when Find is available.
@@ -545,6 +568,13 @@ def analysis_find_unavailable_reason(
     # enabled, armed ``find_open``, mounted nothing, and left focus outside
     # any Input -- where the next typed character fired the screen's own
     # accelerators ("t" armed "Delete this media?", B D4a).
+    if external:
+        # Qodo on #2602: an external detail renders the Read body no matter
+        # which mode the session carried in, so refusing it on a retained
+        # "info"/"highlights" would disable Find over text that is on screen
+        # -- and the gate returned "" for every non-analysis mode before this
+        # task, so that would be a regression, not a tightening.
+        return ""
     if mode in ("info", "highlights"):
         return "This tab has no text to search · switch to Read or Analysis."
     if mode != "analysis":

--- a/tldw_chatbook/Library/library_media_viewer_state.py
+++ b/tldw_chatbook/Library/library_media_viewer_state.py
@@ -521,7 +521,7 @@ def detail_analysis_text(detail: Mapping[str, Any]) -> str:
 def analysis_find_unavailable_reason(
     *, mode: str, analysis: str, generating: bool, editing: bool
 ) -> str:
-    """Why Find cannot open on the Analysis tab right now, or "" when it can.
+    """Why Find cannot open on the Reader tab being read, or "" when it can.
 
     Qodo on #2378: Find opens the bar for the tab being read, and the
     Analysis tab composes its bar only around analysis text. With no text
@@ -538,6 +538,15 @@ def analysis_find_unavailable_reason(
     Returns:
         The user-facing reason, or "" when Find is available.
     """
+    # task-32348 (critique #10, B D4): Find mounts the bar that
+    # ``_compose_active_body`` composes, and only the Read and Analysis
+    # bodies compose one. On Info/Highlights the gate returned "" (the
+    # function only ever considered the Analysis tab), so the button was
+    # enabled, armed ``find_open``, mounted nothing, and left focus outside
+    # any Input -- where the next typed character fired the screen's own
+    # accelerators ("t" armed "Delete this media?", B D4a).
+    if mode in ("info", "highlights"):
+        return "This tab has no text to search · switch to Read or Analysis."
     if mode != "analysis":
         return ""
     if generating:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4436,10 +4436,47 @@ class LibraryScreen(BaseAppScreen):
         # F-keys) and the informational chips, and announce the swap.
         focused = self.focused
         if isinstance(focused, (Input, TextArea)):
-            shortcuts = (("", "typing in field"),) + tuple(
+            swallowed = tuple(
+                pair
+                for pair in shortcuts
+                if len(pair[0]) == 1 and pair[0].isprintable()
+            )
+            kept = tuple(
                 pair
                 for pair in shortcuts
                 if not (len(pair[0]) == 1 and pair[0].isprintable())
+            )
+            # task-32346 (critique #10 P1): the keys really are swallowed --
+            # every one of them is a non-priority Binding and the Input eats
+            # the keypress first (see the binding comments at 1099/1114/1123),
+            # so re-advertising them as live would be the dead-key lie
+            # task-31272 removed. What was missing is the way back: the field
+            # state now names the gesture that re-arms the canvas, and the
+            # verbs stay on screen behind it instead of vanishing.
+            if self.is_mounted and not self._library_slash_would_land():
+                swallowed = tuple(pair for pair in swallowed if pair[0] != "/")
+            esc_pairs = tuple(pair for pair in kept if pair[0] == "esc")
+            if not esc_pairs and self.check_action("library_blur_text_field", ()):
+                esc_pairs = (("esc", "leave field"),)
+            verbs = (
+                (
+                    (
+                        "",
+                        "after esc: "
+                        + " · ".join(f"{key} {label}" for key, label in swallowed),
+                    ),
+                )
+                if swallowed
+                else ()
+            )
+            # AC#2: "F6 next pane" goes LAST so AppFooterStatus's
+            # retain-the-prefix degradation drops it before any canvas verb.
+            f6_pairs = tuple(pair for pair in kept if pair[0] == "F6")
+            rest = tuple(
+                pair for pair in kept if pair[0] not in ("F6", "esc")
+            )
+            shortcuts = (
+                (("", "typing in field"),) + esc_pairs + verbs + rest + f6_pairs
             )
         emergency = self._library_emergency_return_eligibility()
         if emergency.enabled:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -31693,6 +31693,7 @@ class LibraryScreen(BaseAppScreen):
             analysis=analysis,
             generating=self._media_state.generating_analysis,
             editing=self._media_state.editing_analysis,
+            external=self._media_state.reader_session.external_detail,
         )
 
     def _library_media_analysis_provider_reason(self) -> str:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4452,7 +4452,17 @@ class LibraryScreen(BaseAppScreen):
         # swallowed keys, keep the ones that still work (esc / enter /
         # F-keys) and the informational chips, and announce the swap.
         focused = self.focused
-        if isinstance(focused, (Input, TextArea)):
+        # task-32346, coordinator ruling: BELOW 64 COLUMNS this transform
+        # stands down entirely. Task 6 measured that the narrow stage paints
+        # exactly one ~24-character context chip, and that on that stage
+        # Escape genuinely RETURNS TO LIBRARY (``library_narrow_stage_return``
+        # passes, ``library_blur_text_field`` does not) -- so its single chip
+        # is the whole truth there, and adding "typing in field · after esc:
+        # …" only makes AppFooterStatus elide the context to "…". The wide
+        # form below is unchanged at >= 64 columns.
+        if isinstance(focused, (Input, TextArea)) and not (
+            self._library_narrow_stage_return_active()
+        ):
             swallowed = tuple(
                 pair
                 for pair in shortcuts

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4214,8 +4214,15 @@ class LibraryScreen(BaseAppScreen):
                 for key, gated_action, label in (
                     # task-32348: a multi-char key, so it survives the
                     # focused-Input transformation above and stays useful
-                    # while the Find field itself has focus.
-                    ("ctrl+f", "library_media_reader_find", "find"),
+                    # while the Find field itself has focus. The label
+                    # follows the toggle -- with the bar open the key
+                    # closes it, and "find" there would name the wrong half
+                    # of a two-way key.
+                    (
+                        "ctrl+f",
+                        "library_media_reader_find",
+                        "close find" if self._media_state.find_open else "find",
+                    ),
                     ("l", "library_media_read_later", "read later"),
                     ("c", "library_media_use_in_console", "use in Console"),
                     ("t", "library_media_move_to_trash", "trash"),
@@ -4463,8 +4470,26 @@ class LibraryScreen(BaseAppScreen):
             # task-31272 removed. What was missing is the way back: the field
             # state now names the gesture that re-arms the canvas, and the
             # verbs stay on screen behind it instead of vanishing.
+            #
+            # The verbs are baked into a TEXT chip whose key is "", so the two
+            # "/" suppressions further down this function can no longer reach
+            # them -- both are mirrored here or the chip would name a key the
+            # screen refuses (review finding 4). Dead-key predicate first, then
+            # the starter-lifecycle one, which drops only the search label.
             if self.is_mounted and not self._library_slash_would_land():
                 swallowed = tuple(pair for pair in swallowed if pair[0] != "/")
+            if self._library_lifecycle in (
+                LibraryLifecycle.UNKNOWN,
+                LibraryLifecycle.STARTER,
+            ):
+                swallowed = tuple(
+                    pair
+                    for pair in swallowed
+                    if not (
+                        pair[0] == "/"
+                        and pair[1].casefold() in {"focus search", "search"}
+                    )
+                )
             esc_pairs = tuple(pair for pair in kept if pair[0] == "esc")
             if not esc_pairs and self.check_action("library_blur_text_field", ()):
                 esc_pairs = (("esc", "leave field"),)
@@ -24286,8 +24311,13 @@ class LibraryScreen(BaseAppScreen):
             ):
                 return False
             if action == "library_media_reader_find":
-                # task-32348: live exactly where the button is enabled, so
-                # the footer chip below can never advertise a refusal.
+                # task-32348: live only where the button is enabled AND the
+                # Reader is settled -- the fences above (this row, the
+                # viewer view, no sub-state, no pending detail) make the key
+                # strictly narrower than the button, which consults only
+                # ``analysis_find_unavailable_reason``. The footer chip is
+                # gated on this same call, so it can never advertise a
+                # refusal either way.
                 return not self._library_media_find_unavailable_reason()
             if (
                 action == "library_media_move_to_trash"

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1115,6 +1115,12 @@ class LibraryScreen(BaseAppScreen):
             show=False,
         ),
         Binding("t", "library_media_move_to_trash", "Move to trash", show=False),
+        # task-32348 (critique #10, B K20): Find had no key at all -- it was
+        # a Button and nothing else, so a keyboard-only reader could not open
+        # the search bar the guide promises. ``ctrl+f`` is free on this screen
+        # (grep the BINDINGS above) and is not a printable key, so it works
+        # from inside the Reader's own text controls too.
+        Binding("ctrl+f", "library_media_reader_find", "Find", show=False),
         # task-28241: review-set keys, gated in check_action to a plain Reader
         # with a set active. "R" exits (the set stays resumable); "m" toggles
         # the current item's done mark (the manual counterpart to ]'s auto-mark).
@@ -4206,6 +4212,10 @@ class LibraryScreen(BaseAppScreen):
                 # refuse (external/server detail hides l and t). Short
                 # labels: the footer compacts at 100 columns.
                 for key, gated_action, label in (
+                    # task-32348: a multi-char key, so it survives the
+                    # focused-Input transformation above and stays useful
+                    # while the Find field itself has focus.
+                    ("ctrl+f", "library_media_reader_find", "find"),
                     ("l", "library_media_read_later", "read later"),
                     ("c", "library_media_use_in_console", "use in Console"),
                     ("t", "library_media_move_to_trash", "trash"),
@@ -24252,6 +24262,7 @@ class LibraryScreen(BaseAppScreen):
             "library_media_read_later",
             "library_media_use_in_console",
             "library_media_move_to_trash",
+            "library_media_reader_find",
         ):
             # task-28027: Reader action-row accelerators. Only in a plain
             # media Reader (no edit/confirm/analysis-edit sub-state). Read-
@@ -24273,6 +24284,21 @@ class LibraryScreen(BaseAppScreen):
                 session.pending_request is not None
                 or session.loaded_id != self._media_state.selected_media_id
             ):
+                return False
+            if action == "library_media_reader_find":
+                # task-32348: live exactly where the button is enabled, so
+                # the footer chip below can never advertise a refusal.
+                return not self._library_media_find_unavailable_reason()
+            if (
+                action == "library_media_move_to_trash"
+                and self._media_state.find_open
+            ):
+                # task-32348 AC#2 (B D4a): with the Find bar open the user is
+                # typing a query. The bar takes focus on mount, so this is
+                # belt-and-braces -- but the one path where it did NOT (a
+                # tab with no bar, now refused outright) armed "Delete this
+                # media?" from the "t" of "token". The footer chip drops
+                # with the gate.
                 return False
             if action == "library_media_use_in_console":
                 return True
@@ -31558,6 +31584,20 @@ class LibraryScreen(BaseAppScreen):
             event: The Find button press.
         """
         event.stop()
+        self._toggle_library_media_find()
+
+    def action_library_media_reader_find(self) -> None:
+        """Open (or close) the Reader's Find bar from the keyboard (task-32348).
+
+        The same gesture the Find button performs -- one implementation, so
+        the key can never diverge from the control (the ``check_action``
+        gate is the same reason string the button's own disabled state
+        reads).
+        """
+        self._toggle_library_media_find()
+
+    def _toggle_library_media_find(self) -> None:
+        """Open the Find bar for the tab being read, or close an open one."""
         if self._media_state.find_open:
             # task-31269 AC4: Find is a toggle -- a second press closes the
             # bar (live: it did nothing while the bar was open).

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4520,8 +4520,27 @@ class LibraryScreen(BaseAppScreen):
             rest = tuple(
                 pair for pair in kept if pair[0] not in ("F6", "esc")
             )
+            # ...and on a surface the narrow-stage stand-down above does NOT
+            # cover -- ``_library_narrow_stage_return_active`` yields whenever
+            # an earlier Escape action owns the key, and its docstring names
+            # the 60x24 Media viewer as exactly that case -- the single
+            # painted chip must still be a KEY, not a status word. Leading
+            # with "typing in field" there paints that and nothing else
+            # (measured live at 60x24 with the Find bar open), which is less
+            # than the blurred footer said. Escape leads instead: it is the
+            # one key that works from inside the field, which is the same
+            # "recovery outranks navigation below 64 columns" order Task 6's
+            # block uses, so the two read as one grammar at that width.
+            narrow = (
+                self.is_mounted
+                and self.size.width > 0
+                and ordinary_emergency_required(self.size.width)
+            )
+            status = (("", "typing in field"),)
             shortcuts = (
-                (("", "typing in field"),) + esc_pairs + verbs + rest + f6_pairs
+                (esc_pairs + status + verbs + rest + f6_pairs)
+                if narrow
+                else (status + esc_pairs + verbs + rest + f6_pairs)
             )
         emergency = self._library_emergency_return_eligibility()
         if emergency.enabled:

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -34,6 +34,7 @@ from tldw_chatbook.Library.library_media_viewer_state import (
     LibraryMediaHighlightRow,
     LibraryMediaViewerState,
     find_content_matches,
+    looks_like_markdown_content,
 )
 from tldw_chatbook.Widgets.Library.library_canvas_sync import (
     PostRecomposeCallback,
@@ -117,6 +118,12 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             a toggle -- when ``viewer.is_markdown`` is true; the screen is
             responsible for defaulting this per item and never showing
             ``"rendered"`` for a non-markdown item.
+        analysis_content_mode: The same choice for the Analysis tab's own
+            body (task-32365). Separate from ``content_mode`` because the
+            two tabs hold different text: an item's transcript can be plain
+            while its generated analysis is Markdown, and vice versa. Owned
+            by this widget -- the toggle handler below flips it and
+            recomposes -- so it survives the screen's viewer syncs.
     """
 
     DEFAULT_CSS = """
@@ -140,6 +147,7 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         content_query: str = "",
         content_match_index: int = 0,
         content_mode: str = "raw",
+        analysis_content_mode: str = "rendered",
         find_open: bool = False,
         find_focus_pending: bool = False,
         loading: bool = False,
@@ -215,6 +223,7 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         self.content_query = content_query
         self.content_match_index = content_match_index
         self.content_mode = content_mode
+        self.analysis_content_mode = analysis_content_mode
         self.find_open = find_open
         self.find_focus_pending = find_focus_pending
         self.loading = loading
@@ -575,8 +584,24 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                     markup=False,
                 )
 
-    def _compose_content_mode_toggle(self) -> ComposeResult:
+    def _compose_content_mode_toggle(
+        self,
+        *,
+        is_markdown: bool | None = None,
+        mode: str | None = None,
+        prefix: str = "library-media",
+    ) -> ComposeResult:
         """Render the Rendered|Raw toggle, for an item that can render.
+
+        task-32365: the Analysis tab renders the same pair over its own
+        text, so the three things that differ per tab -- whether there is
+        anything to render, which view is selected, and the button ids the
+        press handler keys on -- are arguments, defaulting to the Read
+        tab's. The strip and separator ids stay fixed: only one Reader body
+        composes at a time, so they are still unique, and they carry the
+        width rules (this class's ``DEFAULT_CSS`` and
+        ``#library-media-content-mode-strip``) that keep the row from
+        hitting Textual's bare-``1fr`` non-rendering trap.
 
         The toggle is offered only when ``self.viewer.is_markdown`` is true
         -- a non-markdown item always shows the plain Raw view (no behavior
@@ -600,7 +625,11 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             non-markdown item (see the Info branch of
             ``_compose_active_body``).
         """
-        if not self.viewer.is_markdown:
+        if is_markdown is None:
+            is_markdown = self.viewer.is_markdown
+        if mode is None:
+            mode = self.content_mode
+        if not is_markdown:
             # task-32068: the note is a FACT ABOUT THE ITEM, so it belongs to
             # Info (``_compose_active_body``'s info branch), not above the
             # text on every read. Most items are plain, so critique #8 met it
@@ -610,10 +639,10 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             # affordance for nothing (task-31635, critique #5 item 13).
             return
         with Horizontal(id="library-media-content-mode-strip"):
-            rendered_selected = self.content_mode == "rendered"
+            rendered_selected = mode == "rendered"
             rendered_button = Button(
                 "Rendered (selected)" if rendered_selected else "Rendered",
-                id="library-media-content-mode-rendered",
+                id=f"{prefix}-content-mode-rendered",
                 compact=True,
             )
             rendered_button.set_class(rendered_selected, "-selected")
@@ -622,11 +651,32 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             raw_selected = not rendered_selected
             raw_button = Button(
                 "Raw (selected)" if raw_selected else "Raw",
-                id="library-media-content-mode-raw",
+                id=f"{prefix}-content-mode-raw",
                 compact=True,
             )
             raw_button.set_class(raw_selected, "-selected")
             yield raw_button
+
+    @on(Button.Pressed, "#library-media-analysis-content-mode-rendered")
+    @on(Button.Pressed, "#library-media-analysis-content-mode-raw")
+    def _handle_analysis_content_mode(self, event: Button.Pressed) -> None:
+        """Flip the Analysis tab between its rendered and raw views.
+
+        Handled here rather than on the screen (where the Read tab's twin
+        lives) because the choice is this widget's own state: the screen
+        has no analysis view-mode to keep in step, and a recompose is the
+        whole update -- the Read tab patches in place only to avoid
+        re-parsing a full document on every traversal keystroke, which a
+        deliberate toggle press is not.
+
+        Args:
+            event: The Rendered or Raw press from the Analysis toggle strip.
+        """
+        event.stop()
+        self.analysis_content_mode = (
+            "rendered" if str(event.button.id).endswith("-rendered") else "raw"
+        )
+        self.refresh(recompose=True)
 
     # ---- TASK-31745: rename a finished meeting's speakers, from the reader --
     #: What each refusal means in the user's terms, keyed by the reason
@@ -1015,14 +1065,20 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             # bar works over the analysis text. The screen's search corpus
             # (_library_media_content_matches) is mode-aware, so the query,
             # match count, Prev/Next, and Enter-advance all follow the
-            # active tab. Analysis is plain text -> raw mode, not Markdown.
+            # active tab.
+            analysis_is_markdown = looks_like_markdown_content(self.viewer.analysis)
             matches = find_content_matches(self.viewer.analysis, self.content_query)
             # task-31269: like Read, the bar is collapsed until Find opens
             # it -- an always-mounted bar stole focus on every item load and
             # swallowed the walk keys (critique #4 P0).
+            yield from self._compose_content_mode_toggle(
+                is_markdown=analysis_is_markdown,
+                mode=self.analysis_content_mode,
+                prefix="library-media-analysis",
+            )
             if self.find_open or self.content_query:
                 yield LibraryMediaContentSearchControls(
-                    is_markdown=False,
+                    is_markdown=analysis_is_markdown,
                     query=self.content_query,
                     matches=matches,
                     match_index=self.content_match_index,
@@ -1032,8 +1088,15 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                 self.find_focus_pending = False
             yield LibraryMediaContentBody(
                 content=self.viewer.analysis,
-                is_markdown=False,
-                mode="raw",
+                # task-32365 (critique #10): this body used to pin
+                # ``is_markdown=False, mode="raw"`` because an analysis was
+                # assumed to be plain text. Generated analyses are Markdown
+                # in practice ("## Key contributions" painted as source, A
+                # cap 43), and task-32234 already made the CONTENT sniff --
+                # not a type guess -- the Read tab's authority. Same sniff,
+                # same widget, same Raw toggle.
+                is_markdown=analysis_is_markdown,
+                mode=self.analysis_content_mode,
                 query=self.content_query,
                 match_index=self.content_match_index,
                 id="library-media-viewer-content",

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -410,6 +410,12 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                 analysis=self.viewer.analysis,
                 generating=self.generating_analysis,
                 editing=self.editing_analysis,
+                # Qodo 4 on #2602: an external detail composes the READ body
+                # whatever mode the session carried in, so the gate needs to
+                # know -- without this the KEY opened Find on a server
+                # document while this button stayed disabled, the exact
+                # key/control divergence one shared gate exists to prevent.
+                external=self.external_detail,
             )
             find = Button(
                 library_disabled_action_label("Find", bool(find_reason)),

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -600,7 +600,7 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         is_markdown: bool | None = None,
         mode: str | None = None,
         prefix: str = "library-media",
-        rendered_blocked_reason: str = "",
+        blocked_reason: str = "",
     ) -> ComposeResult:
         """Render the Rendered|Raw toggle, for an item that can render.
 
@@ -654,19 +654,22 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             rendered_button = Button(
                 library_disabled_action_label(
                     "Rendered (selected)" if rendered_selected else "Rendered",
-                    bool(rendered_blocked_reason),
+                    bool(blocked_reason),
                 ),
                 id=f"{prefix}-content-mode-rendered",
                 compact=True,
             )
             rendered_button.set_class(rendered_selected, "-selected")
-            if rendered_blocked_reason:
+            if blocked_reason:
                 # Never a pressable control that changes nothing: while a
-                # query forces the Raw view (see ``_compose_analysis``),
-                # Rendered is refused with its reason rather than accepting
-                # the press and repainting the same body.
+                # query forces the Raw view (see ``_compose_analysis``) the
+                # strip reports the state and says why, and NEITHER half
+                # accepts a press -- Qodo on #2602 found that pressing the
+                # already-selected Raw wrote the stored preference, so
+                # clearing the query no longer restored Rendered and the
+                # line beneath became a false promise.
                 rendered_button.disabled = True
-                rendered_button.tooltip = rendered_blocked_reason
+                rendered_button.tooltip = blocked_reason
             yield rendered_button
             yield Static("|", id="library-media-content-mode-separator", markup=False)
             raw_selected = not rendered_selected
@@ -676,6 +679,9 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                 compact=True,
             )
             raw_button.set_class(raw_selected, "-selected")
+            if blocked_reason:
+                raw_button.disabled = True
+                raw_button.tooltip = blocked_reason
             yield raw_button
 
     @on(Button.Pressed, "#library-media-analysis-content-mode-rendered")
@@ -1117,21 +1123,21 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             # task-31269: like Read, the bar is collapsed until Find opens
             # it -- an always-mounted bar stole focus on every item load and
             # swallowed the walk keys (critique #4 P0).
-            rendered_blocked = (
+            blocked = (
                 ANALYSIS_RENDERED_BLOCKED_BY_SEARCH if self.content_query else ""
             )
             yield from self._compose_content_mode_toggle(
                 is_markdown=analysis_is_markdown,
                 mode=analysis_mode,
                 prefix="library-media-analysis",
-                rendered_blocked_reason=rendered_blocked,
+                blocked_reason=blocked,
             )
-            if rendered_blocked and analysis_is_markdown:
+            if blocked and analysis_is_markdown:
                 # The reason reaches a keyboard-first reader, not only a
                 # mouse tooltip -- the same inline-reason grammar the
                 # Generate gate below uses (task-31981).
                 yield Static(
-                    rendered_blocked,
+                    blocked,
                     id="library-media-analysis-content-mode-reason",
                     classes="library-media-action-reason",
                     markup=False,

--- a/tldw_chatbook/Widgets/Library/library_media_viewer.py
+++ b/tldw_chatbook/Widgets/Library/library_media_viewer.py
@@ -66,6 +66,16 @@ READER_EMPTY_FAILED_COPY = "Nothing loaded — the list could not be loaded."
 #: It now says why THIS item has none.
 RENDERED_VIEW_NOTE = "No Markdown formatting to render — showing the stored text"
 
+#: task-32365 review finding 1: only the Raw view marks a match (rendered
+#: mode mounts the Markdown widget alone, so there is no raw widget to
+#: restyle and the scroll-to-match is a SOURCE line index). An active query
+#: therefore forces Raw on the Analysis tab; this says so and names the way
+#: back, rather than leaving a Rendered button that repaints the same body.
+ANALYSIS_RENDERED_BLOCKED_BY_SEARCH = (
+    "Showing the stored text so matches can be marked · clear the search to "
+    "read it rendered."
+)
+
 
 def empty_reader_copy(*, loading: bool, list_failed: bool) -> str:
     """Return the empty Reader's placeholder copy.
@@ -590,6 +600,7 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         is_markdown: bool | None = None,
         mode: str | None = None,
         prefix: str = "library-media",
+        rendered_blocked_reason: str = "",
     ) -> ComposeResult:
         """Render the Rendered|Raw toggle, for an item that can render.
 
@@ -641,11 +652,21 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         with Horizontal(id="library-media-content-mode-strip"):
             rendered_selected = mode == "rendered"
             rendered_button = Button(
-                "Rendered (selected)" if rendered_selected else "Rendered",
+                library_disabled_action_label(
+                    "Rendered (selected)" if rendered_selected else "Rendered",
+                    bool(rendered_blocked_reason),
+                ),
                 id=f"{prefix}-content-mode-rendered",
                 compact=True,
             )
             rendered_button.set_class(rendered_selected, "-selected")
+            if rendered_blocked_reason:
+                # Never a pressable control that changes nothing: while a
+                # query forces the Raw view (see ``_compose_analysis``),
+                # Rendered is refused with its reason rather than accepting
+                # the press and repainting the same body.
+                rendered_button.disabled = True
+                rendered_button.tooltip = rendered_blocked_reason
             yield rendered_button
             yield Static("|", id="library-media-content-mode-separator", markup=False)
             raw_selected = not rendered_selected
@@ -925,8 +946,22 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
         Returns:
             None.
         """
+        forces_analysis_raw = (
+            self.reader_mode == "analysis"
+            and bool(self.content_query) != bool(query)
+            and looks_like_markdown_content(self.viewer.analysis)
+        )
         self.content_query = query
         self.content_match_index = match_index
+        if forces_analysis_raw:
+            # task-32365 review finding 1: this seam patches in place, so the
+            # composed mode would never follow the query and the marked Raw
+            # view would never appear. Rebuild instead -- the Find bar hands
+            # its own caret back through the existing focus token, so the
+            # swap costs the user nothing.
+            self.find_focus_pending = True
+            self.refresh(recompose=True)
+            return
         self.query_one(
             "#library-media-content-search-controls",
             LibraryMediaContentSearchControls,
@@ -1068,14 +1103,39 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
             # active tab.
             analysis_is_markdown = looks_like_markdown_content(self.viewer.analysis)
             matches = find_content_matches(self.viewer.analysis, self.content_query)
+            # task-32365 review finding 1: only the Raw view can MARK a match
+            # -- rendered mode mounts the Markdown widget alone, so
+            # ``LibraryMediaContentBody.sync_search`` has no raw widget to
+            # restyle and the scroll-to-match applies a SOURCE line index to
+            # a rendered scroller. Before this task the analysis was always
+            # raw, so Find worked; making it renderable would have shipped
+            # "Match 3 of 11" over a body with nothing highlighted. An active
+            # query therefore shows the view that can mark, and the toggle
+            # strip below reads "Raw (selected)" so the swap is stated, not
+            # silent. Clearing the query hands Rendered straight back.
+            analysis_mode = "raw" if self.content_query else self.analysis_content_mode
             # task-31269: like Read, the bar is collapsed until Find opens
             # it -- an always-mounted bar stole focus on every item load and
             # swallowed the walk keys (critique #4 P0).
+            rendered_blocked = (
+                ANALYSIS_RENDERED_BLOCKED_BY_SEARCH if self.content_query else ""
+            )
             yield from self._compose_content_mode_toggle(
                 is_markdown=analysis_is_markdown,
-                mode=self.analysis_content_mode,
+                mode=analysis_mode,
                 prefix="library-media-analysis",
+                rendered_blocked_reason=rendered_blocked,
             )
+            if rendered_blocked and analysis_is_markdown:
+                # The reason reaches a keyboard-first reader, not only a
+                # mouse tooltip -- the same inline-reason grammar the
+                # Generate gate below uses (task-31981).
+                yield Static(
+                    rendered_blocked,
+                    id="library-media-analysis-content-mode-reason",
+                    classes="library-media-action-reason",
+                    markup=False,
+                )
             if self.find_open or self.content_query:
                 yield LibraryMediaContentSearchControls(
                     is_markdown=analysis_is_markdown,
@@ -1096,7 +1156,7 @@ class LibraryMediaViewer(PostRecomposeCallback, Vertical):
                 # not a type guess -- the Read tab's authority. Same sniff,
                 # same widget, same Raw toggle.
                 is_markdown=analysis_is_markdown,
-                mode=self.analysis_content_mode,
+                mode=analysis_mode,
                 query=self.content_query,
                 match_index=self.content_match_index,
                 id="library-media-viewer-content",


### PR DESCRIPTION
Part of the Library critique-10 fix wave (plan: `Docs/superpowers/plans/2026-09-11-library-crit10-wave.md`, group `viewer`). Lands before the `export` (#2601) and `layout` branches, which carry a viewer carve-out and the adjacent footer block.

## What
- **task-32346** — while an Input has focus the footer keeps the canvas verbs visible behind one named key (`typing in field · after esc: …`) instead of blanking to `typing in field | F6 next pane`; it never advertises a key that does nothing (a focused Input eats non-priority bindings, so `u`/`o`/`/` are shown as what follows Escape — the dead-key lie task-31272 removed stays removed); `F6 next pane` is dropped before any canvas verb when width is short; below 64 columns the block stands down entirely so the narrow stage's single chip (`esc back to Library`, owned by the layout branch) is the whole context.
- **task-32348** — the Media viewer's Find opens from the keyboard (`ctrl+f`, with a footer chip) and is refused with a reason on the tabs that cannot search; the `t` trash accelerator cannot fire while a Find gesture is pending. The critique's "not in the Tab order" claim is disproved by a `focus_chain` pin, not "fixed". One cause fixed once in `analysis_find_unavailable_reason`.
- **task-32365** — a Markdown analysis renders (content sniff + a Rendered/Raw toggle owned by the viewer widget); Find over a rendered analysis highlights and scrolls to matches (the seam now rebuilds on a query start/end).

## Evidence
- `Tests/UI/test_library_crit10_viewer.py` (10 tests, red-first) + updated doubles in `test_library_media_reader_flow.py`; the four reader/render files re-run to exactly the base's failing names; 60x24 painted footer pin shared with the layout branch.
- Live-verified on an isolated seeded profile.
- Guides: `library.md`, `library/media-and-conversations.md` with refreshed stamps.

## Review
Task review (approved; 1 Medium, 1 low-medium, 5 low) → fix round 1 (`13d18854c8`, `7fd66fdbd8`, `fbd68a742f`; one decline with evidence — the remaining item belongs to the export branch). Rider noted: the Read tab's Find has the same patch-without-recompose gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three Library critique-10 viewer issues: the typing footer keeps its canvas verbs, Find opens from the keyboard, and stored Markdown analyses render.

**task-32346 — footer under a focused field**
- With a text field focused, the footer leads with `typing in field`, names an honest Escape chip (gated through `check_action`), and keeps the canvas verbs behind `after esc:` instead of blanking them.
- `F6 next pane` is dropped before any verb on narrow widths; below 64 columns the single chip names the one key that works (Escape on the viewer), never a bare status word.

**tasks-32348/32365 — Find and the Analysis tab**
- `ctrl+f` opens the Reader's Find bar with a footer chip, sharing one implementation and one gate with the Find button so the two can't diverge; Info/Highlights refuse Find with a reason, external details stay searchable, and the gate reads the analysis the viewer actually displays.
- An open Find bar disarms the `t` trash accelerator. The analysis view choice persists for the session.
- The Analysis tab runs the same Markdown content sniff and Rendered/Raw toggle as Read, so a stored `## Key contributions` paints as a heading; plain-prose analyses get no toggle.
- An active Find query over a rendered analysis swaps to the Raw view (the only one that marks matches) and back on clear; while the query forces Raw, neither toggle half accepts a press and the reason is shown inline.
- The "Find not in the Tab order" claim is disproved by a `focus_chain` pin rather than fixed.

<sup>Written for commit 6207e5816803d246c77bed0e58fa2ea89cc57090. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2602?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

