### PR TITLE
fix(console): appearance picker Escape crash from sync cancel effect

### DIFF
--- a/Tests/UI/test_console_appearance_picker.py
+++ b/Tests/UI/test_console_appearance_picker.py
@@ -399,3 +399,21 @@ def test_switcher_prefix_renders_placeholder_for_color_only() -> None:
     prefix = _switcher_icon_prefix(color_only)
     assert GLYPH_APPEARANCE_PLACEHOLDER in prefix
     assert prefix.startswith("[#22d3ee]")
+
+
+@pytest.mark.asyncio
+async def test_escape_cancels_with_none_without_crashing(_sandbox_emoji_sources) -> None:
+    """Escape must run the one-shot safe cancel and dismiss with None.
+
+    Regression: _perform_safe_cancel passed the SYNCHRONOUS
+    cancel_filter_timer to run_cancel_effect_once, which awaits the effect --
+    every Escape press raised TypeError before dismissing.
+    """
+    harness = PickerHarness(conversation_id="conv-1", conversation_title="Lab chat")
+    async with harness.run_test(size=(80, 30)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+        await pilot.press("escape")
+        await pilot.pause()
+        assert harness.result is None

--- a/tldw_chatbook/Widgets/Console/console_appearance_picker_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_appearance_picker_modal.py
@@ -387,7 +387,7 @@ class ConsoleAppearancePickerModal(
     async def _perform_safe_cancel(self, *, source: str) -> None:
         del source
 
-        def cancel_filter_timer() -> None:
+        async def cancel_filter_timer() -> None:
             self._cancel_filter_timer()
 
         await self.run_cancel_effect_once(cancel_filter_timer)


### PR DESCRIPTION
## Problem

`ConsoleAppearancePickerModal._perform_safe_cancel` registered its filter-timer cleanup with `run_cancel_effect_once`, which **awaits** the effect — but the effect was a synchronous function. Every safe-cancel gesture on the appearance picker (Escape key, backdrop click, Cancel button) raised:

```
TypeError: object NoneType can't be used in 'await' expression
```

at `Widgets/modal_dismissal.py:257`, and the modal never dismissed.

## Why the suite didn't catch it

`Tests/UI/test_console_appearance_picker.py` had no test exercising the cancel path, and the modal rides `inventory_only_types` in the dismissal-contract inventory, so no contract test covers it either.

## Fix

- `console_appearance_picker_modal.py`: make `cancel_filter_timer` `async` (one word) so the effect matches `run_cancel_effect_once`'s declared `Callable[[], Awaitable[None]]` signature.
- New pilot regression test `test_escape_cancels_with_none_without_crashing`: pushes the picker, presses Escape, asserts dismissal with `None` and no exception. **Fails before the fix with the exact TypeError; passes after.**

## Verification

- Baseline on dev tip: 12 passed; with fix + regression test: **13 passed**
- Unrelated pre-existing redness on dev tip (`test_console_modal_dismissal.py`, 6 tests incl. launch-inventory and ConsoleModelPopover) verified present on a pristine checkout via stash-rerun — untouched by this PR.

## Follow-up worth considering (not in this PR)

Give the picker a real TASK3-style dismissal contract (cancel `None`, success `ConsoleConversationAppearance`) so it leaves `inventory_only_types` — that contract is what surfaced this bug downstream.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the appearance picker crash when canceled with Escape, backdrop click, or Cancel. The safe-cancel path passed a synchronous function to an effect runner that awaits its effect, so every cancel raised `TypeError` and the modal never dismissed. The function is now async, and a regression test presses Escape and asserts the modal dismisses with `None`.

<sup>Written for commit 9a883d033d7af55594da326782700a86a0146172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2625?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

