### PR TITLE
MCP Hub UX Waves D–F + closers: rail IA split, narrow-width triad, bulk actions

### DIFF
--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -30,6 +30,42 @@ organized into four modes: Servers, Tools, Permissions, and Audit.
 - Press **Ctrl+9**, click **⌃9 MCP** in the nav bar, or press **Ctrl+P** →
   "Tab Navigation: Switch to MCP".
 
+## Adding your first MCP server (step by step)
+
+Local servers run as stdio processes chatbook launches for you. Secrets are
+never stored — reference them as `KEY=$ENV_VAR` and export the variable in
+your shell before connecting.
+
+1. **Open the screen** (Ctrl+9). On a fresh install the overview table is
+   showing, with the built-in server listed and the `Add server` and
+   `Import…` buttons at the top. (You can also press `a` in any mode.)
+2. **Press Add server** (or `a`). Fill in:
+   - **Name** — a short id (`docs`); letters, digits, `-`, `_` only.
+   - **Command** — the executable (`npx`, `python3`, `uvx`, …).
+   - **Args** — one per line (e.g. `-y` and `@modelcontextprotocol/server-filesystem`).
+   - **Env** — one `KEY=value` per line; a bare `$VAR` value becomes a
+     placeholder read from your environment at launch.
+3. **Press Save and connect.** The profile is saved and chatbook launches
+   it immediately; the row's status moves from `○ Needs setup` to `● Ready`
+   (or an actionable reason, e.g. a missing `$ENV_VAR`, stays on screen).
+4. **Check permissions.** Press `3` (Permissions). Your server's tools are
+   grouped under a `Server default — <name>` row; every tool starts at
+   **Ask**, meaning each call shows an approval card in Console. Select a
+   row and press **Space** to cycle Inherit → Ask → Allow → Off. The
+   `Server default` row sets the fallback for that whole server — one
+   change instead of one per tool. (Tools you haven't connected yet don't
+   appear here at all; if a server you added is missing, the line under
+   the legend says so and points you back to Servers mode.)
+5. **Try a tool.** Press `2` (Tools), arrow onto the tool, and press `t`
+   to open the Test Tool panel — a form built from the tool's schema (or
+   a raw-JSON box when the schema is too complex). An Ask-gated tool asks
+   once per run; the run is recorded in Audit (`4`).
+
+To remove a server, select its row in Servers mode and use **Delete**
+(a two-step confirm; Escape backs out). **Import…** accepts a
+Claude-Desktop-style `{"mcpServers": …}` config — secret-shaped values
+come in as placeholders, never stored literals.
+
 ## Running Chatbook as a standalone MCP server
 
 Install the packaged optional extra, then configure the external client to

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -158,9 +158,9 @@ decide MCP availability independently.
 
 ## Other registration gates (Servers mode ▸ Tool gates)
 
-Select the built-in server's row in Servers mode; its detail pane has a
-**Tool gates** group under the existing enable/expose checkboxes, split
-into two subheadings:
+Select the **Agent tools** row in the rail (its own section under
+Servers); its detail pane has a **Tool gates** group, split into two
+subheadings:
 
 - **Agent built-ins** — the app's own file, note and library tools: read /
   list / write a file, glob / grep the workspace, create / update a note,
@@ -175,6 +175,9 @@ into two subheadings:
   may cost real money on paid providers) has an additional individual gate
   underneath it. Unlike the local master and workspace root,
   construction-time gates such as `web_deep_search` require an app restart.
+
+The built-in server's own row keeps only the `[mcp]` enable/expose
+controls — the two panes govern different subsystems by design (ADR-148).
 
 The master switch governs the **Console/agent path only**. It does *not*
 control whether an enabled tool (e.g. `web_deep_search`) is exposed to

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -27,7 +27,8 @@ organized into four modes: Servers, Tools, Permissions, and Audit.
 
 Below ~120 terminal columns the layout adapts: the detail panel stacks
 under the main area as a compact, scrollable band instead of squeezing
-three unreadable columns.
+three unreadable columns. In the left rail, ↑/↓ (or `j`/`k`) move the
+selection between servers once a rail row has focus.
 
 ## Getting there
 

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -57,9 +57,12 @@ your shell before connecting.
    **Ask**, meaning each call shows an approval card in Console. Select a
    row and press **Space** to cycle Inherit → Ask → Allow → Off. The
    `Server default` row sets the fallback for that whole server — one
-   change instead of one per tool. (Tools you haven't connected yet don't
-   appear here at all; if a server you added is missing, the line under
-   the legend says so and points you back to Servers mode.)
+   change instead of one per tool. For many rows at once: `shift+space`
+   applies the row's next state to the server's visible tools, and `C`
+   clears its visible overrides — the filter is the scope (clear it to
+   act on all rows). (Tools you haven't connected yet don't appear here
+   at all; if a server you added is missing, the line under the legend
+   says so and points you back to Servers mode.)
 5. **Try a tool.** Press `2` (Tools), arrow onto the tool, and press `t`
    to open the Test Tool panel — a form built from the tool's schema (or
    a raw-JSON box when the schema is too complex). An Ask-gated tool asks

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -25,6 +25,10 @@ MCP manages MCP servers, scoped tools, permissions, and audit readiness
 external tools — most people never need to change anything here."). It's
 organized into four modes: Servers, Tools, Permissions, and Audit.
 
+Below ~120 terminal columns the layout adapts: the detail panel stacks
+under the main area as a compact, scrollable band instead of squeezing
+three unreadable columns.
+
 ## Getting there
 
 - Press **Ctrl+9**, click **⌃9 MCP** in the nav bar, or press **Ctrl+P** →

--- a/Docs/User_Guide/mcp.md
+++ b/Docs/User_Guide/mcp.md
@@ -14,9 +14,6 @@ It does not publish source or collection mutation, checking, briefing generation
 
 Use Console when an agent needs to read or summarize a complete briefing on your behalf. Use external MCP for discovery, receipts, and status automation without exporting private briefing bodies.
 
-> 🚧 **This page is a stub.** The full write-up is planned; the sections
-> below cover orientation only, except where a section says otherwise. See
-> the [guide index](index.md).
 
 ## What this screen is for
 

--- a/Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md
+++ b/Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md
@@ -2,17 +2,17 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Two filter-scoped bulk keys on the Permissions matrix — `shift+space` applies the cursor row's next cycled state to a server's visible tool rows; `C` clears its visible overrides (ADR-149).
+**Goal:** Two filter-scoped bulk keys on the Permissions matrix — `shift+space` applies the cursor row's next cycled state to a server's visible tool rows; `C` clears its visible overrides (ADR-150).
 
 **Architecture:** The canvas (which alone knows visibility) computes the scope and posts one message per gesture; the workbench remains the single writer, executing the bulk as N ordinary profile-scoped `set_tool_state` calls with raw-shell rows skipped and named in the echo. No new store API; audit granularity unchanged (per-row logging).
 
 **Tech Stack:** Textual key bindings (`shift+space`, `C` — no conflicts with the screen's `1-4/a/r/t`), pytest + Pilot, existing PermissionsApp harness.
 
-**Spec:** `Docs/superpowers/specs/2026-09-11-mcp-hub-bulk-permission-actions-design.md`; ADR: `backlog/decisions/149-mcp-hub-bulk-permission-actions.md`.
+**Spec:** `Docs/superpowers/specs/2026-09-11-mcp-hub-bulk-permission-actions-design.md`; ADR: `backlog/decisions/150-mcp-hub-bulk-permission-actions.md`.
 
 ## Global Constraints
 
-- Every write goes through `_call_profile_scoped(service.set_tool_state, ...)` under the SAME validated `PermissionProfileContext` as a single press — no batch store API (ADR-149).
+- Every write goes through `_call_profile_scoped(service.set_tool_state, ...)` under the SAME validated `PermissionProfileContext` as a single press — no batch store API (ADR-150).
 - Raw-shell rows are skipped and the skip is named in the echo (`· N skipped (raw shell)`); raw shell stays a two-state control.
 - The **global row is excluded** — both keys no-op against it via the legend hint line (not a toast); no-op likewise when the server has zero *visible* tool rows.
 - `C` writes only rows that currently hold an override (visible-scoped); the echo says "N visible overrides cleared" and the tooltip/legend teaches the full-clear recipe (clear the filter, then C).
@@ -112,7 +112,7 @@ async def test_bulk_keys_noop_on_global_row_with_hint_not_toast():
 ```python
 @pytest.mark.asyncio
 async def test_shift_space_bulk_sets_visible_tools_of_one_server(tmp_path):
-    """ADR-149: shift+space applies the cursor row's next state to the
+    """ADR-150: shift+space applies the cursor row's next state to the
     server's VISIBLE tool rows only (Wave B order: first press from
     Inherit = Ask), with one echo and no other server touched."""
     app = PermissionsApp(tmp_path / "mcp_permissions.json")

--- a/Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md
+++ b/Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md
@@ -1,0 +1,186 @@
+# MCP Hub Bulk Permission Actions Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Two filter-scoped bulk keys on the Permissions matrix — `shift+space` applies the cursor row's next cycled state to a server's visible tool rows; `C` clears its visible overrides (ADR-149).
+
+**Architecture:** The canvas (which alone knows visibility) computes the scope and posts one message per gesture; the workbench remains the single writer, executing the bulk as N ordinary profile-scoped `set_tool_state` calls with raw-shell rows skipped and named in the echo. No new store API; audit granularity unchanged (per-row logging).
+
+**Tech Stack:** Textual key bindings (`shift+space`, `C` — no conflicts with the screen's `1-4/a/r/t`), pytest + Pilot, existing PermissionsApp harness.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-mcp-hub-bulk-permission-actions-design.md`; ADR: `backlog/decisions/149-mcp-hub-bulk-permission-actions.md`.
+
+## Global Constraints
+
+- Every write goes through `_call_profile_scoped(service.set_tool_state, ...)` under the SAME validated `PermissionProfileContext` as a single press — no batch store API (ADR-149).
+- Raw-shell rows are skipped and the skip is named in the echo (`· N skipped (raw shell)`); raw shell stays a two-state control.
+- The **global row is excluded** — both keys no-op against it via the legend hint line (not a toast); no-op likewise when the server has zero *visible* tool rows.
+- `C` writes only rows that currently hold an override (visible-scoped); the echo says "N visible overrides cleared" and the tooltip/legend teaches the full-clear recipe (clear the filter, then C).
+- Wave-B interplay: the canvas computes the next state with the same `cycle_ui_state` a plain press uses, so the first `shift+space` from Inherit applies **Ask** to the visible set.
+- On the first write failure: stop, toast `Permission update failed: <reason>` (Wave A's pattern), never partial-silence.
+- Copy moves with its pins in the same commit: `_LEGEND_TEXT` (2 verbatim test pins) and the permissions footer hint (`mcp_screen.MCP_MODE_SHORTCUTS` + destination-shell footer pin).
+- TDD: every behavior watched RED first; targeted suites only.
+
+---
+
+### Task 1: Canvas — bindings, messages, hint flash, copy
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py`
+- Modify: `tldw_chatbook/UI/Screens/mcp_screen.py` (`MCP_MODE_SHORTCUTS["permissions"]`)
+- Test: `Tests/UI/test_mcp_permissions_mode.py`, `Tests/UI/test_destination_shells.py` (footer pin)
+
+**Interfaces:**
+- Produces:
+  - `MCPPermissionsMode.BulkStateRequested(server_key: str, tool_names: tuple[str, ...], new_state: str, profile_context)` — canvas-computed visible tool rows of the cursor row's server plus the cursor row's own `cycle_ui_state` next-state.
+  - `MCPPermissionsMode.BulkClearRequested(server_key: str, tool_names: tuple[str, ...], profile_context)` — the server's visible tool rows that currently hold an override.
+  - `MCPPermissionsMode.flash_hint(text: str)` — renders one transient line appended to the legend until the next `update_matrix` (the "existing hint Static" the spec names; not a toast).
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/UI/test_mcp_permissions_mode.py`; the file's `_global_row`, `_server_row`, `_tool_row` helpers and `PermissionsModeApp` harness already exist — check exact helper names with grep before writing):
+
+```python
+@pytest.mark.asyncio
+async def test_shift_space_on_tool_row_posts_bulk_state_for_visible_tools():
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        rows = [
+            _global_row(),
+            _server_row(server_key="local:docs", server_label="docs"),
+            _tool_row(server_key="local:docs", tool_name="fetch"),
+            _tool_row(server_key="local:docs", tool_name="search"),
+        ]
+        await canvas.update_matrix(rows, kill_switch=False, preview="")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=2)
+        await pilot.press("shift+space")
+        await pilot.pause()
+        assert len(app.events) == 1
+        event = app.events[0]
+        assert isinstance(event, MCPPermissionsMode.BulkStateRequested)
+        assert event.server_key == "local:docs"
+        assert sorted(event.tool_names) == ["fetch", "search"]
+        assert event.new_state == "ask"  # Wave B: cycle_ui_state(None) == "ask"
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_posts_only_overridden_visible_rows():
+    # Same shape: tool rows with cycle_current="allow"/None mixed; C posts
+    # BulkClearNamed with only the overridden names.
+
+
+@pytest.mark.asyncio
+async def test_bulk_keys_noop_on_global_row_with_hint_not_toast():
+    # cursor row 0 (global); shift+space AND C post nothing; the legend
+    # gains the hint line via flash_hint; no app.notify.
+```
+
+(Write all three fully in the file; the second/third follow the first's harness shape. The footer pin at `Tests/UI/test_destination_shells.py:3369` gains the new hint text.)
+
+- [ ] **Step 2: Run to verify RED** — `pytest Tests/UI/test_mcp_permissions_mode.py -k bulk -q` → FAIL (no bindings/messages).
+
+- [ ] **Step 3: Implement** in `mcp_permissions_mode.py`:
+
+1. `BINDINGS` gains `Binding("shift+space", "bulk_set", show=False)` and `Binding("C", "bulk_clear", show=False)`.
+2. The two `Message` classes (namespace `mcp_permissions_mode`) per the Interfaces block.
+3. `_legend_extras: list[str]` set by `update_matrix` (replacing the current inline legend_text build) and used by `flash_hint(text)` to re-render `#mcp-perm-legend` with the extra line appended (until the next `update_matrix`).
+4. `_visible_tool_names_for(server_key) -> tuple[str, ...]` helper over `self._visible_rows`.
+5. `action_bulk_set()` / `action_bulk_clear()`: resolve the cursor row exactly like `action_cycle_state` (coordinate_to_cell_key → `_rows_by_key`); global row → `flash_hint("Bulk actions need a server's tool rows — move to one of its rows.")` and return; compute visible tool names (for clear: only rows with `cycle_current is not None`); empty → same hint; else post the message (`new_state` via `cycle_ui_state(row.cycle_current)` for bulk_set).
+6. `_LEGEND_TEXT` gains: `" · shift+space bulk set · C clears overrides"` (update the 2 verbatim pins).
+7. `mcp_screen.py`: `"permissions": _COMMON_SHORTCUTS + (("space", "cycle permission"), ("shift+space", "bulk set"), ("C", "clear overrides"))` (update the destination footer pin).
+
+- [ ] **Step 4: GREEN** — `pytest Tests/UI/test_mcp_permissions_mode.py Tests/UI/test_destination_shells.py -k "bulk or footer or shortcuts" -q`.
+
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 2: Workbench — apply/clear with raw-shell skip, echo, error toast
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_workbench.py`
+- Test: `Tests/UI/test_mcp_workbench.py`
+
+**Interfaces:**
+- Consumes: Task 1's messages.
+- Produces: `on_mcp_permissions_mode_bulk_state_requested` / `on_mcp_permissions_mode_bulk_clear_requested` handlers; shared `_apply_bulk_tool_states(server_key, tool_names, state_or_None, context)`.
+
+- [ ] **Step 1: Write the failing tests** (PermissionsApp, real store; mirror the double-press choreography's settle pauses):
+
+```python
+@pytest.mark.asyncio
+async def test_shift_space_bulk_sets_visible_tools_of_one_server(tmp_path):
+    """ADR-149: shift+space applies the cursor row's next state to the
+    server's VISIBLE tool rows only (Wave B order: first press from
+    Inherit = Ask), with one echo and no other server touched."""
+    app = PermissionsApp(tmp_path / "mcp_permissions.json")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=3)  # local:docs::search
+        await pilot.press("shift+space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        store = app.unified_mcp_service.permission_store.load()
+        docs_tools = store["profiles"]["default"]["servers"]["local:docs"]["tools"]
+        assert docs_tools["search"]["state"] == "ask"
+        assert docs_tools["fetch"]["state"] == "ask"
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("docs: 2 tools → Ask · ")
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_reverts_only_visible_overrides(tmp_path):
+    # Seed search=allow via store; filter the matrix to hide fetch; C on
+    # the docs rows clears ONLY search; fetch's seeded override survives;
+    # echo "docs: 1 visible overrides cleared".
+```
+
+Plus: raw-shell skip test (the `_enable_local_tools(monkeypatch)` + `raw_cli_runtime` harness at test_mcp_workbench.py:10292's pattern: bulk-set local:__local__, assert `shell_exec` untouched and the echo carries `skipped (raw shell)`), and the failure test (service `set_tool_state` raising → toast `Permission update failed: ...`, first-write stop).
+
+- [ ] **Step 2: RED** — `pytest Tests/UI/test_mcp_workbench.py -k "bulk" -q`.
+
+- [ ] **Step 3: Implement** in `mcp_workbench.py`:
+
+```python
+    def on_mcp_permissions_mode_bulk_state_requested(self, event) -> None:
+        event.stop()
+        self.run_worker(
+            self._apply_bulk_tool_states(
+                event.server_key, list(event.tool_names), event.new_state,
+                event.profile_context,
+            ),
+            group="mcp-perm-bulk", exclusive=True,
+        )
+    # bulk_clear: same worker path with state=None and echo verb "cleared".
+```
+
+`_apply_bulk_tool_states`: validate profile context (stale → the existing "Tool policy profile changed" toast); iterate names, `_tool_for(server_key, name)` for hash-needing allows (None + "allow" + not hash-free → skip-with-count like the vanished-tool guard), `_is_raw_shell_tool` → skip-count; each write via `_call_profile_scoped(service.set_tool_state, ...)` under the SAME context; on exception → the Wave-A reason toast and return (partial writes stand, each idempotent); after the batch one `_sync_permissions_mode(echo=...)` with `"{label}: {N} tools → {label_of_state}"` (or `"{label}: {N} visible overrides cleared"`) plus `" · {K} skipped (raw shell)"` when K>0. Clear path counts only rows written (canvas already sent only overridden rows).
+
+- [ ] **Step 4: GREEN + sweep** — the new tests, then `pytest Tests/UI/test_mcp_permissions_mode.py Tests/UI/test_mcp_workbench.py -q`.
+
+- [ ] **Step 5: Commit.**
+
+---
+
+### Task 3: Docs + final sweep + hygiene
+
+- [ ] **Step 1:** `Docs/User_Guide/mcp.md` — in the tutorial's permissions step, after the server-default sentence, add: "For many rows at once: `shift+space` applies the row's next state to the server's visible tools, and `C` clears its visible overrides — the filter is the scope (clear it to act on all rows)."
+- [ ] **Step 2:** Final sweep — all five MCP suites; doc-contract guard (39 pre-existing, zero new); ruff before/after on touched files.
+- [ ] **Step 3:** Backlog task Implementation Notes + Done; commit.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** both keys + messages (T1), global-row exclusion + zero-rows no-op via hint (T1), visible-scope semantics + filter-as-scope (T1 helper + T2 filter test), raw-shell skip + echo suffix (T2), first-failure stop + reason toast (T2), single echo + single resync (T2), footer + legend copy with pins (T1), audit per-row unchanged (constraint — no test change needed), tooltip full-clear recipe — covered by the legend clause copy in T1 step 3.6.
+- **Placeholder scan:** the two sketch tests in T1/T2 are named-but-abbreviated in this plan for brevity; the executor writes them fully per the shown harness shapes — the first test of each task is complete and the rest follow it mechanically.
+- **Type consistency:** message field names (`server_key`, `tool_names`, `new_state`, `profile_context`) used identically in both tasks; `flash_hint(text: str)`.

--- a/Docs/superpowers/plans/2026-09-11-mcp-hub-narrow-width-triad.md
+++ b/Docs/superpowers/plans/2026-09-11-mcp-hub-narrow-width-triad.md
@@ -1,0 +1,297 @@
+# MCP Hub Narrow-Width Triad Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Below 120 columns, stack the inspector under the canvas as a bounded scrolling band instead of squeezing three unreadable columns (ADR-148 decision 2).
+
+**Architecture:** One wrapper container — `#mcp-hub-grid` gains `#mcp-hub-main-row` (a `Horizontal` holding the rail and canvas, ids unchanged) with the inspector as its sibling. The `.mcp-compact` class (already toggled by `on_resize`) flips the grid to `layout: vertical`, turning the same tree into main-row-above/inspector-below; the inspector becomes a `max-height: 12` internally scrolling band. Wide layouts are geometrically unchanged (same fr shares, one nesting level deeper). The Advanced collapsible auto-collapses while compact.
+
+**Tech Stack:** Textual 8.x layout (`layout:` CSS override has in-repo precedent: `css/screen_feature_watchlists.tcss:144`), pytest + Pilot.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-mcp-hub-narrow-width-triad-design.md`; ADR: `backlog/decisions/148-mcp-hub-rail-ia-and-responsive-triad.md`.
+
+## Global Constraints
+
+- Wide layouts (≥120 cols) geometrically unchanged: rail 3fr / canvas 5fr inside the main-row, inspector 3fr of the grid — same shares as today's flat 3/5/3.
+- All existing pane ids stable (`#mcp-hub-rail`, `#mcp-hub-canvas`, `#mcp-hub-inspector`) — triad tests query unchanged.
+- CSS lands in BOTH places, lockstep: `MCPWorkbench.BUNDLED_CSS` / `MCPInspector.BUNDLED_CSS` and the `MCPWorkbench #mcp-hub-*` block in `tldw_chatbook/css/widget_defaults_scoped.tcss` (~line 789).
+- Band: `max-height: 12`, `min-height: 4`, `overflow-y: auto` at compact only; the persisted `advanced_visible` setting is never changed by the auto-collapse (widget state only).
+- TDD: every behavior's test watched RED first; targeted suites only.
+
+---
+
+### Task 1: Wrapper container + stacking CSS + geometry tests
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_workbench.py` (`compose`, `BUNDLED_CSS`)
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_inspector.py` (`BUNDLED_CSS` width 3fr stays; add nothing here — the band rules live in the workbench block)
+- Modify: `tldw_chatbook/css/widget_defaults_scoped.tcss` (the `MCPWorkbench #mcp-hub-*` mirror block)
+- Test: `Tests/UI/test_mcp_workbench.py`
+
+**Interfaces:**
+- Produces: `#mcp-hub-main-row` (Horizontal) wrapping rail + canvas inside `#mcp-hub-grid`; `.mcp-compact` stacks the grid vertically and bounds the inspector band.
+
+- [ ] **Step 1: Write the failing geometry tests**
+
+Append to `Tests/UI/test_mcp_workbench.py`:
+
+```python
+# -- Wave E (2026-09-11 MCP Hub UX program, ADR-148): narrow-width triad --
+
+
+@pytest.mark.asyncio
+async def test_wide_layout_keeps_inspector_beside_the_main_row():
+    """>=120 cols: the triad is geometrically unchanged -- the inspector
+    sits BESIDE the main row (rail+canvas), full height, not as a band."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(160, 44)) as pilot:
+        await pilot.pause()
+        main_row = app.query_one("#mcp-hub-main-row")
+        inspector = app.query_one("#mcp-hub-inspector")
+        assert inspector.region.x >= main_row.region.x + main_row.region.width - 1
+        assert inspector.region.height > 12  # full pane, not a band
+
+
+@pytest.mark.asyncio
+async def test_compact_layout_stacks_inspector_below_as_bounded_band():
+    """<120 cols (ADR-148): the inspector stacks BELOW the main row as a
+    bounded, scrollable band (<=12 rows) at full width -- replacing the
+    old squeezed third column that broke words mid-token."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        grid = app.query_one("#mcp-hub-grid")
+        main_row = app.query_one("#mcp-hub-main-row")
+        inspector = app.query_one("#mcp-hub-inspector")
+        assert "mcp-compact" in grid.classes
+        assert inspector.region.y >= main_row.region.y + main_row.region.height - 1
+        assert inspector.region.height <= 12
+        assert inspector.region.width >= main_row.region.width - 1
+        # The rail+canvas row keeps (nearly) the full width.
+        assert main_row.region.width >= 90
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_mcp_workbench.py -k "wide_layout_keeps or compact_layout_stacks" -q`
+Expected: FAIL (`#mcp-hub-main-row` NoMatches)
+
+- [ ] **Step 3: Implement**
+
+1. `mcp_workbench.compose()`: wrap the rail and canvas in the wrapper —
+
+```python
+        with Horizontal(id="mcp-hub-grid", classes="destination-workbench"):
+            with Horizontal(id="mcp-hub-main-row"):
+                yield MCPRail(... id="mcp-hub-rail", ...)
+                with ContentSwitcher(... id="mcp-hub-canvas", ...):
+                    yield MCPServersMode(id="mcp-mode-canvas-servers")
+            yield MCPInspector(id="mcp-hub-inspector", classes="destination-workbench-pane")
+```
+
+2. `MCPWorkbench.BUNDLED_CSS`: add main-row + stacking rules, and REPLACE the compact inspector squeeze rule:
+
+```css
+    #mcp-hub-main-row {
+        width: 4fr;   /* 8 of the old 11 share-units; inspector keeps 3 */
+        min-width: 0;
+        height: 100%;
+        min-height: 0;
+    }
+    /* ADR-148 Wave E: below 120 cols the grid stacks -- main row on top,
+    inspector as a bounded, internally scrolling band underneath (the old
+    squeezed third column broke words mid-token at ~20 cols). */
+    #mcp-hub-grid.mcp-compact {
+        layout: vertical;
+    }
+    #mcp-hub-grid.mcp-compact #mcp-hub-main-row {
+        width: 100%;
+        height: 1fr;
+    }
+    #mcp-hub-grid.mcp-compact #mcp-hub-inspector {
+        width: 100%;
+        height: auto;
+        max-height: 12;
+        min-height: 4;
+        overflow-y: auto;
+    }
+```
+
+Delete the old `#mcp-hub-grid.mcp-compact #mcp-hub-inspector { width: 2fr; min-width: 20; }` rule (both copies). Keep the compact rail/canvas rules (they now size within the main row).
+
+3. `MCPInspector.BUNDLED_CSS` and its `widget_defaults_scoped.tcss` mirror: change the inspector's own `width: 3fr; min-width: 28` — the width rule MOVES to grid level; set `MCPInspector { width: 3fr; min-width: 28; height: 100%; }` unchanged (the 3fr now competes with main-row's 4fr at grid level, preserving the 3/11 share), and in the workbench BUNDLED_CSS + scoped mirror keep `#mcp-hub-main-row { width: 4fr }` — total grid fr: 4+3 → inspector 3/7 ≈ 43%?? — NO: correct the shares so the ratio matches the old 8:3 — use `#mcp-hub-main-row { width: 8fr }` and leave the inspector at its own 3fr. Verify with the wide geometry test that the inspector share is within ±2 columns of the pre-change layout (assert against a captured baseline from the green run of an untouched wide test, e.g. the existing triad mount test's regions).
+
+4. Mirror every new/changed rule into the `MCPWorkbench #mcp-hub-*` block of `widget_defaults_scoped.tcss` (lockstep).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_mcp_workbench.py -k "wide_layout_keeps or compact_layout_stacks" -q`
+Expected: PASS. Then `pytest Tests/UI/test_mcp_workbench.py -k "100x30 or mounts_rail" -q` — the existing 100x30 layout test must still pass (master switch reachable inside the band).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/MCP_Modules/mcp_workbench.py tldw_chatbook/UI/MCP_Modules/mcp_inspector.py tldw_chatbook/css/widget_defaults_scoped.tcss Tests/UI/test_mcp_workbench.py
+git commit -m "feat(mcp): compact triad stacks the inspector as a bounded band (ADR-148 Wave E)"
+```
+
+---
+
+### Task 2: Advanced auto-collapse at compact + intact-content assertion
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_inspector.py` (new `apply_compact_layout()`)
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_workbench.py` (`_sync_compact_class` calls it)
+- Test: `Tests/UI/test_mcp_inspector.py`, `Tests/UI/test_mcp_workbench.py`
+
+**Interfaces:**
+- Produces: `MCPInspector.apply_compact_layout(compact: bool) -> None` — when True and `#mcp-adv-collapsible` is open, collapse it (widget state only; the persisted `advanced_visible` flag is untouched).
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/UI/test_mcp_inspector.py` (widget-level):
+
+```python
+@pytest.mark.asyncio
+async def test_apply_compact_layout_collapses_open_advanced_without_persisting():
+    """ADR-148 Wave E: a compact terminal collapses an open Advanced
+    collapsible (its JSON dumps are the least band-friendly content) but
+    never touches the persisted advanced_visible preference."""
+    app = InspectorApp()  # the file's existing bare harness
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inspector = app.query_one(MCPInspector)
+        collapsible = app.query_one("#mcp-adv-collapsible", Collapsible)
+        collapsible.collapsed = False
+        await pilot.pause()
+        persisted = inspector._advanced_visible
+
+        inspector.apply_compact_layout(True)
+        await pilot.pause()
+        assert app.query_one("#mcp-adv-collapsible", Collapsible).collapsed
+        assert inspector._advanced_visible is persisted
+```
+
+(Adapt the harness name/monkeypatch of `get_cli_setting("mcp.hub_state", "advanced_visible", ...)` to whatever the file's existing advanced tests use so the collapsible is composed.)
+
+In `Tests/UI/test_mcp_workbench.py` (integration):
+
+```python
+@pytest.mark.asyncio
+async def test_compact_band_renders_select_prompts_without_mid_word_breaks():
+    """The screenshot evidence for ADR-148 showed the Section select
+    clipped to 'Overvi|ew' at 100 cols. At the same size with the stacked
+    band, the full prompt renders on one line."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        section_select = app.query_one("#mcp-adv-section-select", Select)
+        assert section_select.region.width >= 9
+        rendered = "\n".join(
+            "".join(segment.text for segment in strip)
+            for strip in app.screen._compositor.render_strips()
+        )
+        assert "Overview" in rendered
+```
+
+(Guard: this test needs the Advanced area composed — monkeypatch the inspector module's `get_cli_setting` to `advanced_visible=True` exactly as the file's existing advanced-visibility tests do; if that harness pattern differs, mount with the workbench's `_reveal_advanced` path instead.)
+
+- [ ] **Step 2: Run tests to verify they fail** — `pytest ... -k "apply_compact_layout or mid_word_breaks" -q` → FAIL (method missing / select still clipped).
+
+- [ ] **Step 3: Implement**
+
+In `MCPInspector`:
+
+```python
+    def apply_compact_layout(self, compact: bool) -> None:
+        """ADR-148 Wave E: react to the workbench's compact-mode toggle.
+
+        Compact: collapse an OPEN Advanced collapsible -- its JSON dumps
+        are the least band-friendly content at 100 cols -- WITHOUT
+        touching the persisted `advanced_visible` preference (widget
+        state only; leaving compact never re-expands it for you).
+        """
+        if not compact:
+            return
+        try:
+            collapsible = self.query_one("#mcp-adv-collapsible", Collapsible)
+        except NoMatches:
+            return
+        if not collapsible.collapsed:
+            collapsible.collapsed = True
+```
+
+In `MCPWorkbench._sync_compact_class`, after the `set_class(...)` line:
+
+```python
+        try:
+            self.query_one(MCPInspector).apply_compact_layout(
+                0 < width < _COMPACT_WIDTH
+            )
+        except Exception:
+            pass  # pre-compose / torn-down subtree: nothing to collapse
+```
+
+- [ ] **Step 4: Run tests to verify they pass** — the two new tests plus `pytest Tests/UI/test_mcp_inspector.py -k advanced -q`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/MCP_Modules/mcp_inspector.py tldw_chatbook/UI/MCP_Modules/mcp_workbench.py Tests/UI/test_mcp_inspector.py Tests/UI/test_mcp_workbench.py
+git commit -m "feat(mcp): Advanced auto-collapses in the compact band; prompts render intact (ADR-148 Wave E)"
+```
+
+---
+
+### Task 3: Per-mode compact smoke + final sweep + hygiene
+
+**Files:**
+- Test: `Tests/UI/test_mcp_workbench.py` (new per-mode smoke)
+- Modify: `Docs/User_Guide/mcp.md` (one paragraph in "What this screen is for")
+
+**Interfaces:** none new.
+
+- [ ] **Step 1: Write the failing smoke test** (it should already pass after Tasks 1-2 — if it passes immediately, that is the point: it pins the shipped behavior; keep it as the regression net. If any mode fails, fix the mode's compact CSS before proceeding.)
+
+```python
+@pytest.mark.asyncio
+async def test_every_mode_renders_usably_at_100x30():
+    """ADR-148 Wave E sweep: each mode's canvas renders at 100x30 with the
+    stacked band present and no mid-word-broken status line."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        for mode, canvas_id in (
+            ("servers", "mcp-mode-canvas-servers"),
+            ("tools", "mcp-mode-canvas-tools"),
+            ("permissions", "mcp-mode-canvas-permissions"),
+            ("audit", "mcp-mode-canvas-audit"),
+        ):
+            workbench.set_mode(mode)
+            await pilot.pause()
+            canvas = app.query_one(f"#{canvas_id}")
+            assert canvas.display
+            assert canvas.region.height > 3
+        assert app.query_one("#mcp-hub-inspector").region.height <= 12
+```
+
+- [ ] **Step 2: Docs** — append to the end of "What this screen is for" in `Docs/User_Guide/mcp.md`:
+
+```markdown
+Below ~120 terminal columns the layout adapts: the detail panel stacks
+under the main area as a compact, scrollable band instead of squeezing
+three unreadable columns.
+```
+
+- [ ] **Step 3: Final sweep** — `pytest Tests/UI/test_mcp_workbench.py Tests/UI/test_mcp_inspector.py Tests/UI/test_mcp_rail.py Tests/UI/test_mcp_servers_mode.py Tests/UI/test_mcp_permissions_mode.py Tests/UI/test_destination_shells.py -k "mcp or hub or triad or compact or 100x30" -q` then the full five MCP suites; doc-contract guard (39 pre-existing failures, zero new); ruff before/after on touched files.
+
+- [ ] **Step 4: Commit + backlog task notes + Done.**
+
+---
+
+## Self-Review
+
+- **Spec coverage:** stacking (T1), band bounds + internal scroll (T1 CSS), Advanced auto-collapse + word hygiene verification (T2), per-mode 100x30 assertions (T3), F-057 column dropping unchanged (constraint), rail legend abbreviation already shipped in Wave A. Spec open question 1 (band cap scaling with terminal height) resolved to the fixed 12 default; open question 2 (rail Source select at compact) resolved to keeping current compact rail sizing — both recorded here as the defaults the user may override.
+- **Placeholder scan:** none.
+- **Type consistency:** `apply_compact_layout(compact: bool)`; `#mcp-hub-main-row` id used consistently; fr shares 8:3 preserve the wide geometry (verification step included in T1).

--- a/Docs/superpowers/plans/2026-09-11-mcp-hub-rail-ia-split.md
+++ b/Docs/superpowers/plans/2026-09-11-mcp-hub-rail-ia-split.md
@@ -1,0 +1,549 @@
+# MCP Hub Rail IA Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use the superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Split the agent tool catalog out of the built-in server's rail row into its own "Agent tools" rail section (ADR-148), so one row stops fronting three subsystems.
+
+**Architecture:** A new `agent_tools_readiness()` snapshot keyed `agent:builtin` (the existing `BUILTIN_TOOL_SERVER_KEY` store identity, which has no rail presence today) rides beside — not inside — the server snapshots: the rail renders it as a second section, the workbench routes it by `source == "agent"`, and the `Tool gates` checkbox group moves from the built-in server's detail pane to the agent row's detail pane. No store key, store entry, or permission-resolution semantic changes.
+
+**Tech Stack:** Textual 8.x widgets (Button/Static/DataTable), pytest + Textual Pilot, existing MCP Hub harnesses.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-mcp-hub-rail-ia-split-design.md` (identity map verified against code; ADR: `backlog/decisions/148-mcp-hub-rail-ia-and-responsive-triad.md`).
+
+## Global Constraints
+
+- No permission/store semantics change: no new store keys beyond the rail-facing snapshot, no resolution changes, ADR-081 posture untouched.
+- No two rail rows share a `server_key` (ADR-148); the agent row uses `agent:builtin`, the built-in server keeps `builtin:tldw_chatbook`.
+- The agent snapshot NEVER enters `self._snapshots` (overview table, callouts, worst-state summary, and preselection heuristics stay server-only).
+- Selecting the agent row renders the UNSCOPED Permissions preview (`agent:builtin` is never in `_last_hub_tools` — verified).
+- Label discipline: "Unknown" never renders as "Off"; markup-safe labels; tooltips explain outcomes.
+- Tests: targeted runs only (affected MCP suites); TDD — every new behavior's test is watched RED first.
+- House keybinding rules (ADR-031) unchanged — no new bindings in this wave.
+
+---
+
+### Task 1: `agent_tools_readiness` snapshot builder
+
+**Files:**
+- Modify: `tldw_chatbook/MCP/readiness.py` (after `builtin_readiness`, ~line 640)
+- Test: `Tests/UI/test_mcp_servers_mode.py` (new test near the existing readiness tests; `builtin_readiness` is already imported there)
+
+**Interfaces:**
+- Consumes: `ReadinessSnapshot`, `ReadinessState`, `ReasonCode` (all in readiness.py).
+- Produces: `agent_tools_readiness(*, enabled: bool) -> ReadinessSnapshot` with `server_key=BUILTIN_TOOL_SERVER_KEY_FOR_AGENTS` — define `AGENT_TOOLS_SERVER_KEY = "agent:builtin"` in readiness.py (do NOT import permission_store's `BUILTIN_TOOL_SERVER_KEY` into readiness.py — that would invert the dependency; instead assert equality in a test, see step 1).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_agent_tools_readiness_builder_shapes_the_rail_row():
+    from tldw_chatbook.MCP.permission_store import BUILTIN_TOOL_SERVER_KEY
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
+    on = agent_tools_readiness(enabled=True)
+    assert on.server_key == "agent:builtin"
+    assert on.server_key == BUILTIN_TOOL_SERVER_KEY  # same store identity, no new key
+    assert on.source == "agent"
+    assert on.label == "Agent tools"
+    assert on.state is ReadinessState.READY
+    assert "Console" in on.message
+
+    off = agent_tools_readiness(enabled=False)
+    assert off.state is ReadinessState.OFF_OPT_IN
+    assert "Turned off" in off.message
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/UI/test_mcp_servers_mode.py -k agent_tools_readiness -q`
+Expected: FAIL with `ImportError: cannot import name 'agent_tools_readiness'`
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `tldw_chatbook/MCP/readiness.py`, after `builtin_readiness()`:
+
+```python
+#: ADR-148: the rail-facing identity of the in-process agent tool catalog.
+#: Deliberately equal to permission_store.BUILTIN_TOOL_SERVER_KEY ("agent:builtin")
+#: -- the store identity that already exists but had no rail presence. The
+#: equality is pinned by test; readiness.py must not import the store
+#: (dependency direction), so the literal is duplicated once and tested.
+AGENT_TOOLS_SERVER_KEY = "agent:builtin"
+
+
+def agent_tools_readiness(*, enabled: bool) -> ReadinessSnapshot:
+    """Readiness for the in-process agent tool catalog (ADR-148 Wave D).
+
+    Not a server: nothing connects to it and no client launches it -- the
+    state is purely whether the `[console] local_tools_enabled` master
+    switch registers the workspace/web/Watchlists/built-in agent tools.
+    """
+    if enabled:
+        state = ReadinessState.READY
+        message = "In-process tools for Console agents."
+    else:
+        state = ReadinessState.OFF_OPT_IN
+        message = "Turned off — Console agents get no workspace, web, or Watchlists tools."
+    return ReadinessSnapshot(
+        server_key=AGENT_TOOLS_SERVER_KEY,
+        label="Agent tools",
+        source="agent",
+        state=state,
+        reasons=() if enabled else (ReasonCode.NOT_CONFIGURED,),
+        message=message,
+        transport="—",
+        auth_display="—",
+        scope_display="—",
+        detail={"enabled": enabled},
+    )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/UI/test_mcp_servers_mode.py -k agent_tools_readiness -q`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/MCP/readiness.py Tests/UI/test_mcp_servers_mode.py
+git commit -m "feat(mcp): agent_tools_readiness snapshot for the Agent tools rail row (ADR-148)"
+```
+
+---
+
+### Task 2: Rail renders the Agent tools section
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_rail.py` (constructor, `sync_state`, `compose`)
+- Test: `Tests/UI/test_mcp_rail.py`
+
+**Interfaces:**
+- Consumes: `agent_tools_readiness` snapshots passed in by the workbench (Task 4).
+- Produces: `MCPRail(..., agent_snapshot: ReadinessSnapshot | None = None)` constructor kwarg; `sync_state(..., agent_snapshot: ReadinessSnapshot | None = None)`; the agent row's click posts the existing `MCPRail.ServerSelected("agent:builtin")`; `_row_keys` ends with the agent key when present.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_mcp_rail.py` (the file's `_snap` helper and `RailApp` harness already exist):
+
+```python
+def _agent_snap():
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
+    return agent_tools_readiness(enabled=True)
+
+
+@pytest.mark.asyncio
+async def test_rail_renders_agent_tools_section_and_row():
+    class AgentRailApp(RailApp):
+        def compose(self) -> ComposeResult:
+            yield MCPRail(
+                source="local",
+                snapshots=[_snap("local:docs", "docs")],
+                selected_server_key=None,
+                scope_options=[("Personal", "personal")],
+                scope_value="personal",
+                scope_ref_options=[],
+                scope_ref_value=None,
+                agent_snapshot=_agent_snap(),
+                id="mcp-rail",
+            )
+
+    app = AgentRailApp()
+    async with app.run_test() as pilot:
+        headings = [
+            str(widget.renderable)
+            for widget in app.query(".mcp-rail-heading")
+        ]
+        assert headings == ["Source", "Servers", "Agent tools"]
+        rows = list(app.query("Button.mcp-rail-row"))
+        labels = [str(row.label) for row in rows]
+        assert any("Agent tools" in label for label in labels)
+        # Clicking the agent row posts ServerSelected with the store identity.
+        agent_button = next(
+            row for row in rows if "Agent tools" in str(row.label)
+        )
+        await pilot.click(f"#{agent_button.id}")
+        await pilot.pause()
+        assert app.events, "agent row click must post ServerSelected"
+        assert app.events[-1].server_key == "agent:builtin"
+
+
+@pytest.mark.asyncio
+async def test_rail_omits_agent_section_without_snapshot():
+    app = RailApp()  # no agent_snapshot kwarg
+    async with app.run_test() as pilot:
+        headings = [
+            str(widget.renderable)
+            for widget in app.query(".mcp-rail-heading")
+        ]
+        assert "Agent tools" not in headings
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_mcp_rail.py -k agent_tools_section -q && pytest Tests/UI/test_mcp_rail.py -k omits_agent_section -q`
+Expected: FAIL (`unexpected keyword argument 'agent_snapshot'` / heading missing)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `MCPRail.__init__`: add `agent_snapshot: ReadinessSnapshot | None = None` parameter, store as `self.agent_snapshot = agent_snapshot`. In `sync_state`: same parameter, same assignment. In `compose`, after the server-rows loop (the `for index, snap in enumerate(self.snapshots, start=1)` block) and before the `if self.source == "server":` scope block:
+
+```python
+        # ADR-148 Wave D: the in-process agent tool catalog gets its own
+        # rail section -- one row, keyed by the store identity
+        # permission_store.BUILTIN_TOOL_SERVER_KEY ("agent:builtin"), so
+        # no rail row ever shares a server_key with the built-in server.
+        if self.agent_snapshot is not None:
+            yield Static(
+                "Agent tools", classes="destination-section mcp-rail-heading"
+            )
+            self._row_keys.append(self.agent_snapshot.server_key)
+            agent_row = Button(
+                _row_label(self.agent_snapshot, pad_width),
+                id=f"{MCP_RAIL_ROW_PREFIX}{len(self._row_keys) - 1}",
+                classes=f"mcp-rail-row console-action-subdued {STATE_CSS_CLASSES[self.agent_snapshot.state]}",
+                compact=True,
+            )
+            agent_row.tooltip = escape_markup(
+                self.agent_snapshot.message or self.agent_snapshot.label
+            )
+            agent_row.set_class(
+                self.agent_snapshot.server_key == self.selected_server_key,
+                "is-active",
+            )
+            yield agent_row
+```
+
+Also include the agent snapshot in the legend's present-states derivation: change the `if self.snapshots:` legend block to
+
+```python
+        legend_snaps = list(self.snapshots)
+        if self.agent_snapshot is not None:
+            legend_snaps.append(self.agent_snapshot)
+        if legend_snaps:
+            yield Static(
+                _present_states_legend(
+                    legend_snaps, short=budget < _LEGEND_SHORT_BUDGET
+                ),
+                id="mcp-rail-state-legend",
+                markup=False,
+            )
+```
+
+(Note: the F15 budget computation sits just above the legend yield — keep it there; the agent block goes after the rows loop where `pad_width` is already computed.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_mcp_rail.py -q`
+Expected: all PASS (existing tests unaffected — no agent snapshot by default)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/MCP_Modules/mcp_rail.py Tests/UI/test_mcp_rail.py
+git commit -m "feat(mcp): rail renders the Agent tools section (ADR-148 Wave D)"
+```
+
+---
+
+### Task 3: Gates move to the agent detail; built-in detail points there
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py` (`_tool_gate_widgets` gate, `_detail_text` branches)
+- Test: `Tests/UI/test_mcp_servers_mode.py` (re-target 4 existing tests, add 2)
+
+**Interfaces:**
+- Consumes: `agent_tools_readiness` (Task 1) for test fixtures; `all_tool_gates()` unchanged.
+- Produces: `Tool gates` renders for `snapshot.source == "agent"` only; built-in detail shows the pointer line `"Agent tool gates live under Agent tools in the rail."`; `_detail_text` has an `"agent"` branch; gate checkbox ids/`ToolGateChanged` flow unchanged (Wave C/A behavior intact).
+
+- [ ] **Step 1: Re-target the existing pinned tests (they currently pass — after Step 3 they must still pass in their NEW shape; write the new assertions first and watch them fail)**
+
+In `Tests/UI/test_mcp_servers_mode.py`:
+
+1. `test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings_and_note` → rename to `test_tool_gate_checkboxes_render_under_agent_detail_with_subheadings_and_note`; replace `await canvas.show_detail(builtin_readiness(enabled=True))` with `await canvas.show_detail(agent_tools_readiness(enabled=True))` (import it); the subheading/note/checkbox assertions stay identical.
+2. `test_tool_gate_checkboxes_do_not_appear_for_non_builtin_detail` → rename `..._do_not_appear_outside_agent_detail`; extend: gates must NOT render for the built-in snapshot either:
+
+```python
+        await canvas.show_detail(builtin_readiness(enabled=True))
+        await pilot.pause()
+        assert not list(app.query("#mcp-detail-tool-gates Checkbox"))
+```
+
+3. `test_showing_builtin_detail_does_not_post_tool_gate_changed` → keep using the built-in snapshot (still valid), and add a sibling assertion that SHOWING agent detail also posts nothing.
+4. `test_toggling_tool_gate_checkbox_posts_tool_gate_changed_with_section_and_key` and the master-off dependent test (~line 958 and ~line 961 region): switch `show_detail(builtin_readiness(...))` to `show_detail(agent_tools_readiness(...))`.
+
+Add the new built-in-pointer test:
+
+```python
+@pytest.mark.asyncio
+async def test_builtin_detail_points_at_the_agent_tools_row():
+    app = CanvasApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+        await canvas.show_detail(builtin_readiness(enabled=True))
+        await pilot.pause()
+        body = str(app.query_one("#mcp-detail-body", Static).renderable)
+        assert "Agent tool gates live under Agent tools in the rail." in body
+```
+
+And the agent detail body test:
+
+```python
+@pytest.mark.asyncio
+async def test_agent_detail_body_explains_console_scope():
+    app = CanvasApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
+        await pilot.pause()
+        title = str(app.query_one("#mcp-detail-title", Static).renderable)
+        assert "Agent tools" in title
+        body = str(app.query_one("#mcp-detail-body", Static).renderable)
+        assert "Console" in body
+        # No [mcp] server toggles and no Edit/Delete toolbar here.
+        assert not list(app.query("#mcp-detail-builtin-toggles Checkbox"))
+        assert not list(app.query("#mcp-detail-toolbar Button"))
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_mcp_servers_mode.py -k "agent_detail or points_at_the_agent or outside_agent_detail" -q`
+Expected: FAIL (gates don't render for source "agent"; pointer line absent)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mcp_servers_mode.py`:
+
+1. `_tool_gate_widgets`: change the gate from
+
+```python
+        if snapshot is None or snapshot.source != "builtin":
+```
+
+to
+
+```python
+        if snapshot is None or snapshot.source != "agent":
+```
+
+and update its docstring's first line to "Build the `[tools]`/`[console]` gate Checkbox rows (task-3240, moved to the Agent tools detail by ADR-148 Wave D)."
+2. `_detail_text`: add an agent branch before the final `else:  # builtin`:
+
+```python
+        elif snapshot.source == "agent":
+            lines.append(
+                "Registers the in-process tools Console agents can see — it "
+                "does not grant permission; the Permissions matrix still "
+                "gates every call."
+            )
+```
+
+3. `_detail_text`'s `else:  # builtin` branch: append the pointer line:
+
+```python
+            lines.append("Agent tool gates live under Agent tools in the rail.")
+```
+
+- [ ] **Step 4: Run the module suite**
+
+Run: `pytest Tests/UI/test_mcp_servers_mode.py -q`
+Expected: all PASS (re-targeted tests included)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py Tests/UI/test_mcp_servers_mode.py
+git commit -m "feat(mcp): Tool gates move to the Agent tools detail; built-in detail points there (ADR-148)"
+```
+
+---
+
+### Task 4: Workbench wiring — snapshot, rail sync, selection routing
+
+**Files:**
+- Modify: `tldw_chatbook/UI/MCP_Modules/mcp_workbench.py` (`__init__`, `compose`, `_collect_snapshots`, `_sync_children`, `_snapshot_for`)
+- Test: `Tests/UI/test_mcp_workbench.py`
+
+**Interfaces:**
+- Consumes: `agent_tools_readiness` (Task 1), rail kwarg (Task 2), detail routing (Task 3).
+- Produces: `self._agent_snapshot` on the workbench; `_snapshot_for("agent:builtin")` returns it; the agent rail row is selectable end-to-end; `_snapshots` stays server-only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_mcp_workbench.py`:
+
+```python
+@pytest.mark.asyncio
+async def test_agent_tools_rail_row_routes_to_agent_detail(monkeypatch):
+    """ADR-148 Wave D: the Agent tools rail row is selectable, opens the
+    agent detail (Tool gates visible, no [mcp] toggles), stays OUT of the
+    servers overview table, and scopes the Permissions preview to nothing
+    (the unscoped summary -- agent:builtin is never in the hub catalog)."""
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: default,
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+
+        # Not a server row: absent from the overview table...
+        table = app.query_one("#mcp-servers-table", DataTable)
+        table_keys = [
+            table.coordinate_to_cell_key((row, 0))[0].value
+            for row in range(table.row_count)
+        ]
+        assert "agent:builtin" not in table_keys
+        # ...but present in the rail and selectable.
+        await pilot.click("#mcp-rail-row-2")  # 0 All, 1 built-in, 2 agent
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert workbench._selected_server_key == "agent:builtin"
+        assert app.query_one("#mcp-servers-detail").display is True
+        assert list(app.query("#mcp-detail-tool-gates Checkbox"))
+        assert not list(app.query("#mcp-detail-builtin-toggles Checkbox"))
+
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("global default:")
+
+
+@pytest.mark.asyncio
+async def test_agent_snapshot_state_follows_local_master_switch(monkeypatch):
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: (
+            True if key == "local_tools_enabled" else default
+        ),
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        from tldw_chatbook.MCP.readiness import ReadinessState
+
+        assert app.query_one(MCPWorkbench)._agent_snapshot is not None
+        assert (
+            app.query_one(MCPWorkbench)._agent_snapshot.state
+            is ReadinessState.READY
+        )
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_mcp_workbench.py -k "agent_tools_rail_row or agent_snapshot_state" -q`
+Expected: FAIL (`_agent_snapshot` missing / rail has no third row)
+
+- [ ] **Step 3: Write minimal implementation**
+
+In `mcp_workbench.py`:
+
+1. Import: add `agent_tools_readiness` and `AGENT_TOOLS_SERVER_KEY` to the existing `from tldw_chatbook.MCP.readiness import (...)` block.
+2. `__init__`: near `_snapshots`, add `self._agent_snapshot: ReadinessSnapshot | None = None`.
+3. `compose`: the initial `MCPRail(...)` call gains `agent_snapshot=None`.
+4. `_collect_snapshots`: at the top of the `if self._source == "local":` branch (before appending the built-in), set:
+
+```python
+            # ADR-148 Wave D: the agent-tools rail row is derived, not a
+            # server -- it rides beside _snapshots so the overview table,
+            # callouts, worst-state summary, and preselection heuristics
+            # stay server-only.
+            self._agent_snapshot = agent_tools_readiness(
+                enabled=coerce_bool_setting(
+                    get_cli_setting(
+                        "console",
+                        LOCAL_TOOLS_MASTER_KEY,
+                        LOCAL_TOOLS_DEFAULT_ENABLED,
+                    ),
+                    LOCAL_TOOLS_DEFAULT_ENABLED,
+                )
+            )
+```
+
+and in the server-source branch set `self._agent_snapshot = None`. (Imports for `coerce_bool_setting`, `LOCAL_TOOLS_MASTER_KEY`, `LOCAL_TOOLS_DEFAULT_ENABLED` already exist in this module — verify with grep; `_local_agent_hub_tools` uses all three.)
+5. `_snapshot_for`: after the existing loop lookup, add:
+
+```python
+        if (
+            server_key == AGENT_TOOLS_SERVER_KEY
+            and self._agent_snapshot is not None
+        ):
+            return self._agent_snapshot
+```
+
+6. `_sync_children`: the `rail.sync_state(...)` call gains `agent_snapshot=self._agent_snapshot`.
+
+Routing needs NO new branch: `_show_selected_detail` routes through `canvas.show_detail(selected)`, whose source gates (Task 3) do the work; the inspector's `_wired_actions` already gives `source != "local"` the base action set.
+
+- [ ] **Step 4: Run tests to verify they pass, then the full affected suites**
+
+Run: `pytest Tests/UI/test_mcp_workbench.py -k "agent_tools_rail_row or agent_snapshot_state" -q`
+Expected: PASS
+Run: `pytest Tests/UI/test_mcp_workbench.py Tests/UI/test_mcp_rail.py Tests/UI/test_mcp_servers_mode.py Tests/UI/test_mcp_permissions_mode.py Tests/UI/test_mcp_inspector.py -q`
+Expected: all PASS — any test that pinned gates-under-builtin or exact rail row counts is updated in the same commit (grep `mcp-rail-row-` and `mcp-detail-tool-gates` in Tests/ to find them).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/MCP_Modules/mcp_workbench.py Tests/UI/test_mcp_workbench.py
+git commit -m "feat(mcp): workbench wires the Agent tools rail row end-to-end (ADR-148 Wave D)"
+```
+
+---
+
+### Task 5: Docs truth + final verification
+
+**Files:**
+- Modify: `Docs/User_Guide/mcp.md` ("Other registration gates (Servers mode ▸ Tool gates)" section, line ~123)
+- Test: `Tests/MCP/test_mcp_documentation_contract.py` (guard: failure count must not increase)
+
+**Interfaces:**
+- Consumes: shipped behavior from Tasks 1-4.
+- Produces: user-guide truth matching the split.
+
+- [ ] **Step 1: Update the user guide**
+
+In `Docs/User_Guide/mcp.md`, the section currently opens "Select the built-in server's row in Servers mode; its detail pane has a **Tool gates** group under the existing enable/expose checkboxes". Rewrite the opening to:
+
+```markdown
+Select the **Agent tools** row in the rail (its own section under
+Servers); its detail pane has a **Tool gates** group, split into two
+subheadings:
+```
+
+and add one sentence after the subheadings list: "The built-in server's own row keeps only the `[mcp]` enable/expose controls — the two panes govern different subsystems by design (ADR-148)."
+
+- [ ] **Step 2: Guard the doc contract**
+
+Run: `pytest Tests/MCP/test_mcp_documentation_contract.py -q`
+Expected: the SAME pre-existing failure count as the branch point (39 as of 2026-09-11; 26 mcp.md-scoped) — zero new failures. If any NEW failure names the gates section, fix the doc wording (not the test).
+
+- [ ] **Step 3: Final verification sweep**
+
+Run: `pytest Tests/UI/test_mcp_workbench.py Tests/UI/test_mcp_rail.py Tests/UI/test_mcp_servers_mode.py Tests/UI/test_mcp_permissions_mode.py Tests/UI/test_mcp_inspector.py Tests/UI/test_destination_shells.py -q`
+Expected: MCP suites all PASS; destination shells show only the pre-existing failures documented in TASK-32454 (library/schedules/models drift + known flakiness). Ruff on touched files: no NEW findings vs HEAD~.
+
+- [ ] **Step 4: Commit + task hygiene**
+
+```bash
+git add Docs/User_Guide/mcp.md
+git commit -m "docs(mcp): registration gates live under the Agent tools row (ADR-148)"
+```
+
+Create/complete the backlog task (ADR check: covered by ADR-148, linked) with Implementation Notes naming every re-targeted test.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** second rail section (Task 2), gates move + pointer (Task 3), `agent:builtin` key + no-shared-key constraint (Tasks 1-2), unscoped preview (Task 4 test), view-state non-migration (no task needed — `agent:builtin` is new to the rail; old selections restore onto the built-in row unchanged, asserted implicitly by existing restore tests), label honesty `(external MCP)` suffix — **deferred**: the spec's label-suffix work belongs with the duplication-disambiguation follow-up; this plan's Task 5 documents the split only. Noted as an explicit deferral, not a silent gap.
+- **Placeholder scan:** none; every step carries code or exact assertions.
+- **Type consistency:** `agent_tools_readiness(*, enabled: bool)`, `agent_snapshot: ReadinessSnapshot | None`, `AGENT_TOOLS_SERVER_KEY = "agent:builtin"` used consistently across tasks.

--- a/Tests/MCP/test_permission_resolution.py
+++ b/Tests/MCP/test_permission_resolution.py
@@ -909,9 +909,12 @@ def test_resolve_by_key_non_mapping_tool_entry_does_not_raise():
 
 
 def test_cycle_ui_state_full_loop():
-    assert cycle_ui_state(None) == "allow"
-    assert cycle_ui_state("allow") == "ask"
-    assert cycle_ui_state("ask") == "deny"
+    # Wave B (2026-09-11 UX program): the first press from Inherit lands
+    # on Ask, not Allow -- the most permissive state is never the first
+    # stop from the default posture.
+    assert cycle_ui_state(None) == "ask"
+    assert cycle_ui_state("ask") == "allow"
+    assert cycle_ui_state("allow") == "deny"
     assert cycle_ui_state("deny") is None
 
 

--- a/Tests/UI/test_destination_shells.py
+++ b/Tests/UI/test_destination_shells.py
@@ -3366,7 +3366,10 @@ async def test_mcp_destination_footer_shortcuts_follow_mode():
 
         screen.action_mcp_mode("permissions")
         await pilot.pause()
-        assert footer.shortcut_text == f"{common} | space cycle permission{globals_suffix}"
+        assert footer.shortcut_text == (
+            f"{common} | space cycle permission | shift+space bulk set"
+            f" | C clear overrides{globals_suffix}"
+        )
 
         screen.action_mcp_mode("audit")
         await pilot.pause()

--- a/Tests/UI/test_mcp_inspector.py
+++ b/Tests/UI/test_mcp_inspector.py
@@ -6193,3 +6193,28 @@ async def test_editing_the_payload_preserves_real_run_output_when_not_armed():
         assert _adv_result(app) == result_before, (
             "editing the payload while UNARMED must not blank real run output"
         )
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+def test_render_section_payload_renders_error_payloads_as_one_line_status():
+    """A5/F13: a section payload carrying an "error" key (the
+    `_AdvancedSectionShim` normalization for a failed `load_section()`)
+    renders as ONE plain status line, not a raw JSON dump -- the JSON dump
+    is exactly the noise the review flagged on the server-source
+    no-target state. An empty/absent error still falls through to the
+    JSON rendering (it is a legitimate payload, not a failure)."""
+    payload = {"source": "local", "section": "overview", "error": "connection refused"}
+    result = mcp_inspector_module._render_section_payload("overview", payload)
+    assert result == "Could not load this section: connection refused"
+    assert "{" not in result and '"' not in result
+
+    no_error = mcp_inspector_module._render_section_payload(
+        "overview", {"source": "local", "section": "overview"}
+    )
+    assert "{" in no_error
+    blank_error = mcp_inspector_module._render_section_payload(
+        "overview", {"source": "local", "error": ""}
+    )
+    assert "{" in blank_error

--- a/Tests/UI/test_mcp_inspector.py
+++ b/Tests/UI/test_mcp_inspector.py
@@ -6218,3 +6218,33 @@ def test_render_section_payload_renders_error_payloads_as_one_line_status():
         "overview", {"source": "local", "error": ""}
     )
     assert "{" in blank_error
+
+
+# -- Wave E (2026-09-11 MCP Hub UX program, ADR-148): compact band ---------
+
+
+@pytest.mark.asyncio
+async def test_apply_compact_layout_collapses_open_advanced_without_persisting(
+    monkeypatch,
+):
+    """ADR-148 Wave E: a compact terminal collapses an OPEN Advanced
+    collapsible (its JSON dumps are the least band-friendly content) but
+    never touches the persisted `advanced_visible` preference -- leaving
+    compact never re-expands it for you."""
+    monkeypatch.setattr(
+        mcp_inspector_module,
+        "get_cli_setting",
+        _fake_get_cli_setting(advanced_open=True, advanced_visible=True),
+    )
+    app = InspectorApp()
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        inspector = app.query_one(MCPInspector)
+        collapsible = app.query_one("#mcp-adv-collapsible", Collapsible)
+        assert not collapsible.collapsed  # fixture: open and composed
+        persisted = inspector._advanced_visible
+
+        inspector.apply_compact_layout(True)
+        await pilot.pause()
+        assert app.query_one("#mcp-adv-collapsible", Collapsible).collapsed
+        assert inspector._advanced_visible is persisted

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -162,6 +162,12 @@ class PermissionsModeApp(ConsolidatedCSSApp):
     def on_mcp_permissions_mode_state_cycle_requested(self, event) -> None:
         self.events.append(event)
 
+    def on_mcp_permissions_mode_bulk_state_requested(self, event) -> None:
+        self.events.append(event)
+
+    def on_mcp_permissions_mode_bulk_clear_requested(self, event) -> None:
+        self.events.append(event)
+
     def on_mcp_permissions_mode_kill_switch_toggled(self, event) -> None:
         self.events.append(event)
 
@@ -689,7 +695,8 @@ async def test_legend_line_renders_fixed_marker_key():
         legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
         assert legend == (
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
-            "Space cycles Inherit → Ask → Allow → Off"
+            "Space cycles Inherit → Ask → Allow → Off · shift+space bulk "
+            "set · C clears overrides (visible rows only)"
         )
 
 
@@ -736,7 +743,8 @@ async def test_update_matrix_with_no_gate_breadcrumb_shows_bare_legend():
         legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
         assert legend == (
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
-            "Space cycles Inherit → Ask → Allow → Off"
+            "Space cycles Inherit → Ask → Allow → Off · shift+space bulk "
+            "set · C clears overrides (visible rows only)"
         )
 
 
@@ -1608,3 +1616,96 @@ async def test_update_matrix_renders_discovery_hint_line():
         await pilot.pause()
         legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
         assert "no tools yet" not in legend
+
+
+# -- Wave F (2026-09-11 MCP Hub UX program, ADR-149): bulk actions --------
+
+
+@pytest.mark.asyncio
+async def test_shift_space_on_tool_row_posts_bulk_state_for_visible_tools():
+    """ADR-149: shift+space posts ONE BulkStateRequested carrying the
+    server's visible tool rows and the cursor row's own next cycled state
+    (Wave B order: first press from Inherit = Ask)."""
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        rows = [
+            _global_row(),
+            _server_row(server_key="local:docs", server_label="docs"),
+            _tool_row(server_key="local:docs", server_label="docs", tool_name="fetch"),
+            _tool_row(server_key="local:docs", server_label="docs", tool_name="search"),
+        ]
+        await canvas.update_matrix(rows, kill_switch=False, preview="")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=2)
+        await pilot.press("shift+space")
+        await pilot.pause()
+
+        assert len(app.events) == 1
+        event = app.events[0]
+        assert isinstance(event, MCPPermissionsMode.BulkStateRequested)
+        assert event.server_key == "local:docs"
+        assert sorted(event.tool_names) == ["fetch", "search"]
+        assert event.new_state == "ask"  # Wave B: cycle_ui_state(None) == "ask"
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_posts_only_overridden_visible_rows():
+    """ADR-149: C posts BulkClearRequested with ONLY the server's visible
+    tool rows that currently hold an override (cycle_current not None)."""
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        rows = [
+            _global_row(),
+            _server_row(server_key="local:docs", server_label="docs"),
+            _tool_row(
+                server_key="local:docs",
+                server_label="docs",
+                tool_name="fetch",
+                cycle_current="allow",
+            ),
+            _tool_row(server_key="local:docs", server_label="docs", tool_name="search"),
+        ]
+        await canvas.update_matrix(rows, kill_switch=False, preview="")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=2)
+        await pilot.press("C")
+        await pilot.pause()
+
+        assert len(app.events) == 1
+        event = app.events[0]
+        assert isinstance(event, MCPPermissionsMode.BulkClearRequested)
+        assert event.server_key == "local:docs"
+        assert list(event.tool_names) == ["fetch"]
+
+
+@pytest.mark.asyncio
+async def test_bulk_keys_noop_on_global_row_with_hint_not_toast():
+    """ADR-149: the global row owns no server -- both bulk keys no-op
+    against it via the legend hint line (the spec's 'existing hint
+    Static'), never a toast, and never a posted message."""
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        await canvas.update_matrix(
+            [_global_row()], kill_switch=False, preview=""
+        )
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+
+        notified: list[object] = []
+        app.notify = lambda *a, **k: notified.append(a)  # type: ignore[method-assign]
+        await pilot.press("shift+space")
+        await pilot.press("C")
+        await pilot.pause()
+
+        assert not app.events
+        assert not notified
+        legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
+        assert "Bulk actions need a server" in legend

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -1618,12 +1618,12 @@ async def test_update_matrix_renders_discovery_hint_line():
         assert "no tools yet" not in legend
 
 
-# -- Wave F (2026-09-11 MCP Hub UX program, ADR-149): bulk actions --------
+# -- Wave F (2026-09-11 MCP Hub UX program, ADR-150): bulk actions --------
 
 
 @pytest.mark.asyncio
 async def test_shift_space_on_tool_row_posts_bulk_state_for_visible_tools():
-    """ADR-149: shift+space posts ONE BulkStateRequested carrying the
+    """ADR-150: shift+space posts ONE BulkStateRequested carrying the
     server's visible tool rows and the cursor row's own next cycled state
     (Wave B order: first press from Inherit = Ask)."""
     app = PermissionsModeApp()
@@ -1653,7 +1653,7 @@ async def test_shift_space_on_tool_row_posts_bulk_state_for_visible_tools():
 
 @pytest.mark.asyncio
 async def test_bulk_clear_posts_only_overridden_visible_rows():
-    """ADR-149: C posts BulkClearRequested with ONLY the server's visible
+    """ADR-150: C posts BulkClearRequested with ONLY the server's visible
     tool rows that currently hold an override (cycle_current not None)."""
     app = PermissionsModeApp()
     async with app.run_test() as pilot:
@@ -1686,7 +1686,7 @@ async def test_bulk_clear_posts_only_overridden_visible_rows():
 
 @pytest.mark.asyncio
 async def test_bulk_keys_noop_on_global_row_with_hint_not_toast():
-    """ADR-149: the global row owns no server -- both bulk keys no-op
+    """ADR-150: the global row owns no server -- both bulk keys no-op
     against it via the legend hint line (the spec's 'existing hint
     Static'), never a toast, and never a posted message."""
     app = PermissionsModeApp()

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -1540,3 +1540,71 @@ async def test_filter_input_has_nonzero_geometry_with_bundled_css():
         assert filter_input.outer_size.height > 0, (
             "filter Input collapsed to zero height under bundled CSS"
         )
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+def test_undiscovered_servers_hint_names_zero_tool_servers():
+    """C2/F3: local servers that are KNOWN but have no discovered tools are
+    invisible in the matrix (registration/discovery precedes permission) --
+    the hint line names them so "where is docs?" has an answer at the point
+    of confusion. Discovered servers and the built-in row are never named."""
+    from tldw_chatbook.MCP.readiness import ReadinessState, ReadinessSnapshot
+    from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import (
+        _undiscovered_servers_hint,
+    )
+
+    def _snap(key, label, source, tool_count):
+        return ReadinessSnapshot(
+            server_key=key,
+            label=label,
+            source=source,
+            state=ReadinessState.READY,
+            reasons=(),
+            message="",
+            tool_count=tool_count,
+        )
+
+    snapshots = [
+        _snap("local:docs", "docs", "local", None),
+        _snap("local:web", "web", "local", 0),
+        _snap("local:ok", "ok", "local", 3),
+        _snap("builtin:tldw_chatbook", "tldw_chatbook (built-in)", "builtin", None),
+    ]
+    hint = _undiscovered_servers_hint(snapshots)
+    assert hint is not None
+    assert "docs" in hint and "web" in hint
+    assert "ok" not in hint
+    assert "built-in" not in hint
+    assert "Servers" in hint
+
+    # Everything discovered (or nothing known): no hint at all.
+    assert _undiscovered_servers_hint(snapshots[2:]) is None
+    assert _undiscovered_servers_hint([]) is None
+
+
+@pytest.mark.asyncio
+async def test_update_matrix_renders_discovery_hint_line():
+    """C2/F3: the discovery hint renders as its own dim line under the
+    legend (same slot family as the gate breadcrumb), and clears on the
+    next ordinary render that passes no hint."""
+    app = PermissionsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPPermissionsMode)
+        await canvas.update_matrix(
+            [_global_row()],
+            kill_switch=False,
+            preview="global default: ask",
+            discovery_hint="docs · web: no tools yet — connect in Servers mode.",
+        )
+        await pilot.pause()
+        legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
+        assert "no tools yet" in legend
+
+        await canvas.update_matrix(
+            [_global_row()], kill_switch=False, preview="global default: ask"
+        )
+        await pilot.pause()
+        legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
+        assert "no tools yet" not in legend

--- a/Tests/UI/test_mcp_permissions_mode.py
+++ b/Tests/UI/test_mcp_permissions_mode.py
@@ -420,8 +420,9 @@ async def test_space_on_tool_row_posts_next_state_per_cycle_helper():
         assert event.row_kind == "tool"
         assert event.server_key == "local:docs"
         assert event.tool_name == "search"
-        # cycle_ui_state(None) == "allow"
-        assert event.new_state == "allow"
+        # Wave B: cycle_ui_state(None) == "ask" (Allow is a deliberate
+        # second press, never the first stop from Inherit)
+        assert event.new_state == "ask"
 
 
 @pytest.mark.asyncio
@@ -688,7 +689,7 @@ async def test_legend_line_renders_fixed_marker_key():
         legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
         assert legend == (
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
-            "Space cycles Inherit → Allow → Ask → Off"
+            "Space cycles Inherit → Ask → Allow → Off"
         )
 
 
@@ -735,7 +736,7 @@ async def test_update_matrix_with_no_gate_breadcrumb_shows_bare_legend():
         legend = str(app.query_one("#mcp-perm-legend", Static).renderable)
         assert legend == (
             "• override · ⚠ definition changed · ⚑ high-risk floor · "
-            "Space cycles Inherit → Allow → Ask → Off"
+            "Space cycles Inherit → Ask → Allow → Off"
         )
 
 

--- a/Tests/UI/test_mcp_rail.py
+++ b/Tests/UI/test_mcp_rail.py
@@ -846,3 +846,59 @@ def test_short_state_legend_words_cover_every_state():
 
     for label in STATE_LABELS.values():
         assert label.lower() in _SHORT_STATE_LABELS
+
+
+# -- Wave D (2026-09-11 MCP Hub UX program, ADR-148): rail IA split --------
+
+
+def _agent_snap():
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
+    return agent_tools_readiness(enabled=True)
+
+
+class AgentRailApp(RailApp):
+    def compose(self) -> ComposeResult:
+        yield MCPRail(
+            source="local",
+            snapshots=[_snap("local:docs", "docs")],
+            selected_server_key=None,
+            scope_options=[("Personal", "personal")],
+            scope_value="personal",
+            scope_ref_options=[],
+            scope_ref_value=None,
+            agent_snapshot=_agent_snap(),
+            id="mcp-rail",
+        )
+
+
+@pytest.mark.asyncio
+async def test_rail_renders_agent_tools_section_and_row():
+    app = AgentRailApp()
+    async with app.run_test() as pilot:
+        headings = [
+            str(widget.renderable)
+            for widget in app.query(".mcp-rail-heading")
+        ]
+        assert headings == ["Source", "Servers", "Agent tools"]
+        rows = list(app.query("Button.mcp-rail-row"))
+        labels = [str(row.label) for row in rows]
+        assert any("Agent tools" in label for label in labels)
+        agent_button = next(
+            row for row in rows if "Agent tools" in str(row.label)
+        )
+        await pilot.click(f"#{agent_button.id}")
+        await pilot.pause()
+        assert app.events, "agent row click must post ServerSelected"
+        assert app.events[-1].server_key == "agent:builtin"
+
+
+@pytest.mark.asyncio
+async def test_rail_omits_agent_section_without_snapshot():
+    app = RailApp()  # no agent_snapshot kwarg
+    async with app.run_test() as pilot:
+        headings = [
+            str(widget.renderable)
+            for widget in app.query(".mcp-rail-heading")
+        ]
+        assert "Agent tools" not in headings

--- a/Tests/UI/test_mcp_rail.py
+++ b/Tests/UI/test_mcp_rail.py
@@ -858,6 +858,28 @@ def _agent_snap():
 
 
 class AgentRailApp(RailApp):
+    """RailApp + the real contract's selection feedback: the host (the
+    workbench, in the app) owns selection state and re-syncs the rail
+    after every ServerSelected -- arrow navigation advances from the
+    CURRENT selection, so the harness must close that loop too."""
+
+    def on_mcp_rail_server_selected(self, event: MCPRail.ServerSelected) -> None:
+        super().on_mcp_rail_server_selected(event)
+        rail = self.query_one(MCPRail)
+        # Mirror the workbench contract: re-sync the rail with the new
+        # selection (not a bare attribute poke) so the rail's own
+        # focus-restoration path runs exactly as it does in the app.
+        rail.sync_state(
+            source=rail.source,
+            snapshots=rail.snapshots,
+            selected_server_key=event.server_key,
+            scope_options=rail.scope_options,
+            scope_value=rail.scope_value,
+            scope_ref_options=rail.scope_ref_options,
+            scope_ref_value=rail.scope_ref_value,
+            agent_snapshot=rail.agent_snapshot,
+        )
+
     def compose(self) -> ComposeResult:
         yield MCPRail(
             source="local",
@@ -902,3 +924,57 @@ async def test_rail_omits_agent_section_without_snapshot():
             for widget in app.query(".mcp-rail-heading")
         ]
         assert "Agent tools" not in headings
+
+
+# -- F2 (2026-09-11 MCP Hub UX review): rail keyboard navigation ----------
+
+
+@pytest.mark.asyncio
+async def test_rail_arrow_keys_move_selection_through_rows():
+    """F2: up/down move the selection through the rail's rows (All servers,
+    server rows, Agent tools) via the same ServerSelected path a click
+    uses, clamping at the ends (never wrapping). Focus follows the newly
+    selected row so consecutive presses keep working."""
+    app = AgentRailApp()  # rows: All servers(0), docs(1), agent(2)
+    async with app.run_test() as pilot:
+        # Start focused on a rail row (a click's after-state).
+        await pilot.click("#mcp-rail-row-1")
+        await pilot.pause()
+        assert app.events[-1].server_key == "local:docs"
+
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.events[-1].server_key == "agent:builtin"
+
+        # Clamp at the bottom (no wrap to "All servers").
+        await pilot.press("down")
+        await pilot.pause()
+        assert app.events[-1].server_key == "agent:builtin"
+
+        # Paced like real typing: each selection triggers the host's
+        # sync/recompose, and the NEXT key must land after the rail's
+        # focus restoration -- exactly the cadence a keyboard user has.
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.events[-1].server_key == "local:docs"
+        await pilot.press("up")
+        await pilot.pause()
+        # up from docs -> "All servers" (None), then clamp.
+        assert app.events[-1].server_key is None
+        await pilot.press("up")
+        await pilot.pause()
+        assert app.events[-1].server_key is None
+
+
+@pytest.mark.asyncio
+async def test_rail_j_and_k_alias_arrow_navigation():
+    app = AgentRailApp()
+    async with app.run_test() as pilot:
+        await pilot.click("#mcp-rail-row-0")  # All servers
+        await pilot.pause()
+        await pilot.press("j")
+        await pilot.pause()
+        assert app.events[-1].server_key == "local:docs"
+        await pilot.press("k")
+        await pilot.pause()
+        assert app.events[-1].server_key is None

--- a/Tests/UI/test_mcp_rail.py
+++ b/Tests/UI/test_mcp_rail.py
@@ -811,3 +811,38 @@ async def test_scope_a_b_a_dispatches_three_changes_and_mount_echo_zero():
         await pilot.pause()
         changes = [e.scope for e in app.events if isinstance(e, MCPRail.ScopeChanged)]
         assert changes == ["team", "personal", "team"]
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+def test_present_states_legend_abbreviates_when_short():
+    """A6/F15: below the width budget the in-rail legend swaps in the short
+    state words ("setup", "off") so the line stops wrapping to 2-3 rows at
+    narrow rail widths. The long forms stay untouched at wide budgets."""
+    from tldw_chatbook.UI.MCP_Modules.mcp_rail import _present_states_legend
+
+    snapshots = [
+        _snap("local:docs", "docs", ReadinessState.NEEDS_SETUP),
+        _snap("builtin:tldw_chatbook", "tldw_chatbook (built-in)", ReadinessState.OFF_OPT_IN),
+    ]
+    short = _present_states_legend(snapshots, short=True)
+    assert "setup" in short
+    assert "Needs setup" not in short
+    assert "off" in short
+    assert "opt-in" not in short
+    assert "⌂ built-in" in short
+
+    long = _present_states_legend(snapshots)
+    assert "needs setup" in long
+    assert "off (opt-in)" in long
+
+
+def test_short_state_legend_words_cover_every_state():
+    """Completeness pin: every STATE_LABELS word has a short form, so a new
+    ReadinessState can't silently fall out of the abbreviated legend."""
+    from tldw_chatbook.MCP.readiness import STATE_LABELS
+    from tldw_chatbook.UI.MCP_Modules.mcp_rail import _SHORT_STATE_LABELS
+
+    for label in STATE_LABELS.values():
+        assert label.lower() in _SHORT_STATE_LABELS

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -1808,3 +1808,65 @@ async def test_restart_class_gates_carry_a_restart_marker(monkeypatch):
         assert "⟳" not in str(first_cb.label)
         master = app.query_one("#mcp-gate-local_tools_enabled", Checkbox)
         assert "⟳" not in str(master.label)
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+@pytest.mark.asyncio
+async def test_local_detail_toolbar_offers_lifecycle_actions():
+    """C4/F7b: the canvas detail toolbar carries the lifecycle verbs for
+    local profiles -- Connect when not connected, Refresh tools when
+    connected -- posting the same HubActionRequested the inspector's
+    buttons use. Check/diagnostics stay inspector-only (toolbar economy)."""
+
+    class HubActionCaptureApp(CanvasApp):
+        def __init__(self) -> None:
+            super().__init__()
+            self.events: list[object] = []
+
+        def on_mcp_inspector_hub_action_requested(self, event) -> None:
+            self.events.append(event)
+
+    from tldw_chatbook.MCP.readiness import ReadinessState, ReadinessSnapshot
+
+    def _local_snap(connected: bool) -> ReadinessSnapshot:
+        return ReadinessSnapshot(
+            server_key="local:docs",
+            label="docs",
+            source="local",
+            state=ReadinessState.READY if connected else ReadinessState.NEEDS_SETUP,
+            reasons=(),
+            message="",
+            tool_count=2,
+            is_connected=connected,
+        )
+
+    app = HubActionCaptureApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+
+        await canvas.show_detail(_local_snap(connected=False))
+        await pilot.pause()
+        labels = [
+            str(button.label)
+            for button in app.query("#mcp-detail-toolbar Button")
+        ]
+        assert "Connect" in labels
+        assert "Edit" in labels and "Delete" in labels
+        assert "Disconnect" not in labels and "Refresh tools" not in labels
+
+        app.query_one("#mcp-detail-connect", Button).press()
+        await pilot.pause()
+        assert app.events, "Connect press must post a HubActionRequested"
+        assert app.events[-1].action is HubAction.CONNECT
+        assert app.events[-1].server_key == "local:docs"
+
+        await canvas.show_detail(_local_snap(connected=True))
+        await pilot.pause()
+        labels = [
+            str(button.label)
+            for button in app.query("#mcp-detail-toolbar Button")
+        ]
+        assert "Disconnect" in labels and "Refresh tools" in labels
+        assert "Connect" not in labels

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -730,16 +730,11 @@ async def test_builtin_toggles_container_does_not_expand_past_content():
         # nowhere near the height of an expanding 1fr container consuming
         # whatever vertical space the scroll pane has left.
         assert toggles.size.height < 12
-        # Nine gate checkboxes + a title + two subheadings + a note -- still
-        # a content-sized handful of rows, not an expanding 1fr container.
-        assert tool_gates.size.height < 20
-
-        # The tool-gates container sits directly under the [mcp] toggles.
-        gap_between = tool_gates.region.y - (toggles.region.y + toggles.region.height)
-        assert 0 <= gap_between <= 2
-        # The copy button sits directly under the tool-gates container, not
-        # dozens of rows further down the scroll pane.
-        gap = copy_button.region.y - (tool_gates.region.y + tool_gates.region.height)
+        # ADR-148 Wave D: the gate group no longer renders in the built-in
+        # detail at all (it moved to the Agent tools detail), so the copy
+        # button must sit directly under the [mcp] toggles themselves.
+        assert not tool_gates.display
+        gap = copy_button.region.y - (toggles.region.y + toggles.region.height)
         assert 0 <= gap <= 2
 
 
@@ -782,7 +777,7 @@ async def test_showing_builtin_detail_does_not_post_builtin_flag_changed():
 
 
 @pytest.mark.asyncio
-async def test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings_and_note(
+async def test_tool_gate_checkboxes_render_under_agent_detail_with_subheadings_and_note(
     monkeypatch,
 ):
     """The builtin detail pane also renders a "Tool gates" group -- one
@@ -794,6 +789,7 @@ async def test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings
     import tldw_chatbook.config as config_module
     from tldw_chatbook.Agents.local_tool_provider import WEB_DEEP_SEARCH_GATE_KEY
     from tldw_chatbook.Agents.tool_catalog import _GATEABLE_BUILTINS
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
 
     first_builtin_key = _GATEABLE_BUILTINS[0].gate_key
 
@@ -809,7 +805,8 @@ async def test_tool_gate_checkboxes_render_under_builtin_detail_with_subheadings
     app = CanvasApp()
     async with app.run_test() as pilot:
         canvas = app.query_one(MCPServersMode)
-        await canvas.show_detail(builtin_readiness(enabled=True))
+        # ADR-148 Wave D: the gates live in the AGENT detail now
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
         await pilot.pause()
 
         heading_builtin = app.query_one("#mcp-gate-heading-builtin", Static)
@@ -863,10 +860,13 @@ async def test_local_group_dependents_are_disabled_while_master_is_off(monkeypat
 
     monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
 
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
     app = CanvasApp()
     async with app.run_test() as pilot:
         canvas = app.query_one(MCPServersMode)
-        await canvas.show_detail(builtin_readiness(enabled=True))
+        # ADR-148 Wave D: gates render from the AGENT detail now
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
         await pilot.pause()
 
         note = app.query_one("#mcp-gate-local-master-off-note", Static)
@@ -910,10 +910,13 @@ async def test_local_group_dependents_are_enabled_while_master_is_on(monkeypatch
 
     monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
 
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
     app = CanvasApp()
     async with app.run_test() as pilot:
         canvas = app.query_one(MCPServersMode)
-        await canvas.show_detail(builtin_readiness(enabled=True))
+        # ADR-148 Wave D: gates render from the AGENT detail now
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
         await pilot.pause()
 
         assert not list(app.query("#mcp-gate-local-master-off-note"))
@@ -926,7 +929,9 @@ async def test_local_group_dependents_are_enabled_while_master_is_on(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_tool_gate_checkboxes_do_not_appear_for_non_builtin_detail():
+async def test_tool_gate_checkboxes_do_not_appear_outside_agent_detail():
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
     app = CanvasApp()
     async with app.run_test() as pilot:
         canvas = app.query_one(MCPServersMode)
@@ -935,6 +940,17 @@ async def test_tool_gate_checkboxes_do_not_appear_for_non_builtin_detail():
         assert not list(app.query("#mcp-gate-toggles-note"))
         assert not list(app.query("#mcp-gate-heading-builtin"))
         assert not list(app.query("#mcp-gate-heading-local"))
+        # ADR-148 Wave D: the BUILT-IN server detail no longer hosts the
+        # gates either -- they moved to the Agent tools row.
+        await canvas.show_detail(builtin_readiness(enabled=True))
+        await pilot.pause()
+        assert not list(app.query("#mcp-gate-toggles-note"))
+        assert not list(app.query("#mcp-gate-heading-builtin"))
+
+        # ...and showing agent detail (like any detail) posts no echo.
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
+        await pilot.pause()
+        assert not app.events
 
 
 @pytest.mark.asyncio
@@ -978,6 +994,7 @@ async def test_toggling_tool_gate_checkbox_posts_tool_gate_changed_with_section_
     import tldw_chatbook.config as config_module
     from tldw_chatbook.Agents.builtin_tool_gate import LOCAL_TOOLS_MASTER_KEY
     from tldw_chatbook.Agents.local_tool_provider import WEB_DEEP_SEARCH_GATE_KEY
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
 
     def fake_get_cli_setting(section, key=None, default=None):
         if key == LOCAL_TOOLS_MASTER_KEY:
@@ -989,7 +1006,8 @@ async def test_toggling_tool_gate_checkbox_posts_tool_gate_changed_with_section_
     app = CanvasApp()
     async with app.run_test(size=(100, 30)) as pilot:
         canvas = app.query_one(MCPServersMode)
-        await canvas.show_detail(builtin_readiness(enabled=True))
+        # ADR-148 Wave D: gates toggle from the AGENT detail now
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
         await pilot.pause()
 
         checkbox = app.query_one(f"#mcp-gate-{WEB_DEEP_SEARCH_GATE_KEY}", Checkbox)
@@ -1796,10 +1814,13 @@ async def test_restart_class_gates_carry_a_restart_marker(monkeypatch):
 
     monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
 
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
     app = CanvasApp()
     async with app.run_test() as pilot:
         canvas = app.query_one(MCPServersMode)
-        await canvas.show_detail(builtin_readiness(enabled=True))
+        # ADR-148 Wave D: gates render from the AGENT detail now
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
         await pilot.pause()
 
         deep = app.query_one(f"#mcp-gate-{WEB_DEEP_SEARCH_GATE_KEY}", Checkbox)
@@ -1890,3 +1911,36 @@ def test_agent_tools_readiness_builder_shapes_the_rail_row():
     off = agent_tools_readiness(enabled=False)
     assert off.state is ReadinessState.OFF_OPT_IN
     assert "Turned off" in off.message
+
+
+@pytest.mark.asyncio
+async def test_builtin_detail_points_at_the_agent_tools_row():
+    """ADR-148 Wave D: the built-in server's detail keeps only the [mcp]
+    controls and points at the new home for agent tool gates."""
+    app = CanvasApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+        await canvas.show_detail(builtin_readiness(enabled=True))
+        await pilot.pause()
+        body = str(app.query_one("#mcp-detail-body", Static).renderable)
+        assert "Agent tool gates live under Agent tools in the rail." in body
+
+
+@pytest.mark.asyncio
+async def test_agent_detail_body_explains_console_scope():
+    """ADR-148 Wave D: the Agent tools detail explains registration vs
+    permission, carries no [mcp] server toggles, and no Edit/Delete
+    toolbar (it is not a server)."""
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
+    app = CanvasApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+        await canvas.show_detail(agent_tools_readiness(enabled=True))
+        await pilot.pause()
+        title = str(app.query_one("#mcp-detail-title", Static).renderable)
+        assert "Agent tools" in title
+        body = str(app.query_one("#mcp-detail-body", Static).renderable)
+        assert "Console" in body
+        assert not list(app.query("#mcp-detail-builtin-toggles Checkbox"))
+        assert not list(app.query("#mcp-detail-toolbar Button"))

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -1770,3 +1770,41 @@ def test_named_items_text_truncates_at_named_items_cap():
     text = _named_items_text(items, key="name")
     assert text.startswith("10: tool0, tool1, tool2, tool3, tool4, tool5, tool6, tool7")
     assert text.endswith("… +2 more")
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+@pytest.mark.asyncio
+async def test_restart_class_gates_carry_a_restart_marker(monkeypatch):
+    """A4/F12: gates that only take effect after an app restart
+    (web_deep_search) carry a visible "(⟳ restart)" suffix on their
+    checkbox label -- the shared note under the group explains the rule
+    once, but the checkbox itself must signal which class it belongs to.
+    Immediate-effect gates (the built-ins, the master switch) carry no
+    marker."""
+    import tldw_chatbook.config as config_module
+    from tldw_chatbook.Agents.local_tool_provider import WEB_DEEP_SEARCH_GATE_KEY
+    from tldw_chatbook.Agents.tool_catalog import _GATEABLE_BUILTINS
+
+    first_builtin_key = _GATEABLE_BUILTINS[0].gate_key
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        if key == "local_tools_enabled":
+            return True
+        return default
+
+    monkeypatch.setattr(config_module, "get_cli_setting", fake_get_cli_setting)
+
+    app = CanvasApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPServersMode)
+        await canvas.show_detail(builtin_readiness(enabled=True))
+        await pilot.pause()
+
+        deep = app.query_one(f"#mcp-gate-{WEB_DEEP_SEARCH_GATE_KEY}", Checkbox)
+        assert "⟳ restart" in str(deep.label)
+        first_cb = app.query_one(f"#mcp-gate-{first_builtin_key}", Checkbox)
+        assert "⟳" not in str(first_cb.label)
+        master = app.query_one("#mcp-gate-local_tools_enabled", Checkbox)
+        assert "⟳" not in str(master.label)

--- a/Tests/UI/test_mcp_servers_mode.py
+++ b/Tests/UI/test_mcp_servers_mode.py
@@ -1870,3 +1870,23 @@ async def test_local_detail_toolbar_offers_lifecycle_actions():
         ]
         assert "Disconnect" in labels and "Refresh tools" in labels
         assert "Connect" not in labels
+
+
+# -- Wave D (2026-09-11 MCP Hub UX program, ADR-148): rail IA split --------
+
+
+def test_agent_tools_readiness_builder_shapes_the_rail_row():
+    from tldw_chatbook.MCP.permission_store import BUILTIN_TOOL_SERVER_KEY
+    from tldw_chatbook.MCP.readiness import agent_tools_readiness
+
+    on = agent_tools_readiness(enabled=True)
+    assert on.server_key == "agent:builtin"
+    assert on.server_key == BUILTIN_TOOL_SERVER_KEY  # same store identity, no new key
+    assert on.source == "agent"
+    assert on.label == "Agent tools"
+    assert on.state is ReadinessState.READY
+    assert "Console" in on.message
+
+    off = agent_tools_readiness(enabled=False)
+    assert off.state is ReadinessState.OFF_OPT_IN
+    assert "Turned off" in off.message

--- a/Tests/UI/test_mcp_tools_mode.py
+++ b/Tests/UI/test_mcp_tools_mode.py
@@ -931,7 +931,7 @@ async def test_server_column_truncates_long_labels_with_ellipsis():
         long_label_tool = _tool(
             server_key="local:__local__",
             name="fs_edit",
-            server_label="Local workspace, web, and Watchlists",
+            server_label="Local workspace, web, and Watchlists (Console agents)",
         )
         short_label_tool = _tool(
             server_key="local:docs", name="fs_read", server_label="docs"

--- a/Tests/UI/test_mcp_tools_mode.py
+++ b/Tests/UI/test_mcp_tools_mode.py
@@ -915,3 +915,37 @@ async def test_state_column_cells_carry_semantic_color_by_effective_state():
             table.get_cell_at((rows_by_tool["unresolved"], 1)).style
             == state_text("—", "muted").style
         )
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+@pytest.mark.asyncio
+async def test_server_column_truncates_long_labels_with_ellipsis():
+    """A2/F9: the Server column ellipsizes long group labels instead of
+    clipping mid-word with no marker ("Local workspace, web, and" at 160
+    cols read as a different label). Short labels pass through whole."""
+    app = ToolsModeApp()
+    async with app.run_test() as pilot:
+        canvas = app.query_one(MCPToolsMode)
+        long_label_tool = _tool(
+            server_key="local:__local__",
+            name="fs_edit",
+            server_label="Local workspace, web, and Watchlists",
+        )
+        short_label_tool = _tool(
+            server_key="local:docs", name="fs_read", server_label="docs"
+        )
+        await canvas.update_tools([long_label_tool, short_label_tool])
+        await pilot.pause()
+        table = app.query_one("#mcp-tools-table", DataTable)
+
+        long_cell = table.get_cell_at((0, 2))
+        long_text = getattr(long_cell, "plain", str(long_cell))
+        assert long_text.endswith("…")
+        assert "Watchlists" not in long_text
+        assert len(long_text) <= 25
+
+        short_cell = table.get_cell_at((1, 2))
+        short_text = getattr(short_cell, "plain", str(short_cell))
+        assert short_text == "docs"

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -11229,3 +11229,25 @@ async def test_compact_band_renders_select_prompts_without_mid_word_breaks():
             assert "Overview" in rendered
     finally:
         inspector_module.get_cli_setting = original
+
+
+@pytest.mark.asyncio
+async def test_every_mode_renders_usably_at_100x30():
+    """ADR-148 Wave E sweep: each mode's canvas renders at 100x30 with the
+    stacked band present and bounded."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        for mode, canvas_id in (
+            ("servers", "mcp-mode-canvas-servers"),
+            ("tools", "mcp-mode-canvas-tools"),
+            ("permissions", "mcp-mode-canvas-permissions"),
+            ("audit", "mcp-mode-canvas-audit"),
+        ):
+            workbench.set_mode(mode)
+            await pilot.pause()
+            canvas = app.query_one(f"#{canvas_id}")
+            assert canvas.display
+            assert canvas.region.height > 3
+        assert app.query_one("#mcp-hub-inspector").region.height <= 12

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -11191,3 +11191,41 @@ async def test_compact_layout_stacks_inspector_below_as_bounded_band():
         assert inspector.region.width >= main_row.region.width - 1
         # The rail+canvas row keeps (nearly) the full width.
         assert main_row.region.width >= 90
+
+
+@pytest.mark.asyncio
+async def test_compact_band_renders_select_prompts_without_mid_word_breaks():
+    """The screenshot evidence for ADR-148 showed the Section select
+    clipped to 'Overvi|ew' at 100 cols. At the same size with the stacked
+    band, the full prompt renders on one line."""
+    import tldw_chatbook.UI.MCP_Modules.mcp_inspector as inspector_module
+    from textual.widgets import Collapsible
+
+    original = inspector_module.get_cli_setting
+
+    def fake_get_cli_setting(section, key=None, default=None):
+        if key == "advanced_visible":
+            return True
+        return original(section, key, default)
+
+    inspector_module.get_cli_setting = fake_get_cli_setting
+    try:
+        app = WorkbenchApp()
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            # Wave E auto-collapse fired on the compact resize -- the user
+            # can still expand it, and WHEN THEY DO the old mid-word clip
+            # ("Overvi|ew") must be gone: the band is full-width now.
+            collapsible = app.query_one("#mcp-adv-collapsible", Collapsible)
+            assert collapsible.collapsed  # auto-collapsed at 100 cols
+            collapsible.collapsed = False
+            await pilot.pause()
+            section_select = app.query_one("#mcp-adv-section-select", Select)
+            assert section_select.region.width >= 9
+            rendered = "\n".join(
+                "".join(segment.text for segment in strip)
+                for strip in app.screen._compositor.render_strips()
+            )
+            assert "Overview" in rendered
+    finally:
+        inspector_module.get_cli_setting = original

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -11260,12 +11260,12 @@ async def test_every_mode_renders_usably_at_100x30():
         assert app.query_one("#mcp-hub-inspector").region.height <= 12
 
 
-# -- Wave F (2026-09-11 MCP Hub UX program, ADR-149): bulk actions --------
+# -- Wave F (2026-09-11 MCP Hub UX program, ADR-150): bulk actions --------
 
 
 @pytest.mark.asyncio
 async def test_shift_space_bulk_sets_visible_tools_of_one_server(tmp_path):
-    """ADR-149: shift+space applies the cursor row's next state to the
+    """ADR-150: shift+space applies the cursor row's next state to the
     server's VISIBLE tool rows only (Wave B order: first press from
     Inherit = Ask), with one echo and the store holding ordinary
     per-tool entries -- exactly what N single presses would write."""
@@ -11293,7 +11293,7 @@ async def test_shift_space_bulk_sets_visible_tools_of_one_server(tmp_path):
 
 @pytest.mark.asyncio
 async def test_bulk_clear_reverts_only_overridden_rows(tmp_path):
-    """ADR-149: C writes None only for rows that HELD an override; a
+    """ADR-150: C writes None only for rows that HELD an override; a
     never-overridden sibling gains no entry at all."""
     store_path = tmp_path / "mcp_permissions.json"
     MCPPermissionStore(store_path).set_tool_state("local:docs", "search", "ask")

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -10957,3 +10957,112 @@ async def test_test_tool_key_falls_back_to_tools_cursor_row():
             for message, _ in notifications
         )
         assert any("display-only" in message for message, _ in notifications)
+
+
+# -- Wave C (2026-09-11 MCP Hub UX program): flow fixes ---------------------
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_preselection_keeps_overview_on_screen(monkeypatch):
+    """C1/F1: the first-load preselection (F-054/task-2240) keeps the
+    OVERVIEW table on screen -- the rail highlights the row and the
+    inspector explains it, but the Add server/Import toolbar and recovery
+    callouts stay visible instead of being hidden behind a detail view the
+    user never navigated to. An explicit selection still opens the detail
+    exactly as before, and a background resync alone must not flip views."""
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: default,
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test() as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        assert workbench._selected_server_key == "builtin:tldw_chatbook"
+
+        assert app.query_one("#mcp-servers-overview").display is True
+        assert app.query_one("#mcp-servers-detail").display is False
+        state = app.query_one("#mcp-inspector-state", Static)
+        assert "tldw_chatbook (built-in)" in str(state.renderable)
+
+        # A background resync (lifecycle completion, `r`) must not flip it.
+        await workbench._sync_children()
+        await pilot.pause()
+        assert app.query_one("#mcp-servers-overview").display is True
+
+        # An explicit selection opens the detail as before.
+        await workbench._select_server_key("builtin:tldw_chatbook")
+        await pilot.pause()
+        assert app.query_one("#mcp-servers-detail").display is True
+
+
+@pytest.mark.asyncio
+async def test_save_and_connect_runs_lifecycle_after_save():
+    """C3/F7a: the add-server form's "Save and connect" persists the
+    profile and immediately dispatches the connect lifecycle -- the
+    saved->connected journey used to require finding the new row and its
+    Connect action in the inspector."""
+    connect_calls: list[str] = []
+
+    class SaveConnectService(FakeHubService):
+        async def save_local_profile(self, payload):
+            return dict(payload)
+
+        async def connect_local_profile(self, profile_id):
+            connect_calls.append(profile_id)
+            return {"ok": True, "tools": []}
+
+    class SaveConnectApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            super().__init__()
+            self.unified_mcp_service = SaveConnectService()
+
+        def compose(self) -> ComposeResult:
+            yield MCPWorkbench(app_instance=self, id="mcp-workbench")
+
+    app = SaveConnectApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        await workbench.open_add_server_form()
+        await pilot.pause()
+        app.query_one("#mcp-form-id", Input).value = "docs"
+        app.query_one("#mcp-form-command", Input).value = "npx"
+        await pilot.click("#mcp-form-save-connect")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert connect_calls == ["docs"]
+        assert not list(app.query("#mcp-servers-form > *"))
+
+
+@pytest.mark.asyncio
+async def test_non_default_tool_policy_profile_shows_console_context_hint(tmp_path):
+    """C5/F8: with a non-default tool-policy profile selected, a one-line
+    hint under the profile selector says Console applies the profile on top
+    -- the matrix alone reads as if these rows were the whole story."""
+    store_path = tmp_path / "mcp_permissions.json"
+    store = MCPPermissionStore(store_path)
+    payload = store.load()
+    payload["profiles"]["research"] = _imported_tool_policy_profile()
+    store.save(payload)
+    app = PermissionsApp(store_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        hint = app.query_one("#mcp-perm-profile-hint", Static)
+        assert not hint.display  # default profile: no hint
+
+        workbench = app.query_one(MCPWorkbench)
+        await workbench.select_tool_policy_profile("research")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert hint.display
+        text = str(hint.renderable)
+        assert "Console" in text
+        assert "Ask" in text

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -6890,7 +6890,9 @@ async def test_builtin_section_is_distinct_from_the_builtin_mcp_server(tmp_path)
         server_row_labels = {
             row[0] for row in rows if row[0].startswith("Server default")
         }
-        mcp_builtin_label = "Server default — tldw_chatbook"
+        # ADR-148 Wave D (TASK-32459): the external-MCP inventory group now
+        # names its surface explicitly.
+        mcp_builtin_label = "Server default — tldw_chatbook (external MCP)"
         agent_builtin_label = "Server default — Built-in (agent runtime)"
         assert mcp_builtin_label in server_row_labels
         assert agent_builtin_label in server_row_labels
@@ -10354,7 +10356,9 @@ async def test_tools_catalog_includes_local_agent_tools_as_own_group(monkeypatch
         # The full ordinary catalog remains the inspection source. Only
         # descriptor-approved shared identities gain the executable flag.
         assert all(
-            t.server_label == "Local workspace, web, and Watchlists" for t in local
+            t.server_label
+                == "Local workspace, web, and Watchlists (Console agents)"
+                for t in local
         )
         assert all(t.source == "local" for t in local)
         assert all(
@@ -10376,7 +10380,10 @@ async def test_tools_catalog_includes_local_agent_tools_as_own_group(monkeypatch
             for row in permission_rows
             if row.kind == "server" and row.server_key == "local:__local__"
         )
-        assert local_server_row.server_label == "Local workspace, web, and Watchlists"
+        assert (
+            local_server_row.server_label
+            == "Local workspace, web, and Watchlists (Console agents)"
+        )
         labels_by_tool = {
             row.tool_name: row.server_label
             for row in permission_rows
@@ -10386,7 +10393,7 @@ async def test_tools_catalog_includes_local_agent_tools_as_own_group(monkeypatch
             labels_by_tool["fs_list"],
             labels_by_tool["web_fetch"],
             labels_by_tool["watchlists_search_items"],
-        } == {"Local workspace, web, and Watchlists"}
+        } == {"Local workspace, web, and Watchlists (Console agents)"}
         # The pre-existing sources are untouched: the fake's "docs" profile
         # tool still lists under its own key.
         assert any(t.server_key == "local:docs" for t in workbench._last_hub_tools)
@@ -11315,3 +11322,59 @@ async def test_bulk_clear_reverts_only_overridden_rows(tmp_path):
             assert "fetch" not in docs_tools
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
         assert preview.startswith("docs: 1 visible overrides cleared · ")
+
+
+# -- TASK-32459 (ADR-148 Wave D spec deferral): duplicate-row surface labels
+
+
+@pytest.mark.asyncio
+async def test_same_tool_under_both_surfaces_renders_both_labels():
+    """ADR-148's pinned disambiguation test: the same tool name legitimately
+    exists under TWO permission domains -- the external-MCP inventory group
+    (builtin:tldw_chatbook) and the Console agent group (local:__local__).
+    The matrix must render both sections with labels naming the surfaces,
+    so a user allowing fs_read on one path can see the other exists."""
+    from tldw_chatbook.UI.MCP_Modules.mcp_workbench import MCPWorkbench as WB
+
+    class BothSurfacesService(HubLocalProjectionService):
+        class LocalService(HubLocalProjectionService.LocalService):
+            def get_inventory(self):
+                # fs_read exists in BOTH the inventory (external MCP server
+                # catalog) and local_hub_tools (Console agents).
+                return {
+                    "tools": [
+                        {
+                            "name": "fs_read",
+                            "description": "Overlapping name, external copy.",
+                        }
+                    ]
+                }
+
+    class BothSurfacesApp(ConsolidatedCSSApp):
+        def __init__(self) -> None:
+            super().__init__()
+            self.unified_mcp_service = BothSurfacesService()
+
+        def compose(self) -> ComposeResult:
+            yield MCPWorkbench(app_instance=self, id="mcp-workbench")
+
+    app = BothSurfacesApp()
+    async with app.run_test(size=(140, 40)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+
+        rows = _perm_all_rows(app)
+        section_labels = [
+            cells[0].strip() for cells in rows if cells[0].startswith("Server default")
+        ]
+        external = "Server default — tldw_chatbook (external MCP)"
+        console = "Server default — Local workspace, web, and Watchlists (Console agents)"
+        assert external in section_labels
+        assert console in section_labels
+        # And fs_read itself renders under BOTH sections.
+        tool_rows = [cells[0].strip() for cells in rows]
+        assert tool_rows.count("fs_read") == 2

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -246,8 +246,8 @@ async def test_workbench_mounts_rail_canvas_inspector_and_loads_local_servers():
         await pilot.pause()
         workbench = app.query_one(MCPWorkbench)
         assert workbench.active_mode == "servers"
-        # builtin + docs rows (+ "All servers")
-        assert len(list(app.query("Button.mcp-rail-row"))) == 3
+        # builtin + docs rows (+ "All servers" + the Agent tools row)
+        assert len(list(app.query("Button.mcp-rail-row"))) == 4
         canvas = app.query_one(MCPServersMode)
         assert canvas.query_one("#mcp-servers-overview").display
 
@@ -310,7 +310,11 @@ async def test_workbench_at_100x30_keeps_server_master_switch_reachable(monkeypa
     async with app.run_test(size=(100, 30)) as pilot:
         await pilot.pause()
         await app.workers.wait_for_complete()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")
+        # ADR-148 Wave D: gates live in the AGENT row's detail. Selected via
+        # the shared path -- at 100x30 the fourth rail row can sit below the
+        # fold, and this test is about layout reachability, not click routing.
+        workbench = app.query_one(MCPWorkbench)
+        await workbench._select_server_key("agent:builtin")
         await pilot.pause()
 
         checkbox = app.query_one("#mcp-gate-local_tools_enabled", Checkbox)
@@ -940,7 +944,9 @@ async def test_builtin_flag_toggle_saves_setting_and_reloads_catalog(monkeypatch
     app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")  # builtin row
+        # ADR-148 Wave D: this test exercises the BUILT-IN server's [mcp]
+        # toggles, which stay in the built-in row's detail (row 1).
+        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")
         await pilot.pause()
         checkbox = app.query_one("#mcp-builtin-enabled", Checkbox)
         assert checkbox.value is True
@@ -995,7 +1001,9 @@ async def test_builtin_expose_flag_toggle_saves_matching_key(monkeypatch):
     app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")  # builtin row
+        # ADR-148 Wave D: this test exercises the BUILT-IN server's [mcp]
+        # toggles, which stay in the built-in row's detail (row 1).
+        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")
         await pilot.pause()
         await pilot.click("#mcp-builtin-expose-resources")
         await pilot.pause()
@@ -1063,7 +1071,9 @@ async def test_tool_gate_checkbox_toggle_saves_setting_and_reloads_catalog(monke
     app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")  # builtin row
+        # ADR-148 Wave D: gates live in the AGENT row's detail (row 3:
+        # All=0, builtin=1, docs=2, agent=3 under WorkbenchApp's records)
+        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}3")
         await pilot.pause()
 
         # The [console]-section master switch must save under ITS OWN
@@ -1171,7 +1181,9 @@ async def test_focus_is_preserved_across_a_gate_toggle_save_and_resync(monkeypat
     app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")  # builtin row
+        # ADR-148 Wave D: gates live in the AGENT row's detail (row 3:
+        # All=0, builtin=1, docs=2, agent=3 under WorkbenchApp's records)
+        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}3")
         await pilot.pause()
 
         first_gate_id = f"mcp-gate-{_GATEABLE_BUILTINS[0].gate_key}"
@@ -1215,7 +1227,9 @@ async def test_double_space_on_a_gate_checkbox_never_writes_an_mcp_key(monkeypat
     app = WorkbenchApp()
     async with app.run_test(size=(120, 40)) as pilot:
         await pilot.pause()
-        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}1")  # builtin row
+        # ADR-148 Wave D: gates live in the AGENT row's detail (row 3:
+        # All=0, builtin=1, docs=2, agent=3 under WorkbenchApp's records)
+        await pilot.click(f"#{MCP_RAIL_ROW_PREFIX}3")
         await pilot.pause()
 
         gate_key = _GATEABLE_BUILTINS[0].gate_key
@@ -11066,3 +11080,70 @@ async def test_non_default_tool_policy_profile_shows_console_context_hint(tmp_pa
         text = str(hint.renderable)
         assert "Console" in text
         assert "Ask" in text
+
+
+# -- Wave D (2026-09-11 MCP Hub UX program, ADR-148): rail IA split --------
+
+
+@pytest.mark.asyncio
+async def test_agent_tools_rail_row_routes_to_agent_detail(monkeypatch):
+    """ADR-148 Wave D: the Agent tools rail row is selectable, opens the
+    agent detail (Tool gates visible, no [mcp] toggles), stays OUT of the
+    servers overview table, and scopes the Permissions preview to nothing
+    (the unscoped summary -- agent:builtin is never in the hub catalog)."""
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: default,
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+
+        # Not a server row: absent from the overview table...
+        table = app.query_one("#mcp-servers-table", DataTable)
+        table_keys = [
+            table.coordinate_to_cell_key((row, 0))[0].value
+            for row in range(table.row_count)
+        ]
+        assert "agent:builtin" not in table_keys
+        # ...but present in the rail and selectable.
+        await pilot.click("#mcp-rail-row-2")  # 0 All, 1 built-in, 2 agent
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        assert workbench._selected_server_key == "agent:builtin"
+        assert app.query_one("#mcp-servers-detail").display is True
+        assert list(app.query("#mcp-detail-tool-gates Checkbox"))
+        assert not list(app.query("#mcp-detail-builtin-toggles Checkbox"))
+
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("global default:")
+
+
+@pytest.mark.asyncio
+async def test_agent_snapshot_state_follows_local_master_switch(monkeypatch):
+    monkeypatch.setattr(
+        mcp_workbench_module,
+        "get_cli_setting",
+        lambda section, key=None, default=None: (
+            True if key == "local_tools_enabled" else default
+        ),
+    )
+    app = ProblemRecordsApp([])
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+        from tldw_chatbook.MCP.readiness import ReadinessState
+
+        assert app.query_one(MCPWorkbench)._agent_snapshot is not None
+        assert (
+            app.query_one(MCPWorkbench)._agent_snapshot.state
+            is ReadinessState.READY
+        )

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -281,17 +281,26 @@ async def test_workbench_at_100x30_keeps_primary_content_reachable(monkeypatch):
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
-        # Summary wraps to multiple lines instead of clipping at one.
+        # Summary renders whole -- under ADR-148 Wave E's stacked layout
+        # the canvas is WIDER at 100 cols, so the sentence may now fit one
+        # line; the invariant is that it is never clipped mid-sentence
+        # (either it fits, or it wraps to >= 2 lines).
         summary = app.query_one("#mcp-overview-summary", Static)
-        assert summary.region.height >= 2
+        assert summary.region.height >= 1
+        rendered = "\n".join(
+            "".join(segment.text for segment in strip)
+            for strip in app.screen._compositor.render_strips()
+        )
+        summary_text = str(summary.renderable)
+        assert summary_text.splitlines()[0][:60] in rendered
         # Compact columns: everything shown fits the viewport -- no column
-        # silently lost behind horizontal overflow.
+        # silently lost behind horizontal overflow. Under ADR-148 Wave E's
+        # stacked layout the canvas is WIDER at 100 cols, so F-057 may keep
+        # Connection/Auth too -- the invariant is that whatever set renders,
+        # it fits (zero horizontal scroll) and identity+readiness never drop.
         table = app.query_one("#mcp-servers-table", DataTable)
-        assert [str(c.label) for c in table.ordered_columns] == [
-            "Name",
-            "Status",
-            "Tools",
-        ]
+        columns = [str(c.label) for c in table.ordered_columns]
+        assert "Name" in columns and "Status" in columns
         assert table.max_scroll_x == 0
         # Primary actions stay reachable.
         assert app.query_one("#mcp-add-server", Button).region.width > 0
@@ -11147,3 +11156,38 @@ async def test_agent_snapshot_state_follows_local_master_switch(monkeypatch):
             app.query_one(MCPWorkbench)._agent_snapshot.state
             is ReadinessState.READY
         )
+
+
+# -- Wave E (2026-09-11 MCP Hub UX program, ADR-148): narrow-width triad --
+
+
+@pytest.mark.asyncio
+async def test_wide_layout_keeps_inspector_beside_the_main_row():
+    """>=120 cols: the triad is geometrically unchanged -- the inspector
+    sits BESIDE the main row (rail+canvas), full height, not as a band."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(160, 44)) as pilot:
+        await pilot.pause()
+        main_row = app.query_one("#mcp-hub-main-row")
+        inspector = app.query_one("#mcp-hub-inspector")
+        assert inspector.region.x >= main_row.region.x + main_row.region.width - 1
+        assert inspector.region.height > 12  # full pane, not a band
+
+
+@pytest.mark.asyncio
+async def test_compact_layout_stacks_inspector_below_as_bounded_band():
+    """<120 cols (ADR-148): the inspector stacks BELOW the main row as a
+    bounded, scrollable band (<=12 rows) at full width -- replacing the
+    old squeezed third column that broke words mid-token."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(100, 30)) as pilot:
+        await pilot.pause()
+        grid = app.query_one("#mcp-hub-grid")
+        main_row = app.query_one("#mcp-hub-main-row")
+        inspector = app.query_one("#mcp-hub-inspector")
+        assert "mcp-compact" in grid.classes
+        assert inspector.region.y >= main_row.region.y + main_row.region.height - 1
+        assert inspector.region.height <= 12
+        assert inspector.region.width >= main_row.region.width - 1
+        # The rail+canvas row keeps (nearly) the full width.
+        assert main_row.region.width >= 90

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -6980,15 +6980,15 @@ async def test_builtin_enumeration_failure_still_shows_a_cyclable_server_default
 # `_last_hub_tools`, the MCP catalog. Built-in tools never populate that
 # list (Task 3's built-in section is rendered from `builtin_permission_
 # rows()`, a completely separate path -- Constraint 1), so `_tool_for()`
-# always returned `None` for an `agent:builtin` row. Since `cycle_ui_state`
-# is Inherit -> Allow -> Ask -> Off, the FIRST Space press from the default
-# state always lands on "allow" -- which the vanished-tool guard then
-# rejected before any write, with a factually wrong "no longer in the
-# catalog" toast. `ask`/`deny` were consequently unreachable: you can't
-# advance the ring past the step that's permanently blocked. These tests
-# exercise the first press specifically (a pre-seeded "allow" and cycling
-# from there would miss the bug entirely), plus the rest of the ring, an
-# orphaned row, and an MCP-row regression guard.
+# always returned `None` for an `agent:builtin` row. Whichever press
+# first reaches "allow" (Wave B reordered the ring to Inherit -> Ask ->
+# Allow -> Off, so that is now the SECOND press), the vanished-tool guard
+# rejected the transition before any write with a factually wrong "no
+# longer in the catalog" toast. The rungs beyond it were consequently
+# unreachable: you can't advance the ring past the step that's permanently
+# blocked. These tests exercise that transition specifically (a pre-seeded
+# "allow" and cycling from there would miss the bug entirely), plus the
+# rest of the ring, an orphaned row, and an MCP-row regression guard.
 
 
 @pytest.mark.asyncio
@@ -7267,9 +7267,11 @@ async def test_space_cycle_round_trip_mutates_store_and_rerenders_override_marke
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
-        assert tool_entry["state"] == "allow"
+        # Wave B: first press from Inherit stores "ask" -- still an
+        # explicit override, so the marker bullet must render.
+        assert tool_entry["state"] == "ask"
 
-        assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
+        assert _perm_table_texts(app, 3) == ["  search", "Ask •"]
         # Sibling rows are untouched by the single-row mutation.
         assert _perm_table_texts(app, 2) == ["  fetch", "Ask"]
         assert _perm_table_texts(app, 0) == ["Global default", "Ask"]
@@ -7293,11 +7295,12 @@ async def test_space_on_server_default_row_round_trips_through_store(tmp_path):
         await pilot.pause()
 
         payload = app.unified_mcp_service.permission_store.load()
+        # Wave B: first press from Inherit lands on "ask"
         assert (
             payload["profiles"]["default"]["servers"]["local:docs"]["default"]
-            == "allow"
+            == "ask"
         )
-        assert _perm_table_texts(app, 1) == ["Server default — docs", "Allow •"]
+        assert _perm_table_texts(app, 1) == ["Server default — docs", "Ask •"]
 
 
 @pytest.mark.asyncio
@@ -7417,7 +7420,7 @@ async def test_preview_shows_override_count_when_no_server_selected(tmp_path):
         # transient echo prefix now -- the override-count SUFFIX this test
         # exists to pin is still computed correctly underneath it.
         assert str(preview.renderable) == (
-            "search → Allow · global default: ask · 1 override across 1 server"
+            "search → Ask · global default: ask · 1 override across 1 server"
         )
 
 
@@ -7499,8 +7502,8 @@ async def test_double_space_cycle_on_tool_row_stays_on_that_row(tmp_path):
     so a SECOND press used to land on row 0 (Global default) instead of the
     tool row the user was still looking at -- silently cycling the global
     default instead of the tool. Two Space presses on the tool row must
-    advance the TOOL two cycle steps (Inherit -> Allow -> Ask) and must
-    leave the global default untouched.
+    advance the TOOL two cycle steps (Inherit -> Ask -> Allow, Wave B's
+    order) and must leave the global default untouched.
     """
     app = PermissionsApp(tmp_path / "mcp_permissions.json")
     async with app.run_test(size=(120, 40)) as pilot:
@@ -7526,10 +7529,10 @@ async def test_double_space_cycle_on_tool_row_stays_on_that_row(tmp_path):
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
-        # cycle_ui_state(None) == "allow", cycle_ui_state("allow") == "ask"
-        assert tool_entry["state"] == "ask"
+        # Wave B: cycle_ui_state(None) == "ask", cycle_ui_state("ask") == "allow"
+        assert tool_entry["state"] == "allow"
         assert payload["profiles"]["default"]["global_default"] == "ask"
-        assert _perm_table_texts(app, 3) == ["  search", "Ask •"]
+        assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
         assert _perm_table_texts(app, 0) == ["Global default", "Ask"]
 
 
@@ -7719,7 +7722,12 @@ async def test_cycling_the_selected_tool_refreshes_its_open_permission_block(tmp
             == "▸ Global default: Ask"
         )
 
-        await pilot.press("space")  # cycle_ui_state(None) == "allow"
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow)
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
+        await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause()
@@ -7901,6 +7909,8 @@ async def test_reallow_round_trip_clears_config_changed_marker_and_matrix_warnin
         tool_entry = payload["profiles"]["default"]["servers"]["local:docs"]["tools"][
             "search"
         ]
+
+
         assert tool_entry["state"] == "allow"
 
         assert _perm_table_texts(app, 3) == ["  search", "Allow •"]
@@ -8195,7 +8205,8 @@ async def test_space_cycle_prefixes_preview_with_mutation_echo(tmp_path):
         await pilot.pause()
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
+        # Wave B: first press from Inherit echoes Ask
+        assert preview.startswith("search → Ask · ")
 
 
 @pytest.mark.asyncio
@@ -8221,22 +8232,22 @@ async def test_double_space_cycle_echo_replaces_not_appends(tmp_path):
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=3)  # local:docs::search
-        await pilot.press("space")  # cycle_ui_state(None) == "allow"
-        await pilot.pause()
-        await app.workers.wait_for_complete()
-        await pilot.pause(0.3)
-
-        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
-        assert preview.count("→") == 1
-
-        await pilot.press("space")  # cycle_ui_state("allow") == "ask"
+        await pilot.press("space")  # Wave B: cycle_ui_state(None) == "ask"
         await pilot.pause()
         await app.workers.wait_for_complete()
         await pilot.pause(0.3)
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
         assert preview.startswith("search → Ask · ")
+        assert preview.count("→") == 1
+
+        await pilot.press("space")  # Wave B: cycle_ui_state("ask") == "allow"
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
+
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("search → Allow · ")
         assert preview.count("→") == 1
 
 
@@ -8306,7 +8317,8 @@ async def test_full_resync_clears_mutation_echo(tmp_path):
         await app.workers.wait_for_complete()
         await pilot.pause()
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert preview.startswith("search → Allow · ")
+        # Wave B: first press from Inherit echoes Ask
+        assert preview.startswith("search → Ask · ")
 
         # A full `_sync_children()` pass isn't itself a standalone mutation
         # resync -- it must clear the echo without anyone calling a
@@ -8315,7 +8327,7 @@ async def test_full_resync_clears_mutation_echo(tmp_path):
         await pilot.pause()
 
         preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
-        assert not preview.startswith("search → Allow · ")
+        assert not preview.startswith("search → Ask · ")
         assert preview == "global default: ask · 1 override across 1 server"
 
 
@@ -8456,6 +8468,12 @@ async def test_space_cycle_propagates_fresh_states_to_tools_mode_without_full_re
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=3)  # local:docs::search
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow) --
+        # a distinctly different cell from the pre-mutation plain "Ask".
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
         await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
@@ -10830,6 +10848,11 @@ async def test_virtual_cli_permission_cycle_remains_independent_of_raw_shell(
         table = app.query_one("#mcp-perm-table", DataTable)
         table.focus()
         table.move_cursor(row=_perm_row_keys(app).index("local:__virtual_cli__::ls"))
+        # Wave B: two presses to reach "allow" (Inherit -> Ask -> Allow)
+        await pilot.press("space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause(0.3)
         await pilot.press("space")
         await pilot.pause()
         await app.workers.wait_for_complete()
@@ -10840,3 +10863,97 @@ async def test_virtual_cli_permission_cycle_remains_independent_of_raw_shell(
         )
         assert entry is not None and entry["state"] == "allow"
         assert _tools_table_state(app, "ls").startswith("Allow")
+
+
+# -- Wave A (2026-09-11 MCP Hub UX program): bounded polish -----------------
+
+
+@pytest.mark.asyncio
+async def test_entering_permissions_mode_focuses_the_matrix():
+    """A1/F5a: entering Permissions mode puts the keyboard on the matrix.
+    Space-cycling is the mode's primary gesture, but the binding lives on
+    the canvas -- with focus left wherever the previous mode had it (e.g.
+    a mode chip, where Space ACTIVATES the chip), the advertised key did
+    something else entirely. Focus already inside the permissions canvas
+    (e.g. the filter Input mid-typing) is left alone."""
+    app = WorkbenchApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        assert app.screen.focused is table
+
+        filter_input = app.query_one("#mcp-perm-filter-text", Input)
+        filter_input.focus()
+        await pilot.pause()
+        workbench.set_mode("tools")
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        assert app.screen.focused is filter_input
+
+
+@pytest.mark.asyncio
+async def test_cycle_failure_toast_names_the_service_error(tmp_path):
+    """A3/F10: a failed Space-cycle surfaces the service's own error text
+    ("Permission update failed: <reason>"), not just the bare generic
+    sentence -- the typed service methods raise user-ready messages, and
+    the generic toast left the user with nothing to act on."""
+
+    class ExplodingPermissionsService(PermissionsHubService):
+        def set_tool_state(self, *args, **kwargs):
+            raise RuntimeError("profile store busy")
+
+    store_path = tmp_path / "mcp_permissions.json"
+    MCPPermissionStore(store_path)  # create the default profile
+    app = PermissionsApp(store_path)
+    app.unified_mcp_service = ExplodingPermissionsService(store_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        notifications = _capture_notifications(app)
+
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        # Row 0 = global, row 1 = docs server default, row 2 = docs tool.
+        await pilot.press("down", "down", "space")
+        await pilot.pause()
+
+        assert notifications
+        message, severity = notifications[-1]
+        assert severity == "error"
+        assert "Permission update failed" in message
+        assert "profile store busy" in message
+
+
+@pytest.mark.asyncio
+async def test_test_tool_key_falls_back_to_tools_cursor_row():
+    """A7/O5: `t` with nothing selected in the INSPECTOR falls back to the
+    Tools table's cursor row -- telling a user who just arrowed onto a row
+    to "Select a tool in Tools mode first." reads as broken. The fallback
+    drives the same inspector tool view a selection would, so the
+    server-source row surfaces its own honest phase-note refusal."""
+    app = ServerToolsApp()
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        notifications = _capture_notifications(app)
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("tools")
+        await pilot.pause()
+        table = app.query_one("#mcp-tools-table", DataTable)
+        table.focus()
+        table.move_cursor(row=0)
+        await pilot.pause()
+
+        await workbench.open_test_for_selected_tool()
+        await pilot.pause()
+
+        assert workbench.active_mode == "tools"
+        assert not any(
+            "Select a tool in Tools mode first." in message
+            for message, _ in notifications
+        )
+        assert any("display-only" in message for message, _ in notifications)

--- a/Tests/UI/test_mcp_workbench.py
+++ b/Tests/UI/test_mcp_workbench.py
@@ -11251,3 +11251,67 @@ async def test_every_mode_renders_usably_at_100x30():
             assert canvas.display
             assert canvas.region.height > 3
         assert app.query_one("#mcp-hub-inspector").region.height <= 12
+
+
+# -- Wave F (2026-09-11 MCP Hub UX program, ADR-149): bulk actions --------
+
+
+@pytest.mark.asyncio
+async def test_shift_space_bulk_sets_visible_tools_of_one_server(tmp_path):
+    """ADR-149: shift+space applies the cursor row's next state to the
+    server's VISIBLE tool rows only (Wave B order: first press from
+    Inherit = Ask), with one echo and the store holding ordinary
+    per-tool entries -- exactly what N single presses would write."""
+    app = PermissionsApp(tmp_path / "mcp_permissions.json")
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=3)  # local:docs::search
+        await pilot.press("shift+space")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        store = app.unified_mcp_service.permission_store.load()
+        docs_tools = store["profiles"]["default"]["servers"]["local:docs"]["tools"]
+        assert docs_tools["search"]["state"] == "ask"
+        assert docs_tools["fetch"]["state"] == "ask"
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("docs: 2 tools → Ask · ")
+
+
+@pytest.mark.asyncio
+async def test_bulk_clear_reverts_only_overridden_rows(tmp_path):
+    """ADR-149: C writes None only for rows that HELD an override; a
+    never-overridden sibling gains no entry at all."""
+    store_path = tmp_path / "mcp_permissions.json"
+    MCPPermissionStore(store_path).set_tool_state("local:docs", "search", "ask")
+    app = PermissionsApp(store_path)
+    async with app.run_test(size=(120, 40)) as pilot:
+        await pilot.pause()
+        workbench = app.query_one(MCPWorkbench)
+        workbench.set_mode("permissions")
+        await pilot.pause()
+        table = app.query_one("#mcp-perm-table", DataTable)
+        table.focus()
+        table.move_cursor(row=3)  # local:docs::search (the overridden row)
+        await pilot.press("C")
+        await pilot.pause()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        store = app.unified_mcp_service.permission_store.load()
+        docs_servers = store["profiles"]["default"]["servers"]
+        # A None write removes the entry; an emptied server section may be
+        # pruned entirely -- either way the override is GONE and fetch (never
+        # overridden) gained nothing.
+        if "local:docs" in docs_servers:
+            docs_tools = docs_servers["local:docs"].get("tools") or {}
+            assert "search" not in docs_tools
+            assert "fetch" not in docs_tools
+        preview = str(app.query_one("#mcp-perm-preview", Static).renderable)
+        assert preview.startswith("docs: 1 visible overrides cleared · ")

--- a/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
+++ b/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
@@ -1,10 +1,10 @@
 ---
 id: TASK-32452
 title: 'MCP Hub UX Wave A: bounded polish batch'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 18:34'
-updated_date: '2026-09-11 18:36'
+updated_date: '2026-09-11 19:46'
 labels: []
 dependencies: []
 ---
@@ -17,7 +17,7 @@ Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/m
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
+- [x] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
 <!-- AC:END -->
 
 ## Implementation Plan
@@ -25,3 +25,18 @@ Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/m
 <!-- SECTION:PLAN:BEGIN -->
 ADR required: no (routine bounded UI fixes; ADRs 148/149 cover the structural waves). TDD per item, targeted test runs only. 1. Test+impl: auto-focus #mcp-perm-table on set_mode('permissions'). 2. Test+impl: ellipsize Tools Server cell (fixed 24-char budget). 3. Test+impl: cycle-failure toast carries str(exc) first line via _toast. 4. Test+impl: ToolGate.restart_required + ' (⟳ restart)' label suffix on web_deep_search. 5. Test+impl: inspector renders advanced load errors as one-line status. 6. Test+impl: rail legend short-label map below width budget, completeness-pinned. 7. Test+impl: open_test_for_selected_tool falls back to Tools cursor row.
 <!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: TDD per item (test watched RED, then minimal implementation), all seven items on `feat/mcp-hub-ux-wave-a` (commit 8a93ab5).
+- A1 focus: `set_mode("permissions")` focuses `#mcp-perm-table` via `call_after_refresh`; focus already inside the permissions canvas (the filter Input) is respected. A `t`-fallback regression surfaced mid-wave: the first draft fired from any mode (a F-055 mode-hijack), fixed by gating the fallback on `active_mode == "tools"` — the pre-existing no-selection test caught it.
+- A2: fixed 24-column budget + explicit `…` (DataTable has no cell ellipsis/tooltips; width-aware refinement deferred — the server-filter Select still shows full labels).
+- A3: toast carries the first line of the service error (≤140 chars), escaped via `_toast`; stale-profile branch copy unchanged.
+- A4: `ToolGate.restart_required` (default False; True only for `web_deep_search`) + `(⟳ restart)` label suffix; save/reload path untouched (id still built from `gate.key`).
+- A5: `_render_section_payload` branches on a truthy `error` key (the `_AdvancedSectionShim` failure shape) → one-line status; empty error still renders JSON.
+- A6: `_SHORT_STATE_LABELS` keyed off `STATE_LABELS` values with a completeness-pinned test; budget hoisted above the legend yield in `MCPRail.compose` so rows and legend share one computation.
+- A7: `_open_test_for_tools_cursor_row` resolves the cursor row and drives the same `show_tool` path a selection takes, then retries `open_test_panel`.
+- ADR check: none required (routine bounded UI fixes; ADRs 148/149 cover the structural waves). Historical phase docs (2026-07 specs/QA) intentionally left untouched.
+- Verification: targeted suites green — test_mcp_rail 25, test_mcp_tools_mode 30, test_mcp_servers_mode 60, test_mcp_inspector 283, test_mcp_workbench 337 (final combined A+B run: 515 passed). Ruff: no new findings vs clean HEAD. Pre-existing unrelated failures in Tests/MCP/test_mcp_documentation_contract.py (39) exist on clean origin/dev — verified via stash; not addressed here.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
+++ b/backlog/tasks/task-32452 - MCP-Hub-UX-Wave-A-bounded-polish-batch.md
@@ -1,0 +1,27 @@
+---
+id: TASK-32452
+title: 'MCP Hub UX Wave A: bounded polish batch'
+status: In Progress
+assignee: []
+created_date: '2026-09-11 18:34'
+updated_date: '2026-09-11 18:36'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Seven bounded UI fixes from the 2026-09-11 MCP screen UX review (specs on docs/mcp-hub-ux-program): auto-focus the Permissions matrix on mode entry, ellipsize the Tools Server column, surface error reasons in permission toasts, restart markers on restart-class tool gates, one-line Advanced error rendering, width-budgeted rail legend abbreviation, and t-on-cursor-row fallback for Test Tool.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Permissions matrix receives focus when entering Permissions mode,Tools Server column truncates with an ellipsis never mid-word silent clip,Permission failure toast includes the service error reason,web_deep_search gate shows a restart marker; immediate gates do not,Advanced pane renders load errors as a one-line status not raw JSON,Rail legend abbreviates below the width budget with a completeness-pinned map,t opens Test Tool for the Tools-table cursor row when the inspector has no selection
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+ADR required: no (routine bounded UI fixes; ADRs 148/149 cover the structural waves). TDD per item, targeted test runs only. 1. Test+impl: auto-focus #mcp-perm-table on set_mode('permissions'). 2. Test+impl: ellipsize Tools Server cell (fixed 24-char budget). 3. Test+impl: cycle-failure toast carries str(exc) first line via _toast. 4. Test+impl: ToolGate.restart_required + ' (⟳ restart)' label suffix on web_deep_search. 5. Test+impl: inspector renders advanced load errors as one-line status. 6. Test+impl: rail legend short-label map below width budget, completeness-pinned. 7. Test+impl: open_test_for_selected_tool falls back to Tools cursor row.
+<!-- SECTION:PLAN:END -->

--- a/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
+++ b/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
@@ -1,9 +1,10 @@
 ---
 id: TASK-32453
 title: 'MCP Hub UX Wave B: safe permission cycle order'
-status: In Progress
+status: Done
 assignee: []
 created_date: '2026-09-11 19:25'
+updated_date: '2026-09-11 19:46'
 labels: []
 dependencies: []
 ---
@@ -16,5 +17,17 @@ Reorder the Permissions Space-cycle so the first press from Inherit lands on Ask
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
+- [x] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
 <!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: tests-first (updated pins watched RED against the old ring), then the one-map store change. Commit 728d3ea on `feat/mcp-hub-ux-wave-a`.
+- Change surface: `permission_store._CYCLE_UI_STATES` (None→ask→allow→deny→None), `cycle_ui_state` docstring, Permissions legend constant. `cycle_global` deliberately unchanged — from the global default (ask) one press already goes to deny, so Allow is never the first stop there either.
+- Pinned tests updated in the same commit: `test_permission_resolution.py` full-loop; `test_mcp_permissions_mode.py` first-press event + two verbatim legend pins; `test_mcp_workbench.py` — 12 flow tests adjusted intent-preserving (one-press flows now assert the ask/override marker; flows that need `allow` press twice). TASK-627 built-in tests post explicit `new_state` values and needed only comment updates.
+- Trap caught by TDD: a blanket string replacement initially rewrote a structurally identical assertion in the re-allow test (which legitimately expects `allow` after Re-allow); the immediate test run caught it and it was reverted.
+- ADR check: none required (interaction order within existing states; no storage/schema/interface change — rationale recorded in the store comment and program review).
+- Historical phase docs/specs (2026-07) that describe the old ring order were left as dated records; Docs/User_Guide/mcp.md does not pin the order (doc-contract verified).
+- Verification: Tests/MCP/test_permission_resolution.py + test_permission_store.py 119 passed; combined A+B run 515 passed (workbench/permissions-mode/resolution/store).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
+++ b/backlog/tasks/task-32453 - MCP-Hub-UX-Wave-B-safe-permission-cycle-order.md
@@ -1,0 +1,20 @@
+---
+id: TASK-32453
+title: 'MCP Hub UX Wave B: safe permission cycle order'
+status: In Progress
+assignee: []
+created_date: '2026-09-11 19:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Reorder the Permissions Space-cycle so the first press from Inherit lands on Ask, not Allow (Inherit → Ask → Allow → Off). Allow becomes a deliberate second press. Store helper, legend copy, and every pinned test move together in one change (UX program 2026-09-11, safety assumption adopted at review).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 cycle_ui_state(None) returns ask (not allow),Legend reads Space cycles Inherit → Ask → Allow → Off,All pinned tests updated to the new order in the same change,Permission regression suites green
+<!-- AC:END -->

--- a/backlog/tasks/task-32454 - MCP-Hub-UX-Wave-C-flow-fixes.md
+++ b/backlog/tasks/task-32454 - MCP-Hub-UX-Wave-C-flow-fixes.md
@@ -1,0 +1,36 @@
+---
+id: TASK-32454
+title: 'MCP Hub UX Wave C: flow fixes'
+status: Done
+assignee: []
+created_date: '2026-09-11 19:51'
+updated_date: '2026-09-11 20:12'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Five flow improvements from the 2026-09-11 MCP screen UX review: first-run lands on the overview (selection/inspector detail preserved), a discovery breadcrumb naming zero-tool servers in Permissions, Save & connect on the add-server form plus lifecycle actions in the canvas detail toolbar, a profile-context hint line for non-default tool-policy profiles, and the step-by-step add-server tutorial in the user guide.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Fresh-install load shows the overview table while the problem server stays selected and the inspector explains it,Permissions legend names known servers with no discovered tools,Add-server form offers Save and connect; canvas detail toolbar offers Connect/Refresh tools for local profiles,Non-default tool-policy profiles show a one-line Console-context hint,mcp.md gains a step-by-step add-server walkthrough consistent with the new cycle order
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: TDD per item (six tests watched RED, then minimal implementation). Branch `feat/mcp-hub-ux-wave-a`, commits on top of Waves A/B.
+- C1 overview hold: `_hold_canvas_overview` on the workbench, set by the F-054/task-2240 preselect, honored by `_show_selected_detail` (renders `show_detail(None)` — overview with fresh data), cleared by the first explicit selection (`_select_server_key`) or a restored view state. Inspector readiness for the preselected row is unchanged (task-2240's intent preserved).
+- C2 discovery hint: `_undiscovered_servers_hint` (pure, local-source snapshots with `tool_count` None/0, names capped at 3) rendered as a third legend line via `update_matrix(discovery_hint=...)`.
+- C3 Save and connect: `SubmitRequested.connect_after`; `_save_local_profile` dispatches `_start_lifecycle(..., "connect")` after the save+resync. Connect failures surface through the existing lifecycle notification/readiness path (e.g. missing env placeholder). Plain Save demoted to secondary styling; Save-and-connect is primary.
+- C4 toolbar lifecycle: local detail toolbar gains Connect (primary, not connected) / Refresh tools (connected), posting the same `MCPInspector.HubActionRequested` the inspector's readiness buttons post — one execution path. Check-readiness stays inspector-only (toolbar economy); documented as a deliberate narrowing of the chat design.
+- C5 profile hint: `#mcp-perm-profile-hint` Static + `set_profile_hint()`, shown only for non-default profiles ("Console agents run with this profile; persona policy may still floor some tools to Ask."). Per-tool effective-after-persona display remains future work (needs persona policy wired into resolution).
+- C7 tutorial: "Adding your first MCP server (step by step)" section in Docs/User_Guide/mcp.md, consistent with this branch's behavior (overview landing, Save and connect, new cycle order, discovery hint). Doc-contract verified unchanged: 39 failures / 26 mcp.md-scoped before AND after — all pre-existing on origin/dev.
+- F11 (gate-vs-permission pointer) was intentionally not implemented: subsumed by the existing gate breadcrumb, C2's discovery hint, and the Tools-mode diagnostic empty state; Wave F's bulk-action legend work will teach the server-default lever instead.
+- ADR check: none required (flow fixes within existing seams; ADRs 148/149 own the structural decisions).
+- Verification: 6 new tests GREEN; suites — test_mcp_workbench 340 passed, test_mcp_permissions_mode+servers+profile_form 149 passed, test_mcp_rail+tools 56 passed. Pre-existing/unrelated: test_destination_shells has 5 failures on clean origin/dev (library/schedules/models shells) plus flaky schedules timing (verified failing-then-passing in isolation on untouched code); test_mcp_documentation_contract 39 failures pre-existing.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32455 - MCP-Hub-UX-Wave-D-rail-IA-split.md
+++ b/backlog/tasks/task-32455 - MCP-Hub-UX-Wave-D-rail-IA-split.md
@@ -1,0 +1,35 @@
+---
+id: TASK-32455
+title: 'MCP Hub UX Wave D: rail IA split'
+status: Done
+assignee: []
+created_date: '2026-09-11 20:15'
+updated_date: '2026-09-11 20:52'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ADR-148 Wave D: split the agent tool catalog out of the built-in server rail row into its own Agent tools rail section keyed agent:builtin; move Tool gates to the agent detail; built-in detail points there. Plan: Docs/superpowers/plans/2026-09-11-mcp-hub-rail-ia-split.md; spec: Docs/superpowers/specs/2026-09-11-mcp-hub-rail-ia-split-design.md.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Agent tools rail section renders with its own heading and never shares a server_key,Tool gates render in the agent detail only; built-in detail points at the Agent tools row,Agent row routes end-to-end (rail click -> detail, inspector base actions, unscoped permissions preview),Overview table/callouts/preselection stay server-only,mcp.md gates section updated with doc-contract unchanged
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Executed inline per Docs/superpowers/plans/2026-09-11-mcp-hub-rail-ia-split.md (5 tasks, TDD per task). Branch `feat/mcp-hub-ux-wave-d` (stacked on `feat/mcp-hub-ux-wave-a`).
+- `agent_tools_readiness` (readiness.py) keys the row `agent:builtin` via `AGENT_TOOLS_SERVER_KEY`, equality-pinned to permission_store's `BUILTIN_TOOL_SERVER_KEY` (readiness must not import the store).
+- The agent snapshot rides BESIDE `_snapshots` (rail param + workbench state) — overview table, callouts, worst-state summary, and preselection heuristics are untouched and server-only; `_snapshot_for` resolves the agent key.
+- Tool gates render for `source == "agent"` only; the built-in detail keeps `[mcp]` toggles plus the pointer line "Agent tool gates live under Agent tools in the rail." Inspector `_wired_actions` needed no change (base-only already).
+- Plan deviations: (1) `LOCAL_TOOLS_MASTER_KEY` was NOT imported in mcp_workbench (plan's grep assumption half-wrong) — import added; the NameError was caught by the new tests immediately. (2) A blanket click-re-target over-matched two builtin-`[mcp]`-toggle tests (they legitimately keep the built-in row) — reverted; suite green after. (3) The 100x30 layout test selects via `_select_server_key` (fourth rail row can clip at 30 rows; test is about layout, not routing).
+- Re-targeted tests: servers-mode gate render/toggle/master-off/master-on/restart-marker/geometry tests now use the agent snapshot; workbench gate-path tests click the agent rail row; rail-row count pin 3→4.
+- Deferred (recorded in plan self-review): the spec's `(external MCP)` / `(Console agents)` label suffixes for the duplicate matrix rows — follow-up with the duplication-disambiguation work.
+- ADR: covered by ADR-148 (linked); no additional ADR.
+- Verification: 777 passed across test_mcp_workbench + rail + servers + permissions + inspector; destination-shell MCP tests 22 passed; doc-contract unchanged at the pre-existing 39 failures (26 mcp.md-scoped, all on origin/dev before this branch); ruff no new findings (before=after=2 on touched files).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32456 - MCP-Hub-UX-Wave-E-narrow-width-triad.md
+++ b/backlog/tasks/task-32456 - MCP-Hub-UX-Wave-E-narrow-width-triad.md
@@ -1,0 +1,33 @@
+---
+id: TASK-32456
+title: 'MCP Hub UX Wave E: narrow-width triad'
+status: Done
+assignee: []
+created_date: '2026-09-11 20:57'
+updated_date: '2026-09-11 21:10'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ADR-148 Wave E: below 120 columns, stack the inspector under the rail+canvas main row as a bounded scrolling band (max-height 12) instead of squeezing three columns; Advanced auto-collapses while compact. Plan: Docs/superpowers/plans/2026-09-11-mcp-hub-narrow-width-triad.md; spec: Docs/superpowers/specs/2026-09-11-mcp-hub-narrow-width-triad-design.md.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Wide layouts >=120 cols are geometrically unchanged,Compact layout stacks inspector below the main row as a <=12-row full-width scrollable band,Advanced collapsible auto-collapses at compact without touching the persisted preference,Select prompts render without mid-word breaks at 100x30,All four modes render usably at 100x30
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Executed inline per Docs/superpowers/plans/2026-09-11-mcp-hub-narrow-width-triad.md (3 tasks, TDD). Branch `feat/mcp-hub-ux-wave-d` (Wave E stacked on Wave D — same PR series).
+- Layout: `#mcp-hub-main-row` (Horizontal: rail+canvas, ids unchanged) + inspector sibling under `#mcp-hub-grid`; main-row `width: 8fr` preserves the wide 8:3 share exactly. `.mcp-compact` flips the grid to `layout: vertical` (in-repo override precedent) with the inspector as a full-width `max-height: 12; overflow-y: auto` band. CSS landed lockstep in BUNDLED_CSS + widget_defaults_scoped.tcss; the old compact-inspector squeeze rule was deleted in both.
+- Advanced auto-collapse: `MCPInspector.apply_compact_layout(compact)` collapses an open `#mcp-adv-collapsible` (widget state only — `_advanced_visible` untouched), driven from `_sync_compact_class`.
+- Test adaptations forced by the WIDER canvas at 100 cols (stacking gives the canvas more room — an improvement): the summary-wrap assertion now pins "never clipped mid-sentence" instead of "wraps >=2 lines"; the F-057 column-set pin became "Name/Status never drop + zero horizontal scroll". The intact-prompt test expands the auto-collapsed Advanced first (a user can), then asserts "Overview" renders whole — the old "Overvi|ew" clip is gone.
+- Spec open questions resolved to defaults (recorded in plan): band cap fixed at 12; compact rail keeps current sizing (Source select unchanged).
+- ADR: covered by ADR-148 decision 2 (linked).
+- Verification: test_mcp_workbench 346 passed (full); inspector/rail/servers/permissions + destination MCP subsets 456 passed with ONE flaky destination view-state test (fails under suite load, passes twice in isolation and in the re-run subset — same known flakiness class documented in TASK-32454); doc-contract unchanged at the pre-existing 39 failures.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32457 - MCP-Hub-UX-Wave-F-bulk-permission-actions.md
+++ b/backlog/tasks/task-32457 - MCP-Hub-UX-Wave-F-bulk-permission-actions.md
@@ -12,7 +12,7 @@ dependencies: []
 ## Description
 
 <!-- SECTION:DESCRIPTION:BEGIN -->
-ADR-149 Wave F: shift+space applies the cursor row's next cycled state to a server's VISIBLE tool rows; C clears its visible overrides. Filter is the scope; every write stays an ordinary profile-scoped set_tool_state call; raw-shell rows skipped and named in the echo. Plan: Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md.
+ADR-150 Wave F: shift+space applies the cursor row's next cycled state to a server's VISIBLE tool rows; C clears its visible overrides. Filter is the scope; every write stays an ordinary profile-scoped set_tool_state call; raw-shell rows skipped and named in the echo. Plan: Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md.
 <!-- SECTION:DESCRIPTION:END -->
 
 ## Acceptance Criteria
@@ -29,6 +29,6 @@ ADR-149 Wave F: shift+space applies the cursor row's next cycled state to a serv
 - **Design catch from the RED tests:** one captured PermissionProfileContext cannot span the batch — each write changes the profile digest, so write #2 fails `stale_profile` (the single-press path never hits this; it writes once). Fixed with a per-write context re-capture from `_tool_policy_inventory()` plus a selection-identity guard (profile id + selector generation unchanged, else the stale toast and stop; partial writes stand, each idempotent).
 - Wave-B interplay verified: first `shift+space` from Inherit applies Ask to the visible set.
 - Spec open questions resolved to defaults (in-plan): per-row execution-log entries unchanged; shift+space on a server-default row applies that row's own next state.
-- ADR: ADR-149 (linked); no additional ADR.
+- ADR: ADR-150 (linked); no additional ADR.
 - Verification: test_mcp_workbench 348 passed (full); permissions/servers/rail/tools 185 passed; permission resolution/store 119 passed; doc-contract unchanged at the pre-existing 39 failures; ruff before=after on touched files.
 <!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32457 - MCP-Hub-UX-Wave-F-bulk-permission-actions.md
+++ b/backlog/tasks/task-32457 - MCP-Hub-UX-Wave-F-bulk-permission-actions.md
@@ -1,0 +1,34 @@
+---
+id: TASK-32457
+title: 'MCP Hub UX Wave F: bulk permission actions'
+status: Done
+assignee: []
+created_date: '2026-09-11 21:12'
+updated_date: '2026-09-11 21:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+ADR-149 Wave F: shift+space applies the cursor row's next cycled state to a server's VISIBLE tool rows; C clears its visible overrides. Filter is the scope; every write stays an ordinary profile-scoped set_tool_state call; raw-shell rows skipped and named in the echo. Plan: Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 shift+space bulk-applies the row's next state to the server's visible tool rows with one echo,C clears only visible overrides and teaches the full-clear recipe,Global row and zero-visible-rows are hint no-ops not toasts,Raw-shell rows are skipped and named in the echo,First write failure stops the batch with a reason toast,Footer and legend copy updated with their pins
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Executed inline per Docs/superpowers/plans/2026-09-11-mcp-hub-bulk-permission-actions.md (3 tasks, TDD). Branch `feat/mcp-hub-ux-wave-d` (program waves D/E/F share the stacked branch).
+- Canvas (single writer preserved): `shift+space`/`C` bindings post `BulkStateRequested(server_key, tool_names, new_state, profile_context)` / `BulkClearRequested(...)` — the canvas alone knows visibility, so it computes the scope (C sends only overridden rows); no-op cases (global row, zero matching visible rows) flash a transient hint line under the legend via `flash_hint()` (the spec's "existing hint Static"), never a toast. Footer + legend copy landed with their pins (2 verbatim legend tests, destination footer test).
+- Workbench: `_apply_bulk_tool_states` executes the batch as N ordinary `_call_profile_scoped(service.set_tool_state, ...)` calls — no batch API, per-row audit logging unchanged. Raw-shell and vanished-tool rows are skipped and named in the echo; first service failure stops the batch with the Wave-A reason toast; one `_sync_permissions_mode(echo=...)` at the end.
+- **Design catch from the RED tests:** one captured PermissionProfileContext cannot span the batch — each write changes the profile digest, so write #2 fails `stale_profile` (the single-press path never hits this; it writes once). Fixed with a per-write context re-capture from `_tool_policy_inventory()` plus a selection-identity guard (profile id + selector generation unchanged, else the stale toast and stop; partial writes stand, each idempotent).
+- Wave-B interplay verified: first `shift+space` from Inherit applies Ask to the visible set.
+- Spec open questions resolved to defaults (in-plan): per-row execution-log entries unchanged; shift+space on a server-default row applies that row's own next state.
+- ADR: ADR-149 (linked); no additional ADR.
+- Verification: test_mcp_workbench 348 passed (full); permissions/servers/rail/tools 185 passed; permission resolution/store 119 passed; doc-contract unchanged at the pre-existing 39 failures; ruff before=after on touched files.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32458 - MCP-Hub-rail-keyboard-navigation-F2.md
+++ b/backlog/tasks/task-32458 - MCP-Hub-rail-keyboard-navigation-F2.md
@@ -1,0 +1,31 @@
+---
+id: TASK-32458
+title: 'MCP Hub: rail keyboard navigation (F2)'
+status: Done
+assignee: []
+created_date: '2026-09-11 23:10'
+updated_date: '2026-09-11 23:35'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Close the F2 gap from the 2026-09-11 UX review: the rail is Tab-only today. Add up/down (and j/k alias) bindings on MCPRail that move the selection through its rows via the existing ServerSelected path, mirroring table-cursor semantics, with focus kept on the rail so consecutive presses work.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 up/down and j/k on the rail move selection through All-servers, server rows and the Agent tools row,Selection never wraps; clamps at the ends,Consecutive presses work without re-focusing (focus follows the new row),Existing click/selection behavior unchanged
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- F2 from the 2026-09-11 UX review (the one finding dropped during wave decomposition; surfaced in the remaining-work audit). Branch `feat/mcp-hub-ux-wave-d`.
+- `up`/`down` + `j`/`k` bindings on `MCPRail` post the same `ServerSelected` a click posts, clamped at both ends (no wrap); Selects keep their own arrows while focused (widget focus wins).
+- The load-bearing fix the RED tests forced: every selection triggers the host's resync → rail recompose, which DESTROYS the focused row — so focus restoration is scheduled at COMPOSE time (sync_state notes the rail owned focus; compose consumes the flag once the new rows exist and refocuses the selected row). A sync_state-time `call_after_refresh` races the recompose and restores against children that are about to be destroyed.
+- Tests exercise the full loop with a harness that mirrors the workbench contract (host re-syncs the rail after every ServerSelected); paced presses match the real typing cadence across recomposes. One transient failure in the 367-test sweep did not reproduce (known destination-shells flake class).
+- ADR check: none required (keybinding follows ADR-031 htop-style conventions; no structural change).
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32459 - MCP-Hub-duplicate-row-surface-labels-Wave-D-spec-deferral.md
+++ b/backlog/tasks/task-32459 - MCP-Hub-duplicate-row-surface-labels-Wave-D-spec-deferral.md
@@ -1,0 +1,32 @@
+---
+id: TASK-32459
+title: 'MCP Hub: duplicate-row surface labels (Wave D spec deferral)'
+status: Done
+assignee: []
+created_date: '2026-09-11 23:10'
+updated_date: '2026-09-11 23:46'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the deferred label disambiguation from the Wave D spec (ADR-148): the same tool names legitimately appear under both the external-MCP inventory group (builtin:tldw_chatbook) and the Console agent group (local:__local__/virtual CLI) as two separate permission domains -- label them 'tldw_chatbook (external MCP)' and suffix the Console-side group '(Console agents)' so the pairing reads as deliberate, plus the pinned two-row test from the spec.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 builtin inventory group renders as tldw_chatbook (external MCP) in matrix sections, Tools Server column and preview,Console agent group label carries (Console agents),A pinned test renders one tool name under both groups with both surface labels visible,All pinned label tests updated in the same change
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Implements the deferral recorded in Wave D's plan self-review / TASK-32455 notes. Branch `feat/mcp-hub-ux-wave-d`.
+- Two constants carry the change: `Agents/local_tool_provider.LOCAL_SERVER_LABEL` -> "Local workspace, web, and Watchlists (Console agents)" and `hub_tool_catalog.builtin_tools_from_inventory`'s label -> "tldw_chatbook (external MCP)" — every surface (matrix sections, Tools Server column, preview) derives from these.
+- Deliberately NOT suffixed: `VIRTUAL_CLI_SERVER_LABEL` ("Virtual CLI (read-only)" — Console-only tools, no cross-surface duplication) and the approval-path audit label "Local workspace" in unified_control_plane_service (different surface, no duplication, pinned approval copy).
+- The spec's pinned two-row test landed (`test_same_tool_under_both_surfaces_renders_both_labels`: fs_read under both sections, both surface labels rendered). Pinned label tests updated in the same change: the local-catalog assertions, the distinctness pin (`tldw_chatbook (external MCP)` vs `Built-in (agent runtime)`), and the Tools-mode truncation fixture.
+- ADR check: covered by ADR-148 (this is the label half of its decision 1; no new decision).
+- Verification: workbench 349 passed (full); permissions/servers/rail/tools 187 passed; permission resolution/store/control-plane 187 passed; inspector 284 passed; doc-contract unchanged at the pre-existing 39 failures.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32460 - Fix-MCP-documentation-contract-drift-39-failing-tests-on-clean-dev.md
+++ b/backlog/tasks/task-32460 - Fix-MCP-documentation-contract-drift-39-failing-tests-on-clean-dev.md
@@ -1,0 +1,20 @@
+---
+id: TASK-32460
+title: Fix MCP documentation-contract drift (39 failing tests on clean dev)
+status: To Do
+assignee: []
+created_date: '2026-09-11 23:54'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pre-existing on origin/dev (verified 2026-09-11, unrelated to the MCP Hub UX program): Tests/MCP/test_mcp_documentation_contract.py has 39 failures -- the documented standalone/private inventory lists drifted from the code enumerators the contract test reads. Sample failure: Docs/Design/MCP.md documents 'Library tools excluded from standalone (24)' but the actual code list has 21 entries; the same drift hits Docs/User_Guide/mcp.md (26 mcp.md-scoped failures) and release-recovery-setup.md. The contract test IS the oracle: regenerate each documented count + backtick name list from the code enumerators until the suite greens.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 test_mcp_documentation_contract.py fully green on dev,Every documented count matches its code enumerator,Name lists match verbatim
+<!-- AC:END -->

--- a/backlog/tasks/task-32461 - Fix-destination-shell-test-drift-on-clean-dev-5-failures-2-flaky.md
+++ b/backlog/tasks/task-32461 - Fix-destination-shell-test-drift-on-clean-dev-5-failures-2-flaky.md
@@ -1,0 +1,20 @@
+---
+id: TASK-32461
+title: Fix destination-shell test drift on clean dev (5 failures + 2 flaky)
+status: To Do
+assignee: []
+created_date: '2026-09-11 23:54'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Pre-existing on origin/dev (verified 2026-09-11): test_destination_shells.py fails 5 on clean HEAD -- test_library_destination_service_failure_uses_recovery_copy, test_library_policy_denial_uses_runtime_recovery_taxonomy, test_library_policy_denial_uses_runtime_recovery_state_selector, test_destination_action_buttons_explain_their_outcome[schedules], test_models_shell_keeps_external_paths_inside_the_dedicated_edit_view. Additionally test_schedules_pending_run_uses_shared_approval_status_taxonomy and test_schedules_empty_state_reads_as_live_queue_with_recovery_path are flaky (fail under suite load, pass in isolation/rerun). Three unrelated subsystems (library recovery taxonomy, schedules copy, models edit view) -- triage each separately.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 All 5 deterministic failures fixed with root cause,Flaky schedules pair stabilized or root-caused with a follow-up note,Suite green on two consecutive full runs
+<!-- AC:END -->

--- a/backlog/tasks/task-32462 - Design-per-tool-persona-floor-display-in-MCP-Permissions.md
+++ b/backlog/tasks/task-32462 - Design-per-tool-persona-floor-display-in-MCP-Permissions.md
@@ -1,0 +1,20 @@
+---
+id: TASK-32462
+title: 'Design: per-tool persona-floor display in MCP Permissions'
+status: To Do
+assignee: []
+created_date: '2026-09-11 23:54'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Deferred from Wave C (TASK-32454): the Permissions matrix shows stored tool policy only; Console personas layer additional floors (Agents/persona_policy.py persona_floor_state) on top at runtime, so a user auditing a ws-* profile cannot see which tools stay Ask regardless of Allow. The open design question: which persona context resolves the floors when the MCP screen views a workspace profile (the screen has no persona selection; the workspace may have several). Candidate approaches: (a) show floors for the workspace's currently-active assistant persona, (b) a persona picker in the matrix, (c) a read-only 'floors apply' aggregate badge per tool derived from ALL personas for that workspace. v1 shipped an informational hint line only. Needs a product decision before implementation.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Design decided (which persona context + which surface),ADR written if it changes permission-display semantics,Implemented with tests showing effective-after-floor states for a selected workspace profile
+<!-- AC:END -->

--- a/tldw_chatbook/Agents/builtin_tool_gate.py
+++ b/tldw_chatbook/Agents/builtin_tool_gate.py
@@ -581,6 +581,12 @@ class ToolGate:
     description: str
     enabled: bool
     group: str
+    #: Wave A (F12): True for construction-time gates that only take
+    #: effect after an app restart (tool providers build their catalogs at
+    #: startup) -- the UI renders a "(⟳ restart)" suffix on exactly these
+    #: rows so the restart class is visible per-checkbox, not only in the
+    #: group's shared note. Every gate that reads back live stays False.
+    restart_required: bool = False
 
 
 #: The local group's master-switch config key, named so it isn't re-typed
@@ -705,6 +711,7 @@ def all_tool_gates() -> list[ToolGate]:
                 get_cli_setting("tools", WEB_DEEP_SEARCH_GATE_KEY, False), False
             ),
             group="local",
+            restart_required=True,
         )
     )
     gates.append(

--- a/tldw_chatbook/Agents/local_tool_provider.py
+++ b/tldw_chatbook/Agents/local_tool_provider.py
@@ -92,7 +92,12 @@ from .tool_catalog import ToolExecutionPolicy, ToolPathTarget, redact_root_locat
 
 SOURCE = "local"
 LOCAL_SERVER_KEY = "local:__local__"
-LOCAL_SERVER_LABEL = "Local workspace, web, and Watchlists"
+# ADR-148 (Wave D spec): the Console-side group label carries the surface
+# suffix -- the same tool names legitimately exist under BOTH this group
+# and the external-MCP inventory group ("tldw_chatbook (external MCP)",
+# hub_tool_catalog) as two separate permission domains, and the pairing
+# must read as deliberate, not accidental duplication.
+LOCAL_SERVER_LABEL = "Local workspace, web, and Watchlists (Console agents)"
 
 #: task-3240: relocated here from UI/Tools_Settings_Window.py -- this module
 #: is web_deep_search's actual runtime consumer (the [tools] gate read just

--- a/tldw_chatbook/MCP/hub_tool_catalog.py
+++ b/tldw_chatbook/MCP/hub_tool_catalog.py
@@ -181,7 +181,11 @@ def builtin_tools_from_inventory(inventory: dict) -> list[HubTool]:
         tools.append(
             HubTool(
                 server_key="builtin:tldw_chatbook",
-                server_label="tldw_chatbook",
+                # ADR-148 (Wave D spec): the external-MCP inventory group's label names
+                # its surface -- the standalone stdio server's published
+                # catalog, a SEPARATE permission domain from the Console
+                # agent group that shares many tool names.
+                server_label="tldw_chatbook (external MCP)",
                 source="builtin",
                 name=name,
                 description=_text(raw_tool.get("description")),

--- a/tldw_chatbook/MCP/permission_store.py
+++ b/tldw_chatbook/MCP/permission_store.py
@@ -2227,10 +2227,17 @@ def resolve_effective_state_by_key(
     return EffectiveToolState(state=state, origin=origin)
 
 
+#: Wave B (2026-09-11 MCP Hub UX program): the ring starts at Ask, not
+#: Allow -- the most permissive state must never be the first stop from
+#: Inherit (the default posture), so a stray first Space press grants
+#: nothing. `_CYCLE_GLOBAL_STATES` below needs no change: from the global
+#: default ("ask") one press already goes to "deny", and Allow is only
+#: reachable from "deny" -- Allow is never the first press from the
+#: default posture there either.
 _CYCLE_UI_STATES: dict[str | None, str | None] = {
-    None: "allow",
-    "allow": "ask",
-    "ask": "deny",
+    None: "ask",
+    "ask": "allow",
+    "allow": "deny",
     "deny": None,
 }
 
@@ -2248,8 +2255,9 @@ def cycle_ui_state(current: str | None) -> str | None:
         current: The current stored state, or None for "Inherit".
 
     Returns:
-        The next state in the cycle: Inherit -> Allow -> Ask -> Off ->
-        Inherit (None).
+        The next state in the cycle: Inherit -> Ask -> Allow -> Off ->
+        Inherit (None). Ask leads the ring (Wave B) so the most
+        permissive state is never the first press from Inherit.
     """
     return _CYCLE_UI_STATES[current]
 

--- a/tldw_chatbook/MCP/readiness.py
+++ b/tldw_chatbook/MCP/readiness.py
@@ -649,6 +649,45 @@ def builtin_readiness(
     )
 
 
+#: ADR-148 Wave D: the rail-facing identity of the in-process agent tool
+#: catalog. Deliberately equal to permission_store.BUILTIN_TOOL_SERVER_KEY
+#: ("agent:builtin") -- the store identity that already exists but had no
+#: rail presence. The equality is pinned by test; readiness.py must not
+#: import the store (dependency direction), so the literal is duplicated
+#: once and tested.
+AGENT_TOOLS_SERVER_KEY = "agent:builtin"
+
+
+def agent_tools_readiness(*, enabled: bool) -> ReadinessSnapshot:
+    """Readiness for the in-process agent tool catalog (ADR-148 Wave D).
+
+    Not a server: nothing connects to it and no client launches it -- the
+    state is purely whether the `[console] local_tools_enabled` master
+    switch registers the workspace/web/Watchlists/built-in agent tools.
+    """
+    if enabled:
+        state = ReadinessState.READY
+        message = "In-process tools for Console agents."
+    else:
+        state = ReadinessState.OFF_OPT_IN
+        message = (
+            "Turned off — Console agents get no workspace, web, or "
+            "Watchlists tools."
+        )
+    return ReadinessSnapshot(
+        server_key=AGENT_TOOLS_SERVER_KEY,
+        label="Agent tools",
+        source="agent",
+        state=state,
+        reasons=() if enabled else (ReasonCode.NOT_CONFIGURED,),
+        message=message,
+        transport="—",
+        auth_display="—",
+        scope_display="—",
+        detail={"enabled": enabled},
+    )
+
+
 STATE_CSS_CLASSES: dict[ReadinessState, str] = {
     ReadinessState.READY: "mcp-status-ready",
     ReadinessState.CHECKING: "mcp-status-info",

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -824,7 +824,16 @@ def _render_section_payload(section: str, payload: Any) -> str:
     or `OverflowError` (an out-of-range float) -- which should not happen
     for a service-returned dict but must never crash the Advanced pane
     either way.
+
+    Wave A (F13): a Mapping payload carrying a truthy "error" key is a
+    FAILED section load (the `_AdvancedSectionShim` in mcp_workbench.py
+    normalizes exceptions to exactly this shape) -- rendered as ONE plain
+    status line instead of the JSON dump, which is the noise the UX review
+    flagged on the server-source no-target state. An empty/absent "error"
+    is a legitimate payload and still renders as JSON.
     """
+    if isinstance(payload, Mapping) and payload.get("error"):
+        return f"Could not load this section: {str(payload['error']).strip()}"
     try:
         return json.dumps(payload, indent=2, sort_keys=True, default=str)
     except Exception:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_inspector.py
@@ -1278,6 +1278,23 @@ class MCPInspector(Vertical):
         # metadata-only preview the service issued for the visible panel.
         self._test_preview: ToolTestAdmissionPreview | None = None
 
+    def apply_compact_layout(self, compact: bool) -> None:
+        """ADR-148 Wave E: react to the workbench's compact-mode toggle.
+
+        Compact: collapse an OPEN Advanced collapsible -- its JSON dumps
+        are the least band-friendly content at ~100 cols -- WITHOUT
+        touching the persisted `advanced_visible` preference (widget
+        state only; leaving compact never re-expands it for you).
+        """
+        if not compact:
+            return
+        try:
+            collapsible = self.query_one("#mcp-adv-collapsible", Collapsible)
+        except NoMatches:
+            return
+        if not collapsible.collapsed:
+            collapsible.collapsed = True
+
     def _advanced_object_label(self) -> str:
         """Compute the "Showing: <object>" text for `#mcp-adv-object`.
 

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -64,6 +64,52 @@ _SERVER_PROFILES_POINTER = (
     "above is chatbook's client-side gate and still applies."
 )
 
+# Wave C (F8): shown under the profile selector whenever a non-default
+# tool-policy profile is selected -- the matrix reads as the whole story
+# otherwise, but Console applies the profile (and persona policy may floor
+# tools on top of it).
+_PROFILE_HINT_TEXT = (
+    "Console agents run with this profile; persona policy may still floor "
+    "some tools to Ask."
+)
+
+# Wave C (F3): cap on how many undiscovered server names the discovery
+# hint names inline before collapsing to "+N more" -- the hint is one dim
+# line under the legend, not a second table.
+_UNDISCOVERED_NAME_CAP = 3
+
+
+def _undiscovered_servers_hint(snapshots: list) -> str | None:
+    """One-line hint naming KNOWN servers with no discovered tools.
+
+    Wave C (F3): a saved-but-unconnected server contributes zero rows to
+    the matrix (registration/discovery precedes permission -- an
+    undiscovered tool has nothing to permit yet), so "where is docs?" had
+    no answer at the point of confusion. Local-source snapshots only (the
+    built-in row is never "connected", and server-source records embed
+    their own tool lists); `tool_count` None or 0 counts as undiscovered.
+    Returns None when every known server has tools (nothing to explain).
+    """
+    from tldw_chatbook.MCP.readiness import ReadinessSnapshot
+
+    names = [
+        snap.label
+        for snap in snapshots
+        if isinstance(snap, ReadinessSnapshot)
+        and snap.source == "local"
+        and not snap.tool_count
+    ]
+    if not names:
+        return None
+    shown = names[:_UNDISCOVERED_NAME_CAP]
+    text = ", ".join(shown)
+    if len(names) > len(shown):
+        text += f", +{len(names) - len(shown)} more"
+    return (
+        f"No tools yet — {text}. Connect them in Servers mode to configure "
+        "their permissions."
+    )
+
 
 # Task 1 (MCP Hub Phase 6): concrete Rich styles for `state_text()` -- the
 # semantic-state-word coloring shared by every DataTable cell across the Hub
@@ -398,6 +444,14 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         min-height: 0;
         color: $text-muted;
     }
+    /* Wave C (F8): the non-default-profile hint is the same quiet, dimmed
+    one-liner tier as the kill-switch hint below. */
+    #mcp-perm-profile-hint {
+        height: auto;
+        min-height: 0;
+        color: $text-muted;
+        padding: 0 1;
+    }
     /* task-2242: the kill-switch scope hint is the same quiet, dimmed
     one-liner tier as the legend below the matrix. */
     #mcp-perm-kill-switch-hint {
@@ -540,6 +594,11 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
             id="mcp-perm-tool-profile",
             allow_blank=False,
         )
+        # Wave C (F8): populated by `set_profile_hint()` -- hidden while
+        # empty (the default profile needs no Console-context caveat).
+        hint = Static("", id="mcp-perm-profile-hint", markup=False)
+        hint.display = False
+        yield hint
         yield Button(
             _kill_switch_label(self._kill_switch),
             id="mcp-perm-kill-switch",
@@ -593,6 +652,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         preview: str,
         echo: str | None = None,
         gate_breadcrumb: str | None = None,
+        discovery_hint: str | None = None,
         profile_context: PermissionProfileContext | None = None,
     ) -> None:
         """Rebuild the matrix from a fresh `PermRow` list.
@@ -673,8 +733,22 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self._apply_filter()
 
         self.query_one("#mcp-perm-preview", Static).update(f"{echo}{preview}" if echo else preview)
-        legend_text = f"{_LEGEND_TEXT}\n{gate_breadcrumb}" if gate_breadcrumb else _LEGEND_TEXT
+        legend_text = _LEGEND_TEXT
+        for extra_line in (gate_breadcrumb, discovery_hint):
+            if extra_line:
+                legend_text = f"{legend_text}\n{extra_line}"
         self.query_one("#mcp-perm-legend", Static).update(legend_text)
+
+    def set_profile_hint(self, text: str | None) -> None:
+        """Wave C (F8): render (or clear) the non-default-profile hint line
+        under the profile selector. `None`/empty hides the Static entirely
+        so the default profile renders no caveat."""
+        hint = self.query_one("#mcp-perm-profile-hint", Static)
+        if text:
+            hint.update(text)
+            hint.display = True
+        else:
+            hint.display = False
 
     def update_tool_policy_profiles(
         self,

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -53,7 +53,7 @@ _TOOL_ROW_INDENT = "  "
 # through `update_matrix()`.
 _LEGEND_TEXT = (
     "• override · ⚠ definition changed · ⚑ high-risk floor · "
-    "Space cycles Inherit → Allow → Ask → Off"
+    "Space cycles Inherit → Ask → Allow → Off"
 )
 
 # T8: exact copy pinned by the server-source governance section below --

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -53,7 +53,8 @@ _TOOL_ROW_INDENT = "  "
 # through `update_matrix()`.
 _LEGEND_TEXT = (
     "• override · ⚠ definition changed · ⚑ high-risk floor · "
-    "Space cycles Inherit → Ask → Allow → Off"
+    "Space cycles Inherit → Ask → Allow → Off · shift+space bulk set · "
+    "C clears overrides (visible rows only)"
 )
 
 # T8: exact copy pinned by the server-source governance section below --
@@ -471,6 +472,8 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
 
     BINDINGS = [
         Binding("space", "cycle_state", "Cycle permission", show=False),
+        Binding("shift+space", "bulk_set", "Bulk set", show=False),
+        Binding("C", "bulk_clear", "Clear overrides", show=False),
     ]
 
     class StateCycleRequested(Message, namespace="mcp_permissions_mode"):
@@ -506,6 +509,43 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         def __init__(self, profile_id: str) -> None:
             super().__init__()
             self.profile_id = profile_id
+
+    class BulkStateRequested(Message, namespace="mcp_permissions_mode"):
+        """ADR-149 Wave F: `shift+space` on the matrix -- apply the cursor
+        row's next cycled state to the server's VISIBLE tool rows. The
+        canvas (which alone knows visibility) computed the scope and the
+        state; the workbench remains the single writer and executes this
+        as N ordinary profile-scoped `set_tool_state` calls."""
+
+        def __init__(
+            self,
+            server_key: str,
+            tool_names: tuple[str, ...],
+            new_state: str,
+            profile_context: PermissionProfileContext | None = None,
+        ) -> None:
+            super().__init__()
+            self.server_key = server_key
+            self.tool_names = tool_names
+            self.new_state = new_state
+            self.profile_context = profile_context
+
+    class BulkClearRequested(Message, namespace="mcp_permissions_mode"):
+        """ADR-149 Wave F: `C` on the matrix -- clear the server's VISIBLE
+        tool overrides (back to Inherit). Only rows that currently hold an
+        override are sent; the full-clear recipe is to clear the filter
+        first (the filter is the bulk's scope selector)."""
+
+        def __init__(
+            self,
+            server_key: str,
+            tool_names: tuple[str, ...],
+            profile_context: PermissionProfileContext | None = None,
+        ) -> None:
+            super().__init__()
+            self.server_key = server_key
+            self.tool_names = tool_names
+            self.profile_context = profile_context
 
     class KillSwitchToggled(Message, namespace="mcp_permissions_mode"):
         """Posted once per press of `#mcp-perm-kill-switch` (a Library-style
@@ -583,6 +623,11 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self._kill_switch: bool = False
         self._profile_context: PermissionProfileContext | None = None
         self._profile_select_sync = False
+        # ADR-149 Wave F: the extra hint lines currently rendered under the
+        # fixed legend (gate breadcrumb / discovery hint from the last
+        # update_matrix) -- flash_hint() appends to these until the next
+        # update_matrix rebuilds them.
+        self._legend_extras: list[str] = []
 
     def compose(self) -> ComposeResult:
         yield Static(
@@ -733,11 +778,10 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self._apply_filter()
 
         self.query_one("#mcp-perm-preview", Static).update(f"{echo}{preview}" if echo else preview)
-        legend_text = _LEGEND_TEXT
-        for extra_line in (gate_breadcrumb, discovery_hint):
-            if extra_line:
-                legend_text = f"{legend_text}\n{extra_line}"
-        self.query_one("#mcp-perm-legend", Static).update(legend_text)
+        self._legend_extras = [
+            line for line in (gate_breadcrumb, discovery_hint) if line
+        ]
+        self._render_legend()
 
     def set_profile_hint(self, text: str | None) -> None:
         """Wave C (F8): render (or clear) the non-default-profile hint line
@@ -1034,6 +1078,95 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
                 table.move_cursor(row=index)
                 return True
         return False
+
+    def _render_legend(self) -> None:
+        """Render the fixed legend plus whatever extra hint lines are
+        current (`_legend_extras`, Wave F)."""
+        text = _LEGEND_TEXT
+        for line in self._legend_extras:
+            text = f"{text}\n{line}"
+        self.query_one("#mcp-perm-legend", Static).update(text)
+
+    def flash_hint(self, text: str) -> None:
+        """ADR-149 Wave F: one transient hint line under the legend (the
+        spec's 'existing hint Static' -- not a toast). Lives until the
+        next `update_matrix` rebuilds `_legend_extras`, the same
+        next-ordinary-render-clears contract the mutation echo uses."""
+        self._legend_extras = [line for line in self._legend_extras if line] + [text]
+        self._render_legend()
+
+    def _visible_tool_rows_for(self, server_key: str) -> list[PermRow]:
+        """The server's VISIBLE (post-filter) tool rows, matrix order."""
+        return [
+            row
+            for row in self._visible_rows
+            if row.kind == "tool" and row.server_key == server_key
+        ]
+
+    def _bulk_scope(
+        self, *, overrides_only: bool
+    ) -> tuple[PermRow, tuple[str, ...]] | None:
+        """Resolve the bulk gesture's cursor row and visible scope.
+
+        Returns None (after flashing the hint) for the two no-op cases the
+        spec names: the pinned global row (owns no server) and a server
+        with zero matching visible tool rows.
+        """
+        table = self.query_one("#mcp-perm-table", DataTable)
+        if table.row_count == 0 or table.cursor_row < 0:
+            return None
+        try:
+            row_key, _ = table.coordinate_to_cell_key((table.cursor_row, 0))
+        except Exception:
+            return None
+        if row_key is None or row_key.value is None:
+            return None
+        row = self._rows_by_key.get(str(row_key.value))
+        if row is None:
+            return None
+        hint = "Bulk actions need a server's tool rows — move to one of its rows."
+        if row.kind == "global":
+            self.flash_hint(hint)
+            return None
+        tool_rows = self._visible_tool_rows_for(row.server_key)
+        if overrides_only:
+            tool_rows = [r for r in tool_rows if r.cycle_current is not None]
+        if not tool_rows:
+            self.flash_hint(hint)
+            return None
+        return row, tuple(r.tool_name or "" for r in tool_rows)
+
+    def action_bulk_set(self) -> None:
+        """ADR-149 Wave F: `shift+space` -- the cursor row's next cycled
+        state (the SAME cycle_ui_state a plain press computes, so Wave B's
+        safety ordering carries over: the first press from Inherit applies
+        Ask, never Allow) for the server's visible tool rows."""
+        scope = self._bulk_scope(overrides_only=False)
+        if scope is None:
+            return
+        row, tool_names = scope
+        new_state = cycle_ui_state(row.cycle_current)
+        if new_state is None:
+            # Server/tool rungs cycle None -> a state; the global row (the
+            # only rung whose cycle never yields None) is excluded above.
+            new_state = cycle_ui_state(None)
+        self.post_message(
+            self.BulkStateRequested(
+                row.server_key, tool_names, new_state, self._profile_context
+            )
+        )
+
+    def action_bulk_clear(self) -> None:
+        """ADR-149 Wave F: `C` -- clear the server's VISIBLE overrides."""
+        scope = self._bulk_scope(overrides_only=True)
+        if scope is None:
+            return
+        row, tool_names = scope
+        self.post_message(
+            self.BulkClearRequested(
+                row.server_key, tool_names, self._profile_context
+            )
+        )
 
     def action_cycle_state(self) -> None:
         """Cycle the matrix's CURSOR row one Space-press (T2's cycle rules).

--- a/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_permissions_mode.py
@@ -511,7 +511,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
             self.profile_id = profile_id
 
     class BulkStateRequested(Message, namespace="mcp_permissions_mode"):
-        """ADR-149 Wave F: `shift+space` on the matrix -- apply the cursor
+        """ADR-150 Wave F: `shift+space` on the matrix -- apply the cursor
         row's next cycled state to the server's VISIBLE tool rows. The
         canvas (which alone knows visibility) computed the scope and the
         state; the workbench remains the single writer and executes this
@@ -531,7 +531,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
             self.profile_context = profile_context
 
     class BulkClearRequested(Message, namespace="mcp_permissions_mode"):
-        """ADR-149 Wave F: `C` on the matrix -- clear the server's VISIBLE
+        """ADR-150 Wave F: `C` on the matrix -- clear the server's VISIBLE
         tool overrides (back to Inherit). Only rows that currently hold an
         override are sent; the full-clear recipe is to clear the filter
         first (the filter is the bulk's scope selector)."""
@@ -623,7 +623,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self._kill_switch: bool = False
         self._profile_context: PermissionProfileContext | None = None
         self._profile_select_sync = False
-        # ADR-149 Wave F: the extra hint lines currently rendered under the
+        # ADR-150 Wave F: the extra hint lines currently rendered under the
         # fixed legend (gate breadcrumb / discovery hint from the last
         # update_matrix) -- flash_hint() appends to these until the next
         # update_matrix rebuilds them.
@@ -1088,7 +1088,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         self.query_one("#mcp-perm-legend", Static).update(text)
 
     def flash_hint(self, text: str) -> None:
-        """ADR-149 Wave F: one transient hint line under the legend (the
+        """ADR-150 Wave F: one transient hint line under the legend (the
         spec's 'existing hint Static' -- not a toast). Lives until the
         next `update_matrix` rebuilds `_legend_extras`, the same
         next-ordinary-render-clears contract the mutation echo uses."""
@@ -1137,7 +1137,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         return row, tuple(r.tool_name or "" for r in tool_rows)
 
     def action_bulk_set(self) -> None:
-        """ADR-149 Wave F: `shift+space` -- the cursor row's next cycled
+        """ADR-150 Wave F: `shift+space` -- the cursor row's next cycled
         state (the SAME cycle_ui_state a plain press computes, so Wave B's
         safety ordering carries over: the first press from Inherit applies
         Ask, never Allow) for the server's visible tool rows."""
@@ -1157,7 +1157,7 @@ class MCPPermissionsMode(DataTableClickSelectMixin, Vertical):
         )
 
     def action_bulk_clear(self) -> None:
-        """ADR-149 Wave F: `C` -- clear the server's VISIBLE overrides."""
+        """ADR-150 Wave F: `C` -- clear the server's VISIBLE overrides."""
         scope = self._bulk_scope(overrides_only=True)
         if scope is None:
             return

--- a/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_profile_form.py
@@ -43,12 +43,24 @@ class MCPProfileForm(Vertical):
         on FAILED saves -- a successful save unmounts the whole form
         (`hide_form()`) sub-second, so the host must re-surface the warning
         as a toast alongside its own success notify for the user to ever
-        see it."""
+        see it.
 
-        def __init__(self, payload: dict[str, Any], warning: str | None = None) -> None:
+        Wave C (F7a): `connect_after=True` is the "Save and connect"
+        button's request -- the host saves and then dispatches the connect
+        lifecycle for the saved profile.
+        """
+
+        def __init__(
+            self,
+            payload: dict[str, Any],
+            warning: str | None = None,
+            *,
+            connect_after: bool = False,
+        ) -> None:
             super().__init__()
             self.payload = payload
             self.warning = warning
+            self.connect_after = connect_after
 
     class Cancelled(Message, namespace="mcp_profile_form"):
         pass
@@ -123,9 +135,20 @@ class MCPProfileForm(Vertical):
             yield Button(
                 "Save",
                 id="mcp-form-save",
-                classes="console-action-primary",
+                classes="console-action-secondary",
                 compact=True,
                 tooltip="Validate and save this profile.",
+            )
+            # Wave C (F7a): the primary action for a brand-new server is
+            # USING it -- save + connect in one press, so the
+            # saved->connected journey is not a row hunt followed by an
+            # inspector hunt.
+            yield Button(
+                "Save and connect",
+                id="mcp-form-save-connect",
+                classes="console-action-primary",
+                compact=True,
+                tooltip="Save this profile, then connect and discover its tools.",
             )
             yield Button(
                 "Cancel",
@@ -180,12 +203,13 @@ class MCPProfileForm(Vertical):
         self._refresh_save_enabled()
 
     def _refresh_save_enabled(self) -> None:
-        """A4: Save is enabled only once both required fields are filled in
-        (edit mode's disabled-but-prefilled id Input still counts -- this
-        checks `.value`, not `.disabled`) and no submit posted by this form
-        is still awaiting the host's outcome. Called after compose (here, via
-        `on_mount`), on every required-field change, and from `show_error()`
-        so a failed save only re-arms Save when the fields are still valid.
+        """A4: Save and Save-and-connect are enabled only once both
+        required fields are filled in (edit mode's disabled-but-prefilled
+        id Input still counts -- this checks `.value`, not `.disabled`) and
+        no submit posted by this form is still awaiting the host's outcome.
+        Called after compose (here, via `on_mount`), on every required-field
+        change, and from `show_error()` so a failed save only re-arms the
+        buttons when the fields are still valid.
 
         Review fix: the two disable-reasons (missing fields vs. a submit
         already in flight) get DISTINCT tooltips -- collapsing them into one
@@ -194,20 +218,29 @@ class MCPProfileForm(Vertical):
         while both fields were still filled in, which is simply false.
         """
         try:
-            save_button = self.query_one("#mcp-form-save", Button)
             has_id = bool(self.query_one("#mcp-form-id", Input).value.strip())
-            has_command = bool(self.query_one("#mcp-form-command", Input).value.strip())
+            has_command = bool(
+                self.query_one("#mcp-form-command", Input).value.strip()
+            )
         except Exception:
             return
         fields_valid = has_id and has_command
         enabled = fields_valid and not self._submit_in_flight
-        save_button.disabled = not enabled
+        save_button = self.query_one("#mcp-form-save", Button)
+        save_connect_button = self.query_one("#mcp-form-save-connect", Button)
+        for button in (save_button, save_connect_button):
+            button.disabled = not enabled
         if enabled:
             save_button.tooltip = "Validate and save this profile."
+            save_connect_button.tooltip = (
+                "Save this profile, then connect and discover its tools."
+            )
         elif not fields_valid:
             save_button.tooltip = "Enter a profile id and command first."
+            save_connect_button.tooltip = "Enter a profile id and command first."
         else:
             save_button.tooltip = "Save already in progress."
+            save_connect_button.tooltip = "Save already in progress."
 
     def build_payload(self) -> dict[str, Any]:
         """Parse the form into the store's exact save-payload keys.
@@ -294,7 +327,7 @@ class MCPProfileForm(Vertical):
         return ""
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
-        if event.button.id == "mcp-form-save":
+        if event.button.id in ("mcp-form-save", "mcp-form-save-connect"):
             event.stop()
             try:
                 payload = self.build_payload()
@@ -318,7 +351,13 @@ class MCPProfileForm(Vertical):
             # so the in-flight flag (not just the button) reflects reality.
             self._submit_in_flight = True
             self._refresh_save_enabled()
-            self.post_message(self.SubmitRequested(payload, warning or None))
+            self.post_message(
+                self.SubmitRequested(
+                    payload,
+                    warning or None,
+                    connect_after=event.button.id == "mcp-form-save-connect",
+                )
+            )
         elif event.button.id == "mcp-form-cancel":
             event.stop()
             self.post_message(self.Cancelled())

--- a/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
@@ -271,6 +271,7 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         scope_value: str,
         scope_ref_options: list[tuple[str, str]],
         scope_ref_value: str | None,
+        agent_snapshot: ReadinessSnapshot | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
@@ -281,6 +282,10 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         self.scope_value = scope_value
         self.scope_ref_options = scope_ref_options
         self.scope_ref_value = scope_ref_value
+        # ADR-148 Wave D: the in-process agent tool catalog's rail row --
+        # rendered as its own section AFTER the server rows, never inside
+        # `snapshots` (the servers overview/callouts stay server-only).
+        self.agent_snapshot = agent_snapshot
         self._row_keys: list[str | None] = []
         # The value each scope/scope-ref Select was actually constructed
         # with on the most recent compose() (post-clamp — see compose()'s
@@ -326,6 +331,7 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         scope_value: str,
         scope_ref_options: list[tuple[str, str]],
         scope_ref_value: str | None,
+        agent_snapshot: ReadinessSnapshot | None = None,
     ) -> None:
         self.source = source
         self.snapshots = snapshots
@@ -334,6 +340,7 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         self.scope_value = scope_value
         self.scope_ref_options = scope_ref_options
         self.scope_ref_value = scope_ref_value
+        self.agent_snapshot = agent_snapshot
         self.refresh(recompose=True)
 
     def compose(self) -> ComposeResult:
@@ -379,9 +386,14 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
             if layout_width <= 0
             else max(8, min(_MAX_ROW_LABEL, layout_width - _ROW_CHROME))
         )
-        if self.snapshots:
+        legend_snaps = list(self.snapshots)
+        if self.agent_snapshot is not None:
+            legend_snaps.append(self.agent_snapshot)
+        if legend_snaps:
             yield Static(
-                _present_states_legend(self.snapshots, short=budget < _LEGEND_SHORT_BUDGET),
+                _present_states_legend(
+                    legend_snaps, short=budget < _LEGEND_SHORT_BUDGET
+                ),
                 id="mcp-rail-state-legend",
                 markup=False,
             )
@@ -447,6 +459,32 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
             row.tooltip = escape_markup(snap.message or snap.label)
             row.set_class(snap.server_key == self.selected_server_key, "is-active")
             yield row
+        # ADR-148 Wave D: the in-process agent tool catalog gets its own
+        # rail section -- one row, keyed by the store identity
+        # permission_store.BUILTIN_TOOL_SERVER_KEY ("agent:builtin"), so
+        # no rail row ever shares a server_key with the built-in server.
+        if self.agent_snapshot is not None:
+            yield Static(
+                "Agent tools", classes="destination-section mcp-rail-heading"
+            )
+            self._row_keys.append(self.agent_snapshot.server_key)
+            agent_row = Button(
+                _row_label(self.agent_snapshot, pad_width),
+                id=f"{MCP_RAIL_ROW_PREFIX}{len(self._row_keys) - 1}",
+                classes=(
+                    "mcp-rail-row console-action-subdued "
+                    f"{STATE_CSS_CLASSES[self.agent_snapshot.state]}"
+                ),
+                compact=True,
+            )
+            agent_row.tooltip = escape_markup(
+                self.agent_snapshot.message or self.agent_snapshot.label
+            )
+            agent_row.set_class(
+                self.agent_snapshot.server_key == self.selected_server_key,
+                "is-active",
+            )
+            yield agent_row
         if self.source == "server":
             with Vertical(id="mcp-rail-scope"):
                 yield Label("Scope", classes="form-label")

--- a/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
@@ -56,8 +56,30 @@ _ROW_CHROME = 8
 # row.
 _ALL_SERVERS_GUTTER = "  "
 
+# Wave A (F15): abbreviated state words for the in-rail legend at narrow
+# widths -- keyed by STATE_LABELS' values lowercased, and completeness-
+# pinned by test (a new ReadinessState must add a short form or the
+# abbreviated legend silently drops it). "no tools" collapses to the bare
+# glyph (∅) because that glyph IS the word.
+# `_LEGEND_SHORT_BUDGET` (F15): the row-label budget below which the
+# legend switches to the short words -- chosen so the two-entry fresh-
+# install legend ("◦ off · ⌂ built-in") fits a ~24-col compact rail on
+# one line; wide rails keep the full words.
+_LEGEND_SHORT_BUDGET = 32
+_SHORT_STATE_LABELS: dict[str, str] = {
+    "ready": "ready",
+    "checking": "checking",
+    "needs setup": "setup",
+    "needs attention": "attention",
+    "no tools": "∅",
+    "stale": "stale",
+    "off (opt-in)": "off",
+}
 
-def _present_states_legend(snapshots: list[ReadinessSnapshot]) -> str:
+
+def _present_states_legend(
+    snapshots: list[ReadinessSnapshot], *, short: bool = False
+) -> str:
     """Compact glyph legend for the states currently present in the rail.
 
     task-2243: rail rows show glyph+name only, and decoding them required
@@ -74,13 +96,20 @@ def _present_states_legend(snapshots: list[ReadinessSnapshot]) -> str:
     STATE_GLYPHS order) so the line can never drift from the rows it
     decodes; the ⌂ built-in marker is explained whenever a built-in row
     is present (same copy the Servers-mode legend uses).
+
+    Wave A (F15): `short=True` swaps in `_SHORT_STATE_LABELS` -- at narrow
+    rail budgets the long forms wrapped the legend onto 2-3 rows, which
+    is worse than an abbreviated word the glyph disambiguates anyway.
     """
     present = {snap.state for snap in snapshots}
-    parts = [
-        f"{glyph} {STATE_LABELS[state].lower()}"
-        for state, glyph in STATE_GLYPHS.items()
-        if state in present
-    ]
+    parts = []
+    for state, glyph in STATE_GLYPHS.items():
+        if state not in present:
+            continue
+        word = STATE_LABELS[state].lower()
+        if short:
+            word = _SHORT_STATE_LABELS.get(word, word)
+        parts.append(f"{glyph} {word}")
     if any(snap.source == "builtin" for snap in snapshots):
         parts.append("⌂ built-in")
     return " · ".join(parts)
@@ -340,10 +369,19 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         # canvas Servers-mode legend -- present states only, so the line
         # stays short (a fresh install reads "◦ off (opt-in) · ⌂ built-in").
         # Nothing to decode at zero servers: the F-060 empty state below
-        # stands alone.
+        # stands alone. Wave A (F15): at narrow width budgets the legend
+        # abbreviates (`short=True`) so it stays one line instead of
+        # wrapping to 2-3 rows. The budget is computed HERE (before the
+        # rows below reuse it) -- the same F-057 formula the rows use.
+        layout_width = self.region.width
+        budget = (
+            _MAX_ROW_LABEL
+            if layout_width <= 0
+            else max(8, min(_MAX_ROW_LABEL, layout_width - _ROW_CHROME))
+        )
         if self.snapshots:
             yield Static(
-                _present_states_legend(self.snapshots),
+                _present_states_legend(self.snapshots, short=budget < _LEGEND_SHORT_BUDGET),
                 id="mcp-rail-state-legend",
                 markup=False,
             )
@@ -380,13 +418,9 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         # width minus `_ROW_CHROME`, so rows truncate with an ellipsis that
         # FITS the row instead of being cropped mid-word. Width 0 (first
         # compose, pre-layout) falls back to `_MAX_ROW_LABEL`; `on_resize`
-        # recomposes once the real width is known.
-        layout_width = self.region.width
-        budget = (
-            _MAX_ROW_LABEL
-            if layout_width <= 0
-            else max(8, min(_MAX_ROW_LABEL, layout_width - _ROW_CHROME))
-        )
+        # recomposes once the real width is known. The budget itself was
+        # already computed above the legend yield (F15) -- reused, not
+        # recomputed.
         self._row_budget = budget
         pad_width = max(
             (

--- a/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_rail.py
@@ -6,6 +6,7 @@ from typing import Any
 
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
+from textual.binding import Binding
 from textual.containers import Vertical
 from textual.message import Message
 from textual.widgets import Button, Label, Select, Static
@@ -201,6 +202,15 @@ def _row_label(
 class MCPRail(RecomposeCaptureGuard, Vertical):
     """Left rail for the MCP workbench. Index-based row ids; keys in a list.
 
+    F2 (2026-09-11 UX review): arrow keys (and j/k aliases) move the
+    selection through the rows while focus is inside the rail -- the same
+    ServerSelected path a row click takes, mirroring table-cursor
+    semantics. Clamped at both ends (no wrap); focus follows the newly
+    selected row so consecutive presses keep working without re-focusing.
+    The Source/Scope Selects consume their own arrows while focused, which
+    is the correct split: widget focus wins, rail navigation is the
+    fallback for the rail itself and its rows.
+
     ``sync_state()`` (below) drives ``self.refresh(recompose=True)`` on every
     resync; ``RecomposeCaptureGuard`` (task-637) keeps a stale mouse capture
     from leaking app-wide when that recompose tears down a row/Select the
@@ -208,6 +218,13 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
     ``BaseAppScreen`` fix, one level down: the rail isn't a screen, so it
     never inherited that guard).
     """
+
+    BINDINGS = [
+        Binding("up", "move_selection(-1)", show=False),
+        Binding("down", "move_selection(1)", show=False),
+        Binding("k", "move_selection(-1)", show=False),
+        Binding("j", "move_selection(1)", show=False),
+    ]
 
     BUNDLED_CSS = """
     MCPRail {
@@ -307,6 +324,10 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         # fixed budget never pay a recompose (or the mount-echo/render
         # churn that comes with it) for a resize that changes nothing.
         self._row_budget: int = _MAX_ROW_LABEL
+        # F2: set by sync_state when the rail owned focus; consumed by the
+        # compose it triggers, which schedules the actual refocus onto the
+        # selected row (children freshly built at that point).
+        self._refocus_after_recompose: bool = False
 
     def on_resize(self) -> None:
         """F-057: re-truncate row labels when the width-derived budget
@@ -341,7 +362,32 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
         self.scope_ref_options = scope_ref_options
         self.scope_ref_value = scope_ref_value
         self.agent_snapshot = agent_snapshot
+        # F2: the recompose below remounts every row, destroying whichever
+        # row held focus -- without restoring it, arrow navigation (and any
+        # keyboard use of the rail) dies after the first selection because
+        # focus falls outside the rail. Restore onto the SELECTED row, and
+        # only when the rail owned focus in the first place (never steal it
+        # from the canvas the user is typing in).
+        focused = None
+        try:
+            focused = self.screen.focused if self.is_mounted else None
+        except Exception:
+            focused = None
+        if focused is not None and self in focused.ancestors_with_self:
+            # F2: schedule the focus restoration for the compose that this
+            # recompose is about to run -- restoring from sync_state itself
+            # races (the callback can land against the pre-recompose
+            # children, whose destruction drops focus again). Compose-time
+            # scheduling runs with the new children already built.
+            self._refocus_after_recompose = True
         self.refresh(recompose=True)
+
+    def _focus_selected_row(self) -> None:
+        try:
+            index = self._row_keys.index(self.selected_server_key)
+        except ValueError:
+            index = 0
+        self._focus_row_index(index)
 
     def compose(self) -> ComposeResult:
         yield Static("Source", classes="destination-section mcp-rail-heading")
@@ -555,6 +601,12 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
                         "select stays disabled until one exists."
                     )
                 yield scope_ref_select
+        # F2: compose is the one place the freshly built rows exist -- if
+        # the resync that triggered this recompose noted the rail owned
+        # focus, land it on the selected row now.
+        if self._refocus_after_recompose:
+            self._refocus_after_recompose = False
+            self.call_after_refresh(self._focus_selected_row)
         # (No scope selects render for non-server sources; the per-instance
         # echo tags only ever exist on the instances that have them, so the
         # handlers below need no rail-level state to consult or reset.)
@@ -618,3 +670,30 @@ class MCPRail(RecomposeCaptureGuard, Vertical):
             is_blank = event.value is Select.BLANK or event.value is Select.NULL
             ref = None if is_blank else str(event.value)
             self.post_message(self.ScopeChanged(self.scope_value, ref))
+
+    def action_move_selection(self, delta: int) -> None:
+        """F2: move the selection one row (clamped), posting the same
+        `ServerSelected` a row click posts, then focus the new row's
+        button after the resync-triggered recompose so the next press
+        lands without the user re-focusing."""
+        keys = self._row_keys
+        if not keys:
+            return
+        try:
+            index = keys.index(self.selected_server_key)
+        except ValueError:
+            # A selection that is not (or no longer) one of the rail's
+            # rows (e.g. a server-source record cleared by a source
+            # switch) -- arrows resume from the "All servers" end.
+            index = 0
+        new_index = max(0, min(len(keys) - 1, index + delta))
+        self.post_message(self.ServerSelected(keys[new_index]))
+        self.call_after_refresh(self._focus_row_index, new_index)
+
+    def _focus_row_index(self, index: int) -> None:
+        try:
+            self.query_one(
+                f"#{MCP_RAIL_ROW_PREFIX}{index}", Button
+            ).focus()
+        except Exception:
+            pass

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -1221,6 +1221,12 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
             if gate.key == LOCAL_TOOLS_MASTER_KEY
             else gate.tool_name
         )
+        # Wave A (F12): restart-class gates carry a per-checkbox marker so
+        # the restart rule is visible on the row itself, not only in the
+        # group note below -- an enabled-looking checkbox that silently
+        # does nothing until relaunch is the exact confusion this prevents.
+        if gate.restart_required:
+            label = f"{label} (⟳ restart)"
         return Checkbox(
             label,
             value=gate.enabled,

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -947,12 +947,20 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                 return
 
     def _detail_toolbar_widgets(self) -> list[Button]:
-        """Build the local-profile toolbar (Edit/Disconnect/Delete), or the
-        arm-then-confirm pair once Delete has been pressed.
+        """Build the local-profile toolbar (Edit/lifecycle/Disconnect/Delete),
+        or the arm-then-confirm pair once Delete has been pressed.
 
         Local-source snapshots only: built-in is edited via config.toml, and
         server-source profiles are mutated server-side (Advanced), so both
         render no toolbar at all here.
+
+        Wave C (F7b): the lifecycle verbs the inspector's readiness actions
+        carry also live here, on the surface the user is already looking at
+        -- Connect (primary) for a not-yet-connected profile, Refresh tools
+        for a connected one. Both post the SAME `HubActionRequested` the
+        inspector's buttons post, so there is exactly one execution path;
+        diagnostics (Check readiness) stay inspector-only to keep the
+        toolbar to at most four verbs.
         """
         snapshot = self._detail_snapshot
         if snapshot is None or snapshot.source != "local":
@@ -991,6 +999,25 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                     classes="console-action-secondary",
                     compact=True,
                     tooltip="Disconnect the running server.",
+                )
+            )
+            widgets.append(
+                Button(
+                    "Refresh tools",
+                    id="mcp-detail-refresh",
+                    classes="console-action-secondary",
+                    compact=True,
+                    tooltip="Reconnect and refresh the tool catalog.",
+                )
+            )
+        else:
+            widgets.append(
+                Button(
+                    "Connect",
+                    id="mcp-detail-connect",
+                    classes="console-action-primary",
+                    compact=True,
+                    tooltip="Connect and discover this server's tools.",
                 )
             )
         widgets.append(
@@ -1531,6 +1558,23 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
                 self.post_message(
                     MCPInspector.HubActionRequested(
                         HubAction.EDIT_CONFIG, self._detail_snapshot.server_key
+                    )
+                )
+            return
+        if button_id in ("mcp-detail-connect", "mcp-detail-refresh"):
+            # Wave C (F7b): same execution path as the inspector's readiness
+            # action buttons -- the workbench's HubActionRequested handler
+            # routes both through the typed lifecycle methods.
+            event.stop()
+            if self._detail_snapshot is not None:
+                action = (
+                    HubAction.CONNECT
+                    if button_id == "mcp-detail-connect"
+                    else HubAction.REFRESH_DISCOVERY
+                )
+                self.post_message(
+                    MCPInspector.HubActionRequested(
+                        action, self._detail_snapshot.server_key
                     )
                 )
             return

--- a/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_servers_mode.py
@@ -1264,12 +1264,13 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
         )
 
     def _tool_gate_widgets(self) -> list[Widget]:
-        """Build the `[tools]`/`[console]` gate Checkbox rows (task-3240).
+        """Build the `[tools]`/`[console]` gate Checkbox rows (task-3240;
+        moved to the AGENT detail by ADR-148 Wave D).
 
-        Builtin-source snapshots only, same gate as `_builtin_toggle_
-        widgets()` -- spec review finding 5 (branch (b)): `_collect_
-        snapshots()` never produces a `local:__local__` row, so this is the
-        only reachable place for ALL of them. Rendered under two
+        Agent-source snapshots only -- the in-process agent tool catalog
+        this pane fronts is what these gates register. The built-in
+        SERVER's detail keeps only the `[mcp]` controls (its `_detail_text`
+        points here). Rendered under two
         subheadings ("Agent built-ins" / "Local workspace, web, and Watchlists tools") so the
         accepted UX trade-off stays visible rather than papered over: this
         pane is badged as the built-in MCP SERVER, but these checkboxes
@@ -1281,7 +1282,7 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
         stale mapping.
         """
         snapshot = self._detail_snapshot
-        if snapshot is None or snapshot.source != "builtin":
+        if snapshot is None or snapshot.source != "agent":
             self._tool_gate_ids = {}
             return []
         gates = all_tool_gates()
@@ -1459,6 +1460,12 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
             lines.append(f"Resources · {_count_display(snapshot.resource_count)}")
             lines.append(f"Prompts · {_count_display(snapshot.prompt_count)}")
             lines.append("External server records: see Advanced ▸ External Servers.")
+        elif snapshot.source == "agent":
+            lines.append(
+                "Registers the in-process tools Console agents can see — it "
+                "does not grant permission; the Permissions matrix still "
+                "gates every call."
+            )
         else:  # builtin
             lines.append("Runs over stdio when an MCP client launches it:")
             lines.append("  python3 -m tldw_chatbook.MCP")
@@ -1466,6 +1473,9 @@ class MCPServersMode(DataTableClickSelectMixin, Vertical):
             # (a human-readable summary of the expose_* flags) is now the
             # four Checkbox rows built by `_builtin_toggle_widgets()` --
             # this body text no longer dumps flags at all, raw or humanized.
+            # ADR-148 Wave D: the agent tool gates moved to their own rail
+            # row's detail -- leave a pointer so nobody hunts for them here.
+            lines.append("Agent tool gates live under Agent tools in the rail.")
         return "\n".join(lines)
 
     def on_data_table_row_selected(self, event: DataTable.RowSelected) -> None:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_tools_mode.py
@@ -75,6 +75,22 @@ _EMPTY_ACTION_TOOLTIPS: dict[str, str] = {
 _ECHO_CONSUMED = object()
 
 
+# Wave A (F9): rendered-width cap for the Server column. DataTable clips
+# overflowing cell text silently -- a group label like "Local workspace,
+# web, and Watchlists" rendered as "Local workspace, web, and" with no
+# marker, which reads as a DIFFERENT label rather than a truncated one.
+# A fixed budget with an explicit ellipsis keeps the truncation honest;
+# the full label remains visible in the server-filter Select's options.
+_SERVER_CELL_BUDGET = 24
+
+
+def _ellipsize(text: str, budget: int) -> str:
+    """Truncate `text` to `budget` rendered columns with an explicit "…"."""
+    if len(text) <= budget:
+        return text
+    return f"{text[: budget - 1].rstrip()}…"
+
+
 class MCPToolsMode(DataTableClickSelectMixin, Vertical):
     """Canvas for the Tools mode: cross-server catalog, filters, empty state."""
 
@@ -525,8 +541,11 @@ class MCPToolsMode(DataTableClickSelectMixin, Vertical):
                 )
             else:
                 state_cell = state_text("—", "muted")
-            server_cell = (
-                f"{tool.server_label} (stale)" if tool.stale else tool.server_label
+            server_cell = _ellipsize(
+                f"{tool.server_label} (stale)"
+                if tool.stale
+                else tool.server_label,
+                _SERVER_CELL_BUDGET,
             )
             schema_cell = (
                 "form" if parse_schema(tool.input_schema) is not None else "raw"

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -599,9 +599,33 @@ class MCPWorkbench(Container):
         width: 7fr;
         min-width: 30;
     }
+    /* ADR-148 Wave E: the main row carries the old rail+canvas share of
+    the grid (8 of 11 units) so the wide layout is geometrically
+    unchanged, one nesting level deeper. */
+    #mcp-hub-main-row {
+        width: 8fr;
+        min-width: 0;
+        height: 100%;
+        min-height: 0;
+    }
+    /* ADR-148 Wave E: below 120 cols the grid STACKS -- main row on top,
+    the inspector as a bounded, internally scrolling band underneath (the
+    old squeezed third column broke words mid-token at ~20 cols; the
+    `layout:` override has in-repo precedent, e.g.
+    screen_feature_watchlists.tcss). */
+    #mcp-hub-grid.mcp-compact {
+        layout: vertical;
+    }
+    #mcp-hub-grid.mcp-compact #mcp-hub-main-row {
+        width: 100%;
+        height: 1fr;
+    }
     #mcp-hub-grid.mcp-compact #mcp-hub-inspector {
-        width: 2fr;
-        min-width: 20;
+        width: 100%;
+        height: auto;
+        max-height: 12;
+        min-height: 4;
+        overflow-y: auto;
     }
     """
 
@@ -848,24 +872,28 @@ class MCPWorkbench(Container):
 
     def compose(self) -> ComposeResult:
         with Horizontal(id="mcp-hub-grid", classes="destination-workbench"):
-            yield MCPRail(
-                source=self._source,
-                snapshots=[],
-                selected_server_key=None,
-                scope_options=[("Personal", "personal")],
-                scope_value=self._scope,
-                scope_ref_options=[],
-                scope_ref_value=self._scope_ref,
-                agent_snapshot=None,
-                id="mcp-hub-rail",
-                classes="destination-workbench-pane",
-            )
-            with ContentSwitcher(
-                initial="mcp-mode-canvas-servers",
-                id="mcp-hub-canvas",
-                classes="destination-workbench-pane",
-            ):
-                yield MCPServersMode(id="mcp-mode-canvas-servers")
+            # ADR-148 Wave E: rail+canvas live in one main row so the
+            # compact class can stack the inspector UNDER it as a band
+            # instead of squeezing three columns (all pane ids unchanged).
+            with Horizontal(id="mcp-hub-main-row"):
+                yield MCPRail(
+                    source=self._source,
+                    snapshots=[],
+                    selected_server_key=None,
+                    scope_options=[("Personal", "personal")],
+                    scope_value=self._scope,
+                    scope_ref_options=[],
+                    scope_ref_value=self._scope_ref,
+                    agent_snapshot=None,
+                    id="mcp-hub-rail",
+                    classes="destination-workbench-pane",
+                )
+                with ContentSwitcher(
+                    initial="mcp-mode-canvas-servers",
+                    id="mcp-hub-canvas",
+                    classes="destination-workbench-pane",
+                ):
+                    yield MCPServersMode(id="mcp-mode-canvas-servers")
                 # task-2901: Tools/Permissions/Audit (T5/T6/T7 canvases —
                 # every `MCP_HUB_MODES` entry is a real canvas) arrive
                 # hidden behind the ContentSwitcher and are NOT composed

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -976,7 +976,15 @@ class MCPWorkbench(Container):
             # to toggle yet; the post-mount call_after_refresh covers it.
             return
         width = self.size.width
-        grid.set_class(0 < width < _COMPACT_WIDTH, "mcp-compact")
+        compact = 0 < width < _COMPACT_WIDTH
+        grid.set_class(compact, "mcp-compact")
+        # ADR-148 Wave E: collapsing an open Advanced section is a band-
+        # friendliness nicety, never worth failing a resize over -- the
+        # inspector guards its own pre-compose window.
+        try:
+            self.query_one(MCPInspector).apply_compact_layout(compact)
+        except Exception:
+            pass
 
     def _start_initial_load(self) -> None:
         """Kick off the mount-time reload once the subtree is mounted."""

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -17,10 +17,10 @@ from loguru import logger
 from rich.markup import escape as escape_markup
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal
-from textual.css.query import QueryError
+from textual.css.query import NoMatches, QueryError
 from textual.message import Message
 from textual.reactive import reactive
-from textual.widgets import ContentSwitcher
+from textual.widgets import ContentSwitcher, DataTable
 from textual.worker import Worker
 
 from tldw_chatbook.Agents.builtin_tool_gate import (
@@ -3074,7 +3074,16 @@ class MCPWorkbench(Container):
                     severity="warning",
                 )
             else:
-                self.app.notify(_toast("Permission update failed."), severity="error")
+                # Wave A (F10): the typed service methods raise user-ready
+                # messages, so surface the first line instead of a bare
+                # generic sentence -- bounded so a verbose exception can't
+                # turn the toast into a stack dump. `_toast()` escapes the
+                # text (service messages embed store-derived ids).
+                reason = str(exc).strip().splitlines()[0][:140] if str(exc).strip() else type(exc).__name__
+                self.app.notify(
+                    _toast(f"Permission update failed: {reason}"),
+                    severity="error",
+                )
             return
         # Task 3 (MCP Hub Phase 6): the transient mutation echo -- pinned
         # copy shape `"{tool_name} → {ui_label} · "`, TOOL-row cycles only
@@ -3229,6 +3238,39 @@ class MCPWorkbench(Container):
                 group="mcp-tool-clear",
                 exclusive=True,
             )
+            # Wave A (F5a): entering Permissions mode moves the keyboard
+            # onto the matrix -- Space-cycling is the mode's primary
+            # gesture and the binding lives on the canvas, so focus left
+            # over from the previous mode (e.g. a mode chip, where Space
+            # ACTIVATES the chip) made the advertised key do something
+            # else entirely. `call_after_refresh` so the newly-shown canvas
+            # exists before the focus lands; focus already INSIDE the
+            # permissions canvas (the filter Input mid-typing) is respected.
+            if mode == "permissions":
+                self.call_after_refresh(self._focus_permissions_matrix)
+
+    def _focus_permissions_matrix(self) -> None:
+        """F5a: focus `#mcp-perm-table` unless the permissions canvas
+        already owns focus (the filter Input is the one place inside the
+        canvas where the keyboard should stay put)."""
+        try:
+            canvas = self.query_one(MCPPermissionsMode)
+        except NoMatches:
+            return
+        try:
+            focused = self.screen.focused if self.is_mounted else None
+        except Exception:
+            focused = None
+        if focused is not None:
+            try:
+                if canvas in focused.ancestors_with_self:
+                    return
+            except Exception:
+                pass
+        try:
+            canvas.query_one("#mcp-perm-table", DataTable).focus()
+        except NoMatches:
+            pass
 
     async def _clear_tool_view(self) -> None:
         await self.query_one(MCPInspector).show_tool(None)
@@ -4350,6 +4392,17 @@ class MCPWorkbench(Container):
         """
         inspector = self.query_one(MCPInspector)
         status = await inspector.open_test_panel()
+        if status == "no_tool" and self._active_mode == "tools":
+            # Wave A (O5): IN TOOLS MODE the user may have ARROWED onto a
+            # row without selecting it into the inspector -- the visible
+            # cursor row is their evident intent, so drive the same tool
+            # view a selection would and retry before falling back to the
+            # hint. Gated on the active mode: in any OTHER mode the Tools
+            # table's cursor row is not on screen and "resolving" it would
+            # be the same mode hijack F-055 removed (a key advertised in
+            # every mode must not teleport the user based on state they
+            # cannot see).
+            status = await self._open_test_for_tools_cursor_row(inspector)
         if status == "no_tool":
             self.app.notify("Select a tool in Tools mode first.", severity="warning")
             return
@@ -4369,6 +4422,43 @@ class MCPWorkbench(Container):
             )
             return
         self.set_mode("tools")
+
+    async def _open_test_for_tools_cursor_row(self, inspector: MCPInspector) -> str:
+        """Wave A (O5): resolve the Tools table's CURSOR row (arrowed onto,
+        not Enter-selected) into the inspector's tool view and retry the
+        Test Tool open through the exact same path a row selection takes
+        (`on_mcp_tools_mode_tool_selected`'s show_tool call).
+
+        Returns `open_test_panel()`'s status after the retry, or
+        `"no_tool"` when there is no cursor row to resolve (empty table,
+        unmounted canvas, tool dropped from the catalog, or no validated
+        profile context) -- the caller then falls back to its hint.
+        """
+        try:
+            canvas = self.query_one(MCPToolsMode)
+            table = canvas.query_one("#mcp-tools-table", DataTable)
+        except NoMatches:
+            return "no_tool"
+        if table.row_count == 0 or table.cursor_row < 0:
+            return "no_tool"
+        try:
+            row_key, _ = table.coordinate_to_cell_key((table.cursor_row, 0))
+        except Exception:
+            return "no_tool"
+        if row_key is None or row_key.value is None:
+            return "no_tool"
+        tool = self._tool_for_row_key(str(row_key.value))
+        if tool is None:
+            return "no_tool"
+        context = self._validate_profile_context(self._tool_policy_profile_context)
+        if context is None:
+            return "no_tool"
+        await inspector.show_tool(
+            tool,
+            effective=self._effective_for_display(tool),
+            profile_context=context,
+        )
+        return await inspector.open_test_panel()
 
     def _tool_profile_lifecycle_authority(self) -> object | None:
         """Resolve the shared lifecycle after deferred app composition."""

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -3236,6 +3236,154 @@ class MCPWorkbench(Container):
         async with self._sync_children_lock:
             await self._sync_permissions_mode(echo=echo)
 
+    def on_mcp_permissions_mode_bulk_state_requested(
+        self, event: MCPPermissionsMode.BulkStateRequested
+    ) -> None:
+        """ADR-149 Wave F: dispatch one bulk-set (shift+space) in the
+        background -- the canvas computed the visible scope and the next
+        state; this executes it as N ordinary single writes."""
+        event.stop()
+        self.run_worker(
+            self._apply_bulk_tool_states(
+                event.server_key,
+                list(event.tool_names),
+                event.new_state,
+                event.profile_context,
+            ),
+            group="mcp-perm-bulk",
+            exclusive=True,
+        )
+
+    def on_mcp_permissions_mode_bulk_clear_requested(
+        self, event: MCPPermissionsMode.BulkClearRequested
+    ) -> None:
+        """ADR-149 Wave F: dispatch one bulk-clear (C) -- same worker path
+        with a None state; the canvas sent only rows that hold an
+        override."""
+        event.stop()
+        self.run_worker(
+            self._apply_bulk_tool_states(
+                event.server_key,
+                list(event.tool_names),
+                None,
+                event.profile_context,
+            ),
+            group="mcp-perm-bulk",
+            exclusive=True,
+        )
+
+    async def _apply_bulk_tool_states(
+        self,
+        server_key: str,
+        tool_names: list[str],
+        new_state: str | None,
+        context: PermissionProfileContext | None,
+    ) -> None:
+        """ADR-149 Wave F: apply one state (None = clear) to a server's
+        tool rows as N ordinary, individually profile-scoped
+        `set_tool_state` calls -- no batch store API (ADR-149), per-row
+        audit logging unchanged. Raw-shell rows are skipped (their
+        two-state projection makes a generic write a lie) and the skip is
+        named in the echo. First failure stops the batch with the
+        service's own reason; each write is independent and idempotent,
+        so a partial batch stands."""
+        context = self._validate_profile_context(context)
+        if context is None:
+            return
+        service = self._service()
+        if service is None or not tool_names:
+            return
+        label = ""
+        written = 0
+        skipped_raw_shell = 0
+        try:
+            for tool_name in tool_names:
+                if _is_raw_shell_tool(server_key, tool_name):
+                    skipped_raw_shell += 1
+                    continue
+                tool = self._tool_for(server_key, tool_name)
+                if (
+                    new_state == "allow"
+                    and tool is None
+                    and server_key not in HASH_FREE_SERVER_KEYS
+                ):
+                    # Same vanished-tool guard a single press hits -- count
+                    # it as skipped rather than aborting the batch.
+                    skipped_raw_shell += 1
+                    continue
+                if not label:
+                    label = next(
+                        (
+                            tool.server_label
+                            for tool in self._last_hub_tools
+                            if tool.server_key == server_key
+                        ),
+                        server_key,
+                    )
+                # Per-write context: each write changes the profile digest,
+                # so the NEXT write must carry a freshly captured one (the
+                # single-press path never hits this -- it writes once and
+                # re-captures only for the re-render). Re-deriving from the
+                # inventory reads the store once per row -- bounded by the
+                # visible row count. Selection moved mid-batch -> the same
+                # stale toast a single press gives, partial writes stand.
+                _, _, write_context = self._tool_policy_inventory()
+                if (
+                    write_context is None
+                    or write_context.profile_id != context.profile_id
+                    or write_context.selector_generation
+                    != context.selector_generation
+                ):
+                    self.app.notify(
+                        _toast(
+                            "Tool policy profile changed. Refresh and try again."
+                        ),
+                        severity="warning",
+                    )
+                    return
+                self._call_profile_scoped(
+                    service.set_tool_state,
+                    server_key,
+                    tool_name,
+                    new_state,
+                    context=write_context,
+                    tool=tool,
+                )
+                written += 1
+        except Exception as exc:
+            logger.warning(
+                "{}",
+                _safe_diagnostic_message("MCP bulk permission update failed", exc),
+            )
+            if _is_stale_profile_error(exc):
+                self.app.notify(
+                    _toast("Tool policy profile changed. Refresh and try again."),
+                    severity="warning",
+                )
+            else:
+                reason = (
+                    str(exc).strip().splitlines()[0][:140]
+                    if str(exc).strip()
+                    else type(exc).__name__
+                )
+                self.app.notify(
+                    _toast(f"Permission update failed: {reason}"),
+                    severity="error",
+                )
+            return
+        echo_parts = []
+        if new_state is None:
+            echo_parts.append(f"{label}: {written} visible overrides cleared")
+        else:
+            echo_parts.append(
+                f"{label}: {written} tools → {_cycled_ui_label(new_state)}"
+            )
+        if skipped_raw_shell:
+            echo_parts.append(f"{skipped_raw_shell} skipped (raw shell)")
+        echo = " · ".join(echo_parts) + " · "
+        async with self._sync_children_lock:
+            await self._sync_permissions_mode(echo=echo)
+
     async def _show_selected_detail(
         self, canvas: MCPServersMode, selected: ReadinessSnapshot | None
     ) -> None:

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -24,6 +24,9 @@ from textual.widgets import ContentSwitcher, DataTable
 from textual.worker import Worker
 
 from tldw_chatbook.Agents.builtin_tool_gate import (
+    LOCAL_TOOLS_MASTER_KEY,
+)
+from tldw_chatbook.Agents.builtin_tool_gate import (
     BuiltinPermRow,
     LOCAL_TOOLS_DEFAULT_ENABLED,
     builtin_permission_rows,
@@ -73,6 +76,8 @@ from tldw_chatbook.MCP.permission_store import (
     resolve_builtin_state,
 )
 from tldw_chatbook.MCP.readiness import (
+    AGENT_TOOLS_SERVER_KEY,
+    agent_tools_readiness,
     HubAction,
     ReadinessSnapshot,
     ReadinessState,
@@ -623,6 +628,10 @@ class MCPWorkbench(Container):
         self._scope: str = "personal"
         self._scope_ref: str | None = None
         self._snapshots: list[ReadinessSnapshot] = []
+        # ADR-148 Wave D: the Agent tools rail row's snapshot -- rides
+        # BESIDE _snapshots so the overview table, callouts, worst-state
+        # summary, and preselection heuristics stay server-only.
+        self._agent_snapshot: ReadinessSnapshot | None = None
         # T6: raw local-profile catalog records keyed by profile_id, kept in
         # sync with `_snapshots` by `_collect_snapshots()` -- readiness
         # snapshots don't carry every field the add/edit form needs
@@ -847,6 +856,7 @@ class MCPWorkbench(Container):
                 scope_value=self._scope,
                 scope_ref_options=[],
                 scope_ref_value=self._scope_ref,
+                agent_snapshot=None,
                 id="mcp-hub-rail",
                 classes="destination-workbench-pane",
             )
@@ -1281,6 +1291,20 @@ class MCPWorkbench(Container):
         service = self._service()
         if self._source == "local":
             self._server_mutations_available = False
+            # ADR-148 Wave D: the agent-tools rail row is derived, not a
+            # server -- it rides beside _snapshots so the overview table,
+            # callouts, worst-state summary, and preselection heuristics
+            # stay server-only.
+            self._agent_snapshot = agent_tools_readiness(
+                enabled=coerce_bool_setting(
+                    get_cli_setting(
+                        "console",
+                        LOCAL_TOOLS_MASTER_KEY,
+                        LOCAL_TOOLS_DEFAULT_ENABLED,
+                    ),
+                    LOCAL_TOOLS_DEFAULT_ENABLED,
+                )
+            )
             snapshots.append(
                 builtin_readiness(
                     enabled=bool(get_cli_setting("mcp", "enabled", False)),
@@ -1368,6 +1392,13 @@ class MCPWorkbench(Container):
         for snap in self._snapshots:
             if snap.server_key == server_key:
                 return snap
+        # ADR-148 Wave D: the Agent tools rail row resolves from its own
+        # snapshot -- it is deliberately never in `_snapshots`.
+        if (
+            server_key == AGENT_TOOLS_SERVER_KEY
+            and self._agent_snapshot is not None
+        ):
+            return self._agent_snapshot
         return None
 
     def _display_snapshot(self, snapshot: ReadinessSnapshot) -> ReadinessSnapshot:
@@ -1454,6 +1485,7 @@ class MCPWorkbench(Container):
                 scope_value=self._scope,
                 scope_ref_options=[],
                 scope_ref_value=self._scope_ref,
+                agent_snapshot=self._agent_snapshot,
             )
             canvas = self.query_one(MCPServersMode)
             await canvas.update_overview(

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -3239,7 +3239,7 @@ class MCPWorkbench(Container):
     def on_mcp_permissions_mode_bulk_state_requested(
         self, event: MCPPermissionsMode.BulkStateRequested
     ) -> None:
-        """ADR-149 Wave F: dispatch one bulk-set (shift+space) in the
+        """ADR-150 Wave F: dispatch one bulk-set (shift+space) in the
         background -- the canvas computed the visible scope and the next
         state; this executes it as N ordinary single writes."""
         event.stop()
@@ -3257,7 +3257,7 @@ class MCPWorkbench(Container):
     def on_mcp_permissions_mode_bulk_clear_requested(
         self, event: MCPPermissionsMode.BulkClearRequested
     ) -> None:
-        """ADR-149 Wave F: dispatch one bulk-clear (C) -- same worker path
+        """ADR-150 Wave F: dispatch one bulk-clear (C) -- same worker path
         with a None state; the canvas sent only rows that hold an
         override."""
         event.stop()
@@ -3279,9 +3279,9 @@ class MCPWorkbench(Container):
         new_state: str | None,
         context: PermissionProfileContext | None,
     ) -> None:
-        """ADR-149 Wave F: apply one state (None = clear) to a server's
+        """ADR-150 Wave F: apply one state (None = clear) to a server's
         tool rows as N ordinary, individually profile-scoped
-        `set_tool_state` calls -- no batch store API (ADR-149), per-row
+        `set_tool_state` calls -- no batch store API (ADR-150), per-row
         audit logging unchanged. Raw-shell rows are skipped (their
         two-state projection makes a generic write a lie) and the skip is
         named in the echo. First failure stops the batch with the

--- a/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
+++ b/tldw_chatbook/UI/MCP_Modules/mcp_workbench.py
@@ -99,6 +99,8 @@ from tldw_chatbook.UI.MCP_Modules.mcp_permissions_mode import (
     PermissionProfileContext,
     PermRow,
     ToolPolicyProfileOption,
+    _PROFILE_HINT_TEXT,
+    _undiscovered_servers_hint,
     format_tool_state_label,
 )
 from tldw_chatbook.UI.MCP_Modules.mcp_profile_form import MCPImportPanel, MCPProfileForm
@@ -611,6 +613,13 @@ class MCPWorkbench(Container):
         # True once the first load has had its chance to pre-select, so a
         # later resync can never re-hijack a selection the user cleared.
         self._did_initial_preselect: bool = False
+        # Wave C (F1): True while the first-load preselection holds the
+        # canvas on the OVERVIEW -- the rail highlights the row and the
+        # inspector explains it, but the detail view stays one explicit
+        # navigation away. Cleared by the first explicit selection
+        # (`_select_server_key`) or a restored view state, either of which
+        # is real user intent.
+        self._hold_canvas_overview: bool = False
         self._scope: str = "personal"
         self._scope_ref: str | None = None
         self._snapshots: list[ReadinessSnapshot] = []
@@ -1112,10 +1121,12 @@ class MCPWorkbench(Container):
         ]
         if len(problems) == 1:
             self._selected_server_key = problems[0].server_key
+            self._hold_canvas_overview = True
         elif len(self._snapshots) == 1:
             # task-2240: the lone rail row (fresh install's off/opt-in
             # built-in) is worth landing on too -- see the docstring.
             self._selected_server_key = self._snapshots[0].server_key
+            self._hold_canvas_overview = True
 
     def _selected_target_id(self) -> str | None:
         """The server-target id implied by `_selected_server_key`.
@@ -2600,7 +2611,13 @@ class MCPWorkbench(Container):
             preview=preview,
             echo=echo,
             gate_breadcrumb=tool_gate_breadcrumb(),
+            discovery_hint=_undiscovered_servers_hint(self._snapshots),
             profile_context=profile_context,
+        )
+        # Wave C (F8): only a non-default profile needs the Console-context
+        # caveat -- the default profile IS the plain story.
+        canvas.set_profile_hint(
+            _PROFILE_HINT_TEXT if self._tool_policy_profile_id != "default" else None
         )
         await self.query_one(MCPPermissionsMode).update_server_profiles(
             await self._server_governance_profiles(service, refresh=refresh_governance)
@@ -3162,6 +3179,15 @@ class MCPWorkbench(Container):
         -- they can change from other clients/sessions, and this only runs
         on an actual selection change, not on every keystroke.
         """
+        if self._hold_canvas_overview:
+            # Wave C (F1): the first-load preselection explains itself in
+            # the rail + inspector while the overview (Add server, callouts)
+            # stays on screen -- `show_detail(None)` keeps the canvas on the
+            # overview AND refreshes its data underneath, exactly like any
+            # other resync with no selection. The hold is cleared by the
+            # first explicit selection (see `_select_server_key`).
+            await canvas.show_detail(None)
+            return
         if (
             selected is not None
             and self._is_external_record_key(selected.server_key)
@@ -3327,6 +3353,9 @@ class MCPWorkbench(Container):
 
     async def _apply_view_state(self, state: dict[str, Any]) -> None:
         # Tolerant restore: unknown keys ignored; legacy panel shape accepted.
+        # Wave C (F1): a restored view state is explicit prior-user intent
+        # and wins over the first-load overview hold.
+        self._hold_canvas_overview = False
         source = state.get("source") or state.get("selected_source")
         if source in ("local", "server") and source != self._source:
             await self._switch_source(str(source))
@@ -3427,6 +3456,10 @@ class MCPWorkbench(Container):
         `_switch_source()`'s identical T6 clear.
         """
         self._selected_server_key = server_key
+        # Wave C (F1): an explicit selection (rail row, table row, callout,
+        # breadcrumb) is real navigation intent -- the first-load
+        # overview hold, if any, ends here.
+        self._hold_canvas_overview = False
         # T6: selecting a different server invalidates any Tools-mode
         # selection the inspector was showing -- "switching modes or
         # servers clears the tool view" -- and (I1 above) the Findings
@@ -5277,7 +5310,11 @@ class MCPWorkbench(Container):
             return
         self._profile_save_in_flight = True
         self.run_worker(
-            self._save_local_profile(dict(event.payload), warning=event.warning),
+            self._save_local_profile(
+                dict(event.payload),
+                warning=event.warning,
+                connect_after=event.connect_after,
+            ),
             group="mcp-profile-save",
             exclusive=True,
         )
@@ -5289,7 +5326,11 @@ class MCPWorkbench(Container):
             return None
 
     async def _save_local_profile(
-        self, payload: dict[str, Any], warning: str | None = None
+        self,
+        payload: dict[str, Any],
+        warning: str | None = None,
+        *,
+        connect_after: bool = False,
     ) -> None:
         """Run one profile save; on success, also re-surface the form's args
         secret-lint `warning` as a toast (I4 follow-up). The in-form
@@ -5298,6 +5339,13 @@ class MCPWorkbench(Container):
         sub-second after the warning rendered, so without this toast the
         user would never see it on exactly the path where the secret
         actually got persisted into a profile's args.
+
+        Wave C (F7a): `connect_after=True` (the form's "Save and connect")
+        dispatches the connect lifecycle for the just-saved profile once
+        the save and resync land -- the saved->connected journey used to
+        require finding the new row and its inspector Connect action.
+        A connect failure surfaces through the lifecycle's own
+        notification/readiness path (e.g. a missing env placeholder).
         """
         try:
             service = self._service()
@@ -5334,6 +5382,11 @@ class MCPWorkbench(Container):
                 self.app.notify(warning, severity="warning")
             self._snapshots = await self._collect_snapshots()
             await self._sync_children()
+            if connect_after and payload.get("profile_id"):
+                profile_id = str(payload["profile_id"])
+                self._start_lifecycle(
+                    f"local:{profile_id}", profile_id, "connect"
+                )
         finally:
             self._profile_save_in_flight = False
 

--- a/tldw_chatbook/UI/Screens/mcp_screen.py
+++ b/tldw_chatbook/UI/Screens/mcp_screen.py
@@ -41,7 +41,12 @@ _COMMON_SHORTCUTS: tuple[tuple[str, str], ...] = (
 MCP_MODE_SHORTCUTS: dict[str, tuple[tuple[str, str], ...]] = {
     "servers": _COMMON_SHORTCUTS,
     "tools": _COMMON_SHORTCUTS + (("t", "test tool"),),
-    "permissions": _COMMON_SHORTCUTS + (("space", "cycle permission"),),
+    "permissions": _COMMON_SHORTCUTS
+    + (
+        ("space", "cycle permission"),
+        ("shift+space", "bulk set"),
+        ("C", "clear overrides"),
+    ),
     "audit": _COMMON_SHORTCUTS,
 }
 

--- a/tldw_chatbook/css/widget_defaults_scoped.tcss
+++ b/tldw_chatbook/css/widget_defaults_scoped.tcss
@@ -814,9 +814,31 @@
         width: 7fr;
         min-width: 30;
     }
+    /* ADR-148 Wave E: the main row carries the old rail+canvas share of
+    the grid (8 of 11 units) so the wide layout is geometrically
+    unchanged, one nesting level deeper. */
+    MCPWorkbench #mcp-hub-main-row {
+        width: 8fr;
+        min-width: 0;
+        height: 100%;
+        min-height: 0;
+    }
+    /* ADR-148 Wave E: below 120 cols the grid STACKS -- main row on top,
+    the inspector as a bounded, internally scrolling band underneath (the
+    old squeezed third column broke words mid-token at ~20 cols). */
+    MCPWorkbench #mcp-hub-grid.mcp-compact {
+        layout: vertical;
+    }
+    MCPWorkbench #mcp-hub-grid.mcp-compact #mcp-hub-main-row {
+        width: 100%;
+        height: 1fr;
+    }
     MCPWorkbench #mcp-hub-grid.mcp-compact #mcp-hub-inspector {
-        width: 2fr;
-        min-width: 20;
+        width: 100%;
+        height: auto;
+        max-height: 12;
+        min-height: 4;
+        overflow-y: auto;
     }
 
 


### PR DESCRIPTION
## Summary

Implements the structural half of the 2026-09-11 MCP screen UX program (TASK-32455–32459). **Stacked on #2620** (merge that first). Decisions: ADR-148 (rail IA + responsive triad) and ADR-150 (bulk permission actions) — both on the `docs/mcp-hub-ux-program` PR. *(ADR-150 was renumbered from 149: upstream took 149 mid-program.)*

**Wave D — rail IA split (ADR-148):** a second rail section **Agent tools**, keyed `agent:builtin` (the existing store identity; no two rows share a `server_key`). Tool gates moved to its detail pane; the built-in server row keeps `[mcp]` controls + a pointer line. The agent snapshot rides beside `_snapshots` so the overview/callouts/preselection stay server-only; selecting it renders the unscoped permissions preview.

**Wave E — narrow-width triad (ADR-148):** below 120 cols the grid stacks — rail+canvas main row on top, the inspector below as a full-width, ≤12-row scrolling band (`layout: vertical` override). Wide layouts geometrically unchanged. Advanced auto-collapses at compact without touching the persisted preference; the old `Overvi|ew` mid-word clip is gone.

**Wave F — bulk permission actions (ADR-150):** `shift+space` applies the cursor row's next state to a server's *visible* tool rows; `C` clears its visible overrides — the filter is the scope. Every write stays an ordinary profile-scoped `set_tool_state` (per-write context re-capture: each write changes the profile digest); raw-shell rows skipped and named in the echo; first failure stops with the reason.

**Closers:** F2 rail keyboard navigation (up/down + j/k, clamped, compose-time focus restoration — the recompose after every selection destroys the focused row, so restoration must land at compose time) and the duplicate-row surface labels (`tldw_chatbook (external MCP)` / `Local workspace, web, and Watchlists (Console agents)`) with the spec's pinned two-row test.

## Verification

TDD throughout; final sweeps: workbench 349, permissions/servers/rail/tools 187+185, permission resolution/store/control-plane 187, inspector 284–285, destination MCP subsets green. Doc-contract unchanged at its 39 pre-existing upstream failures; one known-flaky destination view-state test documented in the task notes.

## ADR check

ADR-148 and ADR-150 (docs branch PR) own the structural decisions; linked from TASK-32455/32456/32457/32458/32459.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements waves D–F of the 2026-09-11 MCP Hub UX program (TASK-32455–32459), stacked on #2620 (merge that first). The agent tool catalog becomes its own rail section, narrow terminals stack the inspector instead of squeezing three columns, and permissions gains filter-scoped bulk actions.

**Wave D–E: rail split and narrow layouts (TASK-32455/32456)**
- A new `Agent tools` rail section, keyed `agent:builtin` (ADR-148), now holds the Tool gates in its detail pane; the built-in server row keeps `[mcp]` controls plus a pointer to it.
- Below 120 columns the grid stacks: rail+canvas above, inspector below as a full-width, ≤12-row scrolling band; wide layouts are geometrically unchanged.
- The Advanced collapsible auto-collapses while compact without touching the persisted preference.
- F2 closes the keyboard gap: ↑/↓ and j/k move the rail selection, clamped at the ends.
- Duplicate permission rows are now labeled `tldw_chatbook (external MCP)` and `Local workspace, web, and Watchlists (Console agents)` so the pairing reads as deliberate.

**Wave F: bulk permission actions (TASK-32457)**
- `shift+space` applies the cursor row's next state to a server's visible tool rows; `C` clears its visible overrides; the filter is the scope (ADR-150).
- Each write stays an ordinary profile-scoped `set_tool_state` call with per-write context re-capture.
- Raw-shell rows are skipped and named in the echo; the first failure stops the batch with the reason.

The MCP user guide drops its stub banner now that the orientation, tutorial, gate, and bulk-key docs cover the page. New backlog tasks track upstream doc-contract and destination-shell test drift plus the deferred persona-floor design question (TASK-32460–32462).

<sup>Written for commit 65f6c24b2136665d5900e7835ece0458b82d7e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

