### PR TITLE
fix(library-notes): lasting-sync Check refuses honestly, never leaks the root, and names its reason (tasks 32243, 32244, 32269)

### DIFF
--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -498,7 +498,8 @@ separate memory, see [File notes](file-notes.md).
 (not a link to one) on a local disk, outside Chatbook's own data directory,
 not already connected as a sync folder, not the Folder files root, and you
 must be able to write every file in it. **Check changes** refuses anything
-else and names which of those it was, at the control, with the next action —
+else and names which of those it was, in the setup pane's status line, with
+the next action —
 for example "That folder is inside Chatbook's own data directory. Pick a
 folder outside it, then Check again", "Another Chatbook window is using that
 folder", "That folder is already connected", or "Some files there use a
@@ -692,9 +693,9 @@ outside the batch stayed as text and are not counted.
    away). Choose a direction and local destination. Server sync remains
    unavailable until its separate capability is installed.
 4. Choose **Check changes** and review the exact safe, attention, skipped, and
-   deletion-like effects. If the folder cannot be used, the line above the
-   button says which rule it broke and what to do; choose **Choose folder…**
-   again and check the new one.
+   deletion-like effects. If the folder cannot be used, the status line under
+   the pane's "Add files to Library notes" heading says which rule it broke
+   and what to do; choose **Choose folder…** again and check the new one.
 5. Choose **Activate reviewed root**. If the review is stale, choose **Check
    again** instead. **Manage sync folders** appears in the notes toolbar once
    a root is active.

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -494,6 +494,18 @@ The first use of either — or a remembered folder that has since been moved or
 deleted — opens at your home directory instead. **Folder files** keeps its own
 separate memory, see [File notes](file-notes.md).
 
+**What a folder has to be before it can be checked.** It must be a real folder
+(not a link to one) on a local disk, outside Chatbook's own data directory,
+not already connected as a sync folder, not the Folder files root, and you
+must be able to write every file in it. **Check changes** refuses anything
+else and names which of those it was, at the control, with the next action —
+for example "That folder is inside Chatbook's own data directory. Pick a
+folder outside it, then Check again", "Another Chatbook window is using that
+folder", "That folder is already connected", or "Some files there use a
+permission model this sync can't track. Make every file in the folder
+writable, then Check again". A refusal changes nothing: pick a different
+folder, or fix the cause, and **Check changes** again in the same session.
+
 If files or notes change after checking, activation is refused as stale and the
 nearest valid action is **Check again**. Conflicts and deletion choices are not
 silently settled by a global winner policy. Server setup is visibly disabled
@@ -680,9 +692,12 @@ outside the batch stayed as text and are not counted.
    away). Choose a direction and local destination. Server sync remains
    unavailable until its separate capability is installed.
 4. Choose **Check changes** and review the exact safe, attention, skipped, and
-   deletion-like effects.
+   deletion-like effects. If the folder cannot be used, the line above the
+   button says which rule it broke and what to do; choose **Choose folder…**
+   again and check the new one.
 5. Choose **Activate reviewed root**. If the review is stale, choose **Check
-   again** instead.
+   again** instead. **Manage sync folders** appears in the notes toolbar once
+   a root is active.
 
 Existing legacy evidence appears as a paused candidate. Open **Manage sync
 folders**, choose **Review migration**, inspect the current dry-run, and
@@ -1107,3 +1122,18 @@ critique-10 claims reconciled; surface fixes in task-32346, 32348, 32349,
 32354, 32355). This page needed no correction — the note editor's autosave
 story and its guarded return were already stated here; the Library overview is
 what had drifted.*
+
+*Verified against fix/library-notes-w3-sync — 2026-09-11 (task-32269, and the
+task-32243 fix it waited on): the lasting-sync chapter was written from the
+design and had never been walked, because no folder could be admitted — a
+refused **Check changes** crashed over its own refusal and then poisoned the
+folder for the whole session. Walked end to end on this branch at 235x52
+against a 179-file vault under `$HOME`: refusal copy on a folder inside the
+profile → **Choose folder…** → the `$HOME` vault → 60 safe · 0 attention →
+**Activate reviewed root** → "Sync root activated. 60 applied · durable
+receipt recorded" → the notes appear under a **⇄ Sync managed** folder →
+**Manage sync folders** (now reachable) → **Check changes** → "Manual check
+finished." Added: what a folder has to be before it can be checked, and the
+named refusals. Known gap, not fixed here: the root row in **Manage sync
+folders** reads "Sync folder (name unavailable before cutover)" rather than
+the display name you typed.)*

--- a/Docs/User_Guide/library/notes.md
+++ b/Docs/User_Guide/library/notes.md
@@ -494,18 +494,24 @@ The first use of either — or a remembered folder that has since been moved or
 deleted — opens at your home directory instead. **Folder files** keeps its own
 separate memory, see [File notes](file-notes.md).
 
-**What a folder has to be before it can be checked.** It must be a real folder
-(not a link to one) on a local disk, outside Chatbook's own data directory,
-not already connected as a sync folder, not the Folder files root, and you
-must be able to write every file in it. **Check changes** refuses anything
-else and names which of those it was, in the setup pane's status line, with
-the next action —
-for example "That folder is inside Chatbook's own data directory. Pick a
-folder outside it, then Check again", "Another Chatbook window is using that
-folder", "That folder is already connected", or "Some files there use a
-permission model this sync can't track. Make every file in the folder
-writable, then Check again". A refusal changes nothing: pick a different
-folder, or fix the cause, and **Check changes** again in the same session.
+**What a folder has to be before it can be checked.** The folder itself must be
+a real folder (not a link to one) on a local disk, outside Chatbook's own data
+directory, not already connected as a sync folder, and not the Folder files
+root. Every `.md` file inside it must also pass, and one bad file stops the
+whole folder: each must be one you own or share a group with and can write,
+UTF-8 text, 10 MB or smaller, an ordinary file with a single name on disk, and
+consistent in its line endings — all Unix or all Windows, not a mix, and not
+the carriage-return-only style old Mac editors wrote.
+
+**Check changes** refuses anything else and names which rule it was, in the
+setup pane's status line, with the next action — for example "That folder is
+inside Chatbook's own data directory. Pick a folder outside it, then Check
+again", "Another Chatbook window is using that folder", "That folder is
+already connected", "Some files there use a mix of line endings. Save them
+with one style, then Check again", or "Some files there are larger than 10 MB".
+When several files fail for different reasons, the message names the most
+common one. A refusal changes nothing: pick a different folder, or fix the
+cause, and **Check changes** again in the same session.
 
 If files or notes change after checking, activation is refused as stale and the
 nearest valid action is **Check again**. Conflicts and deletion choices are not
@@ -1128,13 +1134,27 @@ what had drifted.*
 task-32243 fix it waited on): the lasting-sync chapter was written from the
 design and had never been walked, because no folder could be admitted — a
 refused **Check changes** crashed over its own refusal and then poisoned the
-folder for the whole session. Walked end to end on this branch at 235x52
-against a 179-file vault under `$HOME`: refusal copy on a folder inside the
-profile → **Choose folder…** → the `$HOME` vault → 60 safe · 0 attention →
+folder for the whole session. Every step in this chapter has now been walked
+on this branch at 235x52, in two sessions.
+
+Session one, a 179-file vault under `$HOME`: refusal copy on a folder inside
+the profile → **Choose folder…** → the `$HOME` vault → 60 safe · 0 attention →
 **Activate reviewed root** → "Sync root activated. 60 applied · durable
 receipt recorded" → the notes appear under a **⇄ Sync managed** folder →
-**Manage sync folders** (now reachable) → **Check changes** → "Manual check
-finished." Added: what a folder has to be before it can be checked, and the
-named refusals. Known gap, not fixed here: the root row in **Manage sync
-folders** reads "Sync folder (name unavailable before cutover)" rather than
-the display name you typed.)*
+**Manage sync folders** (which only exists once a root is active) → **Check
+changes** → "Manual check finished."
+
+Session two made a real conflict — edit the note in Chatbook, edit the same
+file on disk — and walked the half no earlier run could reach: **Check
+changes** → "⚠ Needs attention · Next: Review changes" → **Review** →
+**View comparison** (a real `--- Note / +++ File` diff with both sides' line
+and character counts) → **Keep file** → **Apply reviewed** → an at-action
+receipt with **Undo** and **Dismiss** → **Undo** → **Resolution history**,
+where the entry is recorded "undone" → **Pause** (the action becomes Resume)
+→ **Resume**. **Retarget** and **Disconnect** stay visibly disabled
+throughout, as this chapter says.
+
+Added in this pass: what a folder and its files have to be before they can be
+checked, and the named refusals. Known gap, not fixed here: the root row in
+**Manage sync folders** reads "Sync folder (name unavailable before cutover)"
+rather than the display name you typed — task-32451.)*

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -2746,6 +2746,13 @@
     },
     {
       "call_count": 1,
+      "diagnostic_digest": "3d11fa26ad821fbe252d",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
+      "call_count": 1,
       "diagnostic_digest": "738ee5f3783f1528d3c2",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/library_prompt_browse_controller.py",
@@ -11500,11 +11507,11 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 597,
+    "owner_files": 598,
     "path_privacy_candidate_calls": 709,
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
     "task_492_calls": 1384,
-    "task_494_calls": 7690
+    "task_494_calls": 7691
   }
 }

--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -1254,6 +1254,13 @@
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {
+      "call_count": 1,
+      "diagnostic_digest": "3d11fa26ad821fbe252d",
+      "owner": "TASK-494",
+      "path": "tldw_chatbook/Library/library_notes_lasting_sync_state.py",
+      "reason": "remaining Chatbook production diagnostic owner"
+    },
+    {
       "call_count": 3,
       "diagnostic_digest": "e76895f6c55063aea3db",
       "owner": "TASK-494",
@@ -2742,13 +2749,6 @@
       "diagnostic_digest": "556dd220325841915afd",
       "owner": "TASK-494",
       "path": "tldw_chatbook/UI/Library_Modules/library_notes_controller.py",
-      "reason": "remaining Chatbook production diagnostic owner"
-    },
-    {
-      "call_count": 1,
-      "diagnostic_digest": "3d11fa26ad821fbe252d",
-      "owner": "TASK-494",
-      "path": "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py",
       "reason": "remaining Chatbook production diagnostic owner"
     },
     {

--- a/Tests/Architecture/test_library_modules_size_ratchet.py
+++ b/Tests/Architecture/test_library_modules_size_ratchet.py
@@ -410,7 +410,16 @@ _BUDGETS: dict[str, int] = {
     # vault-detection flag and the two `obsidian_mode` arguments threaded
     # through `_plan_selection`/`check`.
     "tldw_chatbook/UI/Library_Modules/library_note_import_controller.py": 602,
-    "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py": 2023,
+    # 2026-09-11, task-32243 (refused Check names its reason): 2023 -> 2128
+    # (+105), a BEHAVIOUR ADD, not a move -- `_CHECK_REFUSAL_COPY` (one
+    # sentence and one next action per bounded admission reason the runtime
+    # and coordinator can name) plus `_refusal_reason`/`_check_failure_line`,
+    # the two helpers both Check paths now route through instead of each
+    # substituting a fixed "Check failed" string and logging nothing. The
+    # copy is presentation data and stays with the controller that renders
+    # it; splitting a sixteen-row string table across modules to stay under
+    # a line count would make the refusal grammar harder to read, not safer.
+    "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py": 2128,
     "tldw_chatbook/UI/Library_Modules/library_prompt_browse_controller.py": 281,
     # 2026-09-05, wave-6 task 2 (prompts controller PR, series 2/3): born
     # governed the moment this file existed (task-31203 AC#4's glob-based

--- a/Tests/Architecture/test_library_modules_size_ratchet.py
+++ b/Tests/Architecture/test_library_modules_size_ratchet.py
@@ -410,16 +410,15 @@ _BUDGETS: dict[str, int] = {
     # vault-detection flag and the two `obsidian_mode` arguments threaded
     # through `_plan_selection`/`check`.
     "tldw_chatbook/UI/Library_Modules/library_note_import_controller.py": 602,
-    # 2026-09-11, task-32243 (refused Check names its reason): 2023 -> 2128
-    # (+105), a BEHAVIOUR ADD, not a move -- `_CHECK_REFUSAL_COPY` (one
-    # sentence and one next action per bounded admission reason the runtime
-    # and coordinator can name) plus `_refusal_reason`/`_check_failure_line`,
-    # the two helpers both Check paths now route through instead of each
-    # substituting a fixed "Check failed" string and logging nothing. The
-    # copy is presentation data and stays with the controller that renders
-    # it; splitting a sixteen-row string table across modules to stay under
-    # a line count would make the refusal grammar harder to read, not safer.
-    "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py": 2128,
+    # 2026-09-11, task-32243 (refused Check names its reason): 2023 -> 2024
+    # (+1), and that one line is the `check_failure_line` import. The refusal
+    # copy table and its two helpers live in
+    # `Library/library_notes_lasting_sync_state.py` with the rest of this
+    # screen's presentation state; both fallback strings moved into the helper
+    # (keyed on `root_id == ""` => setup), so each of the two Check paths
+    # spends exactly one line on it. This row was briefly pinned at 2128 with
+    # the table in the controller; that was rejected in review and reverted.
+    "tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py": 2024,
     "tldw_chatbook/UI/Library_Modules/library_prompt_browse_controller.py": 281,
     # 2026-09-05, wave-6 task 2 (prompts controller PR, series 2/3): born
     # governed the moment this file existed (task-31203 AC#4's glob-based

--- a/Tests/Notes/test_notes_sync_filesystem.py
+++ b/Tests/Notes/test_notes_sync_filesystem.py
@@ -652,3 +652,40 @@ def test_windows_relative_root_and_duplicate_identity_fail_closed(
 
     with pytest.raises(NotesSyncFilesystemError, match="duplicate_stable_identity"):
         filesystem.observe()
+
+
+def test_writable_file_outside_the_process_primary_group_is_admitted(
+    tmp_path: Path,
+) -> None:
+    """TASK-32244: admission stands in for writability, not egid equality."""
+
+    foreign = next((gid for gid in os.getgroups() if gid != os.getegid()), None)
+    if foreign is None:
+        pytest.skip("caller belongs to a single group")
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "note.md"
+    target.write_bytes(b"body")
+    os.chown(target, -1, foreign)
+
+    with PosixNotesSyncFilesystem(root) as filesystem:
+        observed = filesystem.observe("note.md")
+
+    assert observed.observation.relative_path == "note.md"
+
+
+def test_file_the_caller_cannot_write_still_withholds_writable_admission(
+    tmp_path: Path,
+) -> None:
+    """TASK-32244: the relaxation must not admit a file sync cannot replace."""
+
+    root = tmp_path / "root"
+    root.mkdir()
+    target = root / "note.md"
+    target.write_bytes(b"body")
+    target.chmod(0o444)
+
+    with PosixNotesSyncFilesystem(root) as filesystem:
+        with pytest.raises(NotesSyncFilesystemError, match="unsupported_metadata"):
+            filesystem.observe("note.md")
+        assert filesystem.observe("note.md", require_writable=False)

--- a/Tests/Notes/test_notes_sync_filesystem.py
+++ b/Tests/Notes/test_notes_sync_filesystem.py
@@ -654,10 +654,72 @@ def test_windows_relative_root_and_duplicate_identity_fail_closed(
         filesystem.observe()
 
 
+def _snapshot(*, owner_user: int, owner_group: int, mode: int) -> sync_paths.SafeSyncBytes:
+    """One synthetic descriptor state, the only input `_metadata_issue` reads."""
+
+    return sync_paths.SafeSyncBytes(
+        relative_path=Path("note.md"),
+        content=b"body",
+        identity=sync_paths.SafeSyncFileIdentity(device=1, inode=2, link_count=1),
+        mode=mode,
+        size=4,
+        mtime_ns=0,
+        ctime_ns=0,
+        owner_user=owner_user,
+        owner_group=owner_group,
+        flags=0,
+        extended_attributes=(),
+        has_extended_acl=False,
+    )
+
+
+@pytest.mark.parametrize(
+    ("owner_user", "owner_group", "mode", "issue"),
+    [
+        # TASK-32244 AC#1: supplementary-group membership counts. This is the
+        # `elif owner_group in os.getgroups()` branch, which the chowned-file
+        # test could never reach -- chowning only the group leaves
+        # `owner_user == os.geteuid()` true, so that test measured S_IWUSR.
+        ("foreign", "supplementary", 0o664, None),
+        ("foreign", "supplementary", 0o644, "unsupported_metadata"),
+        # AC#1's other half: owner match, read by the owner bits.
+        ("self", "foreign", 0o644, None),
+        ("self", "foreign", 0o444, "unsupported_metadata"),
+        # Neither: another local user's file is refused however permissive its
+        # mode is. The mode bits are the weakest proxy here -- replacement is a
+        # rename governed by the directory -- and AC#1 asks only for owner
+        # match and supplementary-group membership.
+        ("foreign", "foreign", 0o666, "unsupported_metadata"),
+        ("foreign", "foreign", 0o777, "unsupported_metadata"),
+    ],
+)
+def test_admission_reads_ownership_not_the_process_primary_group(
+    owner_user: str, owner_group: str, mode: int, issue: str | None
+) -> None:
+    """TASK-32244: owner or supplementary group, and nothing wider."""
+
+    supplementary = next(
+        (gid for gid in os.getgroups() if gid != os.getegid()), None
+    )
+    if supplementary is None:
+        pytest.skip("caller belongs to a single group")
+    foreign_group = max(os.getgroups()) + 1000
+    assert foreign_group not in os.getgroups()
+    snapshot = _snapshot(
+        owner_user=os.geteuid() if owner_user == "self" else os.geteuid() + 1,
+        owner_group=(
+            supplementary if owner_group == "supplementary" else foreign_group
+        ),
+        mode=mode,
+    )
+
+    assert PosixNotesSyncFilesystem._metadata_issue(snapshot) == issue
+
+
 def test_writable_file_outside_the_process_primary_group_is_admitted(
     tmp_path: Path,
 ) -> None:
-    """TASK-32244: admission stands in for writability, not egid equality."""
+    """TASK-32244: a real file whose group is not the process egid is admitted."""
 
     foreign = next((gid for gid in os.getgroups() if gid != os.getegid()), None)
     if foreign is None:

--- a/Tests/Notes/test_notes_sync_runtime.py
+++ b/Tests/Notes/test_notes_sync_runtime.py
@@ -3212,7 +3212,45 @@ async def test_root_discovery_refusal_names_its_count_and_dominant_reason(
     assert str(raised.value) == "root_discovery_incomplete"
     assert "2 of 3" in raised.value.detail
     assert "unsupported_metadata" in raised.value.detail
+    # The dominant gate must reach the caller, not only the detail string:
+    # every per-file gate lands on `root_discovery_incomplete`, and the UI
+    # cannot tell a permission refusal from a newline one without this.
+    assert raised.value.reason_code == "unsupported_metadata"
     assert owner._root_paths == {}
+    await owner.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_root_discovery_refusal_carries_a_non_permission_dominant_reason(
+    tmp_path: Path,
+) -> None:
+    """TASK-32244: a newline refusal must not be reported as a permission one."""
+
+    from tldw_chatbook.Notes.notes_sync_runtime import (
+        NotesSyncRootRefused,
+        NotesSyncRootSetup,
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "ok.md").write_text("body", encoding="utf-8")
+    (vault / "mixed.md").write_bytes(b"alpha\r\nbeta\ngamma\n")
+    owner = _refusing_owner(tmp_path)
+    await owner.start()
+
+    with pytest.raises(NotesSyncRootRefused) as raised:
+        await owner.review_setup(
+            NotesSyncRootSetup(
+                display_name="Vault",
+                canonical_path=str(vault),
+                note_scope_id="local_note",
+                direction=NotesSyncDirection.BIDIRECTIONAL,
+            )
+        )
+
+    assert str(raised.value) == "root_discovery_incomplete"
+    assert raised.value.reason_code == "mixed_newlines"
+    assert "1 of 2" in raised.value.detail
     await owner.shutdown()
 
 

--- a/Tests/Notes/test_notes_sync_runtime.py
+++ b/Tests/Notes/test_notes_sync_runtime.py
@@ -3115,3 +3115,102 @@ def test_builder_defaults_keep_the_watcher_base_and_cap(tmp_path: Path) -> None:
 
     assert watcher._interval == 1.0
     assert watcher._max_interval == 10.0
+
+
+def _refusing_owner(tmp_path: Path):
+    from tldw_chatbook.Notes.notes_sync_runtime import build_notes_sync_runtime_owner
+
+    return build_notes_sync_runtime_owner(
+        notes_scope_service=NotesScopeService(
+            _CreatingLocalNotes("old"), None, folder_repository=_Folders()
+        ),
+        cutover_admitted=True,
+        profile_process_is_sole=True,
+        database_path=tmp_path / "sync.sqlite3",
+        migrate_legacy=lambda: None,
+        local_user_id="user-1",
+        recovery_capacity_bytes=1024 * 1024,
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_refusal_names_its_reason_and_leaves_no_root_path_residue(
+    tmp_path: Path,
+) -> None:
+    """TASK-32243: a refused Check must not crash over its own named refusal."""
+
+    from tldw_chatbook.Notes.notes_sync_runtime import (
+        NotesSyncRootRefused,
+        NotesSyncRootSetup,
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "note.md").write_text("body", encoding="utf-8")
+    linked = tmp_path / "linked-vault"
+    linked.symlink_to(vault, target_is_directory=True)
+    owner = _refusing_owner(tmp_path)
+    await owner.start()
+    setup = NotesSyncRootSetup(
+        display_name="Linked",
+        canonical_path=str(linked),
+        note_scope_id="local_note",
+        direction=NotesSyncDirection.BIDIRECTIONAL,
+    )
+
+    with pytest.raises(NotesSyncRootRefused) as first:
+        await owner.review_setup(setup)
+
+    assert str(first.value) == "root_lease_unavailable"
+    assert first.value.reason_code == "root_link_or_reparse"
+    assert owner._root_paths == {}
+
+    # The same folder must reach the same decision a fresh session would reach,
+    # not `lasting_root_overlap` against the residue of the first attempt.
+    with pytest.raises(NotesSyncRootRefused) as second:
+        await owner.review_setup(setup)
+
+    assert second.value.reason_code == "root_link_or_reparse"
+    assert owner._root_paths == {}
+
+    review = await owner.review_setup(replace(setup, canonical_path=str(vault)))
+    assert review.root_id
+    await owner.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_root_discovery_refusal_names_its_count_and_dominant_reason(
+    tmp_path: Path,
+) -> None:
+    """TASK-32244: `root_discovery_incomplete` must not hide a per-file reason."""
+
+    from tldw_chatbook.Notes.notes_sync_runtime import (
+        NotesSyncRootRefused,
+        NotesSyncRootSetup,
+    )
+
+    vault = tmp_path / "vault"
+    vault.mkdir()
+    (vault / "ok.md").write_text("body", encoding="utf-8")
+    for name in ("locked-one.md", "locked-two.md"):
+        blocked = vault / name
+        blocked.write_text("body", encoding="utf-8")
+        blocked.chmod(0o444)
+    owner = _refusing_owner(tmp_path)
+    await owner.start()
+
+    with pytest.raises(NotesSyncRootRefused) as raised:
+        await owner.review_setup(
+            NotesSyncRootSetup(
+                display_name="Vault",
+                canonical_path=str(vault),
+                note_scope_id="local_note",
+                direction=NotesSyncDirection.BIDIRECTIONAL,
+            )
+        )
+
+    assert str(raised.value) == "root_discovery_incomplete"
+    assert "2 of 3" in raised.value.detail
+    assert "unsupported_metadata" in raised.value.detail
+    assert owner._root_paths == {}
+    await owner.shutdown()

--- a/Tests/Notes/test_notes_sync_runtime.py
+++ b/Tests/Notes/test_notes_sync_runtime.py
@@ -3214,3 +3214,65 @@ async def test_root_discovery_refusal_names_its_count_and_dominant_reason(
     assert "unsupported_metadata" in raised.value.detail
     assert owner._root_paths == {}
     await owner.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_cancelled_setup_review_releases_the_lease_and_the_root_path(
+    tmp_path: Path,
+) -> None:
+    """TASK-32243: a cancelled Check must leave no residue either.
+
+    `except Exception` does not catch `CancelledError`, so a cancelled setup
+    review used to leak both `_root_paths` and the coordinator lease -- the
+    lock file stays held and the folder is then refused `passive_process` for
+    the rest of the session, which is worse than the bug this task fixed.
+    """
+
+    from tldw_chatbook.Notes.notes_sync_runtime import (
+        NotesSyncRootSetup,
+        NotesSyncRuntimeOwner,
+    )
+
+    store = NotesDeviceStateStore(tmp_path / "sync.sqlite3")
+    store.initialize()
+    store.set_setting(NotesSyncStoreSetting("cutover_marker", "notes-sync-cutover-v1"))
+    root_path = tmp_path / "setup-root"
+    root_path.mkdir()
+    coordinator = _Coordinator()
+    adapter = _MultiRootAdapter([_input(file_digest=_A, note_digest=_A)])
+    observing = asyncio.Event()
+
+    async def block_forever(_root: NotesSyncRootRecord) -> ReconciliationInput:
+        observing.set()
+        await asyncio.Event().wait()
+        raise AssertionError("unreachable")
+
+    adapter.observe_root = block_forever
+    owner = NotesSyncRuntimeOwner(
+        store=store,
+        migrate_legacy=lambda: None,
+        coordinator=coordinator,
+        adapter=adapter,
+        watcher_factory=lambda _schedule: _Watcher(),
+        cutover_admitted=True,
+        profile_process_is_sole=True,
+    )
+    await owner.start()
+    setup = NotesSyncRootSetup(
+        display_name="Research",
+        canonical_path=str(root_path),
+        note_scope_id="local_note",
+        direction=NotesSyncDirection.BIDIRECTIONAL,
+    )
+
+    review = asyncio.create_task(owner.review_setup(setup))
+    await observing.wait()
+    assert owner._root_paths != {}
+    review.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await review
+
+    assert owner._root_paths == {}
+    assert owner._leases == {}
+    assert coordinator.events[-1:] == ["lease-released"]
+    await owner.shutdown()

--- a/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
+++ b/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
@@ -3052,7 +3052,16 @@ async def test_activation_rejects_malformed_control_results(malformed: object) -
         ("passive_process", "Another Chatbook window is using that folder"),
         ("lasting_root_overlap", "already connected"),
         ("unsupported_metadata", "permission model this sync can't track"),
-        ("root_discovery_incomplete", "permission model this sync can't track"),
+        # TASK-32244: every per-file gate arrives as `root_discovery_incomplete`
+        # carrying the dominant gate as its reason. Permission advice is right
+        # for exactly one of them, so each must reach its own sentence.
+        ("root_discovery_incomplete", "couldn't be read"),
+        ("mixed_newlines", "mix of line endings"),
+        ("unsupported_newline", "older Mac line endings"),
+        ("unsupported_encoding", "not UTF-8 text"),
+        ("max_file_bytes_exceeded", "larger than 10 MB"),
+        ("non_regular", "aren't ordinary files"),
+        ("multiple_links", "more than one name on disk"),
         (
             "notes_sync_cutover_not_admitted",
             "another Chatbook instance owns this profile",

--- a/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
+++ b/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
@@ -3088,7 +3088,7 @@ async def test_refused_check_setup_names_its_reason_and_logs_it(
 
     runtime.review_setup = refuse
     controller.set_setup("display_name", "Notes")
-    controller.set_setup("folder", "/private/root")
+    controller.set_setup("folder", "/zqleakcanary/root")
     messages: list[str] = []
     sink_id = logger.add(
         lambda message: messages.append(message.record["message"]), level="WARNING"
@@ -3104,7 +3104,7 @@ async def test_refused_check_setup_names_its_reason_and_logs_it(
     assert controller.snapshot.phase == "configure"
     joined = "\n".join(messages)
     assert reason in joined
-    assert "/private/root" not in joined
+    assert "/zqleakcanary/root" not in joined
 
 
 async def test_refused_check_root_names_its_reason_and_logs_it() -> None:
@@ -3155,7 +3155,7 @@ async def test_unclassified_check_failure_keeps_the_generic_line_and_logs_a_type
     )
 
     async def fail(*args: object, **kwargs: object) -> object:
-        raise ZeroDivisionError("/private/secret/path")
+        raise ZeroDivisionError("/zqleakcanary/secret/path")
 
     runtime.check_root = fail
     messages: list[str] = []
@@ -3169,5 +3169,5 @@ async def test_unclassified_check_failure_keeps_the_generic_line_and_logs_a_type
 
     joined = "\n".join(messages)
     assert "ZeroDivisionError" in joined
-    assert "/private/secret/path" not in joined
+    assert "/zqleakcanary/secret/path" not in joined
     assert "Check failed" in controller.snapshot.status_line

--- a/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
+++ b/Tests/UI/Library_Modules/test_library_notes_sync_controller.py
@@ -3043,3 +3043,122 @@ async def test_activation_rejects_malformed_control_results(malformed: object) -
     assert controller.snapshot.phase == "review"
     assert controller.snapshot.receipt_line == ""
     assert "invalid" in controller.snapshot.status_line.casefold()
+
+
+@pytest.mark.parametrize(
+    ("reason", "expected"),
+    [
+        ("private_path_overlap", "inside Chatbook's own data directory"),
+        ("passive_process", "Another Chatbook window is using that folder"),
+        ("lasting_root_overlap", "already connected"),
+        ("unsupported_metadata", "permission model this sync can't track"),
+        ("root_discovery_incomplete", "permission model this sync can't track"),
+        (
+            "notes_sync_cutover_not_admitted",
+            "another Chatbook instance owns this profile",
+        ),
+    ],
+)
+async def test_refused_check_setup_names_its_reason_and_logs_it(
+    reason: str, expected: str
+) -> None:
+    """TASK-32243: each refusal reason gets its own copy and one warning."""
+
+    from loguru import logger
+
+    from tldw_chatbook.Notes.notes_sync_runtime import NotesSyncRootRefused
+
+    runtime = _Runtime()
+    controller = LibraryNotesSyncController(
+        runtime=runtime,
+        import_controller=_ImportController(),
+    )
+
+    async def refuse(*args: object, **kwargs: object) -> object:
+        raise NotesSyncRootRefused("root_lease_unavailable", reason_code=reason)
+
+    runtime.review_setup = refuse
+    controller.set_setup("display_name", "Notes")
+    controller.set_setup("folder", "/private/root")
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        await controller.check_setup()
+    finally:
+        logger.remove(sink_id)
+
+    status_line = controller.snapshot.status_line
+    assert expected in status_line
+    assert status_line != "Check failed. Review the folder and settings, then try again."
+    assert controller.snapshot.phase == "configure"
+    joined = "\n".join(messages)
+    assert reason in joined
+    assert "/private/root" not in joined
+
+
+async def test_refused_check_root_names_its_reason_and_logs_it() -> None:
+    """TASK-32243: the persisted-root Check refuses with the same grammar."""
+
+    from loguru import logger
+
+    from tldw_chatbook.Notes.notes_sync_runtime import NotesSyncRootRefused
+
+    runtime = _Runtime()
+    controller = LibraryNotesSyncController(
+        runtime=runtime,
+        import_controller=_ImportController(),
+    )
+
+    async def refuse(*args: object, **kwargs: object) -> object:
+        raise NotesSyncRootRefused(
+            "root_lease_unavailable", reason_code="passive_process"
+        )
+
+    runtime.check_root = refuse
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        await controller.check_root("root-1")
+    finally:
+        logger.remove(sink_id)
+
+    assert "Another Chatbook window is using that folder" in (
+        controller.snapshot.status_line
+    )
+    assert "passive_process" in "\n".join(messages)
+
+
+async def test_unclassified_check_failure_keeps_the_generic_line_and_logs_a_type() -> (
+    None
+):
+    """TASK-32243: an unnamed failure still leaves a trace to debug from."""
+
+    from loguru import logger
+
+    runtime = _Runtime()
+    controller = LibraryNotesSyncController(
+        runtime=runtime,
+        import_controller=_ImportController(),
+    )
+
+    async def fail(*args: object, **kwargs: object) -> object:
+        raise ZeroDivisionError("/private/secret/path")
+
+    runtime.check_root = fail
+    messages: list[str] = []
+    sink_id = logger.add(
+        lambda message: messages.append(message.record["message"]), level="WARNING"
+    )
+    try:
+        await controller.check_root("root-1")
+    finally:
+        logger.remove(sink_id)
+
+    joined = "\n".join(messages)
+    assert "ZeroDivisionError" in joined
+    assert "/private/secret/path" not in joined
+    assert "Check failed" in controller.snapshot.status_line

--- a/backlog/docs/lessons-testing-evidence.md
+++ b/backlog/docs/lessons-testing-evidence.md
@@ -13280,3 +13280,42 @@ lost output, and it is not on by default in the shells these commands run in.
 The same trap sits behind `./scripts/preflight.sh | tail` — a known previous
 incident in this repo, and the reason preflight is always run bare.
 
+
+## A refusal path needs its own test, or it will lose both its name and its cleanup (task-32243, 2026-09-11)
+
+Library ▸ Notes lasting sync shipped on 2026-08-21 with a working happy path and
+a refusal path no test ever entered. `grep root_lease_unavailable Tests/` and
+`grep root_discovery_incomplete Tests/` both returned zero hits for three weeks.
+Two independent defects lived there the whole time, and both are the same shape:
+
+- `_ensure_lease` published a status to the store *before* returning the falsy
+  value its caller turned into `RuntimeError("root_lease_unavailable")`. For a
+  setup review the root is not in the store yet, so the publish raised
+  `NotesDeviceStateError: The requested sync root does not exist` and the honest,
+  named refusal was destroyed by a secondary crash on its way out.
+- `review_setup` popped its `_root_paths` entry only on the branch where
+  `_ensure_lease` *returned* falsy. A raise skipped the pop, so the leaked entry
+  made the coordinator refuse the same folder as `lasting_root_overlap` on every
+  later attempt — for the rest of the session, invisibly, even after the user
+  fixed the real cause. Only a restart cleared it.
+
+Both are invisible to a happy-path suite, and both are the kind of thing a
+reviewer reads straight past: the publish looks like ordinary status reporting,
+and the pop looks like it is on the failure path. The generalisation:
+
+**On any path that refuses, write the test that refuses.** Not a test that the
+error type is raised — a test that (a) the error carries the reason the code
+went to the trouble of computing, and (b) the second attempt reaches the same
+decision a fresh process would. (b) is the one that catches leaked state, and
+nothing else does: one call in isolation passes either way.
+
+Two corollaries worth keeping:
+
+- **Anything you write before you raise can raise first.** A guard that reports,
+  persists, or publishes before it fails has two exits, and the one you did not
+  write the test for is the one users will hit.
+- **Cleanup belongs on one path, not on each failure branch.** The fix here was
+  not a second pop next to the raise — it was moving the lease check inside the
+  `except` block that already released the setup authority for the *other*
+  failure. Two half-cleanups is the bug; one release for every failure is the
+  fix, and it is the smaller diff.

--- a/backlog/tasks/task-32243 - Library-Notes-lasting-sync-a-failed-Check-crashes-over-its-own-named-refusal-leaks-the-root-for-the-session-and-blames-the-user-with-no-log.md
+++ b/backlog/tasks/task-32243 - Library-Notes-lasting-sync-a-failed-Check-crashes-over-its-own-named-refusal-leaks-the-root-for-the-session-and-blames-the-user-with-no-log.md
@@ -3,11 +3,11 @@ id: TASK-32243
 title: >-
   Library Notes lasting sync: a failed Check crashes over its own named refusal,
   leaks the root for the session, and blames the user with no log
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-10 18:05'
-updated_date: '2026-09-11 15:06'
+updated_date: '2026-09-11 15:32'
 labels:
   - library
   - notes
@@ -43,13 +43,13 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A lasting-sync Check that cannot admit a folder reports the runtime's own reason and a next action at the control, not a fixed 'Review the folder and settings' string
-- [ ] #2 `_ensure_lease` surfaces its named failure (`root_lease_unavailable`) rather than being masked by a `NotesDeviceStateError` raised from `_publish` on a root that was never persisted
-- [ ] #3 A failed Check leaves no `_root_paths` residue: retrying the same folder in the same session reaches the same admission decision a fresh session would reach
-- [ ] #4 Every admission failure on this path is logged with the folder and the state name
-- [ ] #5 Covered by a test that a lease failure surfaces `root_lease_unavailable` rather than `NotesDeviceStateError`
-- [ ] #6 Covered by a test that a second Check on the same folder is not rejected with `lasting_root_overlap` because of the first
-- [ ] #7 Covered by a test that the controller renders a distinct named reason per admission state
+- [x] #1 A lasting-sync Check that cannot admit a folder reports the runtime's own reason and a next action at the control, not a fixed 'Review the folder and settings' string
+- [x] #2 `_ensure_lease` surfaces its named failure (`root_lease_unavailable`) rather than being masked by a `NotesDeviceStateError` raised from `_publish` on a root that was never persisted
+- [x] #3 A failed Check leaves no `_root_paths` residue: retrying the same folder in the same session reaches the same admission decision a fresh session would reach
+- [x] #4 Every admission failure on this path is logged with its reason code, the exception type, and the opaque root id -- AMENDED 2026-09-11: the original criterion said "with the folder", but a folder PATH in a persistent sink is exactly what `Docs/security/production-diagnostic-inventory.json` exists to keep out, and the runtime's own path-free grammar (`RootAdmission.__repr__`, the root digest) already refuses to carry one. The opaque root id names which root; on the setup path, where no id exists yet, the record reads `pending-setup`.
+- [x] #5 Covered by a test that a lease failure surfaces `root_lease_unavailable` rather than `NotesDeviceStateError`
+- [x] #6 Covered by a test that a second Check on the same folder is not rejected with `lasting_root_overlap` because of the first
+- [x] #7 Covered by a test that the controller renders a distinct named reason per admission state
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -61,3 +61,19 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 4. Re-pin the diagnostic inventory, run the touched suites against a dev baseline.
 5. Live verification at 235x52: refusal copy on an in-profile vault, then a successful Check on a $HOME vault in the same session.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Root cause was three separate failures stacked on one path, all reproduced headlessly before any edit (scratchpad repro.py: review_setup() twice against a vault inside the profile dir, then a $HOME vault).
+
+1. `_ensure_lease` published a store status for a root the store had never seen. `NotesDeviceStateStore.update_root_status` raised `NotesDeviceStateError` and destroyed the intended `root_lease_unavailable`. It now takes `persist: bool`; `review_setup` and the setup half of `_activate_root` pass `persist=False`. Nothing else changes for a persisted root.
+2. The `_root_paths` pop was reachable only when `_ensure_lease` returned falsy, so a raise leaked the entry and the next attempt on the same folder was refused as `lasting_root_overlap` for the rest of the session. The lease check moved inside the existing `except Exception: await self._release_setup_authority(root_id)` block, which already did exactly this cleanup for the observation failure -- one release path for every failure instead of two half-paths.
+3. The refusal now carries its cause. `NotesSyncRootRefused(RuntimeError)` keeps `str(exc)` as the gate that closed (`root_lease_unavailable`, `root_discovery_incomplete`) and adds `reason_code` (the coordinator's admission reason) and `detail`. `_ensure_lease` records the reason in `_admission_reasons`; `_refuse_lease` reads and pops it. Both Check paths in the controller (`check_setup` and `_check_root`) route through one `_check_failure_line`, which maps sixteen bounded reasons to their own sentence and next action and logs one metadata-only warning. The bare `except Exception` stays -- it just stops being the only thing that knows what happened. `_refusal_reason` only ever returns a key of the literal copy table, so no exception message can carry a path into a status line or a log.
+
+AC#4 was amended before implementing: it asked for the folder path in the log, which the diagnostic inventory exists to prevent. The record carries the reason code, the exception type and the opaque root id instead.
+
+Live, at 235x52 on a scratch profile (captures in wave3-caps/sync/): Check on a folder inside the profile renders "That folder is inside Chatbook's own data directory. Pick a folder outside it, then Check again" (cap-01) and logs `reason=private_path_overlap error_type=NotesSyncRootRefused root_id=pending-setup` (log-refusal-warning.txt); picking a 179-file $HOME vault in the SAME session then checks clean -- 60 safe, 0 attention (cap-02) -- which is the leak being gone. Activation, the synced-placement notes, Manage sync folders and a second Check on the persisted root all follow (cap-03..07).
+
+Files: tldw_chatbook/Notes/notes_sync_runtime.py, tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py, Tests/Notes/test_notes_sync_runtime.py, Tests/UI/Library_Modules/test_library_notes_sync_controller.py, Tests/Architecture/test_library_modules_size_ratchet.py (pin 2023 -> 2128, reason in the pin), Docs/security/production-diagnostic-inventory.json.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32243 - Library-Notes-lasting-sync-a-failed-Check-crashes-over-its-own-named-refusal-leaks-the-root-for-the-session-and-blames-the-user-with-no-log.md
+++ b/backlog/tasks/task-32243 - Library-Notes-lasting-sync-a-failed-Check-crashes-over-its-own-named-refusal-leaks-the-root-for-the-session-and-blames-the-user-with-no-log.md
@@ -1,11 +1,13 @@
 ---
 id: TASK-32243
 title: >-
-  Library Notes lasting sync: a failed Check crashes over its own named
-  refusal, leaks the root for the session, and blames the user with no log
-status: To Do
-assignee: []
+  Library Notes lasting sync: a failed Check crashes over its own named refusal,
+  leaks the root for the session, and blames the user with no log
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-10 18:05'
+updated_date: '2026-09-11 15:06'
 labels:
   - library
   - notes
@@ -49,3 +51,13 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 - [ ] #6 Covered by a test that a second Check on the same folder is not rejected with `lasting_root_overlap` because of the first
 - [ ] #7 Covered by a test that the controller renders a distinct named reason per admission state
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Reproduce headlessly: review_setup() against a vault inside the profile dir and one under /private/tmp; capture the NotesDeviceStateError traceback and the leaked _root_paths entry.
+2. Write RED tests: (a) rejected admission on the setup path raises a reason-carrying error, not NotesDeviceStateError; (b) a failed Check leaves _root_paths empty and the folder is admissible on retry; (c) the controller renders distinct copy per reason and logs a metadata-only warning.
+3. Fix: _ensure_lease(..., persist: bool) with persist=False on the unpersisted setup/activation paths; release the setup authority (which pops _root_paths) on any failure, not only on observation failure; carry admission.reason_code on the raised error; reason-mapped controller copy plus a path-free logger.warning; keep the bare except.
+4. Re-pin the diagnostic inventory, run the touched suites against a dev baseline.
+5. Live verification at 235x52: refusal copy on an in-profile vault, then a successful Check on a $HOME vault in the same session.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32244 - Library-Notes-lasting-sync-admission-rejects-every-file-whose-primary-group-is-not-the-process-egid.md
+++ b/backlog/tasks/task-32244 - Library-Notes-lasting-sync-admission-rejects-every-file-whose-primary-group-is-not-the-process-egid.md
@@ -3,11 +3,11 @@ id: TASK-32244
 title: >-
   Library Notes lasting sync admission rejects every file whose primary group is
   not the process egid
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-10 18:05'
-updated_date: '2026-09-11 15:07'
+updated_date: '2026-09-11 15:32'
 labels:
   - library
   - notes
@@ -30,10 +30,10 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 A file the caller can write is admitted regardless of whether its primary group equals the process egid (owner match and supplementary-group membership both count)
-- [ ] #2 A file that genuinely cannot be written still reports `unsupported_metadata`, with the reason naming what is wrong
-- [ ] #3 `root_discovery_incomplete` names how many files were rejected and the dominant reason, not only that discovery was incomplete
-- [ ] #4 Covered by a test over a file whose group is not the caller's egid but which the caller can write
+- [x] #1 A file the caller can write is admitted regardless of whether its primary group equals the process egid (owner match and supplementary-group membership both count)
+- [x] #2 A file that genuinely cannot be written still reports `unsupported_metadata`, with the reason naming what is wrong
+- [x] #3 `root_discovery_incomplete` names how many files were rejected and the dominant reason, not only that discovery was incomplete
+- [x] #4 Covered by a test over a file whose group is not the caller's egid but which the caller can write
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -44,3 +44,15 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 3. Replace the egid equality with an honest writability test from the snapshot's own owner/group/mode bits (owner match, supplementary-group membership, other bits).
 4. Aggregate the per-file refusals so root_discovery_incomplete names the count and the dominant reason instead of raising on the first refusal.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+`_metadata_issue` demanded `owner_user == os.geteuid() and owner_group == os.getegid()`. The second half is not a writability test: a file you own whose group is any other group you belong to -- or, as in this harness, `wheel` under /private/tmp -- was refused, and the root then failed `root_discovery_incomplete` with no count and no reason. The check now asks the permission bits the snapshot already carries: owner match uses S_IWUSR, supplementary-group membership uses S_IWGRP, otherwise S_IWOTH. A file that genuinely cannot be written still reports `unsupported_metadata` (it previously did NOT -- a 0444 file you own was admitted and would have failed at replace time).
+
+`observe_root` no longer raises on the first refused file. It counts refusals across the walk (`collections.Counter`) and raises `NotesSyncRootRefused("root_discovery_incomplete", detail="N of M files refused; K for <reason>")`; the discovery-level failure names its count too. Worst case is one full walk, which is what a good root already costs.
+
+Proof: before, a vault under /private/tmp (group wheel) refused all files and failed the root; after, the same vault is admitted (scratchpad repro2.py, wave3-caps/sync/repro-after-reasons.txt).
+
+Files: tldw_chatbook/Notes/notes_sync_filesystem.py, tldw_chatbook/Notes/notes_sync_runtime.py, Tests/Notes/test_notes_sync_filesystem.py, Tests/Notes/test_notes_sync_runtime.py.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32244 - Library-Notes-lasting-sync-admission-rejects-every-file-whose-primary-group-is-not-the-process-egid.md
+++ b/backlog/tasks/task-32244 - Library-Notes-lasting-sync-admission-rejects-every-file-whose-primary-group-is-not-the-process-egid.md
@@ -1,11 +1,13 @@
 ---
 id: TASK-32244
 title: >-
-  Library Notes lasting sync admission rejects every file whose primary group
-  is not the process egid
-status: To Do
-assignee: []
+  Library Notes lasting sync admission rejects every file whose primary group is
+  not the process egid
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-10 18:05'
+updated_date: '2026-09-11 15:07'
 labels:
   - library
   - notes
@@ -33,3 +35,12 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 - [ ] #3 `root_discovery_incomplete` names how many files were rejected and the dominant reason, not only that discovery was incomplete
 - [ ] #4 Covered by a test over a file whose group is not the caller's egid but which the caller can write
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Confirm the group check rejects a writable file (own uid, group wheel) under /private/tmp.
+2. RED test over a snapshot whose owner_group is not the caller egid but whose owner/mode make it writable.
+3. Replace the egid equality with an honest writability test from the snapshot's own owner/group/mode bits (owner match, supplementary-group membership, other bits).
+4. Aggregate the per-file refusals so root_discovery_incomplete names the count and the dominant reason instead of raising on the first refusal.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
+++ b/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
@@ -3,11 +3,11 @@ id: TASK-32269
 title: >-
   Library Notes user guide documents an entire lasting-sync chapter that cannot
   be entered
-status: In Progress
+status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-10 18:05'
-updated_date: '2026-09-11 15:07'
+updated_date: '2026-09-11 15:32'
 labels:
   - library
   - notes
@@ -31,9 +31,9 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 The chapter states, in the user's terms, what is required for a folder to be admitted
-- [ ] #2 Every step in the chapter has been walked against a real admitted root before its 'Verified against' stamp is refreshed
-- [ ] #3 Nothing in the chapter describes a surface that cannot be reached from the shipped build
+- [x] #1 The chapter states, in the user's terms, what is required for a folder to be admitted
+- [x] #2 Every step in the chapter has been walked against a real admitted root before its 'Verified against' stamp is refreshed
+- [x] #3 Nothing in the chapter describes a surface that cannot be reached from the shipped build
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -43,3 +43,15 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 2. Walk the lasting-sync chapter live against a real admitted $HOME vault.
 3. Rewrite the chapter: state the admission precondition in the user's terms, list the refusal reasons and their copy, remove or supersede claims that cannot run; refresh the stamp.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+The chapter could not be walked before task-32243 landed, so it was written from the design. Walked end to end on this branch at 235x52 against a 179-file git-backed vault under $HOME: refusal copy on an in-profile folder, Choose folder again, Check (60 safe / 0 attention), Activate ("60 applied · durable receipt recorded"), the notes appearing under a '⇄ Sync managed' folder with '⇄ Synced placement' badges, Manage sync folders (which only exists once a root is active), and a second Check on the persisted root ("Manual check finished").
+
+Added to 'Add from files and lasting sync': what a folder has to be before it can be checked, and the named refusals with their copy. Added to 'Set up lasting folder sync': what a refusal looks like at step 4 and where Manage sync folders appears at step 5. Stamped with the walk.
+
+One gap found and left unfixed, recorded in the stamp: the root row in Manage sync folders reads 'Sync folder (name unavailable before cutover)' instead of the display name the user typed.
+
+Files: Docs/User_Guide/library/notes.md.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
+++ b/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
@@ -1,11 +1,13 @@
 ---
 id: TASK-32269
 title: >-
-  Library Notes user guide documents an entire lasting-sync chapter that
-  cannot be entered
-status: To Do
-assignee: []
+  Library Notes user guide documents an entire lasting-sync chapter that cannot
+  be entered
+status: In Progress
+assignee:
+  - '@claude'
 created_date: '2026-09-10 18:05'
+updated_date: '2026-09-11 15:07'
 labels:
   - library
   - notes
@@ -33,3 +35,11 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 - [ ] #2 Every step in the chapter has been walked against a real admitted root before its 'Verified against' stamp is refreshed
 - [ ] #3 Nothing in the chapter describes a surface that cannot be reached from the shipped build
 <!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Land the task-32243 fix first.
+2. Walk the lasting-sync chapter live against a real admitted $HOME vault.
+3. Rewrite the chapter: state the admission precondition in the user's terms, list the refusal reasons and their copy, remove or supersede claims that cannot run; refresh the stamp.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
+++ b/backlog/tasks/task-32269 - Library-Notes-user-guide-documents-an-entire-lasting-sync-chapter-that-cannot-be-entered.md
@@ -7,7 +7,7 @@ status: Done
 assignee:
   - '@claude'
 created_date: '2026-09-10 18:05'
-updated_date: '2026-09-11 15:32'
+updated_date: '2026-09-11 16:20'
 labels:
   - library
   - notes
@@ -47,11 +47,15 @@ Evidence: Library ▸ Notes critique snapshot `.impeccable/critique/2026-09-10T1
 ## Implementation Notes
 
 <!-- SECTION:NOTES:BEGIN -->
-The chapter could not be walked before task-32243 landed, so it was written from the design. Walked end to end on this branch at 235x52 against a 179-file git-backed vault under $HOME: refusal copy on an in-profile folder, Choose folder again, Check (60 safe / 0 attention), Activate ("60 applied · durable receipt recorded"), the notes appearing under a '⇄ Sync managed' folder with '⇄ Synced placement' badges, Manage sync folders (which only exists once a root is active), and a second Check on the persisted root ("Manual check finished").
+The chapter could not be walked before task-32243 landed, so it was written from the design. Now walked end to end at 235x52 in two sessions.
 
-Added to 'Add from files and lasting sync': what a folder has to be before it can be checked, and the named refusals with their copy. Added to 'Set up lasting folder sync': what a refusal looks like at step 4 and where Manage sync folders appears at step 5. Stamped with the walk.
+Session one, a 179-file git-backed vault under $HOME: refusal copy on an in-profile folder, Choose folder again, Check (60 safe / 0 attention), Activate ('60 applied · durable receipt recorded'), the notes under a '⇄ Sync managed' folder with '⇄ Synced placement' badges, Manage sync folders (which only exists once a root is active), and a second Check on the persisted root.
 
-One gap found and left unfixed, recorded in the stamp: the root row in Manage sync folders reads 'Sync folder (name unavailable before cutover)' instead of the display name the user typed.
+Session two (added in fix round 1, review finding 7) made a real conflict -- note edited in Chatbook, same file edited on disk -- and walked the half no earlier run could reach, because the first vault checked '0 need attention' and no conflict existed to open: Check changes -> '⚠ Needs attention · Next: Review changes' -> Review -> View comparison (a real '--- Note / +++ File' diff with both sides' line and character counts) -> Keep file -> Apply reviewed -> an at-action receipt with Undo and Dismiss -> Undo -> Resolution history, where the entry reads 'undone' -> Pause (the action becomes Resume) -> Resume. Retarget and Disconnect stayed visibly disabled throughout. Captures cap-10..cap-18.
+
+Docs: AC#1 previously listed only the root-level gates. The per-file gates are what a real vault actually trips -- UTF-8, consistent line endings, <=10 MB, ordinary single-link files you can write -- and one bad file stops the whole folder, so the paragraph now says that and gives their copy. The refusal examples were refreshed to match the reason-mapped copy task-32244 added.
+
+One gap found and left unfixed, filed as task-32451: the root row in Manage sync folders reads 'Sync folder (name unavailable before cutover)' instead of the display name the user typed.
 
 Files: Docs/User_Guide/library/notes.md.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32451 - Library-Notes-Manage-sync-folders-shows-a-placeholder-name-for-every-root.md
+++ b/backlog/tasks/task-32451 - Library-Notes-Manage-sync-folders-shows-a-placeholder-name-for-every-root.md
@@ -1,0 +1,34 @@
+---
+id: TASK-32451
+title: Library Notes Manage sync folders shows a placeholder name for every root
+status: To Do
+assignee: []
+created_date: '2026-09-11 16:10'
+labels:
+  - library
+  - notes
+  - ux
+  - critique-notes-2026-09
+  - sync
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Found while walking the lasting-sync chapter for task-32269, once task-32243 made a root reachable at all.
+
+Every row in Manage sync folders reads "Sync folder (name unavailable before cutover)", including a root the user just created and typed a display name for. `library_notes_sync_controller.py:709` hard-codes that literal for every row because the path-free `NotesSyncRootRuntimeSnapshot` carries only root_id/status/next_action -- the display name the user typed at setup has no route to the row, and neither does the folder. With one root the row is merely unhelpful; with two it is unusable, because nothing on screen distinguishes them.
+
+The name is not private the way the path is: the user typed it, it is already shown in the notes folder tree ("Vault sync"), and it is validated as a bounded non-path label by `NotesSyncRootSetup`. The fix is a route for it, not a new path field.
+
+Evidence: captures cap-06 and cap-07 under the wave-3 sync scratchpad (live walk at 235x52 against a 179-file vault, 2026-09-11).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Each row in Manage sync folders shows the display name the user gave that root
+- [ ] #2 Two roots are distinguishable from the list alone
+- [ ] #3 No absolute path reaches the row or any log record through this change
+- [ ] #4 A migrated legacy candidate, which has no user-typed name, still shows something honest rather than a placeholder that claims a name is unavailable
+<!-- AC:END -->

--- a/tldw_chatbook/Library/library_notes_lasting_sync_state.py
+++ b/tldw_chatbook/Library/library_notes_lasting_sync_state.py
@@ -7,6 +7,8 @@ from enum import StrEnum
 from math import ceil
 from typing import Literal
 
+from loguru import logger
+
 from tldw_chatbook.Notes.notes_sync_conflicts import (
     ConflictComparison,
     ConflictHistoryRow,
@@ -805,6 +807,145 @@ def _apply_blocker(
     return LastingSyncApplyBlocker.NONE
 
 
+# TASK-32243: a refused Check used to render one fixed string for every cause,
+# with nothing logged anywhere. Each bounded reason the runtime and coordinator
+# can name gets its own sentence and its own next action here; anything else
+# keeps the generic line but still leaves a typed warning behind.
+_CHECK_REFUSAL_COPY: dict[str, str] = {
+    "private_path_overlap": (
+        "That folder is inside Chatbook's own data directory. "
+        "Pick a folder outside it, then Check again."
+    ),
+    "private_path_check_failed": (
+        "Chatbook could not confirm that folder sits outside its own data. "
+        "Pick a folder in your home directory, then Check again."
+    ),
+    "file_notes_overlap": (
+        "That folder is already in use by Folder files. "
+        "Pick a different folder, then Check again."
+    ),
+    "lasting_root_overlap": (
+        "That folder is already connected. Manage it under Sync folders "
+        "instead of adding it again."
+    ),
+    "passive_process": (
+        "Another Chatbook window is using that folder. "
+        "Close it, then Check again."
+    ),
+    "lock_unavailable": (
+        "Chatbook could not claim that folder. "
+        "Restart Chatbook, then Check again."
+    ),
+    "root_lease_unavailable": (
+        "That folder could not be claimed for sync. "
+        "Close any other Chatbook window using it, then Check again."
+    ),
+    "unsupported_metadata": (
+        "Some files there use a permission model this sync can't track. "
+        "Make every file in the folder writable, then Check again."
+    ),
+    # The bare gate name, which is what a *listing* failure reports. Every
+    # per-file refusal replaces it with the dominant gate below.
+    "root_discovery_incomplete": (
+        "Some files in that folder couldn't be read. "
+        "Check that you can open everything in it, then Check again."
+    ),
+    "mixed_newlines": (
+        "Some files there use a mix of line endings. "
+        "Save them with one style, then Check again."
+    ),
+    "unsupported_newline": (
+        "Some files there use older Mac line endings. "
+        "Save them with Unix or Windows line endings, then Check again."
+    ),
+    "unsupported_encoding": (
+        "Some files there are not UTF-8 text. "
+        "Convert or move them out of the folder, then Check again."
+    ),
+    "max_file_bytes_exceeded": (
+        "Some files there are larger than 10 MB. "
+        "Move them out of the folder, then Check again."
+    ),
+    "non_regular": (
+        "Some entries there aren't ordinary files. "
+        "Move them out of the folder, then Check again."
+    ),
+    "multiple_links": (
+        "Some files there have more than one name on disk. "
+        "Leave a single copy in the folder, then Check again."
+    ),
+    "link_or_reparse": (
+        "Some entries there are links rather than files. "
+        "Move them out of the folder, then Check again."
+    ),
+    "target_changed_during_read": (
+        "Something changed those files while they were being read. "
+        "Check again once the folder is settled."
+    ),
+    "notes_sync_cutover_not_admitted": (
+        "Sync isn't available while another Chatbook instance owns this "
+        "profile. Close the other instance, then Check again."
+    ),
+    "root_offline": (
+        "That folder isn't available right now. Reconnect it, then Check again."
+    ),
+    "root_unavailable": (
+        "That folder can't be read right now. Check that it still exists and "
+        "that you can open it, then Check again."
+    ),
+    "root_not_directory": "That path isn't a folder. Pick a folder, then Check again.",
+    "root_link_or_reparse": (
+        "That path is a link. Pick the folder it points at, then Check again."
+    ),
+    "writable_filesystem_unsupported": (
+        "Chatbook can't write safely on that filesystem. "
+        "Pick a folder on a local disk, then Check again."
+    ),
+    "sync_root_not_active": (
+        "That folder is paused. Resume it, then Check again."
+    ),
+}
+
+
+def _refusal_reason(error: BaseException) -> str:
+    """Return the bounded reason code this failure names, or an empty string.
+
+    Only codes this module already knows are ever returned, so nothing an
+    exception message happens to carry -- a path, a note title -- can reach a
+    status line or a log record through here.
+    """
+
+    code = getattr(error, "reason_code", None)
+    if type(code) is str and code in _CHECK_REFUSAL_COPY:
+        return code
+    text = str(error)
+    return text if text in _CHECK_REFUSAL_COPY else ""
+
+
+def check_failure_line(error: BaseException, *, root_id: str = "") -> str:
+    """Name one refused Check for the user and for the log.
+
+    An empty ``root_id`` means the setup path, where no root exists yet; that
+    also picks the fallback line, since the two paths send the reader to
+    different places when the cause cannot be named.
+    """
+
+    reason = _refusal_reason(error)
+    logger.warning(
+        "notes sync check refused; reason={} error_type={} root_id={}",
+        reason or "unclassified",
+        type(error).__name__,
+        root_id or "pending-setup",
+    )
+    if reason:
+        return _CHECK_REFUSAL_COPY[reason]
+    return (
+        "Check failed. Review root status, then Check again."
+        if root_id
+        else "Check failed. Review the folder and settings, then try again."
+    )
+
+
 __all__ = [
     "LASTING_SYNC_HISTORY_PAGE_SIZE",
     "LastingSyncApplyBlocker",
@@ -817,6 +958,7 @@ __all__ = [
     "LastingSyncSetup",
     "LibraryNotesLastingSyncSnapshot",
     "build_reconciliation_review",
+    "check_failure_line",
     "initial_lasting_sync_snapshot",
     "set_setup_value",
     "validate_lasting_sync_history_page",

--- a/tldw_chatbook/Notes/notes_sync_filesystem.py
+++ b/tldw_chatbook/Notes/notes_sync_filesystem.py
@@ -193,13 +193,17 @@ class PosixNotesSyncFilesystem:
         # It used to demand `owner_group == os.getegid()`, which refuses every
         # file carrying any other group the caller belongs to -- and every file
         # under a directory with a foreign setgid group -- even though the
-        # caller owns it and can write it. Ask the permission bits instead.
+        # caller owns it and can write it. Ask ownership, then the bits.
+        # It stays an OWNERSHIP gate (`d2f5901467`): a file belonging to
+        # another local user is refused however permissive its mode is. Mode
+        # bits are the weakest proxy there anyway -- replacement is a rename
+        # governed by the directory, not by the file.
         if snapshot.owner_user == os.geteuid():
             writable = bool(snapshot.mode & stat.S_IWUSR)
         elif snapshot.owner_group in os.getgroups():
             writable = bool(snapshot.mode & stat.S_IWGRP)
         else:
-            writable = bool(snapshot.mode & stat.S_IWOTH)
+            return "unsupported_metadata"
         return None if writable else "unsupported_metadata"
 
     def observe(

--- a/tldw_chatbook/Notes/notes_sync_filesystem.py
+++ b/tldw_chatbook/Notes/notes_sync_filesystem.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import stat
 import sys
 import uuid
 from dataclasses import dataclass
@@ -188,9 +189,18 @@ class PosixNotesSyncFilesystem:
     def _metadata_issue(snapshot: SafeSyncBytes) -> str | None:
         if snapshot.flags or snapshot.has_extended_acl:
             return "unsupported_metadata"
-        if snapshot.owner_user != os.geteuid() or snapshot.owner_group != os.getegid():
-            return "unsupported_metadata"
-        return None
+        # TASK-32244: this gate stands in for "sync can replace this file".
+        # It used to demand `owner_group == os.getegid()`, which refuses every
+        # file carrying any other group the caller belongs to -- and every file
+        # under a directory with a foreign setgid group -- even though the
+        # caller owns it and can write it. Ask the permission bits instead.
+        if snapshot.owner_user == os.geteuid():
+            writable = bool(snapshot.mode & stat.S_IWUSR)
+        elif snapshot.owner_group in os.getgroups():
+            writable = bool(snapshot.mode & stat.S_IWGRP)
+        else:
+            writable = bool(snapshot.mode & stat.S_IWOTH)
+        return None if writable else "unsupported_metadata"
 
     def observe(
         self,

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -7,7 +7,7 @@ import hashlib
 import sqlite3
 import time
 import weakref
-from collections import OrderedDict
+from collections import Counter, OrderedDict
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, replace
 from datetime import UTC, datetime
@@ -156,6 +156,24 @@ def _validate_projection(status: str, next_action: str) -> None:
         raise ValueError("unknown runtime status")
     if next_action not in _NEXT_ACTIONS:
         raise ValueError("unknown runtime next action")
+
+
+class NotesSyncRootRefused(RuntimeError):
+    """A named lasting-root refusal that carries its own machine-readable cause.
+
+    TASK-32243: the refusal a Check reaches (``root_lease_unavailable``,
+    ``root_discovery_incomplete``) says only which gate closed. ``reason_code``
+    names *why* -- the coordinator's admission reason, or the dominant per-file
+    refusal -- so the UI can answer with a next action instead of "try again".
+    Both fields are bounded machine codes: no path, note or user content.
+    """
+
+    def __init__(
+        self, code: str, *, reason_code: str | None = None, detail: str = ""
+    ) -> None:
+        self.reason_code = reason_code or code
+        self.detail = detail
+        super().__init__(code)
 
 
 @dataclass(frozen=True, slots=True)
@@ -545,19 +563,28 @@ class _ProductionRuntimeAdapter:
             self._discovery_bounds,
         )
         if discovery.failures:
-            raise RuntimeError("root_discovery_incomplete")
+            raise NotesSyncRootRefused(
+                "root_discovery_incomplete",
+                detail=f"{len(discovery.failures)} paths could not be listed",
+            )
         # TASK-23027: reuse is validated per item against state read fresh
         # this pass; see _ObservationReuse. A miss (edit, add, rename, touch,
         # or a cold cache) takes exactly the pre-existing read path.
         reuse = self._observation_reuse.get(root.root_id)
         discovered: dict[str, NotesSyncFileSnapshot] = {}
         reused_files = 0
+        # TASK-32244: refusals are counted across the whole walk instead of
+        # raising on the first one, so "discovery did not finish" can say how
+        # many files were refused and for what.
+        refusals: Counter[str] = Counter()
+        syncable_files = 0
         for candidate in discovery.candidates:
             relative_path = candidate.source.source_path.relative_to(
                 Path(root.canonical_path)
             ).as_posix()
             if Path(relative_path).suffix.casefold() not in _SYNC_FILE_EXTENSIONS:
                 continue
+            syncable_files += 1
             cached_file = reuse.files.get(relative_path) if reuse else None
             if cached_file is not None and _file_snapshot_current(
                 cached_file, candidate.identity
@@ -576,7 +603,16 @@ class _ProductionRuntimeAdapter:
                 )
             except NotesSyncFilesystemError as error:
                 if error.reason_code != "missing_target":
-                    raise RuntimeError("root_discovery_incomplete") from None
+                    refusals[error.reason_code] += 1
+        if refusals:
+            dominant, count = refusals.most_common(1)[0]
+            raise NotesSyncRootRefused(
+                "root_discovery_incomplete",
+                detail=(
+                    f"{sum(refusals.values())} of {syncable_files} files refused; "
+                    f"{count} for {dominant}"
+                ),
+            )
 
         # TASK-21532: this read-all stays. It looks like the projection shape
         # below it -- one field, `binding.state` -- but the same tuple is the
@@ -1072,6 +1108,7 @@ class NotesSyncRuntimeOwner:
         self._active_tasks: dict[str, set[asyncio.Task[object]]] = {}
         self._leases: dict[str, object] = {}
         self._admissions: dict[str, object] = {}
+        self._admission_reasons: dict[str, str] = {}
         self._blocked_roots: set[str] = set()
         self._durably_blocked_roots: set[str] = set()
         self._closed_roots: set[str] = set()
@@ -1569,9 +1606,20 @@ class NotesSyncRuntimeOwner:
             )
         return roots
 
-    async def _ensure_lease(self, root: NotesSyncRootRecord) -> bool:
+    async def _ensure_lease(
+        self, root: NotesSyncRootRecord, *, persist: bool = True
+    ) -> bool:
+        """Admit one root, recording the refusal reason when it is refused.
+
+        ``persist`` is False for a root the store has never seen (a setup
+        review, or the activation of one): publishing a status for it would
+        raise ``NotesDeviceStateError`` from the store and destroy the named
+        refusal this returns (TASK-32243).
+        """
+
         existing = self._leases.get(root.root_id)
         if existing is not None and getattr(existing, "authoritative", False):
+            self._admission_reasons.pop(root.root_id, None)
             return True
         assert self._coordinator is not None
         admission = await asyncio.to_thread(
@@ -1587,6 +1635,7 @@ class NotesSyncRuntimeOwner:
         if admission.state is RootAdmissionState.OWNER:
             self._leases[root.root_id] = admission.require_authority("plan")
             self._admissions[root.root_id] = admission
+            self._admission_reasons.pop(root.root_id, None)
             if root.root_id not in self._durably_blocked_roots:
                 self._blocked_roots.discard(root.root_id)
             return True
@@ -1595,8 +1644,18 @@ class NotesSyncRuntimeOwner:
             RootAdmissionState.OFFLINE: ("offline", "reconnect_folder"),
             RootAdmissionState.REJECTED: ("unsupported", "review_settings"),
         }[admission.state]
-        await self._publish(root.root_id, status, action)
+        if admission.reason_code:
+            self._admission_reasons[root.root_id] = admission.reason_code
+        await self._publish(root.root_id, status, action, persist=persist)
         return False
+
+    def _refuse_lease(self, root_id: str) -> NotesSyncRootRefused:
+        """Name the refusal the last :meth:`_ensure_lease` recorded."""
+
+        return NotesSyncRootRefused(
+            "root_lease_unavailable",
+            reason_code=self._admission_reasons.pop(root_id, None),
+        )
 
     async def _fresh_authority(self, root: NotesSyncRootRecord) -> _FreshAuthority:
         self._require_authority(root.root_id, "plan")
@@ -1766,10 +1825,14 @@ class NotesSyncRuntimeOwner:
                 state=NotesSyncRootState.PENDING,
             )
             self._root_paths[root_id] = setup.canonical_path
-            if matching_root_id is None and not await self._ensure_lease(root):
-                self._root_paths.pop(root_id, None)
-                raise RuntimeError("root_lease_unavailable")
+            # TASK-32243: one release for every failure. The lease refusal used
+            # to skip this, leaking `_root_paths` and rejecting the same folder
+            # as `lasting_root_overlap` for the rest of the session.
             try:
+                if matching_root_id is None and not await self._ensure_lease(
+                    root, persist=False
+                ):
+                    raise self._refuse_lease(root_id)
                 plan = await self._review_candidate(root)
             except Exception:
                 await self._release_setup_authority(root_id)
@@ -1797,6 +1860,7 @@ class NotesSyncRuntimeOwner:
             )
         self._leases.pop(root_id, None)
         self._admissions.pop(root_id, None)
+        self._admission_reasons.pop(root_id, None)
         self._setup_reviews.pop(root_id, None)
         self._root_paths.pop(root_id, None)
         self._root_status.pop(root_id, None)
@@ -1827,7 +1891,7 @@ class NotesSyncRuntimeOwner:
                 await self._publish(root_id, "paused", "resume_sync")
                 raise RuntimeError("sync_root_not_active")
             if not await self._ensure_lease(root):
-                raise RuntimeError("root_lease_unavailable")
+                raise self._refuse_lease(root_id)
             incomplete = await asyncio.to_thread(self._store.list_incomplete_operations)
             root_operations = tuple(
                 operation for operation in incomplete if operation.root_id == root_id
@@ -2540,7 +2604,7 @@ class NotesSyncRuntimeOwner:
             if root.state is not NotesSyncRootState.ACTIVE:
                 raise RuntimeError("sync_root_not_active")
             if not await self._ensure_lease(root):
-                raise RuntimeError("root_lease_unavailable")
+                raise self._refuse_lease(root_id)
             self._require_authority(root_id, "write")
             executor = self._adapter.executor_for(
                 root,
@@ -2647,7 +2711,7 @@ class NotesSyncRuntimeOwner:
                 raise ValueError("activation_review_required")
         if reviewed is None or reviewed.observation_token != token:
             raise ValueError("stale_review")
-        if not await self._ensure_lease(root):
+        if not await self._ensure_lease(root, persist=setup_review is None):
             return NotesSyncControlResult(False, "passive", "open_active_process")
         fresh = await self._review_candidate(root)
         if fresh != reviewed:

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -1834,7 +1834,13 @@ class NotesSyncRuntimeOwner:
                 ):
                     raise self._refuse_lease(root_id)
                 plan = await self._review_candidate(root)
-            except Exception:
+            except BaseException:
+                # BaseException, not Exception: a cancelled Check used to skip
+                # this and leak both `_root_paths` and the coordinator lease,
+                # so the lock file stayed held and the folder was refused
+                # `passive_process` for the rest of the session. The release
+                # awaits safely here -- cancellation is delivered once, at the
+                # await it interrupted, not again inside the handler.
                 await self._release_setup_authority(root_id)
                 raise
             self._setup_reviews[root_id] = _SetupReview(setup, plan)

--- a/tldw_chatbook/Notes/notes_sync_runtime.py
+++ b/tldw_chatbook/Notes/notes_sync_runtime.py
@@ -606,8 +606,14 @@ class _ProductionRuntimeAdapter:
                     refusals[error.reason_code] += 1
         if refusals:
             dominant, count = refusals.most_common(1)[0]
+            # `reason_code`, not only `detail`: every per-file gate lands on
+            # this one exception -- `mixed_newlines`, `unsupported_encoding`,
+            # `max_file_bytes_exceeded`, `non_regular`, … -- so a caller that
+            # reads the gate name alone can only give permission advice, which
+            # is wrong for all but one of them.
             raise NotesSyncRootRefused(
                 "root_discovery_incomplete",
+                reason_code=dominant,
                 detail=(
                     f"{sum(refusals.values())} of {syncable_files} files refused; "
                     f"{count} for {dominant}"

--- a/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
@@ -6,8 +6,6 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Never, Protocol
 
-from loguru import logger
-
 from tldw_chatbook.Library.library_notes_lasting_sync_state import (
     LASTING_SYNC_HISTORY_PAGE_SIZE,
     LastingSyncApplyBlocker,
@@ -19,6 +17,7 @@ from tldw_chatbook.Library.library_notes_lasting_sync_state import (
     LastingSyncRootRow,
     LibraryNotesLastingSyncSnapshot,
     build_reconciliation_review,
+    check_failure_line,
     initial_lasting_sync_snapshot,
     set_setup_value,
     validate_lasting_sync_history_page,
@@ -49,136 +48,6 @@ from tldw_chatbook.Notes.notes_sync_models import (
     NotesSyncDirection,
     NotesSyncOperationState,
 )
-
-
-# TASK-32243: a refused Check used to render one fixed string for every cause,
-# with nothing logged anywhere. Each bounded reason the runtime and coordinator
-# can name gets its own sentence and its own next action here; anything else
-# keeps the generic line but still leaves a typed warning behind.
-_CHECK_REFUSAL_COPY: dict[str, str] = {
-    "private_path_overlap": (
-        "That folder is inside Chatbook's own data directory. "
-        "Pick a folder outside it, then Check again."
-    ),
-    "private_path_check_failed": (
-        "Chatbook could not confirm that folder sits outside its own data. "
-        "Pick a folder in your home directory, then Check again."
-    ),
-    "file_notes_overlap": (
-        "That folder is already in use by Folder files. "
-        "Pick a different folder, then Check again."
-    ),
-    "lasting_root_overlap": (
-        "That folder is already connected. Manage it under Sync folders "
-        "instead of adding it again."
-    ),
-    "passive_process": (
-        "Another Chatbook window is using that folder. "
-        "Close it, then Check again."
-    ),
-    "lock_unavailable": (
-        "Chatbook could not claim that folder. "
-        "Restart Chatbook, then Check again."
-    ),
-    "root_lease_unavailable": (
-        "That folder could not be claimed for sync. "
-        "Close any other Chatbook window using it, then Check again."
-    ),
-    "unsupported_metadata": (
-        "Some files there use a permission model this sync can't track. "
-        "Make every file in the folder writable, then Check again."
-    ),
-    # The bare gate name, which is what a *listing* failure reports. Every
-    # per-file refusal replaces it with the dominant gate below.
-    "root_discovery_incomplete": (
-        "Some files in that folder couldn't be read. "
-        "Check that you can open everything in it, then Check again."
-    ),
-    "mixed_newlines": (
-        "Some files there use a mix of line endings. "
-        "Save them with one style, then Check again."
-    ),
-    "unsupported_newline": (
-        "Some files there use older Mac line endings. "
-        "Save them with Unix or Windows line endings, then Check again."
-    ),
-    "unsupported_encoding": (
-        "Some files there are not UTF-8 text. "
-        "Convert or move them out of the folder, then Check again."
-    ),
-    "max_file_bytes_exceeded": (
-        "Some files there are larger than 10 MB. "
-        "Move them out of the folder, then Check again."
-    ),
-    "non_regular": (
-        "Some entries there aren't ordinary files. "
-        "Move them out of the folder, then Check again."
-    ),
-    "multiple_links": (
-        "Some files there have more than one name on disk. "
-        "Leave a single copy in the folder, then Check again."
-    ),
-    "link_or_reparse": (
-        "Some entries there are links rather than files. "
-        "Move them out of the folder, then Check again."
-    ),
-    "target_changed_during_read": (
-        "Something changed those files while they were being read. "
-        "Check again once the folder is settled."
-    ),
-    "notes_sync_cutover_not_admitted": (
-        "Sync isn't available while another Chatbook instance owns this "
-        "profile. Close the other instance, then Check again."
-    ),
-    "root_offline": (
-        "That folder isn't available right now. Reconnect it, then Check again."
-    ),
-    "root_unavailable": (
-        "That folder can't be read right now. Check that it still exists and "
-        "that you can open it, then Check again."
-    ),
-    "root_not_directory": "That path isn't a folder. Pick a folder, then Check again.",
-    "root_link_or_reparse": (
-        "That path is a link. Pick the folder it points at, then Check again."
-    ),
-    "writable_filesystem_unsupported": (
-        "Chatbook can't write safely on that filesystem. "
-        "Pick a folder on a local disk, then Check again."
-    ),
-    "sync_root_not_active": (
-        "That folder is paused. Resume it, then Check again."
-    ),
-}
-
-
-def _refusal_reason(error: BaseException) -> str:
-    """Return the bounded reason code this failure names, or an empty string.
-
-    Only codes this module already knows are ever returned, so nothing an
-    exception message happens to carry -- a path, a note title -- can reach a
-    status line or a log record through here.
-    """
-
-    code = getattr(error, "reason_code", None)
-    if type(code) is str and code in _CHECK_REFUSAL_COPY:
-        return code
-    text = str(error)
-    return text if text in _CHECK_REFUSAL_COPY else ""
-
-
-def _check_failure_line(
-    error: BaseException, fallback: str, *, root_id: str = ""
-) -> str:
-    """Name one refused Check for the user and for the log."""
-
-    reason = _refusal_reason(error)
-    logger.warning(
-        "notes sync check refused; reason={} error_type={} root_id={}",
-        reason or "unclassified",
-        type(error).__name__,
-        root_id or "pending-setup",
-    )
-    return _CHECK_REFUSAL_COPY.get(reason, fallback)
 
 
 class LastingSyncRuntimePort(Protocol):
@@ -873,11 +742,7 @@ class LibraryNotesSyncController:
                     activation=activation,
                     epoch=epoch,
                 ),
-                status_line=_check_failure_line(
-                    error,
-                    "Check failed. Review root status, then Check again.",
-                    root_id=root_id,
-                ),
+                status_line=check_failure_line(error, root_id=root_id),
             )
             self._publish()
             return
@@ -945,10 +810,7 @@ class LibraryNotesSyncController:
             self._state = replace(
                 self._state,
                 phase="configure",
-                status_line=_check_failure_line(
-                    error,
-                    "Check failed. Review the folder and settings, then try again.",
-                ),
+                status_line=check_failure_line(error),
             )
             self._publish()
             return

--- a/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
@@ -6,6 +6,8 @@ from collections.abc import Awaitable, Callable
 from dataclasses import replace
 from typing import Never, Protocol
 
+from loguru import logger
+
 from tldw_chatbook.Library.library_notes_lasting_sync_state import (
     LASTING_SYNC_HISTORY_PAGE_SIZE,
     LastingSyncApplyBlocker,
@@ -47,6 +49,102 @@ from tldw_chatbook.Notes.notes_sync_models import (
     NotesSyncDirection,
     NotesSyncOperationState,
 )
+
+
+# TASK-32243: a refused Check used to render one fixed string for every cause,
+# with nothing logged anywhere. Each bounded reason the runtime and coordinator
+# can name gets its own sentence and its own next action here; anything else
+# keeps the generic line but still leaves a typed warning behind.
+_CHECK_REFUSAL_COPY: dict[str, str] = {
+    "private_path_overlap": (
+        "That folder is inside Chatbook's own data directory. "
+        "Pick a folder outside it, then Check again."
+    ),
+    "private_path_check_failed": (
+        "Chatbook could not confirm that folder sits outside its own data. "
+        "Pick a folder in your home directory, then Check again."
+    ),
+    "file_notes_overlap": (
+        "That folder is already in use by Folder files. "
+        "Pick a different folder, then Check again."
+    ),
+    "lasting_root_overlap": (
+        "That folder is already connected. Manage it under Sync folders "
+        "instead of adding it again."
+    ),
+    "passive_process": (
+        "Another Chatbook window is using that folder. "
+        "Close it, then Check again."
+    ),
+    "lock_unavailable": (
+        "Chatbook could not claim that folder. "
+        "Restart Chatbook, then Check again."
+    ),
+    "root_lease_unavailable": (
+        "That folder could not be claimed for sync. "
+        "Close any other Chatbook window using it, then Check again."
+    ),
+    "unsupported_metadata": (
+        "Some files there use a permission model this sync can't track. "
+        "Make every file in the folder writable, then Check again."
+    ),
+    "root_discovery_incomplete": (
+        "Some files there use a permission model this sync can't track. "
+        "Make every file in the folder writable, then Check again."
+    ),
+    "notes_sync_cutover_not_admitted": (
+        "Sync isn't available while another Chatbook instance owns this "
+        "profile. Close the other instance, then Check again."
+    ),
+    "root_offline": (
+        "That folder isn't available right now. Reconnect it, then Check again."
+    ),
+    "root_unavailable": (
+        "That folder can't be read right now. Check that it still exists and "
+        "that you can open it, then Check again."
+    ),
+    "root_not_directory": "That path isn't a folder. Pick a folder, then Check again.",
+    "root_link_or_reparse": (
+        "That path is a link. Pick the folder it points at, then Check again."
+    ),
+    "writable_filesystem_unsupported": (
+        "Chatbook can't write safely on that filesystem. "
+        "Pick a folder on a local disk, then Check again."
+    ),
+    "sync_root_not_active": (
+        "That folder is paused. Resume it, then Check again."
+    ),
+}
+
+
+def _refusal_reason(error: BaseException) -> str:
+    """Return the bounded reason code this failure names, or an empty string.
+
+    Only codes this module already knows are ever returned, so nothing an
+    exception message happens to carry -- a path, a note title -- can reach a
+    status line or a log record through here.
+    """
+
+    code = getattr(error, "reason_code", None)
+    if type(code) is str and code in _CHECK_REFUSAL_COPY:
+        return code
+    text = str(error)
+    return text if text in _CHECK_REFUSAL_COPY else ""
+
+
+def _check_failure_line(
+    error: BaseException, fallback: str, *, root_id: str = ""
+) -> str:
+    """Name one refused Check for the user and for the log."""
+
+    reason = _refusal_reason(error)
+    logger.warning(
+        "notes sync check refused; reason={} error_type={} root_id={}",
+        reason or "unclassified",
+        type(error).__name__,
+        root_id or "pending-setup",
+    )
+    return _CHECK_REFUSAL_COPY.get(reason, fallback)
 
 
 class LastingSyncRuntimePort(Protocol):
@@ -729,7 +827,7 @@ class LibraryNotesSyncController:
         self._publish()
         try:
             plan = await self._runtime.check_root(root_id)
-        except Exception:
+        except Exception as error:
             if not self._lifecycle_is_current(root_id, epoch):
                 return
             self._state = replace(
@@ -741,7 +839,11 @@ class LibraryNotesSyncController:
                     activation=activation,
                     epoch=epoch,
                 ),
-                status_line="Check failed. Review root status, then Check again.",
+                status_line=_check_failure_line(
+                    error,
+                    "Check failed. Review root status, then Check again.",
+                    root_id=root_id,
+                ),
             )
             self._publish()
             return
@@ -803,13 +905,16 @@ class LibraryNotesSyncController:
                     direction=direction,
                 )
             )
-        except Exception:
+        except Exception as error:
             if not self._lifecycle_is_current(None, epoch):
                 return
             self._state = replace(
                 self._state,
                 phase="configure",
-                status_line="Check failed. Review the folder and settings, then try again.",
+                status_line=_check_failure_line(
+                    error,
+                    "Check failed. Review the folder and settings, then try again.",
+                ),
             )
             self._publish()
             return

--- a/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
+++ b/tldw_chatbook/UI/Library_Modules/library_notes_sync_controller.py
@@ -88,9 +88,43 @@ _CHECK_REFUSAL_COPY: dict[str, str] = {
         "Some files there use a permission model this sync can't track. "
         "Make every file in the folder writable, then Check again."
     ),
+    # The bare gate name, which is what a *listing* failure reports. Every
+    # per-file refusal replaces it with the dominant gate below.
     "root_discovery_incomplete": (
-        "Some files there use a permission model this sync can't track. "
-        "Make every file in the folder writable, then Check again."
+        "Some files in that folder couldn't be read. "
+        "Check that you can open everything in it, then Check again."
+    ),
+    "mixed_newlines": (
+        "Some files there use a mix of line endings. "
+        "Save them with one style, then Check again."
+    ),
+    "unsupported_newline": (
+        "Some files there use older Mac line endings. "
+        "Save them with Unix or Windows line endings, then Check again."
+    ),
+    "unsupported_encoding": (
+        "Some files there are not UTF-8 text. "
+        "Convert or move them out of the folder, then Check again."
+    ),
+    "max_file_bytes_exceeded": (
+        "Some files there are larger than 10 MB. "
+        "Move them out of the folder, then Check again."
+    ),
+    "non_regular": (
+        "Some entries there aren't ordinary files. "
+        "Move them out of the folder, then Check again."
+    ),
+    "multiple_links": (
+        "Some files there have more than one name on disk. "
+        "Leave a single copy in the folder, then Check again."
+    ),
+    "link_or_reparse": (
+        "Some entries there are links rather than files. "
+        "Move them out of the folder, then Check again."
+    ),
+    "target_changed_during_read": (
+        "Something changed those files while they were being read. "
+        "Check again once the folder is settled."
     ),
     "notes_sync_cutover_not_admitted": (
         "Sync isn't available while another Chatbook instance owns this "


### PR DESCRIPTION
Closes tasks **32243** (P0), **32244**, **32269**. Wave 3, Library ▸ Notes critique.

"Keep a folder synced" is one of the three worlds the Notes canvas advertises and the one the guide gives the most space to. Both critique assessors hit this on their first real attempt and **neither could ever retry**. This branch makes a refused Check refuse honestly, leave no residue, and say why.

---

## The P0, in three proven parts (task-32243)

Reproduced headlessly before any edit, against the exact `review_setup()` the Check button calls:

```
[first] RAISED after 0.21s
  notes_sync_runtime.py:1598 _ensure_lease -> _publish -> update_root_status
  NotesDeviceStateError: The requested sync root does not exist.
[first] _root_paths={'24fa38cb-…': '…/profile/invault'}
[retry-same] RAISED … same crash
[retry-same] _root_paths={'24fa38cb-…': …, '636cd743-…': …}   <- leaking per attempt
```

**1. The named refusal was destroyed by a secondary crash.** On any non-OWNER admission `_ensure_lease` called `_publish(..., persist=True)`, which writes a status to the store. For a setup review the root has never been persisted, so the store raised `NotesDeviceStateError` and the intended `RuntimeError("root_lease_unavailable")` was never reached.
→ `_ensure_lease(root, *, persist: bool = True)`. `review_setup` and the setup half of `_activate_root` (`persist=setup_review is None`) pass `False`. `_ensure_lease` returns `True` for OWNER *before* `_publish`, so no OWNER path can persist a status; the five persisted-root callers keep the default.

**2. Each failed Check leaked a `_root_paths` entry**, so the next attempt on the same folder was rejected `lasting_root_overlap` — permanently, invisibly, even after the user fixed the real cause. No way back but a restart.
→ The lease check moved *inside* the `except` block that already released the setup authority for the observation failure. One release for every failure, not a pop on one branch and a release on another — and it is the smaller diff. Widened to `except BaseException`, because a cancelled Check leaked both `_root_paths` **and** the coordinator lease (lock file held ⇒ the folder is then refused `passive_process` for the session — strictly worse than the bug being fixed).

**3. The controller substituted one fixed string for every cause** — "Check failed. Review the folder and settings, then try again." — and the module contained zero `logger` references, so nothing was written anywhere.
→ `NotesSyncRootRefused(RuntimeError)` keeps `str(exc)` as the gate that closed and adds `reason_code` + `detail`. Both Check paths (`check_setup` **and** `_check_root` — the ticket named only the first; both carried the same string) route through one `check_failure_line`.

## The reason → copy table

Lives in `Library/library_notes_lasting_sync_state.py` with the rest of this screen's presentation state. Both fallback strings are folded into the helper, keyed on `root_id == ""` ⇒ setup, so each call site is one line.

| reason | what the user now reads |
|---|---|
| `private_path_overlap` | That folder is inside Chatbook's own data directory. Pick a folder outside it, then Check again. |
| `passive_process` | Another Chatbook window is using that folder. Close it, then Check again. |
| `lasting_root_overlap` | That folder is already connected. Manage it under Sync folders instead of adding it again. |
| `unsupported_metadata` | Some files there use a permission model this sync can't track. Make every file in the folder writable, then Check again. |
| `notes_sync_cutover_not_admitted` | Sync isn't available while another Chatbook instance owns this profile. |
| `root_discovery_incomplete` | Some files in that folder couldn't be read. *(the listing failure it actually names)* |
| `mixed_newlines`, `unsupported_newline`, `unsupported_encoding`, `max_file_bytes_exceeded`, `non_regular`, `multiple_links`, `link_or_reparse`, `target_changed_during_read` | one sentence and one next action each |
| `root_offline`, `root_unavailable`, `root_not_directory`, `root_link_or_reparse`, `writable_filesystem_unsupported`, `lock_unavailable`, `private_path_check_failed`, `file_notes_overlap`, `root_lease_unavailable`, `sync_root_not_active` | likewise |

Every per-file gate arrives as `root_discovery_incomplete`, so the raise now carries `reason_code=dominant` rather than burying it in `detail` — otherwise a newline problem is reported as a permissions problem. Before/after on the same vault:

```
CODE     : root_discovery_incomplete          CODE     : root_discovery_incomplete
REASON   : root_discovery_incomplete          REASON   : mixed_newlines
USER COPY: …permission model…make every       USER COPY: Some files there use a mix of line
           file writable                                 endings. Save them with one style.
```

**Path-free by construction.** `_refusal_reason` can only return a key of the literal table, so neither `str(error)` nor `detail` can carry a path into a status line or a log. The record is reason + `type(error).__name__` + opaque root id:

```
notes sync check refused; reason=private_path_overlap error_type=NotesSyncRootRefused root_id=pending-setup
```

## Security: foreign-owned files stay refused (task-32244)

`_metadata_issue` demanded `owner_group == os.getegid()` — the caller's *primary* group — which refuses every file carrying any other group the caller belongs to, even one they own and can write. On this host `egid=20`, `getgroups()=[20,12,61,…]`, and everything under `/private/tmp` carries `wheel` (gid 0, not in that list): all 60 fixture files refused, root failed, journey untestable.

It now asks ownership, then the permission bits — and **stays an ownership gate**:

| snapshot | before | after |
|---|---|---|
| me, my group, `0644` | admitted | admitted |
| foreign owner, my supplementary group, `0664` | refused | **admitted** (the fix) |
| me, my group, `0444` | **admitted** (false admit; would fail at replace time) | refused |
| foreign owner, foreign group, `0666` / `0777` | refused | **refused** |

An intermediate revision of this branch let world-writable foreign-owned files through via an `S_IWOTH` fallback; review caught it and it is gone. Mode bits are the weakest proxy there anyway — replacement is a rename governed by the directory, not the file.

`root_discovery_incomplete` also stopped raising on the first refused file: it counts across the walk and reports `"N of M files refused; K for <reason>"`. Worst case is one full walk, which is what a good root already costs.

## RED → GREEN

Nothing pinned any of this before: `grep root_lease_unavailable Tests/` and `grep root_discovery_incomplete Tests/` returned **zero hits** for three weeks.

| test | RED | GREEN |
|---|---|---|
| setup refusal names its reason, no residue | `NotesDeviceStateError`, not the named refusal; `_root_paths` held one leaked entry | named refusal, `_root_paths == {}`, retry reaches the same decision |
| cancelled setup review releases lease + path | `_root_paths` populated after cancel | `{}`, `_leases == {}`, `lease-released` |
| discovery refusal names count **and** dominant gate | `reason_code == 'root_discovery_incomplete'` | `'mixed_newlines'`, `"1 of 2"` |
| ownership gate, 6 synthetic cases | foreign-owned `0666`/`0777` returned `None` | `unsupported_metadata` |
| controller renders a distinct reason (13 cases) | the fixed "Check failed…" string | its own sentence + next action |
| unclassified failure | nothing logged at all | `ZeroDivisionError` logged, canary path absent |

Also mutation-checked by the reviewer: branch runtime + **BASE** controller ⇒ all 8 controller cases fail on the real copy assertion, so the tests pin behaviour, not just the new type.

## Live evidence

Two sessions at 235×52 on scratch profiles; captures `cap-01`…`cap-18`.

- `cap-01` the refusal copy in the pane · `log-refusal-warning.txt` the path-free record
- `cap-02` **the same session**, a 179-file `$HOME` vault checks clean, 60 safe / 0 attention — *the leak is gone*
- `cap-03` "Sync root activated. 60 applied · durable receipt recorded" · `cap-05` notes under a **⇄ Sync managed** folder
- `cap-06`/`cap-07` **Manage sync folders** (which only exists once a root is active) and a re-check
- `cap-11`…`cap-18` a real conflict — note edited in Chatbook, same file edited on disk — through **Review → View comparison** (a real `--- Note / +++ File` diff) **→ Keep file → Apply reviewed →** receipt with **Undo**/**Dismiss** **→ Undo → Resolution history** (entry recorded "undone") **→ Pause → Resume**. Retarget/Disconnect stayed visibly disabled throughout.

## Docs (task-32269)

The chapter documented Check → review → Activate → conflicts → Manage sync folders → Pause/Resume from the *design*; none of it could be entered. It has now been walked end to end, and gained what a folder **and its files** must be before they can be checked — UTF-8, consistent line endings, ≤ 10 MB, ordinary single-link files you can write, with the "one bad file stops the whole folder" consequence stated.

## Housekeeping

- **Rider [task-32451]**: every row in Manage sync folders reads "Sync folder (name unavailable before cutover)" — `library_notes_sync_controller.py:709` hard-codes it, because the path-free `NotesSyncRootRuntimeSnapshot` carries no display name. Unhelpful with one root, unusable with two. Not fixed here.
- **Size pin `2023 → 2024`, +1 line.** The controller's entire diff against dev is five lines: one import and two call sites (`except Exception as error:` and the one-line helper call are line-for-line replacements). The `+1` *is* the import. An earlier revision inlined the copy table and pinned 2128; review rejected that, the table moved to the unbudgeted state module, and the row is now the exact measurement — 2023 would fail the ceiling test.
- Lessons entry added: *a refusal path needs its own test, or it will lose both its name and its cleanup*.
- Diagnostic inventory re-pinned **after** the dev merge (600 owners, exit 0). The one statement moved files with an unchanged digest.

## Counts

`359 passed, 1 skipped, 15 failed` across controller + runtime + filesystem + size-ratchet + inventory on the merged tree. The 15 are pre-existing ratchet rows: the FAILED name set is **byte-identical** to `origin/dev`'s own. `ruff` parity per touched file (28/28, 6/6, 20/20, 1/1, 1/1, 7/7, 12/12). 262 passed under random order. Conflict-marker, duplicate-def, duplicate-const and two-dot sweeps all clean; no dev-side deletions.

Provenance: **not a wave regression** — identical traceback at `c4a7b1911f`; every failure site is original to the feature commits (`0dae7bb8b3`, `eea5244886`, `d2f5901467`). Pre-existing since 2026-08-21, newly found.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A refused lasting-sync Check used to crash over its own refusal, leak the folder so retries were rejected for the whole session, and show a fixed "Check failed" string with no log. It now names the reason with a next action, leaves no residue, and logs a path-free record.

**Bug Fixes**
- `_ensure_lease` no longer writes a store status for a root the store has never seen, so the intended refusal survives instead of being replaced by `NotesDeviceStateError`.
- Failed and cancelled Checks now release the setup authority on every path, so `_root_paths` stays empty and retrying the same folder reaches the same decision a fresh session would.
- Each refusal reason renders its own sentence and next action in the setup pane, and every refusal is logged with the reason code, exception type, and opaque root id — never the path.
- The per-file admission gate checks ownership and permission bits instead of demanding the caller's primary group, so writable files in a supplementary group are admitted while foreign-owned files stay refused.
- `root_discovery_incomplete` now reports how many files were refused and the dominant reason, instead of hiding it.

**Docs**
- The lasting-sync chapter was written from the design and never walked; it's now verified end to end and states what a folder and its files must be before a Check.

<sup>Written for commit 32e21b6d05ae34041d74c0d3a46d022990ee8675. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

