### PR TITLE
MCP Hub UX Waves A–C: polish, safe cycle order, flow fixes

### DIFF
--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -30,6 +30,42 @@ organized into four modes: Servers, Tools, Permissions, and Audit.
 - Press **Ctrl+9**, click **⌃9 MCP** in the nav bar, or press **Ctrl+P** →
   "Tab Navigation: Switch to MCP".
 
+## Adding your first MCP server (step by step)
+
+Local servers run as stdio processes chatbook launches for you. Secrets are
+never stored — reference them as `KEY=$ENV_VAR` and export the variable in
+your shell before connecting.
+
+1. **Open the screen** (Ctrl+9). On a fresh install the overview table is
+   showing, with the built-in server listed and the `Add server` and
+   `Import…` buttons at the top. (You can also press `a` in any mode.)
+2. **Press Add server** (or `a`). Fill in:
+   - **Name** — a short id (`docs`); letters, digits, `-`, `_` only.
+   - **Command** — the executable (`npx`, `python3`, `uvx`, …).
+   - **Args** — one per line (e.g. `-y` and `@modelcontextprotocol/server-filesystem`).
+   - **Env** — one `KEY=value` per line; a bare `$VAR` value becomes a
+     placeholder read from your environment at launch.
+3. **Press Save and connect.** The profile is saved and chatbook launches
+   it immediately; the row's status moves from `○ Needs setup` to `● Ready`
+   (or an actionable reason, e.g. a missing `$ENV_VAR`, stays on screen).
+4. **Check permissions.** Press `3` (Permissions). Your server's tools are
+   grouped under a `Server default — <name>` row; every tool starts at
+   **Ask**, meaning each call shows an approval card in Console. Select a
+   row and press **Space** to cycle Inherit → Ask → Allow → Off. The
+   `Server default` row sets the fallback for that whole server — one
+   change instead of one per tool. (Tools you haven't connected yet don't
+   appear here at all; if a server you added is missing, the line under
+   the legend says so and points you back to Servers mode.)
+5. **Try a tool.** Press `2` (Tools), arrow onto the tool, and press `t`
+   to open the Test Tool panel — a form built from the tool's schema (or
+   a raw-JSON box when the schema is too complex). An Ask-gated tool asks
+   once per run; the run is recorded in Audit (`4`).
+
+To remove a server, select its row in Servers mode and use **Delete**
+(a two-step confirm; Escape backs out). **Import…** accepts a
+Claude-Desktop-style `{"mcpServers": …}` config — secret-shaped values
+come in as placeholders, never stored literals.
+
 ## Running Chatbook as a standalone MCP server
 
 Install the packaged optional extra, then configure the external client to

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -49,8 +49,9 @@ your shell before connecting.
    it immediately; the row's status moves from `○ Needs setup` to `● Ready`
    (or an actionable reason, e.g. a missing `$ENV_VAR`, stays on screen).
 4. **Check permissions.** Press `3` (Permissions). Your server's tools are
-   grouped under a `Server default — <name>` row; every tool starts at
-   **Ask**, meaning each call shows an approval card in Console. Select a
+   grouped under a `Server default — <name>` row; every tool inherits the
+   **global default — Ask out of the box** — meaning each call shows an
+   approval card in Console until you change it. Select a
    row and press **Space** to cycle Inherit → Ask → Allow → Off. The
    `Server default` row sets the fallback for that whole server — one
    change instead of one per tool. (Tools you haven't connected yet don't

--- a/Tests/MCP/test_permission_resolution.py
+++ b/Tests/MCP/test_permission_resolution.py
@@ -909,9 +909,12 @@ def test_resolve_by_key_non_mapping_tool_entry_does_not_raise():
 
 
 def test_cycle_ui_state_full_loop():
-    assert cycle_ui_state(None) == "allow"
-    assert cycle_ui_state("allow") == "ask"
-    assert cycle_ui_state("ask") == "deny"
+    # Wave B (2026-09-11 UX program): the first press from Inherit lands
+    # on Ask, not Allow -- the most permissive state is never the first
+    # stop from the default posture.
+    assert cycle_ui_state(None) == "ask"
+    assert cycle_ui_state("ask") == "allow"
+    assert cycle_ui_state("allow") == "deny"
     assert cycle_ui_state("deny") is None
 
 

--- a/Tests/UI/test_mcp_inspector.py
+++ b/Tests/UI/test_mcp_inspector.py
@@ -6537,3 +6537,28 @@ async def test_an_arg_rule_without_an_owner_falls_back_to_the_reviewed_profile()
             e for e in app.events if isinstance(e, MCPInspector.RemoveArgRuleRequested)
         ]
         assert events[-1].owner_profile_id is None
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+def test_render_section_payload_renders_error_payloads_as_one_line_status():
+    """A5/F13: a section payload carrying an "error" key (the
+    `_AdvancedSectionShim` normalization for a failed `load_section()`)
+    renders as ONE plain status line, not a raw JSON dump -- the JSON dump
+    is exactly the noise the review flagged on the server-source
+    no-target state. An empty/absent error still falls through to the
+    JSON rendering (it is a legitimate payload, not a failure)."""
+    payload = {"source": "local", "section": "overview", "error": "connection refused"}
+    result = mcp_inspector_module._render_section_payload("overview", payload)
+    assert result == "Could not load this section: connection refused"
+    assert "{" not in result and '"' not in result
+
+    no_error = mcp_inspector_module._render_section_payload(
+        "overview", {"source": "local", "section": "overview"}
+    )
+    assert "{" in no_error
+    blank_error = mcp_inspector_module._render_section_payload(
+        "overview", {"source": "local", "error": ""}
+    )
+    assert "{" in blank_error

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -429,8 +429,9 @@ async def test_space_on_tool_row_posts_next_state_per_cycle_helper():
         assert event.row_kind == "tool"
         assert event.server_key == "local:docs"
         assert event.tool_name == "search"
-        # cycle_ui_state(None) == "allow"
-        assert event.new_state == "allow"
+        # Wave B: cycle_ui_state(None) == "ask" (Allow is a deliberate
+        # second press, never the first stop from Inherit)
+        assert event.new_state == "ask"
 
 
 @pytest.mark.asyncio
@@ -699,7 +700,7 @@ async def test_legend_line_renders_fixed_marker_key():
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
             "≡ exact-input allows · "
             "(session) approved until Chatbook exits · "
-            "Space cycles Inherit → Allow → Ask → Off"
+            "Space cycles Inherit → Ask → Allow → Off"
         )
 
 
@@ -748,7 +749,7 @@ async def test_update_matrix_with_no_gate_breadcrumb_shows_bare_legend():
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
             "≡ exact-input allows · "
             "(session) approved until Chatbook exits · "
-            "Space cycles Inherit → Allow → Ask → Off"
+            "Space cycles Inherit → Ask → Allow → Off"
         )
 
 

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -1596,3 +1596,71 @@ async def test_filter_input_has_nonzero_geometry_with_bundled_css():
         assert filter_input.outer_size.height > 0, (
             "filter Input collapsed to zero height under bundled CSS"
         )
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+def test_undiscovered_servers_hint_names_zero_tool_servers():
+    """C2/F3: local servers that are KNOWN but have no discovered tools are
+    invisible in the matrix (registration/discovery precedes permission) --
+    the hint line names them so "where is docs?" has an answer at the point
+    of confusion. Discovered servers and the built-in row are never named."""
+    from tldw_chatbook.MCP.readiness import ReadinessState, ReadinessSnapshot
+    from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import (
+        _undiscovered_servers_hint,
+    )
+
+    def _snap(key, label, source, tool_count):
+        return ReadinessSnapshot(
+            server_key=key,
+            label=label,
+            source=source,
+            state=ReadinessState.READY,
+            reasons=(),
+            message="",
+            tool_count=tool_count,
+        )
+
+    snapshots = [
+        _snap("local:docs", "docs", "local", None),
+        _snap("local:web", "web", "local", 0),
+        _snap("local:ok", "ok", "local", 3),
+        _snap("builtin:tldw_chatbook", "tldw_chatbook (built-in)", "builtin", None),
+    ]
+    hint = _undiscovered_servers_hint(snapshots)
+    assert hint is not None
+    assert "docs" in hint and "web" in hint
+    assert "ok" not in hint
+    assert "built-in" not in hint
+    assert "Servers" in hint
+
+    # Everything discovered (or nothing known): no hint at all.
+    assert _undiscovered_servers_hint(snapshots[2:]) is None
+    assert _undiscovered_servers_hint([]) is None
+
+
+@pytest.mark.asyncio
+async def test_update_matrix_renders_discovery_hint_line():
+    """C2/F3: the discovery hint renders as its own dim line under the
+    legend (same slot family as the gate breadcrumb), and clears on the
+    next ordinary render that passes no hint."""
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        await canvas.update_matrix(
+            [_global_row()],
+            kill_switch=False,
+            preview="global default: ask",
+            discovery_hint="docs · web: no tools yet — connect in Servers mode.",
+        )
+        await pilot.pause()
+        legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
+        assert "no tools yet" in legend
+
+        await canvas.update_matrix(
+            [_global_row()], kill_switch=False, preview="global default: ask"
+        )
+        await pilot.pause()
+        legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
+        assert "no tools yet" not in legend

--- a/Tests/UI/test_mcp_rail.py
+++ b/Tests/UI/test_mcp_rail.py
@@ -811,3 +811,38 @@ async def test_scope_a_b_a_dispatches_three_changes_and_mount_echo_zero():
         await pilot.pause()
         changes = [e.scope for e in app.events if isinstance(e, MCPRail.ScopeChanged)]
         assert changes == ["team", "personal", "team"]
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+def test_present_states_legend_abbreviates_when_short():
+    """A6/F15: below the width budget the in-rail legend swaps in the short
+    state words ("setup", "off") so the line stops wrapping to 2-3 rows at
+    narrow rail widths. The long forms stay untouched at wide budgets."""
+    from tldw_chatbook.UI.MCP_Modules.mcp_rail import _present_states_legend
+
+    snapshots = [
+        _snap("local:docs", "docs", ReadinessState.NEEDS_SETUP),
+        _snap("builtin:tldw_chatbook", "tldw_chatbook (built-in)", ReadinessState.OFF_OPT_IN),
+    ]
+    short = _present_states_legend(snapshots, short=True)
+    assert "setup" in short
+    assert "Needs setup" not in short
+    assert "off" in short
+    assert "opt-in" not in short
+    assert "⌂ built-in" in short
+
+    long = _present_states_legend(snapshots)
+    assert "needs setup" in long
+    assert "off (opt-in)" in long
+
+
+def test_short_state_legend_words_cover_every_state():
+    """Completeness pin: every STATE_LABELS word has a short form, so a new
+    ReadinessState can't silently fall out of the abbreviated legend."""
+    from tldw_chatbook.MCP.readiness import STATE_LABELS
+    from tldw_chatbook.UI.MCP_Modules.mcp_rail import _SHORT_STATE_LABELS
+
+    for label in STATE_LABELS.values():
+        assert label.lower() in _SHORT_STATE_LABELS

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -1933,3 +1933,65 @@ async def test_a_gate_rebuild_repaints_an_optimistic_flip_the_save_rejected(
             str(app.query_one(f"#mcp-gate-{entry.gate_key}", Button).label)
             == f"{entry.title}: off ▸"
         )
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+@pytest.mark.asyncio
+async def test_local_detail_toolbar_offers_lifecycle_actions():
+    """C4/F7b: the canvas detail toolbar carries the lifecycle verbs for
+    local profiles -- Connect when not connected, Refresh tools when
+    connected -- posting the same HubActionRequested the inspector's
+    buttons use. Check/diagnostics stay inspector-only (toolbar economy)."""
+
+    class HubActionCaptureApp(CanvasApp):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events: list[object] = []
+
+        def on_mcp_inspector_hub_action_requested(self, event) -> None:
+            self.events.append(event)
+
+    from tldw_chatbook.MCP.readiness import ReadinessState, ReadinessSnapshot
+
+    def _local_snap(connected: bool) -> ReadinessSnapshot:
+        return ReadinessSnapshot(
+            server_key="local:docs",
+            label="docs",
+            source="local",
+            state=ReadinessState.READY if connected else ReadinessState.NEEDS_SETUP,
+            reasons=(),
+            message="",
+            tool_count=2,
+            is_connected=connected,
+        )
+
+    app = HubActionCaptureApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+
+        await canvas.show_detail(_local_snap(connected=False))
+        await pilot.pause()
+        labels = [
+            str(button.label)
+            for button in app.query("#mcp-detail-toolbar Button")
+        ]
+        assert "Connect" in labels
+        assert "Edit" in labels and "Delete" in labels
+        assert "Disconnect" not in labels and "Refresh tools" not in labels
+
+        app.query_one("#mcp-detail-connect", Button).press()
+        await pilot.pause()
+        assert app.events, "Connect press must post a HubActionRequested"
+        assert app.events[-1].action is HubAction.CONNECT
+        assert app.events[-1].server_key == "local:docs"
+
+        await canvas.show_detail(_local_snap(connected=True))
+        await pilot.pause()
+        labels = [
+            str(button.label)
+            for button in app.query("#mcp-detail-toolbar Button")
+        ]
+        assert "Disconnect" in labels and "Refresh tools" in labels
+        assert "Connect" not in labels

--- a/Tests/UI/test_mcp_tools_mode.py
+++ b/Tests/UI/test_mcp_tools_mode.py
@@ -1061,3 +1061,37 @@ async def test_a_failed_save_repaints_the_master_switch_from_persisted_truth():
             if isinstance(event, MCPToolsMode.LocalToolsEnabledChanged)
         ]
         assert requested[-1] is False
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+@pytest.mark.asyncio
+async def test_server_column_truncates_long_labels_with_ellipsis():
+    """A2/F9: the Server column ellipsizes long group labels instead of
+    clipping mid-word with no marker ("Local workspace, web, and" at 160
+    cols read as a different label). Short labels pass through whole."""
+    app = ToolsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPToolsMode)
+        long_label_tool = _tool(
+            server_key="local:__local__",
+            name="fs_edit",
+            server_label="Local workspace, web, and Watchlists",
+        )
+        short_label_tool = _tool(
+            server_key="local:docs", name="fs_read", server_label="docs"
+        )
+        await canvas.update_tools([long_label_tool, short_label_tool])
+        await pilot.pause()
+        table = app.query_one("#mcp-tools-table", DataTable)
+
+        long_cell = table.get_cell_at((0, 2))
+        long_text = getattr(long_cell, "plain", str(long_cell))
+        assert long_text.endswith("…")
+        assert "Watchlists" not in long_text
+        assert len(long_text) <= 25
+
+        short_cell = table.get_cell_at((1, 2))
+        short_text = getattr(short_cell, "plain", str(short_cell))
+        assert short_text == "docs"

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -11520,3 +11520,112 @@ async def test_test_tool_key_falls_back_to_tools_cursor_row():
             for message, _ in notifications
         )
         assert any("display-only" in message for message, _ in notifications)
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_preselection_keeps_overview_on_screen(monkeypatch):
+    """C1/F1: the first-load preselection (F-054/task-2240) keeps the
+    OVERVIEW table on screen -- the rail highlights the row and the
+    inspector explains it, but the Add server/Import toolbar and recovery
+    callouts stay visible instead of being hidden behind a detail view the
+    user never navigated to. An explicit selection still opens the detail
+    exactly as before, and a background resync alone must not flip views."""
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: default,
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        assert workbench._selected_server_key == "builtin:tldw_chatbook"
+
+        assert app.query_one("#mcp-servers-overview").display is True
+        assert app.query_one("#mcp-servers-detail").display is False
+        state = app.query_one("#mcp-inspector-state", Static)
+        assert "tldw_chatbook (built-in)" in str(state.renderable)
+
+        # A background resync (lifecycle completion, `r`) must not flip it.
+        await workbench._sync_children()
+        await pilot.pause()
+        assert app.query_one("#mcp-servers-overview").display is True
+
+        # An explicit selection opens the detail as before.
+        await workbench._select_server_key("builtin:tldw_chatbook")
+        await pilot.pause()
+        assert app.query_one("#mcp-servers-detail").display is True
+
+
+@pytest.mark.asyncio
+async def test_save_and_connect_runs_lifecycle_after_save():
+    """C3/F7a: the add-server form's "Save and connect" persists the
+    profile and immediately dispatches the connect lifecycle -- the
+    saved->connected journey used to require finding the new row and its
+    Connect action in the inspector."""
+    connect_calls: list[str] = []
+
+    class SaveConnectService(FakeHubService):
+        async def save_local_profile(self, payload):
+            return dict(payload)
+
+        async def connect_local_profile(self, profile_id):
+            connect_calls.append(profile_id)
+            return {"ok": True, "tools": []}
+
+    class SaveConnectApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            super().__init__()
+            self.unified_mcp_service = SaveConnectService()
+
+        def compose(self) -> ComposeResult:
+            yield MCPWorkbench(app_instance=self, id="mcp-workbench")
+
+    app = SaveConnectApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        await workbench.open_add_server_form()
+        await pilot.pause()
+        app.query_one("#mcp-form-id", Input).value = "docs"
+        app.query_one("#mcp-form-command", Input).value = "npx"
+        await pilot.click("#mcp-form-save-connect")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert connect_calls == ["docs"]
+        assert not list(app.query("#mcp-servers-form > *"))
+
+
+@pytest.mark.asyncio
+async def test_non_default_tool_policy_profile_shows_console_context_hint(tmp_path):
+    """C5/F8: with a non-default tool-policy profile selected, a one-line
+    hint under the profile selector says Console applies the profile on top
+    -- the matrix alone reads as if these rows were the whole story."""
+    store_path = tmp_path / "mcp_permissions.json"
+    store = MCPPermissionStore(store_path)
+    payload = store.load()
+    payload["profiles"]["research"] = _imported_tool_policy_profile()
+    store.save(payload)
+    app = PermissionsApp(store_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        hint = app.query_one("#mcp-perm-profile-hint", Static)
+        assert not hint.display  # default profile: no hint
+
+        workbench = app.query_one(MCPWorkbench)
+        await workbench.select_tool_policy_profile("research")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert hint.display
+        text = str(hint.renderable)
+        assert "Console" in text
+        assert "Ask" in text

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -7290,15 +7290,15 @@ async def test_builtin_enumeration_failure_still_shows_a_cyclable_server_default
 # `_last_hub_tools`, the MCP catalog. Built-in tools never populate that
 # list (Task 3's built-in section is rendered from `builtin_permission_
 # rows()`, a completely separate path -- Constraint 1), so `_tool_for()`
-# always returned `None` for an `agent:builtin` row. Since `cycle_ui_state`
-# is Inherit -> Allow -> Ask -> Off, the FIRST Space press from the default
-# state always lands on "allow" -- which the vanished-tool guard then
-# rejected before any write, with a factually wrong "no longer in the
-# catalog" toast. `ask`/`deny` were consequently unreachable: you can't
-# advance the ring past the step that's permanently blocked. These tests
-# exercise the first press specifically (a pre-seeded "allow" and cycling
-# from there would miss the bug entirely), plus the rest of the ring, an
-# orphaned row, and an MCP-row regression guard.
+# always returned `None` for an `agent:builtin` row. Whichever press
+# first reaches "allow" (Wave B reordered the ring to Inherit -> Ask ->
+# Allow -> Off, so that is now the SECOND press), the vanished-tool guard
+# rejected the transition before any write with a factually wrong "no
+# longer in the catalog" toast. The rungs beyond it were consequently
+# unreachable: you can't advance the ring past the step that's permanently
+# blocked. These tests exercise that transition specifically (a pre-seeded
+# "allow" and cycling from there would miss the bug entirely), plus the
+# rest of the ring, an orphaned row, and an MCP-row regression guard.
 
 
 @pytest.mark.asyncio
@@ -7577,9 +7577,11 @@ async def test_space_cycle_round_trip_mutates_store_and_rerenders_override_marke
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
-        assert tool_entry["state"] == "allow"
+        # Wave B: first press from Inherit stores "ask" -- still an
+        # explicit override, so the marker bullet must render.
+        assert tool_entry["state"] == "ask"
 
-        assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
+        assert _perm_table_texts(app, 3) == ["  search", "Ask •"]
         # Sibling rows are untouched by the single-row mutation.
         assert _perm_table_texts(app, 2) == ["  fetch", "Ask"]
         assert _perm_table_texts(app, 0) == ["Global default", "Ask"]
@@ -7603,11 +7605,12 @@ async def test_space_on_server_default_row_round_trips_through_store(tmp_path):
         await pilot.pause()
 
         payload = app.unified_mcp_service.permission_store.load()
+        # Wave B: first press from Inherit lands on "ask"
         assert (
             payload["profiles"]["default"]["servers"]["local:docs"]["default"]
-            == "allow"
+            == "ask"
         )
-        assert _perm_table_texts(app, 1) == ["Server default — docs", "Allow •"]
+        assert _perm_table_texts(app, 1) == ["Server default — docs", "Ask •"]
 
 
 @pytest.mark.asyncio
@@ -7787,7 +7790,7 @@ async def test_preview_shows_override_count_when_no_server_selected(tmp_path):
         # transient echo prefix now -- the override-count SUFFIX this test
         # exists to pin is still computed correctly underneath it.
         assert str(preview.renderable) == (
-            "search → Allow · global default: ask · 1 override across 1 server"
+            "search → Ask · global default: ask · 1 override across 1 server"
         )
 
 
@@ -7869,8 +7872,8 @@ async def test_double_space_cycle_on_tool_row_stays_on_that_row(tmp_path):
     so a SECOND press used to land on row 0 (Global default) instead of the
     tool row the user was still looking at -- silently cycling the global
     default instead of the tool. Two Space presses on the tool row must
-    advance the TOOL two cycle steps (Inherit -> Allow -> Ask) and must
-    leave the global default untouched.
+    advance the TOOL two cycle steps (Inherit -> Ask -> Allow, Wave B's
+    order) and must leave the global default untouched.
     """
     app = PermissionsApp(tmp_path / "mcp_permissions.json")
     async with app.run_test(size=(120, 40)) as pilot:
@@ -7896,10 +7899,10 @@ async def test_double_space_cycle_on_tool_row_stays_on_that_row(tmp_path):
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
-        # cycle_ui_state(None) == "allow", cycle_ui_state("allow") == "ask"
-        assert tool_entry["state"] == "ask"
+        # Wave B: cycle_ui_state(None) == "ask", cycle_ui_state("ask") == "allow"
+        assert tool_entry["state"] == "allow"
         assert payload["profiles"]["default"]["global_default"] == "ask"
-        assert _perm_table_texts(app, 3) == ["  search", "Ask •"]
+        assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
         assert _perm_table_texts(app, 0) == ["Global default", "Ask"]
 
 
@@ -8149,7 +8152,12 @@ async def test_cycling_the_selected_tool_refreshes_its_open_permission_block(tmp
             == "▸ Global default: Ask"
         )
 
-        await pilot.press("space")  # cycle_ui_state(None) == "allow"
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow)
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
+        await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -8331,6 +8339,8 @@ async def test_reallow_round_trip_clears_config_changed_marker_and_matrix_warnin
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
+
+
         assert tool_entry["state"] == "allow"
 
         assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
@@ -8625,7 +8635,8 @@ async def test_space_cycle_prefixes_preview_with_mutation_echo(tmp_path):
         await pilot.pause()
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
+        # Wave B: first press from Inherit echoes Ask
+        assert preview.startswith("search → Ask · ")
 
 
 @pytest.mark.asyncio
@@ -8651,22 +8662,22 @@ async def test_double_space_cycle_echo_replaces_not_appends(tmp_path):
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=3)  # local:docs::search
-        await pilot.press("space")  # cycle_ui_state(None) == "allow"
-        await pilot.pause()
-        await app.workers.wait_for_complete()
-        await pilot.pause(0.3)
-
-        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
-        assert preview.count("→") == 1
-
-        await pilot.press("space")  # cycle_ui_state("allow") == "ask"
+        await pilot.press("space")  # Wave B: cycle_ui_state(None) == "ask"
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause(0.3)
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
         assert preview.startswith("search → Ask · ")
+        assert preview.count("→") == 1
+
+        await pilot.press("space")  # Wave B: cycle_ui_state("ask") == "allow"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
+
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("search → Allow · ")
         assert preview.count("→") == 1
 
 
@@ -8736,7 +8747,8 @@ async def test_full_resync_clears_mutation_echo(tmp_path):
         await app.workers.wait_for_complete()
         await pilot.pause()
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
+        # Wave B: first press from Inherit echoes Ask
+        assert preview.startswith("search → Ask · ")
 
         # A full `_sync_children()` pass isn't itself a standalone mutation
         # resync -- it must clear the echo without anyone calling a
@@ -8745,7 +8757,7 @@ async def test_full_resync_clears_mutation_echo(tmp_path):
         await pilot.pause()
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert not preview.startswith("search → Allow · ")
+        assert not preview.startswith("search → Ask · ")
         assert preview == "global default: ask · 1 override across 1 server"
 
 
@@ -8886,6 +8898,12 @@ async def test_space_cycle_propagates_fresh_states_to_tools_mode_without_full_re
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=3)  # local:docs::search
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow) --
+        # a distinctly different cell from the pre-mutation plain "Ask".
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
         await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
@@ -11283,6 +11301,11 @@ async def test_virtual_cli_permission_cycle_remains_independent_of_raw_shell(
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=_perm_row_keys(app).index("local:__virtual_cli__::ls"))
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow)
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
         await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
@@ -11314,6 +11337,19 @@ async def test_matrix_marks_and_inspector_revokes_session_approvals(tmp_path):
     service = app.unified_mcp_service
     service.session_approvals.add(("default", "local:docs", "search"))
     service.session_approvals.add(("default", "agent:builtin", "calculator"))
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+@pytest.mark.asyncio
+async def test_entering_permissions_mode_focuses_the_matrix():
+    """A1/F5a: entering Permissions mode puts the keyboard on the matrix.
+    Space-cycling is the mode's primary gesture, but the binding lives on
+    the canvas -- with focus left wherever the previous mode had it (e.g.
+    a mode chip, where Space ACTIVATES the chip), the advertised key did
+    something else entirely. Focus already inside the permissions canvas
+    (e.g. the filter Input mid-typing) is left alone."""
+    app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
         workbench = app.query_one(MCPWorkbench)
@@ -11408,3 +11444,79 @@ def test_tool_has_arg_rules_marks_an_inherited_rule(tmp_path):
         has_rules(child_servers, "srv", "other", ancestor_servers=(default_servers,))
         is False
     )
+
+        table = app.query_one("#mcp-perm-table", DataTable)
+        assert app.screen.focused is table
+
+        filter_input = app.query_one("#mcp-perm-filter-text", Input)
+        filter_input.focus()
+        await pilot.pause()
+        workbench.set_mode("tools")
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        assert app.screen.focused is filter_input
+
+
+@pytest.mark.asyncio
+async def test_cycle_failure_toast_names_the_service_error(tmp_path):
+    """A3/F10: a failed Space-cycle surfaces the service's own error text
+    ("Permission update failed: <reason>"), not just the bare generic
+    sentence -- the typed service methods raise user-ready messages, and
+    the generic toast left the user with nothing to act on."""
+
+    class ExplodingPermissionsService(PermissionsHubService):
+        def set_tool_state(self, *args, **kwargs):
+            raise RuntimeError("profile store busy")
+
+    store_path = tmp_path / "mcp_permissions.json"
+    MCPPermissionStore(store_path)  # create the default profile
+    app = PermissionsApp(store_path)
+    app.unified_mcp_service = ExplodingPermissionsService(store_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        notifications = _capture_notifications(app)
+
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        # Row 0 = global, row 1 = docs server default, row 2 = docs tool.
+        await pilot.press("down", "down", "space")
+        await pilot.pause()
+
+        assert notifications
+        message, severity = notifications[-1]
+        assert severity == "error"
+        assert "Permission update failed" in message
+        assert "profile store busy" in message
+
+
+@pytest.mark.asyncio
+async def test_test_tool_key_falls_back_to_tools_cursor_row():
+    """A7/O5: `t` with nothing selected in the INSPECTOR falls back to the
+    Tools table's cursor row -- telling a user who just arrowed onto a row
+    to "Select a tool in Tools mode first." reads as broken. The fallback
+    drives the same inspector tool view a selection would, so the
+    server-source row surfaces its own honest phase-note refusal."""
+    app = ServerToolsApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        notifications = _capture_notifications(app)
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("tools")
+        await pilot.pause()
+        table = app.query_one("#mcp-tools-table", DataTable)
+        table.focus()
+        table.move_cursor(row=0)
+        await pilot.pause()
+
+        await workbench.open_test_for_selected_tool()
+        await pilot.pause()
+
+        assert workbench.active_mode == "tools"
+        assert not any(
+            "Select a tool in Tools mode first." in message
+            for message, _ in notifications
+        )
+        assert any("display-only" in message for message, _ in notifications)

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -7075,6 +7075,11 @@ async def test_space_cycle_on_builtin_server_tool_row_round_trips_through_store(
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=row)
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow)
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
         await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
@@ -7757,8 +7762,11 @@ async def test_preview_counts_recompute_on_every_cycle_not_cached(tmp_path):
         await app.workers.wait_for_complete()
         await pilot.pause()
 
+        # Wave B (2026-09-11 UX program): the first press from Inherit
+        # lands on Ask, never Allow -- the count recompute this test pins
+        # is unchanged; only the rung moved.
         assert str(preview.renderable) == (
-            "tool_00 → Allow · many: 1 allow · 29 ask · 0 off — global default: ask"
+            "tool_00 → Ask · many: 0 allow · 30 ask · 0 off — global default: ask"
         )
 
 
@@ -11445,6 +11453,21 @@ def test_tool_has_arg_rules_marks_an_inherited_rule(tmp_path):
         is False
     )
 
+
+@pytest.mark.asyncio
+async def test_entering_permissions_mode_focuses_the_matrix():
+    """A1/F5a: entering Permissions mode puts the keyboard on the matrix.
+    Space-cycling is the mode's primary gesture, but the binding lives on
+    the canvas -- with focus left wherever the previous mode had it (e.g.
+    a mode chip, where Space ACTIVATES the chip), the advertised key did
+    something else entirely. Focus already inside the permissions canvas
+    (e.g. the filter Input mid-typing) is left alone."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
         table = app.query_one("#mcp-perm-table", DataTable)
         assert app.screen.focused is table
 

--- a/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
+++ b/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-32452
 title: 'MCP Hub UX Wave A: bounded polish batch'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 18:34'
-updated_date: '2026-09-11 18:36'
+updated_date: '2026-09-11 19:46'
 labels: []
 dependencies: []
 ---
@@ -17,7 +17,7 @@ Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/m
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
+- [x] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -25,3 +25,18 @@ Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/m
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no (routine bounded UI fixes; ADRs 148/149 cover the structural waves). TDD per item, targeted test runs only. 1. Test+impl: auto-focus #mcp-perm-table on set_mode('permissions'). 2. Test+impl: ellipsize Tools Server cell (fixed 24-char budget). 3. Test+impl: cycle-failure toast carries str(exc) first line via _toast. 4. Test+impl: ToolGate.restart_required + ' (⟳ restart)' label suffix on web_deep_search. 5. Test+impl: inspector renders advanced load errors as one-line status. 6. Test+impl: rail legend short-label map below width budget, completeness-pinned. 7. Test+impl: open_test_for_selected_tool falls back to Tools cursor row.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: TDD per item (test watched RED, then minimal implementation), all seven items on `feat/mcp-hub-ux-wave-a` (commit 8a93ab5).
+- A1 focus: `set_mode("permissions")` focuses `#mcp-perm-table` via `call_after_refresh`; focus already inside the permissions canvas (the filter Input) is respected. A `t`-fallback regression surfaced mid-wave: the first draft fired from any mode (a F-055 mode-hijack), fixed by gating the fallback on `active_mode == "tools"` — the pre-existing no-selection test caught it.
+- A2: fixed 24-column budget + explicit `…` (DataTable has no cell ellipsis/tooltips; width-aware refinement deferred — the server-filter Select still shows full labels).
+- A3: toast carries the first line of the service error (≤140 chars), escaped via `_toast`; stale-profile branch copy unchanged.
+- A4: `ToolGate.restart_required` (default False; True only for `web_deep_search`) + `(⟳ restart)` label suffix; save/reload path untouched (id still built from `gate.key`).
+- A5: `_render_section_payload` branches on a truthy `error` key (the `_AdvancedSectionShim` failure shape) → one-line status; empty error still renders JSON.
+- A6: `_SHORT_STATE_LABELS` keyed off `STATE_LABELS` values with a completeness-pinned test; budget hoisted above the legend yield in `MCPRail.compose` so rows and legend share one computation.
+- A7: `_open_test_for_tools_cursor_row` resolves the cursor row and drives the same `show_tool` path a selection takes, then retries `open_test_panel`.
+- ADR check: none required (routine bounded UI fixes; ADRs 148/149 cover the structural waves). Historical phase docs (2026-07 specs/QA) intentionally left untouched.
+- Verification: targeted suites green — test_mcp_rail 25, test_mcp_tools_mode 30, test_mcp_servers_mode 60, test_mcp_inspector 283, test_mcp_workbench 337 (final combined A+B run: 515 passed). Ruff: no new findings vs clean HEAD. Pre-existing unrelated failures in Tests/MCP/test_mcp_documentation_contract.py (39) exist on clean origin/dev — verified via stash; not addressed here.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
+++ b/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
@@ -1,0 +1,27 @@
+---
+id: TASK-32452
+title: 'MCP Hub UX Wave A: bounded polish batch'
+status: In Progress
+assignee: []
+created_date: '2026-09-11 18:34'
+updated_date: '2026-09-11 18:36'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/mcp-hub-ux-program): auto-focus the Permissions matrix on mode entry, ellipsize the Tools Server column, surface error reasons in permission toasts, restart markers on restart-class tool gates, one-line Advanced error rendering, width-budgeted rail legend abbreviation, and t-on-cursor-row fallback for Test Tool.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (routine bounded UI fixes; ADRs 148/149 cover the structural waves). TDD per item, targeted test runs only. 1. Test+impl: auto-focus #mcp-perm-table on set_mode('permissions'). 2. Test+impl: ellipsize Tools Server cell (fixed 24-char budget). 3. Test+impl: cycle-failure toast carries str(exc) first line via _toast. 4. Test+impl: ToolGate.restart_required + ' (⟳ restart)' label suffix on web_deep_search. 5. Test+impl: inspector renders advanced load errors as one-line status. 6. Test+impl: rail legend short-label map below width budget, completeness-pinned. 7. Test+impl: open_test_for_selected_tool falls back to Tools cursor row.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
+++ b/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32453
 title: 'MCP Hub UX Wave B: safe permission cycle order'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 19:25'
+updated_date: '2026-09-11 19:46'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,17 @@ Reorder the Permissions Space-cycle so the first press from Inherit lands on Ask
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
+- [x] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: tests-first (updated pins watched RED against the old ring), then the one-map store change. Commit 728d3ea on `feat/mcp-hub-ux-wave-a`.
+- Change surface: `permission_store._CYCLE_UI_STATES` (None→ask→allow→deny→None), `cycle_ui_state` docstring, Permissions legend constant. `cycle_global` deliberately unchanged — from the global default (ask) one press already goes to deny, so Allow is never the first stop there either.
+- Pinned tests updated in the same commit: `test_permission_resolution.py` full-loop; `test_mcp_permissions_mode.py` first-press event + two verbatim legend pins; `test_mcp_workbench.py` — 12 flow tests adjusted intent-preserving (one-press flows now assert the ask/override marker; flows that need `allow` press twice). TASK-627 built-in tests post explicit `new_state` values and needed only comment updates.
+- Trap caught by TDD: a blanket string replacement initially rewrote a structurally identical assertion in the re-allow test (which legitimately expects `allow` after Re-allow); the immediate test run caught it and it was reverted.
+- ADR check: none required (interaction order within existing states; no storage/schema/interface change — rationale recorded in the store comment and program review).
+- Historical phase docs/specs (2026-07) that describe the old ring order were left as dated records; Docs/User_Guide/mcp.md does not pin the order (doc-contract verified).
+- Verification: Tests/MCP/test_permission_resolution.py + test_permission_store.py 119 passed; combined A+B run 515 passed (workbench/permissions-mode/resolution/store).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
+++ b/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
@@ -1,0 +1,20 @@
+---
+id: TASK-32453
+title: 'MCP Hub UX Wave B: safe permission cycle order'
+status: In Progress
+assignee: []
+created_date: '2026-09-11 19:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reorder the Permissions Space-cycle so the first press from Inherit lands on Ask, not Allow (Inherit → Ask → Allow → Off). Allow becomes a deliberate second press. Store helper, legend copy, and every pinned test move together in one change (UX program 2026-09-11, safety assumption adopted at review).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
+<!-- AC:END -->

--- a/backlog/tasks/task-32454 - MCP-Hub-UX-Wave-C-flow-fixes.md
+++ b/backlog/tasks/task-32454 - MCP-Hub-UX-Wave-C-flow-fixes.md
@@ -1,0 +1,36 @@
+---
+id: TASK-32454
+title: 'MCP Hub UX Wave C: flow fixes'
+status: Done
+assignee: []
+created_date: '2026-09-11 19:51'
+updated_date: '2026-09-11 20:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Five flow improvements from the 2026-09-11 MCP screen UX review: first-run lands on the overview (selection/inspector detail preserved), a discovery breadcrumb naming zero-tool servers in Permissions, Save & connect on the add-server form plus lifecycle actions in the canvas detail toolbar, a profile-context hint line for non-default tool-policy profiles, and the step-by-step add-server tutorial in the user guide.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh-install load shows the overview table while the problem server stays selected and the inspector explains it,Permissions legend names known servers with no discovered tools,Add-server form offers Save and connect; canvas detail toolbar offers Connect/Refresh tools for local profiles,Non-default tool-policy profiles show a one-line Console-context hint,mcp.md gains a step-by-step add-server walkthrough consistent with the new cycle order
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: TDD per item (six tests watched RED, then minimal implementation). Branch `feat/mcp-hub-ux-wave-a`, commits on top of Waves A/B.
+- C1 overview hold: `_hold_canvas_overview` on the workbench, set by the F-054/task-2240 preselect, honored by `_show_selected_detail` (renders `show_detail(None)` — overview with fresh data), cleared by the first explicit selection (`_select_server_key`) or a restored view state. Inspector readiness for the preselected row is unchanged (task-2240's intent preserved).
+- C2 discovery hint: `_undiscovered_servers_hint` (pure, local-source snapshots with `tool_count` None/0, names capped at 3) rendered as a third legend line via `update_matrix(discovery_hint=...)`.
+- C3 Save and connect: `SubmitRequested.connect_after`; `_save_local_profile` dispatches `_start_lifecycle(..., "connect")` after the save+resync. Connect failures surface through the existing lifecycle notification/readiness path (e.g. missing env placeholder). Plain Save demoted to secondary styling; Save-and-connect is primary.
+- C4 toolbar lifecycle: local detail toolbar gains Connect (primary, not connected) / Refresh tools (connected), posting the same `MCPInspector.HubActionRequested` the inspector's readiness buttons post — one execution path. Check-readiness stays inspector-only (toolbar economy); documented as a deliberate narrowing of the chat design.
+- C5 profile hint: `#mcp-perm-profile-hint` Static + `set_profile_hint()`, shown only for non-default profiles ("Console agents run with this profile; persona policy may still floor some tools to Ask."). Per-tool effective-after-persona display remains future work (needs persona policy wired into resolution).
+- C7 tutorial: "Adding your first MCP server (step by step)" section in Docs/User_Guide/mcp.md, consistent with this branch's behavior (overview landing, Save and connect, new cycle order, discovery hint). Doc-contract verified unchanged: 39 failures / 26 mcp.md-scoped before AND after — all pre-existing on origin/dev.
+- F11 (gate-vs-permission pointer) was intentionally not implemented: subsumed by the existing gate breadcrumb, C2's discovery hint, and the Tools-mode diagnostic empty state; Wave F's bulk-action legend work will teach the server-default lever instead.
+- ADR check: none required (flow fixes within existing seams; ADRs 148/149 own the structural decisions).
+- Verification: 6 new tests GREEN; suites — test_mcp_workbench 340 passed, test_mcp_permissions_mode+servers+profile_form 149 passed, test_mcp_rail+tools 56 passed. Pre-existing/unrelated: test_destination_shells has 5 failures on clean origin/dev (library/schedules/models shells) plus flaky schedules timing (verified failing-then-passing in isolation on untouched code); test_mcp_documentation_contract 39 failures pre-existing.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/MCP/permission_store.py
+++ b/tldw_chatbook/MCP/permission_store.py
@@ -2450,10 +2450,17 @@ def resolve_effective_state_by_key(
     return EffectiveToolState(state=state, origin=origin)
 
 
+#: Wave B (2026-09-11 MCP Hub UX program): the ring starts at Ask, not
+#: Allow -- the most permissive state must never be the first stop from
+#: Inherit (the default posture), so a stray first Space press grants
+#: nothing. `_CYCLE_GLOBAL_STATES` below needs no change: from the global
+#: default ("ask") one press already goes to "deny", and Allow is only
+#: reachable from "deny" -- Allow is never the first press from the
+#: default posture there either.
 _CYCLE_UI_STATES: dict[str | None, str | None] = {
-    None: "allow",
-    "allow": "ask",
-    "ask": "deny",
+    None: "ask",
+    "ask": "allow",
+    "allow": "deny",
     "deny": None,
 }
 
@@ -2471,8 +2478,9 @@ def cycle_ui_state(current: str | None) -> str | None:
         current: The current stored state, or None for "Inherit".
 
     Returns:
-        The next state in the cycle: Inherit -> Allow -> Ask -> Off ->
-        Inherit (None).
+        The next state in the cycle: Inherit -> Ask -> Allow -> Off ->
+        Inherit (None). Ask leads the ring (Wave B) so the most
+        permissive state is never the first press from Inherit.
     """
     return _CYCLE_UI_STATES[current]
 

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -881,7 +881,16 @@ def _render_section_payload(section: str, payload: Any) -> str:
     or `OverflowError` (an out-of-range float) -- which should not happen
     for a service-returned dict but must never crash the Advanced pane
     either way.
+
+    Wave A (F13): a Mapping payload carrying a truthy "error" key is a
+    FAILED section load (the `_AdvancedSectionShim` in mcp_workbench.py
+    normalizes exceptions to exactly this shape) -- rendered as ONE plain
+    status line instead of the JSON dump, which is the noise the UX review
+    flagged on the server-source no-target state. An empty/absent "error"
+    is a legitimate payload and still renders as JSON.
     """
+    if isinstance(payload, Mapping) and payload.get("error"):
+        return f"Could not load this section: {str(payload['error']).strip()}"
     try:
         return json.dumps(payload, indent=2, sort_keys=True, default=str)
     except Exception:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -94,21 +94,33 @@ def _undiscovered_servers_hint(snapshots: list) -> str | None:
     """
     from tldw_chatbook.MCP.readiness import ReadinessSnapshot
 
-    names = [
-        snap.label
-        for snap in snapshots
-        if isinstance(snap, ReadinessSnapshot)
-        and snap.source == "local"
-        and not snap.tool_count
-    ]
-    if not names:
+    disconnected: list[str] = []
+    connected: list[str] = []
+    for snap in snapshots:
+        if not (isinstance(snap, ReadinessSnapshot) and snap.source == "local"):
+            continue
+        if snap.tool_count:
+            continue
+        # Qodo #2620 #5: zero tools on a CONNECTED local profile means a
+        # failed/empty discovery -- readiness maps that to Refresh, not
+        # Connect -- so the two cases name different verbs.
+        (connected if snap.is_connected else disconnected).append(snap.label)
+    if not disconnected and not connected:
         return None
-    shown = names[:_UNDISCOVERED_NAME_CAP]
-    text = ", ".join(shown)
-    if len(names) > len(shown):
-        text += f", +{len(names) - len(shown)} more"
+    parts = []
+    for names, verb in (
+        (disconnected, "Connect"),
+        (connected, "Refresh the discovery for"),
+    ):
+        if not names:
+            continue
+        shown = names[:_UNDISCOVERED_NAME_CAP]
+        text = ", ".join(shown)
+        if len(names) > len(shown):
+            text += f", +{len(names) - len(shown)} more"
+        parts.append(f"{verb} {text}")
     return (
-        f"No tools yet — {text}. Connect them in Servers mode to configure "
+        f"No tools yet — {'; '.join(parts)} in Servers mode to configure "
         "their permissions."
     )
 
@@ -710,6 +722,27 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         never this sentence, and a previously rendered echo simply
         survives any later re-filter untouched (no re-render of this
         Static happens at all until the NEXT `update_matrix()` call).
+
+        Args:
+            rows: The full `PermRow` list, rendered in the exact order
+                given (grouping/sorting is the workbench's job).
+            kill_switch: The current kill-switch state, relabeled onto the
+                toggle Button (the single writer is the workbench).
+            preview: The plain-language policy sentence for the strip
+                below the matrix; always summarizes the FULL unfiltered
+                matrix, never the filter-narrowed subset.
+            echo: Transient mutation-confirmation copy prefixed onto
+                `preview` for this one render; `None` (every full-resync
+                pass) renders `preview` unprefixed -- that is how a
+                previous echo clears.
+            gate_breadcrumb: An extra legend line for off registration
+                gates; `None` shows no extra line.
+            discovery_hint: An extra legend line naming known servers
+                with no discovered tools; same render/clear contract as
+                `gate_breadcrumb` (the lines stack, legend first).
+            profile_context: The immutable authority this render was
+                captured under; round-tripped on every mutation message
+                so a stale render cannot write into another profile.
         """
         deduped: list[PermRow] = []
         seen_keys: set[str] = set()
@@ -749,8 +782,13 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
 
     def set_profile_hint(self, text: str | None) -> None:
         """Wave C (F8): render (or clear) the non-default-profile hint line
-        under the profile selector. `None`/empty hides the Static entirely
-        so the default profile renders no caveat."""
+        under the profile selector.
+
+        Args:
+            text: The hint sentence. `None` or an empty string HIDES the
+                Static entirely (the default profile renders no caveat);
+                any non-empty string updates and displays it.
+        """
         hint = self.query_one("#mcp-perm-profile-hint", Static)
         if text:
             hint.update(text)

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -66,6 +66,52 @@ _SERVER_PROFILES_POINTER = (
     "above is chatbook's client-side gate and still applies."
 )
 
+# Wave C (F8): shown under the profile selector whenever a non-default
+# tool-policy profile is selected -- the matrix reads as the whole story
+# otherwise, but Console applies the profile (and persona policy may floor
+# tools on top of it).
+_PROFILE_HINT_TEXT = (
+    "Console agents run with this profile; persona policy may still floor "
+    "some tools to Ask."
+)
+
+# Wave C (F3): cap on how many undiscovered server names the discovery
+# hint names inline before collapsing to "+N more" -- the hint is one dim
+# line under the legend, not a second table.
+_UNDISCOVERED_NAME_CAP = 3
+
+
+def _undiscovered_servers_hint(snapshots: list) -> str | None:
+    """One-line hint naming KNOWN servers with no discovered tools.
+
+    Wave C (F3): a saved-but-unconnected server contributes zero rows to
+    the matrix (registration/discovery precedes permission -- an
+    undiscovered tool has nothing to permit yet), so "where is docs?" had
+    no answer at the point of confusion. Local-source snapshots only (the
+    built-in row is never "connected", and server-source records embed
+    their own tool lists); `tool_count` None or 0 counts as undiscovered.
+    Returns None when every known server has tools (nothing to explain).
+    """
+    from tldw_chatbook.MCP.readiness import ReadinessSnapshot
+
+    names = [
+        snap.label
+        for snap in snapshots
+        if isinstance(snap, ReadinessSnapshot)
+        and snap.source == "local"
+        and not snap.tool_count
+    ]
+    if not names:
+        return None
+    shown = names[:_UNDISCOVERED_NAME_CAP]
+    text = ", ".join(shown)
+    if len(names) > len(shown):
+        text += f", +{len(names) - len(shown)} more"
+    return (
+        f"No tools yet — {text}. Connect them in Servers mode to configure "
+        "their permissions."
+    )
+
 
 # Task 1 (MCP Hub Phase 6): concrete Rich styles for `state_text()` -- the
 # semantic-state-word coloring shared by every DataTable cell across the Hub
@@ -400,6 +446,14 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         min-height: 0;
         color: $text-muted;
     }
+    /* Wave C (F8): the non-default-profile hint is the same quiet, dimmed
+    one-liner tier as the kill-switch hint below. */
+    #mcp-perm-profile-hint {
+        height: auto;
+        min-height: 0;
+        color: $text-muted;
+        padding: 0 1;
+    }
     /* task-2242: the kill-switch scope hint is the same quiet, dimmed
     one-liner tier as the legend below the matrix. */
     #mcp-perm-kill-switch-hint {
@@ -542,6 +596,11 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
             id="mcp-perm-tool-profile",
             allow_blank=False,
         )
+        # Wave C (F8): populated by `set_profile_hint()` -- hidden while
+        # empty (the default profile needs no Console-context caveat).
+        hint = Static("", id="mcp-perm-profile-hint", markup=False)
+        hint.display = False
+        yield hint
         yield Button(
             _kill_switch_label(self._kill_switch),
             id="mcp-perm-kill-switch",
@@ -601,6 +660,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         preview: str,
         echo: str | None = None,
         gate_breadcrumb: str | None = None,
+        discovery_hint: str | None = None,
         profile_context: PermissionProfileContext | None = None,
     ) -> None:
         """Rebuild the matrix from a fresh `PermRow` list.
@@ -681,8 +741,22 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self._apply_filter()
 
         self.query_one("#mcp-perm-preview", Static).update(f"{echo}{preview}" if echo else preview)
-        legend_text = f"{_LEGEND_TEXT}\n{gate_breadcrumb}" if gate_breadcrumb else _LEGEND_TEXT
+        legend_text = _LEGEND_TEXT
+        for extra_line in (gate_breadcrumb, discovery_hint):
+            if extra_line:
+                legend_text = f"{legend_text}\n{extra_line}"
         self.query_one("#mcp-perm-legend", Static).update(legend_text)
+
+    def set_profile_hint(self, text: str | None) -> None:
+        """Wave C (F8): render (or clear) the non-default-profile hint line
+        under the profile selector. `None`/empty hides the Static entirely
+        so the default profile renders no caveat."""
+        hint = self.query_one("#mcp-perm-profile-hint", Static)
+        if text:
+            hint.update(text)
+            hint.display = True
+        else:
+            hint.display = False
 
     def update_tool_policy_profiles(
         self,

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -55,7 +55,7 @@ _LEGEND_TEXT = (
     "• override · ⚠ definition changed · ⚑ high-risk floor · "
     "≡ exact-input allows · "
     "(session) approved until Chatbook exits · "
-    "Space cycles Inherit → Allow → Ask → Off"
+    "Space cycles Inherit → Ask → Allow → Off"
 )
 
 # T8: exact copy pinned by the server-source governance section below --

--- a/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
@@ -48,6 +48,14 @@ class MCPProfileForm(Vertical):
         Wave C (F7a): `connect_after=True` is the "Save and connect"
         button's request -- the host saves and then dispatches the connect
         lifecycle for the saved profile.
+
+        Args:
+            payload: The parsed store payload (`build_payload()` shape:
+                profile_id/command/args/env_placeholders/env_literals).
+            warning: Non-blocking args secret-lint text to re-surface as a
+                toast on the success path, or None when clean.
+            connect_after: Dispatch the connect lifecycle after a
+                successful save (the "Save and connect" button).
         """
 
         def __init__(

--- a/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
@@ -43,12 +43,24 @@ class MCPProfileForm(Vertical):
         on FAILED saves -- a successful save unmounts the whole form
         (`hide_form()`) sub-second, so the host must re-surface the warning
         as a toast alongside its own success notify for the user to ever
-        see it."""
+        see it.
 
-        def __init__(self, payload: dict[str, Any], warning: str | None = None) -> None:
+        Wave C (F7a): `connect_after=True` is the "Save and connect"
+        button's request -- the host saves and then dispatches the connect
+        lifecycle for the saved profile.
+        """
+
+        def __init__(
+            self,
+            payload: dict[str, Any],
+            warning: str | None = None,
+            *,
+            connect_after: bool = False,
+        ) -> None:
             super().__init__()
             self.payload = payload
             self.warning = warning
+            self.connect_after = connect_after
 
     class Cancelled(Message, namespace="mcp_profile_form"):
         pass
@@ -123,9 +135,20 @@ class MCPProfileForm(Vertical):
             yield Button(
                 "Save",
                 id="mcp-form-save",
-                classes="console-action-primary",
+                classes="console-action-secondary",
                 compact=True,
                 tooltip="Validate and save this profile.",
+            )
+            # Wave C (F7a): the primary action for a brand-new server is
+            # USING it -- save + connect in one press, so the
+            # saved->connected journey is not a row hunt followed by an
+            # inspector hunt.
+            yield Button(
+                "Save and connect",
+                id="mcp-form-save-connect",
+                classes="console-action-primary",
+                compact=True,
+                tooltip="Save this profile, then connect and discover its tools.",
             )
             yield Button(
                 "Cancel",
@@ -180,12 +203,13 @@ class MCPProfileForm(Vertical):
         self._refresh_save_enabled()
 
     def _refresh_save_enabled(self) -> None:
-        """A4: Save is enabled only once both required fields are filled in
-        (edit mode's disabled-but-prefilled id Input still counts -- this
-        checks `.value`, not `.disabled`) and no submit posted by this form
-        is still awaiting the host's outcome. Called after compose (here, via
-        `on_mount`), on every required-field change, and from `show_error()`
-        so a failed save only re-arms Save when the fields are still valid.
+        """A4: Save and Save-and-connect are enabled only once both
+        required fields are filled in (edit mode's disabled-but-prefilled
+        id Input still counts -- this checks `.value`, not `.disabled`) and
+        no submit posted by this form is still awaiting the host's outcome.
+        Called after compose (here, via `on_mount`), on every required-field
+        change, and from `show_error()` so a failed save only re-arms the
+        buttons when the fields are still valid.
 
         Review fix: the two disable-reasons (missing fields vs. a submit
         already in flight) get DISTINCT tooltips -- collapsing them into one
@@ -194,20 +218,29 @@ class MCPProfileForm(Vertical):
         while both fields were still filled in, which is simply false.
         """
         try:
-            save_button = self.query_one("#mcp-form-save", Button)
             has_id = bool(self.query_one("#mcp-form-id", Input).value.strip())
-            has_command = bool(self.query_one("#mcp-form-command", Input).value.strip())
+            has_command = bool(
+                self.query_one("#mcp-form-command", Input).value.strip()
+            )
         except Exception:
             return
         fields_valid = has_id and has_command
         enabled = fields_valid and not self._submit_in_flight
-        save_button.disabled = not enabled
+        save_button = self.query_one("#mcp-form-save", Button)
+        save_connect_button = self.query_one("#mcp-form-save-connect", Button)
+        for button in (save_button, save_connect_button):
+            button.disabled = not enabled
         if enabled:
             save_button.tooltip = "Validate and save this profile."
+            save_connect_button.tooltip = (
+                "Save this profile, then connect and discover its tools."
+            )
         elif not fields_valid:
             save_button.tooltip = "Enter a profile id and command first."
+            save_connect_button.tooltip = "Enter a profile id and command first."
         else:
             save_button.tooltip = "Save already in progress."
+            save_connect_button.tooltip = "Save already in progress."
 
     def build_payload(self) -> dict[str, Any]:
         """Parse the form into the store's exact save-payload keys.
@@ -294,7 +327,7 @@ class MCPProfileForm(Vertical):
         return ""
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "mcp-form-save":
+        if event.button.id in ("mcp-form-save", "mcp-form-save-connect"):
             event.stop()
             try:
                 payload = self.build_payload()
@@ -318,7 +351,13 @@ class MCPProfileForm(Vertical):
             # so the in-flight flag (not just the button) reflects reality.
             self._submit_in_flight = True
             self._refresh_save_enabled()
-            self.post_message(self.SubmitRequested(payload, warning or None))
+            self.post_message(
+                self.SubmitRequested(
+                    payload,
+                    warning or None,
+                    connect_after=event.button.id == "mcp-form-save-connect",
+                )
+            )
         elif event.button.id == "mcp-form-cancel":
             event.stop()
             self.post_message(self.Cancelled())

--- a/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
@@ -56,8 +56,30 @@ _ROW_CHROME = 8
 # row.
 _ALL_SERVERS_GUTTER = "  "
 
+# Wave A (F15): abbreviated state words for the in-rail legend at narrow
+# widths -- keyed by STATE_LABELS' values lowercased, and completeness-
+# pinned by test (a new ReadinessState must add a short form or the
+# abbreviated legend silently drops it). "no tools" collapses to the bare
+# glyph (∅) because that glyph IS the word.
+# `_LEGEND_SHORT_BUDGET` (F15): the row-label budget below which the
+# legend switches to the short words -- chosen so the two-entry fresh-
+# install legend ("◦ off · ⌂ built-in") fits a ~24-col compact rail on
+# one line; wide rails keep the full words.
+_LEGEND_SHORT_BUDGET = 32
+_SHORT_STATE_LABELS: dict[str, str] = {
+    "ready": "ready",
+    "checking": "checking",
+    "needs setup": "setup",
+    "needs attention": "attention",
+    "no tools": "∅",
+    "stale": "stale",
+    "off (opt-in)": "off",
+}
 
-def _present_states_legend(snapshots: list[ReadinessSnapshot]) -> str:
+
+def _present_states_legend(
+    snapshots: list[ReadinessSnapshot], *, short: bool = False
+) -> str:
     """Compact glyph legend for the states currently present in the rail.
 
     task-2243: rail rows show glyph+name only, and decoding them required
@@ -74,13 +96,20 @@ def _present_states_legend(snapshots: list[ReadinessSnapshot]) -> str:
     STATE_GLYPHS order) so the line can never drift from the rows it
     decodes; the ⌂ built-in marker is explained whenever a built-in row
     is present (same copy the Servers-mode legend uses).
+
+    Wave A (F15): `short=True` swaps in `_SHORT_STATE_LABELS` -- at narrow
+    rail budgets the long forms wrapped the legend onto 2-3 rows, which
+    is worse than an abbreviated word the glyph disambiguates anyway.
     """
     present = {snap.state for snap in snapshots}
-    parts = [
-        f"{glyph} {STATE_LABELS[state].lower()}"
-        for state, glyph in STATE_GLYPHS.items()
-        if state in present
-    ]
+    parts = []
+    for state, glyph in STATE_GLYPHS.items():
+        if state not in present:
+            continue
+        word = STATE_LABELS[state].lower()
+        if short:
+            word = _SHORT_STATE_LABELS.get(word, word)
+        parts.append(f"{glyph} {word}")
     if any(snap.source == "builtin" for snap in snapshots):
         parts.append("⌂ built-in")
     return " · ".join(parts)
@@ -340,10 +369,19 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         # canvas Servers-mode legend -- present states only, so the line
         # stays short (a fresh install reads "◦ off (opt-in) · ⌂ built-in").
         # Nothing to decode at zero servers: the F-060 empty state below
-        # stands alone.
+        # stands alone. Wave A (F15): at narrow width budgets the legend
+        # abbreviates (`short=True`) so it stays one line instead of
+        # wrapping to 2-3 rows. The budget is computed HERE (before the
+        # rows below reuse it) -- the same F-057 formula the rows use.
+        layout_width = self.region.width
+        budget = (
+            _MAX_ROW_LABEL
+            if layout_width <= 0
+            else max(8, min(_MAX_ROW_LABEL, layout_width - _ROW_CHROME))
+        )
         if self.snapshots:
             yield Static(
-                _present_states_legend(self.snapshots),
+                _present_states_legend(self.snapshots, short=budget < _LEGEND_SHORT_BUDGET),
                 id="mcp-rail-state-legend",
                 markup=False,
             )
@@ -380,13 +418,9 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         # width minus `_ROW_CHROME`, so rows truncate with an ellipsis that
         # FITS the row instead of being cropped mid-word. Width 0 (first
         # compose, pre-layout) falls back to `_MAX_ROW_LABEL`; `on_resize`
-        # recomposes once the real width is known.
-        layout_width = self.region.width
-        budget = (
-            _MAX_ROW_LABEL
-            if layout_width <= 0
-            else max(8, min(_MAX_ROW_LABEL, layout_width - _ROW_CHROME))
-        )
+        # recomposes once the real width is known. The budget itself was
+        # already computed above the legend yield (F15) -- reused, not
+        # recomputed.
         self._row_budget = budget
         pad_width = max(
             (

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -977,12 +977,20 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                 return
 
     def _detail_toolbar_widgets(self) -> list[Button]:
-        """Build the local-profile toolbar (Edit/Disconnect/Delete), or the
-        arm-then-confirm pair once Delete has been pressed.
+        """Build the local-profile toolbar (Edit/lifecycle/Disconnect/Delete),
+        or the arm-then-confirm pair once Delete has been pressed.
 
         Local-source snapshots only: built-in is edited via config.toml, and
         server-source profiles are mutated server-side (Advanced), so both
         render no toolbar at all here.
+
+        Wave C (F7b): the lifecycle verbs the inspector's readiness actions
+        carry also live here, on the surface the user is already looking at
+        -- Connect (primary) for a not-yet-connected profile, Refresh tools
+        for a connected one. Both post the SAME `HubActionRequested` the
+        inspector's buttons post, so there is exactly one execution path;
+        diagnostics (Check readiness) stay inspector-only to keep the
+        toolbar to at most four verbs.
         """
         snapshot = self._detail_snapshot
         if snapshot is None or snapshot.source != "local":
@@ -1021,6 +1029,25 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                     classes="console-action-secondary",
                     compact=True,
                     tooltip="Disconnect the running server.",
+                )
+            )
+            widgets.append(
+                Button(
+                    "Refresh tools",
+                    id="mcp-detail-refresh",
+                    classes="console-action-secondary",
+                    compact=True,
+                    tooltip="Reconnect and refresh the tool catalog.",
+                )
+            )
+        else:
+            widgets.append(
+                Button(
+                    "Connect",
+                    id="mcp-detail-connect",
+                    classes="console-action-primary",
+                    compact=True,
+                    tooltip="Connect and discover this server's tools.",
                 )
             )
         widgets.append(
@@ -1597,6 +1624,23 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                 self.post_message(
                     MCPInspector.HubActionRequested(
                         HubAction.EDIT_CONFIG, self._detail_snapshot.server_key
+                    )
+                )
+            return
+        if button_id in ("mcp-detail-connect", "mcp-detail-refresh"):
+            # Wave C (F7b): same execution path as the inspector's readiness
+            # action buttons -- the workbench's HubActionRequested handler
+            # routes both through the typed lifecycle methods.
+            event.stop()
+            if self._detail_snapshot is not None:
+                action = (
+                    HubAction.CONNECT
+                    if button_id == "mcp-detail-connect"
+                    else HubAction.REFRESH_DISCOVERY
+                )
+                self.post_message(
+                    MCPInspector.HubActionRequested(
+                        action, self._detail_snapshot.server_key
                     )
                 )
             return

--- a/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
@@ -98,6 +98,22 @@ def _local_tools_toggle_label(enabled: bool) -> str:
     return f"{_LOCAL_TOOLS_TITLE}: {'on' if enabled else 'off'} ▸"
 
 
+# Wave A (F9): rendered-width cap for the Server column. DataTable clips
+# overflowing cell text silently -- a group label like "Local workspace,
+# web, and Watchlists" rendered as "Local workspace, web, and" with no
+# marker, which reads as a DIFFERENT label rather than a truncated one.
+# A fixed budget with an explicit ellipsis keeps the truncation honest;
+# the full label remains visible in the server-filter Select's options.
+_SERVER_CELL_BUDGET = 24
+
+
+def _ellipsize(text: str, budget: int) -> str:
+    """Truncate `text` to `budget` rendered columns with an explicit "…"."""
+    if len(text) <= budget:
+        return text
+    return f"{text[: budget - 1].rstrip()}…"
+
+
 class MCPToolsMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Tools mode: cross-server catalog, filters, empty state."""
 
@@ -571,8 +587,11 @@ class MCPToolsMode(DataTableClickSelectMixin, Vertical):
                 )
             else:
                 state_cell = state_text("—", "muted")
-            server_cell = (
-                f"{tool.server_label} (stale)" if tool.stale else tool.server_label
+            server_cell = _ellipsize(
+                f"{tool.server_label} (stale)"
+                if tool.stale
+                else tool.server_label,
+                _SERVER_CELL_BUDGET,
             )
             schema_cell = (
                 "form" if parse_schema(tool.input_schema) is not None else "raw"

--- a/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
@@ -108,10 +108,19 @@ _SERVER_CELL_BUDGET = 24
 
 
 def _ellipsize(text: str, budget: int) -> str:
-    """Truncate `text` to `budget` rendered columns with an explicit "…"."""
-    if len(text) <= budget:
-        return text
-    return f"{text[: budget - 1].rstrip()}…"
+    """Truncate `text` to `budget` rendered COLUMNS with an explicit "…".
+
+    Qodo #2620 #7: server labels are user-controlled and may contain wide
+    Unicode -- measuring/slicing by Python character count lets a
+    24-character label occupy far more than 24 cells and bypass the
+    budget entirely. Rich's `Text.truncate` measures and cuts by cell
+    width (Rich is already a hard dependency of every Textual app).
+    """
+    rendered = Text(text)
+    # Rich's Text.truncate mutates in place and returns None on this
+    # version -- read .plain back off the object.
+    rendered.truncate(budget, overflow="ellipsis", pad=False)
+    return rendered.plain
 
 
 class MCPToolsMode(DataTableClickSelectMixin, Vertical):
@@ -587,12 +596,14 @@ class MCPToolsMode(DataTableClickSelectMixin, Vertical):
                 )
             else:
                 state_cell = state_text("—", "muted")
-            server_cell = _ellipsize(
-                f"{tool.server_label} (stale)"
-                if tool.stale
-                else tool.server_label,
-                _SERVER_CELL_BUDGET,
-            )
+            # Qodo #2620 #6: when the label alone consumes the budget, the
+            # "(stale)" suffix -- the only table-level signal that a
+            # discovered local tool is currently disconnected -- was being
+            # truncated away. Reserve its width up front so the marker
+            # always survives the ellipsis.
+            suffix = " (stale)" if tool.stale else ""
+            budget = _SERVER_CELL_BUDGET - len(suffix)
+            server_cell = _ellipsize(tool.server_label, budget) + suffix
             schema_cell = (
                 "form" if parse_schema(tool.input_schema) is not None else "raw"
             )

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -99,6 +99,8 @@ from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import (
     PermissionProfileContext,
     PermRow,
     ToolPolicyProfileOption,
+    _PROFILE_HINT_TEXT,
+    _undiscovered_servers_hint,
     format_tool_state_label,
 )
 from tldw_chatbook.UI.MCP_Modules.mcp_profile_form import MCPImportPanel, MCPProfileForm
@@ -611,6 +613,13 @@ class MCPWorkbench(Container):
         # True once the first load has had its chance to pre-select, so a
         # later resync can never re-hijack a selection the user cleared.
         self._did_initial_preselect: bool = False
+        # Wave C (F1): True while the first-load preselection holds the
+        # canvas on the OVERVIEW -- the rail highlights the row and the
+        # inspector explains it, but the detail view stays one explicit
+        # navigation away. Cleared by the first explicit selection
+        # (`_select_server_key`) or a restored view state, either of which
+        # is real user intent.
+        self._hold_canvas_overview: bool = False
         self._scope: str = "personal"
         self._scope_ref: str | None = None
         self._snapshots: list[ReadinessSnapshot] = []
@@ -1112,10 +1121,12 @@ class MCPWorkbench(Container):
         ]
         if len(problems) == 1:
             self._selected_server_key = problems[0].server_key
+            self._hold_canvas_overview = True
         elif len(self._snapshots) == 1:
             # task-2240: the lone rail row (fresh install's off/opt-in
             # built-in) is worth landing on too -- see the docstring.
             self._selected_server_key = self._snapshots[0].server_key
+            self._hold_canvas_overview = True
 
     def _selected_target_id(self) -> str | None:
         """The server-target id implied by `_selected_server_key`.
@@ -2646,7 +2657,13 @@ class MCPWorkbench(Container):
             preview=preview,
             echo=echo,
             gate_breadcrumb=tool_gate_breadcrumb(),
+            discovery_hint=_undiscovered_servers_hint(self._snapshots),
             profile_context=profile_context,
+        )
+        # Wave C (F8): only a non-default profile needs the Console-context
+        # caveat -- the default profile IS the plain story.
+        canvas.set_profile_hint(
+            _PROFILE_HINT_TEXT if self._tool_policy_profile_id != "default" else None
         )
         await self.query_one(MCPPermissionsMode).update_server_profiles(
             await self._server_governance_profiles(service, refresh=refresh_governance)
@@ -3305,6 +3322,15 @@ class MCPWorkbench(Container):
         -- they can change from other clients/sessions, and this only runs
         on an actual selection change, not on every keystroke.
         """
+        if self._hold_canvas_overview:
+            # Wave C (F1): the first-load preselection explains itself in
+            # the rail + inspector while the overview (Add server, callouts)
+            # stays on screen -- `show_detail(None)` keeps the canvas on the
+            # overview AND refreshes its data underneath, exactly like any
+            # other resync with no selection. The hold is cleared by the
+            # first explicit selection (see `_select_server_key`).
+            await canvas.show_detail(None)
+            return
         if (
             selected is not None
             and self._is_external_record_key(selected.server_key)
@@ -3470,6 +3496,9 @@ class MCPWorkbench(Container):
 
     async def _apply_view_state(self, state: dict[str, Any]) -> None:
         # Tolerant restore: unknown keys ignored; legacy panel shape accepted.
+        # Wave C (F1): a restored view state is explicit prior-user intent
+        # and wins over the first-load overview hold.
+        self._hold_canvas_overview = False
         source = state.get("source") or state.get("selected_source")
         if source in ("local", "server") and source != self._source:
             await self._switch_source(str(source))
@@ -3570,6 +3599,10 @@ class MCPWorkbench(Container):
         `_switch_source()`'s identical T6 clear.
         """
         self._selected_server_key = server_key
+        # Wave C (F1): an explicit selection (rail row, table row, callout,
+        # breadcrumb) is real navigation intent -- the first-load
+        # overview hold, if any, ends here.
+        self._hold_canvas_overview = False
         # T6: selecting a different server invalidates any Tools-mode
         # selection the inspector was showing -- "switching modes or
         # servers clears the tool view" -- and (I1 above) the Findings
@@ -5641,7 +5674,11 @@ class MCPWorkbench(Container):
             return
         self._profile_save_in_flight = True
         self.run_worker(
-            self._save_local_profile(dict(event.payload), warning=event.warning),
+            self._save_local_profile(
+                dict(event.payload),
+                warning=event.warning,
+                connect_after=event.connect_after,
+            ),
             group="mcp-profile-save",
             exclusive=True,
         )
@@ -5653,7 +5690,11 @@ class MCPWorkbench(Container):
             return None
 
     async def _save_local_profile(
-        self, payload: dict[str, Any], warning: str | None = None
+        self,
+        payload: dict[str, Any],
+        warning: str | None = None,
+        *,
+        connect_after: bool = False,
     ) -> None:
         """Run one profile save; on success, also re-surface the form's args
         secret-lint `warning` as a toast (I4 follow-up). The in-form
@@ -5662,6 +5703,13 @@ class MCPWorkbench(Container):
         sub-second after the warning rendered, so without this toast the
         user would never see it on exactly the path where the secret
         actually got persisted into a profile's args.
+
+        Wave C (F7a): `connect_after=True` (the form's "Save and connect")
+        dispatches the connect lifecycle for the just-saved profile once
+        the save and resync land -- the saved->connected journey used to
+        require finding the new row and its inspector Connect action.
+        A connect failure surfaces through the lifecycle's own
+        notification/readiness path (e.g. a missing env placeholder).
         """
         try:
             service = self._service()
@@ -5698,6 +5746,11 @@ class MCPWorkbench(Container):
                 self.app.notify(warning, severity="warning")
             self._snapshots = await self._collect_snapshots()
             await self._sync_children()
+            if connect_after and payload.get("profile_id"):
+                profile_id = str(payload["profile_id"])
+                self._start_lifecycle(
+                    f"local:{profile_id}", profile_id, "connect"
+                )
         finally:
             self._profile_save_in_flight = False
 

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -3421,7 +3421,14 @@ class MCPWorkbench(Container):
     def _focus_permissions_matrix(self) -> None:
         """F5a: focus `#mcp-perm-table` unless the permissions canvas
         already owns focus (the filter Input is the one place inside the
-        canvas where the keyboard should stay put)."""
+        canvas where the keyboard should stay put).
+
+        Qodo #2620 #8: `call_after_refresh` defers past the caller's turn
+        -- a rapid second mode switch means Permissions may no longer be
+        active when this runs, and focusing its (hidden) table would leave
+        the VISIBLE mode without keyboard focus. Guard on the live mode."""
+        if self._active_mode != "permissions":
+            return
         try:
             canvas = self.query_one(MCPPermissionsMode)
         except NoMatches:
@@ -3562,6 +3569,11 @@ class MCPWorkbench(Container):
                 )
         self._source = source
         self._selected_server_key = None
+        # Qodo #2620 #9: a source switch is explicit navigation too -- drop
+        # any surviving first-load overview hold, or a later reload that
+        # restores the active server key keeps rendering the overview over
+        # a selection the user is effectively looking at.
+        self._hold_canvas_overview = False
         # T6: switching source invalidates any Tools-mode selection the
         # inspector was showing (the tool belonged to the OTHER source's
         # catalog), and also clears the finding detail pane (same reasoning).
@@ -3603,6 +3615,12 @@ class MCPWorkbench(Container):
         # breadcrumb) is real navigation intent -- the first-load
         # overview hold, if any, ends here.
         self._hold_canvas_overview = False
+        # Qodo #2620 #1: it also retires the preselect GATE -- otherwise an
+        # "All servers" press during the initial async snapshot collection
+        # leaves `_did_initial_preselect` False, and the still-running
+        # `_preselect_single_problem_on_load()` re-selects the problem row
+        # over the user's cleared selection.
+        self._did_initial_preselect = True
         # T6: selecting a different server invalidates any Tools-mode
         # selection the inspector was showing -- "switching modes or
         # servers clears the tool view" -- and (I1 above) the Findings

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -17,10 +17,10 @@ from loguru import logger
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
-from textual.css.query import QueryError
+from textual.css.query import NoMatches, QueryError
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import ContentSwitcher
+from textual.widgets import ContentSwitcher, DataTable
 from textual.worker import Worker
 
 from tldw_chatbook.Agents.builtin_tool_gate import (
@@ -3211,7 +3211,16 @@ class MCPWorkbench(Container):
                     severity="warning",
                 )
             else:
-                self.app.notify(_toast("Permission update failed."), severity="error")
+                # Wave A (F10): the typed service methods raise user-ready
+                # messages, so surface the first line instead of a bare
+                # generic sentence -- bounded so a verbose exception can't
+                # turn the toast into a stack dump. `_toast()` escapes the
+                # text (service messages embed store-derived ids).
+                reason = str(exc).strip().splitlines()[0][:140] if str(exc).strip() else type(exc).__name__
+                self.app.notify(
+                    _toast(f"Permission update failed: {reason}"),
+                    severity="error",
+                )
             return
         # Task 3 (MCP Hub Phase 6): the transient mutation echo -- pinned
         # copy shape `"{tool_name} → {ui_label} · "`, TOOL-row cycles only
@@ -3372,6 +3381,39 @@ class MCPWorkbench(Container):
                 group="mcp-tool-clear",
                 exclusive=True,
             )
+            # Wave A (F5a): entering Permissions mode moves the keyboard
+            # onto the matrix -- Space-cycling is the mode's primary
+            # gesture and the binding lives on the canvas, so focus left
+            # over from the previous mode (e.g. a mode chip, where Space
+            # ACTIVATES the chip) made the advertised key do something
+            # else entirely. `call_after_refresh` so the newly-shown canvas
+            # exists before the focus lands; focus already INSIDE the
+            # permissions canvas (the filter Input mid-typing) is respected.
+            if mode == "permissions":
+                self.call_after_refresh(self._focus_permissions_matrix)
+
+    def _focus_permissions_matrix(self) -> None:
+        """F5a: focus `#mcp-perm-table` unless the permissions canvas
+        already owns focus (the filter Input is the one place inside the
+        canvas where the keyboard should stay put)."""
+        try:
+            canvas = self.query_one(MCPPermissionsMode)
+        except NoMatches:
+            return
+        try:
+            focused = self.screen.focused if self.is_mounted else None
+        except Exception:
+            focused = None
+        if focused is not None:
+            try:
+                if canvas in focused.ancestors_with_self:
+                    return
+            except Exception:
+                pass
+        try:
+            canvas.query_one("#mcp-perm-table", DataTable).focus()
+        except NoMatches:
+            pass
 
     async def _clear_tool_view(self) -> None:
         await self.query_one(MCPInspector).show_tool(None)
@@ -4709,6 +4751,17 @@ class MCPWorkbench(Container):
         """
         inspector = self.query_one(MCPInspector)
         status = await inspector.open_test_panel()
+        if status == "no_tool" and self._active_mode == "tools":
+            # Wave A (O5): IN TOOLS MODE the user may have ARROWED onto a
+            # row without selecting it into the inspector -- the visible
+            # cursor row is their evident intent, so drive the same tool
+            # view a selection would and retry before falling back to the
+            # hint. Gated on the active mode: in any OTHER mode the Tools
+            # table's cursor row is not on screen and "resolving" it would
+            # be the same mode hijack F-055 removed (a key advertised in
+            # every mode must not teleport the user based on state they
+            # cannot see).
+            status = await self._open_test_for_tools_cursor_row(inspector)
         if status == "no_tool":
             self.app.notify("Select a tool in Tools mode first.", severity="warning")
             return
@@ -4728,6 +4781,43 @@ class MCPWorkbench(Container):
             )
             return
         self.set_mode("tools")
+
+    async def _open_test_for_tools_cursor_row(self, inspector: MCPInspector) -> str:
+        """Wave A (O5): resolve the Tools table's CURSOR row (arrowed onto,
+        not Enter-selected) into the inspector's tool view and retry the
+        Test Tool open through the exact same path a row selection takes
+        (`on_mcp_tools_mode_tool_selected`'s show_tool call).
+
+        Returns `open_test_panel()`'s status after the retry, or
+        `"no_tool"` when there is no cursor row to resolve (empty table,
+        unmounted canvas, tool dropped from the catalog, or no validated
+        profile context) -- the caller then falls back to its hint.
+        """
+        try:
+            canvas = self.query_one(MCPToolsMode)
+            table = canvas.query_one("#mcp-tools-table", DataTable)
+        except NoMatches:
+            return "no_tool"
+        if table.row_count == 0 or table.cursor_row < 0:
+            return "no_tool"
+        try:
+            row_key, _ = table.coordinate_to_cell_key((table.cursor_row, 0))
+        except Exception:
+            return "no_tool"
+        if row_key is None or row_key.value is None:
+            return "no_tool"
+        tool = self._tool_for_row_key(str(row_key.value))
+        if tool is None:
+            return "no_tool"
+        context = self._validate_profile_context(self._tool_policy_profile_context)
+        if context is None:
+            return "no_tool"
+        await inspector.show_tool(
+            tool,
+            effective=self._effective_for_display(tool),
+            profile_context=context,
+        )
+        return await inspector.open_test_panel()
 
     def _tool_profile_lifecycle_authority(self) -> object | None:
         """Resolve the shared lifecycle after deferred app composition."""

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -598,6 +598,14 @@
         min-height: 0;
         color: $text-muted;
     }
+    /* Wave C (F8): the non-default-profile hint is the same quiet, dimmed
+    one-liner tier as the kill-switch hint below. */
+    MCPPermissionsMode #mcp-perm-profile-hint {
+        height: auto;
+        min-height: 0;
+        color: $text-muted;
+        padding: 0 1;
+    }
     /* task-2242: the kill-switch scope hint is the same quiet, dimmed
     one-liner tier as the legend below the matrix. */
     MCPPermissionsMode #mcp-perm-kill-switch-hint {

--- a/tldw_chatbook/css/widget_defaults_self.tcss
+++ b/tldw_chatbook/css/widget_defaults_self.tcss
@@ -535,6 +535,9 @@
     this widget's unit tests mount it without the app-wide tcss bundle
     where the `$ds-*` aliases are defined. */
 
+    /* Wave C (F8): the non-default-profile hint is the same quiet, dimmed
+    one-liner tier as the kill-switch hint below. */
+
     /* task-2242: the kill-switch scope hint is the same quiet, dimmed
     one-liner tier as the legend below the matrix. */
 


### PR DESCRIPTION
## Summary

Implements Waves A–C of the 2026-09-11 MCP screen UX review (TASK-32452/32453/32454; specs + ADRs on `docs/mcp-hub-ux-program`, PR to follow).

**Wave A — bounded polish (7 fixes):** entering Permissions mode focuses the matrix (Space was focus-dependent); Tools Server column ellipsizes instead of clipping mid-word; permission-failure toasts carry the service error reason; `web_deep_search`'s gate shows a `(⟳ restart)` marker (`ToolGate.restart_required`); the Advanced pane renders load errors as one line, not raw JSON; the rail legend abbreviates below a width budget (completeness-pinned map); `t` falls back to the Tools cursor row (gated on being in Tools mode — never a mode hijack).

**Wave B — safe cycle order:** the Space-cycle ring is now Inherit → Ask → Allow → Off; the first press from Inherit grants nothing. `cycle_global` unchanged (already safe). Store map, legend copy, and all pinned tests move together.

**Wave C — flow fixes:** first-load preselection keeps the overview on screen (rail highlights + inspector explains; the hold clears on the first explicit selection or restored state); the Permissions legend names known-but-undiscovered servers; the add-server form gains **Save and connect** plus Connect/Refresh tools in the local detail toolbar (same `HubActionRequested` path as the inspector); non-default tool-policy profiles show a one-line Console-context hint; `mcp.md` gains a step-by-step add-server tutorial.

## Verification

TDD throughout (each behavior watched RED first). Final: test_mcp_workbench 348+, permissions/servers/rail/tools, profile-form suites green; doc-contract unchanged at its pre-existing 39 upstream failures.

## ADR check

None required for A–C individually (bounded fixes; interaction order within existing states). Structural decisions live in ADR-148/150 on the docs branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Waves A–C of the 2026-09-11 MCP Hub UX review: UI polish, safer Permissions cycle order, and first-run/server-management flow fixes, plus fixes from the Qodo review round.

**Behavior changes**
- Permissions Space-cycle now goes Inherit → Ask → Allow → Off; first press from Inherit lands on Ask, never Allow.
- Entering Permissions mode focuses the matrix; `t` in Tools mode falls back to the Tools cursor row.
- Permission-failure toasts include the service error reason.
- Restart-class tool gates (like `web_deep_search`) show a `(⟳ restart)` marker.
- Advanced pane load errors render as one line, not raw JSON.
- Tools Server column ellipsizes long labels by rendered cell width; the `(stale)` suffix always survives truncation.
- Rail legend uses abbreviated state words below a width budget.
- First-load preselection keeps the overview visible and can't be re-hijacked by a background resync; explicit selection opens the detail.
- An "All servers" press during the initial async load no longer lets the preselection re-select over the user's cleared selection.
- Permissions legend names known-but-undiscovered servers with Connect/Refresh verbs by connected state.
- Add-server form offers "Save and connect"; local detail toolbar gets Connect / Refresh tools.
- Non-default tool-policy profiles show a Console-context hint.
- `mcp.md` gains a step-by-step add-server tutorial.

**Notes for review**
- All changes are TDD; tests were watched RED first.
- Store ring, legend copy, and pinned tests move together for the cycle order change.
- The overview hold clears on the first explicit selection or restored view state.
- Doc-contract unchanged at its pre-existing 39 failures.
- No ADR required; structural decisions live in ADR-148/150.
- Bundled CSS regenerated so the profile-hint rule applies in app-wide contexts.

<sup>Written for commit a7d47f12dec1e8992200e2025d42b1e9fb730869. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

