### PR TITLE
feat(settings): Speech & TTS UX fixes from the 2026-09-11 critique

### DIFF
--- a/.impeccable/critique/2026-09-11T23-45-55Z__tldw-chatbook-ui-screens-settings-speech-tts-py.md
+++ b/.impeccable/critique/2026-09-11T23-45-55Z__tldw-chatbook-ui-screens-settings-speech-tts-py.md
@@ -1,0 +1,75 @@
+---
+target: Speech & TTS settings sub-screen (settings speech tts)
+total_score: 22
+max_score: 40
+na_heuristics: 
+p0_count: 0
+p1_count: 3
+timestamp: 2026-09-11T23-45-55Z
+slug: tldw-chatbook-ui-screens-settings-speech-tts-py
+---
+# Critique — Speech & TTS settings sub-screen (settings_speech_tts.py + speech_tts_settings_panel.py)
+
+⚠️ DEGRADED: partial — Assessment A (design review) ran as an isolated sub-agent; Assessment B's sub-agent hit a usage limit mid-run, so the deterministic detector and the live tmux walkthrough were completed inline in the parent context.
+
+## Design Health Score
+
+| # | Heuristic | Score | Key Issue |
+|---|-----------|-------|-----------|
+| 1 | Visibility of System Status | 3 | Superb instrumentation, illegible vocabulary: "Observed … configuration revision 3 | catalog revision none" (panel ~2796-2818) — revision arithmetic is not user status |
+| 2 | Match System / Real World | 1 | "Model policy: Exact / First available", "Voice policy: Exact / Server default" (panel 2473-2541) name the data model; "Restore Non-secret Defaults" leaks threat-model vocabulary into a button |
+| 3 | User Control and Freedom | 4 | Best-in-class 3-way leave guard (Cancel/Discard/Save) on category switch, screen exit, provider switch; draft survives recomposition |
+| 4 | Consistency and Standards | 2 | Adjacent Selects "Default TTS Provider" vs "Configure Provider" share identical 7 options, different semantics; Model/Voice value is a Select for audio.cpp but free-text for six providers |
+| 5 | Error Prevention | 3 | Validation focuses offending field + expands its Collapsible; plaintext-HTTP consent explicit; free-text voice IDs unchecked for existence |
+| 6 | Recognition Rather Than Recall | 1 | Voice/model IDs for 6/7 providers typed from memory (live: "Voice value | alloy" free text); no voice picker in Settings; Kokoro file locations docs-only |
+| 7 | Flexibility and Efficiency | 2 | s/r accelerators + search deep-link ("speech"→1 match→Enter, verified live) good; but every verification is a forced Settings→Save→Speech Lab round-trip, and the handoff button disables itself when dirty |
+| 8 | Aesthetic and Minimalist Design | 1 | Live at 235x52: banner+status rows precede first control; live at 100x30: governance banner fills the ENTIRE first viewport, zero editable controls visible; 7-line provenance paragraphs per package |
+| 9 | Error Recovery | 3 | Failure copy names the next action; diagnosis still requires saved-vs-applied revision reasoning |
+| 10 | Help and Documentation | 2 | Inline copy dominated by scope-police; nothing answers "where do Kokoro model files come from?"; F1 help + docs exist (live footer honest) |
+| **Total** | | **22/40** | **Acceptable — significant improvements needed** |
+
+## Design Specificity Verdict
+
+Hyper-specific to this product — saturated with Chatbook-only constructs (Speech Lab, Studio preferences, Guided setup, Fresh/Stale/Unverified/Missing choice states, credential provenance rungs, Owner IDs). The specificity is almost entirely about internal architecture (ownership, revisions, provenance) rather than the user's task ("make my chat read aloud"). It reads as an ADR-039 ownership contract rendered as a form: honest to the architect, bureaucratic to the operator.
+
+Deterministic scan: detector inapplicable to Python TUI sources (no markup) — clean by vacuity, exit 0 both target and directory.
+
+Live evidence: scope banner, "Model policy/Voice policy" rows, and the raw id leak ("audio.cpp, audio_cpp" in the Scope Inspector AND the bottom status line, confirmed at both 235x52 and 100x30) all render exactly as the source shows.
+
+## What's Working
+
+1. Provenance without secrets — credentials never displayed; env-var shadowing disclosed; the "inspectable, legible authority" principle executed properly.
+2. The leave-guard is airtight — every ownership boundary funnels through one confirm_leave() with a 3-way modal; recoverability is real.
+3. Honest responsive behavior — at 100x30 text wraps, inspector truncates with an explicit "▼ more — scroll" affordance, footer hints advertise only implemented actions (s/r/F1/F6/Ctrl+P/Ctrl+Q).
+
+## Priority Issues
+
+1. [P1] Local-provider first-run dead end (Kokoro) — form assumes artifacts that don't exist; the dependency fact ("Local Kokoro: Unavailable — tldw_chatbook[local_tts]") is computed but hidden in the collapsed Scope inspector. Fix: surface dependency rows inside the Kokoro/Chatterbox/Higgs forms with install extra + model-download pointer; add path-existence check on Browse.
+2. [P1] Free-text "Exact model ID"/"Exact voice ID" for six providers — recall over recognition; wrong IDs surface only at speak time. Fix: render known IDs (LEGACY_DEFAULT_MODELS/VOICES already imported) as Select options with "custom…" escape hatch + "browse voices in Speech Lab" bridge.
+3. [P1] Governance copy crowds out task copy — live-confirmed: at 100x30 the banner consumes the whole first viewport; three "Open Speech Lab" buttons on one screen. Fix: one-line banner + tooltip, one Lab action per screen, move duplicated status Statics into the inspector.
+4. [P2] State banner contradicts leave guard for this category — generic banner says "switching categories keeps this draft" but Speech & TTS resolves the draft on leave (task-2708 already tracks this).
+5. [P2] Flat 15-row provider forms (Chatterbox/Higgs) + one-shot "Restore Non-secret Defaults" with no preview — apply the audio.cpp sub-section/collapsible pattern; preview what Restore resets.
+
+## Persona Red Flags
+
+Jordan (first-timer): "Model policy"/"Voice policy" schema vocabulary; Kokoro "Path to model file" with zero download guidance; first Configure-Provider change can trigger the unsaved-changes modal because Default-Provider auto-fill dirtied the draft (verified in source: handle_default_provider_changed auto-fills → has_unsaved_changes → leave modal); Save payoff line is "Runtime reconfiguration: Kokoro: unchanged" — system talk at the moment they wanted "you're done".
+
+Alex (power user): cannot test from Settings at all by design, and the one fast path (audio.cpp handoff) disables itself when dirty ("Save Settings before opening Speech Lab"); voice IDs discovered in Speech Lab must be retyped into Settings free-text; inspector speaks in pending generations ("Saved generation 3 is pending; generation 2 remains active…") requiring revision math; ElevenLabs output format is a flat 9-option codec list.
+
+## Minor Observations
+
+- Label casing inconsistent in one card: "Default TTS Provider" vs "Model policy" vs "ONNX model file".
+- Raw provider id leaks: "audio.cpp, audio_cpp" (inspector + status line, live-confirmed), "Owner ID: app_tts.kokoro", "audio_cpp parameters".
+- Three "Open Speech Lab" buttons per screen; two simultaneously visible for audio.cpp.
+- Terminology drift: "Lab > Speech > Voice Profiles" vs "Speech Lab" vs "Studio preferences" — three names, two places.
+- Speed range only in placeholder ("0.25 - 4.0"); audio.cpp users see it permanently disabled with the reason in a separate line rather than on the field.
+- Realtime (microphone INPUT engine) card lives inside output-speech settings between Provider setup and Inspector.
+- VAD disabled-not-hidden with rationale copy is genuinely good — copy that pattern elsewhere.
+- TTS_MODULE_GUIDE.md still says "S/TT/S tab" — doc drift vs "Speech Lab".
+
+## Questions to Consider
+
+1. If Settings is contractually forbidden from testing, why does first-time provider setup live here rather than in Speech Lab with Settings as link-out?
+2. Who is "Model policy: Exact / First available" for? Is the policy concept earning its two rows, or is the persistence schema showing through?
+3. The panel spends ~10x the vertical space explaining what it is not allowed to do than helping produce sound — is the honesty budget spent on the architect's anxieties instead of the user's question?
+4. Seven providers in registry order — should the picker lead with the cloud-vs-local split every user actually decides first?

--- a/Docs/Development/TTS/TTS_MODULE_GUIDE.md
+++ b/Docs/Development/TTS/TTS_MODULE_GUIDE.md
@@ -1057,9 +1057,10 @@ Local TTS installs:
    - Generate audio with the default voice
    - Play the audio automatically
 
-### TTS Playground (S/TT/S Tab)
+### TTS Playground (Speech Lab)
 
-The S/TT/S tab provides a comprehensive TTS testing environment:
+The Speech Lab (previously the S/TT/S tab) provides a comprehensive TTS
+testing environment:
 
 1. **Text Input**: Enter any text to synthesize
 2. **Provider Selection**: Choose `audio_cpp` or one of the six legacy

--- a/Docs/User_Guide/settings.md
+++ b/Docs/User_Guide/settings.md
@@ -310,36 +310,33 @@ credentials in the URL, then correct timeout/retry/streaming types in
 
 Application-wide speech and text-to-speech defaults — which TTS provider
 speaks by default, with what model, voice, output format, and speed — plus
-per-provider setup. The pane opens with its scope in a banner: "You are
-editing application-wide Speech & TTS defaults. The Speech Studio can keep
-separate Studio preferences without changing these values.", and an **Open
-Speech Lab** button, because this pane deliberately does *not* talk to any
-server: "Settings reuses accepted in-memory observations only. Open Speech
-Lab to test the server or refresh models and voices." Right below that
-button, a note points at the two surfaces this pane does not manage: "Voice
-profiles are managed in Lab > Speech > Voice Profiles — open Speech Lab,
-above, to get there. Per-character voices are assigned in the Roleplay
-character editor's Voice & Speech section, not here." Ordinary **Save**
-"validates and persists locally. Use Speech Lab for connection tests,
-discovery, generation, and playback."
+per-provider setup. The pane opens with a two-line scope banner — "Editing
+application-wide Speech & TTS defaults — Speech Studio preferences stay
+separate." and "Voice profiles: Speech Lab (open it from the actions below).
+Per-character voices: the Roleplay character editor." — because this pane
+deliberately does *not* talk to any server: "Settings reuses accepted
+in-memory observations only. Open Speech Lab to test the server or refresh
+models and voices." Ordinary **Save** "validates and persists locally. Use
+Speech Lab for connection tests, discovery, generation, and playback."
 
 | Card | What's in it |
 |---|---|
-| **Global defaults** | A status line ("Global default selection: … — effective source …"), the default voice-profile row, **Default TTS Provider** (audio.cpp, OpenAI, ElevenLabs, Kokoro, Chatterbox, Higgs, AllTalk), model policy (**Exact** with an "Exact model ID" box / **First available**), voice policy (**Exact** / **Server default**), **Output format** (MP3 / Opus / AAC / FLAC / WAV), and **Speed** ("0.25 - 4.0"). Capability limits are stated inline — "audio.cpp requires WAV output and speed 1.0." — and validated before Save. |
-| **Provider setup** | A **Configure Provider** picker for editing any provider's setup without switching the default ("Configure Provider does not change the Default TTS Provider."). Credentials get Set / Replace / Clear dialogs: the editor "starts empty", stores "a local config secret; an environment variable is safer and more portable", and Clear "removes only the local-config value. It cannot change a process environment variable." |
+| **Global defaults** | A status line ("Default voice setup: …"), the default voice-profile row, **Default TTS provider** (audio.cpp, OpenAI, ElevenLabs, Kokoro, Chatterbox, Higgs, AllTalk), model policy (**Exact** / **First available**), **Model value** — a dropdown of the provider's known models plus **Custom…** for an exact ID (a saved unknown ID stays selectable as "(custom)"), voice policy (**Exact** / **Server default**), **Voice value** — a dropdown of the provider's known labeled voices plus **Custom…**, with a **Browse in Speech Lab** button beside it to preview voices first, **Output format** (MP3 / Opus / AAC / FLAC / WAV), and **Speed (0.25-4.0)**. Capability limits are stated inline — "audio.cpp requires WAV output and speed 1.0." — and validated before Save. |
+| **Provider setup** | A **Configure provider** picker for editing any provider's setup without switching the default ("Configure provider does not change the Default TTS provider."), plus a "Current status: …" readiness line. Local providers (Kokoro, Chatterbox, Higgs) open with their install/readiness fact inline — "Local Kokoro: not installed — install the extra 'tldw_chatbook[local_tts]' and restart Chatbook first." — and the Kokoro form names its model files ("kokoro-v0_19.onnx (~300 MB) plus voices.json") with a pointer to the download utility. Credentials get Set / Replace / Clear dialogs: the editor "starts empty", stores "a local config secret; an environment variable is safer and more portable", and Clear "removes only the local-config value. It cannot change a process environment variable." Chatterbox and Higgs group their fields into collapsible sections (Compute and generation / Voice and processing / Streaming, and Model and voice / Compute / Generation). |
 | **Configuration inspector** | Read-out of the selected setup and where each value comes from ("Selected provider setup source: …"). |
 | **Realtime engine** | "Optional low-latency voice engine for the Console's hands-free loop (Ctrl+Shift+H)." — a switch plus its engine fields; off means the record → transcribe → reply → speak pipeline is used as before. |
 
-Buttons: **Save**, **Revert**, **Restore Non-secret Defaults** ("Non-secret
-defaults restored in the draft; choose Save to persist them." — credentials
-are left alone), **Open Speech Lab**.
+Buttons: **Save**, **Revert**, **Restore Non-secret Defaults** (draft-only;
+its tooltip and the result line name exactly what resets — global defaults
+and the selected provider, with saved credentials and environment-owned
+values untouched), **Open Speech Lab**.
 
 **This is the one draft category that will not let you walk away silently.**
 Leaving Speech & TTS with unsaved edits raises "Unsaved global Speech & TTS
 settings — Save these application-wide changes before continuing, or discard
 them?" with **Cancel** / **Discard and continue** / **Save and continue** —
-the draft is resolved, not kept (see Quirks: the State banner still claims
-otherwise, task-2708).
+the draft is resolved, not kept, and the State banner says so: "leaving
+Speech & TTS resolves this draft: save or discard first" (task-2708).
 
 ### Interface — Appearance
 
@@ -829,11 +826,6 @@ not open an editor.
   uses its own **Validate Raw TOML**, **Save Raw TOML**, and **Revert Raw TOML** controls. (Speech & TTS is
   the exception — it never leaves a **\*** behind, because leaving it forces
   the save/discard choice.)
-- **Speech & TTS's State banner promises what the category won't do.** While
-  its draft is dirty the shared banner reads "…switching categories keeps this
-  draft." — but leaving Speech & TTS raises "Unsaved global Speech & TTS
-  settings" and the draft is saved or discarded, never kept (backlog
-  task-2708).
 - **The Scope Inspector looks truncated.** Scroll it — "▼ more — scroll the
   inspector" at the bottom means there is more below.
 

--- a/Tests/UI/test_legacy_tts_voice_policy.py
+++ b/Tests/UI/test_legacy_tts_voice_policy.py
@@ -1,7 +1,7 @@
 """Global voice policies must agree with the effective admission contract."""
 
 import pytest
-from textual.widgets import Input, Select, Static
+from textual.widgets import Select, Static
 
 from Tests.UI.test_kokoro_playground_generation import _RecordingAdapter
 from Tests.UI.test_settings_speech_tts_panel import (
@@ -124,7 +124,7 @@ async def test_saved_invalid_kokoro_policy_remains_visible_and_can_be_repaired()
         assert "Exact" in str(error.renderable)
         voice.value = "exact"
         await pilot.pause()
-        app.query_one("#settings-speech-voice-value", Input).value = "af_heart"
+        app.query_one("#settings-speech-voice-value", Select).value = "af_heart"
         await pilot.pause()
         status = app.query_one("#settings-speech-default-status", Static)
         assert "Unsaved" in str(status.renderable)
@@ -146,5 +146,5 @@ async def test_return_to_saved_kokoro_restores_its_explicit_voice():
         app.query_one("#settings-speech-default-provider", Select).value = "kokoro"
         await pilot.pause()
         assert app.query_one("#settings-speech-voice-policy", Select).value == "exact"
-        assert app.query_one("#settings-speech-voice-value", Input).value == "bf_emma"
-        assert app.query_one("#settings-speech-model-value", Input).value == "kokoro"
+        assert app.query_one("#settings-speech-voice-value", Select).value == "bf_emma"
+        assert app.query_one("#settings-speech-model-value", Select).value == "kokoro"

--- a/Tests/UI/test_settings_configuration_hub.py
+++ b/Tests/UI/test_settings_configuration_hub.py
@@ -12004,6 +12004,23 @@ def test_state_banner_dirty_branch_keeps_priority():
     )
 
 
+def test_speech_tts_dirty_banner_names_leave_resolution():
+    """Speech & TTS resolves its draft through the leave modal (task-2708),
+    so its dirty banner must not promise the generic 'switching categories
+    keeps this draft' contract that the other draft categories honor."""
+    app = _build_test_app()
+    screen = SettingsScreen(app)
+    screen._category_has_unsaved_changes = lambda category: (
+        category is SettingsCategoryId.SPEECH_TTS
+    )
+    text = screen._category_state_banner_text(SettingsCategoryId.SPEECH_TTS)
+    assert text == (
+        "State: Unsaved changes | Save (s) or Revert (r) — leaving "
+        "Speech & TTS resolves this draft: save or discard first."
+    )
+    assert "switching categories keeps this draft" not in text
+
+
 def test_workspaces_banner_names_reversal_paths():
     """Workspaces applies immediately; the banner says how each action is
     walked back instead of leaving 'no draft' unexplained (task-1717)."""

--- a/Tests/UI/test_settings_speech_tts_panel.py
+++ b/Tests/UI/test_settings_speech_tts_panel.py
@@ -589,7 +589,7 @@ async def test_global_panel_states_scope_and_mounts_only_selected_provider() -> 
         assert "Studio preferences" in text
         assert screen.query_one("#settings-speech-default-provider", Select)
         assert screen.query_one("#settings-speech-configure-provider", Select)
-        assert screen.query_one("#settings-speech-open-lab", Button)
+        assert screen.query_one("#settings-speech-open-lab-bottom", Button)
         assert len(screen.query(".settings-speech-provider-form")) == 1
 
         configure = screen.query_one("#settings-speech-configure-provider", Select)
@@ -603,18 +603,15 @@ async def test_scope_banner_points_to_the_two_profile_surfaces() -> None:
 
     Voice profiles are a Speech Lab concept and per-character assignment
     lives in the Roleplay character editor (ADR-039 scope separation) --
-    neither is managed from this panel. The card is a static note, not a
-    control: it reuses the existing "Open Speech Lab" button rather than
-    adding a second, competing affordance.
+    neither is managed from this panel. The card is a two-line static
+    note; the single "Open Speech Lab" action lives with the Save actions.
     """
     app = _PanelHarness()
     async with app.run_test(size=(150, 60)):
         note = app.query_one("#settings-speech-profile-surfaces-note", Static)
         assert str(note.renderable) == (
-            "Voice profiles are managed in Lab > Speech > Voice Profiles — "
-            "open Speech Lab, above, to get there. Per-character voices are "
-            "assigned in the Roleplay character editor's Voice & Speech "
-            "section, not here."
+            "Voice profiles: Speech Lab (open it from the actions below). "
+            "Per-character voices: the Roleplay character editor."
         )
 
 
@@ -1243,8 +1240,8 @@ async def test_settings_dismissal_cancel_preserves_dirty_speech_owner() -> None:
             "#settings-speech-tts-panel",
             SpeechTTSSettingsPanel,
         )
-        field = screen.query_one("#settings-speech-model-value", Input)
-        field.value = "dismissal-draft"
+        field = screen.query_one("#settings-speech-voice-value", Select)
+        field.value = "echo"
         field.focus()
         panel._ask_leave_choice = AsyncMock(return_value="cancel")
         await pilot.pause()
@@ -1252,7 +1249,7 @@ async def test_settings_dismissal_cancel_preserves_dirty_speech_owner() -> None:
         assert await screen.flush_pending_work() is False
 
         assert screen.active_category == SettingsCategoryId.SPEECH_TTS.value
-        assert field.value == "dismissal-draft"
+        assert field.value == "echo"
         assert host.focused is field
 
 
@@ -2283,7 +2280,7 @@ async def test_normal_panel_actions_do_not_contact_or_initialize_tts(
     host = DestinationHarness(_build_test_app(), "settings")
     async with host.run_test(size=(190, 55)) as pilot:
         screen = await _open_speech_tts(host, pilot)
-        screen.query_one("#settings-speech-model-value", Input).value = "draft-model"
+        screen.query_one("#settings-speech-model-value", Select).value = "tts-1"
         await pilot.click("#settings-speech-restore-defaults")
         await pilot.pause()
         await pilot.click("#settings-speech-revert")
@@ -3206,8 +3203,10 @@ async def test_settings_generic_save_and_revert_actions_route_to_speech_panel() 
             "#settings-speech-tts-panel",
             SpeechTTSSettingsPanel,
         )
-        model_value = screen.query_one("#settings-speech-model-value", Input)
-        model_value.value = f"{model_value.value}-draft"
+        model_value = screen.query_one("#settings-speech-model-value", Select)
+        model_value.value = (
+            "tts-1-hd" if model_value.value != "tts-1-hd" else "tts-1"
+        )
         await pilot.pause()
         request_save = Mock()
         revert_to_saved = AsyncMock()
@@ -3241,8 +3240,8 @@ async def test_details_and_scope_start_collapsed_on_every_mount() -> None:
             for widget in panel.query(Static)
             if widget.display and widget.is_on_screen
         ).casefold()
-        assert "task: set up" in visible_copy
         assert "current status" in visible_copy
+        assert "provider setup" in visible_copy
         assert "revision" not in visible_copy
         assert "effective source" not in visible_copy
 
@@ -3346,7 +3345,7 @@ async def test_managed_guided_selection_provenance_stays_in_collapsed_details() 
             for widget in panel.query(Static)
             if widget.display and widget.is_on_screen
         ).casefold()
-        assert "task: set up audio.cpp" in visible_copy
+        assert "provider setup" in visible_copy
         assert "current status:" in visible_copy
         assert "selection source" not in visible_copy
 
@@ -3516,8 +3515,11 @@ async def test_dirty_speech_category_cancel_preserves_owner_draft_and_focus() ->
             "#settings-speech-tts-panel",
             SpeechTTSSettingsPanel,
         )
-        model = screen.query_one("#settings-speech-model-value", Input)
-        model.value = "unsaved-exact-model"
+        model = screen.query_one("#settings-speech-model-value", Select)
+        dirty_value = (
+            "tts-1-hd" if model.value != "tts-1-hd" else "tts-1"
+        )
+        model.value = dirty_value
         model.focus()
         panel._ask_leave_choice = AsyncMock(return_value="cancel")
         await pilot.pause()
@@ -3527,8 +3529,8 @@ async def test_dirty_speech_category_cancel_preserves_owner_draft_and_focus() ->
         await pilot.pause()
 
         assert screen.active_category == SettingsCategoryId.SPEECH_TTS.value
-        assert screen.query_one("#settings-speech-model-value", Input).value == (
-            "unsaved-exact-model"
+        assert screen.query_one("#settings-speech-model-value", Select).value == (
+            dirty_value
         )
         assert host.focused is model
         assert panel.has_unsaved_changes() is True
@@ -4252,3 +4254,122 @@ async def test_default_profile_dirty_check_does_not_depend_on_provider_validity(
         await pilot.pause()
 
         assert panel.has_unsaved_changes() is True
+
+
+def _kokoro_defaults_state():
+    state = load_global_speech_tts_state({})
+    state.defaults.provider_id = "kokoro"
+    state.defaults.model_mode = "exact"
+    state.defaults.model_id = "kokoro"
+    state.defaults.voice_mode = "exact"
+    state.defaults.voice_id = "af_heart"
+    return state
+
+
+@pytest.mark.asyncio
+async def test_legacy_voice_value_select_offers_known_voices() -> None:
+    """Recognition over recall: the legacy Voice value control offers the
+    provider's labeled voices instead of a free-text box, and a pick both
+    lands in the draft and dirties it (the 2026-09-11 critique's P1)."""
+    app = _PanelHarness(
+        state=_kokoro_defaults_state(), configure_provider="kokoro"
+    )
+    async with app.run_test(size=(150, 60)) as pilot:
+        voice = app.query_one("#settings-speech-voice-value", Select)
+        assert voice.value == "af_heart"
+        # Raises if the labeled Kokoro voices are not real options.
+        voice.value = "bf_emma"
+        await pilot.pause()
+
+        panel = app.query_one("#panel", SpeechTTSSettingsPanel)
+        assert panel.state.defaults.voice_id == "bf_emma"
+        assert panel.has_unsaved_changes() is True
+
+
+@pytest.mark.asyncio
+async def test_unknown_saved_voice_stays_selectable_as_custom() -> None:
+    """A saved voice the known list does not carry stays selectable as an
+    explicit '(custom)' option -- the never-drop-a-saved-value rule the
+    audio.cpp exact choices already follow."""
+    state = _kokoro_defaults_state()
+    state.defaults.voice_id = "my_cloned_voice"
+    app = _PanelHarness(state=state, configure_provider="kokoro")
+    async with app.run_test(size=(150, 60)):
+        voice = app.query_one("#settings-speech-voice-value", Select)
+        assert voice.value == "my_cloned_voice"
+
+
+@pytest.mark.asyncio
+async def test_custom_entry_modal_sets_voice_id() -> None:
+    """Picking Custom… opens the free-text editor; a confirmed ID becomes
+    the draft value and stays selected after the card rebuild."""
+    app = _PanelHarness(
+        state=_kokoro_defaults_state(), configure_provider="kokoro"
+    )
+    async with app.run_test(size=(150, 60)) as pilot:
+        voice = app.query_one("#settings-speech-voice-value", Select)
+        voice.value = "__custom__"
+        await pilot.pause()
+
+        modal = app.screen
+        assert isinstance(
+            modal, speech_tts_settings_panel_module._CustomIdModal
+        )
+        modal.query_one("#settings-speech-custom-id-value", Input).value = (
+            "af_sky"
+        )
+        await pilot.click("#settings-speech-custom-id-confirm")
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        panel = app.query_one("#panel", SpeechTTSSettingsPanel)
+        assert panel.state.defaults.voice_id == "af_sky"
+        assert (
+            app.query_one("#settings-speech-voice-value", Select).value
+            == "af_sky"
+        )
+
+
+@pytest.mark.asyncio
+async def test_browse_voices_button_navigates_to_speech_lab() -> None:
+    """The Voice value row bridges to Speech Lab with the default provider
+    staged, so a discovered voice no longer has to be retyped from memory."""
+    app = _PanelHarness(
+        state=_kokoro_defaults_state(), configure_provider="kokoro"
+    )
+    async with app.run_test(size=(150, 60)) as pilot:
+        app.query_one("#settings-speech-browse-voices", Button).press()
+        await app.workers.wait_for_complete()
+        await pilot.pause()
+
+        assert app.navigation, "expected a navigation event"
+        assert app.navigation[0].screen_name == "stts"
+
+
+@pytest.mark.asyncio
+async def test_local_provider_forms_surface_dependency_and_model_guidance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The install extra and the model-download story live in the Kokoro
+    form itself, not only inside the collapsed Scope inspector (the
+    2026-09-11 critique's first-run dead-end P1)."""
+    monkeypatch.setattr(
+        speech_tts_settings_panel_module,
+        "speech_local_dependency_availability",
+        lambda **_kwargs: SpeechLocalDependencyAvailability(
+            stt=False, kokoro=False, chatterbox=False, higgs=False
+        ),
+    )
+    app = _PanelHarness(
+        state=_kokoro_defaults_state(), configure_provider="kokoro"
+    )
+    async with app.run_test(size=(150, 60)):
+        status = app.query_one(
+            "#settings-speech-kokoro-dependency-status", Static
+        )
+        assert "tldw_chatbook[local_tts]" in str(status.renderable)
+        assert "not installed" in str(status.renderable)
+        guidance = app.query_one(
+            "#settings-speech-kokoro-model-guidance", Static
+        )
+        assert "kokoro-v0_19.onnx" in str(guidance.renderable)

--- a/Tests/UI/test_settings_speech_tts_panel.py
+++ b/Tests/UI/test_settings_speech_tts_panel.py
@@ -4308,7 +4308,7 @@ async def test_custom_entry_modal_sets_voice_id() -> None:
     )
     async with app.run_test(size=(150, 60)) as pilot:
         voice = app.query_one("#settings-speech-voice-value", Select)
-        voice.value = "__custom__"
+        voice.value = speech_tts_settings_panel_module._CUSTOM_ID_SENTINEL
         await pilot.pause()
 
         modal = app.screen
@@ -4328,12 +4328,16 @@ async def test_custom_entry_modal_sets_voice_id() -> None:
             app.query_one("#settings-speech-voice-value", Select).value
             == "af_sky"
         )
+        # A Save racing the rebuild must not clobber the confirmed ID.
+        panel._collect_visible_state()
+        assert panel.state.defaults.voice_id == "af_sky"
 
 
 @pytest.mark.asyncio
 async def test_browse_voices_button_navigates_to_speech_lab() -> None:
     """The Voice value row bridges to Speech Lab with the default provider
-    staged, so a discovered voice no longer has to be retyped from memory."""
+    staged and the voice selector focused (refresh-voices intent), so a
+    discovered voice no longer has to be retyped from memory."""
     app = _PanelHarness(
         state=_kokoro_defaults_state(), configure_provider="kokoro"
     )
@@ -4342,8 +4346,13 @@ async def test_browse_voices_button_navigates_to_speech_lab() -> None:
         await app.workers.wait_for_complete()
         await pilot.pause()
 
-        assert app.navigation, "expected a navigation event"
+        assert len(app.navigation) == 1
         assert app.navigation[0].screen_name == "stts"
+        assert app.navigation[0].screen_context == {
+            "view": "playground",
+            "provider": "kokoro",
+            "intent": "refresh-voices",
+        }
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_speech_settings_panel_scoped_updates.py
+++ b/Tests/UI/test_speech_settings_panel_scoped_updates.py
@@ -101,7 +101,7 @@ async def test_model_policy_change_rebuilds_only_defaults_and_inspector():
         await _settle(pilot)
 
         assert _identities(panel, untouched) == untouched
-        assert panel.query_one("#settings-speech-model-value", Input).disabled is True
+        assert panel.query_one("#settings-speech-model-value", Select).disabled is True
         assert getattr(host.focused, "id", None) == "settings-speech-model-policy"
 
 

--- a/backlog/tasks/task-32475 - Speech-TTS-settings-UX-fixes-from-2026-09-11-critique.md
+++ b/backlog/tasks/task-32475 - Speech-TTS-settings-UX-fixes-from-2026-09-11-critique.md
@@ -1,0 +1,96 @@
+---
+id: TASK-32475
+title: Speech & TTS settings UX fixes from 2026-09-11 critique
+status: Done
+assignee: []
+created_date: '2026-09-11 23:53'
+updated_date: '2026-09-12 01:02'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Implement the P1+P2 fixes from the impeccable critique of the Speech & TTS settings sub-screen: Kokoro first-run onboarding rows, known-voice/model pickers with custom escape hatch and Speech Lab bridge, governance copy compression, leave-banner contradiction fix, id-leak and casing cleanups, Chatterbox/Higgs form grouping, restore preview.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Kokoro/Chatterbox/Higgs forms surface dependency status and model guidance inline
+- [x] #2 Model and Voice value for legacy providers are Selects of known IDs with Custom escape hatch
+- [x] #3 First viewport shows editable controls (banner compressed to 2 lines, single Open Speech Lab button)
+- [x] #4 Speech & TTS leave banner no longer claims drafts persist across category switches
+- [x] #5 Chatterbox/Higgs forms grouped into collapsible sections
+- [x] #6 Restore states its scope before/after acting
+- [x] #7 Targeted tests updated and passing
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. Panel: compress banner, drop top Lab button, remove task static\n2. Panel: legacy model/voice Selects + custom modal + browse-voices bridge\n3. Panel: local dependency + model guidance rows; casing; speed label; save payoff; restore tooltip/summary\n4. Panel: Collapsible grouping for Chatterbox/Higgs\n5. settings_screen: banner special-case, alias and description id-leak fixes\n6. Update affected tests; run targeted suite\n7. Update docs; live verify
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+- Approach: five critique-driven fix areas landed in one pass over
+  `speech_tts_settings_panel.py` plus three small `settings_screen.py` edits,
+  honoring the user's "preserve, compress" tone decision for governance copy.
+- Onboarding: `_local_dependency_row()` surfaces the same
+  `speech_local_dependency_availability` fact the Scope inspector reports,
+  inline at the top of the Kokoro/Chatterbox/Higgs forms, plus a Kokoro
+  model-file guidance row naming `kokoro-v0_19.onnx` and the docs path; path
+  placeholders now carry the real filenames.
+- Pickers: legacy Model/Voice values moved from free-text Inputs to Selects
+  built from `LEGACY_MODELS`/`LEGACY_MODEL_LABELS`/`LEGACY_VOICE_OPTIONS`
+  (labeled, e.g. "Heart (US Female)"), with a `Custom…` sentinel that opens a
+  `_CustomIdModal` free-text editor, an unknown saved value kept selectable as
+  "(custom)" (the never-drop-a-saved-value precedent from the realtime
+  provider select and audio.cpp exact choices), and a `Browse in Speech Lab`
+  button beside Voice value that stages the default provider. Collection
+  guards ensure the sentinel can never persist.
+- Distill: banner compressed to two lines (fuller text preserved as tooltip),
+  the banner's `#settings-speech-open-lab` button removed (single Lab action
+  with Save at the bottom; handler keeps serving the bottom + audio.cpp
+  handoff buttons), and the redundant "Task: set up …" status static dropped
+  (kept "Current status: …").
+- Clarify: SPEECH_TTS leave-banner special case resolves task-2708's
+  contradiction; `audio_cpp` raw id removed from the category summary and
+  inspector text but deliberately kept in the search vocabulary (tests assert
+  power users grep by config id); row labels sentence-cased; Speed range
+  moved into the label; save payoff now names the next step; Restore got a
+  scope tooltip and a summary result line (no modal — draft-only action).
+- Layout: Chatterbox (Compute and generation / Voice and processing /
+  Streaming) and Higgs (Model and voice / Compute / Generation) grouped into
+  Collapsibles with unchanged field ids, so collection and tests are
+  unaffected.
+- Tests: updated 8 sites where tests drove the old Inputs, added 6 new tests
+  (picker options + draft dirty, unknown-value "(custom)" option, custom
+  modal flow, browse-voices navigation, dependency/guidance rows, SPEECH_TTS
+  banner). Targeted suite green: 137 + 191 + 128 + 104 passed across the
+  speech panel/policy/scoped/ownership/contracts/preferences/category-sweep
+  files; one pre-existing timing flake in `test_audio_cpp_model_library_
+  handoff.py` passes solo and is untouched by this change.
+- Live-verified on an isolated scratch profile (TLDW_CONFIG_PATH + scratch
+  data_dir) at 235x52 and 130-row captures: banner two lines with controls in
+  the first viewport, "Kokoro 82M" model dropdown, dependency and
+  model-guidance rows, filename-bearing placeholders, no `audio_cpp` leak.
+- Environment note: the working tree could not import `tldw_chatbook.Chat`
+  (pre-existing uncommitted WIP imports `Chat.console_appearance`, which was
+  missing from this checkout). Restored the file byte-identical from the
+  sibling worktrees (same md5 in all of them) purely to make verification
+  possible; it is the user's in-flight work, not part of this task's changes.
+- Docs: `Docs/User_Guide/settings.md` Speech & TTS section rewritten against
+  the new UI; the task-2708 Quirks entry removed (fixed);
+  `TTS_MODULE_GUIDE.md` "S/TT/S tab" drift renamed to Speech Lab.
+- Modified files: `Widgets/Settings_Widgets/speech_tts_settings_panel.py`,
+  `UI/Screens/settings_screen.py`, `Tests/UI/test_settings_speech_tts_
+  panel.py`, `Tests/UI/test_settings_configuration_hub.py`,
+  `Tests/UI/test_legacy_tts_voice_policy.py`,
+  `Tests/UI/test_speech_settings_panel_scoped_updates.py`,
+  `Docs/User_Guide/settings.md`, `Docs/Development/TTS/TTS_MODULE_GUIDE.md`.
+- ADR required: no — UI affordance and copy changes within existing
+  boundaries; no schema, ownership, or service-contract change.
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32476 - Speech-TTS-settings-UX-fixes-from-2026-09-11-critique.md
+++ b/backlog/tasks/task-32476 - Speech-TTS-settings-UX-fixes-from-2026-09-11-critique.md
@@ -1,5 +1,5 @@
 ---
-id: TASK-32475
+id: TASK-32476
 title: Speech & TTS settings UX fixes from 2026-09-11 critique
 status: Done
 assignee: []

--- a/tldw_chatbook/UI/Screens/settings_screen.py
+++ b/tldw_chatbook/UI/Screens/settings_screen.py
@@ -3988,7 +3988,7 @@ class SettingsScreen(BaseAppScreen):
             SettingsCategorySummary(
                 SettingsCategoryId.SPEECH_TTS,
                 "Speech & TTS",
-                "Application-wide speech, TTS, voice, audio.cpp, audio_cpp, OpenAI, "
+                "Application-wide speech, TTS, voice, audio.cpp, OpenAI, "
                 "ElevenLabs, Kokoro, Chatterbox, Higgs, and AllTalk defaults and setup.",
                 "Global",
             ),
@@ -8458,6 +8458,14 @@ class SettingsScreen(BaseAppScreen):
             if not validation.valid:
                 return f"State: Needs correction | {validation.message}"
         if self._category_has_unsaved_changes(category):
+            if category is SettingsCategoryId.SPEECH_TTS:
+                # task-2708: the generic contract below is false here -- this
+                # category resolves its draft through the leave modal instead
+                # of carrying it across a category switch.
+                return (
+                    "State: Unsaved changes | Save (s) or Revert (r) — leaving "
+                    "Speech & TTS resolves this draft: save or discard first."
+                )
             return "State: Unsaved changes | Save (s) or Revert (r) — switching categories keeps this draft."
         # task-1717: lead with the persistence badge -- the footer hints
         # already honestly come and go with each category's save model,

--- a/tldw_chatbook/UI/Screens/settings_search_index.py
+++ b/tldw_chatbook/UI/Screens/settings_search_index.py
@@ -552,6 +552,8 @@ def build_field_search_index() -> None:
                 ("settings-speech-model-value", "Model value"),
                 ("settings-speech-voice-value", "TTS voice"),
                 ("settings-speech-voice-value", "Voice value"),
+                # The raw id stays in the SEARCH vocabulary only (power users
+                # grep by config id); visible descriptions use "audio.cpp".
                 ("settings-speech-configure-provider", "audio.cpp audio_cpp"),
                 ("settings-speech-configure-provider", "OpenAI"),
                 ("settings-speech-configure-provider", "ElevenLabs"),

--- a/tldw_chatbook/UI/Screens/settings_speech_tts.py
+++ b/tldw_chatbook/UI/Screens/settings_speech_tts.py
@@ -306,6 +306,8 @@ _CREDENTIAL_LOCAL_LOCATIONS = MappingProxyType(
 )
 
 _MAX_GLOBAL_IDENTIFIER_CHARACTERS = 512
+#: Public alias so pre-save surfaces can pass Save's exact identifier limit.
+MAX_GLOBAL_IDENTIFIER_CHARACTERS = _MAX_GLOBAL_IDENTIFIER_CHARACTERS
 _UNSAFE_IDENTIFIER_CATEGORIES = frozenset({"Cc", "Cf", "Cs"})
 
 
@@ -1495,14 +1497,13 @@ def _string(
     return value
 
 
-def _identifier(
-    provider_id: str,
-    field_id: str,
-    value: object,
-    *,
-    max_characters: int,
-) -> str:
-    """Validate an opaque model or voice identifier without echoing it."""
+def global_identifier_is_valid(value: object, *, max_characters: int) -> bool:
+    """Return whether ``value`` is a storable opaque model/voice identifier.
+
+    The exact predicate ``_identifier`` enforces at Save, exposed as a bool
+    so pre-save surfaces (the Settings custom-ID editor) reject the same
+    inputs Save would reject, without duplicating the rule.
+    """
     if (
         type(value) is not str
         or not value
@@ -1513,19 +1514,29 @@ def _identifier(
             for character in value
         )
     ):
-        _validation_error(
-            provider_id,
-            field_id,
-            "Choose a valid saved identifier.",
-        )
+        return False
     try:
         value.encode("utf-8", errors="strict")
     except UnicodeError:
+        return False
+    return True
+
+
+def _identifier(
+    provider_id: str,
+    field_id: str,
+    value: object,
+    *,
+    max_characters: int,
+) -> str:
+    """Validate an opaque model or voice identifier without echoing it."""
+    if not global_identifier_is_valid(value, max_characters=max_characters):
         _validation_error(
             provider_id,
             field_id,
             "Choose a valid saved identifier.",
         )
+    assert isinstance(value, str)
     return value
 
 

--- a/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
@@ -80,6 +80,9 @@ from tldw_chatbook.TTS.audio_cpp_recipes import (
 from tldw_chatbook.TTS.legacy_catalogs import (
     LEGACY_DEFAULT_MODELS,
     LEGACY_DEFAULT_VOICES,
+    LEGACY_MODEL_LABELS,
+    LEGACY_MODELS,
+    LEGACY_VOICE_OPTIONS,
 )
 from tldw_chatbook.Third_Party.textual_fspicker import (
     FileOpen,
@@ -175,6 +178,9 @@ _LANGUAGE_OPTIONS = [
 LeaveChoice = Literal["save", "discard", "cancel"]
 _GLOBAL_SPEECH_TTS_STACK_WIDTH = 104
 _COLLAPSIBLE_TITLE_FOCUS_SUFFIX = "::collapsible-title"
+# Select-option value for "enter an ID the known list does not carry". Never
+# persists: collection skips it and the handler swaps it for the modal flow.
+_CUSTOM_ID_SENTINEL = "__custom__"
 _AUDIO_CPP_MANAGED_UI_SUPPORTED = os.name != "nt"
 _AUDIO_CPP_MANAGED_FIELD_IDS = frozenset(
     {
@@ -468,6 +474,60 @@ class _OpenAINoneHTTPConfirmationModal(ModalScreen[bool]):
     def handle_confirm(self, event: Button.Pressed) -> None:
         event.stop()
         self.dismiss(True)
+
+
+class _CustomIdModal(ModalScreen[str | None]):
+    """Free-text entry for a model/voice ID outside the known list."""
+
+    BINDINGS = [Binding("escape", "cancel", "Cancel", show=False)]
+
+    def __init__(self, axis_label: str, current: str) -> None:
+        super().__init__()
+        self.axis_label = axis_label
+        self.current = current
+
+    def compose(self) -> ComposeResult:
+        with Vertical(classes="settings-speech-credential-modal"):
+            yield Static(
+                f"Set a custom {self.axis_label} ID",
+                classes="destination-section",
+            )
+            yield Static(
+                "Enter the exact identifier your provider expects. Known "
+                "choices are already offered in the dropdown; this is for "
+                "IDs the list does not carry (for example a voice discovered "
+                "in Speech Lab).",
+                classes="settings-detail-row",
+                markup=False,
+            )
+            yield Input(
+                id="settings-speech-custom-id-value",
+                value=self.current,
+                placeholder="Exact identifier",
+                tooltip=f"Custom {self.axis_label} ID",
+            )
+            with Horizontal(classes="settings-action-row"):
+                yield Button("Cancel", id="settings-speech-custom-id-cancel")
+                yield Button(
+                    "Use this ID",
+                    id="settings-speech-custom-id-confirm",
+                    variant="primary",
+                )
+
+    def action_cancel(self) -> None:
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#settings-speech-custom-id-cancel")
+    def handle_cancel(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(None)
+
+    @on(Button.Pressed, "#settings-speech-custom-id-confirm")
+    def handle_confirm(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(
+            self.query_one("#settings-speech-custom-id-value", Input).value
+        )
 
 
 class _GlobalSpeechTTSLeaveModal(ModalScreen[LeaveChoice]):
@@ -2021,24 +2081,21 @@ class SpeechTTSSettingsPanel(Vertical):
             "Speech & TTS", classes="destination-section settings-column-title"
         )
         with Vertical(id="settings-speech-scope-banner", classes="settings-focus-card"):
-            yield Static(
-                "You are editing application-wide Speech & TTS defaults. "
-                "The Speech Studio can keep separate Studio preferences without "
-                "changing these values.",
+            banner = Static(
+                "Editing application-wide Speech & TTS defaults — Speech Studio "
+                "preferences stay separate.",
                 classes="settings-detail-row",
                 markup=False,
             )
-            yield Button(
-                "Open Speech Lab",
-                id="settings-speech-open-lab",
-                compact=True,
-                tooltip="Open Speech Lab without testing or refreshing a provider.",
+            banner.tooltip = (
+                "You are editing application-wide Speech & TTS defaults. "
+                "The Speech Studio can keep separate Studio preferences "
+                "without changing these values."
             )
+            yield banner
             yield Static(
-                "Voice profiles are managed in Lab > Speech > Voice Profiles "
-                "— open Speech Lab, above, to get there. Per-character "
-                "voices are assigned in the Roleplay character editor's "
-                "Voice & Speech section, not here.",
+                "Voice profiles: Speech Lab (open it from the actions below). "
+                "Per-character voices: the Roleplay character editor.",
                 id="settings-speech-profile-surfaces-note",
                 classes="settings-detail-row",
                 markup=False,
@@ -2080,8 +2137,23 @@ class SpeechTTSSettingsPanel(Vertical):
                 "Restore Non-secret Defaults",
                 id="settings-speech-restore-defaults",
                 disabled=cleanup_pending,
+                tooltip=(
+                    "Reset the global defaults and the selected provider's "
+                    "non-secret fields in the draft. Saved credentials and "
+                    "environment-owned values stay untouched. Nothing "
+                    "persists until you Save."
+                ),
             )
-            yield Button("Open Speech Lab", id="settings-speech-open-lab-bottom")
+            yield Button(
+                "Open Speech Lab",
+                id="settings-speech-open-lab-bottom",
+                compact=True,
+                tooltip=(
+                    "Open the Speech Lab to test, refresh model and voice "
+                    "catalogs, and hear samples. Settings itself never "
+                    "contacts a server."
+                ),
+            )
         yield Static(
             self.result_text,
             id="settings-speech-save-result",
@@ -2146,6 +2218,67 @@ class SpeechTTSSettingsPanel(Vertical):
             await card.recompose()
         self._restore_focus(focus_token)
 
+    def _legacy_model_options(self, provider_id: str) -> list[tuple[str, str]]:
+        """Labeled known models for a legacy provider, plus the custom entry.
+
+        A current value the known list does not carry stays selectable as an
+        explicit "(custom)" option -- the same never-drop-a-saved-value rule
+        the audio.cpp exact choices and the realtime provider select follow.
+        """
+        options: list[tuple[str, str]] = []
+        known = LEGACY_MODELS.get(provider_id, ())
+        labels = LEGACY_MODEL_LABELS.get(provider_id, {})
+        for model_id in known:
+            options.append((labels.get(model_id, model_id), model_id))
+        current = self.state.defaults.model_id
+        if current and current not in known:
+            options.append((f"{current} (custom)", current))
+        options.append(("Custom…", _CUSTOM_ID_SENTINEL))
+        return options
+
+    def _legacy_voice_options(self, provider_id: str) -> list[tuple[str, str]]:
+        """Labeled known voices for a legacy provider, plus the custom entry."""
+        options: list[tuple[str, str]] = list(LEGACY_VOICE_OPTIONS.get(provider_id, ()))
+        known = {value for _label, value in options}
+        current = self.state.defaults.voice_id
+        if current and current not in known:
+            options.append((f"{current} (custom)", current))
+        options.append(("Custom…", _CUSTOM_ID_SENTINEL))
+        return options
+
+    _LOCAL_PROVIDER_DEPENDENCIES: ClassVar[dict[str, tuple[str, str, str]]] = {
+        # provider -> (label, availability attr on the snapshot, install extra)
+        "kokoro": ("Local Kokoro", "kokoro", "local_tts"),
+        "chatterbox": ("Local Chatterbox", "chatterbox", "chatterbox"),
+        "higgs": ("Local Higgs", "higgs", "higgs_tts"),
+    }
+
+    def _local_dependency_row(self, provider_id: str) -> Static | None:
+        """Inline install/readiness fact for a local provider form.
+
+        The same fact the Scope inspector reports, surfaced where the user
+        is about to configure the provider -- a first-run reader should not
+        have to know a collapsed inspector holds it.
+        """
+        info = self._LOCAL_PROVIDER_DEPENDENCIES.get(provider_id)
+        if info is None:
+            return None
+        label, availability_attr, extra = info
+        available = bool(getattr(self._local_dependencies, availability_attr))
+        if available:
+            copy = f"{label}: installed and importable."
+        else:
+            copy = (
+                f"{label}: not installed — install the extra "
+                f"'tldw_chatbook[{extra}]' and restart Chatbook first."
+            )
+        return Static(
+            copy,
+            id=f"settings-speech-{provider_id}-dependency-status",
+            classes="settings-status-row",
+            markup=False,
+        )
+
     def _compose_global_defaults_body(self) -> ComposeResult:
         """Yield the Global defaults card's children.
 
@@ -2184,7 +2317,7 @@ class SpeechTTSSettingsPanel(Vertical):
         )
         yield self._default_profile_row()
         yield self._row(
-            "Default TTS Provider",
+            "Default TTS provider",
             Select(
                 _PROVIDER_OPTIONS,
                 value=defaults.provider_id,
@@ -2240,13 +2373,25 @@ class SpeechTTSSettingsPanel(Vertical):
         else:
             yield self._row(
                 "Model value",
-                Input(
-                    value=defaults.model_id or "",
+                Select(
+                    self._legacy_model_options(defaults.provider_id),
+                    value=(
+                        defaults.model_id
+                        if defaults.model_mode == "exact"
+                        and defaults.model_id
+                        else Select.NULL
+                    ),
                     id="settings-speech-model-value",
+                    allow_blank=defaults.model_mode != "exact",
+                    compact=True,
                     disabled=defaults.model_mode != "exact",
-                    placeholder="Exact model ID",
-                    classes="settings-compact-input settings-speech-draft-field",
+                    tooltip=(
+                        "Known models for this provider; pick Custom… to "
+                        "enter an exact ID"
+                    ),
+                    classes="settings-compact-select settings-speech-draft-field",
                 ),
+                classes="settings-select-row",
                 error=self._default_error(
                     "default_model",
                     "settings-speech-model-value",
@@ -2306,13 +2451,37 @@ class SpeechTTSSettingsPanel(Vertical):
         else:
             yield self._row(
                 "Voice value",
-                Input(
-                    value=defaults.voice_id or "",
-                    id="settings-speech-voice-value",
-                    disabled=defaults.voice_mode != "exact",
-                    placeholder="Exact voice ID",
-                    classes="settings-compact-input settings-speech-draft-field",
+                Horizontal(
+                    Select(
+                        self._legacy_voice_options(defaults.provider_id),
+                        value=(
+                            defaults.voice_id
+                            if defaults.voice_mode == "exact"
+                            and defaults.voice_id
+                            else Select.NULL
+                        ),
+                        id="settings-speech-voice-value",
+                        allow_blank=defaults.voice_mode != "exact",
+                        compact=True,
+                        disabled=defaults.voice_mode != "exact",
+                        tooltip=(
+                            "Known voices for this provider; pick Custom… to "
+                            "enter an exact ID"
+                        ),
+                        classes="settings-compact-select settings-speech-draft-field",
+                    ),
+                    Button(
+                        "Browse in Speech Lab",
+                        id="settings-speech-browse-voices",
+                        compact=True,
+                        tooltip=(
+                            "Open Speech Lab with this provider selected to "
+                            "preview voices before committing one here"
+                        ),
+                    ),
+                    classes="settings-action-row",
                 ),
+                classes="settings-select-row",
                 error=self._default_error(
                     "default_voice",
                     "settings-speech-voice-value",
@@ -2342,12 +2511,12 @@ class SpeechTTSSettingsPanel(Vertical):
             ),
         )
         yield self._row(
-            "Speed",
+            "Speed (0.25-4.0)",
             Input(
                 value=str(defaults.speed),
                 id="settings-speech-speed",
                 disabled=audio_cpp_selected,
-                placeholder="0.25 - 4.0",
+                placeholder="1.0",
                 classes="settings-compact-input settings-speech-draft-field",
             ),
             error=self._default_error(
@@ -2373,20 +2542,13 @@ class SpeechTTSSettingsPanel(Vertical):
         """
         yield Static("Provider setup", classes="destination-section")
         yield Static(
-            f"Task: set up {TTS_PROVIDER_LABELS[self.configure_provider]} for "
-            "application-wide speech.",
-            id="settings-speech-provider-task",
-            classes="settings-status-row",
-            markup=False,
-        )
-        yield Static(
             f"Current status: {self._connection_readiness().connection.value}.",
             id="settings-speech-provider-current-status",
             classes="settings-status-row",
             markup=False,
         )
         yield self._row(
-            "Configure Provider",
+            "Configure provider",
             Select(
                 _PROVIDER_OPTIONS,
                 value=self.configure_provider,
@@ -3212,6 +3374,18 @@ class SpeechTTSSettingsPanel(Vertical):
                 return
 
             if provider_id == "kokoro":
+                dependency_row = self._local_dependency_row(provider_id)
+                if dependency_row is not None:
+                    yield dependency_row
+                yield Static(
+                    "Model files: kokoro-v0_19.onnx (~300 MB) plus voices.json. "
+                    "Set their paths below — see Docs ▸ Development ▸ TTS ▸ "
+                    "Kokoro Model Setup for the download utility and expected "
+                    "filenames.",
+                    id="settings-speech-kokoro-model-guidance",
+                    classes="settings-detail-row",
+                    markup=False,
+                )
                 yield self._select(
                     provider_id,
                     "device",
@@ -3223,13 +3397,13 @@ class SpeechTTSSettingsPanel(Vertical):
                     provider_id,
                     "onnx_model_path",
                     "ONNX model file",
-                    placeholder="Path to model file",
+                    placeholder="kokoro-v0_19.onnx (~300 MB)",
                 )
                 yield self._path(
                     provider_id,
                     "voices_json_path",
                     "Voices JSON file",
-                    placeholder="Path to voices.json",
+                    placeholder="voices.json",
                 )
                 yield self._input(provider_id, "max_tokens", "Max tokens")
                 yield self._switch(provider_id, "voice_mixing", "Voice mixing")
@@ -3239,102 +3413,138 @@ class SpeechTTSSettingsPanel(Vertical):
                 return
 
             if provider_id == "chatterbox":
-                yield self._select(
-                    provider_id,
-                    "device",
-                    "Device",
-                    [("CPU", "cpu"), ("CUDA", "cuda")],
-                )
-                yield self._path(
-                    provider_id,
-                    "voice_resource_directory",
-                    "Voice resource directory",
-                    placeholder="Path to voice resources",
-                )
-                yield self._input(provider_id, "temperature", "Temperature")
-                yield self._input(provider_id, "chunk_size", "Chunk size")
-                yield self._input(
-                    provider_id, "random_seed", "Random seed", placeholder="Optional"
-                )
-                yield self._input(provider_id, "candidates", "Candidates")
-                yield self._switch(
-                    provider_id, "validate_whisper", "Whisper validation"
-                )
-                yield self._switch(provider_id, "preprocess_text", "Text preprocessing")
-                yield self._switch(
-                    provider_id, "normalize_audio", "Audio normalization"
-                )
-                yield self._input(provider_id, "target_db", "Target dB")
-                yield self._input(provider_id, "max_chunk_size", "Max text chunk")
-                yield self._switch(provider_id, "streaming", "Streaming")
-                yield self._input(provider_id, "stream_chunk_size", "Stream chunk size")
-                yield self._switch(provider_id, "crossfade", "Crossfade")
-                yield self._input(
-                    provider_id, "crossfade_ms", "Crossfade duration (ms)"
-                )
+                dependency_row = self._local_dependency_row(provider_id)
+                if dependency_row is not None:
+                    yield dependency_row
+                with Collapsible(
+                    title="Compute and generation",
+                    collapsed=False,
+                    id="settings-speech-chatterbox-group-generation",
+                ):
+                    yield self._select(
+                        provider_id,
+                        "device",
+                        "Device",
+                        [("CPU", "cpu"), ("CUDA", "cuda")],
+                    )
+                    yield self._input(provider_id, "temperature", "Temperature")
+                    yield self._input(provider_id, "chunk_size", "Chunk size")
+                    yield self._input(
+                        provider_id, "random_seed", "Random seed", placeholder="Optional"
+                    )
+                    yield self._input(provider_id, "candidates", "Candidates")
+                with Collapsible(
+                    title="Voice and processing",
+                    collapsed=False,
+                    id="settings-speech-chatterbox-group-processing",
+                ):
+                    yield self._path(
+                        provider_id,
+                        "voice_resource_directory",
+                        "Voice resource directory",
+                        placeholder="Path to voice resources",
+                    )
+                    yield self._switch(
+                        provider_id, "validate_whisper", "Whisper validation"
+                    )
+                    yield self._switch(provider_id, "preprocess_text", "Text preprocessing")
+                    yield self._switch(
+                        provider_id, "normalize_audio", "Audio normalization"
+                    )
+                    yield self._input(provider_id, "target_db", "Target dB")
+                    yield self._input(provider_id, "max_chunk_size", "Max text chunk")
+                with Collapsible(
+                    title="Streaming",
+                    collapsed=True,
+                    id="settings-speech-chatterbox-group-streaming",
+                ):
+                    yield self._switch(provider_id, "streaming", "Streaming")
+                    yield self._input(provider_id, "stream_chunk_size", "Stream chunk size")
+                    yield self._switch(provider_id, "crossfade", "Crossfade")
+                    yield self._input(
+                        provider_id, "crossfade_ms", "Crossfade duration (ms)"
+                    )
                 return
 
             if provider_id == "higgs":
-                yield self._path(
-                    provider_id,
-                    "model_path",
-                    "Model path",
-                    placeholder="Local path or Hugging Face model ID",
-                )
-                yield self._path(
-                    provider_id,
-                    "voice_resource_directory",
-                    "Voice resource directory",
-                    placeholder="Path to voice samples",
-                )
-                yield self._select(
-                    provider_id,
-                    "device",
-                    "Device",
-                    [
-                        ("Auto", "auto"),
-                        ("CPU", "cpu"),
-                        ("CUDA", "cuda"),
-                        ("CUDA 0", "cuda:0"),
-                        ("CUDA 1", "cuda:1"),
-                        ("Apple MPS", "mps"),
-                    ],
-                )
-                yield self._switch(
-                    provider_id,
-                    "enable_flash_attention",
-                    "Enable flash attention",
-                )
-                yield self._select(
-                    provider_id,
-                    "dtype",
-                    "Data type",
-                    [
-                        ("Float32", "float32"),
-                        ("Float16", "float16"),
-                        ("BFloat16", "bfloat16"),
-                    ],
-                )
-                yield self._input(
-                    provider_id,
-                    "max_reference_duration",
-                    "Max reference duration",
-                )
-                yield self._select(
-                    provider_id, "language", "Default language", _LANGUAGE_OPTIONS
-                )
-                yield self._switch(provider_id, "voice_cloning", "Voice cloning")
-                yield self._switch(provider_id, "multi_speaker", "Multi-speaker")
-                yield self._input(provider_id, "speaker_delimiter", "Speaker delimiter")
-                yield self._switch(
-                    provider_id, "track_performance", "Performance tracking"
-                )
-                yield self._input(provider_id, "max_new_tokens", "Max new tokens")
-                yield self._input(provider_id, "temperature", "Temperature")
-                yield self._input(provider_id, "top_p", "Top P")
-                yield self._input(
-                    provider_id, "repetition_penalty", "Repetition penalty"
-                )
+                dependency_row = self._local_dependency_row(provider_id)
+                if dependency_row is not None:
+                    yield dependency_row
+                with Collapsible(
+                    title="Model and voice",
+                    collapsed=False,
+                    id="settings-speech-higgs-group-model",
+                ):
+                    yield self._path(
+                        provider_id,
+                        "model_path",
+                        "Model path",
+                        placeholder="Local path or Hugging Face model ID",
+                    )
+                    yield self._path(
+                        provider_id,
+                        "voice_resource_directory",
+                        "Voice resource directory",
+                        placeholder="Path to voice samples",
+                    )
+                with Collapsible(
+                    title="Compute",
+                    collapsed=False,
+                    id="settings-speech-higgs-group-compute",
+                ):
+                    yield self._select(
+                        provider_id,
+                        "device",
+                        "Device",
+                        [
+                            ("Auto", "auto"),
+                            ("CPU", "cpu"),
+                            ("CUDA", "cuda"),
+                            ("CUDA 0", "cuda:0"),
+                            ("CUDA 1", "cuda:1"),
+                            ("Apple MPS", "mps"),
+                        ],
+                    )
+                    yield self._switch(
+                        provider_id,
+                        "enable_flash_attention",
+                        "Enable flash attention",
+                    )
+                    yield self._select(
+                        provider_id,
+                        "dtype",
+                        "Data type",
+                        [
+                            ("Float32", "float32"),
+                            ("Float16", "float16"),
+                            ("BFloat16", "bfloat16"),
+                        ],
+                    )
+                with Collapsible(
+                    title="Generation",
+                    collapsed=True,
+                    id="settings-speech-higgs-group-generation",
+                ):
+                    yield self._input(
+                        provider_id,
+                        "max_reference_duration",
+                        "Max reference duration",
+                    )
+                    yield self._select(
+                        provider_id, "language", "Default language", _LANGUAGE_OPTIONS
+                    )
+                    yield self._switch(provider_id, "voice_cloning", "Voice cloning")
+                    yield self._switch(provider_id, "multi_speaker", "Multi-speaker")
+                    yield self._input(provider_id, "speaker_delimiter", "Speaker delimiter")
+                    yield self._switch(
+                        provider_id, "track_performance", "Performance tracking"
+                    )
+                    yield self._input(provider_id, "max_new_tokens", "Max new tokens")
+                    yield self._input(provider_id, "temperature", "Temperature")
+                    yield self._input(provider_id, "top_p", "Top P")
+                    yield self._input(
+                        provider_id, "repetition_penalty", "Repetition penalty"
+                    )
                 return
 
             if provider_id == "alltalk":
@@ -3374,12 +3584,12 @@ class SpeechTTSSettingsPanel(Vertical):
                 if isinstance(model_control, (Input, Select))
                 else None
             )
-            self.state.defaults.model_id = (
-                model_value
-                if self.state.defaults.model_mode == "exact"
-                and isinstance(model_value, str)
-                else None
-            )
+            if self.state.defaults.model_mode != "exact":
+                self.state.defaults.model_id = None
+            elif isinstance(model_value, str) and model_value != _CUSTOM_ID_SENTINEL:
+                # The sentinel is a transient modal trigger, never a draft
+                # value: while it is mounted the previous id stays put.
+                self.state.defaults.model_id = model_value
             if isinstance(voice_mode, str):
                 self.state.defaults.voice_mode = voice_mode
             voice_control = self.query_one("#settings-speech-voice-value")
@@ -3388,12 +3598,10 @@ class SpeechTTSSettingsPanel(Vertical):
                 if isinstance(voice_control, (Input, Select))
                 else None
             )
-            self.state.defaults.voice_id = (
-                voice_value
-                if self.state.defaults.voice_mode == "exact"
-                and isinstance(voice_value, str)
-                else None
-            )
+            if self.state.defaults.voice_mode != "exact":
+                self.state.defaults.voice_id = None
+            elif isinstance(voice_value, str) and voice_value != _CUSTOM_ID_SENTINEL:
+                self.state.defaults.voice_id = voice_value
             if isinstance(response_format, str):
                 self.state.defaults.response_format = response_format
             speed = self.query_one("#settings-speech-speed", Input).value
@@ -4535,7 +4743,10 @@ class SpeechTTSSettingsPanel(Vertical):
                 f"unchanged. {handoff_copy}"
             )
         else:
-            result_copy = f"Saved locally. Runtime reconfiguration: {handoff}."
+            result_copy = (
+                f"Saved locally. Runtime reconfiguration: {handoff}. "
+                "Open Speech Lab (below) to hear it."
+            )
         self._set_result(
             result_copy,
             severity=(
@@ -5023,20 +5234,116 @@ class SpeechTTSSettingsPanel(Vertical):
         self._announce_draft_state()
 
     @on(Select.Changed, "#settings-speech-model-value")
-    async def handle_audio_cpp_model_changed(self, event: Select.Changed) -> None:
-        if (
-            self._syncing
-            or self.state.defaults.provider_id != "audio_cpp"
-            or self.state.defaults.model_mode != "exact"
-            or not isinstance(event.value, str)
-            or event.value == self.state.defaults.model_id
-        ):
+    @on(Select.Changed, "#settings-speech-voice-value")
+    async def handle_defaults_value_changed(self, event: Select.Changed) -> None:
+        axis = (
+            "model"
+            if event.select.id == "settings-speech-model-value"
+            else "voice"
+        )
+        if self._syncing or not isinstance(event.value, str):
+            return
+        if self.state.defaults.provider_id != "audio_cpp":
+            await self._handle_legacy_value_changed(event, axis=axis)
+            return
+        current = (
+            self.state.defaults.model_id
+            if axis == "model"
+            else self.state.defaults.voice_id
+        )
+        mode = (
+            self.state.defaults.model_mode
+            if axis == "model"
+            else self.state.defaults.voice_mode
+        )
+        if mode != "exact" or event.value == current:
             return
         self._collect_visible_state()
         await self._replace_card_bodies(
             self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
         )
         self._announce_draft_state()
+
+    async def _handle_legacy_value_changed(
+        self, event: Select.Changed, *, axis: str
+    ) -> None:
+        """Route the Custom… sentinel through the free-text modal.
+
+        Known-list picks need no card rebuild -- the option set is static --
+        so they only collect and announce, exactly like the Input they
+        replaced.
+        """
+        if event.value == _CUSTOM_ID_SENTINEL:
+            current = (
+                self.state.defaults.model_id
+                if axis == "model"
+                else self.state.defaults.voice_id
+            )
+            restore = current if current else Select.NULL
+            with event.select.prevent(Select.Changed):
+                event.select.value = restore
+            self.app.push_screen(
+                _CustomIdModal(
+                    "model" if axis == "model" else "voice",
+                    current or "",
+                ),
+                lambda value: self._custom_id_modal_result(axis, value),
+            )
+            return
+        self._collect_visible_state()
+        self._announce_draft_state()
+
+    def _custom_id_modal_result(self, axis: str, value: str | None) -> None:
+        """Apply one confirmed custom ID, or keep the draft untouched."""
+        cleaned = (value or "").strip()
+        if not cleaned or len(cleaned) > 512:
+            if value is not None:
+                self._set_result(
+                    "Custom ID left unchanged — enter a non-empty identifier "
+                    "of at most 512 characters.",
+                    severity="warning",
+                )
+            return
+        if axis == "model":
+            self.state.defaults.model_id = cleaned
+        else:
+            self.state.defaults.voice_id = cleaned
+        self.run_worker(
+            self._rebuild_after_custom_id(axis), exclusive=True, exit_on_error=False
+        )
+
+    async def _rebuild_after_custom_id(self, axis: str) -> None:
+        await self._replace_card_bodies(
+            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+        )
+        self._announce_draft_state()
+        control_id = (
+            "#settings-speech-model-value"
+            if axis == "model"
+            else "#settings-speech-voice-value"
+        )
+        try:
+            self.query_one(control_id, Select).focus()
+        except QueryError:
+            pass
+
+    @on(Button.Pressed, "#settings-speech-browse-voices")
+    def handle_browse_voices(self, event: Button.Pressed) -> None:
+        event.stop()
+        provider_id = self.state.defaults.provider_id
+        if provider_id not in BUILT_IN_TTS_PROVIDER_ORDER:
+            provider_id = self.configure_provider
+        self.run_worker(
+            self._open_lab(
+                SpeechTTSNavigationTarget(
+                    provider_id,
+                    SpeechTTSNavigationIntent.TEST,
+                ),
+            ),
+            group="settings-speech-open-lab",
+            exclusive=True,
+            exit_on_error=False,
+        )
 
     @on(Input.Changed, "#settings-speech-audio_cpp-base-url")
     def handle_audio_cpp_base_url_changed(self, event: Input.Changed) -> None:
@@ -5445,7 +5752,10 @@ class SpeechTTSSettingsPanel(Vertical):
             return
         self.state = restored
         self.result_text = (
-            "Non-secret defaults restored in the draft; choose Save to persist them."
+            "Non-secret defaults restored in the draft — global defaults and "
+            f"{TTS_PROVIDER_LABELS[self.configure_provider]} setup; saved "
+            "credentials and environment-owned values are unchanged. Choose "
+            "Save to persist."
         )
         try:
             await self.recompose()
@@ -5453,7 +5763,6 @@ class SpeechTTSSettingsPanel(Vertical):
         finally:
             self._transfer_managed_refs()
 
-    @on(Button.Pressed, "#settings-speech-open-lab")
     @on(Button.Pressed, "#settings-speech-open-lab-bottom")
     @on(Button.Pressed, "#settings-speech-audio-cpp-open-lab")
     def handle_open_lab(self, event: Button.Pressed) -> None:

--- a/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
+++ b/tldw_chatbook/Widgets/Settings_Widgets/speech_tts_settings_panel.py
@@ -139,6 +139,8 @@ from tldw_chatbook.UI.Screens.settings_speech_tts import (
     global_speech_tts_provider_configuration_state,
     project_audio_cpp_global_choices,
     required_openai_plaintext_confirmation_fingerprint,
+    MAX_GLOBAL_IDENTIFIER_CHARACTERS,
+    global_identifier_is_valid,
     restore_non_secret_defaults,
     validate_audio_cpp_managed_settings,
 )
@@ -180,7 +182,10 @@ _GLOBAL_SPEECH_TTS_STACK_WIDTH = 104
 _COLLAPSIBLE_TITLE_FOCUS_SUFFIX = "::collapsible-title"
 # Select-option value for "enter an ID the known list does not carry". Never
 # persists: collection skips it and the handler swaps it for the modal flow.
-_CUSTOM_ID_SENTINEL = "__custom__"
+# The leading/trailing spaces make it structurally invalid as an identifier
+# (the shared validator rejects values that change under ``strip()``), so a
+# saved model/voice id can never collide with this UI action.
+_CUSTOM_ID_SENTINEL = " custom "
 _AUDIO_CPP_MANAGED_UI_SUPPORTED = os.name != "nt"
 _AUDIO_CPP_MANAGED_FIELD_IDS = frozenset(
     {
@@ -487,6 +492,12 @@ class _CustomIdModal(ModalScreen[str | None]):
         self.current = current
 
     def compose(self) -> ComposeResult:
+        """Yield the editor: title, guidance, input, and Cancel/Confirm.
+
+        Returns:
+            The modal's widgets; the Input starts pre-filled with the
+            current saved identifier so an edit-in-place is natural.
+        """
         with Vertical(classes="settings-speech-credential-modal"):
             yield Static(
                 f"Set a custom {self.axis_label} ID",
@@ -515,15 +526,28 @@ class _CustomIdModal(ModalScreen[str | None]):
                 )
 
     def action_cancel(self) -> None:
+        """Dismiss with ``None`` (Escape key path; nothing is applied)."""
         self.dismiss(None)
 
     @on(Button.Pressed, "#settings-speech-custom-id-cancel")
     def handle_cancel(self, event: Button.Pressed) -> None:
+        """Dismiss with ``None`` when Cancel is pressed.
+
+        Args:
+            event: The Cancel button press; stopped so the panel never
+                sees it.
+        """
         event.stop()
         self.dismiss(None)
 
     @on(Button.Pressed, "#settings-speech-custom-id-confirm")
     def handle_confirm(self, event: Button.Pressed) -> None:
+        """Dismiss with the input's current text for the panel to validate.
+
+        Args:
+            event: The confirm button press; stopped so the panel never
+                sees it.
+        """
         event.stop()
         self.dismiss(
             self.query_one("#settings-speech-custom-id-value", Input).value
@@ -832,6 +856,10 @@ class SpeechTTSSettingsPanel(Vertical):
         self._leave_save_waiters: dict[int, asyncio.Future[bool]] = {}
         self._managed_lease_hold: AudioCppManagedLeaseHold | None = None
         self._last_focused_control_id: str | None = None
+        # Axes ("model"/"voice") whose confirmed custom ID is written to the
+        # draft but whose Select has not been rebuilt yet. While an axis is
+        # pending, collection must not read the still-mounted stale value.
+        self._custom_id_rebuild_pending: set[str] = set()
         self._audio_cpp_scan_revision = 0
         self._audio_cpp_result_cleanup_pending = audio_cpp_result_cleanup_pending or (
             lambda: False
@@ -3586,6 +3614,10 @@ class SpeechTTSSettingsPanel(Vertical):
             )
             if self.state.defaults.model_mode != "exact":
                 self.state.defaults.model_id = None
+            elif "model" in self._custom_id_rebuild_pending:
+                # A confirmed custom ID is in the draft but not yet on the
+                # mounted Select: keep the confirmed value.
+                pass
             elif isinstance(model_value, str) and model_value != _CUSTOM_ID_SENTINEL:
                 # The sentinel is a transient modal trigger, never a draft
                 # value: while it is mounted the previous id stays put.
@@ -3600,6 +3632,8 @@ class SpeechTTSSettingsPanel(Vertical):
             )
             if self.state.defaults.voice_mode != "exact":
                 self.state.defaults.voice_id = None
+            elif "voice" in self._custom_id_rebuild_pending:
+                pass
             elif isinstance(voice_value, str) and voice_value != _CUSTOM_ID_SENTINEL:
                 self.state.defaults.voice_id = voice_value
             if isinstance(response_format, str):
@@ -5294,41 +5328,70 @@ class SpeechTTSSettingsPanel(Vertical):
         self._announce_draft_state()
 
     def _custom_id_modal_result(self, axis: str, value: str | None) -> None:
-        """Apply one confirmed custom ID, or keep the draft untouched."""
-        cleaned = (value or "").strip()
-        if not cleaned or len(cleaned) > 512:
-            if value is not None:
-                self._set_result(
-                    "Custom ID left unchanged — enter a non-empty identifier "
-                    "of at most 512 characters.",
-                    severity="warning",
-                )
+        """Apply one confirmed custom ID, or keep the draft untouched.
+
+        Acceptance uses ``global_identifier_is_valid`` — the same predicate
+        Save enforces — so a value rejected here could never have persisted.
+        A confirmed value also marks the axis rebuild-pending: until the
+        Select is rebuilt, ``_collect_visible_state`` must not read the
+        still-mounted previous value, or a Save racing the rebuild would
+        overwrite the confirmed ID.
+        """
+        if value is None:
+            return
+        if not global_identifier_is_valid(
+            value, max_characters=MAX_GLOBAL_IDENTIFIER_CHARACTERS
+        ):
+            self._set_result(
+                "Custom ID left unchanged — enter a non-empty identifier "
+                "of at most 512 characters with no leading or trailing "
+                "whitespace.",
+                severity="warning",
+            )
             return
         if axis == "model":
-            self.state.defaults.model_id = cleaned
+            self.state.defaults.model_id = value
         else:
-            self.state.defaults.voice_id = cleaned
+            self.state.defaults.voice_id = value
+        self._custom_id_rebuild_pending.add(axis)
         self.run_worker(
             self._rebuild_after_custom_id(axis), exclusive=True, exit_on_error=False
         )
 
     async def _rebuild_after_custom_id(self, axis: str) -> None:
-        await self._replace_card_bodies(
-            self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
-        )
-        self._announce_draft_state()
-        control_id = (
-            "#settings-speech-model-value"
-            if axis == "model"
-            else "#settings-speech-voice-value"
-        )
+        """Rebuild the defaults card onto the confirmed value, then unfence.
+
+        Args:
+            axis: "model" or "voice"; cleared from the pending set only
+                after the rebuilt Select mounts, in ``finally`` so an
+                exception cannot freeze collection on that axis.
+        """
         try:
-            self.query_one(control_id, Select).focus()
-        except QueryError:
-            pass
+            await self._replace_card_bodies(
+                self._GLOBAL_DEFAULTS_CARD_ID, self._INSPECTOR_CARD_ID
+            )
+            self._announce_draft_state()
+            control_id = (
+                "#settings-speech-model-value"
+                if axis == "model"
+                else "#settings-speech-voice-value"
+            )
+            try:
+                self.query_one(control_id, Select).focus()
+            except QueryError:
+                pass
+        finally:
+            self._custom_id_rebuild_pending.discard(axis)
 
     @on(Button.Pressed, "#settings-speech-browse-voices")
     def handle_browse_voices(self, event: Button.Pressed) -> None:
+        """Open Speech Lab focused on voice selection for this provider.
+
+        The REFRESH_VOICES intent makes the Lab focus its voice selector
+        (TEST would focus the connection-test button instead). Navigation
+        still resolves a dirty draft through the screen's central
+        ``flush_pending_work`` gate, like every other outgoing navigation.
+        """
         event.stop()
         provider_id = self.state.defaults.provider_id
         if provider_id not in BUILT_IN_TTS_PROVIDER_ORDER:
@@ -5337,7 +5400,7 @@ class SpeechTTSSettingsPanel(Vertical):
             self._open_lab(
                 SpeechTTSNavigationTarget(
                     provider_id,
-                    SpeechTTSNavigationIntent.TEST,
+                    SpeechTTSNavigationIntent.REFRESH_VOICES,
                 ),
             ),
             group="settings-speech-open-lab",


### PR DESCRIPTION
## Summary

Implements the P1+P2 fixes from the impeccable UX critique of the Speech & TTS settings sub-screen (scored 22/40; full report in `.impeccable/critique/2026-09-11T23-45-55Z__tldw-chatbook-ui-screens-settings-speech-tts-py.md`, tracked as TASK-32473).

- **First-run onboarding:** local provider forms (Kokoro/Chatterbox/Higgs) surface their install/readiness fact inline — e.g. "Local Kokoro: not installed — install the extra 'tldw_chatbook[local_tts]'" — and the Kokoro form names its model files (`kokoro-v0_19.onnx` ~300 MB + `voices.json`) with a docs pointer. Path placeholders carry the real filenames. Previously these facts lived only inside the collapsed Scope inspector / developer docs.
- **Recognition over recall:** legacy Model/Voice values move from free-text boxes to labeled dropdowns built from the existing legacy catalogs ("Heart (US Female)" instead of retyping `af_heart`), with a `Custom…` free-text escape hatch, an explicit "(custom)" option that keeps unknown saved values selectable, and a **Browse in Speech Lab** bridge that stages the default provider.
- **Governance copy compressed (preserve, not cut):** scope banner is two lines (full text preserved as tooltip), one "Open Speech Lab" action instead of three, redundant "Task: set up…" status line removed.
- **Honest contracts:** the SPEECH_TTS dirty banner now says "leaving Speech & TTS resolves this draft" instead of the false generic "switching categories keeps this draft" (task-2708); the raw `audio_cpp` id is gone from visible descriptions (kept in search vocabulary deliberately); label casing unified; Speed's range moved into its label; Save's payoff names the next step.
- **Layout:** Chatterbox/Higgs forms grouped into collapsible sections (ids unchanged); Restore names its exact scope in tooltip + result line (draft-only, so no modal).

## Evidence

- 6 new tests (picker behavior incl. custom-modal flow, browse-voices navigation, dependency/guidance rows, banner copy) + 8 updated sites.
- Targeted suite on this branch: 137 + 8 + 2 passed across the speech panel/policy/scoped/hub-sweep files. The 5 failures in `test_settings_speech_tts_panel.py` are **pre-existing on clean `dev`** (verified by stashing this branch's changes and re-running — all 5 fail identically without them).
- Live-verified in a tmux scratch profile at 235×52 / 100×30 / 130-row captures: two-line banner with controls in the first viewport, labeled Kokoro dropdowns, dependency and model-guidance rows rendering.

## Notes

- ADR: not required — UI affordance/copy changes within existing ownership boundaries.
- Deferred (deliberately): copy-back of voice IDs discovered in Speech Lab into Settings (playground-side change, own task); Realtime-card relocation (minor).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements the P1/P2 Speech & TTS settings UX fixes from the 2026-09-11 critique (TASK-32476). Legacy model and voice values are now labeled dropdowns of known IDs instead of free-text boxes, local provider forms surface their install/readiness facts inline, and compressed governance copy keeps editable controls in the first viewport.

**Bug Fixes**
- Dropdowns offer the provider's known labeled IDs, a Custom… free-text modal for anything else, and keep saved unknown values selectable as "(custom)"; the sentinel is structurally invalid as an ID so it can never collide with a saved one.
- Custom IDs validate against the same `global_identifier_is_valid` predicate Save enforces, and a pending-axis fence protects the confirmed ID from a racing Save during the card rebuild.
- Browse in Speech Lab stages the default provider and sends a REFRESH_VOICES intent so the Lab focuses its voice selector.
- Local provider forms name the install extra, and Kokoro names its model files (`kokoro-v0_19.onnx` ~300 MB + `voices.json`) with a docs pointer; path placeholders carry the real filenames.
- Chatterbox/Higgs fields are grouped into collapsible sections with unchanged field ids.
- The SPEECH_TTS dirty banner now says "leaving Speech & TTS resolves this draft" instead of "switching categories keeps this draft" (task-2708).
- The raw `audio_cpp` id is removed from visible copy but deliberately kept in the search vocabulary.
- Restore's tooltip and result line name its exact scope; one Open Speech Lab action replaces the previous three; Speed's range moved into its label.
- 6 new tests cover the picker, custom modal, browse navigation, dependency rows, and banner copy; 8 existing test sites updated.
- The 5 failures in `test_settings_speech_tts_panel.py` are pre-existing on clean `dev`.

<sup>Written for commit 334632ed0a06566ddb1091d3ed62dafa10424677. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

