### PR TITLE
fix(library-media): labelled row age, scope line with Clear, list and import-footer copy (crit10 media-rows)

### DIFF
--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -315,9 +315,13 @@ destination, or leaving the Import canvas cancels pending consent.
 Library screen (not just the landing — though never while you're typing in
 a text field, where `i` stays a letter), and entering the form always
 parks the caret in the path field, so you can type or paste a path
-immediately. **Enter** in the path field starts the import once the gate
-line clears — with "⚠" warnings outstanding, Enter,Enter carries the same
-two-press consent as the Start button. **r** re-stages your last import
+immediately. **Enter** in the path field takes two different actions
+depending on where you are, and the footer names the one it will take: on a
+path that has not been checked yet it runs the pre-check and the footer
+reads **`enter check this path`**; once the gate line clears the footer
+reads **`enter start import`** and Enter starts the import. With "⚠"
+warnings outstanding, Enter,Enter carries the same two-press consent as the
+Start button. **r** re-stages your last import
 of the session ("Retry this batch") when the queue has settled — inside a
 text field it stays a letter. **Escape** first backs out of a pending
 "Press Start again" confirm (staying on the form), otherwise returns you
@@ -325,7 +329,8 @@ to the Library landing (a half-filled form is kept, same as switching
 rail rows). At narrow widths the navigation rail collapses to its reachable
 **Nav** handle so the form keeps working width. The footer preserves primary
 and recovery actions first, and F1 lists the same state-derived set:
-`enter start`, `esc back`, and, when available, `r retry`.
+`enter check this path` / `enter start import`, `esc back`, and, when
+available, `r retry`.
 
 The Export form has no screen-specific shortcuts. **Escape** also closes
 the Parakeet install dialog. Global keys live in the
@@ -924,3 +929,9 @@ and the file dialogs' "File name" box takes a typed or pasted absolute/"~"
 path, jumping the listing to it, with Ctrl+A selecting the field.)*
 
 *Verified against fix/library-crit9-import — 2026-09-10 (task-32216: "Show details" leaves focus on the row action it toggled instead of the Keywords field 25 rows up; task-32231: a run of identical settled outcomes collapses into one "✗ failed · N files · reason" row with "Show the N files", "Retry all" and "Dismiss all"; a group whose members need a different transcription model offers no bare "Retry all", matching those rows' own actions; a group never spans two imports.)*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11 (task-32364
+AC#3: the Import footer no longer says "enter start" for both steps — on an
+unchecked path it reads "enter check this path" and only once the Start gate
+clears does it read "enter start import", derived from the same gate Enter
+itself obeys.)*

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -321,7 +321,8 @@ path that has not been checked yet it runs the pre-check and the footer
 reads **`enter check this path`**; once the gate line clears the footer
 reads **`enter start import`** and Enter starts the import. With "⚠"
 warnings outstanding, Enter,Enter carries the same two-press consent as the
-Start button. **r** re-stages your last import of the session ("Retry this batch") when the queue has settled — inside a
+Start button. **r** re-stages your last import of the session ("Retry this
+batch") when the queue has settled — inside a
 text field it stays a letter. **Escape** first backs out of a pending
 "Press Start again" confirm (staying on the form), otherwise returns you
 to the Library landing (a half-filled form is kept, same as switching
@@ -934,3 +935,9 @@ AC#3: the Import footer no longer says "enter start" for both steps — on an
 unchecked path it reads "enter check this path" and only once the Start gate
 clears does it read "enter start import", derived from the same gate Enter
 itself obeys.)*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11, fix round 1
+(task-32364 AC#3 review: the Enter label now reaches the footer on a gate
+transition that does not recompose the canvas — previously only a changed
+type-group set re-registered it, so opening the gate any other way left the
+footer naming the previous step's action.)*

--- a/Docs/User_Guide/library/import-and-export.md
+++ b/Docs/User_Guide/library/import-and-export.md
@@ -321,8 +321,7 @@ path that has not been checked yet it runs the pre-check and the footer
 reads **`enter check this path`**; once the gate line clears the footer
 reads **`enter start import`** and Enter starts the import. With "⚠"
 warnings outstanding, Enter,Enter carries the same two-press consent as the
-Start button. **r** re-stages your last import
-of the session ("Retry this batch") when the queue has settled — inside a
+Start button. **r** re-stages your last import of the session ("Retry this batch") when the queue has settled — inside a
 text field it stays a letter. **Escape** first backs out of a pending
 "Press Start again" confirm (staying on the form), otherwise returns you
 to the Library landing (a half-filled form is kept, same as switching

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -122,7 +122,9 @@ ago · analysed`). The age is labelled, because a bare "10m" on an `audio` or
 `video` row reads as the item's *length*; under a minute it reads **added
 just now**. The row that is open in the Reader ends **· loaded** (**·
 loading** while it is fetching) — the state is a fact about the row, so it
-sits with the other facts rather than in front of the title. The row re-reads its state from the database the moment an
+sits with the other facts rather than in front of the title.
+
+The row re-reads its state from the database the moment an
 analysis is saved — from the Reader's Generate, or from a bulk Analyze run —
 without re-paging the list; until task-31942 lands (the save does not yet
 commit durably), the mark can lag the Reader on a real profile. Its title row
@@ -139,8 +141,8 @@ reuses that same cell for its **☑/☐**, so a row never carries two markers.
 While a filter is active, a row it found only through one of its **keywords**
 adds **· keyword: \<term\>** — the filter searches titles, item text and
 keywords, so without it a hit whose title and body hold nothing you typed
-reads as a mistake (`article · added 2m ago · keyword: notes`). A row whose title or
-text carries the term already shows you why it is there and says nothing
+reads as a mistake (`article · added 2m ago · keyword: notes`). A row whose
+title or text carries the term already shows you why it is there and says nothing
 extra. Long tags are cut to ten columns (`keyword: quokkasand…`; five
 wide CJK characters, or five flag emoji) to keep the line short — the cut
 counts a flag by the two columns it paints and never leaves half of one, so

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -115,16 +115,21 @@ the task-32043 session pins, bulk-delete, and filter-restore pins stay green.
 Live-verified in tmux at 235x52: filter to a hit, then narrow to zero — the
 Reader falls back to "Select a media item to read it here.".)*
 
-**Row markers.** An item's second row says what it is and when it arrived, and
-adds **· analysed** when that item already carries an analysis — so you can
-see what is worth generating without opening anything (`document · added 5m ·
-analysed`). The age is labelled, because a bare "10m" on an `audio` or
-`video` row reads as the item's *length*; under a minute it reads **added
-just now**. It shares the Trash list's grammar (`pdf · trashed 3m`), which is
-also why it is "added 5m" and not "added 5m ago" — on this pane four cells
-are the difference between a keyword row showing its term and hiding it. The row that is open in the Reader ends **· loaded** (**·
-loading** while it is fetching) — the state is a fact about the row, so it
-sits with the other facts rather than in front of the title.
+**Row markers.** An item's second row says what it is and when it last
+changed, and adds **· analysed** when that item already carries an analysis —
+so you can see what is worth generating without opening anything
+(`document · updated 5m · analysed`). The age is labelled, because a bare
+"10m" on an `audio` or `video` row reads as the item's *length*; under a
+minute it reads **updated just now**. The word is **updated**, not "added":
+the value is the item's last-modified time — the same one the Reader's
+preview line calls "Updated:" — so saving an analysis moves it. It shares the
+Trash list's grammar (`pdf · trashed 3m`), which is also why it is
+"updated 5m" and not "updated 5m ago": on this pane four cells are the
+difference between a keyword row showing its term and hiding it.
+
+The row that is open in the Reader ends **· loaded** (**· loading** while it
+is fetching) — the state is a fact about the row, so it sits with the other
+facts rather than in front of the title.
 
 The row re-reads its state from the database the moment an
 analysis is saved — from the Reader's Generate, or from a bulk Analyze run —
@@ -143,7 +148,7 @@ reuses that same cell for its **☑/☐**, so a row never carries two markers.
 While a filter is active, a row it found only through one of its **keywords**
 adds **· keyword: \<term\>** — the filter searches titles, item text and
 keywords, so without it a hit whose title and body hold nothing you typed
-reads as a mistake (`article · added 2m · keyword: notes`). A row whose
+reads as a mistake (`article · updated 2m · keyword: notes`). A row whose
 title or text carries the term already shows you why it is there and says nothing
 extra. Long tags are cut to ten columns (`keyword: quokkasand…`; five
 wide CJK characters, or five flag emoji) to keep the line short — the cut
@@ -154,8 +159,9 @@ ends in an ellipsis a few characters into `keyword:` itself, before the term
 starts. A row that is both analysed and a keyword hit can run out of room at
 the default width too, and the row open in the Reader spends a further nine
 columns on its `· loaded`, so at the automatic narrow width (100 columns) that
-row is the first to clip. The
-Reader's **Info** tab "Keywords:" line applies the same guard: it shows the
+row is the first to clip.
+
+The Reader's **Info** tab "Keywords:" line applies the same guard: it shows the
 full stored keyword but drops a dangling half-flag so that surface's frame
 does not drift either (the edit form still prefills the stored keyword
 verbatim).
@@ -1192,7 +1198,7 @@ other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
 
 *Verified against fix/library-crit10-media-rows — 2026-09-11 (task-32347:
-a media row's age is labelled — "audio · added 10m ago", "added just now"
+a media row's age is labelled — "audio · updated 10m ago", "updated just now"
 under a minute — because a bare "10m" on an audio or video row read as the
 item's length. task-32350: a quiet scope line under the "Media (N)" header
 states the APPLIED scope ("Media · 1 of 11 · filter “notes” · all types ·
@@ -1208,3 +1214,9 @@ instead of prefixing its title with "Loaded ·", and a conversation row reads
 Items pane paint a keyword row's term again. task-32350 review: the scope
 line drops its "of M" half when the screen's Media total is a lower bound,
 rather than stating a flat total the rail itself renders as "5+".)*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11, re-review round 1
+(task-32347: the row age reads `audio · updated 10m`, not "added" — the value
+is the item's last-modified time, the same field the Reader's preview line
+labels "Updated:", so saving an analysis moves it and an "added" label would
+have been false.)*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -117,10 +117,12 @@ Reader falls back to "Select a media item to read it here.".)*
 
 **Row markers.** An item's second row says what it is and when it arrived, and
 adds **· analysed** when that item already carries an analysis — so you can
-see what is worth generating without opening anything (`document · added 5m
-ago · analysed`). The age is labelled, because a bare "10m" on an `audio` or
+see what is worth generating without opening anything (`document · added 5m ·
+analysed`). The age is labelled, because a bare "10m" on an `audio` or
 `video` row reads as the item's *length*; under a minute it reads **added
-just now**. The row that is open in the Reader ends **· loaded** (**·
+just now**. It shares the Trash list's grammar (`pdf · trashed 3m`), which is
+also why it is "added 5m" and not "added 5m ago" — on this pane four cells
+are the difference between a keyword row showing its term and hiding it. The row that is open in the Reader ends **· loaded** (**·
 loading** while it is fetching) — the state is a fact about the row, so it
 sits with the other facts rather than in front of the title.
 
@@ -141,14 +143,18 @@ reuses that same cell for its **☑/☐**, so a row never carries two markers.
 While a filter is active, a row it found only through one of its **keywords**
 adds **· keyword: \<term\>** — the filter searches titles, item text and
 keywords, so without it a hit whose title and body hold nothing you typed
-reads as a mistake (`article · added 2m ago · keyword: notes`). A row whose
+reads as a mistake (`article · added 2m · keyword: notes`). A row whose
 title or text carries the term already shows you why it is there and says nothing
 extra. Long tags are cut to ten columns (`keyword: quokkasand…`; five
 wide CJK characters, or five flag emoji) to keep the line short — the cut
 counts a flag by the two columns it paints and never leaves half of one, so
-the row frame does not drift. It can still be too long for a narrow Items pane:
-at the pane's narrowest the row ends in an ellipsis mid-term, and a row that is
-both analysed and a keyword hit can run out of room at the default width too. The
+the row frame does not drift. It can still be too long for a narrow Items
+pane, and the labelled age made that tighter: at the pane's narrowest the row
+ends in an ellipsis a few characters into `keyword:` itself, before the term
+starts. A row that is both analysed and a keyword hit can run out of room at
+the default width too, and the row open in the Reader spends a further nine
+columns on its `· loaded`, so at the automatic narrow width (100 columns) that
+row is the first to clip. The
 Reader's **Info** tab "Keywords:" line applies the same guard: it shows the
 full stored keyword but drops a dangling half-flag so that surface's frame
 does not drift either (the edit form still prefills the stored keyword
@@ -1195,3 +1201,10 @@ filter box, so an unsubmitted draft in the box can no longer be mistaken for
 what the rows came from. task-32364: the Reader's row ends "· loaded"
 instead of prefixing its title with "Loaded ·", and a conversation row reads
 "5 messages · 16m" with the same separator every other Library list uses.)*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11, fix round 1
+(task-32347 review: the row age drops its " ago" and reads `audio · added
+10m`, the Trash list's own grammar — the four cells are what let a narrow
+Items pane paint a keyword row's term again. task-32350 review: the scope
+line drops its "of M" half when the screen's Media total is a lower bound,
+rather than stating a flat total the rail itself renders as "5+".)*

--- a/Docs/User_Guide/library/media-and-conversations.md
+++ b/Docs/User_Guide/library/media-and-conversations.md
@@ -115,10 +115,14 @@ the task-32043 session pins, bulk-delete, and filter-restore pins stay green.
 Live-verified in tmux at 235x52: filter to a hit, then narrow to zero — the
 Reader falls back to "Select a media item to read it here.".)*
 
-**Row markers.** An item's second row says what it is and how old it is, and
+**Row markers.** An item's second row says what it is and when it arrived, and
 adds **· analysed** when that item already carries an analysis — so you can
-see what is worth generating without opening anything (`document · 5m ·
-analysed`). The row re-reads its state from the database the moment an
+see what is worth generating without opening anything (`document · added 5m
+ago · analysed`). The age is labelled, because a bare "10m" on an `audio` or
+`video` row reads as the item's *length*; under a minute it reads **added
+just now**. The row that is open in the Reader ends **· loaded** (**·
+loading** while it is fetching) — the state is a fact about the row, so it
+sits with the other facts rather than in front of the title. The row re-reads its state from the database the moment an
 analysis is saved — from the Reader's Generate, or from a bulk Analyze run —
 without re-paging the list; until task-31942 lands (the save does not yet
 commit durably), the mark can lag the Reader on a real profile. Its title row
@@ -135,7 +139,7 @@ reuses that same cell for its **☑/☐**, so a row never carries two markers.
 While a filter is active, a row it found only through one of its **keywords**
 adds **· keyword: \<term\>** — the filter searches titles, item text and
 keywords, so without it a hit whose title and body hold nothing you typed
-reads as a mistake (`article · 2m · keyword: notes`). A row whose title or
+reads as a mistake (`article · added 2m ago · keyword: notes`). A row whose title or
 text carries the term already shows you why it is there and says nothing
 extra. Long tags are cut to ten columns (`keyword: quokkasand…`; five
 wide CJK characters, or five flag emoji) to keep the line short — the cut
@@ -344,6 +348,8 @@ left-margin gap).*
 
 | Control | What it does |
 |---|---|
+| Scope line | The quiet line under the "Media (N)" header states the scope the rows in front of you actually came from: the count as **N of M**, the applied filter in quotes, the type ("all types" until you pick one), and the sort — for example `Media · 1 of 11 · filter “notes” · all types · sort: Newest`. The filter box keeps a *draft* until you press Enter, so the box and the list can legitimately disagree; this line always describes the applied scope and never echoes an unsubmitted draft. |
+| "Clear" (on the scope line) | Appears only while a filter or a type is applied. It drops the whole scope this line states — filter *and* type — and empties the filter box with it, so no draft is left behind. The toolbar's "Clear filter" still clears only the filter it names. |
 | "Title/keyword…" / "Clear filter" | Searches the complete local Media source before paging — titles, item text, and the keywords an item is tagged with, so a tag you filed items under finds them even when it appears in no title. It is separate from Find in item, and "Review these" pins exactly what it returned. Clearing restores the unfiltered selection when it is still available. |
 | "type: All types" | Opens one bounded keyboard list containing the complete type set. The row your arrow keys are on carries a leading `█` bar (the same cue the list rows use); ✓ marks the value currently in force, so the row you are on and the row that is active are told apart — on opening, both marks sit on the active row (`█ ✓ All types`). "All types" means no filter; a stored type literally named "All" remains a separate selectable value. Press Escape (or pick the current choice) to cancel. |
 | "sort: Newest" | Opens the same kind of bounded keyboard list with all four orders (Newest, Oldest, Title A-Z, Title Z-A) fully visible, the same leading `█` on the row you are on and ✓ on the active one. Escape cancels. |
@@ -1176,3 +1182,14 @@ loaded the conversation list takes the columns the empty Reader was holding).*
 (task-32228: the Conversations list takes entry focus on arrival like every
 other browse list, so Up/Down walks its rows and the Escape hop -- "focus
 Items", then "focus Library" -- is live and named from the first frame).*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11 (task-32347:
+a media row's age is labelled — "audio · added 10m ago", "added just now"
+under a minute — because a bare "10m" on an audio or video row read as the
+item's length. task-32350: a quiet scope line under the "Media (N)" header
+states the APPLIED scope ("Media · 1 of 11 · filter “notes” · all types ·
+sort: Newest") with a "Clear" that drops filter and type and empties the
+filter box, so an unsubmitted draft in the box can no longer be mistaken for
+what the rows came from. task-32364: the Reader's row ends "· loaded"
+instead of prefixing its title with "Loaded ·", and a conversation row reads
+"5 messages · 16m" with the same separator every other Library list uses.)*

--- a/Docs/User_Guide/library/prompts.md
+++ b/Docs/User_Guide/library/prompts.md
@@ -37,8 +37,11 @@ Basic                                    Advanced
 - **Prompts list** — the default view: an exact "Prompts (N)" header, the
   "Filter prompts… (Enter)" field, a local collection selector, a toolbar
   ("sort: Newest" / "sort: Name", "Select", "Import…", and "Export…"), and
-  one row per prompt showing its name, artifact/source/lane summary, and
-  description and age when present.
+  one row per prompt showing its name, a source/lane summary
+  (`Local · has system and user text`), and description and age when
+  present. A plain Prompt does not repeat "Prompt" on a canvas already
+  titled Prompts; the other artifact types still name themselves
+  (`Recipe · Local · …`).
   Lists longer than one 20-row page have **Previous** and **Next** controls
   plus an exact range, total, and page line, such as **"21-40 of 45 · Page
   2 of 3"**.
@@ -510,3 +513,9 @@ renders.)*
 *Verified against fix/library-crit9-shell — 2026-09-10 (task-32217: with no
 prompt open the list takes the columns the "Select a prompt to edit it here."
 pane was holding — measured at 235 columns, list 50 → 134 cells).*
+
+*Verified against fix/library-crit10-media-rows — 2026-09-11 (task-32364: a
+row on a canvas titled Prompts no longer opens with "Prompt · " — a plain
+Prompt reads `Local · has system and user text`, while Recipe and the other
+artifact types still name themselves — and the lane summary says what the
+prompt has instead of the schema's "System + User".)*

--- a/Tests/Architecture/test_library_media_wiring.py
+++ b/Tests/Architecture/test_library_media_wiring.py
@@ -575,6 +575,15 @@ _MEDIA_CONTROLLER_BOUND_NAMES: tuple[str, ...] = (
     "_library_pending_list_entry_focus_anchor",
     "_library_pending_list_entry_media_return",
     "_local_source_records",
+    # task-32350 (critique #10 review, finding 10): THREE more screen names
+    # are read by this controller and are deliberately NOT listed --
+    # `_library_loaded`, `_library_lookup_error` and `_local_source_counts`,
+    # reached through `self._screen` by `_library_media_unfiltered_total`.
+    # They are absent because this census asserts every listed name is a
+    # PROPERTY on the controller, and those three have no accessor: the
+    # injection site (`library_screen.py`'s `LibraryMediaController(...)`
+    # call) was outside the branch that needed them. Recorded here so the
+    # list still reads as a complete account of this controller's reach.
     # -- shared shell state this cluster also WRITES (getter + setter) (5)
     "_library_canvas_resync_pending",
     "_library_list_entry_focus_timer",

--- a/Tests/Library/test_library_conversations_state.py
+++ b/Tests/Library/test_library_conversations_state.py
@@ -74,10 +74,10 @@ def test_rows_preserve_authoritative_service_order_with_age_labels():
 
     assert isinstance(state, LibraryConversationsCanvasState)
     assert [row.conversation_id for row in state.rows] == ["conv-b", "conv-c", "conv-a"]
-    assert state.rows[0].secondary == "12 messages - 2h"
+    assert state.rows[0].secondary == "12 messages · 2h"
     # No age available -> no " - {age}" suffix.
     assert state.rows[1].secondary == "3 messages"
-    assert state.rows[2].secondary == "5 messages - 3m"
+    assert state.rows[2].secondary == "5 messages · 3m"
     for row in state.rows:
         assert isinstance(row, LibraryConversationRow)
 
@@ -264,7 +264,7 @@ def test_id_title_count_key_fallbacks_using_conversation_id_and_messages_total()
     row = state.rows[0]
     assert row.conversation_id == "cid-99"
     assert row.title == "Fallback Chat"
-    assert row.secondary == "7 messages - 3m"
+    assert row.secondary == "7 messages · 3m"
 
 
 def test_final_page_disables_next_without_dropping_supplied_rows():

--- a/Tests/Library/test_library_media_state.py
+++ b/Tests/Library/test_library_media_state.py
@@ -276,7 +276,11 @@ def test_authoritative_projection_distinguishes_unfiltered_from_literal_all_type
 
 
 def test_rows_with_type_and_age_secondary_and_missing_last():
-    """Rows sorted by recency with secondary showing '{type} · {age}' or fallback."""
+    """Rows sorted by recency with secondary showing '{type} · {age}' or fallback.
+
+    task-32347: the age is labelled ("added 3m ago"), not bare -- on an audio
+    or video row a bare "3m" reads as the item's duration.
+    """
     records = [
         {
             "id": "media-b",
@@ -302,8 +306,8 @@ def test_rows_with_type_and_age_secondary_and_missing_last():
 
     assert isinstance(state, LibraryMediaCanvasState)
     assert [row.media_id for row in state.rows] == ["media-a", "media-b", "media-c"]
-    assert state.rows[0].secondary == "pdf · 3m"
-    assert state.rows[1].secondary == "video · 2h"
+    assert state.rows[0].secondary == "pdf · added 3m ago"
+    assert state.rows[1].secondary == "video · added 2h ago"
     # No age available -> no " · {age}" suffix
     assert state.rows[2].secondary == "audio"
     for row in state.rows:
@@ -504,7 +508,10 @@ def test_limit_truncates_rows_to_max_after_sorting():
 
 
 def test_id_title_type_key_fallbacks():
-    """Test key fallbacks: media_id/id/uuid, title, type/media_type."""
+    """Test key fallbacks: media_id/id/uuid, title, type/media_type.
+
+    task-32347: the secondary's age is labelled ("added 3m ago"), not bare.
+    """
     records = [
         {
             "media_id": "mid-99",
@@ -526,12 +533,12 @@ def test_id_title_type_key_fallbacks():
     row_a = state.rows[0]  # sorted by recency
     assert row_a.media_id == "mid-99"
     assert row_a.title == "Fallback Media"
-    assert row_a.secondary == "video · 3m"
+    assert row_a.secondary == "video · added 3m ago"
 
     row_b = state.rows[1]
     assert row_b.media_id == "uuid-77"
     assert row_b.title == "UUID Media"
-    assert row_b.secondary == "pdf · 2h"
+    assert row_b.secondary == "pdf · added 2h ago"
 
 
 def test_untitled_fallback_for_missing_title():

--- a/Tests/Library/test_library_media_state.py
+++ b/Tests/Library/test_library_media_state.py
@@ -278,7 +278,7 @@ def test_authoritative_projection_distinguishes_unfiltered_from_literal_all_type
 def test_rows_with_type_and_age_secondary_and_missing_last():
     """Rows sorted by recency with secondary showing '{type} · {age}' or fallback.
 
-    task-32347: the age is labelled ("added 3m ago"), not bare -- on an audio
+    task-32347: the age is labelled ("added 3m"), not bare -- on an audio
     or video row a bare "3m" reads as the item's duration.
     """
     records = [
@@ -306,8 +306,8 @@ def test_rows_with_type_and_age_secondary_and_missing_last():
 
     assert isinstance(state, LibraryMediaCanvasState)
     assert [row.media_id for row in state.rows] == ["media-a", "media-b", "media-c"]
-    assert state.rows[0].secondary == "pdf · added 3m ago"
-    assert state.rows[1].secondary == "video · added 2h ago"
+    assert state.rows[0].secondary == "pdf · added 3m"
+    assert state.rows[1].secondary == "video · added 2h"
     # No age available -> no " · {age}" suffix
     assert state.rows[2].secondary == "audio"
     for row in state.rows:
@@ -510,7 +510,7 @@ def test_limit_truncates_rows_to_max_after_sorting():
 def test_id_title_type_key_fallbacks():
     """Test key fallbacks: media_id/id/uuid, title, type/media_type.
 
-    task-32347: the secondary's age is labelled ("added 3m ago"), not bare.
+    task-32347: the secondary's age is labelled ("added 3m"), not bare.
     """
     records = [
         {
@@ -533,12 +533,12 @@ def test_id_title_type_key_fallbacks():
     row_a = state.rows[0]  # sorted by recency
     assert row_a.media_id == "mid-99"
     assert row_a.title == "Fallback Media"
-    assert row_a.secondary == "video · added 3m ago"
+    assert row_a.secondary == "video · added 3m"
 
     row_b = state.rows[1]
     assert row_b.media_id == "uuid-77"
     assert row_b.title == "UUID Media"
-    assert row_b.secondary == "pdf · added 2h ago"
+    assert row_b.secondary == "pdf · added 2h"
 
 
 def test_untitled_fallback_for_missing_title():

--- a/Tests/Library/test_library_media_state.py
+++ b/Tests/Library/test_library_media_state.py
@@ -278,7 +278,7 @@ def test_authoritative_projection_distinguishes_unfiltered_from_literal_all_type
 def test_rows_with_type_and_age_secondary_and_missing_last():
     """Rows sorted by recency with secondary showing '{type} · {age}' or fallback.
 
-    task-32347: the age is labelled ("added 3m"), not bare -- on an audio
+    task-32347: the age is labelled ("updated 3m"), not bare -- on an audio
     or video row a bare "3m" reads as the item's duration.
     """
     records = [
@@ -306,8 +306,8 @@ def test_rows_with_type_and_age_secondary_and_missing_last():
 
     assert isinstance(state, LibraryMediaCanvasState)
     assert [row.media_id for row in state.rows] == ["media-a", "media-b", "media-c"]
-    assert state.rows[0].secondary == "pdf · added 3m"
-    assert state.rows[1].secondary == "video · added 2h"
+    assert state.rows[0].secondary == "pdf · updated 3m"
+    assert state.rows[1].secondary == "video · updated 2h"
     # No age available -> no " · {age}" suffix
     assert state.rows[2].secondary == "audio"
     for row in state.rows:
@@ -510,7 +510,8 @@ def test_limit_truncates_rows_to_max_after_sorting():
 def test_id_title_type_key_fallbacks():
     """Test key fallbacks: media_id/id/uuid, title, type/media_type.
 
-    task-32347: the secondary's age is labelled ("added 3m"), not bare.
+    task-32347: the secondary's age is labelled ("updated 3m") with the
+    field it comes from (`last_modified`), not left bare.
     """
     records = [
         {
@@ -533,12 +534,12 @@ def test_id_title_type_key_fallbacks():
     row_a = state.rows[0]  # sorted by recency
     assert row_a.media_id == "mid-99"
     assert row_a.title == "Fallback Media"
-    assert row_a.secondary == "video · added 3m"
+    assert row_a.secondary == "video · updated 3m"
 
     row_b = state.rows[1]
     assert row_b.media_id == "uuid-77"
     assert row_b.title == "UUID Media"
-    assert row_b.secondary == "pdf · added 2h"
+    assert row_b.secondary == "pdf · updated 2h"
 
 
 def test_untitled_fallback_for_missing_title():

--- a/Tests/Library/test_library_prompts_state.py
+++ b/Tests/Library/test_library_prompts_state.py
@@ -1600,7 +1600,7 @@ def test_list_state_secondary_shows_details_and_age():
         prompt_id=1,
         name="Summarize",
         secondary="Summarizes text · 3m",
-        lane_summary="System + User",
+        lane_summary="has system and user text",
         version=2,
     )
 

--- a/Tests/UI/test_library_crit10_media_rows.py
+++ b/Tests/UI/test_library_crit10_media_rows.py
@@ -1,0 +1,20 @@
+"""Critique #10 media-row fixes: labelled age, applied-scope line, copy polish.
+
+Covers tasks 32347 (the row age says it is an age), 32350 (a scope line
+states the APPLIED filter, never the box's draft) and 32364 (a status word
+never prefixes a title; one separator glyph; the import footer names what
+Enter does at each step).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from tldw_chatbook.Library.library_media_state import media_added_age_copy
+
+
+def test_the_age_label_says_what_the_age_is():
+    now = datetime(2026, 9, 11, 12, 0, tzinfo=timezone.utc)
+    assert media_added_age_copy("2026-09-11T11:50:00+00:00", now=now) == "added 10m ago"
+    assert media_added_age_copy("2026-09-11T11:59:40+00:00", now=now) == "added just now"
+    assert media_added_age_copy("", now=now) == ""

--- a/Tests/UI/test_library_crit10_media_rows.py
+++ b/Tests/UI/test_library_crit10_media_rows.py
@@ -10,7 +10,18 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import pytest
+from textual.widgets import Button, Input, Static
+
 from tldw_chatbook.Library.library_media_state import media_added_age_copy
+from Tests.UI.test_library_media_render_fixes import _apply_media_filter, _host
+from Tests.UI.test_library_media_side_by_side import _open_media_list
+from Tests.UI.test_library_shell import _wait_for_condition
+
+#: ``_host()`` seeds "Interview Recording" (audio) and "Product Demo Video"
+#: (video); "interview" is in exactly one title and no other row's content,
+#: so a one-row applied scope is provable rather than incidental.
+_ONE_HIT_QUERY = "interview"
 
 
 def test_the_age_label_says_what_the_age_is():
@@ -18,3 +29,99 @@ def test_the_age_label_says_what_the_age_is():
     assert media_added_age_copy("2026-09-11T11:50:00+00:00", now=now) == "added 10m ago"
     assert media_added_age_copy("2026-09-11T11:59:40+00:00", now=now) == "added just now"
     assert media_added_age_copy("", now=now) == ""
+
+
+@pytest.mark.asyncio
+async def test_the_media_header_states_the_applied_scope_not_the_typed_draft():
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _apply_media_filter(screen, pilot, _ONE_HIT_QUERY)
+        box = screen.query_one("#library-media-filter", Input)
+        box.value = "a different draft"  # never submitted
+        await pilot.pause()
+        line = screen.query_one("#library-media-scope-line", Static)
+        assert str(line.content).startswith("Media · 1 of "), str(line.content)
+        assert f'filter “{_ONE_HIT_QUERY}”' in str(line.content), str(line.content)
+        assert "a different draft" not in str(line.content), str(line.content)
+        assert screen.query("#library-media-scope-clear")
+
+
+def _ingest_enter_label(*, start_enabled: bool) -> str:
+    """The Enter hint the Ingest footer registers for one Start-gate state."""
+    from types import SimpleNamespace
+
+    from tldw_chatbook.UI.Library_Modules.library_ingest_controller import (
+        LibraryIngestController,
+    )
+    from tldw_chatbook.UI.Screens.library_screen import LibraryScreen
+
+    stub = SimpleNamespace(
+        LIBRARY_INGEST_SHORTCUTS=LibraryScreen.LIBRARY_INGEST_SHORTCUTS,
+        _build_library_ingest_state=lambda: SimpleNamespace(
+            start_enabled=start_enabled
+        ),
+        _library_ingest_start_consent=None,
+        app_instance=None,
+    )
+    shortcuts = LibraryIngestController._library_ingest_shortcuts_for_current_state(
+        stub
+    )
+    key, description = shortcuts[0]
+    assert key == "enter", shortcuts
+    return description
+
+
+def test_the_import_footer_names_what_enter_does_at_each_step():
+    """task-32364 AC#3: one label for two different actions taught the wrong
+    thing at exactly the moment the user commits -- the first Enter on an
+    unvalidated path validates it, only the second starts the import."""
+    assert _ingest_enter_label(start_enabled=False) == "check this path"
+    assert _ingest_enter_label(start_enabled=True) == "start import"
+
+
+@pytest.mark.asyncio
+async def test_a_prompt_row_does_not_repeat_the_canvas_it_is_already_on():
+    """task-32364: "Prompt · " led every row on a canvas titled Prompts."""
+    from tldw_chatbook.Library.library_prompts_state import (
+        PromptListRow,
+        PromptsListState,
+    )
+    from Tests.UI.test_library_prompts_canvas import _CanvasHost
+
+    state = PromptsListState(
+        rows=(
+            PromptListRow(
+                prompt_id=8,
+                name="Outcome first",
+                secondary="Reusable structure",
+                artifact_type="prompt",
+                type_label="Prompt",
+                source_label="Local",
+                lane_summary="has system and user text",
+            ),
+        ),
+        count=1,
+        sort="newest",
+    )
+    async with _CanvasHost(state).run_test() as pilot:
+        label = str(pilot.app.query_one("#library-prompt-row-8", Button).label)
+        assert "Local · has system and user text" in label, label
+        assert "Prompt · " not in label, label
+
+
+@pytest.mark.asyncio
+async def test_clearing_the_applied_filter_also_clears_the_box():
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _apply_media_filter(screen, pilot, _ONE_HIT_QUERY)
+        screen.query_one("#library-media-scope-clear", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen.query_one("#library-media-filter", Input).value,
+            message="The scope line's Clear left a draft in the filter box.",
+        )
+        line = screen.query_one("#library-media-scope-line", Static)
+        assert "filter" not in str(line.content), str(line.content)
+        assert not screen.query("#library-media-scope-clear")

--- a/Tests/UI/test_library_crit10_media_rows.py
+++ b/Tests/UI/test_library_crit10_media_rows.py
@@ -28,7 +28,7 @@ _ONE_HIT_QUERY = "interview"
 
 def test_the_age_label_says_what_the_age_is():
     now = datetime(2026, 9, 11, 12, 0, tzinfo=timezone.utc)
-    assert media_added_age_copy("2026-09-11T11:50:00+00:00", now=now) == "added 10m ago"
+    assert media_added_age_copy("2026-09-11T11:50:00+00:00", now=now) == "added 10m"
     assert media_added_age_copy("2026-09-11T11:59:40+00:00", now=now) == "added just now"
     assert media_added_age_copy("", now=now) == ""
 

--- a/Tests/UI/test_library_crit10_media_rows.py
+++ b/Tests/UI/test_library_crit10_media_rows.py
@@ -8,12 +8,13 @@ Enter does at each step).
 
 from __future__ import annotations
 
+import dataclasses
 from datetime import datetime, timezone
 
 import pytest
 from textual.widgets import Button, Input, Static
 
-from tldw_chatbook.Library.library_media_state import media_added_age_copy
+from tldw_chatbook.Library.library_media_state import media_updated_age_copy
 from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas
 from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
 from Tests.UI.test_library_media_render_fixes import _apply_media_filter, _host
@@ -26,11 +27,15 @@ from Tests.UI.test_library_shell import _wait_for_condition
 _ONE_HIT_QUERY = "interview"
 
 
-def test_the_age_label_says_what_the_age_is():
+def test_the_age_label_names_the_field_the_age_comes_from():
+    """re-review finding A: the value is `last_modified`, so the word is
+    "updated" -- the same word the preview pane uses for it. An "added"
+    label would swap one ambiguity for another, since pressing Generate
+    writes `last_modified` and would move a row's "added" age."""
     now = datetime(2026, 9, 11, 12, 0, tzinfo=timezone.utc)
-    assert media_added_age_copy("2026-09-11T11:50:00+00:00", now=now) == "added 10m"
-    assert media_added_age_copy("2026-09-11T11:59:40+00:00", now=now) == "added just now"
-    assert media_added_age_copy("", now=now) == ""
+    assert media_updated_age_copy("2026-09-11T11:50:00+00:00", now=now) == "updated 10m"
+    assert media_updated_age_copy("2026-09-11T11:59:40+00:00", now=now) == "updated just now"
+    assert media_updated_age_copy("", now=now) == ""
 
 
 @pytest.mark.asyncio
@@ -165,6 +170,45 @@ async def test_the_import_footer_flips_when_the_gate_opens_without_a_recompose(
 
 
 @pytest.mark.asyncio
+async def test_a_gate_change_on_a_suspended_screen_is_latched_for_resume():
+    """Re-review finding B: skipping is fine, dropping is not.
+
+    The resume pass re-registers the footer only when
+    `_library_ingest_suspended_activity` is set, and nothing else
+    re-registers for a reused, resumed screen. A bare return here left a
+    gate that opened on another tab advertising the previous step's action
+    once the user came back.
+    """
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_ingest_keyboard import _enter_ingest_mode
+    from Tests.UI.test_library_shell import (
+        LIBRARY_TEST_SIZE,
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_conversations,
+        _wait_for_library_shell,
+    )
+
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _enter_ingest_mode(screen, pilot)
+
+        controller = screen._ingest_controller
+        screen._library_ingest_suspended_activity = False
+        screen._library_screen_suspended = True
+        try:
+            controller._resync_library_ingest_footer()
+        finally:
+            screen._library_screen_suspended = False
+        assert screen._library_ingest_suspended_activity is True
+
+
+@pytest.mark.asyncio
 async def test_a_prompt_row_does_not_repeat_the_canvas_it_is_already_on():
     """task-32364: "Prompt · " led every row on a canvas titled Prompts."""
     from tldw_chatbook.Library.library_prompts_state import (
@@ -243,6 +287,37 @@ async def test_the_scope_lines_clear_is_painted_inside_the_items_pane():
                 clear.region.x + clear.region.width
                 <= canvas.region.x + canvas.region.width
             ), (size, clear.region, canvas.region)
+
+
+@pytest.mark.asyncio
+async def test_a_clear_whose_request_failed_can_be_pressed_again():
+    """Qodo review: the visible Clear must be able to retry.
+
+    The scope line and its Clear are derived from the APPLIED result, so a
+    browse that fails leaves the filtered page — and the Clear — on screen
+    while `requested_scope` already holds the cleared target. Suppressing on
+    the requested scope alone made every later press a no-op, with nothing
+    the user could do to get back.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        await _apply_media_filter(screen, pilot, _ONE_HIT_QUERY)
+
+        # The state a failed clear leaves behind: requested is the target,
+        # applied still carries the filter the rows and the Clear came from.
+        controller = screen._library_media_browse_controller
+        controller.requested_scope = dataclasses.replace(
+            controller.requested_scope, query="", media_type=None, page=1
+        )
+        assert controller.applied_scope.query == _ONE_HIT_QUERY
+
+        screen.query_one("#library-media-scope-clear", Button).press()
+        await _wait_for_condition(
+            pilot,
+            lambda: not screen._library_media_browse_controller.applied_scope.query,
+            message="A second Clear press after a failed request did nothing.",
+        )
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_crit10_media_rows.py
+++ b/Tests/UI/test_library_crit10_media_rows.py
@@ -14,6 +14,8 @@ import pytest
 from textual.widgets import Button, Input, Static
 
 from tldw_chatbook.Library.library_media_state import media_added_age_copy
+from tldw_chatbook.UI.Screens.library_screen import _sync_library_canvas
+from tldw_chatbook.Widgets.Library.library_media_canvas import LibraryMediaCanvas
 from Tests.UI.test_library_media_render_fixes import _apply_media_filter, _host
 from Tests.UI.test_library_media_side_by_side import _open_media_list
 from Tests.UI.test_library_shell import _wait_for_condition
@@ -81,6 +83,88 @@ def test_the_import_footer_names_what_enter_does_at_each_step():
 
 
 @pytest.mark.asyncio
+async def test_the_import_footer_flips_when_the_gate_opens_without_a_recompose(
+    tmp_path,
+):
+    """task-32364 AC#3, fix round 1: the label has to reach the FOOTER.
+
+    Review finding 1 said nothing re-registers the Ingest footer when the
+    Start gate opens. Tracing it under a real harness narrowed that: the
+    COMMON path is saved by accident -- an empty ``type_groups`` filling in
+    makes ``_update_library_ingest_dynamic_regions`` take its STRUCTURAL
+    branch (``library_screen.py:19219-19228``), which recomposes and
+    re-registers as a side effect. The hole is every gate transition that is
+    NOT structural, and this drives one directly: the same pre-flight result
+    applied twice, with only the blank path -- itself a Start gate -- filled
+    in between. Without ``_resync_library_ingest_footer`` the footer keeps
+    advertising "check this path" while Enter now starts the import.
+    """
+    from tldw_chatbook.Library.library_ingest_state import PreflightResult
+    from tldw_chatbook.Widgets.AppFooterStatus import AppFooterStatus
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_library_ingest_keyboard import _enter_ingest_mode
+    from Tests.UI.test_library_shell import (
+        LIBRARY_TEST_SIZE,
+        LibraryHarness,
+        _active_library_screen,
+        _seed_conversations,
+        _two_conversations,
+        _wait_for_library_shell,
+    )
+
+    app = _build_test_app()
+    _seed_conversations(app, _two_conversations())
+    host = LibraryHarness(app)
+    async with host.run_test(size=LIBRARY_TEST_SIZE) as pilot:
+        screen = _active_library_screen(host)
+        await _wait_for_library_shell(screen, pilot)
+        await _enter_ingest_mode(screen, pilot)
+
+        # Queried fresh every time: a recompose replaces the footer widget,
+        # and a handle bound once goes on reporting the detached copy's text.
+        def footer_text() -> str:
+            return screen.query_one(AppFooterStatus).shortcut_text
+
+        assert "enter check this path" in footer_text(), footer_text()
+
+        # The Start gate also wants a media DB seam, and this harness has
+        # none; it is checked for presence only (library_screen.py:19406).
+        host.app_instance.media_db = object()
+
+        source = tmp_path / "a.pdf"
+        source.write_text("dummy")
+        form = screen._ingest_state.form
+        # A blank path shuts the gate on its own, so the first application
+        # lands the type groups with Start still closed.
+        form.path = ""
+        result = PreflightResult(
+            type_groups={"pdf": [str(source)]},
+            warnings=[],
+            errors=[],
+            total_size=1024,
+            truncated=False,
+            total_files=1,
+        )
+        screen._apply_library_ingest_preflight_result(
+            result, screen._ingest_state.preflight_generation
+        )
+        await pilot.pause()
+        assert screen._build_library_ingest_state().start_enabled is False
+        assert "enter check this path" in footer_text(), footer_text()
+
+        # Now the gate opens with `type_groups` unchanged, so nothing
+        # recomposes and only the explicit resync can move the label.
+        form.path = str(source)
+        screen._apply_library_ingest_preflight_result(
+            result, screen._ingest_state.preflight_generation
+        )
+        await pilot.pause()
+
+        assert screen._build_library_ingest_state().start_enabled is True
+        assert "enter start import" in footer_text(), footer_text()
+
+
+@pytest.mark.asyncio
 async def test_a_prompt_row_does_not_repeat_the_canvas_it_is_already_on():
     """task-32364: "Prompt · " led every row on a canvas titled Prompts."""
     from tldw_chatbook.Library.library_prompts_state import (
@@ -108,6 +192,57 @@ async def test_a_prompt_row_does_not_repeat_the_canvas_it_is_already_on():
         label = str(pilot.app.query_one("#library-prompt-row-8", Button).label)
         assert "Local · has system and user text" in label, label
         assert "Prompt · " not in label, label
+
+
+@pytest.mark.asyncio
+async def test_the_scope_line_says_nothing_it_cannot_stand_behind():
+    """Review finding 2: `of M` must respect `_local_source_total_known`.
+
+    The screen keeps that flag beside the counts because the snapshot's
+    count is sometimes a lower bound (a bounded preview page with no
+    `total`), and every other consumer renders `5+` rather than `5`. A scope
+    line claiming a flat `of 5` where the rail says `5+` is the one kind of
+    statement this line exists to make impossible.
+    """
+    host = _host()
+    async with host.run_test(size=(235, 52)) as pilot:
+        screen = await _open_media_list(host, pilot)
+        assert "of " in str(
+            screen.query_one("#library-media-scope-line", Static).content
+        )
+
+        screen._local_source_total_known["media"] = False
+        _sync_library_canvas(screen, "media")
+        await pilot.pause()
+
+        line = str(screen.query_one("#library-media-scope-line", Static).content)
+        assert " of " not in line, line
+        assert line.startswith("Media · "), line
+
+
+@pytest.mark.asyncio
+async def test_the_scope_lines_clear_is_painted_inside_the_items_pane():
+    """Review finding 3: the live-found off-screen Clear, pinned.
+
+    `query_one(...).press()` is just as happy with a Button painted past the
+    pane edge, which is exactly the state the CSS fix was made for -- an
+    auto-width scope Static pushed its own Clear out of view once the Reader
+    narrowed the list. A region assertion is the only thing that notices.
+    """
+    for size in ((235, 52), (100, 30)):
+        host = _host()
+        async with host.run_test(size=size) as pilot:
+            screen = await _open_media_list(host, pilot)
+            await _apply_media_filter(screen, pilot, _ONE_HIT_QUERY)
+            await pilot.pause()
+
+            clear = screen.query_one("#library-media-scope-clear", Button)
+            canvas = screen.query_one(LibraryMediaCanvas)
+            assert clear.region.width > 0, (size, clear.region)
+            assert (
+                clear.region.x + clear.region.width
+                <= canvas.region.x + canvas.region.width
+            ), (size, clear.region, canvas.region)
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_ingest_keyboard.py
+++ b/Tests/UI/test_library_ingest_keyboard.py
@@ -270,7 +270,9 @@ async def test_ingest_footer_advertises_enter_start_and_esc_back():
         # filters reserved keys (F6) out of the context portion, and that
         # rendering evolves independently of this mode's registered set.
         footer = screen.query_one(AppFooterStatus)
-        assert "enter start" in footer.shortcut_text
+        # task-32364 AC#3: the path field is blank here, so the Start
+        # gate is shut and Enter validates rather than imports.
+        assert "enter check this path" in footer.shortcut_text
         assert "esc back" in footer.shortcut_text
 
 
@@ -290,9 +292,11 @@ def test_f1_help_in_ingest_mode_shows_the_same_shared_ingest_set(monkeypatch):
 
     # The footer and F1 read the same state-derived set. Retry is omitted
     # until a settled last submission exists.
+    # task-32364 AC#3 made the Enter label state-derived, so the shared
+    # per-mode set is the method, not the raw constant it starts from.
     assert (
         screen._library_footer_shortcuts_for_current_state()
-        == screen.LIBRARY_INGEST_SHORTCUTS
+        == screen._library_ingest_shortcuts_for_current_state()
     )
 
     pushed = []
@@ -312,9 +316,8 @@ def test_f1_help_in_ingest_mode_shows_the_same_shared_ingest_set(monkeypatch):
     assert isinstance(panel, WorkbenchHelpPanel)
     shortcuts = list(panel.state.shortcuts)
     # The shared per-mode set leads the panel, exactly as registered.
-    assert shortcuts[: len(screen.LIBRARY_INGEST_SHORTCUTS)] == list(
-        screen.LIBRARY_INGEST_SHORTCUTS
-    )
+    ingest_set = screen._library_ingest_shortcuts_for_current_state()
+    assert shortcuts[: len(ingest_set)] == list(ingest_set)
     keys = {key for key, _description in shortcuts}
     assert "enter" in keys
     assert "esc" in keys

--- a/Tests/UI/test_library_media_reader_shell.py
+++ b/Tests/UI/test_library_media_reader_shell.py
@@ -272,10 +272,12 @@ async def test_compact_reader_keeps_every_toolbar_action_inside_reader():
 
         reader = shell.reader
         loaded_row = shell.items.query_one("#library-media-row-0", Button)
-        # task-30044: the short prefix -- the old "Loaded in Reader" prose
-        # displaced the title in the ~35-cell label.
-        assert "Loaded · " in str(loaded_row.label)
-        assert "Loading" not in str(loaded_row.label)
+        # task-30044: the short state word -- the old "Loaded in Reader"
+        # prose displaced the title in the ~35-cell label. task-32364 AC#1
+        # moved it off the title and onto the fact line entirely.
+        assert " · loaded" in str(loaded_row.label)
+        assert not str(loaded_row.label).lstrip().startswith("Loaded")
+        assert "loading" not in str(loaded_row.label).lower()
         for selector in (
             "#library-media-reader-find",
             "#library-media-read-later",

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -3024,14 +3024,14 @@ async def test_media_items_paint_two_rows_each_with_no_blank_row_between():
 # ---------------------------------------------------------------------------
 
 
-_ANALYSED_SECONDARY = "document · added 5m ago · analysed"
+_ANALYSED_SECONDARY = "document · added 5m · analysed"
 
 
 def _review_state_items(count: int = 4, analysed: int = 2) -> list[dict]:
     """``count`` ``document`` items, the first ``analysed`` of them analysed.
 
     The stamp is fixed 5m30s back so every row's age label is "5m" and the
-    secondary line is exactly the 33-cell ``document · added 5m ago · analysed`` the
+    secondary line is exactly the 30-cell ``document · added 5m · analysed`` the
     Items pane has to hold.
     """
     stamp = (
@@ -3076,8 +3076,8 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
     """task-28008: the row says which items already carry an analysis, in words.
 
     What this pins about width: each parametrized size resolves the Items
-    pane to its own AUTOMATIC width, and the 33-cell
-    ``document · added 5m ago · analysed`` paints whole in it, indented, with room to
+    pane to its own AUTOMATIC width, and the 30-cell
+    ``document · added 5m · analysed`` paints whole in it, indented, with room to
     spare. The narrower 36-cell FLOOR is pinned separately by
     ``test_analysed_secondary_survives_the_36_cell_items_floor`` -- a
     ``>= 36`` assertion here would have claimed a floor that never ran,
@@ -3087,7 +3087,7 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
     the resolver changed under them -- 9187bc0307 (task-31979) hands the
     empty Reader's unused width to the Items list at the wide size, and the
     below-64 Media stage work (c668aaec5e / db86a39b19) re-fitted the narrow
-    one. Both new widths are still far above the 33-cell secondary, so what
+    one. Both new widths are still far above the 30-cell secondary, so what
     the assertion means is unchanged; the resolver's own contract lives in
     Tests/UI/test_library_adaptive_reader_shell.py.
 
@@ -3110,8 +3110,8 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
             _ANALYSED_SECONDARY,
         ], secondaries
         assert [line.strip() for line in secondaries[2:]] == [
-            "document · added 5m ago",
-            "document · added 5m ago",
+            "document · added 5m",
+            "document · added 5m",
         ], secondaries
         assert _items_pane_width(screen) == items_width
 
@@ -3540,7 +3540,7 @@ async def test_returning_to_read_restores_the_reading_position_once():
 
 @pytest.mark.asyncio
 async def test_analysed_secondary_survives_the_36_cell_items_floor():
-    """M-1: the 33-cell secondary at the Items pane's 36-cell floor.
+    """M-1: the 30-cell secondary at the Items pane's 36-cell floor.
 
     The automatic resolver gives Items 52 cells at both tested terminal
     sizes, so the floor only runs when a custom Items width asks for it (a
@@ -3622,17 +3622,17 @@ def _match_reason_items() -> list[dict]:
         (
             (235, 52),
             [
-                "article · added 2m ago · keyword: notes · loa…",
-                "article · added 2m ago",
-                "article · added 2m ago · keyword: notesandmo…",
+                "article · added 2m · keyword: notes · loaded",
+                "article · added 2m",
+                "article · added 2m · keyword: notesandmo…",
             ],
         ),
         (
             (100, 30),
             [
-                "article · added 2m ago · keyword: not…",
-                "article · added 2m ago",
-                "article · added 2m ago · keyword: not…",
+                "article · added 2m · keyword: notes ·…",
+                "article · added 2m",
+                "article · added 2m · keyword: notesan…",
             ],
         ),
     ],
@@ -3648,8 +3648,10 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
     36 cells -- ``notesandmorestuff`` would push the line past it whole.
 
     task-32347 made both sizes tighter and the expectations are now
-    per-size rather than shared: labelling the age costs 10 cells on every
-    row, so the narrow pane clips the term it used to paint whole.
+    per-size rather than shared: labelling the age ("added 2m") costs 6
+    cells on every row, so the narrow pane no longer has room for the
+    trailing "· loaded" on the row the Reader holds. The term itself still
+    paints -- dropping the review round's " ago" is what bought that back.
     """
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_match_reason_items())
@@ -3663,11 +3665,10 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
         lines = _painted_item_lines(host, screen)
         secondaries = [line.strip() for line in lines if "article · " in line]
         # task-32347 cost, pinned rather than hidden: labelling the age
-        # ("added 2m ago", 12 cells where "2m" was 2) made every secondary
-        # 10 cells longer, and task-32364 AC#1 adds "· loaded" to whichever
-        # row the Reader holds. The first row now spends its last cells on
-        # that suffix and ellipsises inside the pane instead of painting the
-        # whole keyword reason.
+        # ("added 2m", 8 cells where "2m" was 2) made every secondary 6
+        # cells longer, and task-32364 AC#1 adds "· loaded" to whichever
+        # row the Reader holds. At the wide size both still fit; at the
+        # narrow one the "· loaded" suffix is what runs out of room.
         assert secondaries == expected, secondaries
 
 
@@ -3678,9 +3679,9 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
 
     The ten-character cap keeps the line SHORT; it does not make it fit
     here. A 36-cell Items pane spends 4 cells on its own padding, so the
-    row has ~28 cells and `article · added 2m ago · keyword: notes` needs 29 -- at the
-    floor a keyword row still cannot show its whole term, for the short
-    keyword as well as the long one. The neighbouring
+    row has ~28 cells and `article · added 2m · keyword: notes` needs 35 --
+    at the floor a keyword row still cannot show its whole term, for the
+    short keyword as well as the long one. The neighbouring
     `test_analysed_secondary_survives_the_36_cell_items_floor` shows what
     a line that DOES fit looks like there; this one is the honest contrast,
     and it exists so nobody re-derives the false "the cap makes it fit".
@@ -3719,21 +3720,21 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
         secondaries = [
             line.strip(" │") for line in lines if "article · " in line
         ]
-        # task-32347 made this worse and the pin says so rather than
-        # softening: with the age labelled, the ~28 cells this pane leaves a
-        # row are spent before the keyword LABEL starts, so at the floor the
-        # reason is not merely cut short -- it is gone. Whether that is an
-        # acceptable price for an unambiguous age is a product call, not a
-        # test's; it is recorded here so nobody re-derives "the cap makes it
-        # fit" from a pin that never said so.
+        # task-32347 costs the floor 6 cells, and the pin says exactly how
+        # far that reaches rather than softening: the row still gets INTO
+        # its "keyword:" label and no further. (The review round's rejected
+        # "added 2m ago" spent 4 more and cut the label off entirely --
+        # that is what the shorter grammar bought back.) Recorded here so
+        # nobody re-derives "the cap makes it fit" from a pin that never
+        # said so.
         assert secondaries == [
-            "article · added 2m ago · …",
-            "article · added 2m ago",
-            "article · added 2m ago · …",
+            "article · added 2m · keyw…",
+            "article · added 2m",
+            "article · added 2m · keyw…",
         ], secondaries
         # The row without a reason still paints whole -- the shortfall is the
         # suffix's own cost, not a regression in the base secondary line.
-        assert "article · added 2m ago" in secondaries, secondaries
+        assert "article · added 2m" in secondaries, secondaries
 
 
 @pytest.mark.asyncio
@@ -4112,7 +4113,7 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
         for _ in range(3):
             await pilot.pause()
         _titles, before = _painted_media_rows(host, screen)
-        assert [line.strip() for line in before] == ["document · added 5m ago"] * 4, before
+        assert [line.strip() for line in before] == ["document · added 5m"] * 4, before
 
         screen.query_one("#library-media-row-0", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-reader-select-analysis")
@@ -4140,9 +4141,9 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
             # task-32364 AC#1: this row is the one open in the Reader, so
             # it carries the state word on its fact line.
             f"{_ANALYSED_SECONDARY} · loaded",
-            "document · added 5m ago",
-            "document · added 5m ago",
-            "document · added 5m ago",
+            "document · added 5m",
+            "document · added 5m",
+            "document · added 5m",
         ], after
         # ...and the only read it cost was one id-scoped row, never a
         # re-page of the list.

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -3024,14 +3024,14 @@ async def test_media_items_paint_two_rows_each_with_no_blank_row_between():
 # ---------------------------------------------------------------------------
 
 
-_ANALYSED_SECONDARY = "document · 5m · analysed"
+_ANALYSED_SECONDARY = "document · added 5m ago · analysed"
 
 
 def _review_state_items(count: int = 4, analysed: int = 2) -> list[dict]:
     """``count`` ``document`` items, the first ``analysed`` of them analysed.
 
     The stamp is fixed 5m30s back so every row's age label is "5m" and the
-    secondary line is exactly the 24-cell ``document · 5m · analysed`` the
+    secondary line is exactly the 33-cell ``document · added 5m ago · analysed`` the
     Items pane has to hold.
     """
     stamp = (
@@ -3076,8 +3076,8 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
     """task-28008: the row says which items already carry an analysis, in words.
 
     What this pins about width: each parametrized size resolves the Items
-    pane to its own AUTOMATIC width, and the 24-cell
-    ``document · 5m · analysed`` paints whole in it, indented, with room to
+    pane to its own AUTOMATIC width, and the 33-cell
+    ``document · added 5m ago · analysed`` paints whole in it, indented, with room to
     spare. The narrower 36-cell FLOOR is pinned separately by
     ``test_analysed_secondary_survives_the_36_cell_items_floor`` -- a
     ``>= 36`` assertion here would have claimed a floor that never ran,
@@ -3087,7 +3087,7 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
     the resolver changed under them -- 9187bc0307 (task-31979) hands the
     empty Reader's unused width to the Items list at the wide size, and the
     below-64 Media stage work (c668aaec5e / db86a39b19) re-fitted the narrow
-    one. Both new widths are still far above the 24-cell secondary, so what
+    one. Both new widths are still far above the 33-cell secondary, so what
     the assertion means is unchanged; the resolver's own contract lives in
     Tests/UI/test_library_adaptive_reader_shell.py.
 
@@ -3110,8 +3110,8 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
             _ANALYSED_SECONDARY,
         ], secondaries
         assert [line.strip() for line in secondaries[2:]] == [
-            "document · 5m",
-            "document · 5m",
+            "document · added 5m ago",
+            "document · added 5m ago",
         ], secondaries
         assert _items_pane_width(screen) == items_width
 
@@ -3540,7 +3540,7 @@ async def test_returning_to_read_restores_the_reading_position_once():
 
 @pytest.mark.asyncio
 async def test_analysed_secondary_survives_the_36_cell_items_floor():
-    """M-1: the 24-cell secondary at the Items pane's 36-cell floor.
+    """M-1: the 33-cell secondary at the Items pane's 36-cell floor.
 
     The automatic resolver gives Items 52 cells at both tested terminal
     sizes, so the floor only runs when a custom Items width asks for it (a
@@ -3638,9 +3638,9 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size):
         lines = _painted_item_lines(host, screen)
         secondaries = [line.strip() for line in lines if "article · " in line]
         assert secondaries == [
-            "article · 2m · keyword: notes",
-            "article · 2m",
-            "article · 2m · keyword: notesandmo…",
+            "article · added 2m ago · keyword: notes",
+            "article · added 2m ago",
+            "article · added 2m ago · keyword: notesandmo…",
         ], secondaries
 
 
@@ -3651,7 +3651,7 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
 
     The ten-character cap keeps the line SHORT; it does not make it fit
     here. A 36-cell Items pane spends 4 cells on its own padding, so the
-    row has ~28 cells and `article · 2m · keyword: notes` needs 29 -- at the
+    row has ~28 cells and `article · added 2m ago · keyword: notes` needs 29 -- at the
     floor a keyword row still cannot show its whole term, for the short
     keyword as well as the long one. The neighbouring
     `test_analysed_secondary_survives_the_36_cell_items_floor` shows what
@@ -3694,12 +3694,12 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
         ]
         assert secondaries == [
             "article · 2m · keyword: n…",
-            "article · 2m",
+            "article · added 2m ago",
             "article · 2m · keyword: n…",
         ], secondaries
         # The row without a reason still paints whole -- the shortfall is the
         # suffix's own cost, not a regression in the base secondary line.
-        assert "article · 2m" in secondaries, secondaries
+        assert "article · added 2m ago" in secondaries, secondaries
 
 
 @pytest.mark.asyncio
@@ -4078,7 +4078,7 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
         for _ in range(3):
             await pilot.pause()
         _titles, before = _painted_media_rows(host, screen)
-        assert [line.strip() for line in before] == ["document · 5m"] * 4, before
+        assert [line.strip() for line in before] == ["document · added 5m ago"] * 4, before
 
         screen.query_one("#library-media-row-0", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-reader-select-analysis")
@@ -4104,9 +4104,9 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
         _titles, after = _painted_media_rows(host, screen)
         assert [line.strip() for line in after] == [
             _ANALYSED_SECONDARY,
-            "document · 5m",
-            "document · 5m",
-            "document · 5m",
+            "document · added 5m ago",
+            "document · added 5m ago",
+            "document · added 5m ago",
         ], after
         # ...and the only read it cost was one id-scoped row, never a
         # re-page of the list.

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -3630,9 +3630,9 @@ def _match_reason_items() -> list[dict]:
         (
             (100, 30),
             [
-                "article · updated 2m · keyword: notes ·…",
+                "article · updated 2m · keyword: notes…",
                 "article · updated 2m",
-                "article · updated 2m · keyword: notesan…",
+                "article · updated 2m · keyword: notes…",
             ],
         ),
     ],
@@ -3648,7 +3648,7 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
     36 cells -- ``notesandmorestuff`` would push the line past it whole.
 
     task-32347 made both sizes tighter and the expectations are now
-    per-size rather than shared: labelling the age ("updated 2m") costs 6
+    per-size rather than shared: labelling the age ("updated 2m") costs 8
     cells on every row, so the narrow pane no longer has room for the
     trailing "· loaded" on the row the Reader holds. The term itself still
     paints -- dropping the review round's " ago" is what bought that back.
@@ -3665,7 +3665,7 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
         lines = _painted_item_lines(host, screen)
         secondaries = [line.strip() for line in lines if "article · " in line]
         # task-32347 cost, pinned rather than hidden: labelling the age
-        # ("updated 2m", 8 cells where "2m" was 2) made every secondary 6
+        # ("updated 2m", 10 cells where "2m" was 2) made every secondary 8
         # cells longer, and task-32364 AC#1 adds "· loaded" to whichever
         # row the Reader holds. At the wide size both still fit; at the
         # narrow one the "· loaded" suffix is what runs out of room.
@@ -3679,7 +3679,7 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
 
     The ten-character cap keeps the line SHORT; it does not make it fit
     here. A 36-cell Items pane spends 4 cells on its own padding, so the
-    row has ~28 cells and `article · updated 2m · keyword: notes` needs 35 --
+    row has ~28 cells and `article · updated 2m · keyword: notes` needs 37 --
     at the floor a keyword row still cannot show its whole term, for the
     short keyword as well as the long one. The neighbouring
     `test_analysed_secondary_survives_the_36_cell_items_floor` shows what
@@ -3728,9 +3728,9 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
         # nobody re-derives "the cap makes it fit" from a pin that never
         # said so.
         assert secondaries == [
-            "article · updated 2m · keyw…",
+            "article · updated 2m · ke…",
             "article · updated 2m",
-            "article · updated 2m · keyw…",
+            "article · updated 2m · ke…",
         ], secondaries
         # The row without a reason still paints whole -- the shortfall is the
         # suffix's own cost, not a regression in the base secondary line.

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -3024,14 +3024,14 @@ async def test_media_items_paint_two_rows_each_with_no_blank_row_between():
 # ---------------------------------------------------------------------------
 
 
-_ANALYSED_SECONDARY = "document · added 5m · analysed"
+_ANALYSED_SECONDARY = "document · updated 5m · analysed"
 
 
 def _review_state_items(count: int = 4, analysed: int = 2) -> list[dict]:
     """``count`` ``document`` items, the first ``analysed`` of them analysed.
 
     The stamp is fixed 5m30s back so every row's age label is "5m" and the
-    secondary line is exactly the 30-cell ``document · added 5m · analysed`` the
+    secondary line is exactly the 30-cell ``document · updated 5m · analysed`` the
     Items pane has to hold.
     """
     stamp = (
@@ -3077,7 +3077,7 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
 
     What this pins about width: each parametrized size resolves the Items
     pane to its own AUTOMATIC width, and the 30-cell
-    ``document · added 5m · analysed`` paints whole in it, indented, with room to
+    ``document · updated 5m · analysed`` paints whole in it, indented, with room to
     spare. The narrower 36-cell FLOOR is pinned separately by
     ``test_analysed_secondary_survives_the_36_cell_items_floor`` -- a
     ``>= 36`` assertion here would have claimed a floor that never ran,
@@ -3110,8 +3110,8 @@ async def test_media_rows_paint_analysed_only_for_analysed_items(size, items_wid
             _ANALYSED_SECONDARY,
         ], secondaries
         assert [line.strip() for line in secondaries[2:]] == [
-            "document · added 5m",
-            "document · added 5m",
+            "document · updated 5m",
+            "document · updated 5m",
         ], secondaries
         assert _items_pane_width(screen) == items_width
 
@@ -3622,17 +3622,17 @@ def _match_reason_items() -> list[dict]:
         (
             (235, 52),
             [
-                "article · added 2m · keyword: notes · loaded",
-                "article · added 2m",
-                "article · added 2m · keyword: notesandmo…",
+                "article · updated 2m · keyword: notes · loaded",
+                "article · updated 2m",
+                "article · updated 2m · keyword: notesandmo…",
             ],
         ),
         (
             (100, 30),
             [
-                "article · added 2m · keyword: notes ·…",
-                "article · added 2m",
-                "article · added 2m · keyword: notesan…",
+                "article · updated 2m · keyword: notes ·…",
+                "article · updated 2m",
+                "article · updated 2m · keyword: notesan…",
             ],
         ),
     ],
@@ -3648,7 +3648,7 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
     36 cells -- ``notesandmorestuff`` would push the line past it whole.
 
     task-32347 made both sizes tighter and the expectations are now
-    per-size rather than shared: labelling the age ("added 2m") costs 6
+    per-size rather than shared: labelling the age ("updated 2m") costs 6
     cells on every row, so the narrow pane no longer has room for the
     trailing "· loaded" on the row the Reader holds. The term itself still
     paints -- dropping the review round's " ago" is what bought that back.
@@ -3665,7 +3665,7 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
         lines = _painted_item_lines(host, screen)
         secondaries = [line.strip() for line in lines if "article · " in line]
         # task-32347 cost, pinned rather than hidden: labelling the age
-        # ("added 2m", 8 cells where "2m" was 2) made every secondary 6
+        # ("updated 2m", 8 cells where "2m" was 2) made every secondary 6
         # cells longer, and task-32364 AC#1 adds "· loaded" to whichever
         # row the Reader holds. At the wide size both still fit; at the
         # narrow one the "· loaded" suffix is what runs out of room.
@@ -3679,7 +3679,7 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
 
     The ten-character cap keeps the line SHORT; it does not make it fit
     here. A 36-cell Items pane spends 4 cells on its own padding, so the
-    row has ~28 cells and `article · added 2m · keyword: notes` needs 35 --
+    row has ~28 cells and `article · updated 2m · keyword: notes` needs 35 --
     at the floor a keyword row still cannot show its whole term, for the
     short keyword as well as the long one. The neighbouring
     `test_analysed_secondary_survives_the_36_cell_items_floor` shows what
@@ -3723,18 +3723,18 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
         # task-32347 costs the floor 6 cells, and the pin says exactly how
         # far that reaches rather than softening: the row still gets INTO
         # its "keyword:" label and no further. (The review round's rejected
-        # "added 2m ago" spent 4 more and cut the label off entirely --
+        # "updated 2m ago" spent 4 more and cut the label off entirely --
         # that is what the shorter grammar bought back.) Recorded here so
         # nobody re-derives "the cap makes it fit" from a pin that never
         # said so.
         assert secondaries == [
-            "article · added 2m · keyw…",
-            "article · added 2m",
-            "article · added 2m · keyw…",
+            "article · updated 2m · keyw…",
+            "article · updated 2m",
+            "article · updated 2m · keyw…",
         ], secondaries
         # The row without a reason still paints whole -- the shortfall is the
         # suffix's own cost, not a regression in the base secondary line.
-        assert "article · added 2m" in secondaries, secondaries
+        assert "article · updated 2m" in secondaries, secondaries
 
 
 @pytest.mark.asyncio
@@ -4113,7 +4113,7 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
         for _ in range(3):
             await pilot.pause()
         _titles, before = _painted_media_rows(host, screen)
-        assert [line.strip() for line in before] == ["document · added 5m"] * 4, before
+        assert [line.strip() for line in before] == ["document · updated 5m"] * 4, before
 
         screen.query_one("#library-media-row-0", Button).press()
         await _wait_for_selector(screen, pilot, "#library-media-reader-select-analysis")
@@ -4141,9 +4141,9 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
             # task-32364 AC#1: this row is the one open in the Reader, so
             # it carries the state word on its fact line.
             f"{_ANALYSED_SECONDARY} · loaded",
-            "document · added 5m",
-            "document · added 5m",
-            "document · added 5m",
+            "document · updated 5m",
+            "document · updated 5m",
+            "document · updated 5m",
         ], after
         # ...and the only read it cost was one id-scoped row, never a
         # re-page of the list.

--- a/Tests/UI/test_library_media_render_fixes.py
+++ b/Tests/UI/test_library_media_render_fixes.py
@@ -3616,15 +3616,40 @@ def _match_reason_items() -> list[dict]:
     ]
 
 
-@pytest.mark.parametrize("size", [(235, 52), (100, 30)], ids=["wide", "narrow"])
+@pytest.mark.parametrize(
+    ("size", "expected"),
+    [
+        (
+            (235, 52),
+            [
+                "article · added 2m ago · keyword: notes · loa…",
+                "article · added 2m ago",
+                "article · added 2m ago · keyword: notesandmo…",
+            ],
+        ),
+        (
+            (100, 30),
+            [
+                "article · added 2m ago · keyword: not…",
+                "article · added 2m ago",
+                "article · added 2m ago · keyword: not…",
+            ],
+        ),
+    ],
+    ids=["wide", "narrow"],
+)
 @pytest.mark.asyncio
-async def test_keyword_only_rows_paint_the_keyword_that_matched(size):
+async def test_keyword_only_rows_paint_the_keyword_that_matched(size, expected):
     """The reason is WORDS on the secondary line, and only where it is needed.
 
     ``Field notes`` matched the query in its own painted title, so it says
     nothing extra; the two rows whose match lives in a keyword name it. The
     keyword is capped at ten characters because the Items pane's floor is
     36 cells -- ``notesandmorestuff`` would push the line past it whole.
+
+    task-32347 made both sizes tighter and the expectations are now
+    per-size rather than shared: labelling the age costs 10 cells on every
+    row, so the narrow pane clips the term it used to paint whole.
     """
     app = _build_media_test_app()
     _seed_conversations(app, _two_conversations(), media=_match_reason_items())
@@ -3637,11 +3662,13 @@ async def test_keyword_only_rows_paint_the_keyword_that_matched(size):
 
         lines = _painted_item_lines(host, screen)
         secondaries = [line.strip() for line in lines if "article · " in line]
-        assert secondaries == [
-            "article · added 2m ago · keyword: notes",
-            "article · added 2m ago",
-            "article · added 2m ago · keyword: notesandmo…",
-        ], secondaries
+        # task-32347 cost, pinned rather than hidden: labelling the age
+        # ("added 2m ago", 12 cells where "2m" was 2) made every secondary
+        # 10 cells longer, and task-32364 AC#1 adds "· loaded" to whichever
+        # row the Reader holds. The first row now spends its last cells on
+        # that suffix and ellipsises inside the pane instead of painting the
+        # whole keyword reason.
+        assert secondaries == expected, secondaries
 
 
 
@@ -3692,10 +3719,17 @@ async def test_keyword_reason_clips_at_the_36_cell_items_floor():
         secondaries = [
             line.strip(" │") for line in lines if "article · " in line
         ]
+        # task-32347 made this worse and the pin says so rather than
+        # softening: with the age labelled, the ~28 cells this pane leaves a
+        # row are spent before the keyword LABEL starts, so at the floor the
+        # reason is not merely cut short -- it is gone. Whether that is an
+        # acceptable price for an unambiguous age is a product call, not a
+        # test's; it is recorded here so nobody re-derives "the cap makes it
+        # fit" from a pin that never said so.
         assert secondaries == [
-            "article · 2m · keyword: n…",
+            "article · added 2m ago · …",
             "article · added 2m ago",
-            "article · 2m · keyword: n…",
+            "article · added 2m ago · …",
         ], secondaries
         # The row without a reason still paints whole -- the shortfall is the
         # suffix's own cost, not a regression in the base secondary line.
@@ -4103,7 +4137,9 @@ async def test_saving_an_analysis_marks_its_row_analysed_without_a_refetch():
 
         _titles, after = _painted_media_rows(host, screen)
         assert [line.strip() for line in after] == [
-            _ANALYSED_SECONDARY,
+            # task-32364 AC#1: this row is the one open in the Reader, so
+            # it carries the state word on its fact line.
+            f"{_ANALYSED_SECONDARY} · loaded",
             "document · added 5m ago",
             "document · added 5m ago",
             "document · added 5m ago",

--- a/Tests/UI/test_library_media_toolbar_adapt.py
+++ b/Tests/UI/test_library_media_toolbar_adapt.py
@@ -237,12 +237,15 @@ async def test_long_type_values_are_capped_in_the_chooser_label():
         sort_button = app.query_one("#library-media-sort", Button)
         for button in (type_button, sort_button):
             assert button.region.x + button.region.width <= right
-def test_wide_row_prefixes_are_short_so_titles_survive():
-    """Row state prefixes must not displace the title (task-30044).
+def test_wide_row_state_is_short_and_never_displaces_the_title():
+    """Row state must not displace the title (task-30044, task-32364 AC#1).
 
     Critique 2026-09-03 P2: the wide-mode prefix "Loaded in Reader
     " consumed ~28 of ~35 label cells, leaving titles as "Quart"/"SQLit" --
     the row that matters most was the one you couldn't identify.
+    Critique #10 closed the other half: the SHORT word still prefixed the
+    title, so the row's identity was displaced by its status. Every row
+    now opens with its title and carries the state on the fact line.
     """
     from tldw_chatbook.Widgets.Library.library_media_canvas import (
         _media_row_label_rest,
@@ -251,18 +254,21 @@ def test_wide_row_prefixes_are_short_so_titles_survive():
     loaded = _media_row_label_rest(
         "Quarterly metrics narrative", "document · 3m", compact=False, loaded=True
     )
-    assert loaded.startswith(" Loaded · Quarterly")
+    assert loaded.startswith(" Quarterly")
+    assert loaded.endswith("document · 3m · loaded")
     loading = _media_row_label_rest(
         "Quarterly metrics narrative",
         "document · 3m",
         compact=False,
         loading=True,
     )
-    assert loading.startswith(" Loading · Quarterly")
+    assert loading.startswith(" Quarterly")
+    assert loading.endswith("document · 3m · loading")
     plain = _media_row_label_rest(
         "Quarterly metrics narrative", "document · 3m", compact=False
     )
     assert plain.startswith(" Quarterly")
+    assert plain.endswith("document · 3m")
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_library_prompts_canvas.py
+++ b/Tests/UI/test_library_prompts_canvas.py
@@ -1331,7 +1331,7 @@ async def test_prompts_canvas_rows_show_first_class_type_source_and_lane_summary
                 artifact_type="recipe",
                 type_label="Recipe",
                 source_label="Server",
-                lane_summary="System + User",
+                lane_summary="has system and user text",
             ),
         ),
         count=1,
@@ -1341,7 +1341,7 @@ async def test_prompts_canvas_rows_show_first_class_type_source_and_lane_summary
 
     async with app.run_test() as pilot:
         label = str(pilot.app.query_one("#library-prompt-row-8", Button).label)
-        assert "Recipe · Server · System + User" in label
+        assert "Recipe · Server · has system and user text" in label
         assert "Reusable structure" in label
 
 
@@ -5235,7 +5235,7 @@ async def test_library_real_recipe_list_pipeline_preserves_type_source_and_lanes
         await _wait_for_selector(screen, pilot, f"#library-prompt-row-{prompt_id}")
 
         button = screen.query_one(f"#library-prompt-row-{prompt_id}", Button)
-        assert "Recipe · Local · System + User" in str(button.label)
+        assert "Recipe · Local · has system and user text" in str(button.label)
         [record] = screen._library_prompt_browse_controller.result.items
         assert record["id"] == f"local:prompt:{prompt_uuid}"
         assert record["local_id"] == prompt_id

--- a/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
+++ b/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
@@ -3,9 +3,10 @@ id: TASK-32347
 title: >-
   Library Media rows: the age suffix '· 10m' reads as a duration on audio and
   video
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-11 06:14'
+updated_date: '2026-09-11 07:36'
 labels:
   - library
   - media
@@ -23,6 +24,26 @@ Every media row ends '· 10m' (audio · 10m, video · 10m, pdf · 10m). The valu
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Age is labelled ('added 10m ago') or replaced by type-aware metadata (duration for audio/video, pages for pdf/ebook, words for article/document) with the date on Info
-- [ ] #2 The pin is updated to the new format, not loosened
+- [x] #1 Age is labelled ('added 10m ago') or replaced by type-aware metadata (duration for audio/video, pages for pdf/ebook, words for article/document) with the date on Info
+- [x] #2 The pin is updated to the new format, not loosened
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. New test for media_added_age_copy in Tests/UI/test_library_crit10_media_rows.py\n2. Add media_added_age_copy beside media_trash_age_copy in library_media_state.py\n3. Swap the two browse call sites (browse state + legacy build_library_media_state); leave the Trash row alone\n4. Update the four pinned secondary strings to the labelled form
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Added media_added_age_copy() beside media_trash_age_copy in library_media_state.py and swapped the two BROWSE call sites (build_library_media_browse_state and the legacy build_library_media_state) to it; the Trash row keeps its own 'trashed <age>' label untouched. format_console_relative_age returns the bare word 'now' under a minute, which no 'N ago' phrasing survives, so that case reads 'added just now'.
+
+AC#2 (the pin updated, not loosened): the four strings that actually constrain the format -- test_library_media_state.py:305-306 and :529/:534 -- now read 'pdf · added 3m ago' / 'video · added 2h ago' / 'video · added 3m ago' / 'pdf · added 2h ago', with task-32347 named in both docstrings. test_media_secondary_fallback_when_no_type_no_age, which the task names, turned out to pin only the NO-TYPE fallback ('media') and needed no change. test_library_media_trash_state.py:490-491 is byte-identical.
+
+Three painted-row pins in Tests/UI/test_library_media_render_fixes.py were re-measured against the real output rather than softened: the labelled age costs ~10 cells on every secondary line. KNOWN COST, recorded in those pins: at the Items pane's narrow (100x30) width a keyword row now clips its term where it used to paint it whole, and at the 36-cell floor a keyword row no longer reaches its 'keyword:' label at all ('article · added 2m ago · …'). Dropping ' ago' would buy 4 of those cells back; the AC's own example and the plan both specify the 'added N ago' wording, so that is a product call left open rather than taken here.
+
+Live-verified at 235x52 and 100x30 on the seeded profile: rows read 'audio · added 1h ago', 'pdf · added 1h ago', 'video · added 1h ago'.
+
+Files: tldw_chatbook/Library/library_media_state.py; Tests/Library/test_library_media_state.py; Tests/UI/test_library_media_render_fixes.py; Tests/UI/test_library_crit10_media_rows.py (new); Docs/User_Guide/library/media-and-conversations.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
+++ b/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
@@ -31,7 +31,10 @@ Every media row ends '· 10m' (audio · 10m, video · 10m, pdf · 10m). The valu
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. New test for media_added_age_copy in Tests/UI/test_library_crit10_media_rows.py\n2. Add media_added_age_copy beside media_trash_age_copy in library_media_state.py\n3. Swap the two browse call sites (browse state + legacy build_library_media_state); leave the Trash row alone\n4. Update the four pinned secondary strings to the labelled form
+1. New test for media_added_age_copy in Tests/UI/test_library_crit10_media_rows.py
+2. Add media_added_age_copy beside media_trash_age_copy in library_media_state.py
+3. Swap the two browse call sites (browse state + legacy build_library_media_state); leave the Trash row alone
+4. Update the four pinned secondary strings to the labelled form
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
+++ b/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
@@ -3,10 +3,10 @@ id: TASK-32347
 title: >-
   Library Media rows: the age suffix '· 10m' reads as a duration on audio and
   video
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 06:14'
-updated_date: '2026-09-11 07:36'
+updated_date: '2026-09-11 08:00'
 labels:
   - library
   - media

--- a/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
+++ b/backlog/tasks/task-32347 - Library-Media-rows-the-age-suffix-·-10m-reads-as-a-duration-on-audio-and-video.md
@@ -49,4 +49,26 @@ Three painted-row pins in Tests/UI/test_library_media_render_fixes.py were re-me
 Live-verified at 235x52 and 100x30 on the seeded profile: rows read 'audio · added 1h ago', 'pdf · added 1h ago', 'video · added 1h ago'.
 
 Files: tldw_chatbook/Library/library_media_state.py; Tests/Library/test_library_media_state.py; Tests/UI/test_library_media_render_fixes.py; Tests/UI/test_library_crit10_media_rows.py (new); Docs/User_Guide/library/media-and-conversations.md.
+## Fix round 1 + re-review round 1
+
+Two copy rulings landed after the notes above were written, so read those as
+the original round only:
+
+1. **`added 3m ago` -> `added 3m`** (review round 1): the LABEL removes the
+   duration reading, and the Trash list's own grammar (`trashed 3m`) is the
+   house style. The four cells went straight to the narrow Items pane -- a
+   keyword row paints its term again, and the 36-cell floor reaches into the
+   `keyword:` label instead of ending before it. So the "product call left
+   open" in the notes above was TAKEN.
+2. **`added 3m` -> `updated 3m`** (re-review finding A): the value is the
+   record's `last_modified`, not its ingest time -- the browse contract maps
+   `updated_at` to `last_modified` and never projects `ingestion_date`, and
+   saving an analysis writes it. "added" would have swapped one ambiguity for
+   another, so the row now uses the same word the preview pane already uses
+   for the same field ("Updated:"). The helper is `media_updated_age_copy`.
+
+Current pins: `pdf · updated 3m`, `video · updated 2h`, `video · updated 3m`,
+`pdf · updated 2h`; the helper returns `updated 10m` / `updated just now` /
+`""`. Every painted pin in `test_library_media_render_fixes.py` was
+re-measured at each step rather than hand-edited.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
+++ b/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
@@ -32,7 +32,11 @@ The filter box keeps a draft while the list shows the last applied query and the
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Failing UI tests for #library-media-scope-line and #library-media-scope-clear\n2. scope_line/scope_clearable on LibraryMediaCanvasState, built inside build_library_media_browse_state from the APPLIED scope\n3. unfiltered_total passed from library_media_controller\n4. scope row in library_media_canvas compose + Clear routed to the existing clear path, which now also blanks the Input\n5. TCSS rule + bundle rebuild
+1. Failing UI tests for #library-media-scope-line and #library-media-scope-clear
+2. scope_line/scope_clearable on LibraryMediaCanvasState, built inside build_library_media_browse_state from the APPLIED scope
+3. unfiltered_total passed from library_media_controller
+4. scope row in library_media_canvas compose + Clear routed to the existing clear path, which now also blanks the Input
+5. TCSS rule + bundle rebuild
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes

--- a/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
+++ b/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
@@ -3,10 +3,10 @@ id: TASK-32350
 title: >-
   Library Media list: the filter box and the applied filter can disagree — add a
   persistent scope line
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 06:15'
-updated_date: '2026-09-11 07:37'
+updated_date: '2026-09-11 08:00'
 labels:
   - library
   - media

--- a/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
+++ b/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
@@ -55,4 +55,24 @@ LIVE-FOUND DEFECT, fixed: with the plan's 'width: auto' the scope Static pushed 
 Live-verified 235x52: 'Media · 11 of 11 · all types · sort: Newest' with no Clear, then 'Media · 2 of 11 · filter “notes” …   Clear' with the list showing 2 rows, then Clear -> box empty, list back to 11, Clear gone. Also checked at 100x30.
 
 Files: tldw_chatbook/Library/library_media_state.py; tldw_chatbook/UI/Library_Modules/library_media_controller.py; tldw_chatbook/Widgets/Library/library_media_canvas.py; tldw_chatbook/css/components/_agentic_terminal.tcss (+ regenerated bundle); Tests/UI/test_library_crit10_media_rows.py; Docs/User_Guide/library/media-and-conversations.md.
+## Fix round 1
+
+Two review findings against the scope line:
+
+- **`N of M` now respects `_local_source_total_known`** (finding 2). The
+  screen keeps that flag because the snapshot's count is sometimes a lower
+  bound, and every other consumer renders `5+`. The line drops its "of M"
+  half rather than state a flat total the rail itself refuses to state.
+  Pinned by `test_the_scope_line_says_nothing_it_cannot_stand_behind`.
+- **The live-found off-screen Clear is pinned** (finding 3) by its painted
+  region at 235x52 and 100x30 -- `press()` succeeds just as happily on a
+  Button painted past the pane edge, which is the exact state the `1fr` +
+  ellipsis CSS fix was made for. Verified the pin fails against the reverted
+  `width: auto`.
+
+Qodo then found a third: the no-op guard in `_request_library_media_filter`
+compared only `requested_scope`, so after a FAILED browse the still-visible
+Clear (derived from the applied result) could never retry. It now suppresses
+only when the applied scope is at the target too, pinned by
+`test_a_clear_whose_request_failed_can_be_pressed_again`.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
+++ b/backlog/tasks/task-32350 - Library-Media-list-the-filter-box-and-the-applied-filter-can-disagree-—-add-a-persistent-scope-line.md
@@ -3,9 +3,10 @@ id: TASK-32350
 title: >-
   Library Media list: the filter box and the applied filter can disagree — add a
   persistent scope line
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-11 06:15'
+updated_date: '2026-09-11 07:37'
 labels:
   - library
   - media
@@ -23,7 +24,31 @@ The filter box keeps a draft while the list shows the last applied query and the
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A scope line under the Media header states the applied filter, type and sort and the count as N of M, with a Clear action
-- [ ] #2 Clearing the applied filter also clears the box
-- [ ] #3 Pinned
+- [x] #1 A scope line under the Media header states the applied filter, type and sort and the count as N of M, with a Clear action
+- [x] #2 Clearing the applied filter also clears the box
+- [x] #3 Pinned
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Failing UI tests for #library-media-scope-line and #library-media-scope-clear\n2. scope_line/scope_clearable on LibraryMediaCanvasState, built inside build_library_media_browse_state from the APPLIED scope\n3. unfiltered_total passed from library_media_controller\n4. scope row in library_media_canvas compose + Clear routed to the existing clear path, which now also blanks the Input\n5. TCSS rule + bundle rebuild
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The scope line is built inside build_library_media_browse_state from result.scope and result.total -- the APPLIED scope -- so the canvas has no way to render the filter Input's unsubmitted draft by accident. LibraryMediaCanvasState gained scope_line/scope_clearable (both defaulted, so build_library_media_state's callers are unaffected) and the builder gained a keyword-only unfiltered_total for the 'N of M' half.
+
+The sort segment reuses library_choice_label with the MEDIA_SORT_CHOICES display label -- the identical call the '#library-media-sort' Button label makes -- so the line and the control cannot name the same sort two ways.
+
+unfiltered_total comes from a new _library_media_unfiltered_total property on LibraryMediaController that reads the screen's _library_loaded / _library_lookup_error / _local_source_counts. DEVIATION worth knowing: the controller is a separate object wired with injected accessors, not a mixin, so the plan's literal 'self._local_source_counts' raised AttributeError at runtime (caught by the new UI test). Adding a proper accessor would mean editing the LibraryMediaController(...) construction block in library_screen.py, which is outside this branch's ownership, so the property reads self._screen directly and says why.
+
+AC#2: handle_library_media_filter_clear now carries both '#library-media-filter-clear' and '#library-media-scope-clear' and blanks the Input before requesting. The scope line's Clear additionally drops the TYPE facet (_request_library_media_filter grew a clear_type keyword) -- without it the Clear rendered by a type-only scope was a dead button, since the query was already ''. The toolbar's 'Clear filter' still clears only the filter its label names, so neither control's copy lies.
+
+LIVE-FOUND DEFECT, fixed: with the plan's 'width: auto' the scope Static pushed its own Clear Button off the Items pane edge the moment the Reader narrowed the list (235x52). The .library-media-scope-line rule takes 1fr with text-overflow: ellipsis instead; the squeeze lands on the Static and the compact Button keeps its natural width, so task-4023's zero-width-Button hazard is not in play.
+
+Live-verified 235x52: 'Media · 11 of 11 · all types · sort: Newest' with no Clear, then 'Media · 2 of 11 · filter “notes” …   Clear' with the list showing 2 rows, then Clear -> box empty, list back to 11, Clear gone. Also checked at 100x30.
+
+Files: tldw_chatbook/Library/library_media_state.py; tldw_chatbook/UI/Library_Modules/library_media_controller.py; tldw_chatbook/Widgets/Library/library_media_canvas.py; tldw_chatbook/css/components/_agentic_terminal.tcss (+ regenerated bundle); Tests/UI/test_library_crit10_media_rows.py; Docs/User_Guide/library/media-and-conversations.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
+++ b/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
@@ -31,7 +31,10 @@ Selecting a media row prefixes its title with 'Loaded ·' (A caps 39/47); conver
 ## Implementation Plan
 
 <!-- SECTION:PLAN:BEGIN -->
-1. Move the Loading/Loaded state word out of the title into the secondary in _media_row_label\n2. Conversations separator hyphen -> middot; 'New Chat' -> 'Untitled conversation'\n3. Prompts row: drop 'Prompt · ' prefix, 'System + User' -> 'has system and user text'\n4. Import footer: state-dependent Enter label
+1. Move the Loading/Loaded state word out of the title into the secondary in _media_row_label
+2. Conversations separator hyphen -> middot; 'New Chat' -> 'Untitled conversation'
+3. Prompts row: drop 'Prompt · ' prefix, 'System + User' -> 'has system and user text'
+4. Import footer: state-dependent Enter label
 <!-- SECTION:PLAN:END -->
 
 ## Implementation Notes
@@ -48,4 +51,23 @@ AC#3: _library_ingest_shortcuts_for_current_state now derives the Enter label fr
 Live-verified 235x52: the conversation row reads '5 messages · 1h · Default · Active'; the media row reads 'pdf · added 1h ago · keyword: notes · loaded' with an unprefixed title; the Import footer reads 'enter check this path'. The open-gate half could NOT be live-verified: local media Import cannot run on this host (POSIX semaphores exhausted -> multiprocessing.Pool [Errno 28]), so the pre-check never settles and the Start gate never opens. Both strings are pinned by a unit test that drives the controller's state directly.
 
 Files: tldw_chatbook/Widgets/Library/library_media_canvas.py; tldw_chatbook/Library/library_conversations_state.py; tldw_chatbook/Widgets/Library/library_prompts_canvas.py; tldw_chatbook/Library/library_prompts_state.py; tldw_chatbook/UI/Library_Modules/library_ingest_controller.py; tldw_chatbook/UI/Screens/library_screen.py (LIBRARY_INGEST_SHORTCUTS only); Tests/UI/test_library_crit10_media_rows.py, test_library_media_toolbar_adapt.py, test_library_media_reader_shell.py, test_library_ingest_keyboard.py, test_library_prompts_canvas.py; Tests/Library/test_library_conversations_state.py, test_library_prompts_state.py; Docs/User_Guide/library/media-and-conversations.md, prompts.md, import-and-export.md.
+## Fix round 1 (review response)
+
+AC#3 was met in the pure function but not in the running app: nothing
+re-registered the Ingest footer when the Start gate opened. Tracing it under
+a real harness narrowed the review's claim -- the common blank-to-valid-path
+transition is saved by accident, because filling in an empty `type_groups`
+sends `_update_library_ingest_dynamic_regions` down its STRUCTURAL branch and
+that recomposes. Every transition that is NOT structural left the footer
+naming the previous step's action. `_resync_library_ingest_footer()` now runs
+at the pre-flight seam every gate transition passes through; the new app-test
+drives a non-structural transition and is red without it.
+
+Also: the Prompts row now keys off `artifact_type` rather than the rendered
+`type_label`, and the state word is built lower-case once.
+
+The two halves of the critique this task could not close honestly are now
+riders rather than notes inside a closed task: **task-32378** (the prompt
+lane summary reads four different ways across Library and Console) and
+**task-32379** (the stored "New Chat" title, a cross-surface product call).
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
+++ b/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
@@ -3,10 +3,10 @@ id: TASK-32364
 title: >-
   Library copy polish: 'Loaded ·' leaks into a selected row's title, hyphen vs
   middot, 'New Chat', 'Prompt · Local ·' prefix, import 'enter start'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 06:19'
-updated_date: '2026-09-11 07:37'
+updated_date: '2026-09-11 08:00'
 labels:
   - library
   - copy

--- a/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
+++ b/backlog/tasks/task-32364 - Library-copy-polish-Loaded-·-leaks-into-a-selected-rows-title-hyphen-vs-middot-New-Chat-Prompt-·-Local-·-prefix-import-enter-start.md
@@ -3,9 +3,10 @@ id: TASK-32364
 title: >-
   Library copy polish: 'Loaded ·' leaks into a selected row's title, hyphen vs
   middot, 'New Chat', 'Prompt · Local ·' prefix, import 'enter start'
-status: To Do
+status: In Progress
 assignee: []
 created_date: '2026-09-11 06:19'
+updated_date: '2026-09-11 07:37'
 labels:
   - library
   - copy
@@ -22,7 +23,29 @@ Selecting a media row prefixes its title with 'Loaded ·' (A caps 39/47); conver
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Status words never prefix a title
-- [ ] #2 One separator glyph across lists
-- [ ] #3 The import footer names what Enter does at each step
+- [x] #1 Status words never prefix a title
+- [x] #2 One separator glyph across lists
+- [x] #3 The import footer names what Enter does at each step
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Move the Loading/Loaded state word out of the title into the secondary in _media_row_label\n2. Conversations separator hyphen -> middot; 'New Chat' -> 'Untitled conversation'\n3. Prompts row: drop 'Prompt · ' prefix, 'System + User' -> 'has system and user text'\n4. Import footer: state-dependent Enter label
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+AC#1: _media_row_label_rest moved the Loading/Loaded word off the TITLE and onto the fact line ('Attention Is All You Need' / 'pdf · added 1h ago · loaded'). task-30044's constraint -- the SHORT word, never the old 'Loaded in Reader' prose -- still holds. Two pins updated: test_library_media_toolbar_adapt.py (now asserts every density opens with the title AND ends with the state word) and test_library_media_reader_shell.py.
+
+AC#2: library_conversations_state._secondary_text changed '-' to '·'; three pins in Tests/Library/test_library_conversations_state.py updated. The 'New Chat' half of the task DESCRIPTION is not in library_conversations_state.py as the plan expected -- that file already falls back to 'Untitled conversation'. The 'New Chat' the critique saw is a REAL STORED TITLE written by Chat/chat_conversation_service.py:155 and chat_persistence_service.py:1206 at creation time; renaming it there would rename user data and touch Console, so it is left alone and reported. AC#2 itself ('one separator glyph') is satisfied.
+
+Prompts copy: library_prompts_canvas.py drops the leading 'Prompt · ' only when type_label == 'Prompt' -- Recipe and Template still name themselves, since the canvas title covers only the first. 'System + User' -> 'has system and user text' in library_prompts_state.py (where the lane summary is actually built; the plan expected it in the canvas). The three sibling lane values ('System only' / 'User only' / 'Empty') keep their older phrasing because the task named only this one -- the resulting mixed register is flagged for a follow-up.
+
+AC#3: _library_ingest_shortcuts_for_current_state now derives the Enter label from _build_library_ingest_state().start_enabled -- the SAME gate handle_library_ingest_path_submitted obeys -- so the footer cannot promise an import the keypress will decline: 'enter check this path' while shut, 'enter start import' once open. LIBRARY_INGEST_SHORTCUTS keeps the open-gate wording as its base. Two pins in test_library_ingest_keyboard.py were re-pointed from the raw constant to the method, which IS the shared single source now.
+
+Live-verified 235x52: the conversation row reads '5 messages · 1h · Default · Active'; the media row reads 'pdf · added 1h ago · keyword: notes · loaded' with an unprefixed title; the Import footer reads 'enter check this path'. The open-gate half could NOT be live-verified: local media Import cannot run on this host (POSIX semaphores exhausted -> multiprocessing.Pool [Errno 28]), so the pre-check never settles and the Start gate never opens. Both strings are pinned by a unit test that drives the controller's state directly.
+
+Files: tldw_chatbook/Widgets/Library/library_media_canvas.py; tldw_chatbook/Library/library_conversations_state.py; tldw_chatbook/Widgets/Library/library_prompts_canvas.py; tldw_chatbook/Library/library_prompts_state.py; tldw_chatbook/UI/Library_Modules/library_ingest_controller.py; tldw_chatbook/UI/Screens/library_screen.py (LIBRARY_INGEST_SHORTCUTS only); Tests/UI/test_library_crit10_media_rows.py, test_library_media_toolbar_adapt.py, test_library_media_reader_shell.py, test_library_ingest_keyboard.py, test_library_prompts_canvas.py; Tests/Library/test_library_conversations_state.py, test_library_prompts_state.py; Docs/User_Guide/library/media-and-conversations.md, prompts.md, import-and-export.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32378 - Prompt-lane-summary-reads-four-different-ways-across-Library-and-Console.md
+++ b/backlog/tasks/task-32378 - Prompt-lane-summary-reads-four-different-ways-across-Library-and-Console.md
@@ -1,0 +1,27 @@
+---
+id: TASK-32378
+title: Prompt lane summary reads four different ways across Library and Console
+status: To Do
+assignee: []
+created_date: '2026-09-11 08:47'
+labels:
+  - library
+  - console
+  - prompts
+  - copy
+  - critique-10
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+task-32364 changed the Library prompts row's 'System + User' to 'has system and user text' but left its three siblings ('System only', 'User only', 'Empty') in the older register, and Console keeps a separate copy of the same logic with a fourth vocabulary ('System + User' / 'System' / 'User' / 'No compiled lanes'). The same prompt now describes its lanes differently depending on which screen you are on. Evidence: critique #10 fix-wave review of task-32364, findings 6 and the implementer's own open follow-up.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 One vocabulary describes a prompt's lanes on every surface that shows it
+- [ ] #2 Console's prompt row consumes the Library vocabulary rather than repeating the branch
+<!-- AC:END -->

--- a/backlog/tasks/task-32379 - A-conversation-you-never-titled-shows-the-stored-literal-New-Chat-in-Library.md
+++ b/backlog/tasks/task-32379 - A-conversation-you-never-titled-shows-the-stored-literal-New-Chat-in-Library.md
@@ -1,0 +1,27 @@
+---
+id: TASK-32379
+title: A conversation you never titled shows the stored literal 'New Chat' in Library
+status: To Do
+assignee: []
+created_date: '2026-09-11 08:48'
+labels:
+  - library
+  - console
+  - conversations
+  - copy
+  - critique-10
+dependencies: []
+priority: low
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Critique #10 named 'New Chat' as schema-speak in the Library conversations list. It is not a Library display fallback -- library_conversations_state already renders a BLANK title as 'Untitled conversation'. 'New Chat' is a real stored title written at creation time by Chat/chat_conversation_service.py and Chat/chat_persistence_service.py, so relabelling it in the Library would also relabel a conversation a user deliberately named that. Deciding what an untitled conversation is called, and where that name is decided, is a cross-surface product call. Evidence: critique #10 fix-wave review of task-32364, finding 8.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 An untitled conversation reads the same way in Console and in Library
+- [ ] #2 A conversation a user deliberately titled 'New Chat' keeps that title
+<!-- AC:END -->

--- a/tldw_chatbook/Library/library_conversations_state.py
+++ b/tldw_chatbook/Library/library_conversations_state.py
@@ -221,7 +221,9 @@ def _secondary_text(message_count: int | None, age: str) -> str:
     if message_count is None:
         return "conversation"
     if age:
-        return f"{message_count} messages - {age}"
+        # task-32364 AC#2: every other Library list separates row facts with
+        # "·"; Conversations was the one hyphen.
+        return f"{message_count} messages · {age}"
     return f"{message_count} messages"
 
 

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -14,8 +14,8 @@ from rich.cells import cell_len, chop_cells
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
-from tldw_chatbook.Library.library_shell_state import library_choice_label
 from tldw_chatbook.Library.library_pager_state import PageFreshness
+from tldw_chatbook.Library.library_shell_state import library_choice_label
 
 LIBRARY_MEDIA_EMPTY_COPY = (
     "No media in your Library yet. Import something to see it here."
@@ -965,21 +965,26 @@ def media_added_age_copy(value: str, *, now: datetime) -> str:
     reader of an `audio` or `video` row reads a DURATION -- the same row
     read 11m and 14m later (A caps 36/39/47). The Trash list solved this
     long ago by labelling its own age ("trashed 3m"); this is the browse
-    list's half of the same rule. ``format_console_relative_age`` returns
-    the word "now" under a minute, which no "N ago" phrasing survives, so
-    that case gets its own sentence.
+    list's half of the same rule, in the same grammar -- "added 3m", not
+    "added 3m ago" (review round 1). The LABEL is what removes the duration
+    reading; you cannot "add" a file FOR ten minutes. The four cells the
+    " ago" cost landed exactly where this pane is tightest: at the Items
+    pane's narrow widths they pushed a keyword row's own term off the line.
+    ``format_console_relative_age`` returns the word "now" under a minute,
+    which no "added N" phrasing survives, so that case gets its own
+    sentence.
 
     Args:
         value: The record's timestamp text.
         now: Reference time.
 
     Returns:
-        "added 10m ago", "added just now", or "" when unparseable.
+        "added 10m", "added just now", or "" when unparseable.
     """
     age = format_console_relative_age(value, now=now)
     if not age:
         return ""
-    return "added just now" if age == "now" else f"added {age} ago"
+    return "added just now" if age == "now" else f"added {age}"
 
 
 def build_library_media_trash_state(
@@ -1337,21 +1342,26 @@ def _secondary_text(
 ) -> str:
     """Return secondary display text: '{type} · {age}' or fallback.
 
+    ``age`` arrives already labelled from ``media_added_age_copy``
+    ("added 5m") or ``media_trash_age_copy`` ("trashed 5m") -- task-32347;
+    the cell counts below are that longer form's.
+
     Rules:
     - If type and age both present: 'type · age'
     - If only type (no age): 'type'
     - If no type: 'media' (regardless of age)
     - task-28008: an item whose newest version carries analysis text gets a
       trailing ' · analysed'. A WORD, not a colour or a glyph: the row has
-      to say what it means at the Items pane's 36-cell floor, which
-      'document · 5m · analysed' (24 cells) fits.
+      to say what it means at the Items pane's 36-cell floor -- which
+      'document · added 5m · analysed' (30 cells) no longer does with room
+      to spare the way the unlabelled 'document · 5m · analysed' (24) did.
     - task-28008 (critique #5 P2): a row the browse filter found through a
       keyword alone gets a trailing ' · keyword: <term>', the term capped
       at ten CELLS (task-31955 -- a code-point cap let ten CJK characters
       take twenty) so an arbitrarily long tag cannot run away with the
       line. The cap does NOT buy a fit: at the Items pane's 36-cell floor
-      'article · 2m · keyword: notes' already clips at the pane edge, and
-      'type · age · analysed · keyword: term' clips at the default width
+      'article · added 2m · keyword: notes' (35 cells) clips at the pane
+      edge, and 'type · age · analysed · keyword: term' clips at the default width
       too -- the cap bounds the damage, it does not remove it. The cap is
       the term's OWN width, not the pane's, so the line does not change
       under the in-place density and select-mode rebuilds, which re-derive

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -958,20 +958,28 @@ def media_trash_age_copy(trash_date: str | None, *, now: datetime | None = None)
     return f"trashed {age}" if age else ""
 
 
-def media_added_age_copy(value: str, *, now: datetime) -> str:
-    """Return the Media row's age, labelled for what it is.
+def media_updated_age_copy(value: str, *, now: datetime) -> str:
+    """Return the Media row's age, labelled for the field it actually is.
 
     task-32347 (critique #10 P1): the bare compact age ("10m") sat where a
     reader of an `audio` or `video` row reads a DURATION -- the same row
     read 11m and 14m later (A caps 36/39/47). The Trash list solved this
     long ago by labelling its own age ("trashed 3m"); this is the browse
-    list's half of the same rule, in the same grammar -- "added 3m", not
-    "added 3m ago" (review round 1). The LABEL is what removes the duration
-    reading; you cannot "add" a file FOR ten minutes. The four cells the
-    " ago" cost landed exactly where this pane is tightest: at the Items
-    pane's narrow widths they pushed a keyword row's own term off the line.
+    list's half of the same rule, in the same grammar -- "updated 3m", not
+    "updated 3m ago" (review round 1). The LABEL is what removes the
+    duration reading. The four cells the " ago" cost landed exactly where
+    this pane is tightest: at the Items pane's narrow widths they pushed a
+    keyword row's own term off the line.
+
+    The word is "updated", not "added" (re-review round 1, finding A): the
+    value is the record's ``last_modified``, which is what the browse
+    contract projects into ``updated_at`` and what the preview pane two
+    functions down already labels "Updated:". An "added" label would be a
+    second ambiguity in place of the first -- pressing Generate writes
+    ``last_modified``, so an "added" age would move when nothing was added.
+
     ``format_console_relative_age`` returns the word "now" under a minute,
-    which no "added N" phrasing survives, so that case gets its own
+    which no "updated N" phrasing survives, so that case gets its own
     sentence.
 
     Args:
@@ -979,12 +987,12 @@ def media_added_age_copy(value: str, *, now: datetime) -> str:
         now: Reference time.
 
     Returns:
-        "added 10m", "added just now", or "" when unparseable.
+        "updated 10m", "updated just now", or "" when unparseable.
     """
     age = format_console_relative_age(value, now=now)
     if not age:
         return ""
-    return "added just now" if age == "now" else f"added {age}"
+    return "updated just now" if age == "now" else f"updated {age}"
 
 
 def build_library_media_trash_state(
@@ -1163,7 +1171,7 @@ def build_library_media_browse_state(
             media_type=_first_present_text(item, ("media_type",)),
             secondary=_secondary_text(
                 _first_present_text(item, ("media_type",)),
-                media_added_age_copy(
+                media_updated_age_copy(
                     _first_present_text(item, ("updated_at",)), now=reference_now
                 ),
                 analysed=bool(item["has_analysis"]),
@@ -1342,8 +1350,8 @@ def _secondary_text(
 ) -> str:
     """Return secondary display text: '{type} · {age}' or fallback.
 
-    ``age`` arrives already labelled from ``media_added_age_copy``
-    ("added 5m") or ``media_trash_age_copy`` ("trashed 5m") -- task-32347;
+    ``age`` arrives already labelled from ``media_updated_age_copy``
+    ("updated 5m") or ``media_trash_age_copy`` ("trashed 5m") -- task-32347;
     the cell counts below are that longer form's.
 
     Rules:
@@ -1353,14 +1361,14 @@ def _secondary_text(
     - task-28008: an item whose newest version carries analysis text gets a
       trailing ' · analysed'. A WORD, not a colour or a glyph: the row has
       to say what it means at the Items pane's 36-cell floor -- which
-      'document · added 5m · analysed' (30 cells) no longer does with room
+      'document · updated 5m · analysed' (30 cells) no longer does with room
       to spare the way the unlabelled 'document · 5m · analysed' (24) did.
     - task-28008 (critique #5 P2): a row the browse filter found through a
       keyword alone gets a trailing ' · keyword: <term>', the term capped
       at ten CELLS (task-31955 -- a code-point cap let ten CJK characters
       take twenty) so an arbitrarily long tag cannot run away with the
       line. The cap does NOT buy a fit: at the Items pane's 36-cell floor
-      'article · added 2m · keyword: notes' (35 cells) clips at the pane
+      'article · updated 2m · keyword: notes' (35 cells) clips at the pane
       edge, and 'type · age · analysed · keyword: term' clips at the default width
       too -- the cap bounds the damage, it does not remove it. The cap is
       the term's OWN width, not the pane's, so the line does not change
@@ -1525,7 +1533,7 @@ def build_library_media_state(
             media_type=entry.media_type,
             secondary=_secondary_text(
                 entry.media_type,
-                media_added_age_copy(entry.updated_raw, now=reference_now),
+                media_updated_age_copy(entry.updated_raw, now=reference_now),
             ),
             selected=entry.media_id == resolved_selected_id,
             checked=entry.media_id in selected_ids,

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -951,6 +951,30 @@ def media_trash_age_copy(trash_date: str | None, *, now: datetime | None = None)
     return f"trashed {age}" if age else ""
 
 
+def media_added_age_copy(value: str, *, now: datetime) -> str:
+    """Return the Media row's age, labelled for what it is.
+
+    task-32347 (critique #10 P1): the bare compact age ("10m") sat where a
+    reader of an `audio` or `video` row reads a DURATION -- the same row
+    read 11m and 14m later (A caps 36/39/47). The Trash list solved this
+    long ago by labelling its own age ("trashed 3m"); this is the browse
+    list's half of the same rule. ``format_console_relative_age`` returns
+    the word "now" under a minute, which no "N ago" phrasing survives, so
+    that case gets its own sentence.
+
+    Args:
+        value: The record's timestamp text.
+        now: Reference time.
+
+    Returns:
+        "added 10m ago", "added just now", or "" when unparseable.
+    """
+    age = format_console_relative_age(value, now=now)
+    if not age:
+        return ""
+    return "added just now" if age == "now" else f"added {age} ago"
+
+
 def build_library_media_trash_state(
     records: Sequence[Any] | None,
     *,
@@ -1123,7 +1147,7 @@ def build_library_media_browse_state(
             media_type=_first_present_text(item, ("media_type",)),
             secondary=_secondary_text(
                 _first_present_text(item, ("media_type",)),
-                format_console_relative_age(
+                media_added_age_copy(
                     _first_present_text(item, ("updated_at",)), now=reference_now
                 ),
                 analysed=bool(item["has_analysis"]),
@@ -1450,7 +1474,7 @@ def build_library_media_state(
             media_type=entry.media_type,
             secondary=_secondary_text(
                 entry.media_type,
-                format_console_relative_age(entry.updated_raw, now=reference_now),
+                media_added_age_copy(entry.updated_raw, now=reference_now),
             ),
             selected=entry.media_id == resolved_selected_id,
             checked=entry.media_id in selected_ids,

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -1361,14 +1361,14 @@ def _secondary_text(
     - task-28008: an item whose newest version carries analysis text gets a
       trailing ' · analysed'. A WORD, not a colour or a glyph: the row has
       to say what it means at the Items pane's 36-cell floor -- which
-      'document · updated 5m · analysed' (30 cells) no longer does with room
+      'document · updated 5m · analysed' (32 cells) no longer does with room
       to spare the way the unlabelled 'document · 5m · analysed' (24) did.
     - task-28008 (critique #5 P2): a row the browse filter found through a
       keyword alone gets a trailing ' · keyword: <term>', the term capped
       at ten CELLS (task-31955 -- a code-point cap let ten CJK characters
       take twenty) so an arbitrarily long tag cannot run away with the
       line. The cap does NOT buy a fit: at the Items pane's 36-cell floor
-      'article · updated 2m · keyword: notes' (35 cells) clips at the pane
+      'article · updated 2m · keyword: notes' (37 cells) clips at the pane
       edge, and 'type · age · analysed · keyword: term' clips at the default width
       too -- the cap bounds the damage, it does not remove it. The cap is
       the term's OWN width, not the pane's, so the line does not change

--- a/tldw_chatbook/Library/library_media_state.py
+++ b/tldw_chatbook/Library/library_media_state.py
@@ -14,6 +14,7 @@ from rich.cells import cell_len, chop_cells
 from tldw_chatbook.Workspaces.conversation_browser_state import (
     format_console_relative_age,
 )
+from tldw_chatbook.Library.library_shell_state import library_choice_label
 from tldw_chatbook.Library.library_pager_state import PageFreshness
 
 LIBRARY_MEDIA_EMPTY_COPY = (
@@ -879,6 +880,12 @@ class LibraryMediaCanvasState:
     analyze_receipt_failed: int = 0
     analyze_receipt_running: bool = False
     analyze_choice_count: int = 0
+    # task-32350: the applied-scope line under the Media header ("Media · 1
+    # of 11 · filter “notes” · all types · sort: Newest") and whether it
+    # carries a Clear. Built from the APPLIED scope only, never from the
+    # filter Input's draft. "" / False is a browse state built without it.
+    scope_line: str = ""
+    scope_clearable: bool = False
 
 
 @dataclass(frozen=True)
@@ -1105,10 +1112,14 @@ def build_library_media_browse_state(
     analyze_receipt_failed: int = 0,
     analyze_receipt_running: bool = False,
     analyze_choice_count: int = 0,
+    unfiltered_total: int | None = None,
 ) -> LibraryMediaCanvasState:
     """Project one exact Media page without filtering, sorting, or slicing it.
 
     Args:
+        unfiltered_total: The Library's whole Media count, for the scope
+            line's "N of M" (task-32350). ``None`` (the default) means the
+            screen has no trustworthy total yet, and the line says "N".
         review_dismiss_receipt_name: Name of the most recently dismissed
             review set, rendered as a "✓ dismissed · <name>" undo receipt
             until acted on or replaced (task-31236). "" (the default)
@@ -1217,6 +1228,34 @@ def build_library_media_browse_state(
             empty_copy = f"No media of type '{result.scope.media_type}'."
         else:
             empty_copy = LIBRARY_MEDIA_EMPTY_COPY
+    # task-32350 (critique #10 P1): the filter box holds a DRAFT until it is
+    # submitted (deliberate -- the debounce at
+    # library_media_controller.py:2235 is what makes typing usable), so the
+    # box and the list can legitimately disagree. Nothing said which one the
+    # rows came from. This line is built from the APPLIED scope only, so it
+    # cannot echo an unsubmitted draft.
+    scope_parts = [
+        f"Media · {result.total} of {unfiltered_total}"
+        if unfiltered_total is not None and unfiltered_total >= result.total
+        else f"Media · {result.total}"
+    ]
+    if result.scope.query:
+        scope_parts.append(f"filter “{result.scope.query}”")
+    scope_parts.append(
+        f"type {result.scope.media_type}"
+        if result.scope.media_type is not None
+        else "all types"
+    )
+    # The same call the sort chooser's own Button label makes
+    # (library_media_canvas.py), so the line and the control can never name
+    # the same sort two ways.
+    scope_parts.append(
+        library_choice_label(
+            "sort", dict(MEDIA_SORT_CHOICES).get(result.scope.sort_by, "Newest")
+        )
+    )
+    scope_line = " · ".join(scope_parts)
+    scope_clearable = bool(result.scope.query) or result.scope.media_type is not None
     return LibraryMediaCanvasState(
         rows=rows,
         type_options=(None, *normalized_types),
@@ -1241,6 +1280,8 @@ def build_library_media_browse_state(
         analyze_receipt_failed=max(0, analyze_receipt_failed),
         analyze_receipt_running=bool(analyze_receipt_running),
         analyze_choice_count=max(0, analyze_choice_count),
+        scope_line=scope_line,
+        scope_clearable=scope_clearable,
     )
 
 

--- a/tldw_chatbook/Library/library_prompts_state.py
+++ b/tldw_chatbook/Library/library_prompts_state.py
@@ -2144,7 +2144,10 @@ def _row(
     if not isinstance(has_user, bool):
         has_user = bool(_raw_text(record.get("user_prompt")).strip())
     if has_system and has_user:
-        lane_summary = "System + User"
+        # task-32364: "System + User" is schema-speak -- the row says what
+        # the prompt HAS, in words. (The three other lane values keep their
+        # older phrasing; this task named only this one.)
+        lane_summary = "has system and user text"
     elif has_system:
         lane_summary = "System only"
     elif has_user:

--- a/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
@@ -942,9 +942,30 @@ class LibraryIngestController:
     def _run_library_ingest_preflight(self) -> Any:
         return self._run_library_ingest_preflight_fn
 
-    @property
-    def _update_library_ingest_dynamic_regions(self) -> Any:
-        return self._update_library_ingest_dynamic_regions_fn
+    def _update_library_ingest_dynamic_regions(self, *args: Any, **kwargs: Any) -> Any:
+        """Repaint the in-place Ingest regions, then resync the footer.
+
+        Qodo review: the Enter hint is derived from the Start gate, so every
+        in-place gate update has to re-register it -- not just the
+        pre-flight seam. Clearing the path, editing an option, switching
+        backend and the rest all funnel through here, so one wrapper covers
+        them where twelve call-site edits would have covered the same
+        ground. (The three SCREEN-side callers of the underlying method are
+        outside this branch's ownership and stay uncovered; the resume pass
+        at ``library_screen.py:8703`` is one of them and re-registers on its
+        own.)
+
+        Args:
+            *args: Forwarded to the screen's repaint (``allow_screen_fallback``
+                / ``allow_structural_recompose``).
+            **kwargs: Forwarded unchanged.
+
+        Returns:
+            Whatever the screen's repaint returns.
+        """
+        result = self._update_library_ingest_dynamic_regions_fn(*args, **kwargs)
+        self._resync_library_ingest_footer()
+        return result
 
     @property
     def _update_library_ingest_gate(self) -> Any:
@@ -993,20 +1014,30 @@ class LibraryIngestController:
         a REGISTRY event, and the Enter label is the first one driven by FORM
         state. Two things re-registered before this existed -- the registry
         listener, which fires once the import is already running, and, by
-        side effect, ``_update_library_ingest_dynamic_regions``'s STRUCTURAL
-        branch, which recomposes when the type-group set (or the unavailable
-        / backend lines) changes. The common blank-to-valid-path transition
-        happens to take that branch; every gate transition that does not left
-        the footer advertising "check this path" while Enter had started
-        starting the import -- the same wrong-label defect this task exists
-        to remove, moved onto the more expensive press.
+        side effect, the STRUCTURAL branch of the screen's in-place repaint,
+        which recomposes when the type-group set (or the unavailable /
+        backend lines) changes. The common blank-to-valid-path transition
+        happens to take that branch; every gate transition that did not left
+        the footer advertising "check this path" while Enter had already
+        started starting the import -- the same wrong-label defect this task
+        exists to remove, moved onto the more expensive press.
+
+        Called from ``_update_library_ingest_dynamic_regions`` above, the one
+        funnel every in-place gate update takes (Qodo review), so no caller
+        has to remember it.
 
         Deduped on the registration tuple, so an unchanged set costs nothing.
         """
-        if (
-            self._library_selected_row_id != LIBRARY_ROW_INGEST_MEDIA
-            or self._library_screen_suspended
-        ):
+        if self._library_selected_row_id != LIBRARY_ROW_INGEST_MEDIA:
+            return
+        if self._library_screen_suspended:
+            # Re-review finding B: the registry listener LATCHES before it
+            # skips, and the resume pass re-registers only when that latch
+            # is set -- nothing else re-registers for a reused, resumed
+            # screen. A bare return here dropped a gate transition that
+            # happened on another tab, so the footer came back naming the
+            # previous step's action.
+            self._library_ingest_suspended_activity = True
             return
         shortcuts = self._library_ingest_shortcuts_for_current_state()
         registration = ("library", tuple(shortcuts))
@@ -1179,7 +1210,6 @@ class LibraryIngestController:
                 self._library_ingest_suspended_activity = True
             else:
                 self._update_library_ingest_dynamic_regions()
-                self._resync_library_ingest_footer()
         registry = self._library_ingest_registry()
         counts_fn = getattr(registry, "counts", None)
         counts = counts_fn() if callable(counts_fn) else {}
@@ -2091,12 +2121,6 @@ class LibraryIngestController:
         # (task-2042) In-place for the same reason as the trigger: the
         # result can land while the user is typing or mid-click.
         self._update_library_ingest_dynamic_regions()
-        # task-32364 AC#3 (fix round 1): the seam every Start-gate transition
-        # passes through, and the gate now drives a FOOTER label. The line
-        # above re-registers only as a side effect of its STRUCTURAL branch,
-        # so a gate that opens without one left the footer naming the
-        # previous step's action.
-        self._resync_library_ingest_footer()
 
     @on(Button.Pressed, "#library-ingest-start")
     def handle_library_ingest_start(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
@@ -956,6 +956,20 @@ class LibraryIngestController:
     ) -> tuple[tuple[str, str], ...]:
         """Return prioritized Ingest hints, including Retry only when live."""
         shortcuts = list(self.LIBRARY_INGEST_SHORTCUTS)
+        # task-32364 AC#3: the first Enter validates the path and the second
+        # runs the queue; one label for two different actions taught the
+        # wrong thing at exactly the moment the user commits. The gate this
+        # reads is the SAME one Enter itself obeys
+        # (``handle_library_ingest_path_submitted``), so the footer can
+        # never promise an import the keypress will decline.
+        state_fn = getattr(self, "_build_library_ingest_state", None)
+        start_enabled = bool(
+            getattr(state_fn(), "start_enabled", False) if callable(state_fn) else False
+        )
+        shortcuts[0] = (
+            "enter",
+            "start import" if start_enabled else "check this path",
+        )
         if getattr(self, "_library_ingest_start_consent", None) is not None:
             shortcuts[1] = ("esc", "cancel")
         registry = getattr(

--- a/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
@@ -986,6 +986,29 @@ class LibraryIngestController:
             shortcuts.insert(2, ("r", "retry"))
         return tuple(shortcuts)
 
+    def _resync_library_ingest_footer(self) -> None:
+        """Re-register the Ingest footer when its state-derived set changed.
+
+        task-32364 AC#3 (fix round 1): every other entry in this set turns on
+        a REGISTRY event, and the registry listener was the only thing that
+        re-registered -- it fires once the import is already running. The
+        Enter label is the first entry driven by FORM state, so without this
+        the first Enter opened the Start gate and the footer went on
+        advertising "check this path" while Enter now started the import: the
+        same wrong-label defect, moved onto the more expensive press.
+
+        Deduped on the registration tuple, so an unchanged set costs nothing.
+        """
+        if (
+            self._library_selected_row_id != LIBRARY_ROW_INGEST_MEDIA
+            or self._library_screen_suspended
+        ):
+            return
+        shortcuts = self._library_ingest_shortcuts_for_current_state()
+        registration = ("library", tuple(shortcuts))
+        if self._footer_shortcut_registration != registration:
+            self.register_footer_shortcuts(source="library", shortcuts=shortcuts)
+
     def _sync_library_ingest_rail_for_width(self, width: int) -> None:
         """Auto-collapse the rail only while narrow Ingest needs the space."""
         # The grid carries a wide min-width and can report its virtual width
@@ -1152,12 +1175,7 @@ class LibraryIngestController:
                 self._library_ingest_suspended_activity = True
             else:
                 self._update_library_ingest_dynamic_regions()
-                shortcuts = self._library_ingest_shortcuts_for_current_state()
-                registration = ("library", tuple(shortcuts))
-                if self._footer_shortcut_registration != registration:
-                    self.register_footer_shortcuts(
-                        source="library", shortcuts=shortcuts
-                    )
+                self._resync_library_ingest_footer()
         registry = self._library_ingest_registry()
         counts_fn = getattr(registry, "counts", None)
         counts = counts_fn() if callable(counts_fn) else {}
@@ -2069,6 +2087,12 @@ class LibraryIngestController:
         # (task-2042) In-place for the same reason as the trigger: the
         # result can land while the user is typing or mid-click.
         self._update_library_ingest_dynamic_regions()
+        # task-32364 AC#3 (fix round 1): this is the seam every Start-gate
+        # transition passes through, and the gate now drives a FOOTER label.
+        # The line above only re-registers as a side effect of its STRUCTURAL
+        # branch (a changed type-group set), so a gate that opens without one
+        # left the footer naming the previous step's action.
+        self._resync_library_ingest_footer()
 
     @on(Button.Pressed, "#library-ingest-start")
     def handle_library_ingest_start(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_ingest_controller.py
@@ -990,12 +990,16 @@ class LibraryIngestController:
         """Re-register the Ingest footer when its state-derived set changed.
 
         task-32364 AC#3 (fix round 1): every other entry in this set turns on
-        a REGISTRY event, and the registry listener was the only thing that
-        re-registered -- it fires once the import is already running. The
-        Enter label is the first entry driven by FORM state, so without this
-        the first Enter opened the Start gate and the footer went on
-        advertising "check this path" while Enter now started the import: the
-        same wrong-label defect, moved onto the more expensive press.
+        a REGISTRY event, and the Enter label is the first one driven by FORM
+        state. Two things re-registered before this existed -- the registry
+        listener, which fires once the import is already running, and, by
+        side effect, ``_update_library_ingest_dynamic_regions``'s STRUCTURAL
+        branch, which recomposes when the type-group set (or the unavailable
+        / backend lines) changes. The common blank-to-valid-path transition
+        happens to take that branch; every gate transition that does not left
+        the footer advertising "check this path" while Enter had started
+        starting the import -- the same wrong-label defect this task exists
+        to remove, moved onto the more expensive press.
 
         Deduped on the registration tuple, so an unchanged set costs nothing.
         """
@@ -2087,11 +2091,11 @@ class LibraryIngestController:
         # (task-2042) In-place for the same reason as the trigger: the
         # result can land while the user is typing or mid-click.
         self._update_library_ingest_dynamic_regions()
-        # task-32364 AC#3 (fix round 1): this is the seam every Start-gate
-        # transition passes through, and the gate now drives a FOOTER label.
-        # The line above only re-registers as a side effect of its STRUCTURAL
-        # branch (a changed type-group set), so a gate that opens without one
-        # left the footer naming the previous step's action.
+        # task-32364 AC#3 (fix round 1): the seam every Start-gate transition
+        # passes through, and the gate now drives a FOOTER label. The line
+        # above re-registers only as a side effect of its STRUCTURAL branch,
+        # so a gate that opens without one left the footer naming the
+        # previous step's action.
         self._resync_library_ingest_footer()
 
     @on(Button.Pressed, "#library-ingest-start")

--- a/tldw_chatbook/UI/Library_Modules/library_media_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_controller.py
@@ -946,7 +946,7 @@ class LibraryMediaController:
         screen = self._screen
         if not screen._library_loaded or screen._library_lookup_error:
             return None
-        # Review finding 1 (fix round 1): the count is sometimes a LOWER
+        # Review finding 2 (fix round 1): the count is sometimes a LOWER
         # BOUND -- a bounded preview page with no `total` -- which is why
         # the screen keeps this flag and why every other consumer renders
         # "5+" rather than "5". A scope line stating a flat "of 5" beside a
@@ -2251,9 +2251,18 @@ class LibraryMediaController:
         query = self._safe_text(query, max_length=200).strip()
         controller = self._library_media_browse_controller
         applied = controller.applied_scope or controller.mutation_refresh_scope
-        if query == controller.requested_scope.query and not (
-            clear_type and controller.requested_scope.media_type is not None
-        ):
+        # Qodo review: the scope line and its Clear are derived from the
+        # APPLIED result, so a failed browse leaves a visible Clear whose
+        # REQUESTED scope is already the target. Testing the requested scope
+        # alone made every later press of that still-visible button a no-op,
+        # with no way to retry. Suppress only when the page the user is
+        # actually looking at is already there too.
+        def _is_target(scope: Any) -> bool:
+            return query == scope.query and not (
+                clear_type and scope.media_type is not None
+            )
+
+        if _is_target(controller.requested_scope) and _is_target(applied):
             return
         self._clear_library_media_selection_for_scope_change()
         if query:
@@ -2313,7 +2322,14 @@ class LibraryMediaController:
 
     @on(Button.Pressed, "#library-media-scope-clear")
     def handle_library_media_scope_clear(self, event: Button.Pressed) -> None:
-        """Clear the whole scope the scope line states (task-32350)."""
+        """Clear the whole scope the scope line states (task-32350).
+
+        Args:
+            event: Press of the scope line's "Clear", routed here by the
+                canvas. Stopped so the shared list-row handlers never see
+                it; the toolbar's "Clear filter" has its own handler
+                because the two clear different things.
+        """
         event.stop()
         self._clear_library_media_filter(clear_type=True)
 

--- a/tldw_chatbook/UI/Library_Modules/library_media_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_controller.py
@@ -946,6 +946,14 @@ class LibraryMediaController:
         screen = self._screen
         if not screen._library_loaded or screen._library_lookup_error:
             return None
+        # Review finding 1 (fix round 1): the count is sometimes a LOWER
+        # BOUND -- a bounded preview page with no `total` -- which is why
+        # the screen keeps this flag and why every other consumer renders
+        # "5+" rather than "5". A scope line stating a flat "of 5" beside a
+        # rail saying "5+" is exactly the claim this line exists to avoid,
+        # so an unknown total drops the "of M" half instead.
+        if not screen._local_source_total_known.get("media", True):
+            return None
         return screen._local_source_counts.get("media")
 
 

--- a/tldw_chatbook/UI/Library_Modules/library_media_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_controller.py
@@ -2282,22 +2282,32 @@ class LibraryMediaController:
         self._stop_library_media_filter_timer()
         self._request_library_media_filter(event.value)
 
-    @on(Button.Pressed, "#library-media-filter-clear")
-    @on(Button.Pressed, "#library-media-scope-clear")
-    def handle_library_media_filter_clear(self, event: Button.Pressed) -> None:
-        event.stop()
+    def _clear_library_media_filter(self, *, clear_type: bool) -> None:
+        """Drop the applied filter, and the type facet when asked.
+
+        Args:
+            clear_type: True for the scope line's Clear, which clears the
+                whole scope that line states; False for the toolbar's
+                "Clear filter", which clears only the filter it names.
+        """
         self._stop_library_media_filter_timer()
         # task-32350 AC#2: clearing the APPLIED filter clears the box too --
         # leaving a draft behind is exactly the split-brain this task closes.
         box = self.query("#library-media-filter")
         if box:
             box.first(Input).value = ""
-        # The scope line's Clear clears the whole scope that line states,
-        # type included; the toolbar's "Clear filter" keeps clearing only
-        # the filter its label names.
-        self._request_library_media_filter(
-            "", clear_type=event.button.id == "library-media-scope-clear"
-        )
+        self._request_library_media_filter("", clear_type=clear_type)
+
+    @on(Button.Pressed, "#library-media-filter-clear")
+    def handle_library_media_filter_clear(self, event: Button.Pressed) -> None:
+        event.stop()
+        self._clear_library_media_filter(clear_type=False)
+
+    @on(Button.Pressed, "#library-media-scope-clear")
+    def handle_library_media_scope_clear(self, event: Button.Pressed) -> None:
+        """Clear the whole scope the scope line states (task-32350)."""
+        event.stop()
+        self._clear_library_media_filter(clear_type=True)
 
     def _load_library_media_list_if_needed(self) -> None:
         """Load the exact list after a direct viewer had no applied page."""

--- a/tldw_chatbook/UI/Library_Modules/library_media_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_media_controller.py
@@ -929,6 +929,25 @@ class LibraryMediaController:
     def _local_source_records(self) -> Any:
         return self._local_source_records_accessor()
 
+    @property
+    def _library_media_unfiltered_total(self) -> int | None:
+        """The rail's whole-Media count, for the scope line's "N of M".
+
+        task-32350. Read straight off the screen: the accessor-injection
+        site lives in a ``library_screen.py`` range this branch does not
+        own, and these three names are getter-only shell state of exactly
+        the kind ``local_source_records_accessor`` already carries.
+
+        Returns:
+            The Library's Media count, or ``None`` while the snapshot is
+            not trustworthy -- the count's ``0`` default would otherwise
+            render as "1 of 0".
+        """
+        screen = self._screen
+        if not screen._library_loaded or screen._library_lookup_error:
+            return None
+        return screen._local_source_counts.get("media")
+
 
     # -- shared shell state this cluster also writes (group (b')) ----------
 
@@ -1908,6 +1927,9 @@ class LibraryMediaController:
                 else ""
             ),
             loaded_id=self._library_media_reader_session.loaded_id or "",
+            # task-32350: the rail's unfiltered Media total, for the scope
+            # line's "N of M".
+            unfiltered_total=self._library_media_unfiltered_total,
         )
         if controller.loading and controller.inflight_scope is not None:
             state = dataclasses.replace(state, query=controller.inflight_scope.query)
@@ -2206,12 +2228,24 @@ class LibraryMediaController:
             fingerprint=self._library_media_browse_controller.requested_scope.fingerprint
         )
 
-    def _request_library_media_filter(self, query: str) -> None:
-        """Request authoritative search while preserving the unfiltered anchor."""
+    def _request_library_media_filter(
+        self, query: str, *, clear_type: bool = False
+    ) -> None:
+        """Request authoritative search while preserving the unfiltered anchor.
+
+        Args:
+            query: The filter text to apply; "" restores the unfiltered
+                anchor scope and its previous selection.
+            clear_type: Also drop the applied type facet (task-32350). The
+                scope line's Clear clears the whole scope it states; the
+                toolbar's "Clear filter" clears only the filter it names.
+        """
         query = self._safe_text(query, max_length=200).strip()
         controller = self._library_media_browse_controller
         applied = controller.applied_scope or controller.mutation_refresh_scope
-        if query == controller.requested_scope.query:
+        if query == controller.requested_scope.query and not (
+            clear_type and controller.requested_scope.media_type is not None
+        ):
             return
         self._clear_library_media_selection_for_scope_change()
         if query:
@@ -2226,6 +2260,8 @@ class LibraryMediaController:
             )
             self._library_media_filter_select_first = False
             scope = self._library_media_unfiltered_scope
+        if clear_type:
+            scope = dataclasses.replace(scope, media_type=None, page=1)
         self._request_library_media_browse(
             scope,
             focus_identity="#library-media-filter",
@@ -2247,10 +2283,21 @@ class LibraryMediaController:
         self._request_library_media_filter(event.value)
 
     @on(Button.Pressed, "#library-media-filter-clear")
+    @on(Button.Pressed, "#library-media-scope-clear")
     def handle_library_media_filter_clear(self, event: Button.Pressed) -> None:
         event.stop()
         self._stop_library_media_filter_timer()
-        self._request_library_media_filter("")
+        # task-32350 AC#2: clearing the APPLIED filter clears the box too --
+        # leaving a draft behind is exactly the split-brain this task closes.
+        box = self.query("#library-media-filter")
+        if box:
+            box.first(Input).value = ""
+        # The scope line's Clear clears the whole scope that line states,
+        # type included; the toolbar's "Clear filter" keeps clearing only
+        # the filter its label names.
+        self._request_library_media_filter(
+            "", clear_type=event.button.id == "library-media-scope-clear"
+        )
 
     def _load_library_media_list_if_needed(self) -> None:
         """Load the exact list after a direct viewer had no applied page."""

--- a/tldw_chatbook/UI/Screens/library_screen.py
+++ b/tldw_chatbook/UI/Screens/library_screen.py
@@ -1291,8 +1291,13 @@ class LibraryScreen(BaseAppScreen):
     #: landing (``action_library_ingest_back``). Shared by the footer and
     #: F1 via ``_library_footer_shortcuts_for_current_state``, the
     #: task-2858 single-source rule.
+    #:
+    #: task-32364 AC#3: the Enter row here is the OPEN-gate wording only.
+    #: ``_library_ingest_shortcuts_for_current_state`` replaces it with
+    #: "check this path" while the gate is shut, because the first Enter on
+    #: an unvalidated path validates rather than imports.
     LIBRARY_INGEST_SHORTCUTS = (
-        ("enter", "start"),
+        ("enter", "start import"),
         ("esc", "back"),
         ("/", "search"),
         ("F6", "next pane"),

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -1018,26 +1018,30 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         # draft until submitted, so it cannot be trusted to describe the
         # rows; this line is projected from the applied scope in
         # build_library_media_browse_state and can only ever agree with them.
-        scope_row = Horizontal(id="library-media-scope-row")
-        scope_row.styles.height = "auto"
-        with scope_row:
-            # Width comes from `.library-media-scope-line` (1fr + ellipsis),
-            # not an inline style: an auto-width Static pushed its own Clear
-            # off the pane edge once the Reader narrowed Items.
-            yield Static(
-                self.canvas.scope_line,
-                id="library-media-scope-line",
-                classes="library-media-scope-line",
-                markup=False,
-            )
-            if self.canvas.scope_clearable:
-                yield Button(
-                    "Clear",
-                    id="library-media-scope-clear",
-                    classes="library-canvas-action",
-                    compact=True,
-                    tooltip="Clear the filter and type this line states.",
+        # A state built by the legacy ``build_library_media_state`` carries no
+        # scope_line; an empty Static would just spend a row saying nothing.
+        if self.canvas.scope_line:
+            scope_row = Horizontal(id="library-media-scope-row")
+            scope_row.styles.height = "auto"
+            with scope_row:
+                # Width comes from `.library-media-scope-line` (1fr +
+                # ellipsis), not an inline style: an auto-width Static
+                # pushed its own Clear off the pane edge once the Reader
+                # narrowed Items.
+                yield Static(
+                    self.canvas.scope_line,
+                    id="library-media-scope-line",
+                    classes="library-media-scope-line",
+                    markup=False,
                 )
+                if self.canvas.scope_clearable:
+                    yield Button(
+                        "Clear",
+                        id="library-media-scope-clear",
+                        classes="library-canvas-action",
+                        compact=True,
+                        tooltip="Clear the filter and type this line states.",
+                    )
         filter_row = Horizontal(classes="ds-toolbar")
         filter_row.styles.height = "auto"
         with filter_row:

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -468,6 +468,10 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         A separate row from "Clear filter" on purpose: the two clear
         different things, and the region-ownership census maps one handler
         to exactly one selector.
+
+        Args:
+            event: Press of the scope line's "Clear", forwarded unchanged to
+                the media controller, which owns the behaviour.
         """
         actions = self._media_actions_for_press(event)
         if actions is not None:

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -196,17 +196,21 @@ def _media_row_label_rest(
     """Return the marker-free Media row label for one responsive density.
 
     task-30044 (critique 2026-09-03 P2): both densities use the SHORT state
-    prefix ("Loaded · " / "Loading · ") -- the old wide-mode prose ("Loaded
-    in Reader            ") consumed ~28 of ~35 label cells and displaced
+    word ("loaded" / "loading") -- the old wide-mode prose ("Loaded in
+    Reader            ") consumed ~28 of ~35 label cells and displaced
     titles to "Quart"/"SQLit", so the row that mattered most was the one
     you couldn't identify.
     """
     visible_title = _visible_row_title(title)
+    # task-32364 AC#1 (critique #10): the state used to prefix the TITLE
+    # ("▸ Loaded · Attention Is All You Need"), so the row's identity was
+    # displaced by its status. task-30044's constraint still holds -- the
+    # SHORT word, never the old prose -- it just belongs on the fact line.
     state = "Loading" if loading else "Loaded" if loaded else ""
-    prefix = f"{state} · " if state else ""
+    detail = f"{secondary} · {state.lower()}" if state else secondary
     if compact:
-        return f" {prefix}{visible_title} · {secondary}"
-    return f" {prefix}{visible_title}\n    {secondary}"
+        return f" {visible_title} · {detail}"
+    return f" {visible_title}\n    {detail}"
 
 
 class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical):

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -451,8 +451,9 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             self.actions.handle_library_media_filter_submitted(event)
 
     @on(Button.Pressed, "#library-media-filter-clear")
+    @on(Button.Pressed, "#library-media-scope-clear")
     def handle_library_media_filter_clear(self, event: Button.Pressed) -> None:
-        """Route "Clear filter" to the media controller."""
+        """Route "Clear filter" and the scope line's Clear to the controller."""
         actions = self._media_actions_for_press(event)
         if actions is not None:
             actions.handle_library_media_filter_clear(event)
@@ -1009,6 +1010,29 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             )
             sets_btn.display = not select_mode
             yield sets_btn
+        # task-32350: the applied scope, stated. The filter Input below is a
+        # draft until submitted, so it cannot be trusted to describe the
+        # rows; this line is projected from the applied scope in
+        # build_library_media_browse_state and can only ever agree with them.
+        scope_row = Horizontal(id="library-media-scope-row")
+        scope_row.styles.height = "auto"
+        with scope_row:
+            scope_static = Static(
+                self.canvas.scope_line,
+                id="library-media-scope-line",
+                classes="library-media-scope-line",
+                markup=False,
+            )
+            scope_static.styles.width = "auto"
+            yield scope_static
+            if self.canvas.scope_clearable:
+                yield Button(
+                    "Clear",
+                    id="library-media-scope-clear",
+                    classes="library-canvas-action",
+                    compact=True,
+                    tooltip="Clear the filter and type this line states.",
+                )
         filter_row = Horizontal(classes="ds-toolbar")
         filter_row.styles.height = "auto"
         with filter_row:

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -455,12 +455,23 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
             self.actions.handle_library_media_filter_submitted(event)
 
     @on(Button.Pressed, "#library-media-filter-clear")
-    @on(Button.Pressed, "#library-media-scope-clear")
     def handle_library_media_filter_clear(self, event: Button.Pressed) -> None:
-        """Route "Clear filter" and the scope line's Clear to the controller."""
+        """Route "Clear filter" to the media controller."""
         actions = self._media_actions_for_press(event)
         if actions is not None:
             actions.handle_library_media_filter_clear(event)
+
+    @on(Button.Pressed, "#library-media-scope-clear")
+    def handle_library_media_scope_clear(self, event: Button.Pressed) -> None:
+        """Route the scope line's Clear to the media controller (task-32350).
+
+        A separate row from "Clear filter" on purpose: the two clear
+        different things, and the region-ownership census maps one handler
+        to exactly one selector.
+        """
+        actions = self._media_actions_for_press(event)
+        if actions is not None:
+            actions.handle_library_media_scope_clear(event)
 
     @on(Button.Pressed, "#library-media-sort")
     def handle_library_media_sort(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -1021,14 +1021,15 @@ class LibraryMediaCanvas(PostRecomposeCallback, RecomposeCaptureGuard, Vertical)
         scope_row = Horizontal(id="library-media-scope-row")
         scope_row.styles.height = "auto"
         with scope_row:
-            scope_static = Static(
+            # Width comes from `.library-media-scope-line` (1fr + ellipsis),
+            # not an inline style: an auto-width Static pushed its own Clear
+            # off the pane edge once the Reader narrowed Items.
+            yield Static(
                 self.canvas.scope_line,
                 id="library-media-scope-line",
                 classes="library-media-scope-line",
                 markup=False,
             )
-            scope_static.styles.width = "auto"
-            yield scope_static
             if self.canvas.scope_clearable:
                 yield Button(
                     "Clear",

--- a/tldw_chatbook/Widgets/Library/library_media_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_media_canvas.py
@@ -206,8 +206,8 @@ def _media_row_label_rest(
     # ("▸ Loaded · Attention Is All You Need"), so the row's identity was
     # displaced by its status. task-30044's constraint still holds -- the
     # SHORT word, never the old prose -- it just belongs on the fact line.
-    state = "Loading" if loading else "Loaded" if loaded else ""
-    detail = f"{secondary} · {state.lower()}" if state else secondary
+    state = "loading" if loading else "loaded" if loaded else ""
+    detail = f"{secondary} · {state}" if state else secondary
     if compact:
         return f" {visible_title} · {detail}"
     return f" {visible_title}\n    {detail}"

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -1014,7 +1014,7 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
                 summary_parts = [
                     part
                     for part in (
-                        "" if row.type_label == "Prompt" else row.type_label,
+                        "" if row.artifact_type == "prompt" else row.type_label,
                         row.source_label,
                         row.lane_summary,
                     )

--- a/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
+++ b/tldw_chatbook/Widgets/Library/library_prompts_canvas.py
@@ -1006,9 +1006,21 @@ class LibraryPromptsListCanvas(PostRecomposeCallback, Vertical):
                 # description) and must be escaped too, not just the name.
                 name = escape_markup(row.name)
                 secondary = escape_markup(row.secondary) if row.secondary else ""
-                artifact_summary = escape_markup(
-                    f"{row.type_label} · {row.source_label} · {row.lane_summary}"
-                )
+                # task-32364: the canvas is already titled Prompts, so a
+                # leading "Prompt · " on every row spent cells telling the
+                # reader where they already are. The other artifact types
+                # (Recipe, Template) still name themselves -- they are the
+                # ones the canvas title does NOT cover.
+                summary_parts = [
+                    part
+                    for part in (
+                        "" if row.type_label == "Prompt" else row.type_label,
+                        row.source_label,
+                        row.lane_summary,
+                    )
+                    if part
+                ]
+                artifact_summary = escape_markup(" · ".join(summary_parts))
                 selection_prefix = ""
                 if state.select_mode:
                     selection_prefix = "☑ " if row.checked else "☐ "

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4095,6 +4095,15 @@ Input.library-media-speaker-input:focus {
     text-style: bold;
 }
 
+/* task-32350 (critique #10 P1): the applied-scope line under the Media
+   header. Quiet by design -- it is a statement of fact, not an action. */
+.library-media-scope-line {
+    color: $ds-text-muted;
+    width: auto;
+    height: 1;
+    padding: 0 1 0 0;
+}
+
 #console-workspace-grid {
     height: $ds-console-workspace-grid-height;
     min-height: 20;

--- a/tldw_chatbook/css/components/_agentic_terminal.tcss
+++ b/tldw_chatbook/css/components/_agentic_terminal.tcss
@@ -4096,12 +4096,19 @@ Input.library-media-speaker-input:focus {
 }
 
 /* task-32350 (critique #10 P1): the applied-scope line under the Media
-   header. Quiet by design -- it is a statement of fact, not an action. */
+   header. Quiet by design -- it is a statement of fact, not an action.
+   `1fr`, not `auto`: this line is long (a filter term and a sort label),
+   and an auto-width Static pushed its own Clear Button off the pane edge
+   once the Reader narrowed Items (live-verified at 235x52). The squeeze
+   lands on the Static, which ellipsises; the compact Button keeps its
+   natural width, so task-4023's zero-width-Button hazard is not in play. */
 .library-media-scope-line {
     color: $ds-text-muted;
-    width: auto;
+    width: 1fr;
     height: 1;
     padding: 0 1 0 0;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
 }
 
 #console-workspace-grid {

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2873,6 +2873,15 @@ Input.library-media-speaker-input:focus {
     text-style: bold;
 }
 
+/* task-32350 (critique #10 P1): the applied-scope line under the Media
+   header. Quiet by design -- it is a statement of fact, not an action. */
+.library-media-scope-line {
+    color: $ds-text-muted;
+    width: auto;
+    height: 1;
+    padding: 0 1 0 0;
+}
+
 /* TASK-716: pressable-but-blocked Library source actions render dim; the
    press handler explains the block instead of a dead disabled button. */
 .library-source-action-blocked {

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -2874,12 +2874,19 @@ Input.library-media-speaker-input:focus {
 }
 
 /* task-32350 (critique #10 P1): the applied-scope line under the Media
-   header. Quiet by design -- it is a statement of fact, not an action. */
+   header. Quiet by design -- it is a statement of fact, not an action.
+   `1fr`, not `auto`: this line is long (a filter term and a sort label),
+   and an auto-width Static pushed its own Clear Button off the pane edge
+   once the Reader narrowed Items (live-verified at 235x52). The squeeze
+   lands on the Static, which ellipsises; the compact Button keeps its
+   natural width, so task-4023's zero-width-Button hazard is not in play. */
 .library-media-scope-line {
     color: $ds-text-muted;
-    width: auto;
+    width: 1fr;
     height: 1;
     padding: 0 1 0 0;
+    text-wrap: nowrap;
+    text-overflow: ellipsis;
 }
 
 /* TASK-716: pressable-but-blocked Library source actions render dim; the


### PR DESCRIPTION
Part of the Library critique-10 fix wave (plan: `Docs/superpowers/plans/2026-09-11-library-crit10-wave.md`, group `media-rows`).

## What
- **task-32347 (critique-10 P1)** — a media row's age reads as an age, not a duration: `added 10m` (with the row's own time column keeping the duration), so "3h" no longer looks like a three-hour recording.
- **task-32350** — a scope line above the Items list states the applied filter (query, type facet, sort) with its own Clear; the Clear stays on screen when the Reader narrows the list (`1fr` + ellipsis, live-captured before/after), drops the type facet too (a type-only scope had a dead Clear otherwise), and the line does not paint an empty row for a legacy-built canvas state.
- **task-32364** — copy polish across the lists and the import footer: the Enter label reaches the footer on every ingest transition (the non-structural branch of the dynamic-region update now re-registers it), "N of M" reads honestly when the total is unknown, and the prompts/conversations row copy pins match what the rows paint.

## Evidence
- `Tests/UI/test_library_crit10_media_rows.py` (8 tests, red-first; the footer pin applies the same pre-flight result twice so the structural branch cannot mask the hole) + pins in `test_library_media_state.py`, `test_library_prompts_canvas.py`; 606 passed across the touched suites; `test_library_media_render_fixes.py` keeps exactly its 5 dev-red names, zero new.
- Live-verified at 235x52 and 100x30 on an isolated seeded profile (captures in the task notes).
- Guides: `library.md`, `library/media-and-conversations.md`, `library/import-and-export.md` with refreshed stamps.

## Review
Task review (Changes requested: 1 high — ingest footer not re-registered when the Start gate opens — 2 medium, 1 low-medium, 7 low, 2 nits) → fix round 1 (`41bae43322`, `49eb56e6fd`, `a9da7f428c`: 11 fixed, 1 declined by controller ruling, 2 became riders task-32378 prompt-lane vocabulary and task-32379 stored "New Chat" title). Scoped re-review in progress. Deviations from the brief are listed in the task notes (controller accessor read, sort label call, scope-line width, Clear drops the type facet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the critique-10 media-row wave: media rows label their age, the Media list states its applied scope with a Clear, and list and import-footer copy is standardized.

- A media row's age now reads as an age — "audio · updated 10m", "updated just now" under a minute — instead of a bare "10m" that read as the item's duration; the word is "updated" because the value is the last-modified time, which Generate moves.
- The scope line under the Media header states the applied filter, type, and sort with the count as "N of M", built only from applied state so the filter box's unsubmitted draft never appears.
- The scope line's Clear drops the filter and type and blanks the box, and stays retryable after a failed clear; the toolbar's "Clear filter" still clears only the filter it names.
- The "of M" half is dropped when the Media total is only a lower bound, matching the rail's "5+".
- The "· loaded"/"· loading" state moved off the row title onto the fact line; titles always open their own rows now.
- Conversations rows use the same "·" separator as every other list; plain prompt rows drop the "Prompt · " prefix; "System + User" reads "has system and user text".
- The Import footer names Enter's action by gate state — "enter check this path" / "enter start import" — and re-registers on every gate transition, including non-structural ones and while suspended.
- The labelled age costs ~8 cells per row: keyword rows clip sooner at the narrow Items width and the "· loaded" row clips first at 100 columns (pinned to the exact new output, not loosened).
- The stored "New Chat" title and the mixed prompt-lane register are filed as task-32379 and task-32378 rather than relabelled here.

<sup>Written for commit c971ecfa63d4351749b185526b5089e77fe22351. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

