### PR TITLE
fix(library): labelled grips, link-on-use hand-off, rail focus shape, narrow footer (crit10 layout)

### DIFF
--- a/Docs/User_Guide/library.md
+++ b/Docs/User_Guide/library.md
@@ -212,7 +212,11 @@ readable measure rather than stretched across the whole canvas.
   - a **Navigation** heading with **Collapse** at the opposite edge. Collapse
     hides the rail without changing the selected destination, search query,
     section disclosures, or canvas. The slim **Nav** handle expands it again;
-    it is keyboard-focusable and remains part of the **F6** pane cycle;
+    it is keyboard-focusable and remains part of the **F6** pane cycle. The
+    handle is five cells wide, so it spells its name **downwards** —
+    `N`/`a`/`v` down the column, with the collapse arrows below it. The
+    handle beside the list pane does the same with that pane's name
+    (**Items**, **Prompts**, **Skills**, **Folder files**);
   - the **Import…** button ("Add files, links, and transcripts to
     your Library.");
   - the **Search Library…** box — submitting it lands on the
@@ -275,6 +279,13 @@ visible stage so its controls remain on-screen. Escape (or the
 **Library notes** link) returns to the notes list — see
 [File Notes](library/file-notes.md).
 
+Opening a **note for editing** is the one place the rail steps aside on a
+wide terminal, deliberately: at 120 columns and more of editor width the
+rail collapses to its **Nav** handle so the note gets the room, and Escape
+(or **Nav**) brings it straight back. Expanding it by hand ends that for the
+rest of the visit — the rail then stays put while you open one note after
+another.
+
 ## Features & controls
 
 ### State glyphs
@@ -305,7 +316,7 @@ leading `▸` uses cannot collide on one control.
 | Control | What it does |
 |---|---|
 | **Collapse** | Hides the wide navigation rail in place and gives the canvas the reclaimed width. The choice lasts for the current Library screen session. |
-| **Nav** | Expands a manually collapsed rail and returns focus to **Search Library…**. On compact terminals, Library's existing one-pane routing takes precedence and the manual collapse returns when the terminal is wide again. |
+| **Nav** | Expands a collapsed rail and returns focus to **Search Library…**. The handle spells `Nav` down its five-cell column, so it is readable without hovering. On compact terminals, Library's existing one-pane routing takes precedence and the manual collapse returns when the terminal is wide again. Used on the rail a note editor collapsed, it also ends that editor's claim on the width for the rest of the visit. |
 | **Import…** | Opens the Import media canvas — see [Import & export](library/import-and-export.md). |
 | **New note** | Opens the production note-creation canvas. It is shown directly in the Get started rail. |
 | **Explore all tools** | Reveals and remembers the complete Library without changing section disclosures. |
@@ -884,3 +895,9 @@ list, and the landing hub is capped at 96 cells).*
 (task-32225: the return chip stands down wherever a canvas owns Escape itself,
 so the footer never names a return the key would not perform; task-32228:
 Conversations arrives with its first row focused like every other browse list).*
+
+*Verified against fix/library-crit10-layout — 2026-09-11 (task-32355: both
+pane handles paint their own name down the column, and the note editor's
+deliberate claim on the rail's width is stated where the rail is described;
+task-32359: a focused rail row carries the house `█` bar, so it is no longer
+the same picture as the active destination).*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -668,7 +668,7 @@ requested load.
 | "Filter conversations… (Enter)" | Type and press Enter to search conversation titles, stable IDs, and indexed message content before the 20-item result page is chosen. Clearing it restores unfiltered page 1. |
 | "Previous" / "Next" | Moves through complete 20-item pages; the final page may contain fewer rows. Disabled buttons state why they cannot move. |
 | Row press | Selects the row and loads it into the **Conversation reader** — not a preview. See below. |
-| "Open in Console" | In the reader header, beside **Read** and **Info** (keyboard: `c`). Stages the conversation as **source context** in Console — see below. |
+| "Resume conversation" / "Restore and resume" | In the reader header, beside **Read** and **Info** (keyboard: `c`). Reopens the original conversation in Console — it does **not** stage it as source context, and it does not depend on workspace membership. |
 | "Use as source" | In the reader header. Stages the open conversation as **source context** in Console. If the conversation is not in the active workspace, the press **links it first**, then continues — see below. |
 | "Link to workspace" | Appears in the same header row only while the open conversation is not in the active workspace. Press it to take on the membership **without** handing anything to Console. |
 | "Undo link" | Appears under the **"✓ linked · \<workspace\>"** receipt after a link, and removes exactly the membership that press added. |
@@ -1191,6 +1191,12 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-layout — 2026-09-11, fix round 1
+(task-32107: the refusal/promise sentence renders directly under the action it
+describes, and Undo removes the membership from the workspace its receipt
+names rather than whichever workspace is active when it is pressed; the
+Resume row above no longer claims to stage source context).*
 
 *Verified against fix/library-crit10-layout — 2026-09-11 (task-32107, user
 decision: "Use as source" links a conversation into the active workspace in

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -669,7 +669,9 @@ requested load.
 | "Previous" / "Next" | Moves through complete 20-item pages; the final page may contain fewer rows. Disabled buttons state why they cannot move. |
 | Row press | Selects the row and loads it into the **Conversation reader** — not a preview. See below. |
 | "Open in Console" | In the reader header, beside **Read** and **Info** (keyboard: `c`). Stages the conversation as **source context** in Console — see below. |
-| "Link to workspace" | Appears in the same header row only while the open conversation is not in the active workspace. One press links it, and "Open in Console" enables in place. |
+| "Use as source" | In the reader header. Stages the open conversation as **source context** in Console. If the conversation is not in the active workspace, the press **links it first**, then continues — see below. |
+| "Link to workspace" | Appears in the same header row only while the open conversation is not in the active workspace. Press it to take on the membership **without** handing anything to Console. |
+| "Undo link" | Appears under the **"✓ linked · \<workspace\>"** receipt after a link, and removes exactly the membership that press added. |
 | "Export…" / "Select" | The shared grammar; export packages conversations into a bundle. |
 
 **The detail pane is a transcript reader.** Pressing a row loads the whole
@@ -860,20 +862,33 @@ Escape's return to the list live at 100x30).*
   collection scopes apply before paging; selections retain captured versions
   across pages, and a failed refresh keeps the last applied rows read-only with
   an exact Retry action. See [Library prompts](prompts.md).
-- **A conversation outside the active workspace says so on the button.**
-  The handoff requires the conversation to be eligible for the active
-  workspace. When it is not, the button dims to "○ Open in Console" and one
-  sentence beneath it states the reason and the remedy — "This conversation
-  is not in this workspace. Press 'Link to workspace' to add it to the
-  active workspace." — with the **"Link to workspace"** button right there
-  to perform it. (The action name is painted once, on the button; the line
-  under it is the explanation, not a second control.) Pressing `c` while it
-  is blocked says that same sentence as a message rather than doing
-  nothing. A block that linking cannot resolve states its own remedy
-  instead and offers no link (with no active workspace: "Select an active
-  workspace before using this item in Console."), never naming a button
-  that is not on screen. The same gate guards the other "Use in Console"
-  actions.
+- **A conversation outside the active workspace links itself on use.**
+  Workspace membership decides which items a Console turn may read, so a
+  conversation that is not in the active workspace cannot simply be handed
+  over in silence — but it is not refused either. **"Use as source" stays
+  pressable**, and one sentence beneath it says what the press will do:
+  "This conversation is not in this workspace. Pressing this adds it to the
+  active workspace first, and you can undo that." The press links it,
+  continues to Console, and leaves a receipt — **"✓ linked ·
+  \<workspace\> · this conversation can now be used in Console"** — with
+  **"Undo link"** beside it, which removes exactly that membership. The
+  separate **"Link to workspace"** button is still there for taking on the
+  membership without a hand-off. (The action name is painted once, on the
+  button; the line under it is the explanation, not a second control.)
+  A block that a link cannot resolve still refuses: the button dims to
+  "○ Use as source", states its own remedy (with no active workspace:
+  "Select an active workspace before using this item in Console.") and
+  offers no link, never naming a button that is not on screen. Pressing `c`
+  while the load fence blocks Resume says that same sentence as a message
+  rather than doing nothing. The rail's "Use in Console" keeps its own
+  pressable-with-reason grammar: it acts on a SET whose members can be
+  blocked for different reasons, so no single link would unblock it.
+- **The reader takes the width once a conversation is open.** With nothing
+  loaded the list absorbs the empty reader's columns (the density rule); as
+  soon as a row is open, the split is restored and the reader gets the
+  majority of a wide terminal — measured at 235x52: reader 132 columns,
+  list 49. At 100x30 the rail steps aside and the two panes share the stage
+  (reader 44, list 45); at 60x24 the reader is the single stage.
 - **Staging now actually reaches the model.** "Use in Console" (media)
   and "Open in Console" (conversations) used to stage content that
   displayed as attached but never made it into what the model was sent
@@ -1176,3 +1191,10 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-layout — 2026-09-11 (task-32107, user
+decision: "Use as source" links a conversation into the active workspace in
+one undoable step, with a receipt and an "Undo link" beside it, and the
+blocks a link cannot resolve keep refusing; task-32361: the reader wins the
+width once a conversation is open — measured live and in tests at 235x52,
+100x30 and 60x24).*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2962,8 +2962,8 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
-      "call_count": 81,
-      "diagnostic_digest": "54b28e7db995a98925a2",
+      "call_count": 82,
+      "diagnostic_digest": "74ef50d2600bb772b7a8",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Screens/library_screen.py",
       "reason": "remaining Chatbook production diagnostic owner"
@@ -11505,6 +11505,6 @@
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1384,
-    "task_494_calls": 7687
+    "task_494_calls": 7688
   }
 }

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -704,3 +704,41 @@ async def test_the_reason_line_sits_directly_under_the_action_it_describes(
             order.index("library-conversation-open-console-blocked")
             == order.index("library-conversation-use-source") + 1
         ), order
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_never_stands_beside_the_refusal_it_resolved() -> None:
+    """task-32107 (re-review P3): "can now be used in Console" has to stay true.
+
+    The other half of the stale-receipt problem the id-based Undo fix does not
+    cover: activate a workspace this conversation is NOT in and the block
+    comes straight back, so the reader would paint the refusal sentence and a
+    receipt claiming the opposite, one under the other.
+    """
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen.query_one("#library-conversation-use-source", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert screen.query_one("#library-conversation-link-receipt", Static).display
+        assert not screen.query_one(
+            "#library-conversation-open-console-blocked", Static
+        ).display
+
+        # The active workspace moves to one this conversation is not in.
+        host.registry.create_workspace(workspace_id="workspace-b", name="Other")
+        host.registry.set_active_workspace("workspace-b")
+        screen._invalidate_library_workspace_depth_state()
+        screen._sync_library_conversation_reader()
+        await pilot.pause()
+
+        blocked = screen.query_one(
+            "#library-conversation-open-console-blocked", Static
+        )
+        receipt = screen.query_one("#library-conversation-link-receipt", Static)
+        assert blocked.display is True, "the block came back"
+        assert receipt.display is False, str(receipt.renderable)
+        assert screen.query_one(
+            "#library-conversation-link-undo", Button
+        ).display is False

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -1,0 +1,394 @@
+"""Library critique #10, group ``layout``: panes, grips and the hand-off.
+
+Covers task-32355 (grip labels, rail beside the note editor), task-32359
+(rail focus is a shape, not a second blue), task-32360 (the narrow-stage
+return and clipped copy), task-32361 (the Conversations width split) and
+task-32107 (link-on-use for the Conversations hand-off).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+from textual.widgets import Button, Static
+
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
+    LibraryAdaptiveReaderPaneGrip,
+)
+
+
+CONVERSATION_ID = "conv-1"
+CONVERSATION_TITLE = "Alpha planning"
+ACTIVE_WORKSPACE_NAME = "Local Default"
+
+
+def _conversations_host(
+    *,
+    linked: bool = False,
+    reason_code: str = "not_in_active_workspace",
+):
+    """Build a Library harness sitting on Conversations with one saved chat.
+
+    The real ``workspace_registry_service`` is used rather than a recording
+    fake: the point of link-on-use is that the link actually changes what
+    ``library_item_context_handoff`` answers, which only a real registry can
+    prove.
+
+    Args:
+        linked: Whether the conversation already belongs to the active
+            workspace (so the hand-off is not blocked at all).
+        reason_code: ``"not_in_active_workspace"`` for the link-resolvable
+            block; ``"no_active_workspace"`` leaves the profile without an
+            active workspace, the block a link cannot resolve.
+
+    Returns:
+        The mounted-ready ``LibraryHarness``, with ``registry`` attached.
+    """
+    from Tests.UI.test_library_shell import (
+        LibraryHarness,
+        _build_test_app,
+        _seed_conversations,
+    )
+    from tldw_chatbook.UI.Screens.library_screen import (
+        LIBRARY_ROW_BROWSE_CONVERSATIONS,
+        LibraryScreen,
+    )
+
+    app = _build_test_app()
+    _seed_conversations(
+        app,
+        [
+            {
+                "id": CONVERSATION_ID,
+                "title": CONVERSATION_TITLE,
+                "version": 4,
+                "message_count": 1,
+                "last_modified": "2026-09-01T12:00:00Z",
+            }
+        ],
+    )
+    registry = app.workspace_registry_service
+    registry.clear_active_workspace()
+    if reason_code != "no_active_workspace":
+        registry.create_workspace(
+            workspace_id="workspace-a", name=ACTIVE_WORKSPACE_NAME
+        )
+        registry.set_active_workspace("workspace-a")
+        if linked:
+            registry.link_membership(
+                "workspace-a",
+                item_type="conversation",
+                item_id=CONVERSATION_ID,
+                title=CONVERSATION_TITLE,
+            )
+    screen = LibraryScreen(app)
+    screen.restore_state({"library_selected_row_id": LIBRARY_ROW_BROWSE_CONVERSATIONS})
+    host = LibraryHarness(app, screen=screen)
+    host.registry = registry
+    host.tldw_app = app
+    return host
+
+
+async def _open_first_conversation(host, pilot):
+    """Settle the Conversations shell with the seeded conversation loaded."""
+    from Tests.UI.test_library_shell import (
+        _active_library_screen,
+        _wait_for_library_shell,
+        _wait_for_selector,
+    )
+
+    screen = _active_library_screen(host)
+    await _wait_for_library_shell(screen, pilot)
+    await _wait_for_selector(screen, pilot, "#library-conversation-reader")
+    for _ in range(40):
+        if screen._conversations_state.reader_state.loaded_id:
+            break
+        await pilot.pause(0.01)
+    await pilot.pause()
+    return screen
+
+
+# --------------------------------------------------------------------------
+# task-32361: the Conversations width split
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_conversation_reader_takes_the_majority_of_a_wide_terminal() -> None:
+    """task-32361 AC#1: the reader wins the width once something is open.
+
+    Measured before the fix at 235x52: reader 44, list 137 -- the layout
+    resolved while the Reader was still empty (``reader_has_item=False``
+    hands its columns to the list) and nothing re-resolved it once the
+    selection settled.
+    """
+    host = _conversations_host(linked=True)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        reader = screen.query_one("#library-conversation-reader")
+        items = screen.query_one("#library-conversations-list")
+        assert reader.region.width > items.region.width, (reader.region, items.region)
+        assert reader.region.width >= 100, reader.region
+
+
+@pytest.mark.asyncio
+async def test_an_empty_conversation_reader_still_gives_its_width_away() -> None:
+    """task-32217 stays intact: nothing open means the list takes the stage."""
+    host = _conversations_host(linked=True)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen._conversations_state.reader_state = dataclasses.replace(
+            screen._conversations_state.reader_state, selected_id=None
+        )
+        screen._sync_library_conversation_reader()
+        await pilot.pause()
+        await pilot.pause()
+        items = screen.query_one("#library-conversations-list")
+        reader = screen.query_one("#library-conversation-reader")
+        assert items.region.width > reader.region.width, (items.region, reader.region)
+
+
+# --------------------------------------------------------------------------
+# task-32355 / task-32360 AC#3: the pane grips
+# --------------------------------------------------------------------------
+
+
+def _painted_column(app, widget) -> str:
+    """Return what a one-column-wide strip of ``widget``'s region paints."""
+    strips = list(app.screen._compositor.render_strips())
+    return "".join(
+        strips[y].crop(widget.region.x, widget.region.right).text.strip()
+        for y in range(widget.region.y, widget.region.bottom)
+    )
+
+
+@pytest.mark.parametrize("size", [(235, 52), (100, 30), (60, 24)])
+@pytest.mark.asyncio
+async def test_both_pane_grips_paint_their_name(size) -> None:
+    """task-32355 AC#1/AC#2: the handle says what it opens, at every width.
+
+    The name goes DOWN the five-cell column -- "Nav" for the Library pane
+    (the name ``Docs/User_Guide/library.md`` uses for this handle) and the
+    pane's own label for the items pane.
+    """
+    host = _conversations_host(linked=True)
+    async with host.run_test(size=size) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        grips = {
+            grip.pane: grip for grip in screen.query(LibraryAdaptiveReaderPaneGrip)
+        }
+        assert set(grips) == {"library", "items"}
+        assert grips["library"].painted_name() == "Nav"
+        assert grips["items"].painted_name() == "Items"
+        assert _painted_column(host.app, grips["library"]).startswith("Nav")
+        assert _painted_column(host.app, grips["items"]).startswith("Items")
+
+
+@pytest.mark.parametrize("size", [(235, 52), (100, 30), (60, 24)])
+@pytest.mark.asyncio
+async def test_the_grips_never_overlap_the_panes_beside_them(size) -> None:
+    """task-32360 AC#3: measured geometry, before any paint claim."""
+    host = _conversations_host(linked=True)
+    async with host.run_test(size=size) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        grips = {
+            grip.pane: grip for grip in screen.query(LibraryAdaptiveReaderPaneGrip)
+        }
+        regions = {
+            pane: grip.region
+            for pane, grip in grips.items()
+        }
+        occupied = sorted(
+            (widget.region.x, widget.region.right, widget.id)
+            for widget in (
+                *grips.values(),
+                screen.query_one("#library-conversation-reader"),
+            )
+            if widget.region.width
+        )
+        for (_, left_right, left_id), (right_x, _, right_id) in zip(
+            occupied, occupied[1:]
+        ):
+            assert left_right <= right_x, (regions, left_id, right_id, occupied)
+
+        # Region assertions are blind to paint-over
+        # (backlog/docs/lessons-live-verification.md), so read the frame too:
+        # the arrow run must not appear on any column outside a grip. B's
+        # capture put "<---" at char column 42 of a 235-cell frame -- which
+        # is the Library grip's OWN column (x=41), not the content area.
+        strips = list(host.app.screen._compositor.render_strips())
+        grip_columns = {
+            column
+            for grip in grips.values()
+            for column in range(grip.region.x, grip.region.right)
+        }
+        for row, strip in enumerate(strips):
+            text = strip.text
+            for column in range(len(text) - 3):
+                if text[column : column + 4] in ("<---", "--->"):
+                    assert column in grip_columns, (row, column, text)
+
+
+# --------------------------------------------------------------------------
+# task-32107: link-on-use for the Conversations hand-off
+# --------------------------------------------------------------------------
+
+
+def _loaded_reader_state():
+    """A settled, complete transcript -- the crit8 fixture, reused."""
+    from tldw_chatbook.Library.library_conversation_reader_state import (
+        ConversationMessageView,
+        ConversationReaderState,
+    )
+
+    return ConversationReaderState(
+        selected_id=CONVERSATION_ID,
+        selected_version=4,
+        loaded_id=CONVERSATION_ID,
+        loaded_version=4,
+        loaded_generation=2,
+        generation=2,
+        messages=(
+            ConversationMessageView(
+                "message-a", "user", "2026-09-01T12:01:00Z", "revision-a", 5, "hello"
+            ),
+        ),
+        message_total=1,
+        complete=True,
+    )
+
+
+BLOCK_SENTENCE = (
+    "This conversation is not in this workspace. Pressing this adds it to "
+    "the active workspace first, and you can undo that."
+)
+
+LINK_RECEIPT = (
+    f"✓ linked · {ACTIVE_WORKSPACE_NAME} · this conversation can now be "
+    "used in Console"
+)
+
+
+def _memberships(host) -> list:
+    return list(
+        host.registry.get_item_memberships(
+            item_type="conversation", item_id=CONVERSATION_ID
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_use_as_source_links_an_unlinked_conversation_and_proceeds() -> None:
+    """task-32107 AC#2: one gesture links and stages, with a receipt."""
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        source = screen.query_one("#library-conversation-use-source", Button)
+        assert not source.disabled, "a link-resolvable block no longer blocks"
+        assert str(source.label) == "Use as source"
+        blocked = screen.query_one(
+            "#library-conversation-open-console-blocked", Static
+        )
+        assert str(blocked.renderable) == BLOCK_SENTENCE, str(blocked.renderable)
+        assert not _memberships(host)
+        staged: list = []
+        host.tldw_app.open_chat_with_handoff = (
+            lambda payload, **kwargs: staged.append(payload)
+        )
+
+        source.press()
+        await pilot.pause()
+        await pilot.pause()
+
+        receipt = screen.query_one("#library-conversation-link-receipt", Static)
+        assert str(receipt.renderable) == LINK_RECEIPT, str(receipt.renderable)
+        assert receipt.display is True
+        assert screen.query_one("#library-conversation-link-undo", Button).display
+        assert _memberships(host)
+        assert staged, "the hand-off still ran"
+        assert staged[0].source_id == CONVERSATION_ID
+
+
+@pytest.mark.asyncio
+async def test_undo_removes_the_membership_the_press_added() -> None:
+    """task-32107 AC#2: the widening is reversible from where it happened."""
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen.query_one("#library-conversation-use-source", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert _memberships(host)
+
+        screen.query_one("#library-conversation-link-undo", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert not _memberships(host)
+        assert not screen.query_one(
+            "#library-conversation-link-receipt", Static
+        ).display
+        assert not screen.query_one(
+            "#library-conversation-link-undo", Button
+        ).display
+
+
+@pytest.mark.asyncio
+async def test_a_block_a_link_cannot_resolve_still_refuses(widget_pilot) -> None:
+    """task-32107 AC#2: the aggregate fallback keeps refusing, exactly as before.
+
+    Driven through the reader's own metadata seam because that is where the
+    non-linkable block arrives: ``library_item_context_handoff`` treats "no
+    active workspace" as nothing to gate against, so the block a link cannot
+    resolve is the aggregate ``LIBRARY_GENERIC_WORKSPACE_BLOCK`` fallback for
+    an item missing from the row model.
+    """
+    from tldw_chatbook.Widgets.Library import LibraryConversationReader
+
+    async with await widget_pilot(
+        LibraryConversationReader,
+        state=_loaded_reader_state(),
+        loaded_metadata={
+            "title": CONVERSATION_TITLE,
+            "_workspace_block": "blocked for this workspace",
+            "_workspace_block_linkable": False,
+            "_workspace_block_detail": (
+                "Select an active workspace before using this item in Console."
+            ),
+        },
+        id="library-conversation-reader",
+    ) as pilot:
+        source = pilot.app.query_one("#library-conversation-use-source", Button)
+        assert source.disabled
+        assert str(source.label).startswith("○ ")
+        assert not pilot.app.query_one(
+            "#library-conversation-link-workspace", Button
+        ).display
+        assert "Select an active workspace" in str(source.tooltip)
+        assert not pilot.app.query_one(
+            "#library-conversation-link-receipt", Static
+        ).display
+
+
+@pytest.mark.asyncio
+async def test_the_receipt_does_not_survive_a_different_conversation() -> None:
+    """The receipt belongs to the conversation it was written for."""
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen.query_one("#library-conversation-use-source", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert screen.query_one("#library-conversation-link-receipt", Static).display
+
+        # Each load replaces the whole loaded-metadata mapping, so the
+        # receipt key cannot ride along to the next conversation.
+        screen._conversations_state.reader_loaded_metadata = {
+            "title": "Another conversation"
+        }
+        screen._sync_library_conversation_reader()
+        await pilot.pause()
+        assert not screen.query_one(
+            "#library-conversation-link-receipt", Static
+        ).display

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -742,3 +742,82 @@ async def test_the_receipt_never_stands_beside_the_refusal_it_resolved() -> None
         assert screen.query_one(
             "#library-conversation-link-undo", Button
         ).display is False
+
+
+# --------------------------------------------------------------------------
+# Qodo bot round: link-on-use edge cases
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_undo_is_withheld_when_the_membership_already_existed() -> None:
+    """Qodo #2 (High): Undo must never delete a link this press did not make.
+
+    ``link_membership`` is ``INSERT OR IGNORE`` and returns the EXISTING row
+    when the membership is already there, so a press reaching it through
+    stale cached eligibility recorded a receipt for a membership it did not
+    create -- and Undo would then remove someone else's link. The hand-off
+    still proceeds (the conversation is eligible either way); only the
+    receipt and its Undo are withheld.
+    """
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        # Link it behind the screen's back, leaving the cached eligibility
+        # (and so the reader's block) stale -- the press still runs.
+        host.registry.link_membership(
+            "workspace-a",
+            item_type="conversation",
+            item_id=CONVERSATION_ID,
+            title=CONVERSATION_TITLE,
+        )
+        staged: list = []
+        host.tldw_app.open_chat_with_handoff = (
+            lambda payload, **kwargs: staged.append(payload)
+        )
+
+        screen.query_one("#library-conversation-use-source", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        assert staged, "the hand-off still runs for an already-linked conversation"
+        assert not screen.query_one(
+            "#library-conversation-link-receipt", Static
+        ).display
+        assert not screen.query_one(
+            "#library-conversation-link-undo", Button
+        ).display
+        assert _memberships(host), "the pre-existing membership is untouched"
+
+
+@pytest.mark.asyncio
+async def test_a_stale_page_refuses_instead_of_promising_a_link() -> None:
+    """Qodo #3 (Medium): no pressable promise that silently does nothing.
+
+    The hand-off returns without staging while the Conversations page is not
+    fresh, so offering "Use as source" (and a sentence promising it will link
+    and continue) presented an actionable control that did nothing. Staleness
+    is now a workspace block a link cannot resolve: the action disables with
+    the "○" marker, states the reason, and no link is offered.
+    """
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen._conversations_state.freshness = "stale"
+        screen._invalidate_library_workspace_depth_state()
+        screen._sync_library_conversation_reader()
+        await pilot.pause()
+
+        source = screen.query_one("#library-conversation-use-source", Button)
+        blocked = screen.query_one(
+            "#library-conversation-open-console-blocked", Static
+        )
+        assert source.disabled is True
+        assert str(source.label).startswith("○ ")
+        assert blocked.display is True
+        assert "out of date" in str(blocked.renderable), str(blocked.renderable)
+        assert not screen.query_one(
+            "#library-conversation-link-workspace", Button
+        ).display
+        # ...and the press is inert either way.
+        assert screen._library_conversation_link_would_unblock() is False

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -528,3 +528,51 @@ async def test_the_focused_rail_row_is_a_shape_not_a_second_blue(size) -> None:
         assert _leftmost(rows, media) != _THICK_LEFT_GLYPH
         # The active row keeps its own treatment and its whole label.
         assert "Conversations" in rows[conversations.region.y]
+
+
+@pytest.mark.asyncio
+async def test_the_field_state_stays_first_when_the_return_chip_joins_it() -> None:
+    """task-32360 / task-32346 (cross-branch): one footer grammar at 60x24.
+
+    While a text field holds focus the footer says so FIRST, on every
+    surface -- every printable key is being inserted as text, which outranks
+    any navigation the footer could advertise. The narrow-stage return chip
+    prepended itself ahead of that marker, making this the one width where
+    the field state was not first. It now follows it.
+    """
+    from unittest.mock import patch
+
+    from textual.widgets import Input
+
+    from Tests.UI.test_library_crit9_shell import (
+        NARROW_TEST_SIZE,
+        _active_library_screen,
+        _library_host,
+        _wait_for_condition,
+        _wait_for_library_shell,
+    )
+
+    host = _library_host()
+    async with host.run_test(size=NARROW_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: ("esc", "back to Library")
+            in tuple((screen._footer_shortcut_registration or ("", ()))[1]),
+            message="The registered footer never named the return.",
+        )
+        # The rail's own search box lives INSIDE the pane this stage closed,
+        # so focusing it bounces (task-32225); the filter is the field that
+        # is actually on screen here.
+        # The branch under test reads ``self.focused`` and nothing else, and
+        # this harness's own entry-focus arm keeps taking the key back from
+        # any field a test focuses; state the input the footer is deciding
+        # about directly rather than racing that arm.
+        with patch.object(type(screen), "focused", property(lambda _self: Input())):
+            chips = screen._library_footer_shortcuts_for_current_state()
+        assert chips[0][0] == "", chips
+        assert "typing in field" in chips[0][1], chips
+        assert ("esc", "back to Library") in chips, chips
+        assert chips.index(("esc", "back to Library")) == 1, chips

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -24,10 +24,15 @@ CONVERSATION_TITLE = "Alpha planning"
 ACTIVE_WORKSPACE_NAME = "Local Default"
 
 
+SECOND_CONVERSATION_ID = "conv-2"
+SECOND_CONVERSATION_TITLE = "Beta planning"
+
+
 def _conversations_host(
     *,
     linked: bool = False,
     reason_code: str = "not_in_active_workspace",
+    second: bool = False,
 ):
     """Build a Library harness sitting on Conversations with one saved chat.
 
@@ -42,6 +47,8 @@ def _conversations_host(
         reason_code: ``"not_in_active_workspace"`` for the link-resolvable
             block; ``"no_active_workspace"`` leaves the profile without an
             active workspace, the block a link cannot resolve.
+        second: Seed a second conversation too, so a test can drive a real
+            second selection through the load path.
 
     Returns:
         The mounted-ready ``LibraryHarness``, with ``registry`` attached.
@@ -57,18 +64,26 @@ def _conversations_host(
     )
 
     app = _build_test_app()
-    _seed_conversations(
-        app,
-        [
+    rows = [
+        {
+            "id": CONVERSATION_ID,
+            "title": CONVERSATION_TITLE,
+            "version": 4,
+            "message_count": 1,
+            "last_modified": "2026-09-01T12:00:00Z",
+        }
+    ]
+    if second:
+        rows.append(
             {
-                "id": CONVERSATION_ID,
-                "title": CONVERSATION_TITLE,
-                "version": 4,
+                "id": SECOND_CONVERSATION_ID,
+                "title": SECOND_CONVERSATION_TITLE,
+                "version": 2,
                 "message_count": 1,
-                "last_modified": "2026-09-01T12:00:00Z",
+                "last_modified": "2026-09-01T11:00:00Z",
             }
-        ],
-    )
+        )
+    _seed_conversations(app, rows)
     registry = app.workspace_registry_service
     registry.clear_active_workspace()
     if reason_code != "no_active_workspace":
@@ -115,22 +130,30 @@ async def _open_first_conversation(host, pilot):
 # --------------------------------------------------------------------------
 
 
+# The AC says "200 columns and wider", so the boundary is pinned, not just
+# the comfortable case. Floors are the measured widths, one per size.
+_MAJORITY_SIZES = {(200, 52): 90, (235, 52): 100}
+
+
+@pytest.mark.parametrize("size, reader_floor", sorted(_MAJORITY_SIZES.items()))
 @pytest.mark.asyncio
-async def test_the_conversation_reader_takes_the_majority_of_a_wide_terminal() -> None:
+async def test_the_conversation_reader_takes_the_majority_of_a_wide_terminal(
+    size, reader_floor
+) -> None:
     """task-32361 AC#1: the reader wins the width once something is open.
 
     Measured before the fix at 235x52: reader 44, list 137 -- the layout
     resolved while the Reader was still empty (``reader_has_item=False``
     hands its columns to the list) and nothing re-resolved it once the
-    selection settled.
+    selection settled. After: 132/49 at 235 and 97/49 at the AC's own 200.
     """
     host = _conversations_host(linked=True)
-    async with host.run_test(size=(235, 52)) as pilot:
+    async with host.run_test(size=size) as pilot:
         screen = await _open_first_conversation(host, pilot)
         reader = screen.query_one("#library-conversation-reader")
         items = screen.query_one("#library-conversations-list")
         assert reader.region.width > items.region.width, (reader.region, items.region)
-        assert reader.region.width >= 100, reader.region
+        assert reader.region.width >= reader_floor, reader.region
 
 
 @pytest.mark.asyncio
@@ -200,14 +223,24 @@ async def test_the_grips_never_overlap_the_panes_beside_them(size) -> None:
             pane: grip.region
             for pane, grip in grips.items()
         }
+        # (review fix round 1) The list pane and the rail are the neighbours
+        # B reported overpainted, so they have to be IN the measurement --
+        # round 0 measured only the grips against the reader.
+        neighbours = [
+            widget
+            for selector in (
+                "#library-rail",
+                "#library-canvas",
+                "#library-conversation-reader",
+            )
+            for widget in screen.query(selector)
+        ]
         occupied = sorted(
             (widget.region.x, widget.region.right, widget.id)
-            for widget in (
-                *grips.values(),
-                screen.query_one("#library-conversation-reader"),
-            )
-            if widget.region.width
+            for widget in (*grips.values(), *neighbours)
+            if widget.region.width and widget.display
         )
+        assert len(occupied) >= 3, occupied
         for (_, left_right, left_id), (right_x, _, right_id) in zip(
             occupied, occupied[1:]
         ):
@@ -375,7 +408,7 @@ async def test_a_block_a_link_cannot_resolve_still_refuses(widget_pilot) -> None
 @pytest.mark.asyncio
 async def test_the_receipt_does_not_survive_a_different_conversation() -> None:
     """The receipt belongs to the conversation it was written for."""
-    host = _conversations_host(linked=False)
+    host = _conversations_host(linked=False, second=True)
     async with host.run_test(size=(235, 52)) as pilot:
         screen = await _open_first_conversation(host, pilot)
         screen.query_one("#library-conversation-use-source", Button).press()
@@ -383,13 +416,22 @@ async def test_the_receipt_does_not_survive_a_different_conversation() -> None:
         await pilot.pause()
         assert screen.query_one("#library-conversation-link-receipt", Static).display
 
-        # Each load replaces the whole loaded-metadata mapping, so the
-        # receipt key cannot ride along to the next conversation.
-        screen._conversations_state.reader_loaded_metadata = {
-            "title": "Another conversation"
-        }
-        screen._sync_library_conversation_reader()
+        # (review fix round 1) Drive a REAL second selection through the load
+        # path, not a hand-assigned mapping: the claim is that the load
+        # replaces the whole mapping, so the load is what has to be exercised.
+        screen.query_one("#library-conversation-row-1", Button).press()
+        for _ in range(60):
+            if (
+                screen._conversations_state.reader_state.loaded_id
+                == SECOND_CONVERSATION_ID
+            ):
+                break
+            await pilot.pause(0.01)
         await pilot.pause()
+        assert (
+            screen._conversations_state.reader_state.loaded_id
+            == SECOND_CONVERSATION_ID
+        ), screen._conversations_state.reader_state.loaded_id
         assert not screen.query_one(
             "#library-conversation-link-receipt", Static
         ).display
@@ -400,18 +442,54 @@ async def test_the_receipt_does_not_survive_a_different_conversation() -> None:
 # --------------------------------------------------------------------------
 
 
-@pytest.mark.asyncio
-async def test_the_narrow_stage_return_is_painted_not_just_registered() -> None:
-    """task-32360 AC#1: the return survives the real footer at 60 columns.
+def _painted_footer(chips, size) -> str:
+    """Return what the REAL footer widget paints for ``chips`` at ``size``.
 
-    Measured, not assumed. The wave plan expected the chip to be lost to the
-    footer's width ladder and prescribed trimming the context to two chips;
-    driving ``AppFooterStatus`` at width 60 with one, two, three and five
-    chips renders "esc back to Library | F1 · F6 · Ctrl+P · Ctrl+Q" in every
-    case -- task-32225's "FIRST, not appended" already carries it. So this
-    is a REGRESSION pin on the existing behaviour, not a new fix: whatever
-    B saw at 60x24 was a route where this context is not active at all.
+    The Library harness mounts no app chrome, so the widget that actually
+    elides -- ``AppFooterStatus`` -- is driven with the very set the screen
+    registered. This is the rendered text, not the registered tuple: the
+    registered tuple is exactly what hid the AC#1 regression in round 1.
     """
+    from Tests.UI.test_chrome_ux_fixes import _FooterHarness, _shown_text
+
+    async def _run() -> str:
+        app = _FooterHarness()
+        async with app.run_test(size=size) as pilot:
+            await pilot.pause()
+            app.footer.set_workbench_shortcuts(source="library", shortcuts=chips)
+            await pilot.pause()
+            return _shown_text(app.footer)
+
+    return _run()
+
+
+@pytest.mark.parametrize("field_focused", [False, True])
+@pytest.mark.asyncio
+async def test_the_narrow_stage_return_is_painted_in_both_focus_states(
+    field_focused: bool,
+) -> None:
+    """task-32360 AC#1: the return is PAINTED at 60x24, typing or not.
+
+    Fix round 1 (review P1). The round-0 pin read the registered tuple, which
+    is blind to the thing that actually decides: at width 60 the real footer
+    paints exactly ONE context chip and only about 24 rendered characters of
+    it. Measured there: "esc back to Library" (19) survives; "esc typing ·
+    back to Library" (28) and Task 1's wide-footer form collapse the WHOLE
+    context to "…". So the field-state marker and the return cannot both
+    paint, and the chip that survives has to name what Escape actually does.
+
+    It does not leave the field here. ``library_narrow_stage_return`` is
+    declared above ``library_blur_text_field``, and with an Input focused on
+    this stage ``check_action("library_blur_text_field")`` is measurably
+    False while ``check_action("library_narrow_stage_return")`` is True --
+    so "esc leaves field" would be a dead key. Nothing the caret would
+    swallow is advertised either: the typing block above has already dropped
+    every printable-key chip.
+    """
+    from unittest.mock import patch
+
+    from textual.widgets import Input
+
     from Tests.UI.test_library_crit9_shell import (
         NARROW_TEST_SIZE,
         _active_library_screen,
@@ -431,21 +509,23 @@ async def test_the_narrow_stage_return_is_painted_not_just_registered() -> None:
             in tuple((screen._footer_shortcut_registration or ("", ()))[1]),
             message="The registered footer never named the return.",
         )
-        chips = screen._library_footer_shortcuts_for_current_state()
+        if field_focused:
+            # This harness's own entry-focus arm takes the key back from any
+            # field a test focuses, and the branch under test reads
+            # ``self.focused`` and nothing else -- state it directly rather
+            # than racing that arm.
+            with patch.object(type(screen), "focused", property(lambda _s: Input())):
+                chips = screen._library_footer_shortcuts_for_current_state()
+                # The key the chip names must be the one Escape performs.
+                assert screen.check_action("library_narrow_stage_return", ()) is True
+                assert screen.check_action("library_blur_text_field", ()) is False
+        else:
+            chips = screen._library_footer_shortcuts_for_current_state()
         assert chips[0] == ("esc", "back to Library"), chips
 
-        # ...and that short context SURVIVES the real footer at this width.
-        # The Library harness mounts no app chrome, so the widget that does
-        # the eliding is driven directly with the very set registered above.
-        from Tests.UI.test_chrome_ux_fixes import _FooterHarness, _shown_text
-
-        footer_app = _FooterHarness()
-        async with footer_app.run_test(size=NARROW_TEST_SIZE) as footer_pilot:
-            await footer_pilot.pause()
-            footer_app.footer.set_workbench_shortcuts(source="library", shortcuts=chips)
-            await footer_pilot.pause()
-            shown = _shown_text(footer_app.footer)
-            assert "back to Library" in shown, shown
+    shown = await _painted_footer(chips, NARROW_TEST_SIZE)
+    assert "esc back to Library" in shown, shown
+    assert "…" not in shown, shown
 
 
 # --------------------------------------------------------------------------
@@ -531,48 +611,96 @@ async def test_the_focused_rail_row_is_a_shape_not_a_second_blue(size) -> None:
 
 
 @pytest.mark.asyncio
-async def test_the_field_state_stays_first_when_the_return_chip_joins_it() -> None:
-    """task-32360 / task-32346 (cross-branch): one footer grammar at 60x24.
+async def test_only_one_context_chip_paints_at_sixty_columns() -> None:
+    """task-32360 AC#1, fix round 1: the budget the chip choice turns on.
 
-    While a text field holds focus the footer says so FIRST, on every
-    surface -- every printable key is being inserted as text, which outranks
-    any navigation the footer could advertise. The narrow-stage return chip
-    prepended itself ahead of that marker, making this the one width where
-    the field state was not first. It now follows it.
+    Round 1 of this branch put the field-state marker at the head so it would
+    be first, as every wider surface has it. Measured here, that silently
+    dropped the return: the footer keeps ONE chip at this width, so "first"
+    and "only" are the same thing. Pinned so a future re-ordering has to see
+    the cost, and so the ~24-character budget is a measurement in the suite
+    rather than a number in a report.
     """
-    from unittest.mock import patch
+    cases = {
+        (("esc", "back to Library"),): True,
+        (("esc", "back to Library"), ("", "typing in field")): True,
+        (("", "typing in field"), ("esc", "back to Library")): False,
+        (("esc", "typing · back to Library"),): False,
+        (("", "typing in field · after esc: back to Library"),): False,
+    }
+    for chips, return_survives in cases.items():
+        shown = await _painted_footer(chips, (60, 24))
+        assert ("esc back to Library" in shown) is return_survives, (chips, shown)
 
-    from textual.widgets import Input
 
-    from Tests.UI.test_library_crit9_shell import (
-        NARROW_TEST_SIZE,
-        _active_library_screen,
-        _library_host,
-        _wait_for_condition,
-        _wait_for_library_shell,
-    )
+@pytest.mark.asyncio
+async def test_undo_unlinks_the_workspace_the_receipt_names() -> None:
+    """task-32107 (review fix round 1): Undo reverses THIS press, not the moment.
 
-    host = _library_host()
-    async with host.run_test(size=NARROW_TEST_SIZE) as pilot:
-        screen = _active_library_screen(host)
-        await _wait_for_library_shell(screen, pilot)
-        screen.query_one("#library-row-browse-media").press()
-        await _wait_for_condition(
-            pilot,
-            lambda: ("esc", "back to Library")
-            in tuple((screen._footer_shortcut_registration or ("", ()))[1]),
-            message="The registered footer never named the return.",
+    Creating a workspace from the rail activates it and recomposes the
+    reader from the same metadata mapping, so a standing receipt can outlive
+    the active workspace it was written for. Undo read
+    ``get_active_workspace()`` and would have removed a membership the press
+    never added -- a data effect in the opposite direction of the one the
+    user asked to reverse.
+    """
+    host = _conversations_host(linked=False)
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_first_conversation(host, pilot)
+        screen.query_one("#library-conversation-use-source", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+        assert _memberships(host)
+
+        # The active workspace moves on while the receipt stands.
+        host.registry.create_workspace(workspace_id="workspace-b", name="Other")
+        host.registry.set_active_workspace("workspace-b")
+        host.registry.link_membership(
+            "workspace-b",
+            item_type="conversation",
+            item_id=CONVERSATION_ID,
+            title=CONVERSATION_TITLE,
         )
-        # The rail's own search box lives INSIDE the pane this stage closed,
-        # so focusing it bounces (task-32225); the filter is the field that
-        # is actually on screen here.
-        # The branch under test reads ``self.focused`` and nothing else, and
-        # this harness's own entry-focus arm keeps taking the key back from
-        # any field a test focuses; state the input the footer is deciding
-        # about directly rather than racing that arm.
-        with patch.object(type(screen), "focused", property(lambda _self: Input())):
-            chips = screen._library_footer_shortcuts_for_current_state()
-        assert chips[0][0] == "", chips
-        assert "typing in field" in chips[0][1], chips
-        assert ("esc", "back to Library") in chips, chips
-        assert chips.index(("esc", "back to Library")) == 1, chips
+        screen._invalidate_library_workspace_depth_state()
+        await pilot.pause()
+
+        screen.query_one("#library-conversation-link-undo", Button).press()
+        await pilot.pause()
+        await pilot.pause()
+
+        remaining = {
+            membership.workspace_id for membership in _memberships(host)
+        }
+        assert remaining == {"workspace-b"}, remaining
+
+
+@pytest.mark.asyncio
+async def test_the_reason_line_sits_directly_under_the_action_it_describes(
+    widget_pilot,
+) -> None:
+    """task-32107 (review fix round 1): "Pressing this" needs the right "this".
+
+    The sentence used to be yielded after the Archive/Restore pair, so the
+    control directly above it was "Archive conversation" and the deixis
+    pointed at the wrong button.
+    """
+    from tldw_chatbook.Widgets.Library import LibraryConversationReader
+
+    async with await widget_pilot(
+        LibraryConversationReader,
+        state=_loaded_reader_state(),
+        loaded_metadata={
+            "title": CONVERSATION_TITLE,
+            "_workspace_block": "not in this workspace",
+            "_workspace_block_linkable": True,
+        },
+        id="library-conversation-reader",
+    ) as pilot:
+        reader = pilot.app.query_one(
+            "#library-conversation-reader", LibraryConversationReader
+        )
+        order = [child.id for child in reader.walk_children() if child.id]
+        assert (
+            order.index("library-conversation-open-console-blocked")
+            == order.index("library-conversation-use-source") + 1
+        ), order

--- a/Tests/UI/test_library_crit10_layout.py
+++ b/Tests/UI/test_library_crit10_layout.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import dataclasses
 
 import pytest
+from textual.app import App
 from textual.widgets import Button, Static
 
 from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
@@ -392,3 +393,138 @@ async def test_the_receipt_does_not_survive_a_different_conversation() -> None:
         assert not screen.query_one(
             "#library-conversation-link-receipt", Static
         ).display
+
+
+# --------------------------------------------------------------------------
+# task-32360 AC#1/AC#2: the narrow stage's return, and clipped copy
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_the_narrow_stage_return_is_painted_not_just_registered() -> None:
+    """task-32360 AC#1: the return survives the real footer at 60 columns.
+
+    Measured, not assumed. The wave plan expected the chip to be lost to the
+    footer's width ladder and prescribed trimming the context to two chips;
+    driving ``AppFooterStatus`` at width 60 with one, two, three and five
+    chips renders "esc back to Library | F1 · F6 · Ctrl+P · Ctrl+Q" in every
+    case -- task-32225's "FIRST, not appended" already carries it. So this
+    is a REGRESSION pin on the existing behaviour, not a new fix: whatever
+    B saw at 60x24 was a route where this context is not active at all.
+    """
+    from Tests.UI.test_library_crit9_shell import (
+        NARROW_TEST_SIZE,
+        _active_library_screen,
+        _library_host,
+        _wait_for_condition,
+        _wait_for_library_shell,
+    )
+
+    host = _library_host()
+    async with host.run_test(size=NARROW_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        screen.query_one("#library-row-browse-media").press()
+        await _wait_for_condition(
+            pilot,
+            lambda: ("esc", "back to Library")
+            in tuple((screen._footer_shortcut_registration or ("", ()))[1]),
+            message="The registered footer never named the return.",
+        )
+        chips = screen._library_footer_shortcuts_for_current_state()
+        assert chips[0] == ("esc", "back to Library"), chips
+
+        # ...and that short context SURVIVES the real footer at this width.
+        # The Library harness mounts no app chrome, so the widget that does
+        # the eliding is driven directly with the very set registered above.
+        from Tests.UI.test_chrome_ux_fixes import _FooterHarness, _shown_text
+
+        footer_app = _FooterHarness()
+        async with footer_app.run_test(size=NARROW_TEST_SIZE) as footer_pilot:
+            await footer_pilot.pause()
+            footer_app.footer.set_workbench_shortcuts(source="library", shortcuts=chips)
+            await footer_pilot.pause()
+            shown = _shown_text(footer_app.footer)
+            assert "back to Library" in shown, shown
+
+
+# --------------------------------------------------------------------------
+# task-32359: the focused rail row differs from the active one by shape
+# --------------------------------------------------------------------------
+
+
+_THICK_LEFT_GLYPH = "█"
+
+
+class _RailRowsHost(App):
+    """Two real rail rows under the production stylesheet: one active.
+
+    The shape of ``library_rail.py``'s rows exactly: a ``Button`` classed
+    ``library-rail-row``, the active destination additionally carrying
+    ``library-rail-row-selected``. ``AUTO_FOCUS = None`` keeps both genuinely
+    blurred until a test moves focus, so the observed cue is the one a real
+    Tab/arrow produces.
+    """
+
+    AUTO_FOCUS = None
+
+    def __init__(self) -> None:
+        from Tests.UI.consolidated_css import APP_STYLESHEETS
+
+        self.CSS_PATH = [str(path) for path in APP_STYLESHEETS]
+        super().__init__()
+
+    def compose(self):
+        from textual.containers import Vertical
+
+        with Vertical():
+            yield Button("Media", id="rail-media", classes="library-rail-row")
+            yield Button(
+                "▸ Conversations",
+                id="rail-conversations",
+                classes="library-rail-row library-rail-row-selected",
+            )
+
+
+def _rail_rows(app) -> list[str]:
+    return [
+        "".join(segment.text for segment in strip)
+        for strip in app.screen._compositor.render_strips()
+    ]
+
+
+def _leftmost(rows: list[str], widget) -> str:
+    line = rows[widget.region.y]
+    return line[widget.region.x] if widget.region.x < len(line) else ""
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("size", [(235, 52), (100, 30)])
+async def test_the_focused_rail_row_is_a_shape_not_a_second_blue(size) -> None:
+    """task-32359 AC#1/AC#2: focus paints the house bar; active does not.
+
+    B measured both states as bold + underline over backgrounds three RGB
+    units apart (rgb(25,68,102) vs rgb(28,70,102)) -- indistinguishable, and
+    colour-only. Focus everywhere else on this screen is the ``█`` left bar
+    (task-31983), so the rail stops being the exception.
+    """
+    app = _RailRowsHost()
+    async with app.run_test(size=size) as pilot:
+        media = app.query_one("#rail-media", Button)
+        conversations = app.query_one("#rail-conversations", Button)
+
+        media.focus()
+        await pilot.pause()
+        rows = _rail_rows(app)
+        assert _leftmost(rows, media) == _THICK_LEFT_GLYPH, rows[media.region.y]
+        assert _leftmost(rows, conversations) != _THICK_LEFT_GLYPH
+        assert media.styles.border_left[0]
+        assert not conversations.styles.border_left[0]
+
+        conversations.focus()
+        await pilot.pause()
+        rows = _rail_rows(app)
+        assert _leftmost(rows, conversations) == _THICK_LEFT_GLYPH
+        assert _leftmost(rows, media) != _THICK_LEFT_GLYPH
+        # The active row keeps its own treatment and its whole label.
+        assert "Conversations" in rows[conversations.region.y]

--- a/Tests/UI/test_library_crit8_conversation_handoff.py
+++ b/Tests/UI/test_library_crit8_conversation_handoff.py
@@ -95,11 +95,15 @@ async def test_workspace_refusal_is_inline_with_a_link_action(
         # is single-line and truncates (fix round 1). It is the refusal
         # SENTENCE, not a second copy of the action name (task-32101).
         assert str(blocked.renderable) == (
-            "This conversation is not in this workspace. Press 'Link to "
-            "workspace' to add it to the active workspace."
+            "This conversation is not in this workspace. Pressing this "
+            "adds it to the active workspace first, and you can undo that."
         )
         assert blocked.display is True
-        assert open_console.disabled is True
+        # task-32107 (user decision, critique #10): a block a LINK can
+        # resolve no longer disables the hand-off -- the press links and
+        # proceeds in one undoable step, and the sentence above says so.
+        # "Link to workspace" stays for membership without a hand-off.
+        assert open_console.disabled is False
         assert link.display is True
         assert link.disabled is False
         assert str(link.label) == "Link to workspace"
@@ -289,11 +293,13 @@ async def test_mounted_reader_offers_the_link_then_enables_the_handoff() -> None
         )
         link = screen.query_one("#library-conversation-link-workspace", Button)
         assert str(blocked.renderable) == (
-            "This conversation is not in this workspace. Press 'Link to "
-            "workspace' to add it to the active workspace."
+            "This conversation is not in this workspace. Pressing this "
+            "adds it to the active workspace first, and you can undo that."
         )
-        assert str(open_console.label) == "○ Use as source"
-        assert open_console.disabled is True
+        # task-32107: pressable, and unmarked -- the "○" marker means
+        # blocked, so it follows the button's real disabled state.
+        assert str(open_console.label) == "Use as source"
+        assert open_console.disabled is False
         assert link.display is True
         # Resume is independent of source workspace eligibility.
         assert screen.check_action("library_conversation_open_console", ()) is True
@@ -449,8 +455,10 @@ async def test_blocked_state_paints_the_action_name_once(widget_pilot) -> None:
         blocked = pilot.app.query_one(
             "#library-conversation-open-console-blocked", Static
         )
-        assert str(open_console.label) == "○ Use as source"
-        assert open_console.disabled is True
+        # task-32107: the action is pressable now, so it carries no "○";
+        # the one-name/one-sentence rule this test exists for is unchanged.
+        assert str(open_console.label) == "Use as source"
+        assert open_console.disabled is False
         assert blocked.display is True
         assert "Use as source" not in str(blocked.renderable)
         # ...and it is the very sentence the tooltip gives.

--- a/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
+++ b/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
@@ -4,10 +4,10 @@ title: >-
   Library hand-off consistency: Conversations 'Open in Console' is disabled when
   ineligible while the rail's Use-in-Console stays blocked-but-pressable
   (TASK-716)
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-08 22:43'
-updated_date: '2026-09-11 07:02'
+updated_date: '2026-09-11 07:45'
 labels:
   - library
   - console
@@ -26,8 +26,8 @@ task-32056 (PR #2523) disables the conversation reader's 'Open in Console' for a
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A recorded decision picks one blocked-action grammar for Console hand-offs in Library
-- [ ] #2 The other surface is aligned to it, or the difference is documented with its reason
+- [x] #1 A recorded decision picks one blocked-action grammar for Console hand-offs in Library
+- [x] #2 The other surface is aligned to it, or the difference is documented with its reason
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -35,6 +35,22 @@ task-32056 (PR #2523) disables the conversation reader's 'Open in Console' for a
 <!-- SECTION:PLAN:BEGIN -->
 1. Failing tests for link-on-use, Undo, and a non-linkable refusal.\n2. Reader: a link-resolvable block no longer disables Use as source; receipt + Undo ride the metadata seam.\n3. Screen: link first then proceed; Undo mirrors the link.\n4. Record the user decision under ## Decision; update the 32101 pins to the new grammar.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Implements the user's recorded decision (`## Decision` in this file): LINK-ON-USE. Pressing 'Use as source' on a conversation whose only block is one a link can resolve (`not_in_active_workspace`, `cross_workspace`) links it into the active workspace and proceeds, in one step, with a '✓ linked · <workspace> · this conversation can now be used in Console' receipt and an 'Undo link' beside it. 'Link to workspace' stays for membership without a hand-off. The blocks a link cannot resolve -- and the load fence -- still disable the action, marked '○' as before.
+
+One predicate, not two: `library_conversation_link_would_unblock(state, loaded_metadata)` answers both the reader's affordance and the screen handler's decision to link before staging, so the button's enabled state and the press's behaviour cannot disagree. `_link_selected_conversation_to_workspace` now returns the workspace display name and writes `_workspace_link_receipt` into `reader_loaded_metadata`; `_undo_selected_conversation_workspace_link` is its exact inverse (same fence, same registry, `unlink_membership`, receipt cleared). The receipt is per-load: each conversation load replaces the whole metadata mapping, pinned by test rather than by an added clear.
+
+The task-32101 pins were UPDATED, not loosened: one control, one action name, one sentence -- the sentence now says what the press will do ('This conversation is not in this workspace. Pressing this adds it to the active workspace first, and you can undo that.') instead of naming a second button, and it still does not repeat the action name. The '○' marker follows the button's real disabled state, so a pressable action never wears the glyph the legend reserves for a blocked one.
+
+AC#2 second half: the rail's `#library-use-in-console` keeps TASK-716's pressable-with-reason grammar, and the reason is recorded in the Decision -- it acts on a SET whose members can be blocked differently, so no single link would unblock it.
+
+Live-verified at 235x52 on the seeded profile: press links + stages (Console opens), returning to Library shows the receipt and Undo, Undo removes the membership and the refusal sentence returns.
+
+Files: tldw_chatbook/Widgets/Library/library_conversation_reader.py, tldw_chatbook/Widgets/Library/__init__.py, tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_crit10_layout.py, Tests/UI/test_library_crit8_conversation_handoff.py, Docs/User_Guide/library/media-and-conversations.md.
+<!-- SECTION:NOTES:END -->
 
 ## Decision
 

--- a/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
+++ b/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
@@ -78,6 +78,28 @@ Files: tldw_chatbook/Widgets/Library/library_conversation_reader.py, tldw_chatbo
   Console" control row (it is `Resume conversation`/`Restore and resume`, and
   it does not stage source context) is corrected while the page is open
   (review nit 9).
+
+### Fix round 2 (re-review P3)
+
+The other half of the stale-receipt problem the id-based Undo fix did not
+cover: activating a workspace this conversation is NOT in brings the block
+straight back, and the reader painted the refusal sentence with a receipt
+claiming "this conversation can now be used in Console" directly under it.
+
+`_workspace_link_receipt()` now withholds the receipt (and its Undo) while any
+workspace block stands. That is the receipt's own claim restated as its
+display rule, so it needs no extra state and no second copy of "which
+workspace is active": the block is recomputed on every sync, and the receipt
+reappears untouched if that workspace is made active again. Pinned red-first
+with a workspace switch (`test_the_receipt_never_stands_beside_the_refusal_it_resolved`).
+
+Chosen over the suggested id-match because the reader is a pure widget: an
+id comparison would need the active workspace id injected at BOTH metadata
+sites, one of which is outside this branch's owned ranges, to answer a
+question the existing block already answers. Residual, deliberately not
+covered: switching to a DIFFERENT workspace that also holds this membership
+leaves a receipt naming the first one while its claim is still true; Undo
+still removes the membership that receipt names, so the two stay consistent.
 <!-- SECTION:NOTES:END -->
 
 ## Decision

--- a/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
+++ b/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
@@ -4,9 +4,10 @@ title: >-
   Library hand-off consistency: Conversations 'Open in Console' is disabled when
   ineligible while the rail's Use-in-Console stays blocked-but-pressable
   (TASK-716)
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-08 22:43'
+updated_date: '2026-09-11 07:02'
 labels:
   - library
   - console
@@ -28,3 +29,31 @@ task-32056 (PR #2523) disables the conversation reader's 'Open in Console' for a
 - [ ] #1 A recorded decision picks one blocked-action grammar for Console hand-offs in Library
 - [ ] #2 The other surface is aligned to it, or the difference is documented with its reason
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing tests for link-on-use, Undo, and a non-linkable refusal.\n2. Reader: a link-resolvable block no longer disables Use as source; receipt + Undo ride the metadata seam.\n3. Screen: link first then proceed; Undo mirrors the link.\n4. Record the user decision under ## Decision; update the 32101 pins to the new grammar.
+<!-- SECTION:PLAN:END -->
+
+## Decision
+
+Decided by the user, 2026-09-11 (critique-10 fix wave, branch `fix/library-crit10-layout`).
+
+**Link-on-use.** Pressing "Use as source" on a conversation whose only block
+is one a link can resolve (`not_in_active_workspace`, `cross_workspace`)
+links it into the active workspace and proceeds, in one step, with a
+"✓ linked · <workspace>" receipt and an "Undo link" beside it. The separate
+"Link to workspace" button stays for membership without a hand-off.
+
+What the gate protects, and keeps protecting: workspace membership decides
+which items a Console turn is allowed to read, so a hand-off that widened it
+silently would change what the model can see without anyone saying so — which
+is why the link is a visible, reversible act with its own receipt rather than
+an implicit side effect, and why `no_active_workspace` and the aggregate
+`LIBRARY_GENERIC_WORKSPACE_BLOCK` fallback still refuse exactly as they do
+today.
+
+The rail's `#library-use-in-console` keeps TASK-716's pressable-with-reason
+grammar: it acts on a SET whose members may be blocked for different reasons,
+so there is no single link that would unblock it.

--- a/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
+++ b/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
@@ -33,7 +33,10 @@ task-32056 (PR #2523) disables the conversation reader's 'Open in Console' for a
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Failing tests for link-on-use, Undo, and a non-linkable refusal.\n2. Reader: a link-resolvable block no longer disables Use as source; receipt + Undo ride the metadata seam.\n3. Screen: link first then proceed; Undo mirrors the link.\n4. Record the user decision under ## Decision; update the 32101 pins to the new grammar.
+1. Failing tests for link-on-use, Undo, and a non-linkable refusal.
+2. Reader: a link-resolvable block no longer disables Use as source; receipt + Undo ride the metadata seam.
+3. Screen: link first then proceed; Undo mirrors the link.
+4. Record the user decision under ## Decision; update the 32101 pins to the new grammar.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -50,6 +53,31 @@ AC#2 second half: the rail's `#library-use-in-console` keeps TASK-716's pressabl
 Live-verified at 235x52 on the seeded profile: press links + stages (Console opens), returning to Library shows the receipt and Undo, Undo removes the membership and the refusal sentence returns.
 
 Files: tldw_chatbook/Widgets/Library/library_conversation_reader.py, tldw_chatbook/Widgets/Library/__init__.py, tldw_chatbook/UI/Screens/library_screen.py, Tests/UI/test_library_crit10_layout.py, Tests/UI/test_library_crit8_conversation_handoff.py, Docs/User_Guide/library/media-and-conversations.md.
+
+### Fix round 1 (review P2s)
+
+- The refusal/promise sentence is yielded directly under "Use as source"
+  instead of after the Archive/Restore pair. The copy says "Pressing this",
+  so its position is load-bearing and it had been pointing at "Archive
+  conversation". Pinned by child order.
+- Undo now unlinks the workspace the RECEIPT names, by id
+  (`_workspace_link_receipt_id`), not `get_active_workspace()`. Creating a
+  workspace from the rail activates it and recomposes the reader from the
+  same metadata mapping, so a standing receipt can outlive its workspace;
+  the old code would then have removed a membership the press never added.
+  Pinned with a workspace switch between the link and the Undo -- verified
+  the pin fails against the old one-line shape (it removed workspace-b's
+  membership and left workspace-a's).
+- The link is now gated on the same `freshness == "fresh"` answer the
+  hand-off itself checks, so a press can no longer widen the workspace and
+  then stage nothing (review nit 10).
+- The "receipt does not survive a different conversation" pin drives a real
+  second selection through the load path instead of hand-assigning the
+  metadata mapping (review nit 6).
+- `Docs/User_Guide/library/media-and-conversations.md`: the stale "Open in
+  Console" control row (it is `Resume conversation`/`Restore and resume`, and
+  it does not stage source context) is corrected while the page is open
+  (review nit 9).
 <!-- SECTION:NOTES:END -->
 
 ## Decision

--- a/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
+++ b/backlog/tasks/task-32107 - Library-hand-off-consistency-Conversations-Open-in-Console-is-disabled-when-ineligible-while-the-rails-Use-in-Console-stays-blocked-but-pressable-TASK-716.md
@@ -100,6 +100,39 @@ question the existing block already answers. Residual, deliberately not
 covered: switching to a DIFFERENT workspace that also holds this membership
 leaves a receipt naming the first one while its claim is still true; Undo
 still removes the membership that receipt names, so the two stay consistent.
+
+### Bot round (Qodo, PR #2603)
+
+Three findings, all real, all fixed red-first.
+
+- **High — Undo could delete an existing link.** `link_membership` is
+  `INSERT OR IGNORE` and returns the EXISTING row when the membership is
+  already there, so a press arriving through stale cached eligibility got a
+  receipt for a link it never made and Undo would have removed someone
+  else's membership. The link path now reads `get_item_memberships` first and
+  records the receipt only for a membership it actually inserted; the
+  hand-off still proceeds either way, and the depth-state refresh still runs
+  (skipping it left the cached eligibility stale and made the hand-off refuse
+  the conversation it had just accepted -- caught by the pin).
+- **Medium — a stale page offered a dead action.** `Use as source` was
+  pressable for a link-resolvable block even while the Conversations page was
+  not fresh, where the hand-off returns without staging. Staleness is now
+  reported through the ONE workspace-block seam as a block a link cannot
+  resolve, so the action disables with its "○" marker and its reason, no link
+  is offered, and the reader, the tooltip and the `c` accelerator cannot
+  disagree about it. Resume is unaffected -- reopening the original never
+  needed a fresh list.
+- **Medium — repeated protocol strings.** Fixed by DELETION: the handler's
+  own `freshness != "fresh"` check (added in review fix round 1) is gone,
+  because a non-fresh page is now a block and the predicate is already False
+  for it. The remaining `_workspace_link_receipt` metadata key is declined as
+  a constant: it is the fifth key on an established controller-to-reader
+  seam whose four siblings (`_workspace_block`, `_workspace_block_detail`,
+  `_workspace_block_linkable`, `_list_status`) are all plain literals, and
+  hoisting one of five would make the seam less consistent, not more.
+
+Pins: `test_undo_is_withheld_when_the_membership_already_existed`,
+`test_a_stale_page_refuses_instead_of_promising_a_link`.
 <!-- SECTION:NOTES:END -->
 
 ## Decision

--- a/backlog/tasks/task-32355 - Library-rail-collapses-to-an-unlabelled-grip-while-a-note-editor-is-open-at-235-columns-grips-are-unlabelled-at-every-width.md
+++ b/backlog/tasks/task-32355 - Library-rail-collapses-to-an-unlabelled-grip-while-a-note-editor-is-open-at-235-columns-grips-are-unlabelled-at-every-width.md
@@ -31,7 +31,9 @@ With a note open at 235 columns the rail is replaced by '--->' with no label (A 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Decide rule-vs-preference for the rail beside a note editor from the config evidence.\n2. Label the grips Nav/Items above 5 cells, guillemet below.\n3. Docs + pinned painted assertions at 235/100/60.
+1. Decide rule-vs-preference for the rail beside a note editor from the config evidence.
+2. Label the grips Nav/Items above 5 cells, guillemet below.
+3. Docs + pinned painted assertions at 235/100/60.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -44,4 +46,5 @@ AC#2: the handle carried its name only in `_name`/`tooltip`, neither of which a 
 Live at 235x52, 100x30 and 60x24 on the seeded profile: both handles paint their name, including on the rail a note editor collapsed.
 
 Files: tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py, Tests/UI/test_library_crit10_layout.py, Docs/User_Guide/library.md.
+
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32355 - Library-rail-collapses-to-an-unlabelled-grip-while-a-note-editor-is-open-at-235-columns-grips-are-unlabelled-at-every-width.md
+++ b/backlog/tasks/task-32355 - Library-rail-collapses-to-an-unlabelled-grip-while-a-note-editor-is-open-at-235-columns-grips-are-unlabelled-at-every-width.md
@@ -3,9 +3,10 @@ id: TASK-32355
 title: >-
   Library rail: collapses to an unlabelled '--->' grip while a note editor is
   open at 235 columns; grips are unlabelled at every width
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:17'
+updated_date: '2026-09-11 07:44'
 labels:
   - library
   - layout
@@ -22,7 +23,25 @@ With a note open at 235 columns the rail is replaced by '--->' with no label (A 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 At 120 columns and wider the rail stays beside the note editor, or the collapse is documented as intended and the handle is labelled 'Nav'
-- [ ] #2 Every pane grip carries a label or a footer hint
-- [ ] #3 Pinned
+- [x] #1 At 120 columns and wider the rail stays beside the note editor, or the collapse is documented as intended and the handle is labelled 'Nav'
+- [x] #2 Every pane grip carries a label or a footer hint
+- [x] #3 Pinned
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Decide rule-vs-preference for the rail beside a note editor from the config evidence.\n2. Label the grips Nav/Items above 5 cells, guillemet below.\n3. Docs + pinned painted assertions at 235/100/60.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The rail-beside-editor branch is settled by evidence, not by preference: the collapse is the Notes WORK-FIRST session (`library_notes_controller.py:2379-2386`, `NotesWorkSessionPhase.ACTIVE -> library_open=False`), a deliberate rule that activates ONLY at 120+ columns of editor width (`Tests/UI/test_library_notes_work_session.py` pins 119 -> INACTIVE, 120/121 -> ACTIVE) and is cancelled for the rest of the visit by one manual expand (MANUAL_LIBRARY_EXPAND -> MANUALLY_CANCELLED). The profile's persisted `[library.reader] library_open = true` says the user's preference is OPEN, so the collapse is the rule, not stored state. `library.md:273`'s '120 columns and wider the rail stays beside it' is about the FILE NOTES workspace, not the note editor; the page now states the editor rule where the rail is described. AC#1 is therefore taken via its second branch, the labelled handle.
+
+AC#2: the handle carried its name only in `_name`/`tooltip`, neither of which a terminal paints. The column is five cells wide and 20-45 rows tall, so `LibraryAdaptiveReaderPaneGrip.render` now spells the name DOWNWARDS above the arrows -- 'Nav' for the Library pane (the guide's own name for this handle; 'Library' would not fit), the pane's own label for the items pane ('Items', 'Prompts', 'Skills', 'Folderfiles'). A horizontal label cannot hold any of those at five cells, which is why the plan's 'Nav >' / 'Items >' shape was not used. The arrow rows are untouched, so the 35/65-per-cent pins still hold.
+
+Live at 235x52, 100x30 and 60x24 on the seeded profile: both handles paint their name, including on the rail a note editor collapsed.
+
+Files: tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py, Tests/UI/test_library_crit10_layout.py, Docs/User_Guide/library.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32359 - Library-rail-active-and-focused-rows-are-visually-identical.md
+++ b/backlog/tasks/task-32359 - Library-rail-active-and-focused-rows-are-visually-identical.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32359
 title: 'Library rail: active and focused rows are visually identical'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:18'
+updated_date: '2026-09-11 07:45'
 labels:
   - library
   - accessibility
@@ -20,6 +21,22 @@ Both the active destination and the focused row render bold + underline with bac
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The focused rail row is distinguishable from the active row by a glyph or shape, not colour alone
-- [ ] #2 Pinned with a painted assertion
+- [x] #1 The focused rail row is distinguishable from the active row by a glyph or shape, not colour alone
+- [x] #2 Pinned with a painted assertion
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Painted-frame failing test: focused rail row vs active rail row.\n2. CSS-only: focus gets the house thick left bar; active keeps the background.\n3. Rebuild the bundle.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+CSS-only, as scoped: `.library-rail-row` had no `:focus` rule at all and fell back to the Button default, so the focused row and the active destination both rendered bold + underline over backgrounds three RGB units apart. `.library-rail-row:focus` now takes the house focus shape -- `border-left: thick $ds-action-focus` with `padding: 0 1 0 0` so the label neither shifts nor clips, plus `outline: none` to suppress the generic `*:focus{outline:solid}` fallback. `-selected` keeps the background treatment, unchanged. `library_rail.py` untouched.
+
+Pinned with the painted-frame idiom from `Tests/UI/test_library_row_focus_cue_t31983.py` at 235x52 and 100x30: focus the Media row while Conversations is active, assert the block glyph paints on the focused row and not on the active one, then swap and assert the reverse. Live-confirmed at 235x52 on the seeded profile (F6 + Tab into the rail: the focused Media row paints the bar, the active Conversations row keeps only its marker).
+
+Files: tldw_chatbook/css/components/_agentic_terminal.tcss (+ regenerated bundle), Tests/UI/test_library_crit10_layout.py, Docs/User_Guide/library.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32359 - Library-rail-active-and-focused-rows-are-visually-identical.md
+++ b/backlog/tasks/task-32359 - Library-rail-active-and-focused-rows-are-visually-identical.md
@@ -28,7 +28,9 @@ Both the active destination and the focused row render bold + underline with bac
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Painted-frame failing test: focused rail row vs active rail row.\n2. CSS-only: focus gets the house thick left bar; active keeps the background.\n3. Rebuild the bundle.
+1. Painted-frame failing test: focused rail row vs active rail row.
+2. CSS-only: focus gets the house thick left bar; active keeps the background.
+3. Rebuild the bundle.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-32360 - Library-below-64-columns-the-rail-only-stage-has-no-labelled-return-and-copy-clips-mid-word-without-an-ellipsis.md
+++ b/backlog/tasks/task-32360 - Library-below-64-columns-the-rail-only-stage-has-no-labelled-return-and-copy-clips-mid-word-without-an-ellipsis.md
@@ -3,9 +3,10 @@ id: TASK-32360
 title: >-
   Library below 64 columns: the rail-only stage has no labelled return and copy
   clips mid-word without an ellipsis
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-11 06:18'
+updated_date: '2026-09-11 07:45'
 labels:
   - library
   - layout
@@ -22,7 +23,27 @@ At 60x24 on the rail-only stage Escape is the only return and the footer never s
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The footer names the return on every single-stage surface
+- [x] #1 The footer names the return on every single-stage surface
 - [ ] #2 Clipped copy ends in an ellipsis
-- [ ] #3 Grips never overpaint content
+- [x] #3 Grips never overpaint content
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Footer: return a SHORT context on the narrow stage so the return chip survives the tier.\n2. text-overflow: ellipsis on the canvas classes that clip.\n3. Measure grip regions at 235/100/60 before touching geometry.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Two of three ACs closed; AC#2 left open with its measurement.
+
+AC#1 (footer names the return) was ALREADY TRUE and is now pinned as a regression. The plan expected the chip to be lost to AppFooterStatus's width ladder and prescribed trimming the narrow-stage context to two chips; driving the real footer widget at width 60 with one, two, three and five chips renders 'esc back to Library | F1 · F6 · Ctrl+P · Ctrl+Q' in EVERY case, and the live app at 60x24 on a Library browse list paints exactly that. task-32225's 'FIRST, not appended' already carries it, so the prescribed trim would have dropped chips the footer was not painting anyway -- a no-op dressed as a fix, and it was reverted. Whatever B captured at 60x24 was a surface where this context is not active at all (the predicate stands down when an earlier Escape action owns the key, and requires a CLOSED Library pane).
+
+AC#3 (grips never overpaint) was ALSO already true, by two independent measurements: `grip.region.right <= neighbour.region.x` holds at 235x52, 100x30 and 60x24, and a painted-frame scan finds no '<---'/'--->' run on any column outside a grip's own columns. B's '17-media-list.txt' runs at char columns 42, 42 and 183 ARE the grips' own columns (x=41 and x=182) -- the arrows looked stray because the handle was unlabelled, which task-32355 now fixes. Both assertions are pinned.
+
+AC#2 (clipped copy ends in an ellipsis) NOT DONE, reproduced and narrowed. Live at 60x24 on Notes: the status line paints 'Library notes · Ready · Next: / Create a note or add from' and loses 'files.' (a HEIGHT clip -- the Static resolved two lines for three lines of content), and the toolbar paints 'New  Sort: Newest  Sel' (a WIDTH crop of the Button by its container). `text-overflow: ellipsis` on `.library-canvas-action` and `#library-notes-status` was tried and measured live: NO EFFECT on either, because neither loss is the horizontal text-overflow the property governs. The existing `#library-shell-grid.library-notes-compact` rules already carry the right fix for both (`width: auto` on the actions, `height: 1` + `text-wrap: nowrap` + `text-overflow: ellipsis` on the status) -- they are simply not in effect at 60x24 on the Notes route, so the real defect is the compact gate in `library_notes_controller.py` (`legacy_compact`), a file this branch does not own. Needs its own task against the Notes canvas.
+
+Files: Tests/UI/test_library_crit10_layout.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32360 - Library-below-64-columns-the-rail-only-stage-has-no-labelled-return-and-copy-clips-mid-word-without-an-ellipsis.md
+++ b/backlog/tasks/task-32360 - Library-below-64-columns-the-rail-only-stage-has-no-labelled-return-and-copy-clips-mid-word-without-an-ellipsis.md
@@ -31,7 +31,9 @@ At 60x24 on the rail-only stage Escape is the only return and the footer never s
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Footer: return a SHORT context on the narrow stage so the return chip survives the tier.\n2. text-overflow: ellipsis on the canvas classes that clip.\n3. Measure grip regions at 235/100/60 before touching geometry.
+1. Footer: return a SHORT context on the narrow stage so the return chip survives the tier.
+2. text-overflow: ellipsis on the canvas classes that clip.
+3. Measure grip regions at 235/100/60 before touching geometry.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -46,4 +48,48 @@ AC#3 (grips never overpaint) was ALSO already true, by two independent measureme
 AC#2 (clipped copy ends in an ellipsis) NOT DONE, reproduced and narrowed. Live at 60x24 on Notes: the status line paints 'Library notes · Ready · Next: / Create a note or add from' and loses 'files.' (a HEIGHT clip -- the Static resolved two lines for three lines of content), and the toolbar paints 'New  Sort: Newest  Sel' (a WIDTH crop of the Button by its container). `text-overflow: ellipsis` on `.library-canvas-action` and `#library-notes-status` was tried and measured live: NO EFFECT on either, because neither loss is the horizontal text-overflow the property governs. The existing `#library-shell-grid.library-notes-compact` rules already carry the right fix for both (`width: auto` on the actions, `height: 1` + `text-wrap: nowrap` + `text-overflow: ellipsis` on the status) -- they are simply not in effect at 60x24 on the Notes route, so the real defect is the compact gate in `library_notes_controller.py` (`legacy_compact`), a file this branch does not own. Needs its own task against the Notes canvas.
 
 Files: Tests/UI/test_library_crit10_layout.py.
+
+### Fix round 1 (review P1)
+
+AC#1's tick was WRONG after the round-0 cross-branch commit and is now earned
+again by a PAINTED pin in both focus states.
+
+What the review measured and I confirmed: at width 60 the real
+`AppFooterStatus` paints exactly ONE context chip, about 24 rendered
+characters of it. `esc back to Library` (19) survives; `esc typing · back to
+Library` (28), `esc typing · leaves field` (25) and Task 1's wide-footer form
+all collapse the WHOLE context to `…`. So the field-state marker and the
+return cannot both paint, and round 0's ordering commit silently dropped the
+return whenever a field had focus.
+
+The coordinator's ruling was to paint `esc leaves field` in that state. That
+chip would be a DEAD KEY here, which the same ruling forbids: the
+`library_narrow_stage_return` binding is declared ABOVE
+`library_blur_text_field`, and on this stage with an Input focused
+`check_action("library_blur_text_field")` is measurably **False** while
+`check_action("library_narrow_stage_return")` is **True** -- Escape performs
+the return, not a blur. Both answers are now asserted inside the pin, so the
+chip can never drift away from the key. The single chip therefore stays
+`esc back to Library` in both states (the review's own option (a)), and the
+"typing" signal yields at this one width; nothing the caret would swallow is
+advertised either, because the typing block above has already dropped every
+printable-key chip.
+
+The 32346 grammar item (field state first) holds at every width where more
+than one chip paints; the eliding is `AppFooterStatus`'s, so that is where
+the wide/narrow grammar belongs -- flagged to the coordinator, not worked
+around here.
+
+Pins added: `test_the_narrow_stage_return_is_painted_in_both_focus_states`
+(painted, parametrized over field-focused true/false, asserts no `…`) and
+`test_only_one_context_chip_paints_at_sixty_columns` (the budget itself).
+The round-0 registered-tuple pin is gone -- it was blind to this.
+### Fix round 1 (review nit 5)
+
+The AC#3 geometry half measured only the two grips against the reader. The
+list pane and the rail -- the neighbours B actually reported overpainted --
+are now in the same sorted-span assertion, with a floor on how many spans were
+measured so the check cannot silently degrade to two. The whole-frame scan for
+`<---`/`--->` runs outside grip columns is unchanged; it is what carries the
+claim.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32361 - Library-Conversations-at-235-columns-the-reader-gets-~48-columns-while-the-list-sits-80-empty.md
+++ b/backlog/tasks/task-32361 - Library-Conversations-at-235-columns-the-reader-gets-~48-columns-while-the-list-sits-80-empty.md
@@ -29,7 +29,8 @@ The list takes ~140 columns and is mostly empty; the reader wraps at ~48 (B D11 
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Measure the conversations split at 235/100/60 with a conversation open.\n2. Give the reader the majority from the measurement, not a guessed ratio.
+1. Measure the conversations split at 235/100/60 with a conversation open.
+2. Give the reader the majority from the measurement, not a guessed ratio.
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -42,4 +43,11 @@ Fix: `LibraryConversationReader.sync_state` -- the one place every selection cha
 Measured after, live and in tests: 235x52 reader 132 / list 49; 100x30 reader 44 / list 45 (the rail steps aside; AC#1 is bounded at 200 columns); 60x24 reader 50, no list (single stage). Pinned both ways -- the majority with a conversation open, and task-32217's empty-pane widening still intact.
 
 Files: tldw_chatbook/Widgets/Library/library_conversation_reader.py, Tests/UI/test_library_crit10_layout.py, Docs/User_Guide/library/media-and-conversations.md.
+
+### Fix round 1 (review nit 7)
+
+The AC states "200 columns and wider" but the pin ran only at 235. It is now
+parametrized over (200, 52) and (235, 52) with the measured floor for each --
+reader 97 / list 49 at 200, reader 132 / list 49 at 235 -- so the boundary the
+AC names is the boundary that is pinned.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32361 - Library-Conversations-at-235-columns-the-reader-gets-~48-columns-while-the-list-sits-80-empty.md
+++ b/backlog/tasks/task-32361 - Library-Conversations-at-235-columns-the-reader-gets-~48-columns-while-the-list-sits-80-empty.md
@@ -3,9 +3,10 @@ id: TASK-32361
 title: >-
   Library Conversations at 235 columns: the reader gets ~48 columns while the
   list sits 80% empty
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11 06:18'
+updated_date: '2026-09-11 07:45'
 labels:
   - library
   - layout
@@ -22,5 +23,23 @@ The list takes ~140 columns and is mostly empty; the reader wraps at ~48 (B D11 
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 With a conversation open the reader takes the majority of the width at 200 columns and wider
+- [x] #1 With a conversation open the reader takes the majority of the width at 200 columns and wider
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Measure the conversations split at 235/100/60 with a conversation open.\n2. Give the reader the majority from the measurement, not a guessed ratio.
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause, traced rather than assumed. The adaptive layout asks `reader_has_item` (`selected_id is not None`), but the Conversations layout is resolved ONLY from `AdaptiveReaderShellResized`, which the shell posts on mount -- one refresh BEFORE `_ensure_library_conversation_reader_selection` settles the selection. Nothing re-resolved after that, so the empty-Reader rule (task-31979, which hands the Reader's columns to the list) stayed applied with a conversation open. Measured at 235x52 before: list 137, Reader 44; a single re-resolve produced list 50, Reader 132 -- so the ratio was never wrong, the layout was stale.
+
+Fix: `LibraryConversationReader.sync_state` -- the one place every selection change reaches this pane -- posts `AdaptiveReaderShellResized` when the open/empty answer flips, and the screen's existing `@on` handler re-resolves. No new resolver rule and no invented ratio.
+
+Measured after, live and in tests: 235x52 reader 132 / list 49; 100x30 reader 44 / list 45 (the rail steps aside; AC#1 is bounded at 200 columns); 60x24 reader 50, no list (single stage). Pinned both ways -- the majority with a conversation open, and task-32217's empty-pane widening still intact.
+
+Files: tldw_chatbook/Widgets/Library/library_conversation_reader.py, Tests/UI/test_library_crit10_layout.py, Docs/User_Guide/library/media-and-conversations.md.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -12915,6 +12915,25 @@ class LibraryScreen(BaseAppScreen):
         ).strip()
         if not conversation_id:
             return "", False, ""
+        if self._conversations_state.freshness != "fresh":
+            # (Qodo bot round #3) The hand-off returns without staging while
+            # the page is not fresh, so a pressable "Use as source" -- and
+            # the sentence promising it will link and continue -- was an
+            # actionable control that did nothing. Reported here as the block
+            # it is: NOT link-resolvable, so the action disables with its "○"
+            # marker and no link is offered. Reported through this one seam
+            # rather than a second metadata key so the reader, the tooltip
+            # and the `c` accelerator cannot disagree about it. Resume is
+            # unaffected -- reopening the original never needed a fresh list.
+            return (
+                # Inline, like the canvas's own "List may be out of date"
+                # (library_conversations_state.py): one writer, one reader
+                # echoing it, so a constant would be ceremony.
+                "from a list that may be out of date",
+                False,
+                "This list may be out of date. Refresh Conversations before "
+                "using this one in Console.",
+            )
         state = self._library_workspace_depth_state()
         eligible, reason_copy = library_item_context_handoff(
             state, item_type="conversation", item_id=conversation_id
@@ -13067,6 +13086,22 @@ class LibraryScreen(BaseAppScreen):
             active = registry.get_active_workspace()
             if active is None:
                 raise ValueError("no active workspace")
+            # (Qodo bot round #2) ``link_membership`` is INSERT OR IGNORE and
+            # returns the EXISTING row when the membership is already there.
+            # A press that reaches it through stale cached eligibility would
+            # otherwise get a receipt for a link it did not make, and Undo
+            # would delete someone else's membership. Read first, receipt
+            # only what this press inserted.
+            # ponytail: read-then-write, not an atomic "did it insert?" from
+            # the registry -- one UI thread makes the window unreachable
+            # here; push the answer into `link_membership` if a second writer
+            # ever shares it.
+            already_linked = any(
+                membership.workspace_id == active.workspace_id
+                for membership in registry.get_item_memberships(
+                    item_type="conversation", item_id=conversation_id
+                )
+            )
             registry.link_membership(
                 active.workspace_id,
                 item_type="conversation",
@@ -13088,9 +13123,14 @@ class LibraryScreen(BaseAppScreen):
                 )
             return ""
         workspace_name = str(getattr(active, "name", "") or active.workspace_id)
-        self._set_library_conversation_link_receipt(
-            workspace_name, active.workspace_id
-        )
+        if not already_linked:
+            # Nothing was added when it was already linked, so there is
+            # nothing to undo -- but the refresh below still has to run, or
+            # the cached eligibility that sent us here stays stale and the
+            # hand-off refuses the conversation it just accepted.
+            self._set_library_conversation_link_receipt(
+                workspace_name, active.workspace_id
+            )
         self._invalidate_library_workspace_depth_state()
         self._sync_library_conversation_reader()
         return workspace_name
@@ -34015,14 +34055,11 @@ class LibraryScreen(BaseAppScreen):
             # task-32107: one gesture, not two. A failed link leaves the
             # refusal exactly as it was and does not stage anything.
             #
-            # (review fix round 1) Gated on the SAME freshness answer the
-            # hand-off itself checks first (`_open_selected_conversation_handoff`
-            # returns silently unless it is "fresh"). Without this the press
-            # would widen the workspace and then stage nothing, which is a
-            # data effect with no visible result but the receipt.
-            if self._conversations_state.freshness != "fresh":
-                event.stop()
-                return
+            # (Qodo bot round #1) The freshness check that stood here is
+            # gone, not moved: a page that is not fresh is now reported as a
+            # non-linkable workspace block, so this predicate is already
+            # False for it and the literal had nowhere left to disagree with
+            # `_open_selected_conversation_handoff`'s own.
             if not self._link_selected_conversation_to_workspace():
                 event.stop()
                 return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -450,6 +450,7 @@ from ...Widgets.Library import (
     LibraryStudyHandoffCanvas,
     LibraryStudyHandoffCanvasState,
     library_conversation_block_sentence,
+    library_conversation_link_would_unblock,
     library_dim_label_text,
     library_rag_scope_shows_recovery,
     skill_editor_warning_lines,
@@ -12916,19 +12917,104 @@ class LibraryScreen(BaseAppScreen):
         """Use the same retained-identity load fence as the Resume button."""
         return self._conversations_state.reader_state.loaded_actions_eligible
 
-    def _link_selected_conversation_to_workspace(self) -> None:
+    def _library_conversation_link_would_unblock(self) -> bool:
+        """Return whether a workspace link is what blocks the hand-off.
+
+        (task-32107) Asks the reader's OWN predicate, over the same three
+        inputs, so the enabled state of "Use as source" and this handler's
+        decision to link before staging cannot disagree.
+
+        Returns:
+            True when linking into the active workspace resolves the only
+            block.
+        """
+        blocked, linkable, _detail = self._library_conversation_workspace_block()
+        return library_conversation_link_would_unblock(
+            self._conversations_state.reader_state,
+            {
+                "_workspace_block": blocked,
+                "_workspace_block_linkable": linkable,
+            },
+        )
+
+    def _set_library_conversation_link_receipt(self, workspace_name: str) -> None:
+        """Record (or clear) the workspace the last press linked into.
+
+        A fresh mapping rather than a mutation: ``reader_loaded_metadata`` is
+        typed as a ``Mapping`` and is replaced wholesale by each load, which
+        is what clears the receipt when a different conversation opens.
+
+        Args:
+            workspace_name: The linked workspace's display name, or ``""``.
+        """
+        self._conversations_state.reader_loaded_metadata = {
+            **self._conversations_state.reader_loaded_metadata,
+            "_workspace_link_receipt": workspace_name,
+        }
+
+    def _undo_selected_conversation_workspace_link(self) -> None:
+        """Remove the membership the last "Use as source" press added.
+
+        The exact inverse of ``_link_selected_conversation_to_workspace``:
+        same load fence, same registry, same refresh -- ``unlink_membership``
+        instead of ``link_membership``, and the receipt cleared.
+        """
+        if not self._conversations_state.reader_state.loaded_actions_eligible:
+            return
+        registry = getattr(self.app_instance, "workspace_registry_service", None)
+        notify = getattr(self.app_instance, "notify", None)
+        conversation_id = str(
+            self._conversations_state.reader_state.loaded_id or ""
+        ).strip()
+        if registry is None or not conversation_id:
+            if callable(notify):
+                notify(
+                    "Workspaces are unavailable, so this link cannot be "
+                    "undone.",
+                    severity="warning",
+                )
+            return
+        try:
+            active = registry.get_active_workspace()
+            if active is None:
+                raise ValueError("no active workspace")
+            registry.unlink_membership(
+                active.workspace_id,
+                item_type="conversation",
+                item_id=conversation_id,
+            )
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Library conversation workspace link could not be undone."
+            )
+            if callable(notify):
+                notify(
+                    "This link could not be undone. Try again.",
+                    severity="warning",
+                )
+            return
+        self._set_library_conversation_link_receipt("")
+        self._invalidate_library_workspace_depth_state()
+        self._sync_library_conversation_reader()
+
+    def _link_selected_conversation_to_workspace(self) -> str:
         """Link the open conversation into the active workspace (task-32056).
 
         The remedy the refusal used to name without offering. A no-op when
         the registry, the active workspace, or the loaded conversation is
         missing -- each of those already blocks the action's own affordance.
+
+        Returns:
+            The linked workspace's display name, or ``""`` when nothing was
+            linked (task-32107: "Use as source" links first and only
+            proceeds on a real name, so a failed link stages nothing).
         """
         # (review round 2) This writes membership for the RETAINED
         # ``loaded_id``. The same fence that hides the button re-checks here,
         # so no sync window can persist the conversation the user already
         # navigated away from.
         if not self._conversations_state.reader_state.loaded_actions_eligible:
-            return
+            return ""
         registry = getattr(self.app_instance, "workspace_registry_service", None)
         notify = getattr(self.app_instance, "notify", None)
         conversation_id = str(
@@ -12941,7 +13027,7 @@ class LibraryScreen(BaseAppScreen):
                     "be linked.",
                     severity="warning",
                 )
-            return
+            return ""
         try:
             active = registry.get_active_workspace()
             if active is None:
@@ -12965,9 +13051,12 @@ class LibraryScreen(BaseAppScreen):
                     "workspace. Try again.",
                     severity="warning",
                 )
-            return
+            return ""
+        workspace_name = str(getattr(active, "name", "") or active.workspace_id)
+        self._set_library_conversation_link_receipt(workspace_name)
         self._invalidate_library_workspace_depth_state()
         self._sync_library_conversation_reader()
+        return workspace_name
 
     def _selected_media_handoff_payload(self) -> ChatHandoffPayload | None:
         return self._media_controller._selected_media_handoff_payload()
@@ -33805,12 +33894,28 @@ class LibraryScreen(BaseAppScreen):
 
     @on(Button.Pressed, "#library-conversation-use-source")
     def use_selected_conversation_as_source(self, event: Button.Pressed) -> None:
-        """Stage the loaded transcript under the existing workspace source rules.
+        """Stage the loaded transcript, linking it first when that is the block.
 
         Args:
             event: Source action press forwarded to the browse controller.
         """
+        if self._library_conversation_link_would_unblock():
+            # task-32107: one gesture, not two. A failed link leaves the
+            # refusal exactly as it was and does not stage anything.
+            if not self._link_selected_conversation_to_workspace():
+                event.stop()
+                return
         return self._conversations_controller.use_selected_conversation_as_source(event)
+
+    @on(Button.Pressed, "#library-conversation-link-undo")
+    def undo_selected_conversation_workspace_link(self, event: Button.Pressed) -> None:
+        """Remove the membership the last "Use as source" press added.
+
+        Args:
+            event: The Undo press, stopped here like its sibling handlers.
+        """
+        event.stop()
+        self._undo_selected_conversation_workspace_link()
 
     @on(Button.Pressed, "#library-conversation-link-workspace")
     def link_selected_conversation_to_workspace(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4460,23 +4460,24 @@ class LibraryScreen(BaseAppScreen):
             # pane" and no return). Recovery outranks navigation here anyway,
             # which is the order that ladder assumes.
             #
-            # Cross-branch (task-32360 with task-32346): while a text field
-            # holds focus the footer says SO FIRST on every other surface --
-            # every printable key is being inserted as text, which outranks
-            # any navigation the footer could advertise. Prepending the
-            # return chip ahead of that marker made this one width the
-            # exception. The field state keeps the head; the return follows
-            # it, still ahead of the navigation chips.
-            rest = tuple(pair for pair in shortcuts if pair[0] != "esc")
-            field_state = (
-                rest[:1]
-                if isinstance(focused, (Input, TextArea)) and rest and rest[0][0] == ""
-                else ()
-            )
-            shortcuts = (
-                field_state
-                + (("esc", "back to Library"),)
-                + rest[len(field_state) :]
+            # Cross-branch (task-32360 with task-32346), fix round 1: the
+            # return stays at the head EVEN WHILE A TEXT FIELD HOLDS FOCUS,
+            # and this is the one surface where that is not a style choice.
+            # Measured against the real ``AppFooterStatus`` at width 60: it
+            # paints exactly ONE context chip, and only ~24 rendered
+            # characters of it -- "esc back to Library" (19) survives;
+            # "esc typing · back to Library" (28) collapses the WHOLE context
+            # to "…". So one chip is all there is, and it has to be the one
+            # that names what Escape actually does here. It does not leave
+            # the field: this binding is declared ABOVE
+            # ``library_blur_text_field``, whose ``check_action`` is
+            # measurably False while this one owns the key, so a chip reading
+            # "leaves field" would be the dead-key lie task-32051 and
+            # task-32225 both exist to prevent. Nothing is advertised that
+            # the caret would swallow either -- the block above has already
+            # dropped every printable-key chip.
+            shortcuts = (("esc", "back to Library"),) + tuple(
+                pair for pair in shortcuts if pair[0] != "esc"
             )
         # re-review N4: below 64 columns the box "/" jumps to can be inside a
         # CLOSED pane -- mounted, so the handler finds it, but unfocusable, so
@@ -12953,19 +12954,29 @@ class LibraryScreen(BaseAppScreen):
             },
         )
 
-    def _set_library_conversation_link_receipt(self, workspace_name: str) -> None:
+    def _set_library_conversation_link_receipt(
+        self, workspace_name: str, workspace_id: str = ""
+    ) -> None:
         """Record (or clear) the workspace the last press linked into.
 
         A fresh mapping rather than a mutation: ``reader_loaded_metadata`` is
         typed as a ``Mapping`` and is replaced wholesale by each load, which
         is what clears the receipt when a different conversation opens.
 
+        The ID is stored beside the NAME (review fix round 1) because Undo
+        has to remove the membership this press added, not whatever is active
+        by the time it is pressed -- creating a workspace from the rail
+        activates it and recomposes the reader from this same mapping, so the
+        active workspace can change underneath a standing receipt.
+
         Args:
             workspace_name: The linked workspace's display name, or ``""``.
+            workspace_id: That workspace's id, or ``""`` to clear.
         """
         self._conversations_state.reader_loaded_metadata = {
             **self._conversations_state.reader_loaded_metadata,
             "_workspace_link_receipt": workspace_name,
+            "_workspace_link_receipt_id": workspace_id,
         }
 
     def _undo_selected_conversation_workspace_link(self) -> None:
@@ -12974,6 +12985,11 @@ class LibraryScreen(BaseAppScreen):
         The exact inverse of ``_link_selected_conversation_to_workspace``:
         same load fence, same registry, same refresh -- ``unlink_membership``
         instead of ``link_membership``, and the receipt cleared.
+
+        It unlinks the workspace the RECEIPT names, read back by id, not
+        whatever is active now (review fix round 1): activating a different
+        workspace while the receipt stands would otherwise make Undo remove a
+        membership this press never added.
         """
         if not self._conversations_state.reader_state.loaded_actions_eligible:
             return
@@ -12982,7 +12998,13 @@ class LibraryScreen(BaseAppScreen):
         conversation_id = str(
             self._conversations_state.reader_state.loaded_id or ""
         ).strip()
-        if registry is None or not conversation_id:
+        workspace_id = str(
+            self._conversations_state.reader_loaded_metadata.get(
+                "_workspace_link_receipt_id"
+            )
+            or ""
+        ).strip()
+        if registry is None or not conversation_id or not workspace_id:
             if callable(notify):
                 notify(
                     "Workspaces are unavailable, so this link cannot be "
@@ -12991,11 +13013,8 @@ class LibraryScreen(BaseAppScreen):
                 )
             return
         try:
-            active = registry.get_active_workspace()
-            if active is None:
-                raise ValueError("no active workspace")
             registry.unlink_membership(
-                active.workspace_id,
+                workspace_id,
                 item_type="conversation",
                 item_id=conversation_id,
             )
@@ -13069,7 +13088,9 @@ class LibraryScreen(BaseAppScreen):
                 )
             return ""
         workspace_name = str(getattr(active, "name", "") or active.workspace_id)
-        self._set_library_conversation_link_receipt(workspace_name)
+        self._set_library_conversation_link_receipt(
+            workspace_name, active.workspace_id
+        )
         self._invalidate_library_workspace_depth_state()
         self._sync_library_conversation_reader()
         return workspace_name
@@ -33918,6 +33939,15 @@ class LibraryScreen(BaseAppScreen):
         if self._library_conversation_link_would_unblock():
             # task-32107: one gesture, not two. A failed link leaves the
             # refusal exactly as it was and does not stage anything.
+            #
+            # (review fix round 1) Gated on the SAME freshness answer the
+            # hand-off itself checks first (`_open_selected_conversation_handoff`
+            # returns silently unless it is "fresh"). Without this the press
+            # would widen the workspace and then stage nothing, which is a
+            # data effect with no visible result but the receipt.
+            if self._conversations_state.freshness != "fresh":
+                event.stop()
+                return
             if not self._link_selected_conversation_to_workspace():
                 event.stop()
                 return

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -4459,8 +4459,24 @@ class LibraryScreen(BaseAppScreen):
             # painted (live capture at 60x24 showed "/ focus search | F6 next
             # pane" and no return). Recovery outranks navigation here anyway,
             # which is the order that ladder assumes.
-            shortcuts = (("esc", "back to Library"),) + tuple(
-                pair for pair in shortcuts if pair[0] != "esc"
+            #
+            # Cross-branch (task-32360 with task-32346): while a text field
+            # holds focus the footer says SO FIRST on every other surface --
+            # every printable key is being inserted as text, which outranks
+            # any navigation the footer could advertise. Prepending the
+            # return chip ahead of that marker made this one width the
+            # exception. The field state keeps the head; the return follows
+            # it, still ahead of the navigation chips.
+            rest = tuple(pair for pair in shortcuts if pair[0] != "esc")
+            field_state = (
+                rest[:1]
+                if isinstance(focused, (Input, TextArea)) and rest and rest[0][0] == ""
+                else ()
+            )
+            shortcuts = (
+                field_state
+                + (("esc", "back to Library"),)
+                + rest[len(field_state) :]
             )
         # re-review N4: below 64 columns the box "/" jumps to can be inside a
         # CLOSED pane -- mounted, so the handler finds it, but unfocusable, so

--- a/tldw_chatbook/Widgets/Library/__init__.py
+++ b/tldw_chatbook/Widgets/Library/__init__.py
@@ -11,6 +11,7 @@ from .library_conversations_canvas import LibraryConversationsCanvas
 from .library_conversation_reader import (
     LibraryConversationReader,
     library_conversation_block_sentence,
+    library_conversation_link_would_unblock,
 )
 from .library_adaptive_reader_shell import (
     LIBRARY_ADAPTIVE_READER_GRIP_CLASS,
@@ -134,6 +135,7 @@ __all__ = [
     "LibraryConversationsCanvas",
     "LibraryConversationReader",
     "library_conversation_block_sentence",
+    "library_conversation_link_would_unblock",
     "LibraryExportCanvas",
     "LibraryLandingAttentionAction",
     "LibraryLandingCanvas",

--- a/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
+++ b/tldw_chatbook/Widgets/Library/library_adaptive_reader_shell.py
@@ -29,6 +29,13 @@ LIBRARY_ARROW_UPPER_POSITION_RATIO = 0.35
 #: recompose hands them focus unless someone puts it back).
 LIBRARY_ADAPTIVE_READER_GRIP_CLASS = "library-adaptive-reader-pane-grip"
 
+#: (task-32355) What a grip PAINTS where its pane's spoken name would not fit
+#: or would not be the name the guide uses. The Library pane's tooltip says
+#: "Expand Library pane"; the handle itself is the "Nav" handle
+#: (``Docs/User_Guide/library.md``), which is also the only form that reads in
+#: a five-cell column.
+LIBRARY_PANE_GRIP_NAMES = {"Library": "Nav"}
+
 
 class PaneToggleRequested(Message):
     """Request a manual toggle of one optional pane."""
@@ -161,23 +168,56 @@ class LibraryAdaptiveReaderPaneGrip(Button):
         if self.tooltip != copy:
             self.tooltip = copy
 
-    def render(self) -> Content:
-        """Paint the Library pair around the single centered Items arrow.
+    def painted_name(self) -> str:
+        """Return the name this grip paints down its own column.
+
+        (task-32355, critique #10 A cap 11 / B D10) The handle used to carry
+        its name only in ``_name`` and ``tooltip`` -- neither of which a
+        terminal paints -- so every collapsed pane was an unexplained
+        ``--->``. The column is five cells wide and twenty to forty-five rows
+        tall, so the name goes DOWN it; a horizontal label cannot hold
+        "Prompts" or "Folder files" at any Library width.
 
         Returns:
-            Content: Full-height grip content with arrows at the approved rows.
+            The letters to paint, one per row, already trimmed to the rows
+            above the first arrow. Empty when there is no room at all.
         """
+        name = LIBRARY_PANE_GRIP_NAMES.get(self.pane_label, self.pane_label)
+        return "".join(name.split())[: max(self._first_arrow_row(), 0)]
+
+    def _first_arrow_row(self) -> int:
+        """Return the topmost row ``render`` paints an arrow on."""
+        return min(self._arrow_rows())
+
+    def _arrow_rows(self) -> set[int]:
+        """Return the rows the collapse arrow is painted on."""
         height = max(self.content_region.height, 1)
         last_row = height - 1
         if self.pane == "library" and height > 1:
             upper_row = round(last_row * LIBRARY_ARROW_UPPER_POSITION_RATIO)
-            arrow_rows = {upper_row, last_row - upper_row}
-        else:
-            arrow_rows = {last_row // 2}
+            return {upper_row, last_row - upper_row}
+        return {last_row // 2}
+
+    def render(self) -> Content:
+        """Paint the pane's name above the arrows it already carries.
+
+        Returns:
+            Content: Full-height grip content -- the name one letter per row
+            from the top, then the arrows at the approved rows.
+        """
+        height = max(self.content_region.height, 1)
+        arrow_rows = self._arrow_rows()
         arrow = self.label.plain
-        return Content.from_text(
-            "\n".join(arrow if row in arrow_rows else " " for row in range(height))
-        )
+        name = self.painted_name()
+        lines = [
+            name[row]
+            if row < len(name)
+            else arrow
+            if row in arrow_rows
+            else " "
+            for row in range(height)
+        ]
+        return Content.from_text("\n".join(lines))
 
     @on(Button.Pressed)
     def request_toggle(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_conversation_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_conversation_reader.py
@@ -17,6 +17,9 @@ from tldw_chatbook.Library.library_conversation_reader_state import (
     ConversationReaderState,
 )
 from tldw_chatbook.Library.library_shell_state import library_disabled_action_label
+from tldw_chatbook.Widgets.Library.library_adaptive_reader_shell import (
+    AdaptiveReaderShellResized,
+)
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
@@ -41,6 +44,37 @@ def _open_console_disabled_tooltip(state: ConversationReaderState) -> str | None
     ):
         return "The selected conversation does not match the retained transcript."
     return "Wait for the complete selected transcript before opening it in Console."
+
+
+def library_conversation_link_would_unblock(
+    state: ConversationReaderState,
+    loaded_metadata: Mapping[str, Any],
+) -> bool:
+    """Return whether a workspace link is what would unblock this hand-off.
+
+    (task-32107) The ONE rule behind both the reader's link affordance and
+    the screen handler's decision to link before staging: the button's
+    enabled state and the press's behaviour cannot disagree because they ask
+    the same question of the same three inputs.
+
+    Fenced by ``loaded_actions_eligible`` (review round 2 of task-32056): the
+    link writes membership for the RETAINED ``loaded_id``, so while a newly
+    selected conversation is still loading, the visible-but-stale transcript
+    would otherwise be the one linked.
+
+    Args:
+        state: The reader state, whose load fence answers first.
+        loaded_metadata: The controller-injected metadata carrying
+            ``_workspace_block`` and ``_workspace_block_linkable``.
+
+    Returns:
+        True when a link into the active workspace resolves the only block.
+    """
+    return (
+        state.loaded_actions_eligible
+        and bool(str(loaded_metadata.get("_workspace_block") or "").strip())
+        and bool(loaded_metadata.get("_workspace_block_linkable"))
+    )
 
 
 def library_conversation_block_sentence(
@@ -79,9 +113,16 @@ def library_conversation_block_sentence(
     if not blocked:
         return None
     if link_offered:
+        # task-32107 (user decision, critique #10): the primary action no
+        # longer refuses a block a link can resolve -- it links and proceeds
+        # -- so the line says what the press will DO rather than sending the
+        # reader to a second button. Membership decides what a Console turn
+        # may read, so the widening is still stated before it happens. The
+        # action's NAME stays on the action (task-32101 AC#4): this line
+        # points at the control above it, it does not re-label it.
         return (
-            f"This conversation is {blocked}. Press 'Link to workspace' "
-            "to add it to the active workspace."
+            f"This conversation is {blocked}. Pressing this adds it to the "
+            "active workspace first, and you can undo that."
         )
     return detail or f"This conversation is {blocked}."
 
@@ -129,33 +170,40 @@ class LibraryConversationReader(Vertical):
         return str(self.loaded_metadata.get("_workspace_block_detail") or "").strip()
 
     def _workspace_link_offered(self) -> bool:
-        """Whether "Link to workspace" would actually resolve the block.
-
-        (review round 2) Fenced by ``loaded_actions_eligible`` like every
-        other action here: the remedy writes membership for the RETAINED
-        ``loaded_id``, so while a newly selected conversation is still
-        loading the visible-but-stale transcript would otherwise be the one
-        linked.
-        """
-        return (
-            self.state.loaded_actions_eligible
-            and bool(self._workspace_block())
-            and bool(self.loaded_metadata.get("_workspace_block_linkable"))
+        """Whether a workspace link would actually resolve the block."""
+        return library_conversation_link_would_unblock(
+            self.state, self.loaded_metadata
         )
 
     def _actions_enabled(self) -> bool:
-        """Whether the Console hand-off may run right now."""
+        """Whether the Console hand-off may run with nothing else happening."""
         return self.state.loaded_actions_eligible and not self._workspace_block()
+
+    def _source_press_enabled(self) -> bool:
+        """Whether "Use as source" may be pressed at all.
+
+        (task-32107, user decision) A block a LINK can resolve no longer
+        disables the hand-off -- pressing it links the conversation into the
+        active workspace and proceeds, in one undoable step. The load fence
+        and the blocks a link cannot resolve still disable it.
+        """
+        return self._actions_enabled() or self._workspace_link_offered()
+
+    def _workspace_link_receipt(self) -> str:
+        """Return the workspace the last press linked into, or empty."""
+        return str(self.loaded_metadata.get("_workspace_link_receipt") or "").strip()
 
     def _source_label(self) -> str:
         """Return the hand-off button label, marked when it is refused.
 
         (task-32101) The non-colour disabled marker belongs on the control
         that carries the action name, so the reason line beneath it need not
-        repeat that name to carry the marker.
+        repeat that name to carry the marker. It follows the button's real
+        ``disabled`` state (task-32107): a pressable action never wears the
+        "○" the glyph legend reserves for a blocked one.
         """
         return library_disabled_action_label(
-            "Use as source", not self._actions_enabled()
+            "Use as source", not self._source_press_enabled()
         )
 
     def _blocked_reason_line(self) -> str:
@@ -241,7 +289,7 @@ class LibraryConversationReader(Vertical):
                 classes="library-canvas-action",
                 compact=True,
             )
-            source.disabled = not self._actions_enabled()
+            source.disabled = not self._source_press_enabled()
             source.tooltip = self._open_console_tooltip()
             yield source
             for action, label in (
@@ -280,6 +328,28 @@ class LibraryConversationReader(Vertical):
             )
             link.display = self._workspace_link_offered()
             yield link
+            # (task-32107) The receipt for the membership "Use as source"
+            # just wrote, and its inverse. Workspace membership decides what
+            # a Console turn may read, so the widening is a visible,
+            # reversible act rather than a silent side effect.
+            receipt_workspace = self._workspace_link_receipt()
+            receipt = Static(
+                f"✓ linked · {receipt_workspace} · this conversation can now "
+                "be used in Console",
+                id="library-conversation-link-receipt",
+                classes="library-conversation-reader-block-reason",
+                markup=False,
+            )
+            receipt.display = bool(receipt_workspace)
+            yield receipt
+            undo = Button(
+                "Undo link",
+                id="library-conversation-link-undo",
+                classes="library-canvas-action",
+                compact=True,
+            )
+            undo.display = bool(receipt_workspace)
+            yield undo
             retry = Button(
                 "Try again",
                 id="library-conversation-reader-retry",
@@ -486,7 +556,19 @@ class LibraryConversationReader(Vertical):
         selected_metadata: Mapping[str, Any] | None = None,
     ) -> None:
         """Patch state, labels, and progressive message rows in place."""
+        # task-32361 (critique #10, B D11): the adaptive layout asks
+        # ``reader_has_item`` -- ``selected_id is not None`` -- but it is only
+        # resolved from ``AdaptiveReaderShellResized``, and the Conversations
+        # selection settles one refresh AFTER the shell mounts. Measured at
+        # 235x52 with a conversation open: list 137, Reader 44, because the
+        # empty-Reader rule (task-31979) had already given the list the
+        # Reader's columns and nothing re-asked. Announce the flip from the
+        # one place every selection change reaches this pane; the screen's
+        # existing ``@on(AdaptiveReaderShellResized)`` re-resolves.
+        had_item = self.state.selected_id is not None
         self.state = state
+        if self.is_mounted and (state.selected_id is not None) != had_item:
+            self.post_message(AdaptiveReaderShellResized())
         if loaded_metadata is not None or metadata is not None:
             self.loaded_metadata = dict(loaded_metadata or metadata or {})
         if selected_metadata is not None:
@@ -508,6 +590,8 @@ class LibraryConversationReader(Vertical):
                 "#library-conversation-open-console-blocked", Static
             )
             link = self.query_one("#library-conversation-link-workspace", Button)
+            receipt = self.query_one("#library-conversation-link-receipt", Static)
+            undo = self.query_one("#library-conversation-link-undo", Button)
             retry = self.query_one("#library-conversation-reader-retry", Button)
             find_position = self.query_one(
                 "#library-conversation-find-position", Static
@@ -562,7 +646,7 @@ class LibraryConversationReader(Vertical):
         open_console.disabled = not state.loaded_actions_eligible
         open_console.tooltip = _open_console_disabled_tooltip(state)
         source.label = self._source_label()
-        source.disabled = not self._actions_enabled()
+        source.disabled = not self._source_press_enabled()
         source.tooltip = self._open_console_tooltip()
         for action, button in archive_buttons.items():
             button.display = bool(self.loaded_metadata.get("archived")) == (
@@ -572,6 +656,13 @@ class LibraryConversationReader(Vertical):
         blocked_reason.update(self._blocked_reason_line())
         blocked_reason.display = bool(self._blocked_reason_line())
         link.display = self._workspace_link_offered()
+        receipt_workspace = self._workspace_link_receipt()
+        receipt.update(
+            f"✓ linked · {receipt_workspace} · this conversation can now "
+            "be used in Console"
+        )
+        receipt.display = bool(receipt_workspace)
+        undo.display = bool(receipt_workspace)
         retry.display = bool(state.error or state.unavailable)
 
         self._message_sync_generation += 1

--- a/tldw_chatbook/Widgets/Library/library_conversation_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_conversation_reader.py
@@ -292,6 +292,25 @@ class LibraryConversationReader(Vertical):
             source.disabled = not self._source_press_enabled()
             source.tooltip = self._open_console_tooltip()
             yield source
+            # (task-32107 review, fix round 1) Directly under the control it
+            # describes. The sentence says "Pressing this", so its position is
+            # load-bearing: yielded after the Archive/Restore pair it sat
+            # under "Archive conversation" and the deixis pointed at the
+            # wrong button. ``sync_state`` patches by id, so only this order
+            # matters.
+            blocked_reason = Static(
+                self._blocked_reason_line(),
+                id="library-conversation-open-console-blocked",
+                classes="library-conversation-reader-block-reason",
+                markup=False,
+            )
+            # (fix round 1) Visibility and content come from ONE predicate:
+            # the line answers the load fence first, so gating display on
+            # the workspace block alone showed "Wait for the selected
+            # conversation to finish loading." under a button that was on
+            # screen for a different reason.
+            blocked_reason.display = bool(self._blocked_reason_line())
+            yield blocked_reason
             for action, label in (
                 ("archive", "Archive conversation"),
                 ("restore", "Restore only"),
@@ -307,19 +326,6 @@ class LibraryConversationReader(Vertical):
                 )
                 button.disabled = not self.state.loaded_actions_eligible
                 yield button
-            blocked_reason = Static(
-                self._blocked_reason_line(),
-                id="library-conversation-open-console-blocked",
-                classes="library-conversation-reader-block-reason",
-                markup=False,
-            )
-            # (fix round 1) Visibility and content come from ONE predicate:
-            # the line answers the load fence first, so gating display on
-            # the workspace block alone showed "Wait for the selected
-            # conversation to finish loading." under a button that was on
-            # screen for a different reason.
-            blocked_reason.display = bool(self._blocked_reason_line())
-            yield blocked_reason
             link = Button(
                 "Link to workspace",
                 id="library-conversation-link-workspace",

--- a/tldw_chatbook/Widgets/Library/library_conversation_reader.py
+++ b/tldw_chatbook/Widgets/Library/library_conversation_reader.py
@@ -190,7 +190,19 @@ class LibraryConversationReader(Vertical):
         return self._actions_enabled() or self._workspace_link_offered()
 
     def _workspace_link_receipt(self) -> str:
-        """Return the workspace the last press linked into, or empty."""
+        """Return the workspace the last press linked into, or empty.
+
+        (re-review P3) Withheld while ANY workspace block stands, because the
+        receipt's whole claim is "this conversation can now be used in
+        Console". Activating a workspace this conversation is not in brings
+        the block straight back, and the reader would otherwise paint the
+        refusal sentence and a receipt contradicting it, one under the other.
+        The block is recomputed on every sync, so this needs no state of its
+        own -- and the receipt reappears untouched if that workspace is made
+        active again.
+        """
+        if self._workspace_block():
+            return ""
         return str(self.loaded_metadata.get("_workspace_link_receipt") or "").strip()
 
     def _source_label(self) -> str:

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -1974,6 +1974,22 @@ ConsoleRunLogModal {
     text-style: bold underline;
 }
 
+/* task-32359 (critique #10, B D9): the active destination and the focused
+   row rendered identically -- bold + underline over rgb(25,68,102) vs
+   rgb(28,70,102), three RGB units apart and colour-only. The rail had no
+   `:focus` rule of its own and fell back to the Button default. Focus
+   everywhere else on this screen is a SHAPE -- the house `█` left bar
+   (task-31983) -- so the rail stops being the exception: `-selected` above
+   keeps the background treatment, focus adds the bar. The bar replaces the
+   row's 1-column left padding (`padding: 0 1` -> `0 1 0 0`) so the label
+   neither shifts nor is clipped, and `outline: none` suppresses the generic
+   `*:focus{outline:solid}` fallback (core/_reset.tcss). */
+.library-rail-row:focus {
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
+    outline: none;
+}
+
 /* Flashcards-due emphasis on the create-flashcards rail row. Bright uses an
    accent text color (not a background fill) so the row stands out without
    reading as selected -- real selection is `.library-rail-row-selected`'s
@@ -2329,8 +2345,7 @@ ConsoleRunLogModal {
     padding: 0 1;
     background: $ds-surface-raised;
     color: $ds-text-primary;
-    border: none;
-}
+    border: none;}
 
 /* task-4023 AC#1 (RC-07): Legible Disabled (TASK-1801/DESIGN.md) for the
    Library's action buttons. Measured live before this rule: select-mode
@@ -2568,8 +2583,7 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     min-height: 1;
     margin: 0 0 1 0;
-    color: $ds-text-muted;
-}
+    color: $ds-text-muted;}
 
 #library-notes-empty {
     width: 100%;

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -2345,7 +2345,8 @@ ConsoleRunLogModal {
     padding: 0 1;
     background: $ds-surface-raised;
     color: $ds-text-primary;
-    border: none;}
+    border: none;
+}
 
 /* task-4023 AC#1 (RC-07): Legible Disabled (TASK-1801/DESIGN.md) for the
    Library's action buttons. Measured live before this rule: select-mode
@@ -2583,7 +2584,8 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     min-height: 1;
     margin: 0 0 1 0;
-    color: $ds-text-muted;}
+    color: $ds-text-muted;
+}
 
 #library-notes-empty {
     width: 100%;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -1247,7 +1247,8 @@ $ds-library-source-browser-width: 31;
     padding: 0 1;
     background: $ds-surface-raised;
     color: $ds-text-primary;
-    border: none;}
+    border: none;
+}
 
 /* task-4023 AC#1 (RC-07): Legible Disabled (TASK-1801/DESIGN.md) for the
    Library's action buttons. Measured live before this rule: select-mode
@@ -1414,7 +1415,8 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     min-height: 1;
     margin: 0 0 1 0;
-    color: $ds-text-muted;}
+    color: $ds-text-muted;
+}
 
 #library-notes-empty {
     width: 100%;

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -882,6 +882,22 @@ $ds-library-source-browser-width: 31;
     text-style: bold underline;
 }
 
+/* task-32359 (critique #10, B D9): the active destination and the focused
+   row rendered identically -- bold + underline over rgb(25,68,102) vs
+   rgb(28,70,102), three RGB units apart and colour-only. The rail had no
+   `:focus` rule of its own and fell back to the Button default. Focus
+   everywhere else on this screen is a SHAPE -- the house `█` left bar
+   (task-31983) -- so the rail stops being the exception: `-selected` above
+   keeps the background treatment, focus adds the bar. The bar replaces the
+   row's 1-column left padding (`padding: 0 1` -> `0 1 0 0`) so the label
+   neither shifts nor is clipped, and `outline: none` suppresses the generic
+   `*:focus{outline:solid}` fallback (core/_reset.tcss). */
+.library-rail-row:focus {
+    border-left: thick $ds-action-focus;
+    padding: 0 1 0 0;
+    outline: none;
+}
+
 /* Flashcards-due emphasis on the create-flashcards rail row. Bright uses an
    accent text color (not a background fill) so the row stands out without
    reading as selected -- real selection is `.library-rail-row-selected`'s
@@ -1231,8 +1247,7 @@ $ds-library-source-browser-width: 31;
     padding: 0 1;
     background: $ds-surface-raised;
     color: $ds-text-primary;
-    border: none;
-}
+    border: none;}
 
 /* task-4023 AC#1 (RC-07): Legible Disabled (TASK-1801/DESIGN.md) for the
    Library's action buttons. Measured live before this rule: select-mode
@@ -1399,8 +1414,7 @@ with stray left-edge border fragments), and padding 0 1 so the full
     height: auto;
     min-height: 1;
     margin: 0 0 1 0;
-    color: $ds-text-muted;
-}
+    color: $ds-text-muted;}
 
 #library-notes-empty {
     width: 100%;


### PR DESCRIPTION
Part of the Library critique-10 fix wave (plan: `Docs/superpowers/plans/2026-09-11-library-crit10-wave.md`, group `layout`).

## What
- **task-32355** — the three pane grips carry their label, so a first-time user can tell a splitter from a border and knows which pane it resizes.
- **task-32107 + decision task-32057/32107 (user: link-on-use)** — pressing "Use as source" on a conversation links it to the active workspace in one undoable step and paints a receipt naming the workspace; the refusal copy only appears when there is nothing to link to. The receipt and its Undo are withheld while any workspace block stands, so the receipt can never contradict the refusal beside it. The decision text is recorded verbatim in the task.
- **task-32361** — the Conversations split gives the reader its width back at the standard stage.
- **task-32359** — rail focus is a shape (outline), not a second blue; the selected row and the focused row read differently at a glance.
- **task-32360** — the field state keeps the head of the narrow footer (`esc back to Library` in both states, painted pins at 60 cols); AC#1 and AC#3 were already true and are pinned as regressions; AC#2 (the legacy_compact gate) stays open and lands with the notes-details branch.

## Evidence
- `Tests/UI/test_library_crit10_layout.py` (21 tests, red-first, incl. 60x24 footer pins) + updated pins in `test_library_crit8_conversation_handoff.py`, `test_library_row_focus_cue_t31983.py`, `test_library_conversation_reader.py` (59 passed). Failing-name sets on the touched suites match the base.
- Live-verified at 235x52, 100x30 and 60x24 on an isolated seeded profile.
- Guides: `library.md`, `library/media-and-conversations.md` with refreshed stamps; TCSS source + rebuilt bundle.

## Review
Task review (Changes requested: 1 P1 on the 60-col footer, refuted by measurement — blur is inactive on the narrow stage so the return wins — 3 P2, rest P3) → fix round 1 (`6024a06897`, 10 fixed / 2 declined with evidence) → scoped re-review (12/12 settled; 1 new P3: a link receipt could outlive the refusal after a workspace switch) → fix round 2 (`4831835460`). Residual recorded in the task notes: switching to a second workspace that also holds the membership leaves a receipt naming the first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Library critique-10 layout wave: pane grips now spell their names, focused rail rows read by shape, the Conversations reader gets the width back once open, and "Use as source" links an unlinked conversation in one undoable step.

**Behavior changes**
- "Use as source" links a conversation to the active workspace first, proceeds to Console, and shows a "✓ linked · \<workspace\>" receipt with Undo beside it.
- Blocks a link cannot resolve (no active workspace, stale page) disable the button and refuse.
- The receipt and Undo are withheld while any workspace block stands, so they never contradict a refusal beside it.
- The receipt is recorded only for a membership the press actually inserted, so Undo never deletes an existing link.

**Bug fixes**
- Pane grips paint their name down the column: "Nav" for the Library pane, the pane's own label for the items pane.
- The Conversations split re-resolves when a conversation opens, so the reader takes the majority at 200+ columns (132 vs 49 at 235x52).
- Focused rail rows get the house `█` left bar; active rows keep the background treatment.
- The narrow footer paints "esc back to Library" at 60 columns in both focus states; the field-state marker yields because only one chip can paint there.
- task-32360 AC#2 (clipped copy ellipsis) stays open — it needs the Notes compact gate, outside this branch's owned files.

<sup>Written for commit 8fdc0d857a7a235fff6c0e0e0600a6ad7e28b251. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

