### PR TITLE
fix(tests): reconcile speech settings panel suite with the CSS split and splash boot

### DIFF
--- a/Tests/UI/test_settings_speech_tts_panel.py
+++ b/Tests/UI/test_settings_speech_tts_panel.py
@@ -275,14 +275,23 @@ _BUNDLE = (
     / "css"
     / "tldw_cli_modular.tcss"
 )
+# TASK-25812 split the per-screen rules out of the boot bundle: the speech
+# disclosure/modal styles the "real styles" tests verify now live in the
+# sheet SettingsScreen itself attaches via CSS_PATH, not in _BUNDLE.
+_SETTINGS_SHEET = (
+    Path(__file__).resolve().parents[2]
+    / "tldw_chatbook"
+    / "css"
+    / "screen_agentic_settings.tcss"
+)
 
 
 class _StyledDestinationHarness(DestinationHarness):
-    CSS_PATH = _BUNDLE
+    CSS_PATH = [_BUNDLE, _SETTINGS_SHEET]
 
 
 class _StyledPanelHarness(_PanelHarness):
-    CSS_PATH = _BUNDLE
+    CSS_PATH = [_BUNDLE, _SETTINGS_SHEET]
 
 
 def test_speech_tts_is_a_first_class_core_settings_category() -> None:
@@ -299,6 +308,7 @@ def test_speech_tts_is_a_first_class_core_settings_category() -> None:
     assert SettingsCategoryId.SPEECH_TTS in dict(screen._category_groups())["Core"]
 
 
+@pytest.mark.loopback_network
 @pytest.mark.asyncio
 async def test_production_settings_actions_cross_the_pushed_screen_boundary(
     monkeypatch: pytest.MonkeyPatch,
@@ -337,6 +347,9 @@ async def test_production_settings_actions_cross_the_pushed_screen_boundary(
     app = _build_test_app(configured_default="settings")
 
     async with app.run_test(size=(190, 55)) as pilot:
+        # Factory apps boot the 7s animated splash (app.py's splash reads
+        # ship enabled); any keypress skips it so Settings mounts promptly.
+        await pilot.press("space")
         for _ in range(200):
             if isinstance(app.screen, SettingsScreen):
                 break
@@ -2281,9 +2294,11 @@ async def test_normal_panel_actions_do_not_contact_or_initialize_tts(
     async with host.run_test(size=(190, 55)) as pilot:
         screen = await _open_speech_tts(host, pilot)
         screen.query_one("#settings-speech-model-value", Select).value = "tts-1"
-        await pilot.click("#settings-speech-restore-defaults")
+        # press() not pilot.click: the actions row sits below the fold at
+        # this size and these tests verify routing, not hit regions.
+        screen.query_one("#settings-speech-restore-defaults", Button).press()
         await pilot.pause()
-        await pilot.click("#settings-speech-revert")
+        screen.query_one("#settings-speech-revert", Button).press()
         await pilot.pause()
 
     assert calls == []
@@ -3284,7 +3299,7 @@ async def test_details_and_scope_start_collapsed_on_every_mount() -> None:
 
 @pytest.mark.asyncio
 async def test_production_bundle_applies_speech_disclosure_styles() -> None:
-    bundled_css = _BUNDLE.read_text(encoding="utf-8")
+    sheet_css = _SETTINGS_SHEET.read_text(encoding="utf-8")
     for selector in (
         "#settings-speech-details,\n#settings-speech-scope-inspector",
         "#settings-speech-details > CollapsibleTitle,\n"
@@ -3292,10 +3307,12 @@ async def test_production_bundle_applies_speech_disclosure_styles() -> None:
         "#settings-speech-details > Contents,\n"
         "#settings-speech-scope-inspector > Contents",
     ):
-        assert selector in bundled_css
+        assert selector in sheet_css
 
     app = _StyledPanelHarness(configure_provider="audio_cpp")
-    assert Path(app.CSS_PATH).resolve() == _BUNDLE.resolve()
+    assert _SETTINGS_SHEET.resolve() in [
+        Path(sheet).resolve() for sheet in app.CSS_PATH
+    ]
 
     async with app.run_test(size=(120, 40)):
         details = app.query_one("#settings-speech-details", Collapsible)
@@ -3470,11 +3487,12 @@ async def test_speech_save_and_revert_clicks_work_while_a_field_is_focused() -> 
         endpoint = screen.query_one("#settings-speech-openai-base-url", Input)
 
         endpoint.focus()
-        await pilot.click("#settings-speech-save")
+        screen.query_one("#settings-speech-save", Button).press()
+        await pilot.pause()
         request_save.assert_called_once_with()
 
         endpoint.focus()
-        await pilot.click("#settings-speech-revert")
+        screen.query_one("#settings-speech-revert", Button).press()
         await pilot.pause()
         revert_to_saved.assert_awaited_once_with()
 

--- a/Tests/UI/test_settings_speech_tts_panel.py
+++ b/Tests/UI/test_settings_speech_tts_panel.py
@@ -3460,7 +3460,12 @@ async def test_speech_shortcuts_defer_to_focused_text_entry_and_resume_after_blu
 @pytest.mark.asyncio
 async def test_speech_save_and_revert_clicks_work_while_a_field_is_focused() -> None:
     host = DestinationHarness(_build_test_app(), "settings")
-    async with host.run_test(size=(190, 55)) as pilot:
+    # Tall enough that the actions row is genuinely on-screen: this test
+    # exercises the real hit-tested mouse path from a focused field, so the
+    # buttons must be clickable, not pressed programmatically. (The panel
+    # mounts ~115 rows; at the usual (190, 55) the actions sit below nested
+    # folds and scroll_visible cannot reach them.)
+    async with host.run_test(size=(190, 130)) as pilot:
         screen = await _open_speech_tts(host, pilot)
         panel = screen.query_one(
             "#settings-speech-tts-panel",
@@ -3484,16 +3489,22 @@ async def test_speech_save_and_revert_clicks_work_while_a_field_is_focused() -> 
         )
         panel.request_save = request_save
         panel.revert_to_saved = revert_to_saved
+        # Let the provider-change rebuild's focus restoration finish (it
+        # re-asserts the pre-change focus after the card swap) before the
+        # endpoint takes focus, so the clicks below really start focused.
+        await pilot.pause(0.5)
         endpoint = screen.query_one("#settings-speech-openai-base-url", Input)
 
         endpoint.focus()
-        screen.query_one("#settings-speech-save", Button).press()
         await pilot.pause()
+        assert pilot.app.focused is endpoint
+        await pilot.click("#settings-speech-save")
         request_save.assert_called_once_with()
 
         endpoint.focus()
-        screen.query_one("#settings-speech-revert", Button).press()
         await pilot.pause()
+        assert pilot.app.focused is endpoint
+        await pilot.click("#settings-speech-revert")
         revert_to_saved.assert_awaited_once_with()
 
 


### PR DESCRIPTION
## Summary

Five tests in `Tests/UI/test_settings_speech_tts_panel.py` have been failing on `dev` without CI noticing — **PR Fast Lane runs an explicit file allowlist that excludes this file**, so nothing gated them. All five reconciled:

| Test | Root cause | Fix |
|---|---|---|
| `test_production_bundle_applies_speech_disclosure_styles` | TASK-25812 (b62407e2) intentionally moved speech disclosure styles out of the boot bundle into `screen_agentic_settings.tcss`; the test still asserted them against `tldw_cli_modular.tcss` | Styled harnesses load `[_BUNDLE, _SETTINGS_SHEET]` (mirroring the real `SettingsScreen.CSS_PATH`); assertions read the settings sheet |
| `test_credential_editor_is_a_bounded_modal_with_real_styles` | Same — the modal's `width: 70` rule now lives only in the lazy sheet, so the harness-styled modal rendered unbounded (120 wide) | Same harness fix; modal now renders within 40–80 |
| `test_normal_panel_actions_do_not_contact_or_initialize_tts` | Actions row below the fold at (190, 55) since the split changed test-time layout → `pilot.click` OutOfBounds | `press()` the buttons — these tests verify routing, not hit regions (per the repo's pilot-click lesson) |
| `test_speech_save_and_revert_clicks_work_while_a_field_is_focused` | Same OutOfBounds on Save/Revert | Same `press()` conversion |
| `test_production_settings_actions_cross_the_pushed_screen_boundary` | Layered: factory apps boot the 7s animated splash (app.py's splash reads default to enabled) and the test waited 2s for Settings; once past that, the save flow's health probe of the configured `127.0.0.1:8080` tripped the egress guard | A keypress skips the splash; `@pytest.mark.loopback_network` for the refused-connection probe per the guard's own guidance |

## Evidence

- Full file: **128 passed, 0 failed** (was 5 failed on clean `dev`).
- Bisect pinned the layout regression to b62407e2 (`perf(css): split the agentic-terminal module off the pre-first-paint parse`); the splash and egress layers were masked behind it.
- No product code changed — tests only.

## Note for maintainers

These five were invisible because PR Fast Lane's allowlist excludes this file. Worth considering adding it (or a nightly shard) so the suite can't silently rot again.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reconciles the speech settings panel tests with the CSS split and splash boot so the suite goes from five failures to 128 passing. No product code changes.

**Bug Fixes**
- Two style tests now load `[_BUNDLE, _SETTINGS_SHEET]` and read speech disclosure rules from `screen_agentic_settings.tcss`, where TASK-25812 moved them.
- The no-contact action test presses Restore/Revert directly since the buttons are below the fold and it verifies routing, not hit regions.
- The focused-field save/revert test runs at a taller viewport so the actions row is on-screen and real `pilot.click()` works; focus is asserted before each click after a settle pause.
- The production boot test skips the animated splash with a keypress and marks the save-flow loopback probe with `@pytest.mark.loopback_network`.

**Follow-up**
- These failures were invisible because PR Fast Lane's file allowlist excludes this file; consider adding it or a nightly shard.

<sup>Written for commit b3649c328deb7268e2cca95d81feb7e5013e789a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2636?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

