### PR TITLE
Design token system and design-language constitution (ADR-150)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -230,6 +230,32 @@ Critical files for common tasks:
 - Security: `path_validation.py`, `input_validation.py`
 - UI: `form_components.py`, reactive patterns in any widget
 
+## Design Language (UI Tokens) — ADR-150
+
+All UI work is governed by a design-token system. **Read
+`backlog/docs/design-language.md` before creating or modifying any screen,
+widget, or stylesheet.**
+
+Hard rules:
+
+- Every consistent visual value is a `$ds-*` token in
+  `tldw_chatbook/css/core/_variables.tcss` — spacing (`$ds-space-*`),
+  sizing (`$ds-control-*`), motion (`$ds-duration-*`), opacity, typography
+  emphasis, colors, status, and component states. Do not invent literals or
+  ad-hoc tokens in feature sheets; the governance test
+  (`Tests/UI/test_design_token_governance.py`) fails on undefined `$ds-*`
+  references and on new hex literals outside the token file.
+- Describe new UI by composing tokens, component patterns, layout laws, and
+  interaction rules from the constitution — never "make it look modern".
+- Adding a value the language can't express? Add the token to
+  `_variables.tcss` first, then use it.
+- Never edit `tldw_chatbook/css/tldw_cli_modular.tcss` directly; edit source
+  modules and rebuild with `python tldw_chatbook/css/build_css.py`.
+- Python code assigns token-backed CSS classes instead of ad-hoc
+  `styles.*` literals for token-covered values.
+- Changing an existing token's value is a visual-breaking change; verify
+  live per `backlog/docs/lessons-live-verification.md`.
+
 ## Code Style
 
 - Type hints for public APIs

--- a/Tests/QA/test_scheduling_css_tokens.py
+++ b/Tests/QA/test_scheduling_css_tokens.py
@@ -9,6 +9,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 SOURCE_CSS = REPO_ROOT / "tldw_chatbook/css/features/_scheduling.tcss"
 GENERATED_CSS = REPO_ROOT / "tldw_chatbook/css/tldw_cli_modular.tcss"
+# TASK-24459's screen-owned split moves scheduling-*-pure rules out of the
+# main bundle into this lazily loaded sheet; pane styling is checked there.
+SCREEN_CSS = REPO_ROOT / "tldw_chatbook/css/screen_feature_scheduling.tcss"
 AGENTIC_TERMINAL_CSS = REPO_ROOT / "tldw_chatbook/css/components/_agentic_terminal.tcss"
 
 MODULE_BANNER = "/* ===== MODULE: features/_scheduling.tcss ===== */"
@@ -40,7 +43,9 @@ def test_generated_bundle_contains_scheduling_module_banner() -> None:
 
 
 def test_scheduling_panes_declare_design_grid_border() -> None:
-    for path in (SOURCE_CSS, GENERATED_CSS):
+    # Post-split (TASK-24459) the pane rules live in the screen-owned sheet;
+    # the source module keeps the canonical definitions.
+    for path in (SOURCE_CSS, SCREEN_CSS):
         css = path.read_text(encoding="utf-8")
         for selector in SELECTORS:
             rule = _rule_block(css, selector)

--- a/Tests/QA/test_scheduling_css_tokens.py
+++ b/Tests/QA/test_scheduling_css_tokens.py
@@ -43,8 +43,11 @@ def test_generated_bundle_contains_scheduling_module_banner() -> None:
 
 
 def test_scheduling_panes_declare_design_grid_border() -> None:
-    # Post-split (TASK-24459) the pane rules live in the screen-owned sheet;
-    # the source module keeps the canonical definitions.
+    """Pane borders use the $ds-grid-line token in source and screen sheet.
+
+    Post-split (TASK-24459) the pane rules live in the screen-owned sheet;
+    the source module keeps the canonical definitions, so both are checked.
+    """
     for path in (SOURCE_CSS, SCREEN_CSS):
         css = path.read_text(encoding="utf-8")
         for selector in SELECTORS:

--- a/Tests/UI/test_design_token_governance.py
+++ b/Tests/UI/test_design_token_governance.py
@@ -33,11 +33,13 @@ _RAW_SPACING_RE = re.compile(
     r"\b(?:padding|margin)(?:-(?:top|right|bottom|left))?\s*:\s*[0-9]"
 )
 
-# Legacy sheets with pre-existing hex literals, pinned at current counts
-# (ratchet: may only decrease). Counts verified 2026-08-05.
+# Legacy sheets with pre-existing hex literals in ACTIVE declarations,
+# pinned at current counts (ratchet: may only decrease). Comments are
+# stripped before counting, so documented measurements never consume
+# allowance and removing one never creates allowance for a real literal.
+# Active counts verified 2026-09-11 (_lists.tcss has comment-only hexes).
 _HEX_GRANDFATHERED: dict[str, int] = {
-    "components/_lists.tcss": 4,
-    "components/_agentic_terminal.tcss": 6,
+    "components/_agentic_terminal.tcss": 1,
 }
 
 # Every sheet that existed when ADR-150 landed (2026-09-11), including the
@@ -155,17 +157,30 @@ def test_documented_design_vocabulary_is_available() -> None:
 
 
 def test_hex_literals_are_ratcheted_outside_token_definitions() -> None:
+    """Raw hex colors may only shrink, never grow, outside token definitions.
+
+    Comments are stripped before counting: only active declarations are
+    governed, so documenting a measured color in a comment can neither fail
+    CI nor free up allowance for a real hardcoded color.
+    """
     for module in _source_modules():
         relative = str(module.relative_to(CSS_ROOT))
         if module == TOKENS_FILE:
             continue
-        count = len(_HEX_RE.findall(module.read_text(encoding="utf-8")))
+        text = _strip_comments(module.read_text(encoding="utf-8"))
+        count = len(_HEX_RE.findall(text))
         allowance = _HEX_GRANDFATHERED.get(relative, 0)
         assert count <= allowance, (
             f"{relative} has {count} hex literals (allowance {allowance}). "
             "Colors belong in core/_variables.tcss tokens (ADR-150). "
             "The grandfathered allowance may only decrease."
         )
+
+
+def test_hex_ratchet_ignores_comments() -> None:
+    """Regression: hex strings inside /* */ comments must not be counted."""
+    css = "/* measured #51677e at 3:1 */\n.card { color: #ff8fa3; }\n"
+    assert _HEX_RE.findall(_strip_comments(css)) == ["#ff8fa3"]
 
 
 def test_new_sheets_must_use_spacing_tokens() -> None:

--- a/Tests/UI/test_design_token_governance.py
+++ b/Tests/UI/test_design_token_governance.py
@@ -1,0 +1,183 @@
+"""Design-token governance (ADR-150, TASK-32475).
+
+Mechanical enforcement of the design-token system:
+
+1. Every ``$ds-*`` token referenced in any TCSS source module must be defined
+   in ``core/_variables.tcss`` — agents may not invent tokens ad hoc in
+   feature sheets, and renamed/removed tokens fail loudly instead of silently
+   falling back.
+2. Hex-color ratchet: raw hex literals are legal only in token definitions
+   (``core/_variables.tcss``) and the theme catalog (``Themes/``). The two
+   legacy source sheets that still carry hex literals are grandfathered at
+   their current counts; the count may only go down.
+3. New sheets start clean: any ``*.tcss`` module not in the grandfathered
+   manifest must use the spacing scale and may not introduce raw numeric
+   ``padding``/``margin`` declarations or hex literals at all.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CSS_ROOT = REPO_ROOT / "tldw_chatbook/css"
+TOKENS_FILE = CSS_ROOT / "core/_variables.tcss"
+
+# Matches a full token name used anywhere (definition or reference).
+_TOKEN_RE = re.compile(r"\$ds-[a-z0-9-]+")
+# A token definition line, e.g. `$ds-space-1: 1;`
+_DEFINITION_RE = re.compile(r"^\s*(\$ds-[a-z0-9-]+)\s*:", re.MULTILINE)
+_HEX_RE = re.compile(r"#[0-9a-fA-F]{6}\b")
+_RAW_SPACING_RE = re.compile(
+    r"\b(?:padding|margin)(?:-(?:top|right|bottom|left))?\s*:\s*[0-9]"
+)
+
+# Legacy sheets with pre-existing hex literals, pinned at current counts
+# (ratchet: may only decrease). Counts verified 2026-08-05.
+_HEX_GRANDFATHERED: dict[str, int] = {
+    "components/_lists.tcss": 4,
+    "components/_agentic_terminal.tcss": 6,
+}
+
+# Every sheet that existed when ADR-150 landed (2026-09-11), including the
+# legacy files not in the build manifest (_unified_sidebar, _new_ingest,
+# _chatbooks_improved). Anything NOT in this set is a post-ADR sheet and must
+# be token-clean.
+_LEGACY_SHEETS: frozenset[str] = frozenset(
+    """
+    core/_variables.tcss core/_reset.tcss core/_base.tcss core/_typography.tcss
+    layout/_windows.tcss layout/_tabs.tcss layout/_sidebars.tcss
+    layout/_panes.tcss layout/_containers.tcss
+    components/_buttons.tcss components/_forms.tcss components/_lists.tcss
+    components/_navigation.tcss components/_change_review.tcss
+    components/_messages.tcss components/_dialogs.tcss components/_status.tcss
+    components/_agentic_terminal.tcss components/_workbench.tcss
+    components/_widgets.tcss components/_settings_splash_theme.tcss
+    components/_shared_components.tcss components/_unified_sidebar.tcss
+    components/_profile_interview.tcss components/_settings_personal_context.tcss
+    features/_chat.tcss features/_conversations.tcss features/_notes.tcss
+    features/_media.tcss features/_llm-management.tcss
+    features/_tools-settings.tcss features/_ingest.tcss
+    features/_evaluation_unified.tcss features/_evals.tcss
+    features/_metrics.tcss features/_embeddings.tcss features/_splash.tcss
+    features/_wizards.tcss features/_chatbooks.tcss features/_scheduling.tcss
+    features/_code_repo.tcss features/_coding.tcss features/_tab_dropdown.tcss
+    features/_watchlists.tcss features/_lab.tcss features/_logs.tcss
+    features/_writing.tcss features/config_search.tcss
+    features/feature_alerts.tcss features/_new_ingest.tcss
+    features/_chatbooks_improved.tcss features/_research_workspace.tcss
+    utilities/_helpers.tcss utilities/_states.tcss utilities/_overrides.tcss
+    """.split()
+)
+
+_COMMENT_RE = re.compile(r"/\*.*?\*/", re.DOTALL)
+
+
+def _strip_comments(css: str) -> str:
+    """Comments may mention tokens prose-style ('the $ds-focus contract');
+    only real declarations are governed."""
+    return _COMMENT_RE.sub("", css)
+
+
+def _source_modules() -> list[Path]:
+    """All TCSS source modules, excluding generated bundles and themes."""
+    modules: list[Path] = []
+    for subdir in ("core", "layout", "components", "features", "utilities"):
+        directory = CSS_ROOT / subdir
+        if directory.is_dir():
+            modules.extend(sorted(directory.glob("*.tcss")))
+    return modules
+
+
+def _defined_tokens() -> set[str]:
+    return set(_DEFINITION_RE.findall(TOKENS_FILE.read_text(encoding="utf-8")))
+
+
+def test_all_referenced_ds_tokens_are_defined() -> None:
+    """No sheet may reference a $ds-* token that _variables.tcss lacks."""
+    defined = _defined_tokens()
+    assert "$ds-space-1" in defined, "token catalog sanity check failed"
+
+    offenders: dict[str, sorted] = {}
+    for module in _source_modules():
+        text = _strip_comments(module.read_text(encoding="utf-8"))
+        referenced = set(_TOKEN_RE.findall(text)) - defined
+        if referenced:
+            offenders[str(module.relative_to(CSS_ROOT))] = sorted(referenced)
+
+    assert not offenders, (
+        "Undefined $ds-* tokens referenced (define them in "
+        "core/_variables.tcss, per ADR-150):\n"
+        + "\n".join(f"  {mod}: {', '.join(toks)}" for mod, toks in offenders.items())
+    )
+
+
+def test_defined_tokens_have_no_orphans_in_catalog() -> None:
+    """Token definitions must be unique — a redefinition is a silent override."""
+    definitions = _DEFINITION_RE.findall(TOKENS_FILE.read_text(encoding="utf-8"))
+    duplicates = sorted({tok for tok in definitions if definitions.count(tok) > 1})
+    assert not duplicates, f"Duplicate token definitions: {duplicates}"
+
+
+def test_documented_design_vocabulary_is_available() -> None:
+    """ADR-150's catalog must exist even before a feature consumes a token."""
+    required = {
+        "$ds-space-0",
+        "$ds-space-1",
+        "$ds-space-2",
+        "$ds-space-3",
+        "$ds-space-inline",
+        "$ds-space-stack",
+        "$ds-space-section",
+        "$ds-space-inset",
+        "$ds-control-height",
+        "$ds-control-height-compact",
+        "$ds-textarea-min-height",
+        "$ds-duration-fast",
+        "$ds-duration-medium",
+        "$ds-duration-slow",
+        "$ds-opacity-dim",
+        "$ds-text-strong",
+        "$ds-text-emphasis",
+        "$ds-hover-bg",
+        "$ds-hover-fg",
+        "$ds-disabled-bg",
+        "$ds-text-disabled-readable",
+        "$ds-sidebar-width",
+        "$ds-sidebar-min-width",
+        "$ds-sidebar-max-width",
+    }
+    missing = sorted(required - _defined_tokens())
+    assert not missing, (
+        f"Documented design-language tokens missing from catalog: {missing}"
+    )
+
+
+def test_hex_literals_are_ratcheted_outside_token_definitions() -> None:
+    for module in _source_modules():
+        relative = str(module.relative_to(CSS_ROOT))
+        if module == TOKENS_FILE:
+            continue
+        count = len(_HEX_RE.findall(module.read_text(encoding="utf-8")))
+        allowance = _HEX_GRANDFATHERED.get(relative, 0)
+        assert count <= allowance, (
+            f"{relative} has {count} hex literals (allowance {allowance}). "
+            "Colors belong in core/_variables.tcss tokens (ADR-150). "
+            "The grandfathered allowance may only decrease."
+        )
+
+
+def test_new_sheets_must_use_spacing_tokens() -> None:
+    """Modules added after ADR-150 may not hardcode numeric padding/margin."""
+    for module in _source_modules():
+        relative = str(module.relative_to(CSS_ROOT))
+        if relative in _LEGACY_SHEETS:
+            continue
+        matches = _RAW_SPACING_RE.findall(
+            _strip_comments(module.read_text(encoding="utf-8"))
+        )
+        assert not matches, (
+            f"{relative} is a post-ADR-150 sheet and must use the "
+            "$ds-space-* scale instead of raw numeric padding/margin."
+        )

--- a/backlog/decisions/150-design-token-system-and-design-language.md
+++ b/backlog/decisions/150-design-token-system-and-design-language.md
@@ -1,0 +1,64 @@
+# ADR-150: Design token system and design-language constitution
+
+Status: Accepted
+Date: 2026-08-05
+Related Tasks: TASK-32475
+
+## Decision
+
+UI styling in tldw_chatbook is governed by a design-token system. Every
+visual value that must stay consistent across screens — spacing, control
+sizing, motion duration, opacity, typography emphasis, colors, status and
+component-state semantics — exists as a `$ds-*` token defined in
+`tldw_chatbook/css/core/_variables.tcss`, or as a written rule in
+`backlog/docs/design-language.md`. Contributors and agents compose new UI
+from these tokens and rules; they do not invent literals per screen.
+
+Token rules:
+
+- All tokens live in one place: `core/_variables.tcss`. Tokens are scalar,
+  single-value definitions (Textual TCSS substitutes variables per token).
+- Naming is `$ds-<category>-<name>[-<variant>]`; semantic aliases (e.g.
+  `$ds-space-stack`) point at scale values, never at raw literals of their
+  own.
+- A new raw value may only enter a stylesheet by first becoming a token in
+  `_variables.tcss`. Feature-scoped one-off geometry may remain literal but
+  is expected to migrate when a second consumer appears.
+- A governance test fails the build when a `$ds-*` token is referenced but
+  not defined.
+- Python code does not set ad-hoc `styles.*` literals for values covered by
+  tokens; it assigns token-backed CSS classes or uses values that already
+  exist as tokens.
+
+The constitution document (`backlog/docs/design-language.md`) is the
+human- and agent-readable specification: token catalog, layout laws,
+interaction rules, component-state conventions, and the process for adding
+tokens. AGENTS.md points at it as required reading before UI work.
+
+## Alternatives considered
+
+- **Status quo (per-screen literals):** rejected — every new screen re-opens
+  the same styling debates; ~7,100 hardcoded dimension declarations and ~900
+  hex literals have already accumulated, and existing design rules survive
+  only as comments.
+- **Full migration to tokens in one pass:** rejected for now — rewriting
+  thousands of declarations in one change is unreviewable and risks visual
+  regressions. The system is introduced additively with exemplar sheets and
+  a ratchet: new work must use tokens; legacy literals migrate opportunistically.
+- **Tokens in Python (`Constants.py`):** rejected as the primary home — the
+  stylesheet is where values are consumed; a single token file keeps one
+  source of truth. Python-side consumers reference tokens by name via CSS
+  classes, not duplicated constants.
+- **Multi-value composite tokens (e.g. `$ds-border-panel: round $border`):**
+  deferred — Textual variable substitution semantics for multi-token values
+  are not verified in this repo; tokens are scalar until that is tested.
+
+## Consequences
+
+- `core/_variables.tcss` becomes the design vocabulary; it is append-mostly
+  and changes to existing token values are visual-breaking changes requiring
+  deliberate review.
+- New UI PRs are reviewable against the constitution ("which token/rule
+  justifies this value?") instead of taste.
+- The bundle sync guard and the new governance test enforce the system
+  mechanically.

--- a/backlog/docs/design-language.md
+++ b/backlog/docs/design-language.md
@@ -1,0 +1,173 @@
+# Design Language — tldw_chatbook UI Constitution
+
+Status: governing document (ADR-150, TASK-32475)
+Audience: humans and agents building or modifying any screen, widget, or
+stylesheet in this repo.
+
+> Humans define the design language. Agents speak the design language.
+> Prompts are temporary; this document is memory.
+
+When you design a new screen or modify UI, **compose from the tokens and
+rules below**. Do not invent visual values per screen. If the language
+cannot express what you need, extend the language first (see "Adding to the
+language"), then compose.
+
+## 1. Where things live
+
+| Concern | Location |
+|---|---|
+| Design tokens (`$ds-*`) | `tldw_chatbook/css/core/_variables.tcss` |
+| Textual theme palettes (raw hex) | `tldw_chatbook/css/Themes/themes.py` |
+| Stylesheet modules | `tldw_chatbook/css/{core,layout,components,features,utilities}/` |
+| Build manifest (module order) | `tldw_chatbook/css/build_css.py` (`CSS_MODULES`) |
+| Generated bundle (never edit) | `tldw_chatbook/css/tldw_cli_modular.tcss` |
+| Governance tests | `Tests/UI/test_design_token_governance.py`, `test_css_bundle_sync_guard.py` |
+
+Textual TCSS substitutes variables **per token**: tokens are scalar,
+single-value definitions (`$ds-space-1: 1;`, `$ds-duration-fast: 0.2s;`).
+Multi-value composite tokens are not used (ADR-150).
+
+## 2. Token catalog
+
+### 2.1 Color and semantic meaning (existing layer)
+
+- **Surfaces:** `$ds-surface-panel`, `$ds-surface-raised`,
+  `$ds-surface-inspector`, `$ds-grid-line`, `$ds-column-line`
+- **Text:** `$ds-text-primary`, `$ds-text-muted`, `$ds-text-disabled`
+- **Focus (non-obscuring focus contract):** `$ds-focus-bg`, `$ds-focus-fg`,
+  `$ds-focus-accent`, `$ds-action-focus`, `$ds-input-focus-border`,
+  `$ds-input-focus-bg`, `$ds-input-focus-accent`, `$ds-control-edge`
+- **Status:** `$ds-status-ready | -running | -info | -warning |
+  -approval-required | -blocked | -error | -error-readable | -paused |
+  -unsaved | -recovered`
+- **Authority / source roles:** `$ds-authority-*`, `$ds-source-role-*`
+
+Never use raw hex in stylesheets; theme variables (`$primary`, `$surface`,
+`$text-muted`, …) and `$ds-*` aliases are the only legal colors. Error text
+that must be **read** uses `$ds-status-error-readable`, not `$error`
+(a11y, TASK-2230).
+
+### 2.2 Spacing scale
+
+`$ds-space-0 | -1 | -2 | -3` (0–3 cells/rows). The TUI's physical unit is
+one cell; the scale is deliberately tiny. Prefer the semantic aliases, which
+make intent visible:
+
+| Token | Use for |
+|---|---|
+| `$ds-space-inline` | gap between siblings in a horizontal row (buttons, chips) |
+| `$ds-space-stack` | gap between stacked fields/rows in a form |
+| `$ds-space-section` | gap between major sections; title ↔ content separation |
+| `$ds-space-inset` | padding inside a panel, card, or bordered box |
+
+### 2.3 Control sizing
+
+- `$ds-control-height: 3` — standard action control (buttons, selects,
+  single-line inputs)
+- `$ds-control-height-compact: 1` — tab bars, status lines, chip rows
+- `$ds-textarea-min-height: 5` — multi-line text inputs
+
+### 2.4 Motion
+
+`$ds-duration-fast: 0.2s` (hover feedback), `$ds-duration-medium: 0.3s`
+(panel/visibility changes), `$ds-duration-slow: 0.5s` (large layout shifts
+only). No other durations in new UI.
+
+### 2.5 Opacity and the disabled state
+
+`$ds-opacity-dim: 70%` is the only opacity token, for de-emphasized but
+readable secondary content. **Opacity is not the disabled mechanism** for
+action controls: stacking `opacity: 50%` on already-dim text composited to a
+measured 1.34:1 and made disabled controls look absent (TASK-25822). The
+disabled state is `$ds-disabled-bg` + `$ds-text-disabled-readable` at full
+opacity; hover on disabled keeps the disabled surface.
+
+### 2.6 Typography emphasis
+
+TUI typography is weight/style, not size. `$ds-text-strong: bold`,
+`$ds-text-emphasis: italic`. The focus marker `bold underline` is part of
+the focus contract and stays as-is.
+
+### 2.7 Component states
+
+Every interactive control must define, at minimum:
+
+- **rest:** default surface; editable fields carry the one-column left
+  `$ds-control-edge` (task-1586 convention)
+- **hover:** `$ds-hover-bg` / `$ds-hover-fg` — must NOT reuse the focus
+  surface (hover is not focus)
+- **focus:** `$ds-focus-bg` / `$ds-focus-fg` / `bold underline` — the
+  non-obscuring focus contract: focus must be visibly distinct from rest
+  AND must not obscure content. Never alias the focus surface back to a
+  resting surface (this nullified focus twice: TASK-345, task-1586)
+- **disabled:** `$ds-disabled-bg` + `$ds-text-disabled-readable` at full
+  opacity (never opacity-stacked — see §2.5); hover on disabled keeps the
+  disabled surface
+
+### 2.8 Layout laws
+
+- **Standard shell sidebar:** `$ds-sidebar-width: 25%`,
+  `$ds-sidebar-min-width: 35`, `$ds-sidebar-max-width: 80`, docked left,
+  collapsible to zero width (never a sliver).
+- **Feature geometry stays local** until a second consumer appears; then it
+  promotes to `_variables.tcss` (e.g. `$ds-console-composer-height`).
+- Pane borders use `$ds-grid-line` / `$ds-column-line`, never raw hex.
+
+## 3. Interaction rules (binding on all screens)
+
+1. **Focus is sacred.** Every keyboard-reachable element must show visible,
+   non-obscuring focus per §2.7. An invisible focus indicator is a critical
+   defect (a Tab+Enter once activated "Save as…" invisibly).
+2. **Selects are three shapes.** A `Select` may draw its own border, draw it
+   on `SelectCurrent`, or be borderless-compact. Style only what every shape
+   has — its colors — unless you have measured the geometry (TASK-2300).
+3. **Left borders cost a column, never a row** — prefer them over
+   top/bottom edges in dense one-row forms.
+4. **Readable beats decorative.** Status hues that fail contrast on dark
+   canvases use the `-readable` variant for text.
+5. **Footer hints advertise only implemented actions**; screens do not bind
+   terminal-convention keys (see `backlog/decisions/031-*.md`).
+
+## 4. How to describe a new screen (the recipe)
+
+When asking an agent (or planning yourself) for new UI, describe it in the
+language:
+
+1. **Layout law:** which shell pattern (sidebar screen, three-pane
+   workbench, modal dialog, compact strip) and which layout tokens apply.
+2. **Component inventory:** which existing components/classes
+   (`.form-input`, `.form-section-title`, `.status-area`, `Button`,
+   …) fill each region. New components reuse state tokens from §2.7.
+3. **Semantic meaning:** which status/authority/source-role tokens each
+   element carries.
+4. **States:** confirm rest/hover/focus/disabled are all specified.
+5. **Exceptions:** anything the tokens cannot express → add a token first.
+
+A good brief sounds like: *"Standard sidebar shell (`$ds-sidebar-*`), a
+stacked form (`$ds-space-stack`) of `.form-input` fields, actions row at
+`$ds-space-section` with default Button states, status line using
+`$ds-status-unsaved` when dirty."* — no colors, no pixels, no "modern".
+
+## 5. Adding to the language
+
+1. Add the token to `core/_variables.tcss` in the right section, scalar
+   value, `$ds-<category>-<name>[-<variant>]` naming. Aliases point at
+   scale tokens, never at raw literals.
+2. If it is a **rule** rather than a value, add it to this document.
+3. Rebuild the bundle: `python tldw_chatbook/css/build_css.py` (the app also
+   rebuilds on boot when sources are newer; the committed bundle must
+   reproduce — `test_css_bundle_sync_guard.py` enforces this).
+4. Run `pytest Tests/UI/test_design_token_governance.py Tests/UI/`.
+5. Changing an **existing token's value** is a visual-breaking change:
+   expect to verify live (`backlog/docs/lessons-live-verification.md`).
+
+## 6. What is deliberately NOT tokenized yet
+
+- The ~7,000 legacy dimension literals in feature sheets — migrate
+  opportunistically when touching a file; new sheets must be token-clean.
+- Python-side `styles.*` mutations (~250 call sites) — new code assigns
+  token-backed classes instead of ad-hoc literals.
+- Multi-value composite tokens (e.g. `border: round $border` as one token)
+  — blocked on verified Textual substitution semantics (ADR-150).
+- Feature-scoped geometry tokens already in `_variables.tcss` (`$ds-home-*`,
+  `$ds-library-*`, …) — promote to layout laws when reused.

--- a/backlog/tasks/task-32475 - Design-token-system-and-design-language-constitution-for-UI.md
+++ b/backlog/tasks/task-32475 - Design-token-system-and-design-language-constitution-for-UI.md
@@ -1,0 +1,115 @@
+---
+id: TASK-32475
+title: Design token system and design-language constitution for UI
+status: Done
+assignee:
+  - '@kimi'
+created_date: '2026-08-05'
+labels:
+  - ui
+  - css
+  - design-system
+dependencies: []
+priority: high
+---
+
+## Renumbering provenance
+
+Originally TASK-2511 (2026-08-05); the backlog was regenerated while the work
+waited on verification, and on dev the reissued id collided with an unrelated
+task. Renumbered to TASK-32475 when the branch was rebased onto origin/dev
+(b277f16193) for PR.
+
+## Description (the why)
+
+New screens and widgets are currently styled by inventing literals: thousands
+of hardcoded dimension declarations and hex literals live across the TCSS
+sources, and 250+ Python call sites mutate `styles.*` directly. The existing
+`$ds-*` vocabulary in `core/_variables.tcss` covers semantic color and status
+but nothing else, and the design rules that do exist (non-obscuring focus
+contract, control-edge convention) survive only as comments. Every new UI
+session therefore re-opens the same architectural debates. The goal is a
+governed design language: anything that must stay consistent across screens
+exists as a token or a written rule, so agents and contributors compose UI
+from the language instead of inventing it.
+
+## Acceptance Criteria (the what)
+
+- [x] `core/_variables.tcss` token catalog covers spacing scale, control
+  sizing, motion durations, opacity, typography emphasis, and component-state
+  semantics, alongside the existing color/status tokens
+- [x] A design-language constitution exists under `backlog/docs/` describing
+  the token catalog, naming rules, layout laws, interaction rules, and the
+  process for adding tokens, and is linked from AGENTS.md
+- [x] A governance pytest fails when a `$ds-*` token is referenced but not
+  defined in `core/_variables.tcss`
+- [x] Exemplar sheets (`components/_buttons.tcss`, `components/_forms.tcss`)
+  consume tokens with no visual change (values map 1:1)
+- [x] The committed CSS bundle reproduces from sources (bundle sync guard
+  passes) and the existing CSS test suite still passes
+- [x] ADR created and linked (long-lived UX structure decision)
+
+## Implementation Plan (the how)
+
+ADR required: yes
+ADR path: backlog/decisions/150-design-token-system-and-design-language.md
+Reason: long-lived UX/application structure and governance decision per
+AGENTS.md ADR criteria.
+
+1. Extend `core/_variables.tcss` with spacing/sizing/motion/opacity/
+   typography/state token sections; scalar single-value tokens only (Textual
+   variable substitution is per-token)
+2. Tokenize exemplar sheets `_buttons.tcss` and `_forms.tcss` plus the
+   `.sidebar` layout law with 1:1 value mappings (pure refactor)
+3. Add `Tests/UI/test_design_token_governance.py`: every `$ds-*` referenced
+   in any TCSS source must be defined in `core/_variables.tcss`; hex ratchet;
+   post-ADR sheets must use the spacing scale
+4. Write `backlog/docs/design-language.md` constitution; link from AGENTS.md
+5. Rebuild the bundle, run CSS tests, open PR against dev
+
+## Implementation Notes
+
+Implemented the design-token system additively (ADR-150), no visual changes;
+PR #2628 against dev.
+
+- `core/_variables.tcss`: added token sections — spacing scale
+  (`$ds-space-0..3` + semantic aliases `inline/stack/section/inset`),
+  control sizing (`$ds-control-height`, `-compact`,
+  `$ds-textarea-min-height`), motion (`$ds-duration-fast/medium/slow`),
+  opacity (`$ds-opacity-dim`), typography emphasis
+  (`$ds-text-strong`, `-emphasis`), component-state surfaces
+  (`$ds-hover-*`, `$ds-disabled-bg`), and layout-law sidebar geometry
+  (`$ds-sidebar-width/min/max`). All scalar single-value tokens; every value
+  taken 1:1 from literals already in production stylesheets.
+  Deliberately omitted `$ds-opacity-disabled`/`$ds-disabled-fg` from the
+  original design: TASK-25822 established that disabled action controls use
+  `$ds-disabled-bg` + `$ds-text-disabled-readable` at full opacity.
+- Tokenized exemplars: `components/_buttons.tcss`,
+  `components/_forms.tcss`, and the `.sidebar` layout law in
+  `layout/_sidebars.tcss` (1:1 value mappings, pure refactor).
+- `Tests/UI/test_design_token_governance.py`: fails on any `$ds-*`
+  referenced but not defined (comments stripped first), duplicate
+  definitions, hex literals outside `_variables.tcss`/`Themes/` (legacy
+  sheets ratcheted at pinned counts), and raw numeric padding/margin in
+  sheets added after ADR-150. Includes a documented-vocabulary availability
+  test so the catalog exists before any consumer.
+- `backlog/docs/design-language.md`: the constitution — token catalog,
+  interaction rules, the new-screen recipe, token-addition process. Linked
+  from a new "Design Language (UI Tokens)" section in AGENTS.md.
+- Fixed a pre-existing dev failure: `Tests/QA/test_scheduling_css_tokens.py`
+  expected pane rules in the main bundle, but TASK-24459's screen-owned
+  split moved them to `screen_feature_scheduling.tcss`; the test now checks
+  the screen sheet.
+- Regenerated `tldw_cli_modular.tcss` + the six screen-owned sheets via
+  `build_css.py` (they embed the token definitions).
+
+Verification: 48 CSS tests passed in an isolated worktree off origin/dev
+(b277f16193), including the bundle sync guard and the governance suite.
+Known pre-existing failure NOT addressed (fails on pristine origin/dev,
+unrelated): `Tests/UI/test_css_class_coverage_contract.py` —
+`console-activity-*`/`library-details-*` classes composed without rules.
+
+Recovery note: the original 2026-08-05 working-tree edits were lost when the
+repo branch moved; the work was re-applied onto origin/dev in a git worktree,
+renumbering ADR-042 → ADR-150 (collision) and the task id (regenerated
+backlog collision).

--- a/tldw_chatbook/css/components/_buttons.tcss
+++ b/tldw_chatbook/css/components/_buttons.tcss
@@ -12,9 +12,9 @@ Button {
 
 /* Shared hover state with readable, non-obscuring cues */
 Button:hover {
-    background: $surface-lighten-1;
-    color: $text;
-    text-style: bold;
+    background: $ds-hover-bg;
+    color: $ds-hover-fg;
+    text-style: $ds-text-strong;
 }
 
 /* Enhanced focus state with visible, non-obscuring cues */
@@ -43,21 +43,21 @@ Button.-style-flat:disabled {
     opacity: 100%;
     text-opacity: 100%;
     text-style: none;
-    background: $surface-darken-1;
+    background: $ds-disabled-bg;
     color: $ds-text-disabled-readable;
 }
 
 Button:disabled:hover {
-    background: $surface-darken-1;
+    background: $ds-disabled-bg;
     text-style: none;
 }
 
 .sidebar-toggle {
     width: 1fr;              /* Equal flexible width */
-    height: 3;
+    height: $ds-control-height;
     /* margin-right: 1; Removed default margin, apply specific below */
     border: none;
-    background: $surface-darken-1;
-    color: $text;
+    background: $ds-disabled-bg;
+    color: $ds-text-primary;
 }
-.sidebar-toggle:hover { background: $surface; }
+.sidebar-toggle:hover { background: $ds-surface-raised; }

--- a/tldw_chatbook/css/components/_forms.tcss
+++ b/tldw_chatbook/css/components/_forms.tcss
@@ -5,68 +5,68 @@
  * ======================================== */
 
 .form-label {
-    margin-bottom: 1;
-    text-style: bold;
+    margin-bottom: $ds-space-stack;
+    text-style: $ds-text-strong;
 }
 
 .form-section-title {
-    text-style: bold;
+    text-style: $ds-text-strong;
     color: $secondary;
-    margin: 2 0 1 0;
+    margin: $ds-space-section 0 $ds-space-stack 0;
     border-bottom: solid $primary-background;
-    padding-bottom: 1;
+    padding-bottom: $ds-space-stack;
 }
 
 .form-description {
-    color: $text-muted;
-    margin-bottom: 2;
-    text-style: italic;
+    color: $ds-text-muted;
+    margin-bottom: $ds-space-section;
+    text-style: $ds-text-emphasis;
 }
 
 .form-actions {
-    margin-top: 2;
+    margin-top: $ds-space-section;
     layout: horizontal;
     height: auto;
     align: center middle;
 }
 
 .form-actions Button {
-    margin: 0 1 0 0;
+    margin: 0 $ds-space-inline 0 0;
 }
 
 .provider-models-textarea {
-    height: 5;
-    margin-bottom: 1;
+    height: $ds-textarea-min-height;
+    margin-bottom: $ds-space-stack;
 }
 
 /* Standardized form components */
 .form-input {
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-textarea {
     width: 100%;
     height: auto;
-    min-height: 5;
-    margin-bottom: 1;
+    min-height: $ds-textarea-min-height;
+    margin-bottom: $ds-space-stack;
 }
 
 
 .form-checkbox {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Form layout helpers */
 .form-row {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-col {
     width: 1fr;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .form-col:first-child {
@@ -79,14 +79,14 @@
 
 /* Form sections */
 .form-section-collapsible {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Button groups */
 .button-group {
     width: 100%;
     height: auto;
-    margin: 2 0;
+    margin: $ds-space-section 0;
 }
 
 .button-group-left {
@@ -102,29 +102,29 @@
 }
 
 .form-button {
-    margin: 0 1;
+    margin: 0 $ds-space-inline;
 }
 
 /* Status areas */
 .status-label {
-    margin-top: 2;
+    margin-top: $ds-space-section;
     margin-bottom: 0;
-    color: $text-muted;
+    color: $ds-text-muted;
 }
 
 .status-area {
     width: 100%;
-    background: $surface;
+    background: $ds-surface-raised;
     border: round $border;
-    padding: 1;
-    margin-top: 1;
+    padding: $ds-space-inset;
+    margin-top: $ds-space-stack;
 }
 
 /* Title/Author input fields fix */
 .title-author-row Input {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 Input:focus,
@@ -280,13 +280,13 @@ Select:focus {
 ToggleButton:focus {
     outline: none;
     border: solid $ds-focus-accent;
-    background: $surface;
+    background: $ds-surface-raised;
 }
 
 ToggleButton.-textual-compact:focus {
     outline: none;
     border: none;
-    background: $surface;
+    background: $ds-surface-raised;
 }
 
 ToggleButton:focus > .toggle--label,
@@ -304,11 +304,11 @@ Switch:focus {
 
 /* New base media ingestion form styling */
 .form-input {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
     border: solid $primary;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .form-input:focus {
@@ -324,13 +324,13 @@ Switch:focus {
 }
 
 .form-select {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-checkbox {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Responsive metadata columns */
@@ -338,7 +338,7 @@ Switch:focus {
     layout: horizontal;
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .metadata-col {
@@ -350,48 +350,48 @@ Switch:focus {
 .mode-toggle-container {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
-    padding: 1;
+    margin-bottom: $ds-space-stack;
+    padding: $ds-space-inset;
 }
 
 .mode-title {
-    text-style: bold;
+    text-style: $ds-text-strong;
     color: $primary;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .mode-toggle {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 /* Essential container sections - CRITICAL for Input widget visibility */
 .essential-section {
     width: 100%;
     height: auto;        /* Allow container to size to content */
-    margin-bottom: 2;
-    padding: 1;
+    margin-bottom: $ds-space-section;
+    padding: $ds-space-inset;
 }
 
 .media-options-section {
     width: 100%;
     height: auto;
-    margin-bottom: 2;
+    margin-bottom: $ds-space-section;
 }
 
 .options-section {
     width: 100%;
     height: auto;
-    margin-bottom: 2;
-    padding: 1;
+    margin-bottom: $ds-space-section;
+    padding: $ds-space-inset;
 }
 
 .process-button-section {
     width: 100%;
     height: auto;
-    margin-top: 2;
-    padding: 1;
+    margin-top: $ds-space-section;
+    padding: $ds-space-inset;
     align: center middle;
 }
 
@@ -399,13 +399,13 @@ Switch:focus {
 .time-range-row {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .time-col {
     width: 1fr;
     height: auto;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .time-col:first-child {
@@ -432,11 +432,11 @@ Switch:focus {
 /* Form textarea styling */
 .form-textarea {
     width: 100%;
-    min-height: 5;
+    min-height: $ds-textarea-min-height;
     max-height: 10;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
     border: solid $primary;
-    padding: 1;
+    padding: $ds-space-inset;
 }
 
 .form-textarea:focus {

--- a/tldw_chatbook/css/core/_variables.tcss
+++ b/tldw_chatbook/css/core/_variables.tcss
@@ -133,3 +133,81 @@ $ds-library-source-action-width: auto;
 $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
+
+/* ========================================
+ * SPACING SCALE (ADR-150)
+ * ========================================
+ * The only legal whitespace values in new UI. Cells (horizontal) and rows
+ * (vertical) are the TUI's physical units; the scale is deliberately tiny.
+ * Raw numeric padding/margin in new stylesheets must come from this scale.
+ * ======================================== */
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+/* Semantic aliases — use these in components so intent is visible:
+ *   inline:  gap between siblings in a horizontal row (buttons, chips)
+ *   stack:   gap between vertically stacked fields/rows in a form
+ *   section: gap separating major sections or a section title from content
+ *   inset:   padding inside a panel, card, or bordered box */
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+/* ========================================
+ * CONTROL SIZING (ADR-150)
+ * ======================================== */
+/* Standard action control height (buttons). Compact strips (tab bars,
+ * status lines, chip rows) use the compact height. */
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+/* Default/minimum height for multi-line text inputs. */
+$ds-textarea-min-height: 5;
+
+/* ========================================
+ * MOTION (ADR-150)
+ * ========================================
+ * Transition durations. fast: hover/affordance feedback; medium: panel and
+ * visibility changes; slow: large layout shifts only. No duration outside
+ * this scale in new UI. */
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+/* ========================================
+ * OPACITY (ADR-150)
+ * ========================================
+ * Legacy de-emphasis only. The disabled state of action controls is NOT
+ * opacity: TASK-25822 measured opacity-on-dim-text compositing to 1.34:1
+ * (reads as absent, not unavailable) — disabled uses $ds-disabled-bg +
+ * $ds-text-disabled-readable with full opacity. */
+$ds-opacity-dim: 70%;
+
+/* ========================================
+ * TYPOGRAPHY EMPHASIS (ADR-150)
+ * ========================================
+ * TUI typography is weight/style, not size — one cell is one glyph.
+ * Scalar keywords only (Textual substitutes variables per token). */
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+/* ========================================
+ * COMPONENT STATE SURFACES (ADR-150)
+ * ========================================
+ * The resting/hover/disabled surface vocabulary for action controls.
+ * Focus is governed separately by the non-obscuring focus contract above
+ * ($ds-focus-bg/$ds-focus-fg) — hover must NOT reuse the focus surface. */
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+/* ========================================
+ * LAYOUT LAWS (ADR-150)
+ * ========================================
+ * App-shell geometry shared by every screen using the standard sidebar
+ * shell. Feature-specific geometry stays in its feature sheet until a
+ * second consumer appears, then it promotes here. */
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;

--- a/tldw_chatbook/css/layout/_sidebars.tcss
+++ b/tldw_chatbook/css/layout/_sidebars.tcss
@@ -178,11 +178,12 @@
 /* Generic .sidebar (used by #chat-left-sidebar and potentially others) */
 .sidebar {
     dock: left;
-    width: 25%; /* Reduced from 35% for better chat area space */
-    min-width: 35; /* Reduced from 45 */
-    max-width: 80; /* Maximum width (optional) */
+    /* Layout law (ADR-150): standard shell sidebar geometry is tokenized. */
+    width: $ds-sidebar-width; /* Reduced from 35% for better chat area space */
+    min-width: $ds-sidebar-min-width; /* Reduced from 45 */
+    max-width: $ds-sidebar-max-width; /* Maximum width (optional) */
     background: $boost;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
     border-right: solid $surface;
     height: 100%;
     overflow-y: auto;

--- a/tldw_chatbook/css/screen_agentic_console.tcss
+++ b/tldw_chatbook/css/screen_agentic_console.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/screen_agentic_library.tcss
+++ b/tldw_chatbook/css/screen_agentic_library.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/screen_agentic_settings.tcss
+++ b/tldw_chatbook/css/screen_agentic_settings.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/screen_feature_evals.tcss
+++ b/tldw_chatbook/css/screen_feature_evals.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/screen_feature_scheduling.tcss
+++ b/tldw_chatbook/css/screen_feature_scheduling.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/screen_feature_watchlists.tcss
+++ b/tldw_chatbook/css/screen_feature_watchlists.tcss
@@ -75,6 +75,36 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+$ds-textarea-min-height: 5;
+
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+$ds-opacity-dim: 70%;
+
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 
 .tldw-agentic-split-preamble-end { }
 

--- a/tldw_chatbook/css/tldw_cli_modular.tcss
+++ b/tldw_chatbook/css/tldw_cli_modular.tcss
@@ -146,6 +146,84 @@ $ds-library-source-action-min-width: 0;
 $ds-library-source-action-height: 1;
 $ds-library-source-browser-width: 31;
 
+/* ========================================
+ * SPACING SCALE (ADR-150)
+ * ========================================
+ * The only legal whitespace values in new UI. Cells (horizontal) and rows
+ * (vertical) are the TUI's physical units; the scale is deliberately tiny.
+ * Raw numeric padding/margin in new stylesheets must come from this scale.
+ * ======================================== */
+$ds-space-0: 0;
+$ds-space-1: 1;
+$ds-space-2: 2;
+$ds-space-3: 3;
+/* Semantic aliases — use these in components so intent is visible:
+ *   inline:  gap between siblings in a horizontal row (buttons, chips)
+ *   stack:   gap between vertically stacked fields/rows in a form
+ *   section: gap separating major sections or a section title from content
+ *   inset:   padding inside a panel, card, or bordered box */
+$ds-space-inline: $ds-space-1;
+$ds-space-stack: $ds-space-1;
+$ds-space-section: $ds-space-2;
+$ds-space-inset: $ds-space-1;
+
+/* ========================================
+ * CONTROL SIZING (ADR-150)
+ * ======================================== */
+/* Standard action control height (buttons). Compact strips (tab bars,
+ * status lines, chip rows) use the compact height. */
+$ds-control-height: 3;
+$ds-control-height-compact: 1;
+/* Default/minimum height for multi-line text inputs. */
+$ds-textarea-min-height: 5;
+
+/* ========================================
+ * MOTION (ADR-150)
+ * ========================================
+ * Transition durations. fast: hover/affordance feedback; medium: panel and
+ * visibility changes; slow: large layout shifts only. No duration outside
+ * this scale in new UI. */
+$ds-duration-fast: 0.2s;
+$ds-duration-medium: 0.3s;
+$ds-duration-slow: 0.5s;
+
+/* ========================================
+ * OPACITY (ADR-150)
+ * ========================================
+ * Legacy de-emphasis only. The disabled state of action controls is NOT
+ * opacity: TASK-25822 measured opacity-on-dim-text compositing to 1.34:1
+ * (reads as absent, not unavailable) — disabled uses $ds-disabled-bg +
+ * $ds-text-disabled-readable with full opacity. */
+$ds-opacity-dim: 70%;
+
+/* ========================================
+ * TYPOGRAPHY EMPHASIS (ADR-150)
+ * ========================================
+ * TUI typography is weight/style, not size — one cell is one glyph.
+ * Scalar keywords only (Textual substitutes variables per token). */
+$ds-text-strong: bold;
+$ds-text-emphasis: italic;
+
+/* ========================================
+ * COMPONENT STATE SURFACES (ADR-150)
+ * ========================================
+ * The resting/hover/disabled surface vocabulary for action controls.
+ * Focus is governed separately by the non-obscuring focus contract above
+ * ($ds-focus-bg/$ds-focus-fg) — hover must NOT reuse the focus surface. */
+$ds-hover-bg: $surface-lighten-1;
+$ds-hover-fg: $ds-text-primary;
+$ds-disabled-bg: $surface-darken-1;
+
+/* ========================================
+ * LAYOUT LAWS (ADR-150)
+ * ========================================
+ * App-shell geometry shared by every screen using the standard sidebar
+ * shell. Feature-specific geometry stays in its feature sheet until a
+ * second consumer appears, then it promotes here. */
+$ds-sidebar-width: 25%;
+$ds-sidebar-min-width: 35;
+$ds-sidebar-max-width: 80;
+
 /* ===== MODULE: core/_reset.tcss ===== */
 /* ========================================
  * CORE: Reset/Normalize
@@ -557,11 +635,12 @@ Tabs:focus .-active {
 /* Generic .sidebar (used by #chat-left-sidebar and potentially others) */
 .sidebar {
     dock: left;
-    width: 25%; /* Reduced from 35% for better chat area space */
-    min-width: 35; /* Reduced from 45 */
-    max-width: 80; /* Maximum width (optional) */
+    /* Layout law (ADR-150): standard shell sidebar geometry is tokenized. */
+    width: $ds-sidebar-width; /* Reduced from 35% for better chat area space */
+    min-width: $ds-sidebar-min-width; /* Reduced from 45 */
+    max-width: $ds-sidebar-max-width; /* Maximum width (optional) */
     background: $boost;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
     border-right: solid $surface;
     height: 100%;
     overflow-y: auto;
@@ -971,9 +1050,9 @@ Button {
 
 /* Shared hover state with readable, non-obscuring cues */
 Button:hover {
-    background: $surface-lighten-1;
-    color: $text;
-    text-style: bold;
+    background: $ds-hover-bg;
+    color: $ds-hover-fg;
+    text-style: $ds-text-strong;
 }
 
 /* Enhanced focus state with visible, non-obscuring cues */
@@ -1002,24 +1081,24 @@ Button.-style-flat:disabled {
     opacity: 100%;
     text-opacity: 100%;
     text-style: none;
-    background: $surface-darken-1;
+    background: $ds-disabled-bg;
     color: $ds-text-disabled-readable;
 }
 
 Button:disabled:hover {
-    background: $surface-darken-1;
+    background: $ds-disabled-bg;
     text-style: none;
 }
 
 .sidebar-toggle {
     width: 1fr;              /* Equal flexible width */
-    height: 3;
+    height: $ds-control-height;
     /* margin-right: 1; Removed default margin, apply specific below */
     border: none;
-    background: $surface-darken-1;
-    color: $text;
+    background: $ds-disabled-bg;
+    color: $ds-text-primary;
 }
-.sidebar-toggle:hover { background: $surface; }
+.sidebar-toggle:hover { background: $ds-surface-raised; }
 
 /* ===== MODULE: components/_forms.tcss ===== */
 /* ========================================
@@ -1029,68 +1108,68 @@ Button:disabled:hover {
  * ======================================== */
 
 .form-label {
-    margin-bottom: 1;
-    text-style: bold;
+    margin-bottom: $ds-space-stack;
+    text-style: $ds-text-strong;
 }
 
 .form-section-title {
-    text-style: bold;
+    text-style: $ds-text-strong;
     color: $secondary;
-    margin: 2 0 1 0;
+    margin: $ds-space-section 0 $ds-space-stack 0;
     border-bottom: solid $primary-background;
-    padding-bottom: 1;
+    padding-bottom: $ds-space-stack;
 }
 
 .form-description {
-    color: $text-muted;
-    margin-bottom: 2;
-    text-style: italic;
+    color: $ds-text-muted;
+    margin-bottom: $ds-space-section;
+    text-style: $ds-text-emphasis;
 }
 
 .form-actions {
-    margin-top: 2;
+    margin-top: $ds-space-section;
     layout: horizontal;
     height: auto;
     align: center middle;
 }
 
 .form-actions Button {
-    margin: 0 1 0 0;
+    margin: 0 $ds-space-inline 0 0;
 }
 
 .provider-models-textarea {
-    height: 5;
-    margin-bottom: 1;
+    height: $ds-textarea-min-height;
+    margin-bottom: $ds-space-stack;
 }
 
 /* Standardized form components */
 .form-input {
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-textarea {
     width: 100%;
     height: auto;
-    min-height: 5;
-    margin-bottom: 1;
+    min-height: $ds-textarea-min-height;
+    margin-bottom: $ds-space-stack;
 }
 
 
 .form-checkbox {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Form layout helpers */
 .form-row {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-col {
     width: 1fr;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .form-col:first-child {
@@ -1103,14 +1182,14 @@ Button:disabled:hover {
 
 /* Form sections */
 .form-section-collapsible {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Button groups */
 .button-group {
     width: 100%;
     height: auto;
-    margin: 2 0;
+    margin: $ds-space-section 0;
 }
 
 .button-group-left {
@@ -1126,29 +1205,29 @@ Button:disabled:hover {
 }
 
 .form-button {
-    margin: 0 1;
+    margin: 0 $ds-space-inline;
 }
 
 /* Status areas */
 .status-label {
-    margin-top: 2;
+    margin-top: $ds-space-section;
     margin-bottom: 0;
-    color: $text-muted;
+    color: $ds-text-muted;
 }
 
 .status-area {
     width: 100%;
-    background: $surface;
+    background: $ds-surface-raised;
     border: round $border;
-    padding: 1;
-    margin-top: 1;
+    padding: $ds-space-inset;
+    margin-top: $ds-space-stack;
 }
 
 /* Title/Author input fields fix */
 .title-author-row Input {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 Input:focus,
@@ -1304,13 +1383,13 @@ Select:focus {
 ToggleButton:focus {
     outline: none;
     border: solid $ds-focus-accent;
-    background: $surface;
+    background: $ds-surface-raised;
 }
 
 ToggleButton.-textual-compact:focus {
     outline: none;
     border: none;
-    background: $surface;
+    background: $ds-surface-raised;
 }
 
 ToggleButton:focus > .toggle--label,
@@ -1328,11 +1407,11 @@ Switch:focus {
 
 /* New base media ingestion form styling */
 .form-input {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
     border: solid $primary;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .form-input:focus {
@@ -1348,13 +1427,13 @@ Switch:focus {
 }
 
 .form-select {
-    height: 3;
+    height: $ds-control-height;
     width: 100%;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .form-checkbox {
-    margin: 1 0;
+    margin: $ds-space-stack 0;
 }
 
 /* Responsive metadata columns */
@@ -1362,7 +1441,7 @@ Switch:focus {
     layout: horizontal;
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .metadata-col {
@@ -1374,48 +1453,48 @@ Switch:focus {
 .mode-toggle-container {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
-    padding: 1;
+    margin-bottom: $ds-space-stack;
+    padding: $ds-space-inset;
 }
 
 .mode-title {
-    text-style: bold;
+    text-style: $ds-text-strong;
     color: $primary;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .mode-toggle {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 /* Essential container sections - CRITICAL for Input widget visibility */
 .essential-section {
     width: 100%;
     height: auto;        /* Allow container to size to content */
-    margin-bottom: 2;
-    padding: 1;
+    margin-bottom: $ds-space-section;
+    padding: $ds-space-inset;
 }
 
 .media-options-section {
     width: 100%;
     height: auto;
-    margin-bottom: 2;
+    margin-bottom: $ds-space-section;
 }
 
 .options-section {
     width: 100%;
     height: auto;
-    margin-bottom: 2;
-    padding: 1;
+    margin-bottom: $ds-space-section;
+    padding: $ds-space-inset;
 }
 
 .process-button-section {
     width: 100%;
     height: auto;
-    margin-top: 2;
-    padding: 1;
+    margin-top: $ds-space-section;
+    padding: $ds-space-inset;
     align: center middle;
 }
 
@@ -1423,13 +1502,13 @@ Switch:focus {
 .time-range-row {
     width: 100%;
     height: auto;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
 }
 
 .time-col {
     width: 1fr;
     height: auto;
-    padding: 0 1;
+    padding: 0 $ds-space-inline;
 }
 
 .time-col:first-child {
@@ -1456,11 +1535,11 @@ Switch:focus {
 /* Form textarea styling */
 .form-textarea {
     width: 100%;
-    min-height: 5;
+    min-height: $ds-textarea-min-height;
     max-height: 10;
-    margin-bottom: 1;
+    margin-bottom: $ds-space-stack;
     border: solid $primary;
-    padding: 1;
+    padding: $ds-space-inset;
 }
 
 .form-textarea:focus {


### PR DESCRIPTION
## Summary

Introduces a governed design language for UI work (TASK-32475, ADR-150): everything that must stay consistent across screens now exists as a `$ds-*` token in `core/_variables.tcss` or as a written rule in `backlog/docs/design-language.md`, instead of being re-invented per screen (~7k hardcoded dimension literals had accumulated).

**Additive, no visual change** — every token value maps 1:1 to literals already in production.

## What changed

- **Token catalog** (`core/_variables.tcss`): spacing scale (`$ds-space-0..3` + semantic aliases `inline/stack/section/inset`), control sizing (`$ds-control-height`, `-compact`, `$ds-textarea-min-height`), motion (`$ds-duration-fast/medium/slow`), opacity (`$ds-opacity-dim`), typography emphasis (`$ds-text-strong/-emphasis`), component-state surfaces (`$ds-hover-bg/-fg`, `$ds-disabled-bg`), layout laws (`$ds-sidebar-width/min/max`)
- **Constitution** (`backlog/docs/design-language.md`): token catalog, naming rules, interaction rules (non-obscuring focus contract, Select-three-shapes, TASK-25822 disabled convention), the new-screen recipe, and the token-addition process; linked from a new AGENTS.md section
- **Governance test** (`Tests/UI/test_design_token_governance.py`): fails on undefined `$ds-*` references, duplicate definitions, hex literals outside the token file (legacy sheets ratcheted at pinned counts), and raw numeric padding/margin in post-ADR sheets
- **Exemplars**: `_buttons.tcss`, `_forms.tcss`, and the `.sidebar` layout law consume tokens
- **Bundle + screen-owned sheets regenerated** via `build_css.py` (screen sheets embed the new token definitions)

## Deliberate deviations while rebasing onto dev

- Dropped `$ds-opacity-disabled`/`$ds-disabled-fg` from the catalog: TASK-25822 established that disabled action controls use `$ds-disabled-bg` + `$ds-text-disabled-readable` at full opacity (opacity stacking measured 1.34:1)
- ADR renumbered 042 → 150 (collision with `042-watchlists-reader-first-ia.md`); task renumbered to 32475 (regenerated-backlog collision)

## Also fixed (pre-existing dev failure)

- `Tests/QA/test_scheduling_css_tokens.py` expected pane rules in the main bundle, but TASK-24459's screen-owned split moved them to `screen_feature_scheduling.tcss` — the test now checks the screen sheet

## Test plan

- [x] `Tests/UI/test_design_token_governance.py` — 5 passed
- [x] `Tests/UI/test_css_bundle_sync_guard.py`, `test_css_build_integrity.py`, `test_console_agent_tool_row_css.py`, `Tests/QA/test_agentic_terminal_css_tokens.py`, `test_scheduling_css_tokens.py` — 48 passed total
- [ ] `Tests/UI/test_css_class_coverage_contract.py` — **fails on pristine origin/dev** (missing `console-activity-*`/`library-details-*` rules; unrelated to this change, left as-is)

## Scope note

Legacy literals (~7k declarations) are not migrated; the system is a ratchet: new sheets must be token-clean, legacy migrates opportunistically (ADR-150).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a design-token system so UI styling stays consistent: spacing, sizing, motion, opacity, typography emphasis, and component-state surfaces now live as `$ds-*` tokens in `core/_variables.tcss` instead of being re-invented per screen. This is additive—every token maps 1:1 to the literal it replaces—so there is no visual change; legacy sheets keep their literals under a pinned ratchet.

- Adds `backlog/docs/design-language.md` as the governing constitution (token catalog, interaction rules, new-screen recipe) and links it from AGENTS.md, alongside the ADR-150 and task-32475 records.
- Adds `Tests/UI/test_design_token_governance.py` that fails on undefined or duplicate tokens, new hex literals outside the token file, and raw numeric padding/margin in post-ADR sheets.
- The hex ratchet counts only active declarations; colors mentioned in comments don't consume allowance.
- Consumes tokens in exemplar sheets (`_buttons.tcss`, `_forms.tcss`, `.sidebar` layout law) and regenerates the bundle plus screen-owned sheets.
- Fixes a pre-existing failure in `Tests/QA/test_scheduling_css_tokens.py`: the scheduling pane rules moved to `screen_feature_scheduling.tcss` under TASK-24459, so the test now checks that sheet.

<sup>Written for commit 05e048245c652f1c6b1e72b4da19abb2777dcb7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

