### PR TITLE
docs: record dev branch-protection baseline

### DIFF
--- a/backlog/docs/branch-protection-baseline.md
+++ b/backlog/docs/branch-protection-baseline.md
@@ -1,0 +1,30 @@
+# dev branch-protection baseline (2026-09-12)
+
+Deliberate owner decision recorded after the PR #2634 merge flow. Do not
+re-tighten these without the owner's say-so.
+
+## Standing state
+
+- **Required approving reviews: 0.** Set to 0 by the owner on 2026-09-12
+  after a same-day change to 1 blocked every PR authored from the owner's
+  own account (GitHub refuses self-approval, and no reviewing bot has
+  write access — Qodo posts findings but cannot approve). If reviews are
+  re-required, owner-authored bot-driven PRs like the backlog small-batch
+  series become unmergeable without manual help.
+- **"Require branches to be up to date" (strict): false.** Relaxed the same
+  day by the owner's instruction after four consecutive merge windows were
+  lost to a structural race: dev merges PRs roughly every ten minutes, a
+  full CI run takes about thirteen, and the frequently-regenerated
+  `Docs/security/production-diagnostic-inventory.json` conflicts on nearly
+  every dev merge. The required check ("Derived artifacts reproduce from
+  their sources") still runs on every PR head; only the must-contain-
+  latest-dev condition is gone.
+- **Only required status check:** "Derived artifacts reproduce from their
+  sources". **enforce_admins:** on. Force pushes and deletions: off.
+
+## Verified the same day
+
+- No workflow, script, or tool in this repository calls the branch
+  protection or rulesets APIs (searched `.github/` and `scripts/`), so
+  nothing automated can re-tighten these settings — only a manual
+  repository-settings action can.


### PR DESCRIPTION
Records the 2026-09-12 owner decision standing state (approving reviews 0, strict up-to-date off, single required check) and the verification that no in-repo automation can re-tighten it — so future agents and humans know the relaxed settings are deliberate. Docs-only; from the PR #2634 merge flow.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a docs note recording the deliberately relaxed dev branch-protection settings (0 required reviews, strict up-to-date off, one required check) so future agents and humans don't re-tighten them by accident.

- Reviews are 0 because GitHub blocks self-approval and no bot has write access, so requiring one blocked every owner-authored PR.
- Strict mode is off because dev merges outpace CI (~10 min cadence vs ~13 min runs) and a frequently regenerated file conflicts on nearly every merge.
- Verified no in-repo workflow or script calls the branch-protection or rulesets APIs, so only manual settings changes can tighten these again.

<sup>Written for commit 6118edb0d2073661bdf8dee4aca17d5db674e286. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2647?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

