### PR TITLE
fix(console): recover dispatch ownership stranded by cursor changes

### DIFF
--- a/Docs/security/production-diagnostic-inventory.json
+++ b/Docs/security/production-diagnostic-inventory.json
@@ -344,8 +344,8 @@
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
-      "call_count": 87,
-      "diagnostic_digest": "b01c4cdca44176b29894",
+      "call_count": 88,
+      "diagnostic_digest": "50b2232452d6a87b8699",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_chat_store.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
@@ -376,6 +376,13 @@
       "diagnostic_digest": "99780cd67ef9bc88a3ae",
       "owner": "TASK-492",
       "path": "tldw_chatbook/Chat/console_cost_tracker.py",
+      "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
+    },
+    {
+      "call_count": 1,
+      "diagnostic_digest": "2491b1bd675f69e15216",
+      "owner": "TASK-492",
+      "path": "tldw_chatbook/Chat/console_dispatch_repository.py",
       "reason": "high-risk Chat/provider/summarization/tool/MCP diagnostic owner"
     },
     {
@@ -11535,11 +11542,11 @@
   "schema_version": 3,
   "scope": "tldw_chatbook/**/*.py",
   "summary": {
-    "owner_files": 602,
+    "owner_files": 603,
     "path_privacy_candidate_calls": 709,
     "persistent_sink_files": 12,
     "task_31551_calls": 55,
-    "task_492_calls": 1390,
+    "task_492_calls": 1392,
     "task_494_calls": 7709
   }
 }

--- a/Docs/superpowers/plans/2026-09-11-dispatch-cursor-recovery.md
+++ b/Docs/superpowers/plans/2026-09-11-dispatch-cursor-recovery.md
@@ -62,3 +62,32 @@ requires POSIX filesystem guards (`persona_visual_publication_denied` reproduced
 against an isolated snapshot). Its library does not write dispatch checkpoints or
 conversation cursors. Collections lifecycle-lock creation and bundled tiktoken hash
 errors are separate failures; neither explains the pre-existing cursor mismatch.
+
+
+## PR review follow-up
+
+All six Qodo findings are addressed. Branch creation, ancestor editing, and
+subtree deletion now check durable dispatch ownership under the same immediate
+transaction as their writes, before runtime publication. Sibling failure rolls
+back its runtime node; voice recovery selection returns False on cursor refusal.
+Post-commit Sync v2 projection stays outside the branch transaction. Deleted or
+missing conversations retain the documented False cursor result.
+
+Recovery integration tests use a closing in-memory SQLite fixture, fixed complete
+SQL statements, and transaction-managed deliberate corruption. Isolated helper
+tests cover read-only/write decisions, malformed ancestry and competing owners
+without initializing the application schema or store.
+
+Diagnostic statement review found only the intended bounded quarantine error code,
+the constant pending-dispatch warning, and revised wording of the existing cursor
+exception diagnostic. No new content, secret, path, URL, or sink destination was
+introduced. Regenerate the diagnostic inventory with this review recorded.
+
+
+Review verification: 27 new recovery tests pass. Across the targeted dispatch,
+branch-tree, edit/resend, regeneration and voice files, 197 tests pass and seven
+fail; all seven also fail on unchanged dev at fb74902e2b. These are the two
+previously recorded dispatch/queue expectations plus five edit/regenerate tests
+with outdated fake persistence, substitution signatures, and selection expectations.
+New tests pass Ruff check and formatting; the modified production files have the
+same 262 pre-existing Ruff findings as dev, with no added findings.

--- a/Docs/superpowers/plans/2026-09-11-dispatch-cursor-recovery.md
+++ b/Docs/superpowers/plans/2026-09-11-dispatch-cursor-recovery.md
@@ -1,0 +1,64 @@
+# Dispatch cursor recovery
+
+Goal: preserve the exact unresolved durable send when navigation writes a stale
+conversation cursor, and recover already-stranded valid checkpoints on restore.
+
+ADR required: no new ADR. This is a repair of the existing matching-checkpoint
+recovery contract in ADR-079 (Console Library conversation authority). No schema,
+provider authority, checkpoint payload, or automatic replay policy changes.
+
+## Investigation
+
+The incident had a single accepted checkpoint with matching user/assistant versions,
+but the local conversation cursor selected the earlier greeting. The database passed
+its integrity check. The checkpoint predates the provided startup log. The error was
+`checkpoint_not_active_path`, not evidence that JSON or the database was corrupt.
+
+`insert_with_messages` commits the user, assistant, checkpoint, and assistant cursor
+together. `set_conversation_active_cursor` previously overwrote that cursor without
+checking outstanding dispatch ownership. Store navigation writes through this API.
+A regression reproduces the bad state through the production writer. The available
+log starts after the original send and cannot identify the historical caller or the
+reason the accepted send did not reach its dispatch marker.
+
+## Implementation
+
+- Guard cursor writes within an immediate transaction: every pending checkpoint must
+  remain on the requested path. Rejected selection keeps the runtime cursor intact;
+  before-first rewind restores its old runtime cursor on ownership refusal.
+- Reconcile an off-path checkpoint only after full payload/version/role validation,
+  exact assistant-to-user parent validation, complete nondeleted same-conversation
+  ancestry, cycle rejection, and competing-owner checks. Re-read under an immediate
+  transaction before repairing only the local cursor. Keep ambiguous records
+  quarantined; do not delete records or infer authority from an empty message.
+- Restore the committed cursor into the session instead of its stale pre-reconcile
+  snapshot. Existing Retry/Retry-anyway/Discard semantics and reconstruction checks
+  remain in force. Nothing automatically invokes a provider.
+- Record the bounded quarantine error code, without checkpoint payloads or content.
+
+## Verification
+
+`Tests/Chat/test_console_dispatch_cursor_recovery.py` covers cursor rejection,
+before-first rewind, old-state restore, accepted/dispatch-started Discard without
+provider replay, version/parent/payload corruption, cyclic/competing ownership,
+revalidation between read/write passes, and failed repair rollback.
+
+The original code failed the writer, restore, and runtime-selection regressions.
+The repaired code also restored the affected database snapshot to its original
+pending turn. That checkpoint's reconstructability flags correctly disabled Retry;
+Discard remained available. The live profile was not modified.
+
+The existing targeted suites have separately baseline-confirmed failures: seven
+Canvas manifest-integrity failures, two outdated migration-version assertions, one
+postcommit test's provider-start expectation, and one queue callback type expectation.
+Do not weaken those unrelated checks to make this fix appear fully green.
+
+## Separate startup findings
+
+The generic worker-state logger warns for unregistered handlers on every state
+transition, including success. These messages do not establish worker failure.
+Buddy installation independently fails on Windows because artwork publication
+requires POSIX filesystem guards (`persona_visual_publication_denied` reproduced
+against an isolated snapshot). Its library does not write dispatch checkpoints or
+conversation cursors. Collections lifecycle-lock creation and bundled tiktoken hash
+errors are separate failures; neither explains the pre-existing cursor mismatch.

--- a/Tests/Chat/test_console_dispatch_cursor_recovery.py
+++ b/Tests/Chat/test_console_dispatch_cursor_recovery.py
@@ -1,0 +1,241 @@
+"""An unresolved durable send must survive stale navigation cursor writes."""
+
+from dataclasses import replace
+
+import pytest
+
+from Tests.Chat.test_console_dispatch_recovery import (
+    _acceptance,
+    _database,
+    _insert,
+    _raw_semantic_corruption,
+    _restored_store,
+    _start,
+    _NoReplayGateway,
+)
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
+from tldw_chatbook.DB.ChaChaNotes_DB import InputError
+
+
+def _stranded(tmp_path):
+    db, conversation_id, repository = _database(tmp_path / "stranded.sqlite")
+    greeting = db.add_message(
+        {
+            "conversation_id": conversation_id,
+            "sender": "assistant",
+            "role": "assistant",
+            "content": "greeting",
+        }
+    )
+    checkpoint = _insert(
+        db,
+        repository,
+        replace(
+            _acceptance(conversation_id),
+            parent_message_id=greeting,
+        ),
+    )
+    return db, conversation_id, repository, greeting, checkpoint
+
+
+@pytest.mark.parametrize("clear", [False, True])
+def test_cursor_writer_cannot_strand_unresolved_dispatch(tmp_path, clear):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with pytest.raises(InputError, match="dispatch"):
+        db.set_conversation_active_leaf(conversation_id, None if clear else greeting)
+    assert (
+        db.get_conversation_active_leaf(conversation_id)
+        == checkpoint.assistant_message_id
+    )
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+
+
+def test_restore_repairs_old_cursor_and_publishes_same_pending_turn(tmp_path):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+    store, session_id = _restored_store(db, conversation_id)
+    recovery = store.dispatch_recovery_for_session(session_id)
+    assert recovery.kind is ConsoleDispatchRecoveryKind.ACCEPTED
+    assert recovery.checkpoint == checkpoint
+    assert (
+        db.get_conversation_active_leaf(conversation_id)
+        == checkpoint.assistant_message_id
+    )
+    assert [m.persisted_message_id for m in store.messages_for_session(session_id)] == [
+        greeting,
+        checkpoint.user_message_id,
+        checkpoint.assistant_message_id,
+    ]
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+    assert db.get_message_by_id(checkpoint.assistant_message_id)["content"] == ""
+
+
+@pytest.mark.parametrize("corruption", ["version", "parent", "payload"])
+def test_invalid_stranded_owner_is_not_repaired(tmp_path, corruption):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+        if corruption == "payload":
+            cursor.execute(
+                "UPDATE console_dispatch_checkpoints SET frozen_authority_json='{}'"
+            )
+    if corruption != "payload":
+        assignment = (
+            "version=2" if corruption == "version" else "parent_message_id=NULL"
+        )
+        _raw_semantic_corruption(
+            db,
+            f"UPDATE messages SET {assignment} WHERE id=?",
+            (checkpoint.assistant_message_id,),
+        )
+        db.get_connection().commit()
+    recovery = repository.reconcile_for_session(conversation_id)
+    assert recovery.kind is ConsoleDispatchRecoveryKind.QUARANTINED
+    assert recovery.actions == ()
+    assert db.get_conversation_active_leaf(conversation_id) == greeting
+
+
+def test_store_rejected_navigation_keeps_runtime_and_database_cursor(tmp_path):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    store, session_id = _restored_store(db, conversation_id)
+    with pytest.raises(RuntimeError, match="cursor"):
+        store.set_active_leaf(session_id, greeting)
+    assert (
+        store.messages_for_session(session_id)[-1].persisted_message_id
+        == checkpoint.assistant_message_id
+    )
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+
+
+@pytest.mark.parametrize("started", [False, True])
+@pytest.mark.asyncio
+async def test_repaired_owner_can_be_discarded_without_provider_replay(
+    tmp_path, started
+):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    if started:
+        checkpoint = _start(repository, checkpoint)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+    store, session_id = _restored_store(db, conversation_id)
+    assert store.dispatch_recovery_for_session(session_id).checkpoint == checkpoint
+    gateway = _NoReplayGateway(db)
+    controller = ConsoleChatController(
+        store=store, provider_gateway=gateway, agent_runtime_enabled=False
+    )
+    result = await controller.discard_dispatch_recovery(session_id)
+    assert result.accepted
+    assert gateway.resolve_calls == 0
+    assert db.get_message_by_id(checkpoint.user_message_id)["deleted"] == 0
+    assert (
+        db.get_message_by_id(checkpoint.assistant_message_id)[
+            "assistant_generation_state"
+        ]
+        == "discarded"
+    )
+    assert repository.reconcile_for_session(conversation_id) is None
+    store.set_active_leaf(session_id, greeting)
+    assert db.get_conversation_active_leaf(conversation_id) == greeting
+
+
+def test_repair_rereads_owner_after_read_pass(tmp_path, monkeypatch):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+    original = repository._reconcile_pass
+
+    def change_between_passes(conversation_id, *, allow_writes):
+        result = original(conversation_id, allow_writes=allow_writes)
+        if not allow_writes:
+            _raw_semantic_corruption(
+                db,
+                "UPDATE messages SET version=2 WHERE id=?",
+                (checkpoint.assistant_message_id,),
+            )
+            db.get_connection().commit()
+        return result
+
+    monkeypatch.setattr(repository, "_reconcile_pass", change_between_passes)
+    recovery = repository.reconcile_for_session(conversation_id)
+    assert recovery.kind is ConsoleDispatchRecoveryKind.QUARANTINED
+    assert db.get_conversation_active_leaf(conversation_id) == greeting
+
+
+def test_repair_write_failure_retains_checkpoint_and_cursor(tmp_path):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+        cursor.execute(
+            "CREATE TRIGGER fail_cursor BEFORE UPDATE OF active_leaf_message_id ON conversations "
+            "BEGIN SELECT RAISE(ABORT, 'fail'); END"
+        )
+    recovery = repository.reconcile_for_session(conversation_id)
+    assert recovery.error_code == "checkpoint_reconcile_error"
+    assert db.get_conversation_active_leaf(conversation_id) == greeting
+    assert (
+        db.get_connection()
+        .execute("SELECT checkpoint_revision FROM console_dispatch_checkpoints")
+        .fetchone()[0]
+        == checkpoint.checkpoint_revision
+    )
+
+
+def test_before_first_rewind_cannot_strand_pending_turn(tmp_path):
+    db, conversation_id, repository = _database(tmp_path / "before.sqlite")
+    checkpoint = _insert(db, repository, _acceptance(conversation_id))
+    store, session_id = _restored_store(db, conversation_id)
+    assert store.set_active_path_before(session_id, checkpoint.user_message_id) is False
+    assert store.active_leaf(session_id) == checkpoint.assistant_message_id
+    assert (
+        db.get_conversation_active_leaf(conversation_id)
+        == checkpoint.assistant_message_id
+    )
+
+
+@pytest.mark.parametrize("problem", ["cycle", "competing_owner"])
+def test_repair_rejects_ambiguous_ancestry(tmp_path, problem):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
+            (greeting, conversation_id),
+        )
+    if problem == "cycle":
+        _raw_semantic_corruption(
+            db,
+            "UPDATE messages SET parent_message_id=? WHERE id=?",
+            (checkpoint.assistant_message_id, checkpoint.user_message_id),
+        )
+    else:
+        _raw_semantic_corruption(
+            db,
+            "UPDATE messages SET assistant_generation_state='accepted' WHERE id=?",
+            (greeting,),
+        )
+    db.get_connection().commit()
+    recovery = repository.reconcile_for_session(conversation_id)
+    assert recovery.kind is ConsoleDispatchRecoveryKind.QUARANTINED
+    assert db.get_conversation_active_leaf(conversation_id) == greeting
+
+
+def test_cursor_can_stay_on_pending_owner_path(tmp_path):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    db.set_conversation_active_leaf(conversation_id, checkpoint.assistant_message_id)
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint

--- a/Tests/Chat/test_console_dispatch_cursor_recovery.py
+++ b/Tests/Chat/test_console_dispatch_cursor_recovery.py
@@ -8,7 +8,6 @@ from Tests.Chat.test_console_dispatch_recovery import (
     _acceptance,
     _database,
     _insert,
-    _raw_semantic_corruption,
     _restored_store,
     _start,
     _NoReplayGateway,
@@ -18,8 +17,30 @@ from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
 from tldw_chatbook.DB.ChaChaNotes_DB import InputError
 
 
-def _stranded(tmp_path):
-    db, conversation_id, repository = _database(tmp_path / "stranded.sqlite")
+@pytest.fixture
+def database():
+    result = _database(":memory:")
+    try:
+        yield result
+    finally:
+        result[0].close_connection()
+
+
+def _raw_semantic_corruption(db, sql, params):
+    connection = db.get_connection()
+    authorization = db._semantic_mutation_authorization_for_coordinator(connection)
+    connection.create_function("console_semantic_mutation_authorized", 2, lambda *_: 1)
+    try:
+        with db.transaction(immediate=True) as cursor:
+            cursor.execute(sql, params)
+    finally:
+        connection.create_function(
+            "console_semantic_mutation_authorized", 2, authorization._sqlite_authorized
+        )
+
+
+def _stranded(database):
+    db, conversation_id, repository = database
     greeting = db.add_message(
         {
             "conversation_id": conversation_id,
@@ -40,8 +61,8 @@ def _stranded(tmp_path):
 
 
 @pytest.mark.parametrize("clear", [False, True])
-def test_cursor_writer_cannot_strand_unresolved_dispatch(tmp_path, clear):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_cursor_writer_cannot_strand_unresolved_dispatch(database, clear):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with pytest.raises(InputError, match="dispatch"):
         db.set_conversation_active_leaf(conversation_id, None if clear else greeting)
     assert (
@@ -51,8 +72,8 @@ def test_cursor_writer_cannot_strand_unresolved_dispatch(tmp_path, clear):
     assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
 
 
-def test_restore_repairs_old_cursor_and_publishes_same_pending_turn(tmp_path):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_restore_repairs_old_cursor_and_publishes_same_pending_turn(database):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with db.transaction() as cursor:
         cursor.execute(
             "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
@@ -76,8 +97,8 @@ def test_restore_repairs_old_cursor_and_publishes_same_pending_turn(tmp_path):
 
 
 @pytest.mark.parametrize("corruption", ["version", "parent", "payload"])
-def test_invalid_stranded_owner_is_not_repaired(tmp_path, corruption):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_invalid_stranded_owner_is_not_repaired(database, corruption):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with db.transaction() as cursor:
         cursor.execute(
             "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
@@ -88,23 +109,24 @@ def test_invalid_stranded_owner_is_not_repaired(tmp_path, corruption):
                 "UPDATE console_dispatch_checkpoints SET frozen_authority_json='{}'"
             )
     if corruption != "payload":
-        assignment = (
-            "version=2" if corruption == "version" else "parent_message_id=NULL"
+        statement = (
+            "UPDATE messages SET version=2 WHERE id=?"
+            if corruption == "version"
+            else "UPDATE messages SET parent_message_id=NULL WHERE id=?"
         )
         _raw_semantic_corruption(
             db,
-            f"UPDATE messages SET {assignment} WHERE id=?",
+            statement,
             (checkpoint.assistant_message_id,),
         )
-        db.get_connection().commit()
     recovery = repository.reconcile_for_session(conversation_id)
     assert recovery.kind is ConsoleDispatchRecoveryKind.QUARANTINED
     assert recovery.actions == ()
     assert db.get_conversation_active_leaf(conversation_id) == greeting
 
 
-def test_store_rejected_navigation_keeps_runtime_and_database_cursor(tmp_path):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_store_rejected_navigation_keeps_runtime_and_database_cursor(database):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     store, session_id = _restored_store(db, conversation_id)
     with pytest.raises(RuntimeError, match="cursor"):
         store.set_active_leaf(session_id, greeting)
@@ -118,9 +140,9 @@ def test_store_rejected_navigation_keeps_runtime_and_database_cursor(tmp_path):
 @pytest.mark.parametrize("started", [False, True])
 @pytest.mark.asyncio
 async def test_repaired_owner_can_be_discarded_without_provider_replay(
-    tmp_path, started
+    database, started
 ):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     if started:
         checkpoint = _start(repository, checkpoint)
     with db.transaction() as cursor:
@@ -149,8 +171,8 @@ async def test_repaired_owner_can_be_discarded_without_provider_replay(
     assert db.get_conversation_active_leaf(conversation_id) == greeting
 
 
-def test_repair_rereads_owner_after_read_pass(tmp_path, monkeypatch):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_repair_rereads_owner_after_read_pass(database, monkeypatch):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with db.transaction() as cursor:
         cursor.execute(
             "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
@@ -166,7 +188,6 @@ def test_repair_rereads_owner_after_read_pass(tmp_path, monkeypatch):
                 "UPDATE messages SET version=2 WHERE id=?",
                 (checkpoint.assistant_message_id,),
             )
-            db.get_connection().commit()
         return result
 
     monkeypatch.setattr(repository, "_reconcile_pass", change_between_passes)
@@ -175,8 +196,8 @@ def test_repair_rereads_owner_after_read_pass(tmp_path, monkeypatch):
     assert db.get_conversation_active_leaf(conversation_id) == greeting
 
 
-def test_repair_write_failure_retains_checkpoint_and_cursor(tmp_path):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_repair_write_failure_retains_checkpoint_and_cursor(database):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with db.transaction() as cursor:
         cursor.execute(
             "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
@@ -197,8 +218,8 @@ def test_repair_write_failure_retains_checkpoint_and_cursor(tmp_path):
     )
 
 
-def test_before_first_rewind_cannot_strand_pending_turn(tmp_path):
-    db, conversation_id, repository = _database(tmp_path / "before.sqlite")
+def test_before_first_rewind_cannot_strand_pending_turn(database):
+    db, conversation_id, repository = database
     checkpoint = _insert(db, repository, _acceptance(conversation_id))
     store, session_id = _restored_store(db, conversation_id)
     assert store.set_active_path_before(session_id, checkpoint.user_message_id) is False
@@ -210,8 +231,8 @@ def test_before_first_rewind_cannot_strand_pending_turn(tmp_path):
 
 
 @pytest.mark.parametrize("problem", ["cycle", "competing_owner"])
-def test_repair_rejects_ambiguous_ancestry(tmp_path, problem):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_repair_rejects_ambiguous_ancestry(database, problem):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     with db.transaction() as cursor:
         cursor.execute(
             "UPDATE conversations SET active_leaf_message_id=? WHERE id=?",
@@ -229,13 +250,86 @@ def test_repair_rejects_ambiguous_ancestry(tmp_path, problem):
             "UPDATE messages SET assistant_generation_state='accepted' WHERE id=?",
             (greeting,),
         )
-    db.get_connection().commit()
     recovery = repository.reconcile_for_session(conversation_id)
     assert recovery.kind is ConsoleDispatchRecoveryKind.QUARANTINED
     assert db.get_conversation_active_leaf(conversation_id) == greeting
 
 
-def test_cursor_can_stay_on_pending_owner_path(tmp_path):
-    db, conversation_id, repository, greeting, checkpoint = _stranded(tmp_path)
+def test_cursor_can_stay_on_pending_owner_path(database):
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
     db.set_conversation_active_leaf(conversation_id, checkpoint.assistant_message_id)
     assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+
+
+@pytest.mark.parametrize("action", ["sibling", "delete", "edit"])
+def test_pending_dispatch_blocks_branch_mutation_without_side_effects(database, action):
+    from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
+
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
+    store, session_id = _restored_store(db, conversation_id)
+    before = store.messages_for_session(session_id)
+    with pytest.raises((RuntimeError, ValueError), match="dispatch"):
+        if action == "sibling":
+            store.create_sibling(
+                greeting, role=ConsoleMessageRole.USER, content="fork", persist=True
+            )
+        elif action == "delete":
+            store.delete_message(greeting)
+        else:
+            store.update_message_content(greeting, "changed")
+    assert store.messages_for_session(session_id) == before
+    assert db.get_message_by_id(greeting)["content"] == "greeting"
+    assert db.get_message_by_id(greeting)["deleted"] == 0
+    assert (
+        db.get_conversation_active_leaf(conversation_id)
+        == checkpoint.assistant_message_id
+    )
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+    with db.transaction() as cursor:
+        assert cursor.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 3
+
+
+def test_deleted_conversation_cursor_returns_false_with_retained_checkpoint(database):
+    db, conversation_id, _, _, _ = _stranded(database)
+    with db.transaction() as cursor:
+        cursor.execute(
+            "UPDATE conversations SET deleted=1 WHERE id=?", (conversation_id,)
+        )
+    assert (
+        db.set_conversation_active_cursor(
+            conversation_id, active_leaf_message_id=None, before_message_id=None
+        )
+        is False
+    )
+
+
+def test_voice_recovery_selection_preserves_cursor_when_dispatch_refuses(database):
+    from tldw_chatbook.Chat.console_voice_promotion import (
+        ConsoleVoicePromotionLease,
+        ResolvedVoicePromotionDestination,
+    )
+
+    db, conversation_id, repository, greeting, checkpoint = _stranded(database)
+    store, session_id = _restored_store(db, conversation_id)
+    incarnation = store._settings_session_incarnations[session_id]
+    lease = ConsoleVoicePromotionLease(
+        "lease",
+        session_id,
+        incarnation,
+        1,
+        "promotion",
+        checkpoint.assistant_message_id,
+        ResolvedVoicePromotionDestination(
+            session_id,
+            incarnation,
+            conversation_id,
+            checkpoint.assistant_message_id,
+            True,
+        ),
+    )
+    store._voice_promotion_leases[session_id] = lease
+    store._voice_promotion_contexts[session_id] = object()
+    assert store.select_voice_promotion_recovery_leaf(lease, greeting) is False
+    assert store.active_leaf(session_id) == checkpoint.assistant_message_id
+    assert repository.reconcile_for_session(conversation_id).checkpoint == checkpoint
+    assert session_id not in store._voice_promotion_selection_decisions

--- a/Tests/Chat/test_console_dispatch_cursor_recovery_unit.py
+++ b/Tests/Chat/test_console_dispatch_cursor_recovery_unit.py
@@ -1,0 +1,118 @@
+"""Isolated ancestry decisions without store construction or schema migrations."""
+
+import sqlite3
+from contextlib import closing
+
+import pytest
+
+from Tests.Chat.test_console_dispatch_recovery import _acceptance
+from tldw_chatbook.Chat.console_chat_models import ConsoleDispatchRecoveryKind
+from tldw_chatbook.Chat.console_dispatch_checkpoint import (
+    ConsoleDispatchCheckpoint,
+    ConsoleDispatchCheckpointState,
+)
+from tldw_chatbook.Chat.console_dispatch_repository import (
+    ConsoleDispatchRepository,
+    _RECONCILE_WRITE_NEEDED,
+)
+
+
+@pytest.mark.parametrize(
+    "problem, allow_writes, expected_error",
+    [
+        (None, False, None),
+        (None, True, None),
+        ("cycle", True, "invalid_checkpoint_ancestry"),
+        ("parent", True, "invalid_checkpoint_ancestry"),
+        ("missing", True, "invalid_checkpoint_ancestry"),
+        ("competing", True, "duplicate_active_path_owner"),
+        ("invalid", True, "invalid_checkpoint"),
+    ],
+)
+def test_stranded_ancestry_decision(monkeypatch, problem, allow_writes, expected_error):
+    acceptance = _acceptance("conversation")
+    checkpoint = ConsoleDispatchCheckpoint(
+        assistant_message_id=acceptance.assistant_message_id,
+        user_message_id=acceptance.user_message_id,
+        conversation_id=acceptance.conversation_id,
+        preparation_id=acceptance.preparation_id,
+        attempt_id=acceptance.attempt_id,
+        state=ConsoleDispatchCheckpointState.ACCEPTED,
+        checkpoint_revision=1,
+        user_message_version=1,
+        assistant_message_version=1,
+        origin="manual",
+        queue_entry_id=None,
+        frozen_authority=acceptance.frozen_authority,
+        resolved_destination=acceptance.resolved_destination,
+        reconstructability=acceptance.reconstructability,
+    )
+    repository = ConsoleDispatchRepository(None)
+    # Payload validation and selected-path discovery have separate integration
+    # coverage. Isolate the helper's traversal and write/no-write decisions here.
+    monkeypatch.setattr(
+        repository,
+        "_checkpoint_from_row",
+        lambda row: (None, "invalid_checkpoint")
+        if problem == "invalid"
+        else (checkpoint, None),
+    )
+    monkeypatch.setattr(
+        repository,
+        "_reconcile_checkpoint_free_owner",
+        lambda *_: object() if problem == "competing" else None,
+    )
+    with closing(sqlite3.connect(":memory:")) as connection:
+        connection.row_factory = sqlite3.Row
+        with connection:
+            connection.execute(
+                "CREATE TABLE messages (id TEXT, conversation_id TEXT, deleted INTEGER, "
+                "parent_message_id TEXT, provider_continuation_json TEXT, assistant_generation_state TEXT)"
+            )
+            connection.execute(
+                "CREATE TABLE conversations (id TEXT, deleted INTEGER, active_leaf_message_id TEXT, "
+                "active_leaf_before_message_id TEXT)"
+            )
+            connection.execute(
+                "INSERT INTO conversations VALUES ('conversation', 0, 'old', 'before')"
+            )
+            connection.executemany(
+                "INSERT INTO messages VALUES (?, 'conversation', 0, ?, NULL, NULL)",
+                [
+                    ("assistant-1", "wrong" if problem == "parent" else "user-1"),
+                    (
+                        "user-1",
+                        "assistant-1"
+                        if problem == "cycle"
+                        else "missing"
+                        if problem == "missing"
+                        else None,
+                    ),
+                ],
+            )
+        with connection, closing(connection.cursor()) as cursor:
+            result = repository._reconcile_stranded_checkpoint(
+                cursor,
+                "conversation",
+                {"assistant_message_id": "assistant-1"},
+                allow_writes=allow_writes,
+            )
+        actual_cursor = tuple(
+            connection.execute(
+                "SELECT active_leaf_message_id, active_leaf_before_message_id FROM conversations"
+            ).fetchone()
+        )
+        if expected_error:
+            assert result.kind is ConsoleDispatchRecoveryKind.QUARANTINED
+            assert result.error_code == expected_error
+            assert result.actions == ()
+        elif allow_writes:
+            assert result.checkpoint == checkpoint
+            assert result.kind is ConsoleDispatchRecoveryKind.ACCEPTED
+        else:
+            assert result is _RECONCILE_WRITE_NEEDED
+        assert actual_cursor == (
+            ("assistant-1", None)
+            if allow_writes and expected_error is None
+            else ("old", "before")
+        )

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -10778,22 +10778,22 @@ class ConsoleChatStore:
         self._set_message_attachments(message, tuple(attachments))
         previous_updated_at = self._sessions[session_id].updated_at
         previous_active_leaf = self._active_leaf_by_session[session_id]
-        self._sessions[session_id].updated_at = _utc_now_iso()
-        self._register_tree_node(session_id, message, parent_native_id=parent_native_id)
-        # Retarget the active leaf and rematerialize the active-path view
-        # BEFORE persisting so the Sync v2 sequence helper (which walks the
-        # active-path VIEW) sees the new node on-path and emits its real
-        # on-path ordinal, not ``None``. This intentionally does NOT route
-        # through ``set_active_leaf``, whose bundled ordering also writes the
-        # DB active-leaf pointer -- that pointer write must happen AFTER
-        # persistence to capture the node's real ``persisted_message_id``.
-        self._active_leaf_by_session[session_id] = message.id
-        self._recompute_active_path(session_id)
         try:
-            if persist:
-                self._persist_new_message_or_defer(
-                    session_id=session_id, message=message
+            with self._dispatch_branch_mutation(session_id):
+                self._sessions[session_id].updated_at = _utc_now_iso()
+                self._register_tree_node(
+                    session_id, message, parent_native_id=parent_native_id
                 )
+                self._active_leaf_by_session[session_id] = message.id
+                self._recompute_active_path(session_id)
+                if persist:
+                    self._persist_new_message_or_defer(
+                        session_id=session_id, message=message, enqueue_sync=False
+                    )
+                if not self._persist_active_leaf(session_id, message.id):
+                    raise ValueError(
+                        "Resolve pending dispatch before changing conversation branches."
+                    )
         except Exception:
             self._rollback_new_tree_node(
                 session_id,
@@ -10802,10 +10802,8 @@ class ConsoleChatStore:
                 previous_updated_at=previous_updated_at,
             )
             raise
-        # Write-through the DB active-leaf pointer now that (for persist=True)
-        # the node owns a persisted id. For the persist=False path this mirrors
-        # the old ``set_active_leaf`` call with a still-``None`` id, which is fine.
-        self._persist_active_leaf(session_id, message.id)
+        if persist:
+            self._enqueue_sync_v2_message_if_ready(message)
         self._bump_payload_revision(session_id)
         self._bump_conversation_context_epoch(session_id)
         return self._snapshot(message)
@@ -12038,14 +12036,25 @@ class ConsoleChatStore:
             candidate.provider_continuation_warning = None
             candidate.provider_continuation_remote = False
             candidate.provider_continuation_actions_enabled = True
-        persisted = self._persist_existing_message(
-            candidate,
-            force_metadata_write=provenance_cleared,
-            clear_generation_provenance=generation_cleared,
-        )
+        with self._dispatch_branch_mutation(session_id):
+            persisted = self._persist_existing_message(
+                candidate,
+                force_metadata_write=provenance_cleared,
+                clear_generation_provenance=generation_cleared,
+                enqueue_sync=False,
+            )
+            if (
+                persisted
+                and on_active_path
+                and descendant_ids
+                and content != previous_content
+            ):
+                if not self._persist_active_leaf(session_id, message.id):
+                    raise ValueError("Resolve pending dispatch before editing this message.")
         if not persisted:
             return self._snapshot(message)
 
+        self._enqueue_sync_v2_message_if_ready(candidate)
         # The durable write is the commit point.  Only now may the live store
         # expose the replacement or advance any process-local invalidation fence.
         self._nodes_by_session[session_id][message.id] = candidate
@@ -13321,12 +13330,23 @@ class ConsoleChatStore:
         parent_native_id = self._native_parent_by_message.get(message_id)
         on_active_path = message_id in self.active_path_message_ids(session_id)
         subtree_ids = self._subtree_ids(session_id, message_id)
+        if self.persistence is None or message.persisted_message_id is None:
+            with self._dispatch_branch_mutation(session_id):
+                if on_active_path and not self._persist_active_leaf(
+                    session_id, parent_native_id
+                ):
+                    raise ValueError("Resolve pending dispatch before deleting this message.")
         tombstones: list[dict[str, Any]] = []
         if self.persistence is not None and message.persisted_message_id is not None:
             deleter = getattr(self.persistence, "delete_message_subtree", None)
             if not callable(deleter):
                 raise RuntimeError("Message deletion could not be persisted.")
-            tombstones = deleter(message_id=message.persisted_message_id)
+            with self._dispatch_branch_mutation(session_id):
+                tombstones = deleter(message_id=message.persisted_message_id)
+                if on_active_path and not self._persist_active_leaf(
+                    session_id, parent_native_id
+                ):
+                    raise ValueError("Resolve pending dispatch before deleting this message.")
             self._project_sync_v2_message_deletes(tombstones)
         for node_id in subtree_ids:
             self._invalidate_generation_attempt(node_id)
@@ -13361,7 +13381,6 @@ class ConsoleChatStore:
         self._purge_tool_markers(session_id, set(subtree_ids))
         if on_active_path:
             self._active_leaf_by_session[session_id] = parent_native_id
-            self._persist_active_leaf(session_id, parent_native_id)
         self._recompute_active_path(session_id)
         self._bump_payload_revision(session_id)
         if on_active_path:
@@ -15375,7 +15394,8 @@ class ConsoleChatStore:
             self._voice_promotion_selection_decisions[lease.session_id] = decision
 
         try:
-            self._persist_active_leaf(lease.session_id, message_id)
+            if not self._persist_active_leaf(lease.session_id, message_id):
+                return False
             with self._voice_promotion_lock:
                 if (
                     self._voice_promotion_selection_decisions.get(lease.session_id)
@@ -18873,6 +18893,7 @@ class ConsoleChatStore:
         message: ConsoleChatMessage,
         terminal_receipt_id: str | None = None,
         terminal_outcome: str | None = None,
+        enqueue_sync: bool = True,
     ) -> None:
         if self.persistence is None:
             return
@@ -18889,6 +18910,7 @@ class ConsoleChatStore:
             message=message,
             terminal_receipt_id=terminal_receipt_id,
             terminal_outcome=terminal_outcome,
+            enqueue_sync=enqueue_sync,
         )
 
     def register_provider_trace_settlement(
@@ -19445,6 +19467,7 @@ class ConsoleChatStore:
         terminal_persistence: bool = False,
         terminal_receipt_id: str | None = None,
         terminal_outcome: str | None = None,
+        enqueue_sync: bool = True,
     ) -> bool:
         if self.persistence is None:
             return False
@@ -19674,7 +19697,8 @@ class ConsoleChatStore:
         else:
             if message.id == self._active_leaf_by_session.get(session_id):
                 self._persist_active_leaf(session_id, message.id)
-            self._enqueue_sync_v2_message_if_ready(message)
+            if enqueue_sync:
+                self._enqueue_sync_v2_message_if_ready(message)
         # Trajectory sidecar (schema v38): every persisted Console message
         # gets a user/assistant row in the LOCAL-ONLY sidecar, batched with
         # any tool rows stashed while this row was still streaming.
@@ -21578,6 +21602,31 @@ class ConsoleChatStore:
             if not children:
                 return current
             current = children[-1]
+
+    @contextmanager
+    def _dispatch_branch_mutation(self, session_id: str | None):
+        """Keep branch edits atomic with admission of a durable dispatch owner.
+
+        Refuse before inserting siblings, editing ancestors, or tombstoning a
+        subtree. Hold the write transaction through the durable branch changes so
+        another connection cannot accept a send between this check and mutation.
+        """
+        session = self._sessions.get(session_id)
+        conversation_id = session.persisted_conversation_id if session is not None else None
+        db = getattr(self.persistence, "db", None)
+        if conversation_id is None or db is None:
+            yield
+            return
+        with db.transaction(immediate=True) as cursor:
+            pending = cursor.execute(
+                "SELECT 1 FROM console_dispatch_checkpoints WHERE conversation_id = ? LIMIT 1",
+                (conversation_id,),
+            ).fetchone()
+            if pending is not None:
+                raise ValueError(
+                    "Resolve pending dispatch before changing conversation branches."
+                )
+            yield
 
     def _persist_active_leaf(
         self,

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -255,7 +255,7 @@ from tldw_chatbook.Chat.thinking_blocks import (
     read_thinking_blocks_json,
 )
 from tldw_chatbook.Chat.trajectory import contains_local_path
-from tldw_chatbook.DB.ChaChaNotes_DB import TrajectoryRowWrite
+from tldw_chatbook.DB.ChaChaNotes_DB import InputError, TrajectoryRowWrite
 from tldw_chatbook.Sync_Interop.hashing import canonical_payload_hash
 from tldw_chatbook.TTS.profile_errors import ProfileValidationError
 from tldw_chatbook.TTS.profile_types import CharacterRef
@@ -2812,10 +2812,20 @@ class ConsoleChatStore:
             session.generation_durable_snapshot = generation_durable_snapshot
             session.generation_metadata_status = generation_metadata_status
             self.hydrate_session_capture_policy(session.id)
-            self._hydrate_dispatch_recovery(
+            recovery = self._hydrate_dispatch_recovery(
                 session.id,
                 str(persisted_conversation_id),
             )
+            if recovery is not None and recovery.checkpoint is not None:
+                # Reconciliation may have repaired an older stranded cursor.
+                # Publish the committed cursor, not the pre-reconcile snapshot.
+                database = getattr(self.persistence, "db", None)
+                if database is not None:
+                    active_leaf_persisted_id, active_leaf_before_persisted_id = (
+                        database.get_conversation_active_cursor(
+                            str(persisted_conversation_id)
+                        )
+                    )
             session.library_policy_hydrated = False
             coordinator = self.library_policy_coordinator
             if coordinator is not None:
@@ -13567,6 +13577,10 @@ class ConsoleChatStore:
                     before_message_id=before_message_id,
                 )
             )
+        except InputError:
+            self._active_leaf_by_session[session_id] = previous_leaf
+            self._recompute_active_path(session_id)
+            return False
         except Exception:
             logger.bind(
                 session_id=session_id,
@@ -13595,9 +13609,9 @@ class ConsoleChatStore:
         and the persistence adapter exposes a raw ``db`` seam -- write-throughs
         the local-only ``conversations.active_leaf_message_id`` pointer (mapped
         to the leaf node's *persisted* id, or ``None`` when the leaf is cleared
-        or not yet persisted). A durable write failure is logged, never raised:
-        the in-memory pointer is authoritative and already updated, matching
-        this store's persist-through convention elsewhere.
+        or not yet persisted). An ownership refusal leaves both cursors intact.
+        Other durable write failures retain the existing in-memory write-through
+        convention and are logged.
 
         Args:
             session_id: Native Console session ID.
@@ -13607,15 +13621,17 @@ class ConsoleChatStore:
         Raises:
             KeyError: If the session is unknown, or ``message_id`` is not
                 ``None`` and does not reference a node in the session's tree.
+            RuntimeError: Pending dispatch ownership refuses the cursor change.
         """
         self._session_or_raise(session_id)
         nodes = self._nodes_by_session.get(session_id, {})
         if message_id is not None and message_id not in nodes:
             raise KeyError(f"Unknown Console message: {message_id}")
+        if not self._persist_active_leaf(session_id, message_id):
+            raise RuntimeError("Conversation cursor change was refused.")
         previous_leaf = self._active_leaf_by_session.get(session_id)
         self._active_leaf_by_session[session_id] = message_id
         self._recompute_active_path(session_id)
-        self._persist_active_leaf(session_id, message_id)
         self._bump_payload_revision(session_id)
         if message_id != previous_leaf:
             self._bump_conversation_context_epoch(session_id)
@@ -21569,7 +21585,7 @@ class ConsoleChatStore:
         message_id: str | None,
         *,
         content_safe_diagnostic: bool = False,
-    ) -> None:
+    ) -> bool:
         """Write-through the local-only active-leaf pointer for a persisted conv.
 
         No-op unless the session owns a persisted conversation AND the
@@ -21577,35 +21593,36 @@ class ConsoleChatStore:
         ``persistence_db = getattr(self.persistence, "db", None)`` pattern in
         ``persist_session_if_needed``). Maps the in-memory leaf to its persisted
         message id (``None`` when cleared or not yet persisted).
+
+        Returns False only for an ownership refusal. Other I/O errors preserve
+        the historical in-memory write-through behavior.
         """
         session = self._sessions.get(session_id)
-        conversation_id = (
-            session.persisted_conversation_id if session is not None else None
-        )
+        conversation_id = session.persisted_conversation_id if session is not None else None
         if conversation_id is None:
-            return
+            return True
         persistence_db = getattr(self.persistence, "db", None)
         if persistence_db is None:
-            return
+            return True
         leaf_persisted_id: str | None = None
         if message_id is not None:
             node = self._nodes_by_session.get(session_id, {}).get(message_id)
             leaf_persisted_id = node.persisted_message_id if node is not None else None
         try:
-            persistence_db.set_conversation_active_leaf(
-                conversation_id, leaf_persisted_id
-            )
+            persistence_db.set_conversation_active_leaf(conversation_id, leaf_persisted_id)
+        except InputError:
+            logger.warning("console_cursor_pending_dispatch")
+            return False
         except Exception:
             if content_safe_diagnostic:
                 logger.warning("terminal_persistence_bookkeeping_unavailable")
-                return
+                return True
             logger.bind(
                 session_id=session_id,
                 conversation_id=conversation_id,
-            ).exception(
-                "Failed to persist Console active-leaf pointer; the in-memory "
-                "pointer keeps the applied value."
-            )
+            ).exception("Failed to persist Console active-leaf pointer.")
+            return True
+        return True
 
     def _persist_context_summary(
         self,

--- a/tldw_chatbook/Chat/console_dispatch_repository.py
+++ b/tldw_chatbook/Chat/console_dispatch_repository.py
@@ -7,6 +7,8 @@ import re
 import sqlite3
 from collections.abc import Mapping
 
+from loguru import logger
+
 from tldw_chatbook.Chat.console_dispatch_checkpoint import (
     ConsoleAssistantSettlement,
     ConsoleContinuationHandoff,
@@ -463,15 +465,14 @@ class ConsoleDispatchRepository:
             )
         active_ids = self._active_path_ids(cursor, conversation_id)
         if assistant_id not in active_ids:
-            return self._quarantined(
+            return self._reconcile_stranded_checkpoint(
+                cursor,
                 conversation_id,
-                assistant_id,
-                "checkpoint_not_active_path",
+                row,
+                allow_writes=allow_writes,
             )
 
-        continuation = read_provider_continuation_json(
-            row["provider_continuation_json"]
-        )
+        continuation = read_provider_continuation_json(row["provider_continuation_json"])
         if continuation.checkpoint is not None:
             if continuation.checkpoint.state != "active":
                 return self._quarantined(
@@ -504,9 +505,7 @@ class ConsoleDispatchRepository:
                 ),
             )
             if updated.rowcount != 1:
-                raise sqlite3.IntegrityError(
-                    "Continuation precedence message CAS failed."
-                )
+                raise sqlite3.IntegrityError("Continuation precedence message CAS failed.")
             self._delete_exact_checkpoint(cursor, row)
             return ConsoleDispatchRecoveryState(
                 kind=ConsoleDispatchRecoveryKind.CONTINUATION,
@@ -538,6 +537,78 @@ class ConsoleDispatchRepository:
                 assistant_id,
                 error_code or "invalid_checkpoint",
             )
+        return console_dispatch_recovery_from_checkpoint(checkpoint)
+
+    def _reconcile_stranded_checkpoint(
+        self,
+        cursor: sqlite3.Cursor,
+        conversation_id: str,
+        row: sqlite3.Row,
+        *,
+        allow_writes: bool,
+    ) -> "ConsoleDispatchRecoveryState | _ReconcileWriteNeeded":
+        """Restore a proven pending turn stranded by an older cursor writer.
+
+        This repairs only the local view pointer, never the checkpoint or its
+        authority. No request is dispatched; ordinary explicit recovery follows.
+        """
+        assistant_id = str(row["assistant_message_id"])
+        checkpoint, error_code = self._checkpoint_from_row(row)
+        if checkpoint is None:
+            return self._quarantined(
+                conversation_id, assistant_id, error_code or "invalid_checkpoint"
+            )
+        # Do not select a different branch over another unresolved owner.
+        if self._reconcile_checkpoint_free_owner(cursor, conversation_id) is not None:
+            return self._quarantined(
+                conversation_id, assistant_id, "duplicate_active_path_owner"
+            )
+        seen: set[str] = set()
+        current: str | None = assistant_id
+        while current is not None:
+            if current in seen:
+                return self._quarantined(
+                    conversation_id, assistant_id, "invalid_checkpoint_ancestry"
+                )
+            seen.add(current)
+            ancestor = cursor.execute(
+                "SELECT parent_message_id, provider_continuation_json, assistant_generation_state "
+                "FROM messages WHERE id = ? AND conversation_id = ? AND deleted = 0",
+                (current, conversation_id),
+            ).fetchone()
+            if ancestor is None or (
+                current == assistant_id
+                and ancestor["parent_message_id"] != checkpoint.user_message_id
+            ):
+                return self._quarantined(
+                    conversation_id, assistant_id, "invalid_checkpoint_ancestry"
+                )
+            if current != assistant_id:
+                continuation = read_provider_continuation_json(
+                    ancestor["provider_continuation_json"]
+                )
+                if ancestor["assistant_generation_state"] in {
+                    "accepted",
+                    "dispatch_started",
+                    "continuation_active",
+                } or (
+                    ancestor["provider_continuation_json"] is not None
+                    and (
+                        continuation.checkpoint is None
+                        or continuation.checkpoint.state != "complete"
+                    )
+                ):
+                    return self._quarantined(
+                        conversation_id, assistant_id, "invalid_checkpoint_ancestry"
+                    )
+            current = ancestor["parent_message_id"]
+        if not allow_writes:
+            return _RECONCILE_WRITE_NEEDED
+        cursor.execute(
+            "UPDATE conversations SET active_leaf_message_id = ?, active_leaf_before_message_id = NULL "
+            "WHERE id = ? AND deleted = 0",
+            (assistant_id, conversation_id),
+        )
         return console_dispatch_recovery_from_checkpoint(checkpoint)
 
     def _reconcile_checkpoint_free_owner(
@@ -707,6 +778,7 @@ class ConsoleDispatchRepository:
             if re.fullmatch(r"[a-z][a-z0-9_]{0,63}", error_code or "")
             else "invalid_checkpoint"
         )
+        logger.warning("console_dispatch_recovery_quarantined error_code={}", bounded)
         return ConsoleDispatchRecoveryState(
             kind=ConsoleDispatchRecoveryKind.QUARANTINED,
             assistant_message_id=assistant_message_id,

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -12527,6 +12527,11 @@ UPDATE db_schema_version
             InputError: The cursor would leave an unresolved dispatch owner off path.
         """
         with self.transaction(immediate=True) as conn:
+            if conn.execute(
+                "SELECT 1 FROM conversations WHERE id = ? AND deleted = 0",
+                (conversation_id,),
+            ).fetchone() is None:
+                return False
             # A view cursor is not dispatch authority. Never let a stale view
             # strand the exact durable send which still owns this conversation.
             stranded = conn.execute(

--- a/tldw_chatbook/DB/ChaChaNotes_DB.py
+++ b/tldw_chatbook/DB/ChaChaNotes_DB.py
@@ -12522,8 +12522,32 @@ UPDATE db_schema_version
         Returns:
             ``True`` when one non-deleted conversation row was updated; ``False``
             when the conversation is missing or deleted.
+
+        Raises:
+            InputError: The cursor would leave an unresolved dispatch owner off path.
         """
-        with self.transaction() as conn:
+        with self.transaction(immediate=True) as conn:
+            # A view cursor is not dispatch authority. Never let a stale view
+            # strand the exact durable send which still owns this conversation.
+            stranded = conn.execute(
+                """WITH RECURSIVE target_path(id, parent_message_id) AS (
+                       SELECT id, parent_message_id FROM messages
+                        WHERE id = ? AND conversation_id = ? AND deleted = 0
+                       UNION
+                       SELECT m.id, m.parent_message_id FROM messages m
+                         JOIN target_path p ON m.id = p.parent_message_id
+                        WHERE m.conversation_id = ? AND m.deleted = 0
+                   )
+                   SELECT 1 FROM console_dispatch_checkpoints c
+                    WHERE c.conversation_id = ? AND NOT EXISTS (
+                        SELECT 1 FROM target_path p WHERE p.id = c.assistant_message_id
+                    ) LIMIT 1""",
+                (active_leaf_message_id, conversation_id, conversation_id, conversation_id),
+            ).fetchone()
+            if stranded is not None:
+                raise InputError(
+                    "Resolve pending dispatch before changing the conversation cursor."
+                )
             updated = conn.execute(
                 "UPDATE conversations "
                 "SET active_leaf_message_id = ?, "


### PR DESCRIPTION
## Summary
Prevent conversation navigation and branch edits from stranding a pending dispatch. Restore a validated stranded checkpoint to its original turn without replaying the provider request; keep ambiguous ownership quarantined.

Cursor changes preserve runtime state on refusal. Sibling creation, ancestor editing and subtree deletion check ownership transactionally; voice recovery selection respects refusal. Deleted conversations retain the documented cursor result. All six Qodo findings are addressed.

## Validation
- 27 new recovery regression and isolated unit tests pass after rebasing onto dev.
- 79 targeted recovery, branch-tree and voice tests pass.
- Broader targeted runs: 197 passed; seven failures reproduce on unchanged dev and are documented in the implementation notes.
- New tests pass Ruff; no additional production lint findings.
- Reviewed and regenerated the production diagnostic inventory.
