### PR TITLE
feat(console): persona session identity — label parity + dynamic identity macros (task-32481)

### DIFF
--- a/Docs/superpowers/plans/2026-09-11-agent-chat-fork-spawn.md
+++ b/Docs/superpowers/plans/2026-09-11-agent-chat-fork-spawn.md
@@ -1,0 +1,1702 @@
+# Agent Chat Fork & Spawn Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `fork_chat` and `new_chat` runtime agent tools that let a Console agent create confirmed, background workstream chats for the user (fork = verbatim active-path copy with lineage columns; new = fresh chat).
+
+**Architecture:** Both tools ride the existing injected-callable runtime-tool seam (`install_skill`/`run_skill_script` pattern): bridge closures in `run_reply` do policy validation → blocking per-call confirm → controller-side execution; `AgentService` pins schemas for primary runs and `agent_runtime` dispatches to injected `LoopDeps` callables. Fork copying is a new pure-ish service method over the existing conversation tree read; sessions surface via a non-activating restore plus the standard console-sync worker.
+
+**Tech Stack:** Python ≥3.11, Textual 8.x, SQLite (FTS5) via `ChaChaNotes_DB`, pytest with real in-memory SQLite.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md` — read it first; this plan argues from it.
+**ADR:** `backlog/decisions/150-agent-chat-fork-and-spawn.md` · **Task:** TASK-32482 · **Follow-ups:** TASK-32480 (sub-agents), preset/provider integration (post ADR-147).
+
+## Global Constraints
+
+- **No DB schema migration** in either database. The lineage columns `conversations.parent_conversation_id` / `forked_from_message_id` already exist (`DB/ChaChaNotes_DB.py:468-469`).
+- **Advertised must equal usable** (the #847 lesson, restated at `console_chat_controller.py:12114-12126`): only inject a confirm/execute callable when a UI sink is wired, so the bridge never builds a tool the model can never succeed with.
+- **Primary agents only**: every schema pin and `LoopDeps` population for these tools is gated on `agent_kind == AGENT_KIND_PRIMARY` (spec §Architecture; sub-agents are TASK-32480).
+- **Fail closed**: any UI error, no-UI, cancel, or timeout in a confirm round denies the call and returns a `ToolResult(ok=False, ...)`; never an exception across the tool seam.
+- **The working tree carries unrelated in-flight WIP** (provider-routing PR). Every commit step stages ONLY the files its task lists — never `git add -A`.
+- **Targeted tests only**: run the test files each task names. Do not run the full suite unless the user asks (AGENTS.md testing rule).
+- Tool result payloads are JSON strings; opening prompts are drafts (`store.set_session_draft`), never auto-sent.
+- The fork copy read must use raised caps (`root_limit=10_000, depth_cap=10_000` — the same policy as `console_conversation_hydration.load_console_conversation_tree`); silent truncation is a bug.
+
+**Anchor-drift warning:** line numbers below were verified against the working tree on 2026-09-11 with the uncommitted provider-routing WIP present. If anchors drift, locate the named symbol (`grep -n`) and apply the change there; the structures are stable.
+
+---
+
+### Task 1: Lineage passthrough in `ChatPersistenceService.create_conversation`
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py:216-331` (`create_conversation`)
+- Test: `Tests/Chat/test_chat_persistence_service.py` (reuse its existing real in-memory-DB fixture)
+
+**Interfaces:**
+- Consumes: `self.db.add_conversation(conv_data)` which already accepts `forked_from_message_id` / `parent_conversation_id` as passthrough keys (`DB/ChaChaNotes_DB.py:7725-7764`).
+- Produces: `create_conversation(..., parent_conversation_id: str | None = None, forked_from_message_id: str | None = None) -> str` — later tasks (7) call it with lineage kwargs. The `ConsoleChatPersistence` protocol (`Chat/console_chat_store.py:205-220`) declares `create_conversation(self, **kwargs) -> str`, so no protocol change.
+
+- [ ] **Step 1: Write the failing test** (append to `Tests/Chat/test_chat_persistence_service.py`; reuse that file's existing db/service fixture names — check the top of the file and use its pattern for constructing the service)
+
+```python
+def test_create_conversation_records_fork_lineage(persistence_service_with_db):
+    db, service = persistence_service_with_db  # adapt names to the file's fixture
+    parent_id = service.create_conversation(conversation_title="Source")
+    child_id = service.create_conversation(
+        conversation_title="Fork of Source",
+        parent_conversation_id=parent_id,
+        forked_from_message_id="msg-abc",
+    )
+    row = db.get_conversation_by_id(child_id)
+    assert row is not None
+    assert row["parent_conversation_id"] == parent_id
+    assert row["forked_from_message_id"] == "msg-abc"
+    assert row["title"] == "Fork of Source"
+
+
+def test_create_conversation_without_lineage_unchanged(persistence_service_with_db):
+    db, service = persistence_service_with_db
+    conv_id = service.create_conversation(conversation_title="Plain")
+    row = db.get_conversation_by_id(conv_id)
+    assert row["parent_conversation_id"] is None
+    assert row["forked_from_message_id"] is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/Chat/test_chat_persistence_service.py -k lineage -v`
+Expected: FAIL with `TypeError: create_conversation() got an unexpected keyword argument 'parent_conversation_id'`
+
+- [ ] **Step 3: Implement** — in `create_conversation`'s signature add after `speech_preferences`:
+
+```python
+        parent_conversation_id: Optional[str] = None,
+        forked_from_message_id: Optional[str] = None,
+```
+
+and inside the body, where `conversation_data` is built (before the `metadata` json.dumps line), add:
+
+```python
+        if parent_conversation_id is not None:
+            conversation_data["parent_conversation_id"] = parent_conversation_id
+        if forked_from_message_id is not None:
+            conversation_data["forked_from_message_id"] = forked_from_message_id
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/Chat/test_chat_persistence_service.py -v`
+Expected: PASS (all, including pre-existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/chat_persistence_service.py Tests/Chat/test_chat_persistence_service.py
+git commit -m "feat: fork lineage passthrough in console persistence create_conversation"
+```
+
+---
+
+### Task 2: `copy_conversation_active_path` on `ChatConversationService`
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/chat_conversation_service.py` (new method near `get_conversation_tree`, ~line 1112)
+- Test: `Tests/Chat/test_chat_conversation_service.py`
+
+**Interfaces:**
+- Consumes: `self.get_conversation_tree(conversation_id, root_limit=..., depth_cap=...)` (same file, :1059) returning `{"conversation": dict, "root_threads": [nodes]}` where each node carries `id, parent_message_id, sender, content, role, timestamp, image_data, image_mime_type, usage_json, metadata_json, provider_continuation_json, children`; `self.db.get_conversation_active_leaf`, `self.db.add_message`, `self.db.set_conversation_active_leaf`.
+- Produces: `copy_conversation_active_path(self, source_conversation_id: str, target_conversation_id: str) -> dict` returning `{"copied": int, "leaf_message_id": str | None}`; raises `ValueError("empty_history")` when the source has no messages. Task 7's executor calls this.
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/Chat/test_chat_conversation_service.py`, reusing its existing db/service fixture pattern)
+
+```python
+def _seed_chain(db, service, conv_id, texts):
+    """Seed a linear parent->child chain; returns message ids in order."""
+    ids = []
+    parent = None
+    for sender, text in texts:
+        mid = db.add_message(
+            {
+                "conversation_id": conv_id,
+                "sender": sender,
+                "content": text,
+                "parent_message_id": parent,
+            }
+        )
+        ids.append(str(mid))
+        parent = mid
+    db.set_conversation_active_leaf(conv_id, ids[-1])
+    return ids
+
+
+def test_copy_active_path_copies_and_remaps(service_with_db):
+    db, service = service_with_db  # adapt to the file's fixture names
+    src = service.create_conversation(title="Src")
+    ids = _seed_chain(db, service, src, [("user", "hello"), ("assistant", "hi"), ("user", "go")])
+    dst = service.create_conversation(title="Dst")
+
+    outcome = service.copy_conversation_active_path(src, dst)
+
+    assert outcome["copied"] == 3
+    copied = db.get_messages_for_conversation(dst)
+    assert [m["content"] for m in copied] == ["hello", "hi", "go"]
+    assert [m["sender"] for m in copied] == ["user", "assistant", "user"]
+    # parents remapped: each copied message's parent is the previous copied one
+    assert copied[0]["parent_message_id"] is None
+    assert copied[1]["parent_message_id"] == copied[0]["id"]
+    assert copied[2]["parent_message_id"] == copied[1]["id"]
+    # ids are fresh, not the source's
+    assert {m["id"] for m in copied}.isdisjoint(set(ids))
+    # active leaf points at the copied leaf
+    assert db.get_conversation_active_leaf(dst) == copied[-1]["id"] == outcome["leaf_message_id"]
+
+
+def test_copy_active_path_ignores_inactive_branch(service_with_db):
+    db, service = service_with_db
+    src = service.create_conversation(title="Src")
+    root = db.add_message({"conversation_id": src, "sender": "user", "content": "root"})
+    kept = db.add_message({"conversation_id": src, "sender": "assistant", "content": "kept",
+                           "parent_message_id": root})
+    db.add_message({"conversation_id": src, "sender": "assistant", "content": "dropped",
+                    "parent_message_id": root})
+    db.set_conversation_active_leaf(src, kept)
+    dst = service.create_conversation(title="Dst")
+
+    outcome = service.copy_conversation_active_path(src, dst)
+
+    assert outcome["copied"] == 2
+    contents = [m["content"] for m in db.get_messages_for_conversation(dst)]
+    assert contents == ["root", "kept"]
+
+
+def test_copy_active_path_falls_back_to_latest_when_no_leaf(service_with_db):
+    db, service = service_with_db
+    src = service.create_conversation(title="Src")
+    _seed_chain(db, service, src, [("user", "a"), ("assistant", "b")])
+    db.set_conversation_active_leaf(src, None)  # API-created conversation, never opened
+    dst = service.create_conversation(title="Dst")
+
+    outcome = service.copy_conversation_active_path(src, dst)
+
+    assert outcome["copied"] == 2
+
+
+def test_copy_active_path_empty_history_raises(service_with_db):
+    db, service = service_with_db
+    src = service.create_conversation(title="Empty")
+    dst = service.create_conversation(title="Dst")
+    with pytest.raises(ValueError, match="empty_history"):
+        service.copy_conversation_active_path(src, dst)
+
+
+def test_copy_active_path_preserves_fields(service_with_db):
+    db, service = service_with_db
+    src = service.create_conversation(title="Src")
+    mid = db.add_message({
+        "conversation_id": src, "sender": "assistant", "content": "tool stuff",
+        "role": "tool", "metadata_json": '{"k": 1}', "usage_json": '{"tokens": 5}',
+        "provider_continuation_json": '{"ckpt": true}',
+    })
+    db.set_conversation_active_leaf(src, mid)
+    dst = service.create_conversation(title="Dst")
+
+    service.copy_conversation_active_path(src, dst)
+
+    copied = db.get_messages_for_conversation(dst)[0]
+    assert copied["role"] == "tool"
+    assert copied["metadata_json"] == '{"k": 1}'
+    assert copied["usage_json"] == '{"tokens": 5}'
+    assert copied["provider_continuation_json"] == '{"ckpt": true}'
+
+
+def test_copy_active_path_atomic_rollback(service_with_db, monkeypatch):
+    db, service = service_with_db
+    src = service.create_conversation(title="Src")
+    _seed_chain(db, service, src, [("user", "a"), ("assistant", "b"), ("user", "c")])
+    dst = service.create_conversation(title="Dst")
+
+    real_add_message = db.add_message
+    calls = {"n": 0}
+
+    def flaky_add_message(msg_data):
+        calls["n"] += 1
+        if calls["n"] == 3:
+            raise RuntimeError("boom mid-copy")
+        return real_add_message(msg_data)
+
+    monkeypatch.setattr(db, "add_message", flaky_add_message)
+    with pytest.raises(RuntimeError, match="boom mid-copy"):
+        service.copy_conversation_active_path(src, dst)
+    monkeypatch.undo()
+    assert db.get_messages_for_conversation(dst) == []  # nothing created
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_chat_conversation_service.py -k copy_active_path -v`
+Expected: FAIL with `AttributeError: ... has no attribute 'copy_conversation_active_path'`
+
+- [ ] **Step 3: Implement** — add to `ChatConversationService` after `get_conversation_tree`:
+
+```python
+    def copy_conversation_active_path(
+        self, source_conversation_id: str, target_conversation_id: str
+    ) -> dict[str, Any]:
+        """Copy the source conversation's active path into the target, verbatim.
+
+        Walks the active-leaf ancestry (root -> leaf) of ``source_conversation_id``
+        and re-inserts each message into ``target_conversation_id`` with fresh ids
+        and remapped parents, preserving sender/role/content, images, usage,
+        metadata, provider-continuation payloads, and timestamps. Runs inside a
+        single transaction: a mid-copy failure rolls back everything. Sibling
+        branches off the active path are NOT copied (fork = the path the user
+        sees; combine with rewind for mid-conversation forks).
+
+        Returns:
+            ``{"copied": <int>, "leaf_message_id": <new id of the copied leaf>}``
+
+        Raises:
+            ValueError: ``empty_history`` when the source has no messages.
+        """
+        tree = self.get_conversation_tree(
+            source_conversation_id, root_limit=10_000, depth_cap=10_000
+        )
+        nodes: dict[str, dict[str, Any]] = {}
+
+        def _walk(node: dict[str, Any]) -> None:
+            nodes[str(node["id"])] = node
+            for child in node.get("children") or []:
+                _walk(child)
+
+        for root in tree.get("root_threads") or []:
+            _walk(root)
+        if not nodes:
+            raise ValueError("empty_history")
+
+        leaf_id = self.db.get_conversation_active_leaf(source_conversation_id)
+        if leaf_id is None or leaf_id not in nodes:
+            # Conversations created outside the Console have no leaf pointer;
+            # fall back to the most recent message by timestamp.
+            leaf_id = max(nodes, key=lambda i: str(nodes[i].get("timestamp") or ""))
+
+        path: list[dict[str, Any]] = []
+        cursor: str | None = leaf_id
+        while cursor is not None and cursor in nodes:
+            path.append(nodes[cursor])
+            cursor = nodes[cursor].get("parent_message_id")
+        path.reverse()
+
+        id_map: dict[str, str] = {}
+        with self.db.transaction():
+            for node in path:
+                old_id = str(node["id"])
+                new_id = self.db.add_message(
+                    {
+                        "conversation_id": target_conversation_id,
+                        "sender": node.get("sender") or node.get("role") or "user",
+                        "content": node.get("content") or "",
+                        "role": node.get("role"),
+                        "parent_message_id": id_map.get(str(node.get("parent_message_id"))),
+                        "image_data": node.get("image_data"),
+                        "image_mime_type": node.get("image_mime_type"),
+                        "timestamp": node.get("timestamp"),
+                        "usage_json": node.get("usage_json"),
+                        "metadata_json": node.get("metadata_json"),
+                        "provider_continuation_json": node.get("provider_continuation_json"),
+                    }
+                )
+                if new_id is None:
+                    raise RuntimeError("copy_active_path: message insert failed")
+                id_map[old_id] = str(new_id)
+
+        new_leaf = id_map.get(str(leaf_id))
+        self.db.set_conversation_active_leaf(target_conversation_id, new_leaf)
+        return {"copied": len(path), "leaf_message_id": new_leaf}
+```
+
+Note: `add_message` opens its own nested transaction; the outer `self.db.transaction()` makes the whole copy atomic (nested-depth tracking is built into `TransactionContextManager`, `DB/ChaChaNotes_DB.py:3350-3378`).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_chat_conversation_service.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/chat_conversation_service.py Tests/Chat/test_chat_conversation_service.py
+git commit -m "feat: copy_conversation_active_path fork primitive with parent remap and atomicity"
+```
+
+---
+
+### Task 3: Tool name constants and schemas
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py:75-123` (constants + `RUNTIME_TOOL_NAMES`)
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (schemas after `RUN_SKILL_SCRIPT_TOOL_SCHEMA`, ~line 320)
+- Test: `Tests/Agents/test_agent_chat_create_tools.py` (new)
+
+**Interfaces:**
+- Produces: `FORK_CHAT_TOOL_NAME = "fork_chat"`, `NEW_CHAT_TOOL_NAME = "new_chat"` (in `RUNTIME_TOOL_NAMES`); `FORK_CHAT_TOOL_SCHEMA` / `NEW_CHAT_TOOL_SCHEMA` (`ToolSchema(id="runtime:fork_chat"|"runtime:new_chat", ...)`). Tasks 4 and 7 import these names.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""fork_chat / new_chat runtime-tool constants and schema shapes."""
+from tldw_chatbook.Agents.agent_models import (
+    FORK_CHAT_TOOL_NAME,
+    NEW_CHAT_TOOL_NAME,
+    RUNTIME_TOOL_NAMES,
+)
+from tldw_chatbook.Agents.tool_catalog import FORK_CHAT_TOOL_SCHEMA, NEW_CHAT_TOOL_SCHEMA
+
+
+def test_names_are_runtime_tools():
+    assert FORK_CHAT_TOOL_NAME == "fork_chat"
+    assert NEW_CHAT_TOOL_NAME == "new_chat"
+    assert FORK_CHAT_TOOL_NAME in RUNTIME_TOOL_NAMES
+    assert NEW_CHAT_TOOL_NAME in RUNTIME_TOOL_NAMES
+
+
+def test_fork_chat_schema_shape():
+    assert FORK_CHAT_TOOL_SCHEMA.id == "runtime:fork_chat"
+    assert FORK_CHAT_TOOL_SCHEMA.name == FORK_CHAT_TOOL_NAME
+    props = FORK_CHAT_TOOL_SCHEMA.parameters["properties"]
+    assert set(props) == {"title", "opening_prompt", "instructions"}
+    assert FORK_CHAT_TOOL_SCHEMA.parameters["required"] == []
+    for text in (FORK_CHAT_TOOL_SCHEMA.description,):
+        assert "user" in text and "confirm" in text  # documents the confirm contract
+
+
+def test_new_chat_schema_shape():
+    assert NEW_CHAT_TOOL_SCHEMA.id == "runtime:new_chat"
+    assert NEW_CHAT_TOOL_SCHEMA.name == NEW_CHAT_TOOL_NAME
+    props = NEW_CHAT_TOOL_SCHEMA.parameters["properties"]
+    assert set(props) == {"title", "opening_prompt", "instructions"}
+    assert NEW_CHAT_TOOL_SCHEMA.parameters["required"] == []
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/Agents/test_agent_chat_create_tools.py -v`
+Expected: FAIL with `ImportError: cannot import name 'FORK_CHAT_TOOL_NAME'`
+
+- [ ] **Step 3: Implement.** In `agent_models.py`, after `READ_AGENT_MESSAGES_TOOL_NAME` (line ~103):
+
+```python
+FORK_CHAT_TOOL_NAME = "fork_chat"
+NEW_CHAT_TOOL_NAME = "new_chat"
+```
+
+and add both to the `RUNTIME_TOOL_NAMES` frozenset (lines 106-123). In `tool_catalog.py`, after `RUN_SKILL_SCRIPT_TOOL_SCHEMA`:
+
+```python
+FORK_CHAT_TOOL_SCHEMA = ToolSchema(
+    id="runtime:fork_chat",
+    name=FORK_CHAT_TOOL_NAME,
+    description=(
+        "Fork the current chat into a new chat so the user can pursue a parallel "
+        "workstream: the conversation's active message history is copied verbatim "
+        "into a brand-new chat (nothing is removed from the current chat). The "
+        "user is asked to confirm every fork. The copy is a snapshot at the "
+        "moment of this call — your current in-progress reply is NOT included, "
+        "so put the workstream's framing into opening_prompt. opening_prompt is "
+        "placed in the new chat's input box as a draft the user reviews and "
+        "sends themselves; it is never sent automatically. instructions, when "
+        "given, become the new chat's standing system prompt (refused for "
+        "character chats). The new chat opens in the background; the user "
+        "switches to it when ready. Use sparingly — each call shows the user an "
+        "approval card, and do not retry after the user declines."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Short title for the new chat, e.g. 'Workstream: DB migration'.",
+            },
+            "opening_prompt": {
+                "type": "string",
+                "description": (
+                    "First message for the workstream, delivered as a draft in "
+                    "the new chat's input box for the user to review, edit, and send."
+                ),
+            },
+            "instructions": {
+                "type": "string",
+                "description": (
+                    "Optional standing system prompt for the new chat, replacing "
+                    "the forked chat's system prompt. Not allowed when the current "
+                    "chat is bound to a character."
+                ),
+            },
+        },
+        "required": [],
+    },
+)
+
+NEW_CHAT_TOOL_SCHEMA = ToolSchema(
+    id="runtime:new_chat",
+    name=NEW_CHAT_TOOL_NAME,
+    description=(
+        "Create a brand-new, empty chat for a parallel workstream unrelated to "
+        "the current conversation's history. The user is asked to confirm every "
+        "creation. opening_prompt is placed in the new chat's input box as a "
+        "draft the user reviews and sends themselves; it is never sent "
+        "automatically. instructions, when given, become the new chat's standing "
+        "system prompt. The new chat opens in the same workspace, in the "
+        "background; the user switches to it when ready. Use sparingly — each "
+        "call shows the user an approval card, and do not retry after the user "
+        "declines."
+    ),
+    parameters={
+        "type": "object",
+        "properties": {
+            "title": {
+                "type": "string",
+                "description": "Short title for the new chat.",
+            },
+            "opening_prompt": {
+                "type": "string",
+                "description": "Draft first message placed in the new chat's input box.",
+            },
+            "instructions": {
+                "type": "string",
+                "description": "Optional standing system prompt for the new chat.",
+            },
+        },
+        "required": [],
+    },
+)
+```
+
+Import the two name constants in `tool_catalog.py`'s existing `agent_models` import block.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest Tests/Agents/test_agent_chat_create_tools.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_models.py tldw_chatbook/Agents/tool_catalog.py Tests/Agents/test_agent_chat_create_tools.py
+git commit -m "feat: fork_chat/new_chat tool names and schemas"
+```
+
+---
+
+### Task 4: AgentService injection, schema pins, LoopDeps, and dispatch
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_service.py` (`__init__` ~1031-1151; `_run_one` pin block ~2500-2556; `LoopDeps` population ~4650-4701; `build_first_request_schema_plan` ~588-636)
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (dispatch branches after the `run_skill_script` branch, ~1663)
+- Test: `Tests/Agents/test_agent_runtime.py` (extend `make_deps`, ~line 41); `Tests/Agents/test_agent_chat_create_tools.py` (extend)
+
+**Interfaces:**
+- Consumes: `FORK_CHAT_TOOL_SCHEMA` / `NEW_CHAT_TOOL_SCHEMA` (Task 3); the recipe comment at `agent_models.py:84` ("name-constant + RUNTIME_TOOL_NAMES + tool_catalog schema + LoopDeps field + dispatch-branch + primary-agent-only-service-gate").
+- Produces:
+  - `AgentService.__init__(..., fork_chat_tool: Callable[[dict], ToolResult] | None = None, new_chat_tool: Callable[[dict], ToolResult] | None = None)` stored as `self._fork_chat_tool` / `self._new_chat_tool`.
+  - `LoopDeps.fork_chat: Callable[[dict], ToolResult] | None = None` and `LoopDeps.new_chat: Callable[[dict], ToolResult] | None = None`.
+  - `build_first_request_schema_plan(..., fork_chat_enabled: bool = False, new_chat_enabled: bool = False)` (Task 7 passes these at the bridge call site, `console_agent_bridge.py:3343-3346` pattern).
+  - Dispatch contract: a tool call named `fork_chat`/`new_chat` with the deps field non-None calls `deps.fork_chat(dict(call.args))` / `deps.new_chat(dict(call.args))` after emitting `STEP_TOOL_CALL`; when the field is None the call falls through to `deps.invoke_tool(call)` (existing fallback, `agent_runtime.py:1682-1684`).
+
+- [ ] **Step 1: Write the failing dispatch tests** (extend `Tests/Agents/test_agent_runtime.py`; the file already imports `LoopDeps`, `run_agent_loop`, `ModelTurn`, `ToolCall`, `SPAWN_TOOL_NAME` and defines `fence`/`make_deps`/`run`/`CFG`)
+
+Add to `make_deps` two optional kwargs forwarded into `LoopDeps`:
+
+```python
+def make_deps(turns, *, invoke=None, spawn=None, cancel=None, clock=None,
+              fork_chat=None, new_chat=None):
+    ...
+    return LoopDeps(
+        ...,
+        fork_chat=fork_chat,
+        new_chat=new_chat,
+    )
+```
+
+Then append tests:
+
+```python
+def test_fork_chat_dispatches_to_injected_callable():
+    seen = []
+
+    def fake_fork(args):
+        seen.append(args)
+        return ToolResult(ok=True, content='{"conversation_id": "c2"}')
+
+    out = run(
+        [
+            ModelTurn(text=fence("fork_chat", {"title": "W: db"})),
+            ModelTurn(text="Forked."),
+        ],
+        fork_chat=fake_fork,
+    )
+    assert out.status == RUN_DONE and out.final_text == "Forked."
+    assert seen == [{"title": "W: db"}]
+    kinds = [s.kind for s in out.steps]
+    assert kinds == ["model", "tool_call", "tool_result", "model"]
+    assert out.steps[1].tool_name == "fork_chat"
+
+
+def test_new_chat_dispatches_to_injected_callable():
+    seen = []
+
+    def fake_new(args):
+        seen.append(args)
+        return ToolResult(ok=False, error="user_denied")
+
+    out = run(
+        [
+            ModelTurn(text=fence("new_chat", {"title": "W: api"})),
+            ModelTurn(text="Declined."),
+        ],
+        new_chat=fake_new,
+    )
+    assert out.status == RUN_DONE
+    assert seen == [{"title": "W: api"}]
+
+
+def test_chat_create_tools_fall_through_when_not_wired():
+    # No fork_chat/new_chat in deps: the generic invoke_tool path handles it,
+    # exactly like any other unknown runtime tool name.
+    calls = []
+    out = run(
+        [
+            ModelTurn(text=fence("new_chat", {"title": "x"})),
+            ModelTurn(text="done"),
+        ],
+        invoke=lambda c: calls.append(c) or ToolResult(ok=True, content="ok"),
+    )
+    assert out.status == RUN_DONE
+    assert calls[0].name == "new_chat"
+```
+
+Note: `CFG.allowed_tools` governs only catalog tools, not runtime names (`agent_service.py:2491-2499` comment) — no `allowed_tools` change needed.
+
+Also add the pin-gating matrix test (spec §Testing: "schema pinned for primary runs and absent for subagent kinds") via a small pure helper introduced in Step 3:
+
+```python
+def test_chat_create_pin_gating_matrix():
+    from tldw_chatbook.Agents.agent_service import _chat_create_runtime_schemas
+    from tldw_chatbook.Agents.agent_models import AGENT_KIND_PRIMARY, AGENT_KIND_SUBAGENT
+
+    tool = lambda args: ToolResult(ok=True, content="{}")
+    primary = _chat_create_runtime_schemas(AGENT_KIND_PRIMARY, tool, tool)
+    assert [s.name for s in primary] == ["fork_chat", "new_chat"]
+    assert _chat_create_runtime_schemas(AGENT_KIND_SUBAGENT, tool, tool) == []
+    assert _chat_create_runtime_schemas(AGENT_KIND_PRIMARY, None, tool) == [
+        s for s in primary if s.name == "new_chat"
+    ]
+    assert _chat_create_runtime_schemas(AGENT_KIND_PRIMARY, None, None) == []
+```
+
+And extend `Tests/Agents/test_agent_chat_create_tools.py` for the first-plan flags (real signature: `build_first_request_schema_plan(registry, allowed_tools, budget, *, skill_file_enabled, install_skill_enabled, run_skill_script_enabled, run_log_active, ...) -> FirstRequestSchemaPlan` with a `.runtime_schemas` tuple; `RunBudget` and `ToolCatalogRegistry` construct with defaults — crib from existing callers via `grep -n "build_first_request_schema_plan(" tldw_chatbook/ Tests/`):
+
+```python
+def test_first_request_schema_plan_includes_chat_create_tools():
+    from tldw_chatbook.Agents.agent_service import build_first_request_schema_plan
+    from tldw_chatbook.Agents.tool_catalog import ToolCatalogRegistry
+    from tldw_chatbook.Agents.agent_models import RunBudget
+
+    registry = ToolCatalogRegistry()
+    budget = RunBudget()
+
+    def _names(**flags):
+        plan = build_first_request_schema_plan(
+            registry, (), budget,
+            skill_file_enabled=False,
+            install_skill_enabled=False,
+            run_skill_script_enabled=False,
+            run_log_active=False,
+            **flags,
+        )
+        return {s.name for s in plan.runtime_schemas}
+
+    on = _names(fork_chat_enabled=True, new_chat_enabled=True)
+    assert "fork_chat" in on and "new_chat" in on
+    off = _names(fork_chat_enabled=False, new_chat_enabled=False)
+    assert "fork_chat" not in off and "new_chat" not in off
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents/test_agent_runtime.py -k "fork_chat or new_chat or chat_create" Tests/Agents/test_agent_chat_create_tools.py -v`
+Expected: FAIL — `TypeError: make_deps() got an unexpected keyword argument 'fork_chat'`, then dispatch falls through, and plan flags missing.
+
+- [ ] **Step 3: Implement.**
+
+`agent_runtime.py` — add two fields to `LoopDeps` after `run_skill_script` (mirror its comment style):
+
+```python
+    fork_chat: Callable[[dict], ToolResult] | None = None
+    new_chat: Callable[[dict], ToolResult] | None = None
+```
+
+Dispatch branches after the `run_skill_script` branch (~1663), before the generic fallback:
+
+```python
+                elif call.name == FORK_CHAT_TOOL_NAME and deps.fork_chat is not None:
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.fork_chat(dict(call.args))
+                elif call.name == NEW_CHAT_TOOL_NAME and deps.new_chat is not None:
+                    add(STEP_TOOL_CALL, tool_name=call.name, args=dict(call.args))
+                    result = deps.new_chat(dict(call.args))
+```
+
+Import `FORK_CHAT_TOOL_NAME` / `NEW_CHAT_TOOL_NAME` in `agent_runtime.py`'s existing `agent_models` import.
+
+`agent_service.py` — `__init__`: add after `run_skill_script_tool`:
+
+```python
+        fork_chat_tool: Callable[[dict], ToolResult] | None = None,
+        new_chat_tool: Callable[[dict], ToolResult] | None = None,
+```
+
+stored after `self._run_skill_script_tool = run_skill_script_tool`:
+
+```python
+        # Primary-only by design (ADR-150): children never create chats in v1.
+        self._fork_chat_tool = fork_chat_tool
+        self._new_chat_tool = new_chat_tool
+```
+
+`_run_one` pin block — introduce a module-level pure helper (unit-testable; keeps `_run_one` thin) and call it. Append immediately after the `RUN_SKILL_SCRIPT_TOOL_SCHEMA` pin (~2538), before `progress_inbox = None`:
+
+```python
+        runtime_schemas.extend(
+            _chat_create_runtime_schemas(agent_kind, self._fork_chat_tool, self._new_chat_tool)
+        )
+```
+
+with the helper at module level (near `build_first_request_schema_plan`):
+
+```python
+def _chat_create_runtime_schemas(
+    agent_kind: str,
+    fork_chat_tool: "Callable[[dict], ToolResult] | None",
+    new_chat_tool: "Callable[[dict], ToolResult] | None",
+) -> list[ToolSchema]:
+    """ADR-150: fork_chat/new_chat are primary-only in v1 (sub-agents: TASK-32480)."""
+    if agent_kind != AGENT_KIND_PRIMARY:
+        return []
+    schemas: list[ToolSchema] = []
+    if fork_chat_tool is not None:
+        schemas.append(FORK_CHAT_TOOL_SCHEMA)
+    if new_chat_tool is not None:
+        schemas.append(NEW_CHAT_TOOL_SCHEMA)
+    return schemas
+```
+
+`LoopDeps` population (~4689-4701) — after `run_skill_script=self._run_skill_script_tool`:
+
+```python
+            fork_chat=(
+                self._fork_chat_tool
+                if agent_kind == AGENT_KIND_PRIMARY
+                and self._fork_chat_tool is not None
+                else None
+            ),
+            new_chat=(
+                self._new_chat_tool
+                if agent_kind == AGENT_KIND_PRIMARY
+                and self._new_chat_tool is not None
+                else None
+            ),
+```
+
+`build_first_request_schema_plan` (~588-636) — add parameters `fork_chat_enabled: bool = False, new_chat_enabled: bool = False` next to `install_skill_enabled` / `run_skill_script_enabled` (lines 616-619), and append the same two schema appends gated on the flags wherever `INSTALL_SKILL_TOOL_SCHEMA` is appended in that function. Import both schemas in `agent_service.py`'s existing `tool_catalog` import.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Agents/test_agent_runtime.py Tests/Agents/test_agent_chat_create_tools.py -v`
+Expected: PASS (all)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_service.py tldw_chatbook/Agents/agent_runtime.py Tests/Agents/test_agent_runtime.py Tests/Agents/test_agent_chat_create_tools.py
+git commit -m "feat: agent service seam for fork_chat/new_chat (pins, deps, dispatch, first-plan flags)"
+```
+
+---
+
+### Task 5: Controller confirm rounds (`request_chat_create_confirm`)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (state ~2188-2236; methods modeled on `request_skill_script_confirm` :6253-6438, `resolve_pending_skill_script` :6472-6509, `_marshal_pending_skill_script` :6463-6470, `_remount_parked_skill_script` :6440-6461)
+- Test: `Tests/Chat/test_console_chat_create_confirm.py` (new; crib the `make_controller` fixture from `Tests/Chat/test_console_skill_script_confirm.py:60-116`)
+
+**Interfaces:**
+- Produces (consumed by Task 7):
+  - `request_chat_create_confirm(payload: dict, *, session_id: str | None = None) -> dict` returning `{"allow": bool, "remember": bool}`. Session-scoped remember: a prior `remember=True` decision for `(session_id, tool)` short-circuits subsequent rounds for that tool in that session with `{"allow": True, "remember": True}` (no card).
+  - `resolve_pending_chat_create(allow: bool, remember: bool, request_id: str | None = None) -> None` (UI thread).
+  - `pending_chat_create_ids() -> list[str]` (tests).
+  - `set_pending_chat_create: Callable[[dict | None], None] | None = None` attribute (wired by Task 6).
+  - `self._chat_create_session_grants: dict[str, set[str]]` (session_id → tool names), cleared for a session in `close_session`.
+- Payload contract in/out: request payload keys `tool` ("fork_chat"|"new_chat"), `title`, `opening_prompt`, `instructions`, `fork_source_title` (fork only), `fork_message_count` (fork only). The card payload additionally carries `session_id`, `request_id`, `timeout_seconds`, `deadline_monotonic` (added by the controller, mirroring the skill-script card payload).
+
+- [ ] **Step 1: Write the failing tests** (new file; the fixture mirrors `test_console_skill_script_confirm.py`)
+
+```python
+"""Confirm rounds for agent-initiated chat creation (fork_chat / new_chat)."""
+import threading
+
+import pytest
+
+from tldw_chatbook.Chat.console_chat_controller import ConsoleChatController
+from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
+from Tests.Chat.test_console_skill_script_confirm import _FakeApp, _wait_until  # reuse fakes
+
+
+@pytest.fixture
+def make_controller():
+    made = []
+
+    def _make() -> ConsoleChatController:
+        store = ConsoleChatStore()
+        controller = ConsoleChatController(store=store, provider_gateway=object())
+        controller.app = _FakeApp()
+        controller.pending_chat_create_payloads = []
+        controller.set_pending_chat_create = controller.pending_chat_create_payloads.append
+        made.append(controller)
+        return controller
+
+    yield _make
+    for controller in made:
+        controller.begin_shutdown()
+
+
+def _payload(tool="fork_chat", **extra):
+    return {"tool": tool, "title": "W: db", "opening_prompt": "go", "instructions": ""}
+
+
+def test_allow_round_trip(make_controller):
+    controller = make_controller()
+    result = {}
+    t = threading.Thread(target=lambda: result.update(
+        decision=controller.request_chat_create_confirm(_payload(), session_id="s1")))
+    t.start()
+    _wait_until(lambda: bool(controller.pending_chat_create_ids()))
+    controller.resolve_pending_chat_create(True, False, request_id=controller.pending_chat_create_ids()[0])
+    t.join(timeout=5)
+    assert result["decision"] == {"allow": True, "remember": False}
+
+
+def test_deny_round_trip(make_controller):
+    controller = make_controller()
+    result = {}
+    t = threading.Thread(target=lambda: result.update(
+        decision=controller.request_chat_create_confirm(_payload(), session_id="s1")))
+    t.start()
+    _wait_until(lambda: bool(controller.pending_chat_create_ids()))
+    controller.resolve_pending_chat_create(False, False, request_id=controller.pending_chat_create_ids()[0])
+    t.join(timeout=5)
+    assert result["decision"] == {"allow": False, "remember": False}
+
+
+def test_remember_grants_session_scope(make_controller):
+    controller = make_controller()
+    results = []
+
+    def first():
+        results.append(controller.request_chat_create_confirm(_payload(), session_id="s1"))
+    t = threading.Thread(target=first)
+    t.start()
+    _wait_until(lambda: bool(controller.pending_chat_create_ids()))
+    controller.resolve_pending_chat_create(True, True, request_id=controller.pending_chat_create_ids()[0])
+    t.join(timeout=5)
+
+    # Second call in the same session: no card, straight allow.
+    decision = controller.request_chat_create_confirm(_payload(), session_id="s1")
+    assert decision == {"allow": True, "remember": True}
+    assert controller.pending_chat_create_payloads == [controller.pending_chat_create_payloads[0]]
+
+    # Different tool in the same session still confirms.
+    t2 = threading.Thread(target=lambda: results.append(
+        controller.request_chat_create_confirm(_payload(tool="new_chat"), session_id="s1")))
+    t2.start()
+    _wait_until(lambda: len(controller.pending_chat_create_ids()) > 0)
+    controller.resolve_pending_chat_create(True, False, request_id=controller.pending_chat_create_ids()[-1])
+    t2.join(timeout=5)
+    assert results[-1] == {"allow": True, "remember": False}
+
+
+def test_no_ui_fails_closed_immediately(make_controller):
+    controller = make_controller()
+    controller.app = None
+    controller.set_pending_chat_create = None
+    decision = controller.request_chat_create_confirm(_payload())
+    assert decision == {"allow": False, "remember": False}
+```
+
+Adapt `_wait_until` import: if it is a private helper in the skill-script test module, copy it into this file instead of importing (check how that module defines it).
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_chat_create_confirm.py -v`
+Expected: FAIL with `AttributeError: 'ConsoleChatController' object has no attribute 'request_chat_create_confirm'`
+
+- [ ] **Step 3: Implement** — in `console_chat_controller.py`, mirroring the skill-script machinery piece for piece:
+
+State (next to `_pending_skill_script_rounds`, ~2230):
+
+```python
+        self._pending_chat_create_lock = threading.Lock()
+        self._pending_chat_create_rounds: dict[str, dict[str, Any]] = {}
+        self._parked_chat_create_payloads: dict[str, dict[str, Any]] = {}
+        self._chat_create_session_grants: dict[str, set[str]] = {}
+        self.set_pending_chat_create: Callable[[dict | None], None] | None = None
+        self.chat_create_confirm_timeout_seconds: Callable[[], int] | None = None
+```
+
+`request_chat_create_confirm` — copy `request_skill_script_confirm` (:6253-6438) and change: the rounds/parked maps to the ones above; the marshal target to `set_pending_chat_create`; the parked-remount target map; AND insert the grant short-circuit at the top, after the no-UI guard:
+
+```python
+        tool = str(payload.get("tool") or "")
+        if tool in self._chat_create_session_grants.get(owning_session_id, set()):
+            return {"allow": True, "remember": True}
+```
+
+(compute `owning_session_id` first, exactly as the skill-script method does), and in the success path, when the decision is allow+remember:
+
+```python
+                    if decision.get("remember", False):
+                        self._chat_create_session_grants.setdefault(owning_session_id, set()).add(tool)
+```
+
+`resolve_pending_chat_create`, `pending_chat_create_ids`, `_marshal_pending_chat_create`, `_remount_parked_chat_create`: direct mirrors of the four skill-script counterparts (:6440-6520), renamed. Register `_remount_parked_chat_create` wherever `_remount_parked_skill_script` is registered (session switch/new/close hooks — `grep -n "_remount_parked_skill_script" tldw_chatbook/Chat/console_chat_controller.py` and add the sibling call at each site). In `close_session`, add `self._chat_create_session_grants.pop(session_id, None)` (locate `def close_session` and add the line alongside its existing per-session teardown).
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_chat_create_confirm.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_chat_create_confirm.py
+git commit -m "feat: chat-create confirm rounds with session-scoped remember and parking"
+```
+
+---
+
+### Task 6: Confirm card widget + UI wiring
+
+**Files:**
+- Create: `tldw_chatbook/Widgets/Chat_Widgets/chat_create_confirm_card.py`
+- Modify: `tldw_chatbook/UI/Screens/chat_screen_state.py:8` (`TaskResumeState`)
+- Modify: `tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py` (mount branch, ~line 67)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (wiring kwargs ~4837-4856; `@on` handlers ~16638-16650)
+- Modify: `tldw_chatbook/UI/Console_Modules/skill.py` (setter next to `_set_console_pending_skill_script`, ~183-186, and a decision forwarder next to its handler, ~201-215)
+- Test: `Tests/Chat/test_chat_create_confirm_card.py` (new)
+
+**Interfaces:**
+- Consumes: `TaskResumeState` (`chat_screen_state.py:8`) currently holding `pending_skill_install` / `pending_skill_script`; the mount pattern `script_card.set_script(task_state.pending_skill_script)` (`chat_task_cards.py:67`); the screen-wiring pattern `"set_pending_skill_script": getattr(skill, "_set_console_pending_skill_script", None)` (`chat_screen.py:4854-4856`).
+- Produces: `ChatCreateConfirmCard` widget with `set_payload(payload: dict | None)` and a `ChatCreateConfirmCard.ChatCreateDecided` message carrying `allow: bool, remember: bool, request_id: str`; `TaskResumeState.pending_chat_create: dict[str, Any] | None = None` + `has_pending_chat_create()`; screen kwargs entry `"set_pending_chat_create"`; `@on(ChatCreateConfirmCard.ChatCreateDecided)` handler forwarding to `controller.resolve_pending_chat_create`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+"""ChatCreateConfirmCard renders the payload and emits decisions."""
+import pytest
+
+from tldw_chatbook.Widgets.Chat_Widgets.chat_create_confirm_card import ChatCreateConfirmCard
+
+
+def _payload(**over):
+    base = {
+        "tool": "fork_chat",
+        "title": "W: DB migration",
+        "opening_prompt": "Please plan the schema migration.",
+        "instructions": "Focus only on the DB migration.",
+        "fork_source_title": "API redesign",
+        "fork_message_count": 12,
+        "request_id": "r-1",
+    }
+    base.update(over)
+    return base
+
+
+@pytest.mark.parametrize(
+    "allow,remember",
+    [(True, False), (True, True), (False, False)],
+)
+def test_decisions_carry_request_id(allow, remember):
+    card = ChatCreateConfirmCard()
+    card.set_payload(_payload())
+    messages = []
+    card.post_message = lambda m: messages.append(m)  # capture instead of pump
+    card._decide(allow=allow, remember=remember)
+    assert len(messages) == 1
+    decided = messages[0]
+    assert decided.allow is allow
+    assert decided.remember is remember
+    assert decided.request_id == "r-1"
+
+
+def test_clear_payload_hides_card():
+    card = ChatCreateConfirmCard()
+    card.set_payload(_payload())
+    card.set_payload(None)
+    assert card.display is False
+
+
+def test_header_reflects_tool():
+    card = ChatCreateConfirmCard()
+    card.set_payload(_payload(tool="new_chat"))
+    assert "new chat" in card._header_text().lower()
+    card.set_payload(_payload())
+    assert "fork" in card._header_text().lower()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest Tests/Chat/test_chat_create_confirm_card.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'tldw_chatbook.Widgets.Chat_Widgets.chat_create_confirm_card'`
+
+- [ ] **Step 3: Implement.** New card (read `Widgets/Chat_Widgets/skill_script_confirm_card.py` first and match its class structure, styling constants, and markup helpers; the skeleton below is the behavioral contract):
+
+```python
+"""Approval card for agent-initiated chat creation (fork_chat / new_chat)."""
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal
+from textual.widget import Widget
+from textual.widgets import Button, Static
+
+
+class ChatCreateConfirmCard(Widget):
+    """Show one pending chat-creation request; emit the user's decision."""
+
+    DEFAULT_CSS = """
+    ChatCreateConfirmCard { border: round $accent; padding: 0 1; }
+    ChatCreateConfirmCard .chat-create-body { margin: 0 1; }
+    """
+
+    class ChatCreateDecided(Message):  # import Message from textual.message
+        def __init__(self, allow: bool, remember: bool, request_id: str) -> None:
+            super().__init__()
+            self.allow = allow
+            self.remember = remember
+            self.request_id = request_id
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._payload: dict | None = None
+
+    def compose(self) -> ComposeResult:
+        yield Static("", id="chat-create-header")
+        yield Static("", id="chat-create-body", classes="chat-create-body")
+        with Horizontal(id="chat-create-actions"):
+            yield Button("Allow", id="chat-create-allow", variant="success")
+            yield Button("Allow for this session", id="chat-create-allow-remember")
+            yield Button("Deny", id="chat-create-deny", variant="error")
+
+    def set_payload(self, payload: dict | None) -> None:
+        self._payload = payload
+        self.display = payload is not None
+        if payload is None:
+            return
+        self.query_one("#chat-create-header", Static).update(self._header_text())
+        self.query_one("#chat-create-body", Static).update(self._body_text())
+
+    def _header_text(self) -> str:
+        assert self._payload is not None
+        verb = "Fork this chat" if self._payload.get("tool") == "fork_chat" else "Create new chat"
+        return f"[b]{verb}[/b] — “{self._payload.get('title', '')}”"
+
+    def _body_text(self) -> str:
+        assert self._payload is not None
+        lines: list[str] = []
+        if self._payload.get("tool") == "fork_chat":
+            lines.append(
+                f"Copies {self._payload.get('fork_message_count', '?')} messages from "
+                f"“{self._payload.get('fork_source_title', '')}” into a new chat."
+            )
+        if self._payload.get("opening_prompt"):
+            lines.append(f"[b]Opening prompt (draft for the input box):[/b]\n{self._payload['opening_prompt']}")
+        if self._payload.get("instructions"):
+            lines.append(f"[b]System prompt:[/b]\n{self._payload['instructions']}")
+        return "\n\n".join(lines)
+
+    @on(Button.Pressed, "#chat-create-allow")
+    def _allow(self) -> None:
+        self._decide(allow=True, remember=False)
+
+    @on(Button.Pressed, "#chat-create-allow-remember")
+    def _allow_remember(self) -> None:
+        self._decide(allow=True, remember=True)
+
+    @on(Button.Pressed, "#chat-create-deny")
+    def _deny(self) -> None:
+        self._decide(allow=False, remember=False)
+
+    def _decide(self, *, allow: bool, remember: bool) -> None:
+        if self._payload is None:
+            return
+        request_id = str(self._payload.get("request_id", ""))
+        self.set_payload(None)
+        self.post_message(self.ChatCreateDecided(allow, remember, request_id))
+```
+
+(Fix the `Message` import: `from textual.message import Message`. Match the sibling cards' CSS/markup-escape conventions — escape user/model text with the same helper the skill card uses.)
+
+Then:
+1. `chat_screen_state.py` `TaskResumeState`: add `pending_chat_create: dict[str, Any] | None = None` and `has_pending_chat_create()` mirroring `has_pending_skill_script()` (see `chat_task_cards.py:72` for how the sibling helper is consumed).
+2. `chat_task_cards.py`: mirror the skill-script mount branch at ~67 — when `task_state.has_pending_chat_create()`, mount/update a `ChatCreateConfirmCard` with `task_state.pending_chat_create`, and tear it down when absent, exactly as the sibling branch does for the script card.
+3. `UI/Console_Modules/skill.py`: add `_set_console_pending_chat_create` directly after `_set_console_pending_skill_script` (:183-186), same `replace(current, pending_chat_create=payload)` body; add `handle_console_chat_create_decided(self, allow, remember, request_id)` next to `handle_console_skill_script_decided` (:201-215) forwarding to `controller.resolve_pending_chat_create(allow, remember, request_id=request_id)`.
+4. `chat_screen.py`: add to the controller-construction kwargs (next to `"set_pending_skill_script"`, :4854-4856): `"set_pending_chat_create": getattr(skill, "_set_console_pending_chat_create", None),` and a handler next to the skill-script one (:16638-16650):
+
+```python
+    @on(ChatCreateConfirmCard.ChatCreateDecided)
+    def handle_console_chat_create_decided(self, event: Any) -> None:
+        event.stop()
+        self._skill.handle_console_chat_create_decided(
+            event.allow, event.remember, request_id=event.request_id
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_chat_create_confirm_card.py Tests/Chat/test_console_skill_script_confirm.py -v`
+Expected: PASS (new file passes; skill-script card suite unchanged)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/Chat_Widgets/chat_create_confirm_card.py tldw_chatbook/UI/Screens/chat_screen_state.py tldw_chatbook/Widgets/Chat_Widgets/chat_task_cards.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/skill.py Tests/Chat/test_chat_create_confirm_card.py
+git commit -m "feat: chat-create confirmation card and Console wiring"
+```
+
+---
+
+### Task 7: Bridge closures, controller executor, session completion
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (`run_reply` signature ~3385-3441; closures after `run_skill_script_tool` ~3865; flags helper ~2823-2880 + call site ~3343-3346; `AgentService(...)` construction ~4165-4179)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (`execute_agent_chat_create` + partials at the `run_reply` invocation ~12108-12128)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` (`_complete_agent_chat_create` + wiring kwargs)
+- Test: `Tests/Chat/test_console_chat_create_integration.py` (new)
+
+**Interfaces:**
+- Consumes: Task 4 (`fork_chat_tool`/`new_chat_tool` AgentService params, first-plan flags), Task 5 (`request_chat_create_confirm`, `resolve_pending_chat_create`, grants), Tasks 1-2 (`create_conversation` lineage kwargs, `copy_conversation_active_path`).
+- Produces:
+  - `run_reply(..., request_chat_create_confirm: Callable[[dict], dict] | None = None, execute_agent_chat_create: Callable[[dict], dict] | None = None)`; closures `fork_chat_tool(payload: dict) -> ToolResult` and `new_chat_tool(payload: dict) -> ToolResult` built only when BOTH callables are non-None (advertised-equals-usable).
+  - `ConsoleChatController.execute_agent_chat_create(payload: dict) -> dict` — payload `{tool, session_id, title, opening_prompt, instructions}`; returns `{"ok": True, "title", "conversation_id", "workspace_id", "copied_messages", "draft_set": True}` or `{"ok": False, "kind": <error kind>, "error": <message>}` with kinds: `source_not_persisted`, `empty_history`, `character_conflict`, `payload_too_large`, `session_gone`, `execution_failed`.
+  - Screen-side `complete_agent_chat_create(**kwargs)` (UI thread): creates the non-activated session, sets the draft, invalidates the persisted-rows cache, triggers console-sync, toasts.
+  - Conversation metadata key `console_agent_handoff` = `{"draft": str, "created_via": "fork_chat"|"new_chat", "source_run_id": str}` (Task 8 rehydrates).
+  - Caps (module-level in the bridge, next to the closures): `CHAT_CREATE_TITLE_MAX = 120`, `CHAT_CREATE_PAYLOAD_MAX = 20_000`, denial terminal threshold `2`.
+
+- [ ] **Step 1: Write the failing integration tests** (new file; crib the fake-app/controller fixture from Task 5 and the real in-memory-DB service pattern from `Tests/Chat/test_chat_conversation_service.py`)
+
+```python
+"""End-to-end bridge closures for fork_chat / new_chat with fakes + real SQLite."""
+import json
+
+import pytest
+
+from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+from tldw_chatbook.Chat.chat_persistence_service import ChatPersistenceService
+from tldw_chatbook.Chat.console_agent_bridge import (
+    build_chat_create_tool_closures,
+)
+
+
+class _FakeConfirm:
+    def __init__(self, decisions):
+        self.decisions = list(decisions)
+        self.payloads = []
+
+    def __call__(self, payload):
+        self.payloads.append(payload)
+        return self.decisions.pop(0)
+
+
+class _FakeExecutor:
+    def __init__(self, result=None):
+        self.calls = []
+        self.result = result or {"ok": True, "title": "W", "conversation_id": "c2",
+                                 "workspace_id": None, "copied_messages": 3, "draft_set": True}
+
+    def __call__(self, payload):
+        self.calls.append(payload)
+        return dict(self.result)
+
+
+def test_fork_chat_tool_happy_path():
+    confirm, executor = _FakeConfirm([{"allow": True, "remember": False}]), _FakeExecutor()
+    fork_tool, new_tool = build_chat_create_tool_closures(
+        confirm=confirm, execute=executor, session_id="s1", run_id="r1"
+    )
+    result = fork_tool({"title": "W: db", "opening_prompt": "go", "instructions": ""})
+    assert result.ok
+    data = json.loads(result.content)
+    assert data["conversation_id"] == "c2" and data["draft_set"] is True
+    assert "user" in data["note"].lower()
+    assert executor.calls[0]["tool"] == "fork_chat"
+
+
+def test_deny_returns_error_without_execution():
+    confirm, executor = _FakeConfirm([{"allow": False, "remember": False}]), _FakeExecutor()
+    fork_tool, _ = build_chat_create_tool_closures(confirm=confirm, execute=executor,
+                                                   session_id="s1", run_id="r1")
+    result = fork_tool({"title": "x"})
+    assert not result.ok and "declined" in result.error.lower()
+    assert executor.calls == []
+
+
+def test_denial_guard_terminals_after_two():
+    confirm = _FakeConfirm([{"allow": False, "remember": False}, {"allow": False, "remember": False}])
+    executor = _FakeExecutor()
+    fork_tool, _ = build_chat_create_tool_closures(confirm=confirm, execute=executor,
+                                                   session_id="s1", run_id="r1")
+    assert not fork_tool({}).ok
+    assert not fork_tool({}).ok
+    third = fork_tool({})
+    assert not third.ok and "denied_repeatedly" in third.error
+    assert confirm.payloads.__len__() == 2  # no third card
+
+
+def test_remember_skips_confirm_for_that_tool_only():
+    confirm, executor = _FakeConfirm([{"allow": True, "remember": True}]), _FakeExecutor()
+    fork_tool, new_tool = build_chat_create_tool_closures(confirm=confirm, execute=executor,
+                                                          session_id="s1", run_id="r1")
+    assert fork_tool({}).ok                      # card shown, remembered
+    assert fork_tool({}).ok                      # no card (session grant path via executor note)
+    assert not new_tool({}).ok                   # confirm has no decisions left -> deny fail-closed
+```
+
+(The remember behavior above is closure-side memo of the controller's grant: the closure records `remember=True` per tool and skips calling confirm on later calls in the same run — the controller grants dict covers cross-run-within-session. Assert accordingly.)
+
+Executor-level tests with a real in-memory DB (fixture pattern from `Tests/Chat/test_chat_conversation_service.py`), driving `ConsoleChatController.execute_agent_chat_create` with `complete_agent_chat_create` stubbed to record kwargs:
+
+```python
+def test_execute_fork_copies_history_and_lineage(real_db_controller):
+    controller, db = real_db_controller
+    src_session = controller.store.create_session(title="Src", activate=True)
+    src_conv = controller.store.persistence.create_conversation(conversation_title="Src")
+    src_session.persisted_conversation_id = src_conv
+    ChatConversationService(db).create_conversation  # sanity import
+    svc = ChatConversationService(db)
+    ids = [db.add_message({"conversation_id": src_conv, "sender": "user", "content": "hi"})]
+    db.set_conversation_active_leaf(src_conv, str(ids[0]))
+
+    outcome = controller.execute_agent_chat_create(
+        {"tool": "fork_chat", "session_id": src_session.id, "title": "W: db",
+         "opening_prompt": "go", "instructions": ""}
+    )
+    assert outcome["ok"], outcome
+    forked = db.get_conversation_by_id(outcome["conversation_id"])
+    assert forked["parent_conversation_id"] == src_conv
+    msgs = db.get_messages_for_conversation(outcome["conversation_id"])
+    assert [m["content"] for m in msgs] == ["hi"]
+    assert outcome["copied_messages"] == 1
+
+
+def test_execute_fork_refuses_instructions_on_character_chat(real_db_controller):
+    controller, db = real_db_controller
+    session = controller.store.create_session(title="Char", character_id=7, character_name="Rex")
+    conv = controller.store.persistence.create_conversation(conversation_title="Char", character_id=7)
+    session.persisted_conversation_id = conv
+    db.add_message({"conversation_id": conv, "sender": "user", "content": "hi"})
+    outcome = controller.execute_agent_chat_create(
+        {"tool": "fork_chat", "session_id": session.id, "title": "x",
+         "opening_prompt": "", "instructions": "be terse"}
+    )
+    assert not outcome["ok"] and outcome["kind"] == "character_conflict"
+
+
+def test_execute_fork_ephemeral_source_error(real_db_controller):
+    controller, db = real_db_controller
+    session = controller.store.create_session(title="Tmp", ephemeral=True)
+    outcome = controller.execute_agent_chat_create(
+        {"tool": "fork_chat", "session_id": session.id, "title": "x"})
+    assert not outcome["ok"] and outcome["kind"] == "source_not_persisted"
+
+
+def test_execute_fork_empty_history_error(real_db_controller):
+    controller, db = real_db_controller
+    session = controller.store.create_session(title="Empty")
+    conv = controller.store.persistence.create_conversation(conversation_title="Empty")
+    session.persisted_conversation_id = conv
+    outcome = controller.execute_agent_chat_create(
+        {"tool": "fork_chat", "session_id": session.id, "title": "x"})
+    assert not outcome["ok"] and outcome["kind"] == "empty_history"
+
+
+def test_execute_payload_too_large(real_db_controller):
+    controller, db = real_db_controller
+    session = controller.store.create_session(title="S")
+    outcome = controller.execute_agent_chat_create(
+        {"tool": "new_chat", "session_id": session.id, "title": "x",
+         "opening_prompt": "y" * 20_001, "instructions": ""})
+    assert not outcome["ok"] and outcome["kind"] == "payload_too_large"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_chat_create_integration.py -v`
+Expected: FAIL — `ImportError: cannot import name 'build_chat_create_tool_closures'` and missing `execute_agent_chat_create`.
+
+- [ ] **Step 3: Implement.**
+
+`console_agent_bridge.py` — module-level helper (exported for tests; called from `run_reply`), placed after the `run_skill_script_tool` closure region:
+
+```python
+CHAT_CREATE_TITLE_MAX = 120
+CHAT_CREATE_PAYLOAD_MAX = 20_000
+_CHAT_CREATE_DENIAL_LIMIT = 2
+
+
+def build_chat_create_tool_closures(
+    *,
+    confirm: Callable[[dict], dict],
+    execute: Callable[[dict], dict],
+    session_id: str,
+    run_id: str,
+) -> tuple[Callable[[dict], ToolResult], Callable[[dict], ToolResult]]:
+    """Build the fork_chat/new_chat runtime-tool closures for one run.
+
+    Both share one per-run denial counter (terminal after two denials) and one
+    per-run remember memo (the controller's session grants cover cross-run
+    remembers inside the same session).
+    """
+    denials = {"fork_chat": 0, "new_chat": 0}
+    remembered: set[str] = set()
+
+    def _run(tool: str, args: dict) -> ToolResult:
+        if denials[tool] >= _CHAT_CREATE_DENIAL_LIMIT:
+            return ToolResult(
+                ok=False,
+                error=(
+                    "denied_repeatedly: the user declined twice; chat creation "
+                    "is disabled for the rest of this run. Do not retry."
+                ),
+            )
+        title = str(args.get("title") or "").strip()[:CHAT_CREATE_TITLE_MAX]
+        opening_prompt = str(args.get("opening_prompt") or "")
+        instructions = str(args.get("instructions") or "")
+        if len(opening_prompt) > CHAT_CREATE_PAYLOAD_MAX or len(instructions) > CHAT_CREATE_PAYLOAD_MAX:
+            return ToolResult(ok=False, error="payload_too_large: opening_prompt/instructions exceed 20000 chars")
+        payload = {
+            "tool": tool,
+            "session_id": session_id,
+            "run_id": run_id,
+            "title": title,
+            "opening_prompt": opening_prompt,
+            "instructions": instructions,
+        }
+        if tool not in remembered:
+            try:
+                decision = confirm(dict(payload))
+            except Exception:  # noqa: BLE001 — a UI error fails closed
+                decision = {"allow": False, "remember": False}
+            if not isinstance(decision, Mapping) or not decision.get("allow", False):
+                denials[tool] += 1
+                return ToolResult(
+                    ok=False,
+                    error="The user declined. Do not retry this turn.",
+                )
+            if decision.get("remember", False):
+                remembered.add(tool)
+        outcome = execute(dict(payload))
+        if not isinstance(outcome, dict) or not outcome.get("ok"):
+            kind = str(outcome.get("kind", "execution_failed")) if isinstance(outcome, dict) else "execution_failed"
+            return ToolResult(ok=False, error=f"{kind}: {outcome.get('error', 'chat creation failed') if isinstance(outcome, dict) else 'chat creation failed'}")
+        copied = outcome.get("copied_messages")
+        note = (
+            "The new chat opened in the background (same workspace) with your "
+            "opening prompt as a draft in its input box; the user reviews and "
+            "sends it themselves. Do not send messages into the new chat."
+        )
+        content = json.dumps(
+            {
+                "title": outcome.get("title"),
+                "conversation_id": outcome.get("conversation_id"),
+                "workspace_id": outcome.get("workspace_id"),
+                "copied_messages": copied,
+                "draft_set": bool(outcome.get("draft_set")),
+                "note": note,
+            }
+        )
+        return ToolResult(ok=True, content=content)
+
+    def fork_chat_tool(args: dict) -> ToolResult:
+        return _run("fork_chat", args)
+
+    def new_chat_tool(args: dict) -> ToolResult:
+        return _run("new_chat", args)
+
+    return fork_chat_tool, new_chat_tool
+```
+
+In `run_reply`: add the two parameters to the signature (after `request_skill_script_confirm`); build the closures near where `run_skill_script_tool` is built:
+
+```python
+        fork_chat_tool = new_chat_tool = None
+        if request_chat_create_confirm is not None and execute_agent_chat_create is not None:
+            fork_chat_tool, new_chat_tool = build_chat_create_tool_closures(
+                confirm=request_chat_create_confirm,
+                execute=execute_agent_chat_create,
+                session_id=session_id,
+                run_id=str(run_id),
+            )
+```
+
+(`run_id` — use the run identifier available in `run_reply`'s scope; if only `conversation_id`/`assistant_message_id` are in scope, use `assistant_message_id` and name it accordingly.) Pass `fork_chat_tool=fork_chat_tool, new_chat_tool=new_chat_tool` into the `AgentService(...)` construction (~4165-4179). Extend the first-plan call path: the flags helper at :2823-2880 and its call site at :3343-3346 gain `fork_chat_enabled=bool(fork_chat_tool is not None)` and `new_chat_enabled=bool(new_chat_tool is not None)` (the call-site booleans are computed where `script_tool_enabled` is, ~3548).
+
+`console_chat_controller.py` — the executor (module import of `ChatConversationService` at top):
+
+```python
+    def execute_agent_chat_create(self, payload: dict) -> dict:
+        """WORKER THREAD: create the confirmed chat (conversation + copy) and
+        marshal UI completion. Returns an outcome dict (see TASK-32482 spec)."""
+        tool = str(payload.get("tool") or "")
+        session_id = str(payload.get("session_id") or "")
+        session = next((s for s in self.store.sessions() if s.id == session_id), None)
+        if session is None:
+            return {"ok": False, "kind": "session_gone", "error": "source session not found"}
+        title = str(payload.get("title") or "").strip()
+        opening_prompt = str(payload.get("opening_prompt") or "")
+        instructions = str(payload.get("instructions") or "")
+        if len(opening_prompt) > 20_000 or len(instructions) > 20_000:
+            return {"ok": False, "kind": "payload_too_large", "error": "payload exceeds 20000 chars"}
+        persistence = self.store.persistence
+        db = getattr(persistence, "db", None)
+        if persistence is None or db is None:
+            return {"ok": False, "kind": "execution_failed", "error": "persistence unavailable"}
+
+        source_conv: str | None = None
+        source_row: dict[str, Any] | None = None
+        copied = 0
+        if tool == "fork_chat":
+            source_conv = session.persisted_conversation_id
+            if session.ephemeral or not source_conv:
+                return {"ok": False, "kind": "source_not_persisted",
+                        "error": "the current chat is temporary; nothing to fork"}
+            conversation_service = ChatConversationService(db)
+            tree = conversation_service.get_conversation_tree(
+                source_conv, root_limit=10_000, depth_cap=10_000
+            )
+            source_row = dict(tree.get("conversation") or {})
+            if not title:
+                title = f"Fork of {source_row.get('title') or 'chat'}"[:120]
+            if instructions and source_row.get("character_id"):
+                return {"ok": False, "kind": "character_conflict",
+                        "error": "character chats keep their persona; fork without instructions"}
+        elif not title:
+            title = "New Chat"
+
+        handoff_metadata = {
+            "console_agent_handoff": {
+                "draft": opening_prompt,
+                "created_via": tool,
+                "source_run_id": str(payload.get("run_id") or ""),
+            }
+        }
+        try:
+            if tool == "fork_chat":
+                new_conv = persistence.create_conversation(
+                    conversation_title=title,
+                    scope_type=source_row.get("scope_type") or "global",
+                    workspace_id=source_row.get("workspace_id"),
+                    system_prompt=instructions or source_row.get("system_prompt"),
+                    character_id=source_row.get("character_id"),
+                    assistant_kind=source_row.get("assistant_kind"),
+                    assistant_id=source_row.get("assistant_id"),
+                    assistant_authority_id=source_row.get("assistant_authority_id"),
+                    metadata=handoff_metadata,
+                    parent_conversation_id=source_conv,
+                    forked_from_message_id=source_row.get("active_leaf_message_id"),
+                )
+                copy_outcome = ChatConversationService(db).copy_conversation_active_path(
+                    str(source_conv), new_conv
+                )
+                copied = int(copy_outcome["copied"])
+            else:
+                workspace_id = session.workspace_id
+                scope = "global" if workspace_id in (None, CONSOLE_GLOBAL_WORKSPACE_ID) else "workspace"
+                new_conv = persistence.create_conversation(
+                    conversation_title=title,
+                    scope_type=scope,
+                    workspace_id=None if scope == "global" else workspace_id,
+                    system_prompt=instructions or None,
+                    metadata=handoff_metadata,
+                )
+        except ValueError as exc:
+            if "empty_history" in str(exc):
+                return {"ok": False, "kind": "empty_history",
+                        "error": "nothing to fork yet; use new_chat"}
+            return {"ok": False, "kind": "copy_failed", "error": str(exc)}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "kind": "copy_failed", "error": str(exc)}
+
+        if self.app is not None and self.complete_agent_chat_create is not None:
+            self.app.call_from_thread(
+                self.complete_agent_chat_create,
+                session_id=session_id,
+                conversation_id=new_conv,
+                title=title,
+                tool=tool,
+                opening_prompt=opening_prompt,
+                workspace_id=(source_row or {}).get("workspace_id") if tool == "fork_chat" else session.workspace_id,
+            )
+        return {
+            "ok": True, "title": title, "conversation_id": new_conv,
+            "workspace_id": (source_row or {}).get("workspace_id") if tool == "fork_chat" else session.workspace_id,
+            "copied_messages": copied, "draft_set": bool(opening_prompt),
+        }
+```
+
+Add `self.complete_agent_chat_create: Callable[..., None] | None = None` to controller state (Task 5's block). Import `CONSOLE_GLOBAL_WORKSPACE_ID` from `Chat/console_chat_store.py` (it defines it) if not already imported.
+
+Define the `real_db_controller` fixture concretely at the top of the integration test file:
+
+```python
+@pytest.fixture
+def real_db_controller():
+    """Controller + real in-memory SQLite store, with UI completion stubbed."""
+    from Tests.Chat.test_console_skill_script_confirm import _FakeApp
+    from tldw_chatbook.DB.ChaChaNotes_DB import ChaChaNotesDB  # adapt to the class name/
+    # constructor pattern used by Tests/Chat/test_chat_persistence_service.py's db fixture
+    db = <in-memory ChaChaNotes DB per that fixture>
+    persistence = ChatPersistenceService(db)
+    store = ConsoleChatStore(persistence=persistence)
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+    controller.app = _FakeApp()
+    completed = []
+    controller.complete_agent_chat_create = lambda **kw: completed.append(kw)
+    yield controller, db
+    controller.begin_shutdown()
+```
+
+(Crib the exact in-memory DB construction from the persistence-service test fixture — the class name and args differ across DB modules; reuse whatever that suite does so schema/migrations initialize identically. `ChatPersistenceService` additionally needs its `workspace_registry` argument if its tests pass one — mirror them.)
+
+Controller `run_reply` invocation (~12108-12128), next to the skill confirms (same advertised-equals-usable guard):
+
+```python
+                request_chat_create_confirm=(
+                    functools.partial(self.request_chat_create_confirm, session_id=session_id)
+                    if self.set_pending_chat_create is not None
+                    else None
+                ),
+                execute_agent_chat_create=(
+                    self.execute_agent_chat_create
+                    if self.complete_agent_chat_create is not None
+                    else None
+                ),
+```
+
+`chat_screen.py` — the UI-thread completion, next to `_park_console_approval`:
+
+```python
+    def _complete_agent_chat_create(
+        self, *, session_id: str, conversation_id: str, title: str,
+        tool: str, opening_prompt: str, workspace_id,
+    ) -> None:
+        controller = self._console_chat_controller
+        if controller is None:
+            return
+        store = controller.store
+        nodes: list = []
+        leaf = None
+        if tool == "fork_chat":
+            from tldw_chatbook.Chat.console_conversation_hydration import (
+                console_messages_from_conversation_tree,
+            )
+            service = getattr(self.app, "chat_conversation_scope_service", None)
+            maybe_tree = service.get_conversation_tree(
+                conversation_id, mode="local", depth_cap=10_000, root_limit=10_000
+            )
+            import inspect as _inspect
+            tree = maybe_tree if not _inspect.isawaitable(maybe_tree) else None
+            if tree is None:  # async facade: fall back to sync service read
+                from tldw_chatbook.Chat.chat_conversation_service import ChatConversationService
+                tree = ChatConversationService(store.persistence.db).get_conversation_tree(
+                    conversation_id, root_limit=10_000, depth_cap=10_000
+                )
+            nodes = list(console_messages_from_conversation_tree(tree, db=self.app.chachanotes_db))
+            leaf = self.app.chachanotes_db.get_conversation_active_leaf(conversation_id)
+        session = store.restore_persisted_session(
+            title=title,
+            workspace_id=workspace_id,
+            persisted_conversation_id=conversation_id,
+            all_nodes=nodes,
+            active_leaf_persisted_id=leaf,
+            activate=False,
+        )
+        if opening_prompt:
+            store.set_session_draft(session.id, opening_prompt)
+        self._invalidate_console_persisted_rows_cache()
+        self.run_worker(self._sync_native_console_chat_ui, exclusive=True, group="console-sync")
+        verb = "Forked" if tool == "fork_chat" else "New"
+        self.app_instance.notify(f"{verb} chat created: {title}")
+```
+
+(Prefer the sync service read directly and drop the awaitable branch if `chat_conversation_scope_service.get_conversation_tree` is async in this build — the excerpt shows the hydration path awaiting it; simplest is to always use the sync `ChatConversationService`. `activate=False` requires Task 8.) Wire the kwargs entry next to `set_pending_skill_script` (:4854-4856): `"complete_agent_chat_create": self._complete_agent_chat_create,`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_chat_create_integration.py Tests/Chat/test_console_chat_create_confirm.py Tests/Chat/test_chat_create_confirm_card.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/UI/Screens/chat_screen.py Tests/Chat/test_console_chat_create_integration.py
+git commit -m "feat: fork_chat/new_chat bridge closures, executor, and background session completion"
+```
+
+---
+
+### Task 8: Store — non-activating restore and one-shot draft rehydration
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` (`restore_persisted_session` :1210-1316; draft rehydrate inside it)
+- Test: `Tests/Chat/test_console_chat_store.py` (extend; reuse `FakePersistence` :1376-1464 and the real-DB variant :1676-1678)
+
+**Interfaces:**
+- Consumes: Task 7's `console_agent_handoff` metadata key; `restore_persisted_session` currently calls `create_session` WITHOUT `activate=False` (activates — excerpt H(3)); `set_session_draft` (:1957).
+- Produces: `restore_persisted_session(..., activate: bool = True)` forwarded to `create_session(activate=activate)`; when the restored conversation's metadata contains `console_agent_handoff.draft`, the session draft is set from it and the key is removed from persisted metadata (one-shot: it survives restarts until the chat is first opened).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_restore_persisted_session_activate_false_keeps_current(real_db_store):
+    store, db = real_db_store  # adapt: ConsoleChatStore(persistence=ChatPersistenceService(db))
+    first = store.create_session(title="A")
+    conv = store.persistence.create_conversation(conversation_title="B")
+    restored = store.restore_persisted_session(
+        title="B", workspace_id=None, persisted_conversation_id=conv,
+        all_nodes=[], activate=False,
+    )
+    assert store.active_session_id == first.id  # NOT switched
+    assert restored.persisted_conversation_id == conv
+
+
+def test_restore_rehydrates_handoff_draft_once(real_db_store):
+    store, db = real_db_store
+    conv = store.persistence.create_conversation(
+        conversation_title="C",
+        metadata={"console_agent_handoff": {"draft": "please plan the migration",
+                                            "created_via": "fork_chat", "source_run_id": "r9"}},
+    )
+    restored = store.restore_persisted_session(
+        title="C", workspace_id=None, persisted_conversation_id=conv,
+        all_nodes=[], activate=False,
+    )
+    assert restored.draft == "please plan the migration"
+    # one-shot: the persisted key was cleared
+    row = db.get_conversation_by_id(conv)
+    assert "console_agent_handoff" not in (row.get("metadata") or "{}")
+
+
+def test_restore_without_handoff_leaves_draft_alone(real_db_store):
+    store, db = real_db_store
+    conv = store.persistence.create_conversation(conversation_title="D")
+    restored = store.restore_persisted_session(
+        title="D", workspace_id=None, persisted_conversation_id=conv,
+        all_nodes=[], activate=False,
+    )
+    assert restored.draft == ""
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_chat_store.py -k "restore_persisted or handoff" -v`
+Expected: FAIL with `TypeError: restore_persisted_session() got an unexpected keyword argument 'activate'`
+
+- [ ] **Step 3: Implement** — in `restore_persisted_session`: add `activate: bool = True` to the signature; forward `activate=activate` into its internal `create_session(...)` call; after `session.persisted_conversation_id = str(persisted_conversation_id)`, add:
+
+```python
+            handoff_draft = None
+            db = getattr(self.persistence, "db", None)
+            if db is not None:
+                row = db.get_conversation_by_id(str(persisted_conversation_id))
+                raw_metadata = (row or {}).get("metadata") or "{}"
+                try:
+                    metadata_obj = json.loads(raw_metadata) if isinstance(raw_metadata, str) else {}
+                except ValueError:
+                    metadata_obj = {}
+                handoff = metadata_obj.pop("console_agent_handoff", None) if isinstance(metadata_obj, dict) else None
+                if isinstance(handoff, dict) and handoff.get("draft"):
+                    handoff_draft = str(handoff["draft"])
+                    # one-shot: clear the key so a later restore does not re-fill
+                    # the composer. Optimistic-locked update (version from the
+                    # row we just read); on a version race, skip clearing — the
+                    # worst case is the draft re-filling once on a later restore.
+                    try:
+                        db.update_conversation(
+                            str(persisted_conversation_id),
+                            {"metadata": json.dumps(metadata_obj, allow_nan=False)},
+                            int((row or {}).get("version") or 1),
+                        )
+                    except Exception:  # noqa: BLE001 — ConflictError et al.
+                        logger.opt(exception=True).debug(
+                            "Failed to clear console_agent_handoff after rehydrate"
+                        )
+            ...
+            if handoff_draft:
+                self.set_session_draft(session.id, handoff_draft)
+```
+
+(`json` is already imported in `console_chat_store.py`; `db.update_conversation(conversation_id, update_data, expected_version)` is the optimistic-locked signature at `DB/ChaChaNotes_DB.py:8746` — `metadata` expects a JSON string, which is what we pass. `logger` is the module's existing loguru logger; if the module uses a different name, mirror it.)
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_chat_store.py -v`
+Expected: PASS (all — including pre-existing restore tests with default `activate=True`)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_store.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat: non-activating persisted-session restore and one-shot agent handoff draft rehydration"
+```
+
+---
+
+### Task 9: Docs, task hygiene, and verification
+
+**Files:**
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+- Modify: `backlog/tasks/task-32482 - Agent-chat-fork-and-spawn-tools-fork_chat-new_chat.md`
+- Modify: `Docs/User_Guide/console.md` (one-paragraph workstream blurb, only if it lists agent tools; otherwise skip)
+
+**Interfaces:** none (documentation + closure).
+
+- [ ] **Step 1: Document the tools** — in `agent-runs-and-tools.md`, next to the `run_skill_script`/`install_skill` documentation, add a `fork_chat` / `new_chat` section stating: what each does; that every call requires approval (Allow / Allow for this session / Deny); that "Allow for this session" is per-tool and ends with the session; that the opening prompt is a draft the user sends; the mid-turn snapshot boundary (the agent's current reply is not in the fork); that chats open in the background with a toast; character-chat and temporary-chat refusals; and that the copied chat records lineage (parent + fork point).
+- [ ] **Step 2: Update the backlog task** — check off the ACs in TASK-32482, add the `## Implementation Notes` section (approach, files touched, decisions: no-migration, session-scoped remember, denial guard, one-shot draft rehydration, deferred follow-ups TASK-32480 + preset PR), set status via `backlog task edit 32482 -s Done --notes "..."` only after steps 3-4 pass.
+- [ ] **Step 3: Run the full targeted verification list**
+
+```bash
+pytest Tests/Chat/test_chat_persistence_service.py \
+       Tests/Chat/test_chat_conversation_service.py \
+       Tests/Agents/test_agent_chat_create_tools.py \
+       Tests/Agents/test_agent_runtime.py \
+       Tests/Chat/test_console_chat_create_confirm.py \
+       Tests/Chat/test_chat_create_confirm_card.py \
+       Tests/Chat/test_console_chat_create_integration.py \
+       Tests/Chat/test_console_chat_store.py \
+       Tests/Chat/test_console_skill_script_confirm.py \
+       Tests/Chat/test_console_rewind_summarize.py -v
+```
+
+Expected: PASS across the board (rewind suite included as a regression guard on active-leaf semantics).
+
+- [ ] **Step 4: Live verification** (per `backlog/docs/lessons-live-verification.md`; requires the user or a driver session with the app running and a reachable provider): have an agent propose two workstreams and call `fork_chat` + `new_chat`; confirm the card shows full bodies; allow; verify toast, workspace listing (both membership + persisted paths), drafts in the composers; send in the fork and verify the source chat does not receive it; restart the app and verify both chats and (unopened) drafts persist. Record the outcome in the task notes.
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/User_Guide/console/agent-runs-and-tools.md "backlog/tasks/task-32482 - Agent-chat-fork-and-spawn-tools-fork_chat-new_chat.md"
+git commit -m "docs: fork_chat/new_chat user guide + task closure"
+```
+
+---
+
+## Sequencing note (vs. the provider-routing PR)
+
+This plan is written against the working tree **including** the uncommitted provider-routing WIP (`agent_service.py` runtime-schema block at :2500-2556, `console_agent_bridge.py` flag plumbing at :2823-2880/:3343-3346). If that PR rebases, re-verify four anchors before starting Task 4: the `_run_one` runtime_schemas block end, the `LoopDeps` construction tail, the `build_first_request_schema_plan` flag list, and the bridge flags helper. All edits here are additive (new lines only) except the two `create_conversation`/`restore_persisted_session` signature extensions, which are in files the routing PR does not touch.

--- a/Docs/superpowers/plans/2026-09-11-agent-provider-routing.md
+++ b/Docs/superpowers/plans/2026-09-11-agent-provider-routing.md
@@ -1,0 +1,1532 @@
+# Agent Provider Routing Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Let a Console master agent spawn sub-agents onto a specific provider+model (including `custom-ep:` registry endpoints) or a user-configured sub-agent default, with children owning their own sampling/API params.
+
+**Architecture:** A new pure resolver (`Agents/agent_routing.py`) resolves provider → model → base_url → params for every spawn through a four-level routing order and a six-layer params stack, validated through the existing readiness seams. `AgentService.spawn()` calls it before fleet reservation; failures come back as `SpawnAdmissionRefusal` tool errors. The resolved target is snapshotted onto the run row (schema v16) so resume/continuation is stable.
+
+**Tech Stack:** Python 3.11+, Textual 8.x, SQLite (idempotent ALTER migrations), pytest.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md`
+**ADR:** `backlog/decisions/147-agent-provider-routing.md` (amends ADR-146)
+**Task:** TASK-32477
+
+## Global Constraints
+
+- Python ≥ 3.11; type hints on public APIs; Google-style docstrings.
+- All SQL parameterized; schema changes bump `_CURRENT_SCHEMA_VERSION` and add idempotent ALTERs (`DB/AgentRuns_DB.py` pattern).
+- `Agents/agent_service.py` stays the ONLY impure Agents module — new logic goes in pure modules.
+- New `[agents]` config keys ship COMMENTED-OUT in `config.py`; defaults live in `Agents/agent_routing.py` and are read via `_setting` (from `Agents/run_log.py`).
+- Spawn tool args carry identity only: `provider`/`model` strings, NEVER URLs or params.
+- No silent cross-provider fallback: every routing failure is a loud tool error naming the failing level.
+- Frozen dataclasses; params represented as `tuple[tuple[str, object], ...]` (sorted pairs) outside config-parse boundaries.
+- Tests: real SQLite in-memory for DB tests; run targeted pytest only — NEVER the full suite unless the user explicitly opts in (AGENTS.md testing rule).
+- `timeout` command is unavailable in this environment.
+
+---
+
+### Task 1: `Chat/sampling_params.py` — shared param keys, validator, merge helpers
+
+**Files:**
+- Create: `tldw_chatbook/Chat/sampling_params.py`
+- Modify: `tldw_chatbook/Chat/console_session_settings.py:1561-1640` (five private merge helpers move out; call sites keep working via import aliases)
+- Test: `Tests/Chat/test_sampling_params.py` (new)
+
+**Interfaces:**
+- Consumes: nothing (new leaf module; stdlib only).
+- Produces:
+  - `KNOWN_SAMPLING_PARAM_KEYS: frozenset[str]`
+  - `validate_sampling_params(params: Mapping[str, object]) -> list[str]`
+  - `params_to_tuple(params: Mapping[str, object]) -> tuple[tuple[str, object], ...]` (sorted)
+  - `params_to_dict(pairs: tuple[tuple[str, object], ...] | Iterable...) -> dict`
+  - `float_setting_from_sources(sources, key, default)`, `optional_float_setting_from_sources(sources, key)`, `optional_int_setting_from_sources(sources, key)`, `optional_string_setting_from_sources(sources, key)`, `bool_setting_from_sources(sources, key, default)` — moved VERBATIM from `console_session_settings.py:1561-1640`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Chat/test_sampling_params.py
+from tldw_chatbook.Chat.sampling_params import (
+    KNOWN_SAMPLING_PARAM_KEYS,
+    params_to_dict,
+    params_to_tuple,
+    validate_sampling_params,
+)
+
+def test_known_keys_accepted():
+    assert validate_sampling_params(
+        {"temperature": 0.2, "top_k": 40, "reasoning_effort": "low"}
+    ) == []
+
+def test_unknown_key_rejected_as_typo_guard():
+    errors = validate_sampling_params({"temprature": 0.2})
+    assert len(errors) == 1 and "unknown" in errors[0].lower()
+
+def test_bool_rejected_for_numeric_key():
+    # bool IS an int subclass; without an explicit guard `seed: true`
+    # would pass an int check.
+    assert validate_sampling_params({"seed": True}) != []
+
+def test_wrong_type_rejected():
+    assert validate_sampling_params({"temperature": "hot"}) != []
+    assert validate_sampling_params({"max_tokens": 1.5}) != []
+
+def test_streaming_is_not_a_sampling_param():
+    assert "streaming" not in KNOWN_SAMPLING_PARAM_KEYS
+
+def test_params_tuple_round_trip_sorted():
+    pairs = params_to_tuple({"top_p": 0.9, "temperature": 0.2})
+    assert pairs == (("temperature", 0.2), ("top_p", 0.9))
+    assert params_to_dict(pairs) == {"temperature": 0.2, "top_p": 0.9}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_sampling_params.py -v`
+Expected: FAIL (`ModuleNotFoundError: tldw_chatbook.Chat.sampling_params`)
+
+- [ ] **Step 3: Implement `sampling_params.py` and move the helpers**
+
+```python
+# tldw_chatbook/Chat/sampling_params.py
+"""Shared sampling-param keys, validation, and layer-merge helpers (ADR-147).
+
+Single source of truth for the param names a preset, a registry entry, or
+the agent resolver may carry. Transport-level keys (``streaming``) are
+deliberately excluded: child runs keep the run loop's streaming policy.
+"""
+from __future__ import annotations
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+KNOWN_SAMPLING_PARAM_KEYS: frozenset[str] = frozenset({
+    "temperature", "top_p", "min_p", "top_k", "max_tokens", "seed",
+    "presence_penalty", "frequency_penalty",
+    "reasoning_effort", "reasoning_summary", "verbosity",
+    "thinking_effort", "thinking_budget_tokens",
+})
+_FLOAT_KEYS = frozenset({
+    "temperature", "top_p", "min_p", "presence_penalty", "frequency_penalty",
+})
+_INT_KEYS = frozenset({"top_k", "max_tokens", "seed", "thinking_budget_tokens"})
+_STRING_KEYS = frozenset({
+    "reasoning_effort", "reasoning_summary", "verbosity", "thinking_effort",
+})
+
+def validate_sampling_params(params: Mapping[str, Any]) -> list[str]:
+    """Return validation errors for ``params``; empty list means valid."""
+    errors: list[str] = []
+    for key, value in params.items():
+        if key not in KNOWN_SAMPLING_PARAM_KEYS:
+            errors.append(f"unknown sampling param '{key}'")
+            continue
+        if isinstance(value, bool):
+            errors.append(f"'{key}' must not be a boolean")
+        elif key in _FLOAT_KEYS and not isinstance(value, (int, float)):
+            errors.append(f"'{key}' must be a number")
+        elif key in _INT_KEYS and not isinstance(value, int):
+            errors.append(f"'{key}' must be an integer")
+        elif key in _STRING_KEYS and not isinstance(value, str):
+            errors.append(f"'{key}' must be a string")
+    return errors
+
+def params_to_tuple(params: Mapping[str, Any]) -> tuple[tuple[str, Any], ...]:
+    return tuple(sorted(params.items()))
+
+def params_to_dict(pairs: Iterable[tuple[str, Any]]) -> dict[str, Any]:
+    return dict(pairs)
+```
+
+Then MOVE the five `_*_setting_from_sources` helpers from
+`console_session_settings.py:1561-1640` into this module under public names
+(drop the leading underscore), and in `console_session_settings.py` replace
+the moved defs with:
+
+```python
+from tldw_chatbook.Chat.sampling_params import (
+    bool_setting_from_sources as _bool_setting_from_sources,
+    float_setting_from_sources as _float_setting_from_sources,
+    optional_float_setting_from_sources as _optional_float_setting_from_sources,
+    optional_int_setting_from_sources as _optional_int_setting_from_sources,
+    optional_string_setting_from_sources as _optional_string_setting_from_sources,
+)
+```
+
+- [ ] **Step 4: Run new tests + the byte-identical regression**
+
+Run: `pytest Tests/Chat/test_sampling_params.py Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_settings_defaults.py -v`
+Expected: all PASS — the two existing suites green prove the move changed
+no session-default behavior.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/sampling_params.py tldw_chatbook/Chat/console_session_settings.py Tests/Chat/test_sampling_params.py
+git commit -m "feat: shared sampling-param keys/validator + merge helpers (TASK-32477)"
+```
+
+---
+
+### Task 2: Registry entry `params` (amends ADR-146)
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/custom_endpoint_registry.py` (`CustomEndpointEntry`, `_parse_models` area:353, `load_custom_endpoints`:109, `build_entry_mutation`:207, `validate_entry`:237)
+- Test: `Tests/Chat/test_custom_endpoint_registry.py` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 1's `validate_sampling_params`, `params_to_tuple`, `params_to_dict`.
+- Produces: `CustomEndpointEntry.params: tuple[tuple[str, object], ...]` (default `()`), consumed by the resolver (Task 5) and the endpoint modal (Task 9).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# appended to Tests/Chat/test_custom_endpoint_registry.py
+def test_entry_loads_params_table():
+    config = {"custom_endpoints": {"qwen-local": {
+        "display_name": "Qwen Local", "family": "llama_cpp",
+        "base_url": "http://127.0.0.1:8080",
+        "params": {"temperature": 0.2, "top_k": 40},
+    }}}
+    entries = load_custom_endpoints(config)
+    assert entries["qwen-local"].params == (("temperature", 0.2), ("top_k", 40))
+
+def test_entry_without_params_unchanged():
+    config = {"custom_endpoints": {"plain": {
+        "display_name": "Plain", "family": "ollama",
+        "base_url": "http://127.0.0.1:11434",
+    }}}
+    assert load_custom_endpoints(config)["plain"].params == ()
+
+def test_invalid_param_key_drops_entry_with_warning(caplog):
+    config = {"custom_endpoints": {"bad": {
+        "display_name": "Bad", "family": "ollama",
+        "base_url": "http://127.0.0.1:11434",
+        "params": {"temprature": 0.2},
+    }}}
+    with caplog.at_level(logging.WARNING):
+        entries = load_custom_endpoints(config)
+    assert "bad" not in entries
+    assert any("bad" in record.getMessage() for record in caplog.records)
+
+def test_validate_entry_reports_param_errors():
+    errors = validate_entry(
+        "Name", "ollama", "http://127.0.0.1:11434",
+        params={"seed": "not-an-int"},
+    )
+    assert any("seed" in error for error in errors)
+
+def test_entry_mutation_round_trips_params():
+    entry = CustomEndpointEntry(
+        slug="qwen-local", display_name="Qwen Local", family="llama_cpp",
+        base_url="http://127.0.0.1:8080",
+        params=(("temperature", 0.2),),
+    )
+    mutation = build_entry_mutation(entry)
+    assert mutation["custom_endpoints.qwen-local"]["params"] == {
+        "temperature": 0.2,
+    }
+    reloaded = load_custom_endpoints(
+        {"custom_endpoints": {
+            "qwen-local": mutation["custom_endpoints.qwen-local"],
+        }}
+    )
+    assert reloaded["qwen-local"].params == (("temperature", 0.2),)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_custom_endpoint_registry.py -k params -v`
+Expected: FAIL (`TypeError: load_custom_endpoints...` / assertion on missing `.params`)
+
+- [ ] **Step 3: Implement**
+
+- Add field to `CustomEndpointEntry`: `params: tuple[tuple[str, object], ...] = ()` (append after `created_from` so positional constructors keep working).
+- Add `_parse_params(value: object) -> tuple[tuple[str, object], ...]`: non-Mapping → `()`; Mapping → validate via `validate_sampling_params`; any error → raise `ValueError` so `load_custom_endpoints`' existing invalid-entry drop logs the slug and skips.
+- `load_custom_endpoints`: `params=_parse_params(raw.get("params"))`.
+- `build_entry_mutation`: include `"params": params_to_dict(entry.params)` only when non-empty.
+- `validate_entry(display_name, family, base_url, *, params: Mapping | None = None)`: extend the signature and append `validate_sampling_params(params or {})` errors.
+
+- [ ] **Step 4: Run the registry suite**
+
+Run: `pytest Tests/Chat/test_custom_endpoint_registry.py -v`
+Expected: PASS (new + all pre-existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/custom_endpoint_registry.py Tests/Chat/test_custom_endpoint_registry.py
+git commit -m "feat: registry entry params table (ADR-147 amends ADR-146, TASK-32477)"
+```
+
+---
+
+### Task 3: `AgentDefinition` gains `provider` + `params`
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (`AgentDefinition`:358-376, `validate_agent_definition`:379-404, `definition_fingerprint`:407-421, definition dict:417, `definition_from_row`:424-434)
+- Test: `Tests/Agents/test_agent_models.py` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 1's `validate_sampling_params`, `params_to_dict`, `params_to_tuple`.
+- Produces: `AgentDefinition.provider: str`, `AgentDefinition.params: tuple[tuple[str, object], ...]` — consumed by the resolver (Task 5), spawn integration (Task 6), schema builder (Task 7), DB layer (Task 4), settings panel (Task 9).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# appended to Tests/Agents/test_agent_models.py
+def test_definition_provider_and_params_default_empty():
+    defn = AgentDefinition(name="reader", instructions="Read files.")
+    assert defn.provider == "" and defn.params == ()
+    assert validate_agent_definition(defn) == []
+
+def test_definition_rejects_unknown_provider():
+    defn = AgentDefinition(
+        name="reader", instructions="Read files.", provider="not-a-provider"
+    )
+    assert any("provider" in e for e in validate_agent_definition(defn))
+
+def test_definition_accepts_custom_ep_slug_form():
+    defn = AgentDefinition(
+        name="reader", instructions="Read files.", provider="custom-ep:qwen-local"
+    )
+    assert validate_agent_definition(defn) == []
+
+def test_definition_rejects_bad_custom_ep_slug():
+    defn = AgentDefinition(
+        name="reader", instructions="Read files.", provider="custom-ep:BAD SLUG"
+    )
+    assert validate_agent_definition(defn) != []
+
+def test_definition_rejects_unknown_param_key():
+    defn = AgentDefinition(
+        name="reader", instructions="Read files.",
+        params=(("temprature", 0.2),),
+    )
+    assert any("temprature" in e for e in validate_agent_definition(defn))
+
+def test_fingerprint_legacy_shape_unchanged_for_model_only_preset():
+    # provider/params enter the fingerprint ONLY when set, so a legacy
+    # model-only preset keeps its pre-ADR-147 fingerprint (the audit
+    # identity persisted on existing run rows stays comparable).
+    defn = AgentDefinition(name="reader", instructions="Read files.", model="m1")
+    import hashlib, json
+    legacy = hashlib.sha256(json.dumps({
+        "instructions": defn.instructions,
+        "tool_allowlist": sorted(defn.tool_allowlist),
+        "model": defn.model,
+    }, sort_keys=True).encode("utf-8")).hexdigest()[:16]
+    assert definition_fingerprint(defn) == legacy
+
+def test_fingerprint_changes_with_provider():
+    base = AgentDefinition(name="reader", instructions="Read files.", model="m1")
+    routed = AgentDefinition(
+        name="reader", instructions="Read files.", model="m1", provider="ollama"
+    )
+    assert definition_fingerprint(base) != definition_fingerprint(routed)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents/test_agent_models.py -k "provider or params or fingerprint" -v`
+Expected: FAIL (`TypeError: unexpected keyword argument 'provider'`)
+
+- [ ] **Step 3: Implement**
+
+Append two fields AFTER `enabled` (positional-constructor safety):
+
+```python
+    provider: str = ""
+    params: tuple[tuple[str, object], ...] = ()
+```
+
+Update the class docstring: replace the "``model`` overrides the parent's
+model on the SAME provider endpoint" sentence with the ADR-147 semantics
+(model on the preset's `provider`; `model` without `provider` keeps the
+legacy same-endpoint behavior; `params` are the role-owned top layer of the
+child's sampling stack).
+
+In `validate_agent_definition`, append:
+
+```python
+    if defn.provider:
+        if defn.provider.startswith("custom-ep:"):
+            # Lazy: keeps Agents/ -> Chat/ edges out of module import time.
+            from tldw_chatbook.Chat.custom_endpoint_registry import (
+                SLUG_PATTERN,
+                split_custom_endpoint_id,
+            )
+            slug = split_custom_endpoint_id(defn.provider)
+            if slug is None or not SLUG_PATTERN.fullmatch(slug):
+                errors.append("provider custom-ep id has an invalid slug")
+        else:
+            from tldw_chatbook.Chat.console_provider_support import (
+                supported_console_provider_readiness_keys,
+            )
+            from tldw_chatbook.Chat.provider_readiness import provider_config_key
+            if provider_config_key(defn.provider) not in set(
+                supported_console_provider_readiness_keys()
+            ):
+                errors.append(
+                    f"provider '{defn.provider}' is not a known provider id"
+                )
+    errors.extend(validate_sampling_params(params_to_dict(defn.params)))
+```
+
+In `definition_fingerprint`, keep legacy payloads byte-identical unless the
+new fields are set:
+
+```python
+    payload_dict = {
+        "instructions": defn.instructions,
+        "tool_allowlist": sorted(defn.tool_allowlist),
+        "model": defn.model,
+    }
+    if defn.provider:
+        payload_dict["provider"] = defn.provider
+    if defn.params:
+        payload_dict["params"] = [list(pair) for pair in defn.params]
+    payload = json.dumps(payload_dict, sort_keys=True)
+```
+
+In the definition dict (was :417) add `"provider": defn.provider` and
+`"params": params_to_dict(defn.params)`. In `definition_from_row` add
+`provider=row.get("provider", "")` and
+`params=params_to_tuple(row.get("params", {}))` — the DB layer hands over
+`params` already JSON-decoded (same contract as `tool_allowlist`).
+
+- [ ] **Step 4: Run the module suite**
+
+Run: `pytest Tests/Agents/test_agent_models.py -v`
+Expected: PASS (new + all pre-existing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_models.py Tests/Agents/test_agent_models.py
+git commit -m "feat: AgentDefinition provider + params with legacy-stable fingerprint (TASK-32477)"
+```
+
+---
+
+### Task 4: AgentRuns DB schema v16 — preset routing columns + run snapshot
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py` (`_CURRENT_SCHEMA_VERSION`:57, `agent_definitions` DDL:281, idempotent ALTERs:385-424, `create_agent_definition`:1142, `update_agent_definition`:1178, definition row decode, `create_run`:1061-1141)
+- Create: `tldw_chatbook/DB/migrations/agent_runs_v15_to_v16_agent_routing.sql` (repo keeps per-version SQL files, e.g. `agent_runs_v14_to_v15_runtime_owner.sql`)
+- Test: `Tests/DB/test_agent_runs_db.py` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 3's `AgentDefinition.provider/.params`.
+- Produces: `create_run(..., resolved_provider=None, resolved_model=None, resolved_base_url=None, resolved_params_json=None)`; definition rows carry `provider` + `params` (JSON-decoded) — consumed by Task 6 (snapshot write) and Task 8 (snapshot read).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# appended to Tests/DB/test_agent_runs_db.py
+def test_schema_v16_definition_columns(db):
+    cols = {row[1] for row in db._conn.execute(
+        "PRAGMA table_info(agent_definitions)").fetchall()}
+    assert {"provider", "params_json"} <= cols
+
+def test_schema_v16_run_snapshot_columns(db):
+    cols = {row[1] for row in db._conn.execute(
+        "PRAGMA table_info(agent_runs)").fetchall()}
+    assert {"resolved_provider", "resolved_model",
+            "resolved_base_url", "resolved_params_json"} <= cols
+
+def test_definition_round_trip_with_routing(db):
+    defn = AgentDefinition(
+        name="implementer", instructions="Implement the task.",
+        provider="custom-ep:qwen-local", model="qwen3.8-27b",
+        params=(("temperature", 0.2),),
+    )
+    defn_id = db.create_agent_definition(defn)
+    loaded = db.get_agent_definition(defn_id)  # use the existing getter name
+    assert loaded.provider == "custom-ep:qwen-local"
+    assert loaded.params == (("temperature", 0.2),)
+
+def test_definition_legacy_defaults(db):
+    defn = AgentDefinition(name="reader", instructions="Read files.")
+    db.create_agent_definition(defn)
+    loaded = db.get_agent_definition_by_name("reader")  # existing getter name
+    assert loaded.provider == "" and loaded.params == ()
+
+def test_run_snapshot_persists(db, conversation):
+    run_id = db.create_run(
+        conversation_id=conversation, status="running",
+        resolved_provider="custom-ep:qwen-local", resolved_model="qwen3.8-27b",
+        resolved_base_url="http://127.0.0.1:8080",
+        resolved_params_json='{"temperature": 0.2}',
+    )  # shape to the existing create_run signature; kwargs are new
+    row = db.get_run(run_id)
+    assert row["resolved_provider"] == "custom-ep:qwen-local"
+    assert row["resolved_params_json"] == '{"temperature": 0.2}'
+
+def test_run_snapshot_defaults_null(db, conversation):
+    run_id = db.create_run(conversation_id=conversation, status="running")
+    row = db.get_run(run_id)
+    assert row["resolved_provider"] is None
+```
+
+(Fixture names `db` / `conversation` and the getter names `get_agent_definition`
+/ `get_run` are placeholders ONLY in the sense of "match the file's existing
+fixtures/accessors" — open `Tests/DB/test_agent_runs_db.py` and reuse its
+fixtures and the DB class's real method names; do not invent new ones.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/DB/test_agent_runs_db.py -k "v16 or routing or snapshot" -v`
+Expected: FAIL (columns missing / unexpected kwargs)
+
+- [ ] **Step 3: Implement**
+
+- `_CURRENT_SCHEMA_VERSION = 16`.
+- Fresh-table DDL for `agent_definitions` gains
+  `provider TEXT NOT NULL DEFAULT ''` and `params_json TEXT NOT NULL DEFAULT '{}'`.
+- In `_initialize_schema`, after the existing ALTER block (line ~424):
+
+```python
+            # v15->v16 (ADR-147, TASK-32477): preset routing fields on
+            # agent_definitions; resolved-target snapshot on agent_runs.
+            # Same idempotent-ALTER mechanism as every column above.
+            definition_columns = {
+                row[1]
+                for row in conn.execute(
+                    "PRAGMA table_info(agent_definitions)"
+                ).fetchall()
+            }
+            if "provider" not in definition_columns:
+                conn.execute(
+                    "ALTER TABLE agent_definitions ADD COLUMN provider "
+                    "TEXT NOT NULL DEFAULT ''"
+                )
+            if "params_json" not in definition_columns:
+                conn.execute(
+                    "ALTER TABLE agent_definitions ADD COLUMN params_json "
+                    "TEXT NOT NULL DEFAULT '{}'"
+                )
+            for column in (
+                "resolved_provider", "resolved_model",
+                "resolved_base_url", "resolved_params_json",
+            ):
+                if column not in existing_columns:
+                    conn.execute(
+                        f"ALTER TABLE agent_runs ADD COLUMN {column} TEXT"
+                    )
+```
+
+- `DB/migrations/agent_runs_v15_to_v16_agent_routing.sql` carries the same
+  five ALTERs (matching the repo's per-version SQL file pattern).
+- `create_agent_definition` / `update_agent_definition`: INSERT/UPDATE gain
+  `provider` and `params_json` (`json.dumps(params_to_dict(defn.params))`).
+- The definition-row decoder gains `provider=row["provider"]` and
+  `params=json.loads(row["params_json"])` so `definition_from_row` receives
+  them decoded (same contract as `tool_allowlist`).
+- `create_run`: add four keyword-only args defaulting `None`; extend the
+  INSERT column list (was :1121-1134) unconditionally — post-migration the
+  columns always exist.
+
+- [ ] **Step 4: Run the DB suite**
+
+Run: `pytest Tests/DB/test_agent_runs_db.py Tests/Agents/test_agent_runs_db_connection_reuse.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/DB/AgentRuns_DB.py tldw_chatbook/DB/migrations/agent_runs_v15_to_v16_agent_routing.sql Tests/DB/test_agent_runs_db.py
+git commit -m "feat: AgentRuns schema v16 — preset routing + resolved-target snapshot (TASK-32477)"
+```
+
+---
+
+### Task 5: `Agents/agent_routing.py` — the pure resolver + six-layer params
+
+**Files:**
+- Create: `tldw_chatbook/Agents/agent_routing.py`
+- Modify: `tldw_chatbook/Chat/console_session_settings.py` (`build_default_console_session_settings`:509 gains an optional keyword-only `extra_sources`)
+- Test: `Tests/Agents/test_agent_routing.py` (new)
+
+**Interfaces:**
+- Consumes: Task 1 (`Chat/sampling_params.py`), Task 2 (`CustomEndpointEntry.params`), Task 3 (`AgentDefinition.provider/.params`), `load_custom_endpoints` / `entry_for` / `split_custom_endpoint_id` (`Chat/custom_endpoint_registry.py`), `supported_console_provider_readiness_keys` (`Chat/console_provider_support.py:311`), `provider_config_key` / `get_provider_readiness` (`Chat/provider_readiness.py:344,476`), `_setting` (`Agents/run_log.py`).
+- Produces (consumed by Tasks 6-9):
+  - `AgentsRoutingConfig` + `load_agents_routing_config() -> AgentsRoutingConfig`
+  - `RoutingError(Exception)` with `.code: str` and `.level: str`
+  - `SpawnTarget(provider: str, model: str, base_url: str | None, params: tuple[tuple[str, object], ...], source: str)`
+  - `resolve_spawn_target(app_config, *, parent_provider, parent_model, preset=None, override_provider="", override_model="", routing, readiness=None) -> SpawnTarget`
+  - `resolve_child_params(app_config, provider, model, *, preset_params=()) -> tuple[tuple[str, object], ...]`
+  - `allowlist_matches(allowlist, provider, model) -> bool` (public: the settings panel's stale-entry check reuses it)
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Agents/test_agent_routing.py
+from tldw_chatbook.Agents.agent_models import AgentDefinition
+from tldw_chatbook.Agents.agent_routing import (
+    AgentsRoutingConfig, RoutingError, allowlist_matches,
+    load_agents_routing_config, resolve_child_params, resolve_spawn_target,
+)
+
+READY = lambda cfg, provider: None                      # readiness fake: ready
+NOT_READY = lambda cfg, provider: "no API key"          # readiness fake: blocked
+CFG_OFF = AgentsRoutingConfig()                         # everything default
+CFG_ON = AgentsRoutingConfig(
+    spawn_override_enabled=True,
+    spawn_override_allowlist=("llama_cpp", "custom-ep:qwen-local/qwen3.8-*"),
+)
+PRESET = AgentDefinition(
+    name="implementer", instructions="Implement.",
+    provider="custom-ep:qwen-local", model="qwen3.8-27b",
+    params=(("temperature", 0.2),),
+)
+APP_CFG = {
+    "custom_endpoints": {"qwen-local": {
+        "display_name": "Qwen Local", "family": "llama_cpp",
+        "base_url": "http://127.0.0.1:8080",
+        "params": {"top_k": 40},
+    }},
+    "chat_defaults": {"temperature": 0.9},
+    "api_settings": {"llama_cpp": {"model": "llama-3-8b"}},
+}
+
+def test_inherit_parent_when_nothing_configured():
+    t = resolve_spawn_target(APP_CFG, parent_provider="moonshot",
+        parent_model="kimi-k2", routing=CFG_OFF, readiness=READY)
+    assert (t.provider, t.model, t.source) == ("moonshot", "kimi-k2", "inherit")
+    assert t.base_url is None
+
+def test_preset_routes_across_providers():
+    t = resolve_spawn_target(APP_CFG, parent_provider="moonshot",
+        parent_model="kimi-k2", preset=PRESET, routing=CFG_OFF, readiness=READY)
+    assert t.provider == "custom-ep:qwen-local" and t.model == "qwen3.8-27b"
+    assert t.base_url == "http://127.0.0.1:8080" and t.source == "preset"
+
+def test_preset_model_only_keeps_parent_endpoint():
+    legacy = AgentDefinition(name="r", instructions="i", model="qwen3.8-27b")
+    t = resolve_spawn_target(APP_CFG, parent_provider="llama_cpp",
+        parent_model="llama-3-8b", preset=legacy, routing=CFG_OFF, readiness=READY)
+    assert (t.provider, t.model) == ("llama_cpp", "qwen3.8-27b")
+
+def test_subagent_default_used_when_no_preset_or_override():
+    cfg = AgentsRoutingConfig(subagent_default_provider="llama_cpp",
+                              subagent_default_model="qwen3.8-27b")
+    t = resolve_spawn_target(APP_CFG, parent_provider="moonshot",
+        parent_model="kimi-k2", routing=cfg, readiness=READY)
+    assert (t.provider, t.model, t.source) == ("llama_cpp", "qwen3.8-27b", "default")
+
+def test_override_refused_when_disabled():
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            override_provider="llama_cpp", routing=CFG_OFF, readiness=READY)
+        assert False, "expected RoutingError"
+    except RoutingError as e:
+        assert e.code == "override_disabled" and e.level == "override"
+
+def test_override_provider_not_allowlisted():
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            override_provider="openai", routing=CFG_ON, readiness=READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "provider_not_allowlisted"
+
+def test_final_provider_guard_refuses_model_only_onto_paid_default():
+    cfg = AgentsRoutingConfig(spawn_override_enabled=True,
+        spawn_override_allowlist=("llama_cpp",),
+        subagent_default_provider="moonshot", subagent_default_model="kimi-k2")
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="anthropic",
+            parent_model="claude", override_model="kimi-k2-thinking",
+            routing=cfg, readiness=READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "provider_not_allowlisted"
+
+def test_final_provider_guard_allows_model_only_on_parent_provider():
+    t = resolve_spawn_target(APP_CFG, parent_provider="llama_cpp",
+        parent_model="llama-3-8b", override_model="qwen3.8-27b",
+        routing=CFG_ON, readiness=READY)
+    assert (t.provider, t.model) == ("llama_cpp", "qwen3.8-27b")
+
+def test_allowlist_glob_matching():
+    al = ("llama_cpp/qwen3.8-*", "custom-ep:box")
+    assert allowlist_matches(al, "llama_cpp", "Qwen3.8-27B")      # case-insensitive
+    assert not allowlist_matches(al, "llama_cpp", "llama-3-8b")
+    assert allowlist_matches(al, "custom-ep:box", "anything")
+    assert not allowlist_matches(al, "custom-ep:other", "anything")
+
+def test_unknown_endpoint_slug():
+    bad = AgentDefinition(name="r", instructions="i", provider="custom-ep:gone")
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            preset=bad, routing=CFG_OFF, readiness=READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "unknown_endpoint_slug" and e.level == "preset"
+
+def test_unknown_provider():
+    bad = AgentDefinition(name="r", instructions="i", provider="not-a-provider")
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            preset=bad, routing=CFG_OFF, readiness=READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "unknown_provider"
+
+def test_provider_not_ready():
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            preset=PRESET, routing=CFG_OFF, readiness=NOT_READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "provider_not_ready" and "no API key" in str(e)
+
+def test_no_model_resolved_only_when_routed_and_unconfigured():
+    preset = AgentDefinition(name="r", instructions="i", provider="custom-ep:qwen-local")
+    try:
+        resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+            preset=preset, routing=CFG_OFF, readiness=READY)
+        assert False
+    except RoutingError as e:
+        assert e.code == "no_model_resolved"
+    # inherit path with blank parent model never raises:
+    t = resolve_spawn_target(APP_CFG, parent_provider="llama_cpp",
+        parent_model="", routing=CFG_OFF, readiness=READY)
+    assert t.model == ""
+
+def test_builtin_provider_configured_model_fills_blank():
+    preset = AgentDefinition(name="r", instructions="i", provider="llama_cpp")
+    t = resolve_spawn_target(APP_CFG, parent_provider="m", parent_model="k",
+        preset=preset, routing=CFG_OFF, readiness=READY)
+    assert t.model == "llama-3-8b"   # from api_settings.llama_cpp.model
+
+def test_params_precedence_preset_over_entry_over_chat_defaults():
+    t = resolve_spawn_target(APP_CFG, parent_provider="moonshot",
+        parent_model="kimi-k2", preset=PRESET, routing=CFG_OFF, readiness=READY)
+    merged = dict(t.params)
+    assert merged["temperature"] == 0.2    # preset beats chat_defaults 0.9
+    assert merged["top_k"] == 40           # entry params present
+    assert "streaming" not in merged
+
+def test_params_never_come_from_parent():
+    # parent params simply are not an input; resolved params come from the
+    # child's own provider stack.
+    t = resolve_spawn_target(APP_CFG, parent_provider="moonshot",
+        parent_model="kimi-k2", routing=CFG_OFF, readiness=READY)
+    assert dict(t.params)["temperature"] == 0.9   # chat_defaults, not a parent value
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents/test_agent_routing.py -v`
+Expected: FAIL (`ModuleNotFoundError`)
+
+- [ ] **Step 3a: Add `extra_sources` to `build_default_console_session_settings`**
+
+In `console_session_settings.py:509`:
+
+```python
+def build_default_console_session_settings(
+    app_config, provider=None, model=None, *, extra_sources=()
+):
+```
+
+and change the source tuple (was :538) to:
+
+```python
+    default_sources = (model_profile, saved_defaults, *extra_sources, chat_defaults, provider_settings)
+```
+
+Each `extra_sources` entry is a Mapping of param name → value slotting
+between saved defaults and chat_defaults. Default `()` keeps behavior
+byte-identical.
+
+- [ ] **Step 3b: Implement `Agents/agent_routing.py`**
+
+```python
+"""Pure spawn-target routing for sub-agents (ADR-147, TASK-32477).
+
+Resolution order (each level fills only blanks left above): ad-hoc spawn
+args (gated) -> preset fields -> [agents] sub-agent default -> inherit
+parent. Params are NEVER inherited from the parent; they resolve through
+the six-layer stack in resolve_child_params.
+"""
+from __future__ import annotations
+
+import fnmatch
+import logging
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from tldw_chatbook.Agents.agent_models import AgentDefinition
+from tldw_chatbook.Chat.sampling_params import (
+    KNOWN_SAMPLING_PARAM_KEYS, params_to_dict, params_to_tuple,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_SUBAGENT_DEFAULT_PROVIDER = ""
+DEFAULT_SUBAGENT_DEFAULT_MODEL = ""
+DEFAULT_SPAWN_OVERRIDE_ENABLED = False
+DEFAULT_SPAWN_OVERRIDE_ALLOWLIST: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class AgentsRoutingConfig:
+    subagent_default_provider: str = DEFAULT_SUBAGENT_DEFAULT_PROVIDER
+    subagent_default_model: str = DEFAULT_SUBAGENT_DEFAULT_MODEL
+    spawn_override_enabled: bool = DEFAULT_SPAWN_OVERRIDE_ENABLED
+    spawn_override_allowlist: tuple[str, ...] = DEFAULT_SPAWN_OVERRIDE_ALLOWLIST
+
+
+def load_agents_routing_config() -> AgentsRoutingConfig:
+    """Read the [agents] routing keys via the same _setting accessor the
+    other agent keys use (Agents/run_log.py)."""
+    from tldw_chatbook.Agents.run_log import _setting
+
+    raw = _setting("spawn_override_allowlist", DEFAULT_SPAWN_OVERRIDE_ALLOWLIST) or ()
+    if isinstance(raw, str):
+        raw = (raw,)
+    return AgentsRoutingConfig(
+        subagent_default_provider=str(
+            _setting("subagent_default_provider", "") or "").strip(),
+        subagent_default_model=str(
+            _setting("subagent_default_model", "") or "").strip(),
+        spawn_override_enabled=bool(_setting("spawn_override_enabled", False)),
+        spawn_override_allowlist=tuple(
+            str(entry).strip() for entry in raw if str(entry).strip()),
+    )
+
+
+class RoutingError(Exception):
+    """A refused spawn routing. ``code`` is machine-readable; ``level``
+    names the failing resolution level (override / preset / default)."""
+
+    def __init__(self, code: str, message: str, *, level: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.level = level
+
+
+@dataclass(frozen=True)
+class SpawnTarget:
+    provider: str
+    model: str
+    base_url: str | None
+    params: tuple[tuple[str, object], ...]
+    source: str  # "override" | "preset" | "default" | "inherit"
+
+
+def allowlist_matches(allowlist: tuple[str, ...], provider: str, model: str) -> bool:
+    """Bare 'provider' entries match any model; 'provider/glob' entries
+    additionally fnmatch the model (case-insensitive)."""
+    for entry in allowlist:
+        entry_provider, sep, glob = entry.partition("/")
+        if entry_provider != provider:
+            continue
+        if not sep:
+            return True
+        if model and fnmatch.fnmatchcase(model.lower(), glob.lower()):
+            return True
+    return False
+
+
+def _allowlist_covers_provider(allowlist: tuple[str, ...], provider: str) -> bool:
+    return any(entry.partition("/")[0] == provider for entry in allowlist)
+
+
+def _configured_model_for(app_config: Mapping[str, Any], provider: str) -> str:
+    """The provider's configured/default model (mirrors the console
+    selection builder's configured_model lookup); '' when none. Registry
+    entries carry no default model by design (ADR-146)."""
+    from tldw_chatbook.Chat.custom_endpoint_registry import split_custom_endpoint_id
+    from tldw_chatbook.Chat.provider_readiness import provider_config_key
+
+    if split_custom_endpoint_id(provider):
+        return ""
+    api_settings = app_config.get("api_settings")
+    if not isinstance(api_settings, Mapping):
+        return ""
+    section = api_settings.get(provider_config_key(provider))
+    if not isinstance(section, Mapping):
+        return ""
+    for key in ("model", "api_model", "default_model"):
+        value = str(section.get(key) or "").strip()
+        if value:
+            return value
+    return ""
+
+
+def _default_readiness(app_config: Mapping[str, Any], provider: str) -> str | None:
+    """None when the provider may be sent to, else the human-readable block.
+    Wraps get_provider_readiness (Chat/provider_readiness.py:476) — the same
+    readiness the Console send path projects, custom-ep aware per ADR-146."""
+    from tldw_chatbook.Chat.provider_readiness import get_provider_readiness
+
+    readiness = get_provider_readiness(app_config, provider)
+    return None if readiness.ready else readiness.summary
+
+
+def resolve_child_params(
+    app_config: Mapping[str, Any],
+    provider: str,
+    model: str,
+    *,
+    preset_params: tuple[tuple[str, object], ...] = (),
+) -> tuple[tuple[str, object], ...]:
+    """Six-layer stack, highest first: preset params -> per-model profile ->
+    console.provider_defaults -> registry entry params -> chat_defaults ->
+    api_settings scalars -> function fallbacks. Layers 2-6 are merged by
+    build_default_console_session_settings; entry params ride its
+    extra_sources seam; preset params overlay last."""
+    from tldw_chatbook.Chat.console_session_settings import (
+        build_default_console_session_settings,
+    )
+    from tldw_chatbook.Chat.custom_endpoint_registry import (
+        entry_for, split_custom_endpoint_id,
+    )
+
+    entry_params: dict[str, object] = {}
+    if split_custom_endpoint_id(provider):
+        entry = entry_for(app_config, provider)
+        if entry is not None:
+            entry_params = params_to_dict(entry.params)
+    extra = (entry_params,) if entry_params else ()
+    settings = build_default_console_session_settings(
+        app_config, provider, model or None, extra_sources=extra)
+    merged = {
+        key: getattr(settings, key)
+        for key in KNOWN_SAMPLING_PARAM_KEYS
+        if getattr(settings, key, None) is not None
+    }
+    merged.update(params_to_dict(preset_params))
+    return params_to_tuple(merged)
+
+
+def resolve_spawn_target(
+    app_config: Mapping[str, Any],
+    *,
+    parent_provider: str,
+    parent_model: str,
+    preset: AgentDefinition | None = None,
+    override_provider: str = "",
+    override_model: str = "",
+    routing: AgentsRoutingConfig,
+    readiness: Callable[[Mapping[str, Any], str], str | None] | None = None,
+) -> SpawnTarget:
+    """Resolve where a spawned child runs. Raises RoutingError on refusal."""
+    from tldw_chatbook.Chat.console_provider_support import (
+        supported_console_provider_readiness_keys,
+    )
+    from tldw_chatbook.Chat.custom_endpoint_registry import (
+        entry_for, split_custom_endpoint_id,
+    )
+    from tldw_chatbook.Chat.provider_readiness import provider_config_key
+
+    override_provider = (override_provider or "").strip()
+    override_model = (override_model or "").strip()
+    if (override_provider or override_model) and not routing.spawn_override_enabled:
+        raise RoutingError(
+            "override_disabled",
+            "ad-hoc provider/model args are disabled "
+            "([agents] spawn_override_enabled = false)",
+            level="override")
+    if override_provider and not _allowlist_covers_provider(
+            routing.spawn_override_allowlist, override_provider):
+        raise RoutingError(
+            "provider_not_allowlisted",
+            f"provider '{override_provider}' is not in spawn_override_allowlist",
+            level="override")
+
+    if override_provider:
+        provider, source = override_provider, "override"
+    elif preset is not None and preset.provider:
+        provider, source = preset.provider, "preset"
+    elif routing.subagent_default_provider:
+        provider, source = routing.subagent_default_provider, "default"
+    else:
+        provider, source = parent_provider, "inherit"
+
+    model = (
+        override_model
+        or (preset.model if preset is not None else "")
+        or routing.subagent_default_model
+    )
+    if not model and provider == parent_provider:
+        model = parent_model
+    if not model and source != "inherit":
+        model = _configured_model_for(app_config, provider)
+        if not model:
+            raise RoutingError(
+                "no_model_resolved",
+                f"target provider '{provider}' has no configured/default "
+                "model; set one or name a model",
+                level=source)
+
+    if (override_provider or override_model) and provider != parent_provider \
+            and not allowlist_matches(
+                routing.spawn_override_allowlist, provider, model):
+        raise RoutingError(
+            "provider_not_allowlisted",
+            f"final target '{provider}/{model}' matches no allowlist entry",
+            level="override")
+
+    base_url: str | None = None
+    if split_custom_endpoint_id(provider):
+        entry = entry_for(app_config, provider)
+        if entry is None:
+            raise RoutingError(
+                "unknown_endpoint_slug",
+                f"registry has no endpoint '{provider}'",
+                level=source)
+        base_url = entry.base_url
+    elif provider_config_key(provider) not in set(
+            supported_console_provider_readiness_keys()):
+        raise RoutingError(
+            "unknown_provider",
+            f"'{provider}' is not a known provider id",
+            level=source)
+
+    check = readiness if readiness is not None else _default_readiness
+    blocked = check(app_config, provider)
+    if blocked is not None:
+        raise RoutingError("provider_not_ready", blocked, level=source)
+
+    params = resolve_child_params(
+        app_config, provider, model,
+        preset_params=preset.params if preset is not None else ())
+    return SpawnTarget(
+        provider=provider, model=model, base_url=base_url,
+        params=params, source=source)
+```
+
+(If `ProviderReadiness`'s attribute names differ from `.ready`/`.summary`,
+adapt `_default_readiness` to the real type at `provider_readiness.py:476` —
+unit tests always inject `readiness=`, so they never depend on it.)
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest Tests/Agents/test_agent_routing.py Tests/Chat/test_console_session_settings.py Tests/Chat/test_console_settings_defaults.py -v`
+Expected: PASS (existing suites prove `extra_sources=()` changed nothing)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_routing.py tldw_chatbook/Chat/console_session_settings.py Tests/Agents/test_agent_routing.py
+git commit -m "feat: pure spawn-target resolver with six-layer params (TASK-32477)"
+```
+
+---
+
+### Task 6: Spawn integration — resolver hook, child config, snapshot
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_models.py` (`AgentConfig`:449-533 gains two kw-only fields)
+- Modify: `tldw_chatbook/Agents/agent_runtime.py:1450-1499` (spawn dispatch parses `provider`/`model` args)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (spawn closure:3115; child config:3300-3314; child kwargs:3330-3356; `_run_one`:2368; `call_model` send:1753)
+- Test: `Tests/Agents/test_agent_routing_integration.py` (new; reuse the AgentService construction fixtures from `Tests/Agents/test_fleet_runtime.py`)
+
+**Interfaces:**
+- Consumes: Task 4 (`create_run` resolved_* kwargs), Task 5 (`resolve_spawn_target`, `load_agents_routing_config`, `RoutingError`, `SpawnTarget`).
+- Produces: `AgentConfig.base_url: str | None`, `AgentConfig.sampling_params: tuple[tuple[str, object], ...]`; spawn rows carry resolved_* snapshots (read by Task 8).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Agents/test_agent_routing_integration.py
+# Build AgentService exactly as Tests/Agents/test_fleet_runtime.py does,
+# with a capturing stub for self.chat_call.
+
+def test_routed_preset_child_uses_own_provider_and_params(service, ...):
+    # preset 'implementer' -> custom-ep:qwen-local/qwen3.8-27b params temp 0.2
+    result = service.run_turn(..., messages=[{"role":"user","content":"go"}])
+    child_calls = [c for c in service.chat_call.calls
+                   if c["api_endpoint"] == "custom-ep:qwen-local"]
+    assert child_calls, "child never called the routed provider"
+    assert child_calls[0]["model"] == "qwen3.8-27b"
+    assert child_calls[0]["temp"] == 0.2
+    assert child_calls[0]["api_base_url"] == "http://127.0.0.1:8080"
+
+def test_override_refusal_returns_tool_error_and_spawns_nothing(service, ...):
+    # spawn_override_enabled=false; primary's stubbed model emits a
+    # spawn_subagent tool call with provider=llama_cpp
+    ...
+    assert refusal visible in tool results and "[override_disabled]" in it
+    assert no child run row was created
+
+def test_refusal_consumes_no_fleet_slot(service, ...):
+    # after the refused spawn, a subsequent legal spawn still fits the budget
+    ...
+
+def test_run_row_carries_resolved_snapshot(service, db, ...):
+    ...
+    row = db.get_run(child_run_id)
+    assert row["resolved_provider"] == "custom-ep:qwen-local"
+    assert json.loads(row["resolved_params_json"])["temperature"] == 0.2
+
+def test_plain_spawn_snapshot_matches_parent(service, db, ...):
+    # no routing configured: child inherits provider/model and the snapshot
+    # still records them (source=inherit)
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents/test_agent_routing_integration.py -v`
+Expected: FAIL (resolver never called; AgentConfig has no such fields)
+
+- [ ] **Step 3: Implement**
+
+a. `AgentConfig` (`agent_models.py`, after `reasoning_replay`):
+
+```python
+    base_url: str | None = field(default=None, kw_only=True)
+    sampling_params: tuple[tuple[str, object], ...] = field(default=(), kw_only=True)
+```
+
+b. `agent_service.py` module level:
+
+```python
+#: AgentConfig.sampling_params keys -> chat_api_call kwarg names
+#: (signature at Chat/Chat_Functions.py:899-941).
+_CHAT_CALL_PARAM_MAP = {
+    "temperature": "temp", "top_p": "topp", "min_p": "minp", "top_k": "topk",
+    "max_tokens": "max_tokens", "seed": "seed",
+    "presence_penalty": "presence_penalty", "frequency_penalty": "frequency_penalty",
+    "reasoning_effort": "reasoning_effort", "reasoning_summary": "reasoning_summary",
+    "verbosity": "verbosity", "thinking_effort": "thinking_effort",
+    "thinking_budget_tokens": "thinking_budget_tokens",
+}
+```
+
+c. `call_model` (`agent_service.py`), immediately before `resp = self.chat_call(...)`
+(was :1753):
+
+```python
+            for param_key, param_value in config.sampling_params:
+                call_kwargs[_CHAT_CALL_PARAM_MAP[param_key]] = param_value
+            if config.base_url:
+                call_kwargs["api_base_url"] = config.base_url
+```
+
+d. `spawn` closure signature (was :3115) and resolver hook immediately after
+the `resolved` definition lookup completes (before the budget work at
+~:3229):
+
+```python
+        def spawn(
+            spawn_task: str,
+            *,
+            allowed_tools: tuple[str, ...] | None = None,
+            agent: str | None = None,
+            inline: bool = False,
+            provider: str = "",
+            model: str = "",
+        ) -> ToolResult:
+```
+
+```python
+            # ADR-147: resolve WHERE the child runs before touching budget
+            # or fleet capacity. A refusal is an admission refusal: no child
+            # run, no slot consumed, error back to the supervisor model.
+            try:
+                target = resolve_spawn_target(
+                    self._app_config,
+                    parent_provider=api_endpoint,
+                    parent_model=config.model,
+                    preset=resolved,
+                    override_provider=provider,
+                    override_model=model,
+                    routing=load_agents_routing_config(),
+                )
+            except RoutingError as err:
+                return SpawnAdmissionRefusal(
+                    ok=False, error=f"[{err.code}] {err}"
+                )
+```
+
+(`self._app_config`: use the app-config reference the service already holds
+for readiness/gateway wiring; if the service holds none, thread it from the
+constructor's call site in `Chat/console_chat_controller.py`, which builds
+the `ConsoleProviderSelection`.)
+
+e. Child construction: replace `child_model = config.model` /
+`if resolved.model: child_model = resolved.model` (was :3282-3291) with the
+resolved target (the preset `model`-only legacy path is INSIDE the resolver,
+so delete the inline override here), and extend `AgentConfig`/`child_kwargs`:
+
+```python
+            child_model = target.model or config.model
+            child_config = AgentConfig(
+                model=child_model,
+                ...,  # unchanged fields as today
+                base_url=target.base_url,
+                sampling_params=target.params,
+            )
+            child_kwargs = dict(
+                ...,
+                api_endpoint=target.provider,
+                resolved_provider=target.provider,
+                resolved_model=child_model,
+                resolved_base_url=target.base_url,
+                resolved_params_json=(
+                    json.dumps(params_to_dict(target.params)) if target.params else None
+                ),
+            )
+```
+
+f. `_run_one` (was :2368): add four keyword-only args
+(`resolved_provider=None, resolved_model=None, resolved_base_url=None,
+resolved_params_json=None`) and forward them to its `create_run(...)` call.
+
+g. `agent_runtime.py` spawn dispatch (was :1458-1491):
+
+```python
+                        override_provider = str(call.args.get("provider") or "").strip()
+                        override_model = str(call.args.get("model") or "").strip()
+```
+
+and pass both into `deps.spawn(...)` on the named and unnamed branches alike.
+
+- [ ] **Step 4: Run integration + neighboring suites**
+
+Run: `pytest Tests/Agents/test_agent_routing_integration.py Tests/Agents/test_fleet_runtime.py Tests/Agents/test_agent_models.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_models.py tldw_chatbook/Agents/agent_runtime.py tldw_chatbook/Agents/agent_service.py Tests/Agents/test_agent_routing_integration.py
+git commit -m "feat: spawn routing integration — resolver hook, child config, snapshot (TASK-32477)"
+```
+
+---
+
+### Task 7: Spawn schema gating + master visibility
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/tool_catalog.py` (`SPAWN_TOOL_SCHEMA`:66, `build_spawn_schema`:86-125)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (schema build call site :2514)
+- Test: `Tests/Agents/test_tool_catalog.py` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 5's `AgentsRoutingConfig`, `allowlist_matches`; Task 3's `AgentDefinition.provider/.model`.
+- Produces: `build_spawn_schema(definitions, *, override_enabled=False, override_targets: Sequence[tuple[str, tuple[str, ...]]] = ()) -> ToolSchema` — same signature consumed by the Task 6 call site.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+def test_spawn_schema_omits_override_args_when_disabled():
+    schema = build_spawn_schema([PRESET], override_enabled=False)
+    assert "provider" not in schema.parameters["properties"]
+    assert "model" not in schema.parameters["properties"]
+
+def test_spawn_schema_offers_override_args_when_enabled():
+    schema = build_spawn_schema(
+        [PRESET], override_enabled=True,
+        override_targets=(("custom-ep:qwen-local", ("qwen3.8-27b",)),),
+    )
+    props = schema.parameters["properties"]
+    assert props["provider"]["type"] == "string"
+    assert props["model"]["type"] == "string"
+    assert "custom-ep:qwen-local" in props["provider"]["description"]
+    assert "qwen3.8-27b" in props["provider"]["description"]
+
+def test_roster_lines_carry_routing():
+    schema = build_spawn_schema([PRESET])
+    desc = schema.parameters["properties"]["agent"]["description"]
+    assert "implementer" in desc and "custom-ep:qwen-local" in desc
+
+def test_roster_lines_omit_routing_when_unrouted():
+    plain = AgentDefinition(name="reader", instructions="Read.")
+    schema = build_spawn_schema([plain])
+    desc = schema.parameters["properties"]["agent"]["description"]
+    assert "runs on" not in desc
+
+def test_identity_schema_unchanged_with_no_definitions():
+    assert build_spawn_schema([]) is SPAWN_TOOL_SCHEMA
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents -k spawn_schema -v`
+Expected: FAIL (`TypeError: unexpected keyword argument 'override_enabled'`)
+
+- [ ] **Step 3: Implement**
+
+Extend `build_spawn_schema` (`tool_catalog.py:86`):
+
+```python
+def build_spawn_schema(
+    definitions: Sequence[AgentDefinition],
+    *,
+    override_enabled: bool = False,
+    override_targets: Sequence[tuple[str, tuple[str, ...]]] = (),
+) -> ToolSchema:
+```
+
+- Roster lines gain routing when a definition sets `provider` or `model`:
+  `f"- {d.name} — {d.description} (runs on {d.provider or 'parent'} / {d.model or 'default model'})"`
+- When `override_enabled`: add `provider` / `model` optional string
+  properties; the `provider` description enumerates `override_targets` as
+  `provider (models: a, b)` lines; the `model` description notes globs are
+  NOT expanded here — the master picks from the enumerated models.
+- Call site (`agent_service.py:2514`): build `override_targets` from
+  `load_agents_routing_config()` + app config — for each allowlisted
+  provider, its configured model (`api_settings` section) or, for
+  `custom-ep:` entries, `CustomEndpointEntry.models` — and pass
+  `override_enabled`. Keep the `SPAWN_TOOL_SCHEMA` identity return when no
+  definitions AND override disabled (byte-identical pre-ADR-147 payloads).
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest Tests/Agents -k "spawn_schema or first_request_schema" -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/tool_catalog.py tldw_chatbook/Agents/agent_service.py Tests/Agents/
+git commit -m "feat: spawn schema gating + allowlist/roster visibility (TASK-32477)"
+```
+
+---
+
+### Task 8: Resume / continuation reuses the persisted snapshot
+
+**Files:**
+- Modify: `tldw_chatbook/DB/AgentRuns_DB.py` (add `get_run_resolved_target`)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (the continuation branch that re-resolves a retained child's definition — search `resumed_from_run_id` and the fleet retained-transcript continuation)
+- Test: `Tests/Agents/test_fleet_continuation.py` (exists — extend)
+
+**Interfaces:**
+- Consumes: Task 4 snapshot columns; Task 6's spawn wiring.
+- Produces: `AgentRunsDB.get_run_resolved_target(run_id: str) -> dict | None` returning `{"provider", "model", "base_url", "params_json"}` or None for legacy/never-routed rows.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# appended to Tests/Agents/test_fleet_continuation.py
+def test_continuation_reuses_snapshot_after_preset_edit(service, db, ...):
+    # 1. preset 'implementer' routes to custom-ep:qwen-local; run + finish a child
+    # 2. EDIT the preset to provider='ollama'
+    # 3. continue the retained child (send_to_agent)
+    # assert: the continued child's chat_call still went to
+    # custom-ep:qwen-local (snapshot), not ollama (live re-resolution)
+    ...
+
+def test_continuation_legacy_row_reroutes_live(service, db, ...):
+    # simulate a pre-v16 row: UPDATE agent_runs SET resolved_provider = NULL
+    # assert: continuation resolves through resolve_spawn_target as today
+    ...
+
+def test_get_run_resolved_target_none_for_plain_rows(db, conversation):
+    run_id = db.create_run(conversation_id=conversation, status="running")
+    assert db.get_run_resolved_target(run_id) is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Agents/test_fleet_continuation.py -k snapshot -v`
+Expected: FAIL (`AttributeError: get_run_resolved_target`)
+
+- [ ] **Step 3: Implement**
+
+a. `AgentRuns_DB.py`:
+
+```python
+    def get_run_resolved_target(self, run_id: str) -> dict | None:
+        """The v16 resolved-target snapshot for ``run_id``; None for legacy
+        rows (NULL snapshot) so callers fall back to live re-resolution."""
+        row = self._conn.execute(  # match the file's connection accessor
+            "SELECT resolved_provider, resolved_model, resolved_base_url,"
+            " resolved_params_json FROM agent_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+        if row is None or row[0] is None:
+            return None
+        return {
+            "provider": row[0], "model": row[1],
+            "base_url": row[2], "params_json": row[3],
+        }
+```
+
+b. In the continuation spawn path (the branch that re-resolves the retained
+child's `AgentDefinition` by name): first `get_run_resolved_target(prior_run_id)`;
+on a hit, build the child's `api_endpoint` / `AgentConfig.model` /
+`base_url` / `sampling_params` from the snapshot and skip
+`resolve_spawn_target`; on None, fall through to the Task 6 resolver path.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest Tests/Agents/test_fleet_continuation.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/DB/AgentRuns_DB.py tldw_chatbook/Agents/agent_service.py Tests/Agents/test_fleet_continuation.py
+git commit -m "feat: continuation reuses persisted resolved-target snapshot (TASK-32477)"
+```
+
+---
+
+### Task 9: Settings UI — preset routing, defaults, override policy, Test routing
+
+**Files:**
+- Modify: `tldw_chatbook/Widgets/settings_agents_panel.py` (`compose`:57, `_load_bulk_reader_preset`:178, `_save`:221)
+- Modify: `tldw_chatbook/Widgets/Console/console_endpoint_template_modal.py` (params section)
+- Test: `Tests/Widgets/test_settings_agents_panel_routing.py` (new), `Tests/Widgets/test_console_endpoint_template_params.py` (new)
+
+**Interfaces:**
+- Consumes: Task 3 fields, Task 4 DB accessors, Task 5's `resolve_spawn_target` / `load_agents_routing_config` / `allowlist_matches`, Task 2 entry `params`, `save_settings_to_cli_config` (the writer the registry module documents), the Console provider-option builder (`console_session_settings.py`, registry-aware options :402/:457).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# Tests/Widgets/test_settings_agents_panel_routing.py — Textual run_test pilot
+async def test_panel_saves_preset_routing(pilot_env):
+    # set provider Select to custom-ep:qwen-local, model Input, params
+    # TextArea "temperature = 0.2"; save; reload definition from DB
+    assert loaded.provider == "custom-ep:qwen-local"
+    assert loaded.params == (("temperature", 0.2),)
+
+async def test_panel_rejects_bad_param_key_on_save(pilot_env):
+    # params "temprature = 0.2" -> save blocked, error naming the key shown
+    ...
+
+async def test_panel_flags_stale_allowlist_slug(pilot_env):
+    # allowlist contains custom-ep:deleted-slug -> a warning line names it
+    # AND the config value is left untouched
+    ...
+
+async def test_test_routing_reports_readiness(pilot_env, monkeypatch):
+    # one ready preset, one preset targeting a deleted slug -> report lists
+    # the first as ready (provider/model) and the second with
+    # [unknown_endpoint_slug]
+    ...
+
+async def test_allowlist_model_glob_entries_round_trip(pilot_env):
+    # save "llama_cpp/qwen3.8-*" entries; config reload preserves them
+    ...
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Widgets/test_settings_agents_panel_routing.py -v`
+Expected: FAIL (controls do not exist)
+
+- [ ] **Step 3: Implement**
+
+Agents panel (`settings_agents_panel.py`):
+- Preset section: provider `Select` (options from the Console provider-option
+  builder so custom-ep entries appear by `display_name`), model `Input`,
+  params `TextArea` (one `key = value` per line, parsed with
+  `toml`-free splitting on `=`; validated via `validate_sampling_params`;
+  save blocked with the error shown when invalid).
+- Defaults section: sub-agent default provider `Select` (plus an
+  "(inherit parent)" empty option) and model `Input`.
+- Override section: `spawn_override_enabled` `Checkbox`, allowlist
+  `TextArea` (one entry per line; each line must parse as a known provider
+  id or `provider/glob`; deleted `custom-ep:` slugs produce a flagged
+  warning `Static`, never a silent config rewrite).
+- "Test routing" `Button`: for each enabled preset and for the configured
+  default, call `resolve_spawn_target(self.app_config, ...)`; render one
+  line each — `preset name -> provider / model — ready` or
+  `preset name -> [code] message`. No child is spawned; the resolver is pure.
+- `_save` writes presets via `update_agent_definition` and the four
+  `[agents]` keys via `save_settings_to_cli_config("agents", {...})`.
+
+Endpoint modal (`console_endpoint_template_modal.py`): optional params
+`TextArea` (same `key = value` grammar and validator), threaded into
+`build_entry_mutation`; empty means no `params` table.
+
+- [ ] **Step 4: Run tests**
+
+Run: `pytest Tests/Widgets/test_settings_agents_panel_routing.py Tests/Widgets/test_console_endpoint_template_params.py Tests/UI/test_settings_agents_category.py -v`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Widgets/settings_agents_panel.py tldw_chatbook/Widgets/Console/console_endpoint_template_modal.py Tests/Widgets/test_settings_agents_panel_routing.py Tests/Widgets/test_console_endpoint_template_params.py
+git commit -m "feat: settings UI for agent routing + endpoint params (TASK-32477)"
+```
+
+---
+
+### Task 10: Config template + user guide
+
+**Files:**
+- Modify: `tldw_chatbook/config.py` (after the `[agents]` `autowake_enabled` block, :3088)
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md`
+
+- [ ] **Step 1: Insert the commented template block**
+
+```toml
+# --- Sub-agent routing (ADR-147) ---
+# Default provider/model for spawned sub-agents when neither the spawn call
+# nor the named agent preset routes them. Empty = inherit the parent's.
+# subagent_default_provider = ""
+# subagent_default_model = ""
+#
+# Let the supervisor model pass ad-hoc provider/model args to
+# spawn_subagent. Off by default: routing then comes only from presets and
+# the default above. Ad-hoc args never carry URLs or sampling params.
+# spawn_override_enabled = false
+#
+# Ad-hoc targets the supervisor may pick. One entry per list item: a
+# provider id ("llama_cpp", "custom-ep:qwen-local") or "provider/model-glob"
+# ("llama_cpp/qwen3.8-*"). Presets are user-authored and never gated.
+# spawn_override_allowlist = []
+```
+
+- [ ] **Step 2: Add the user-guide section** — new section in
+`agent-runs-and-tools.md`: "Routing sub-agents to other providers/models"
+covering: the four-level resolution order; preset provider/model/params
+fields; the `[agents]` keys; the allowlist glob form; the six-layer params
+stack; the plain-spawn params behavior change; a "route by task shape"
+tiering guide (fast workhorse for recon/mechanical edits; mid-tier for
+routine delegation; deep reasoning only for hard, well-scoped tasks; an
+intent-strong model for ambiguous judgment work); the resume snapshot rule;
+and the "Test routing" button.
+
+- [ ] **Step 3: Verify the config template parses**
+
+Run: `python -c "import toml; toml.load('tldw_chatbook/config.py'.replace('config.py',''))"` — NO; instead: `python -c "import tldw_chatbook.config"` and eyeball the rendered template section. (The template lives inside a Python string in `config.py`; import proves no syntax break.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tldw_chatbook/config.py Docs/User_Guide/console/agent-runs-and-tools.md
+git commit -m "docs: agents routing config template + user guide (TASK-32477)"
+```
+
+---
+
+### Task 11: Live verification (per `backlog/docs/lessons-live-verification.md`)
+
+**Files:** none (evidence only; record findings in the task's Implementation Notes)
+
+- [ ] **Step 1:** Start a real local endpoint (llama.cpp or ollama) serving a small model; register it as `custom-ep:qwen-local` with `params = { temperature = 0.2 }`.
+- [ ] **Step 2:** In Settings → Agents, create preset `implementer` (provider `custom-ep:qwen-local`, model the served id); set the sub-agent default to the same; enable `spawn_override_enabled` with allowlist `["custom-ep:qwen-local/qwen*"]`; run **Test routing** — expect "ready".
+- [ ] **Step 3:** In Console with a cheap cloud model, ask the master to delegate a two-step task to `implementer`; then ask it to spawn ad-hoc onto `openai` — expect a `[provider_not_allowlisted]` tool error visible in the transcript.
+- [ ] **Step 4:** Inspect the child's run row: `resolved_provider = custom-ep:qwen-local`, `resolved_params_json` has `temperature: 0.2`; the run log's request shows the endpoint's params, not the master's.
+- [ ] **Step 5:** Edit the preset to another provider; continue the finished child — it must stay on `custom-ep:qwen-local` (snapshot semantics).
+- [ ] **Step 6:** Record pass/fail + screenshots/log excerpts in TASK-32477 Implementation Notes; then `backlog task edit 32477 -s Done` only after all ACs check.
+
+---
+
+## Self-Review Notes (already applied)
+
+- Spec coverage: every spec section maps to a task — resolver/order (T5),
+  params stack (T1/T5), registry params (T2), AgentDefinition (T3), DB v16
+  (T4), spawn integration + security policy (T6), schema gating/visibility
+  (T7), resume snapshot (T8), settings UI + Test routing (T9), config/docs
+  (T10), live verification (T11).
+- Type consistency: `params` is `tuple[tuple[str, object], ...]` across
+  Tasks 1-6, 8, 9; `params_json` is the JSON object form at the DB
+  boundary; `SpawnTarget` fields match Task 6's consumption.
+- Deferred: preset `fallback_models` (TASK-32479), thinking ceiling,
+  provider-scoped role matrices — all recorded as spec non-goals.

--- a/Docs/superpowers/plans/2026-09-11-console-run-hooks.md
+++ b/Docs/superpowers/plans/2026-09-11-console-run-hooks.md
@@ -1,0 +1,1211 @@
+# Console Run Hooks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Claude Code–style lifecycle hooks for Console chat sessions — user-configured external commands fired at six session/run events, with deny-only guardrails.
+
+**Architecture:** A pure engine module (`Agents/run_hooks.py`) parses `[hooks]` config and executes argv-list subprocesses with a JSON stdin protocol; fire points ride existing seams — the review-hook chain (PreToolUse), a new optional runtime dep mirroring `run_skill_script` (PostToolUse), the submit path (UserPromptSubmit), the approval bridges and run-settle paths (ApprovalRequested, Stop, SubagentStop). The engine is a `ConsoleRuntime`-owned singleton so headless wake runs share it.
+
+**Tech Stack:** Python ≥3.11 stdlib only (`subprocess`, `asyncio.to_thread`, `concurrent.futures`, `threading`) — no new dependencies.
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md` (ADR-148: `backlog/decisions/148-console-run-hooks.md`). The plan argues from the spec — read both.
+
+## Global Constraints
+
+- No new dependencies; stdlib only.
+- Commands are argv lists — never a shell string, never `shell=True`.
+- Deny-only: no hook output can produce an "allow"/"proceed" verdict; hooks only add refusals.
+- Shared budget constant `HOOK_IO_BUDGET_CHARS = 4000` governs every truncation site (payload fields, stdout, stderr); default timeout `HOOK_DEFAULT_TIMEOUT_S = 10.0`.
+- Blocking-event semantics: `PreToolUse` fails CLOSED on any unclean outcome; `UserPromptSubmit` fails OPEN (only an explicit block rejects the send).
+- Event loop safety: nothing on the event loop may call blocking `engine.fire` — `submit_draft` is async on the loop, so that path uses `await engine.fire_async(...)`; the run/review chain runs in threads and uses `engine.fire(...)`.
+- Timeouts kill the whole process group (`start_new_session=True` + `os.killpg`; `taskkill /T` on Windows).
+- Targeted test runs only (AGENTS.md rule): never run the full suite unless the user asks.
+- Commits add ONLY the files named in the step (`git add <paths>` then `git commit`) — this working tree carries unrelated WIP; do not sweep it (repo lesson, see `git log` fix commits).
+- Settings sub-screen is OUT OF SCOPE (next PR); the config schema here is that PR's contract.
+
+---
+
+### Task 1: Engine config model + validation
+
+**Files:**
+- Create: `tldw_chatbook/Agents/run_hooks.py`
+- Test: `Tests/Agents/test_run_hooks.py`
+
+**Interfaces:**
+- Consumes: nothing (first task).
+- Produces: `HOOK_EVENTS`, `TOOL_NAME_EVENTS`, `HookSpec(event, command: tuple[str, ...], matcher: str | None, timeout_s: float)`, `RunHooksConfig(enabled: bool, hooks: tuple[HookSpec, ...])`, `load_hooks_config(config: Mapping) -> RunHooksConfig`, `HOOK_IO_BUDGET_CHARS`, `HOOK_DEFAULT_TIMEOUT_S`. Later tasks import these exact names.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+"""Tests for the Console run-hooks engine (spec: 2026-09-11-console-run-hooks-design)."""
+
+import sys
+
+import pytest
+
+from tldw_chatbook.Agents.run_hooks import (
+    HOOK_DEFAULT_TIMEOUT_S,
+    HOOK_EVENTS,
+    HookSpec,
+    RunHooksConfig,
+    load_hooks_config,
+)
+
+
+def _cfg(enabled=True, **hook_kwargs):
+    base = {"event": "PreToolUse", "command": ["/bin/true"]}
+    base.update(hook_kwargs)
+    return {"hooks": {"enabled": enabled, "hook": [base]} if hook_kwargs or True else None}
+
+
+class TestLoadHooksConfig:
+    def test_empty_section_is_no_op(self):
+        result = load_hooks_config({})
+        assert result == RunHooksConfig(enabled=True, hooks=())
+
+    def test_master_switch_off(self):
+        result = load_hooks_config({"hooks": {"enabled": False}})
+        assert result.enabled is False
+
+    def test_valid_hook_parsed(self):
+        result = load_hooks_config(
+            {"hooks": {"hook": [{"event": "PreToolUse", "matcher": "fs_*",
+                                  "command": ["/bin/guard", "--strict"], "timeout_s": 5}]}}
+        )
+        assert result.hooks == (HookSpec("PreToolUse", ("/bin/guard", "--strict"), "fs_*", 5.0),)
+
+    def test_unknown_event_disables_that_hook(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Nope", "command": ["/bin/true"]}]}})
+        assert result.hooks == ()
+
+    def test_matcher_rejected_on_non_tool_event(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Stop", "matcher": "fs_*",
+                                                         "command": ["/bin/true"]}]}})
+        assert result.hooks == ()
+
+    def test_empty_command_rejected(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Stop", "command": []}]}})
+        assert result.hooks == ()
+
+    def test_non_positive_timeout_rejected(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Stop", "command": ["/bin/true"],
+                                                         "timeout_s": 0}]}})
+        assert result.hooks == ()
+
+    def test_string_command_rejected(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Stop", "command": "/bin/true"}]}})
+        assert result.hooks == ()
+
+    def test_default_timeout_applied(self):
+        result = load_hooks_config({"hooks": {"hook": [{"event": "Stop", "command": ["/bin/true"]}]}})
+        assert result.hooks[0].timeout_s == HOOK_DEFAULT_TIMEOUT_S
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_run_hooks.py -v`
+Expected: collection error — `ModuleNotFoundError`/`ImportError` for `tldw_chatbook.Agents.run_hooks`.
+
+- [ ] **Step 3: Implement the config model**
+
+```python
+# tldw_chatbook/Agents/run_hooks.py
+"""Console run hooks: user-configured external commands on session/run lifecycle events.
+
+Spec: Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md (ADR-148).
+Deny-only guardrails, argv-list commands, JSON-on-stdin protocol, per-purpose
+fail direction (PreToolUse fails closed, UserPromptSubmit fails open).
+"""
+
+from __future__ import annotations
+
+import fnmatch
+from dataclasses import dataclass
+from typing import Mapping
+
+from loguru import logger
+
+HOOK_EVENTS: frozenset[str] = frozenset(
+    {"UserPromptSubmit", "PreToolUse", "PostToolUse", "ApprovalRequested", "Stop", "SubagentStop"}
+)
+TOOL_NAME_EVENTS: frozenset[str] = frozenset({"PreToolUse", "PostToolUse"})
+HOOK_IO_BUDGET_CHARS: int = 4000
+HOOK_DEFAULT_TIMEOUT_S: float = 10.0
+BLOCKING_EVENTS: frozenset[str] = frozenset({"UserPromptSubmit", "PreToolUse"})
+
+
+@dataclass(frozen=True)
+class HookSpec:
+    event: str
+    command: tuple[str, ...]
+    matcher: str | None = None
+    timeout_s: float = HOOK_DEFAULT_TIMEOUT_S
+
+    def matches_tool(self, tool_name: str) -> bool:
+        if self.matcher is None:
+            return True
+        return fnmatch.fnmatchcase(tool_name, self.matcher)
+
+
+@dataclass(frozen=True)
+class RunHooksConfig:
+    enabled: bool = True
+    hooks: tuple[HookSpec, ...] = ()
+
+
+def _parse_hook(raw: object) -> HookSpec | None:
+    if not isinstance(raw, dict):
+        logger.warning("run-hooks: hook entry is not a table; disabled: {!r}", raw)
+        return None
+    event = raw.get("event")
+    if event not in HOOK_EVENTS:
+        logger.warning("run-hooks: unknown event {!r}; hook disabled", event)
+        return None
+    command = raw.get("command")
+    if not isinstance(command, list) or not command or not all(isinstance(a, str) for a in command):
+        logger.warning("run-hooks: command must be a non-empty list of strings; hook disabled")
+        return None
+    matcher = raw.get("matcher")
+    if matcher is not None:
+        if event not in TOOL_NAME_EVENTS:
+            logger.warning("run-hooks: matcher is only valid on {}, got {}; hook disabled",
+                           sorted(TOOL_NAME_EVENTS), event)
+            return None
+        if not isinstance(matcher, str) or not matcher:
+            logger.warning("run-hooks: matcher must be a non-empty string; hook disabled")
+            return None
+    timeout = raw.get("timeout_s", HOOK_DEFAULT_TIMEOUT_S)
+    if not isinstance(timeout, (int, float)) or timeout <= 0:
+        logger.warning("run-hooks: timeout_s must be positive; hook disabled")
+        return None
+    return HookSpec(event=event, command=tuple(command), matcher=matcher, timeout_s=float(timeout))
+
+
+def load_hooks_config(config: Mapping) -> RunHooksConfig:
+    section = config.get("hooks") if isinstance(config, Mapping) else None
+    if not isinstance(section, Mapping):
+        return RunHooksConfig(enabled=True, hooks=())
+    enabled = section.get("enabled", True)
+    hooks = tuple(h for h in (_parse_hook(r) for r in section.get("hook", [])) if h is not None)
+    return RunHooksConfig(enabled=bool(enabled), hooks=hooks)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_run_hooks.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_hooks.py Tests/Agents/test_run_hooks.py
+git commit -m "feat(run-hooks): config model + fail-loud validation for [hooks]"
+```
+
+---
+
+### Task 2: Engine execution core
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/run_hooks.py`
+- Test: `Tests/Agents/test_run_hooks.py`
+
+**Interfaces:**
+- Consumes: Task 1's `HookSpec`, `RunHooksConfig`, `HOOK_IO_BUDGET_CHARS`, `BLOCKING_EVENTS`.
+- Produces: `HookOutcome(blocked: bool, reason: str, context: str)`, `RunHooksEngine(config_provider, cwd_provider)` with `.fire(event, *, session_id, run_id, data) -> HookOutcome`, `async .fire_async(...) -> HookOutcome`, `.notify(event, **same) -> None`. Tasks 5–8 consume these.
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/Agents/test_run_hooks.py`)
+
+```python
+import asyncio
+import json
+import os
+import signal
+import time
+
+from tldw_chatbook.Agents.run_hooks import HookOutcome, RunHooksEngine
+
+
+def _engine(*hooks, enabled=True):
+    cfg = RunHooksConfig(enabled=enabled, hooks=tuple(hooks))
+    return RunHooksEngine(lambda: cfg, lambda: os.getcwd())
+
+
+class TestFire:
+    def test_exit0_clean_pass_logs_stdout(self):
+        eng = _engine(HookSpec("Stop", (sys.executable, "-c", "print('done')")))
+        out = eng.fire("Stop", session_id="s", run_id="r", data={})
+        assert out == HookOutcome(blocked=False, reason="", context="")
+
+    def test_json_decision_beats_exit_code(self):
+        code = "import sys; print(json.dumps({'decision':'deny','reason':'nope'}))" \
+               .replace("json.dumps", "__import__('json').dumps")
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c", code)))
+        out = eng.fire("PreToolUse", session_id="s", data={"tool_name": "fs_write"})
+        assert out.blocked is True and out.reason == "nope"
+
+    def test_exit2_is_deny_shorthand(self):
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c",
+            "import sys; sys.stderr.write('blocked'); sys.exit(2)")))
+        out = eng.fire("PreToolUse", session_id="s", data={"tool_name": "t"})
+        assert out.blocked is True and "blocked" in out.reason
+
+    def test_allow_decision_ignored(self):
+        code = "print(__import__('json').dumps({'decision':'allow'}))"
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c", code)))
+        out = eng.fire("PreToolUse", session_id="s", data={"tool_name": "t"})
+        assert out.blocked is False
+
+    def test_pretooluse_crash_fails_closed(self):
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c", "sys.exit(1)")))
+        out = eng.fire("PreToolUse", session_id="s", data={"tool_name": "t"})
+        assert out.blocked is True and "failed" in out.reason
+
+    def test_userpromptsubmit_crash_fails_open(self):
+        eng = _engine(HookSpec("UserPromptSubmit", (sys.executable, "-c", "sys.exit(1)")))
+        out = eng.fire("UserPromptSubmit", session_id="s", data={"prompt": "hi"})
+        assert out.blocked is False
+
+    def test_userpromptsubmit_stdout_is_context(self):
+        eng = _engine(HookSpec("UserPromptSubmit", (sys.executable, "-c", "print('extra ctx')")))
+        out = eng.fire("UserPromptSubmit", session_id="s", data={"prompt": "hi"})
+        assert out.blocked is False and out.context == "extra ctx"
+
+    def test_userpromptsubmit_block(self):
+        eng = _engine(HookSpec("UserPromptSubmit", (sys.executable, "-c",
+            "print(__import__('json').dumps({'decision':'block','reason':'no'}))")))
+        out = eng.fire("UserPromptSubmit", session_id="s", data={"prompt": "hi"})
+        assert out.blocked is True and out.reason == "no"
+
+    def test_payload_envelope_on_stdin(self):
+        seen = {}
+        code = ("import sys, json; p=json.load(sys.stdin); "
+                "open(%r,'w').write(json.dumps(p))" % "/tmp/hook_payload.json")
+        eng = _engine(HookSpec("Stop", (sys.executable, "-c", code)))
+        eng.fire("Stop", session_id="s1", run_id="r1", data={"status": "completed"})
+        with open("/tmp/hook_payload.json") as fh:
+            seen = json.load(fh)
+        assert seen["hook_event"] == "Stop" and seen["session_id"] == "s1"
+        assert seen["run_id"] == "r1" and seen["data"] == {"status": "completed"}
+        assert "timestamp" in seen and "cwd" in seen
+
+    def test_truncation_to_budget(self):
+        eng = _engine(HookSpec("UserPromptSubmit", (sys.executable, "-c", "print('x'*999999)")))
+        out = eng.fire("UserPromptSubmit", session_id="s", data={"prompt": "hi"})
+        assert len(out.context) <= HOOK_IO_BUDGET_CHARS
+
+    def test_first_deny_wins_across_concurrent_hooks(self):
+        eng = _engine(
+            HookSpec("PreToolUse", (sys.executable, "-c",
+                "import time; time.sleep(0.5); print('late')")),
+            HookSpec("PreToolUse", (sys.executable, "-c", "sys.exit(2)")),
+        )
+        start = time.monotonic()
+        out = eng.fire("PreToolUse", session_id="s", data={"tool_name": "t"})
+        assert out.blocked is True and time.monotonic() - start < 0.45
+
+    def test_master_switch_off_fires_nothing(self):
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c", "sys.exit(2)")), enabled=False)
+        assert eng.fire("PreToolUse", session_id="s", data={}).blocked is False
+
+    def test_engine_never_raises(self):
+        eng = _engine(HookSpec("Stop", ("/nonexistent/hook-binary", "--x")))
+        assert eng.fire("Stop", session_id="s", data={}) == HookOutcome()
+
+
+class TestTimeoutKill:
+    def test_timeout_kills_process_group(self):
+        if sys.platform == "win32":
+            pytest.skip("POSIX process-group test")
+        child_marker = "/tmp/hook_child_alive.txt"
+        code = (
+            "import subprocess, sys, time;"
+            "subprocess.Popen([sys.executable, '-c', "
+            "\"open('%s','w').write('alive'); import time; time.sleep(30)\"]);"
+            "time.sleep(30)" % child_marker
+        )
+        eng = _engine(HookSpec("PreToolUse", (sys.executable, "-c", code), timeout_s=1.0))
+        out = eng.fire("PreToolUse", session_id="s", data={})
+        assert out.blocked is True  # fail-closed on timeout
+        time.sleep(0.4)  # give the orphan-check a moment
+        try:
+            os.remove(child_marker)
+            pytest.fail("hook's child survived the process-group kill")
+        except FileNotFoundError:
+            pass  # marker never written OR child died before writing: group died
+
+
+class TestFireAsync:
+    def test_loop_stays_responsive_while_hook_sleeps(self):
+        eng = _engine(HookSpec("UserPromptSubmit", (sys.executable, "-c",
+            "import time; time.sleep(1)")))
+
+        async def main():
+            ticks = 0
+
+            async def ticker():
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.05)
+                    ticks += 1
+
+            task = asyncio.create_task(ticker())
+            await eng.fire_async("UserPromptSubmit", session_id="s", data={"prompt": "x"})
+            task.cancel()
+            return ticks
+
+        ticks = asyncio.run(main())
+        assert ticks >= 8  # loop kept ticking through the 1s hook
+
+
+class TestNotify:
+    def test_notify_returns_immediately_and_eventually_runs(self):
+        marker = "/tmp/hook_notify_marker.txt"
+        try:
+            os.remove(marker)
+        except FileNotFoundError:
+            pass
+        eng = _engine(HookSpec("PostToolUse", (sys.executable, "-c",
+            "open('%s','w').write('x')" % marker)))
+        eng.notify("PostToolUse", session_id="s", data={"tool_name": "t"})
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and not os.path.exists(marker):
+            time.sleep(0.05)
+        assert os.path.exists(marker)
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_run_hooks.py -v`
+Expected: FAIL — `HookOutcome`/`RunHooksEngine` not importable.
+
+- [ ] **Step 3: Implement the execution core** (append to `run_hooks.py`)
+
+```python
+import asyncio
+import datetime
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import Any, Callable
+
+
+@dataclass(frozen=True)
+class HookOutcome:
+    blocked: bool = False
+    reason: str = ""
+    context: str = ""
+
+
+def _truncate(text: str) -> str:
+    return text if len(text) <= HOOK_IO_BUDGET_CHARS else text[:HOOK_IO_BUDGET_CHARS] + "…[truncated]"
+
+
+@dataclass(frozen=True)
+class _Decision:
+    denied: bool = False
+    reason: str = ""
+    context: str = ""
+
+
+def _decide(event: str, proc: subprocess.CompletedProcess) -> _Decision:
+    stdout, stderr = proc.stdout or "", proc.stderr or ""
+    parsed: dict[str, Any] | None = None
+    try:
+        candidate = json.loads(stdout)
+        parsed = candidate if isinstance(candidate, dict) else None
+    except (ValueError, TypeError):
+        parsed = None
+    decision = (parsed or {}).get("decision")
+    if event == "UserPromptSubmit":
+        if decision == "block" or proc.returncode == 2:
+            reason = str((parsed or {}).get("reason") or stderr or "blocked by hook")
+            return _Decision(denied=True, reason=reason)
+        return _Decision(context=_truncate(stdout.strip()))
+    if event == "PreToolUse":
+        if decision == "deny" or proc.returncode == 2:
+            reason = str((parsed or {}).get("reason") or stderr or "denied by hook")
+            return _Decision(denied=True, reason=reason)
+        if proc.returncode != 0:
+            return _Decision(denied=True, reason=f"hook failed (exit {proc.returncode}); failing closed")
+        return _Decision()
+    return _Decision()
+
+
+def _kill_process_group(proc: subprocess.Popen) -> None:
+    if sys.platform == "win32":
+        subprocess.run(["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                       capture_output=True, check=False)
+    else:
+        try:
+            os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            proc.kill()
+
+
+def _run_hook(spec: HookSpec, payload: dict[str, Any]) -> tuple[HookSpec, _Decision | None]:
+    started = time.monotonic()
+    try:
+        proc = subprocess.Popen(
+            spec.command,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            cwd=payload.get("cwd") or None,
+            start_new_session=(sys.platform != "win32"),
+        )
+    except OSError as exc:
+        logger.warning("run-hooks: failed to start {}: {}", spec.command, exc)
+        return spec, (_Decision(denied=True, reason="hook failed to start; failing closed")
+                      if spec.event == "PreToolUse" else None)
+    try:
+        stdout, stderr = proc.communicate(json.dumps(payload), timeout=spec.timeout_s)
+        completed = subprocess.CompletedProcess(spec.command, proc.returncode,
+                                                stdout=stdout, stderr=stderr)
+        decision = _decide(spec.event, completed)
+    except subprocess.TimeoutExpired:
+        _kill_process_group(proc)
+        proc.communicate()
+        decision = (_Decision(denied=True, reason=f"hook timed out after {spec.timeout_s}s; failing closed")
+                    if spec.event == "PreToolUse" else None)
+    logger.info("run-hooks: event={} hook={} exit={} took_ms={}",
+                spec.event, spec.command[0], proc.returncode,
+                int((time.monotonic() - started) * 1000))
+    return spec, decision
+
+
+class RunHooksEngine:
+    """Executes configured hooks for lifecycle events. Never raises to callers."""
+
+    def __init__(self, config_provider: Callable[[], RunHooksConfig],
+                 cwd_provider: Callable[[], str]) -> None:
+        self._config_provider = config_provider
+        self._cwd_provider = cwd_provider
+        self._pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="run-hook")
+        self._notify_worker = ThreadPoolExecutor(max_workers=1, thread_name_prefix="run-hook-notify")
+
+    def _matching(self, event: str, tool_name: str | None) -> list[HookSpec]:
+        cfg = self._config_provider()
+        if not cfg.enabled:
+            return []
+        return [h for h in cfg.hooks if h.event == event and tool_name is not None
+                and h.matches_tool(tool_name)] or \
+               [h for h in cfg.hooks if h.event == event and tool_name is None]
+
+    def _payload(self, event: str, session_id: str, run_id: str | None, data: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "hook_event": event,
+            "session_id": session_id,
+            "run_id": run_id,
+            "timestamp": datetime.datetime.now(datetime.timezone.utc).isoformat(),
+            "cwd": self._cwd_provider(),
+            "data": data,
+        }
+
+    def fire(self, event: str, *, session_id: str, run_id: str | None = None,
+             data: dict[str, Any] | None = None) -> HookOutcome:
+        tool_name = (data or {}).get("tool_name")
+        specs = self._matching(event, tool_name)
+        if not specs:
+            return HookOutcome()
+        payload = self._payload(event, session_id, run_id, data or {})
+        futures = [self._pool.submit(_run_hook, s, payload) for s in specs]
+        outcome = HookOutcome()
+        for fut, spec in zip(futures, specs):
+            try:
+                _, decision = fut.result()
+            except Exception as exc:  # engine never raises to callers
+                logger.warning("run-hooks: hook {} raised {}", spec.command, exc)
+                decision = _Decision(denied=True, reason="hook raised; failing closed") \
+                    if spec.event == "PreToolUse" else None
+            if decision is None:
+                continue
+            if decision.denied and not outcome.blocked:
+                outcome = HookOutcome(blocked=True, reason=decision.reason)
+            if decision.context and not outcome.context:
+                outcome = HookOutcome(blocked=outcome.blocked, reason=outcome.reason,
+                                      context=decision.context)
+        return outcome
+
+    async def fire_async(self, event: str, **kwargs: Any) -> HookOutcome:
+        return await asyncio.to_thread(self.fire, event, **kwargs)
+
+    def notify(self, event: str, **kwargs: Any) -> None:
+        try:
+            self._notify_worker.submit(self.fire, event, **kwargs)
+        except RuntimeError:  # executor shutdown/queue full — drop, never stall chat
+            logger.warning("run-hooks: notify executor unavailable; {} dropped", event)
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_run_hooks.py -v`
+Expected: all PASS. If `test_timeout_kills_process_group` flakes on the marker race, strengthen the child to write the marker immediately before the parent's sleep, not after.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_hooks.py Tests/Agents/test_run_hooks.py
+git commit -m "feat(run-hooks): subprocess execution core — JSON protocol, deny-only, fail direction, process-group timeout"
+```
+
+---
+
+### Task 3: Review-hook integration (`wrap_review`)
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/run_hooks.py`
+- Test: `Tests/Agents/test_run_hooks.py`
+
+**Interfaces:**
+- Consumes: Task 2's `RunHooksEngine.fire`; `ToolCall(name, args: dict, call_id, raw_arguments)` from `Agents/agent_models.py`.
+- Produces: `RunHooksEngine.wrap_review(inner, *, session_id) -> Callable[[list[ToolCall], str], dict[str, str]]`. Task 6 consumes it. Verdict maps are **name-keyed** (agent_runtime.py:352: "Returns a name -> verdict map"); `"proceed"` or a refusal string.
+
+- [ ] **Step 1: Write the failing tests** (append)
+
+```python
+from tldw_chatbook.Agents.agent_models import ToolCall
+
+
+class TestWrapReview:
+    def _engine_with(self, spec):
+        cfg = RunHooksConfig(enabled=True, hooks=(spec,))
+        return RunHooksEngine(lambda: cfg, lambda: os.getcwd())
+
+    def test_deny_short_circuits_before_inner(self):
+        eng = self._engine_with(HookSpec("PreToolUse", (sys.executable, "-c", "sys.exit(2)"),
+                                         matcher="fs_*"))
+        called = []
+
+        def inner(calls, run_id):
+            called.append([c.name for c in calls])
+            return {c.name: "proceed" for c in calls}
+
+        wrapped = eng.wrap_review(inner, session_id="s")
+        verdicts = wrapped([ToolCall(name="fs_write", args={"path": "x"}),
+                            ToolCall(name="calculator", args={})], "run-1")
+        assert verdicts["fs_write"] != "proceed" and "hook" in verdicts["fs_write"].lower() \
+            or verdicts["fs_write"] == ""  # refusal string per protocol
+        assert verdicts["fs_write"] not in ("proceed",)
+        assert called == [["calculator"]]  # denied call never reaches the permission store
+
+    def test_clean_pass_delegates_to_inner(self):
+        eng = self._engine_with(HookSpec("PreToolUse", (sys.executable, "-c", "pass")))
+
+        def inner(calls, run_id):
+            return {c.name: "proceed" for c in calls}
+
+        wrapped = eng.wrap_review(inner, session_id="s")
+        assert wrapped([ToolCall(name="fs_write", args={})], "run-1") == {"fs_write": "proceed"}
+
+    def test_no_hooks_configured_is_identity(self):
+        eng = _engine()
+
+        def inner(calls, run_id):
+            return {c.name: "proceed" for c in calls}
+
+        assert eng.wrap_review(inner, session_id="s") is inner
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_run_hooks.py::TestWrapReview -v`
+Expected: FAIL — `wrap_review` not defined.
+
+- [ ] **Step 3: Implement `wrap_review`** (method on `RunHooksEngine`)
+
+```python
+    def wrap_review(self, inner: Callable[[list, str], dict[str, str]], *,
+                    session_id: str) -> Callable[[list, str], dict[str, str]]:
+        """Wrap a review_tool_calls callable so PreToolUse hooks deny first.
+
+        Denied names are EXCLUDED from the inner review (no approval card for
+        a call a hook already refused) and merged back as refusal strings.
+        Hooks can never produce "proceed" — deny-only, enforced here.
+        """
+        if not any(h.event == "PreToolUse" for h in self._config_provider().hooks):
+            return inner
+
+        def review(calls: list, run_id: str) -> dict[str, str]:
+            refusals: dict[str, str] = {}
+            surviving = []
+            for call in calls:
+                outcome = self.fire(
+                    "PreToolUse", session_id=session_id, run_id=run_id,
+                    data={"tool_name": call.name, "tool_args": call.args},
+                )
+                if outcome.blocked:
+                    refusals[call.name] = outcome.reason
+                else:
+                    surviving.append(call)
+            verdicts = dict(inner(surviving, run_id)) if surviving else {}
+            verdicts.update(refusals)
+            return verdicts
+
+        return review
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_run_hooks.py -v`
+Expected: all PASS. Clean up the first test's sloppy assertion to a single strict line: `assert verdicts["fs_write"] not in ("proceed",)` and `assert called == [["calculator"]]`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/run_hooks.py Tests/Agents/test_run_hooks.py
+git commit -m "feat(run-hooks): deny-only PreToolUse wrapper around the review verdict chain"
+```
+
+---
+
+### Task 4: Runtime ownership + `[hooks]` config section
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_runtime.py` (beside `ensure_chat_store`, ~line 550; follow its idempotent `ensure_*` pattern)
+- Modify: `tldw_chatbook/config.py` (follow the `coerce_bool_setting` pattern at ~line 1549)
+- Modify: `tldw_chatbook/config.toml.example` (if the example template lives elsewhere, `rg -l "local_tools_enabled" --glob "*.toml*"` finds it)
+- Test: `Tests/Agents/test_run_hooks.py`, `Tests/Chat/test_console_viewless_hooks.py` (append ownership test there — it is the runtime-ownership test home)
+
+**Interfaces:**
+- Consumes: `RunHooksEngine`, `load_hooks_config` (Tasks 1–2); `ensure_console_runtime` (`Chat/console_runtime.py:1087`).
+- Produces: `ConsoleRuntime.ensure_run_hooks() -> RunHooksEngine | None` — returns `None` when no hooks are configured (so every fire site can `if engine is not None`). Tasks 5–8 consume this.
+
+- [ ] **Step 1: Write the failing test** (append to `Tests/Chat/test_console_viewless_hooks.py`)
+
+```python
+def test_ensure_run_hooks_is_idempotent_and_none_without_config():
+    from tldw_chatbook.Chat.console_runtime import ensure_console_runtime
+    runtime = ensure_console_runtime(app=None)  # follow this file's existing fixture style
+    engine1 = runtime.ensure_run_hooks()
+    engine2 = runtime.ensure_run_hooks()
+    assert engine1 is engine2
+    # with an empty config the engine is absent: fire sites skip entirely
+```
+
+(Adapt the `ensure_console_runtime(...)` invocation to however this test module already builds its runtime — read its existing fixtures first and reuse them.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Chat/test_console_viewless_hooks.py -k run_hooks -v`
+Expected: FAIL — `ensure_run_hooks` missing.
+
+- [ ] **Step 3: Implement**
+
+In `console_runtime.py`, inside `class ConsoleRuntime` (beside `ensure_chat_store`):
+
+```python
+    def ensure_run_hooks(self) -> "RunHooksEngine | None":
+        """App-owned hooks engine (spec 2026-09-11). None = no [hooks] configured.
+
+        Idempotent like every ensure_* here: the config provider reads the
+        app's loaded config fresh each call, so config edits apply to the
+        next fire without rebuilding the engine (mtime-cached upstream).
+        """
+        existing = getattr(self, "_run_hooks_engine", _UNSET)
+        if existing is not _UNSET:
+            return existing
+        from tldw_chatbook.Agents.run_hooks import RunHooksEngine, load_hooks_config
+        app_config = getattr(self._app, "config", {}) or {}
+        engine: RunHooksEngine | None = None
+        if load_hooks_config(app_config).hooks:
+            engine = RunHooksEngine(lambda: load_hooks_config(
+                getattr(self._app, "config", {}) or {}),
+                lambda: str(getattr(self._app, "workspace_root", "") or os.getcwd()))
+        self._run_hooks_engine = engine
+        return engine
+```
+
+Add `_UNSET = object()` at module level and `_run_hooks_engine: Any = _UNSET` handling consistent with how this class stores lazily-built objects (mirror `ensure_chat_store`'s attribute pattern; adapt `self._app` to whatever the runtime actually holds — read the class fields first).
+
+In `config.py`, beside the console settings assembly (~line 1549):
+
+```python
+final_console_settings_cli["hooks_enabled"] = coerce_bool_setting(
+    final_console_settings_cli.get("hooks_enabled", True),
+)
+```
+
+— only if hooks need a UI-visible mirror flag; otherwise the engine reads the raw `[hooks]` table directly and `config.py` needs nothing beyond defaults documentation. Prefer the latter (no `config.py` change) if the loaded config object already exposes raw sections to the runtime; verify with `rg -n "def get_console_settings|raw_sections|self\\._config" tldw_chatbook/config.py | head` and pick the existing raw-section accessor.
+
+Append to the example config template (beside `local_tools_enabled`, ~line 2953):
+
+```toml
+[hooks]
+enabled = true
+# [[hooks.hook]] entries: event / matcher / command / timeout_s
+# event: UserPromptSubmit | PreToolUse | PostToolUse | ApprovalRequested | Stop | SubagentStop
+# matcher: tool-name glob, valid only on PreToolUse/PostToolUse
+# command: argv list, no shell — e.g. ["/usr/local/bin/guard.sh", "--strict"]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Chat/test_console_viewless_hooks.py -k run_hooks Tests/Agents/test_run_hooks.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_runtime.py tldw_chatbook/config.py tldw_chatbook/config.toml.example Tests/Chat/test_console_viewless_hooks.py
+git commit -m "feat(run-hooks): ConsoleRuntime-owned engine singleton + [hooks] config surface"
+```
+
+---
+
+### Task 5: `post_tool_call` runtime dep (PostToolUse fire point)
+
+**Files:**
+- Modify: `tldw_chatbook/Agents/agent_runtime.py` (dep field beside `run_skill_script` ~line 391; fire point in the dispatch loop immediately after BOTH `_emit_record(... "tool_result" ...)` calls, ~lines 1724–1742, using the still-full `content`, guarded by `verdict == "proceed"`)
+- Modify: `tldw_chatbook/Agents/agent_service.py` (ctor param beside `run_skill_script_tool` ~line 1045; storage ~line 1151; deps wiring beside `run_skill_script=self._run_skill_script_tool` ~line 4701)
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (pass `post_tool_call=` at the `AgentService(` construction — `rg -n "AgentService\(" tldw_chatbook/Chat/console_agent_bridge.py`)
+- Test: `Tests/Agents/test_run_hooks.py` (dep contract), `Tests/Agents/test_agent_runtime_review_hook.py` (append fire-point test — it is the runtime dispatch test home)
+
+**Interfaces:**
+- Consumes: `ensure_run_hooks()` (Task 4); `ToolCall(name, args, call_id)`.
+- Produces: `AgentDeps.post_tool_call: Callable[[str, str, dict, str, bool], None] | None` — `(tool_name, call_id, args, result_content, ok)`; fires only on dispatched calls; engine truncates content. `RunHooksEngine.post_tool_dep(*, session_id) -> Callable[...]` helper.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/Agents/test_run_hooks.py` (append):
+
+```python
+class TestPostToolDep:
+    def test_dep_fires_notify_with_full_payload(self):
+        fired = []
+        eng = _engine(HookSpec("PostToolUse", (sys.executable, "-c", "pass")))
+        dep = eng.post_tool_dep(session_id="s")
+        # intercept notify to observe without racing the executor
+        eng.notify = lambda event, **kw: fired.append((event, kw))
+        dep("fs_write", "call-1", {"path": "x"}, "full result " * 1000, True)
+        event, kw = fired[0]
+        assert event == "PostToolUse"
+        assert kw["data"]["tool_name"] == "fs_write"
+        assert len(kw["data"]["tool_result"]) <= HOOK_IO_BUDGET_CHARS
+        assert kw["data"]["is_error"] is False
+```
+
+In `Tests/Agents/test_agent_runtime_review_hook.py` (append, reusing this module's existing dispatch-loop test fixtures — read them first):
+
+```python
+def test_post_tool_call_dep_fires_only_on_dispatched_calls():
+    """Refused calls fire nothing; dispatched calls carry name/call_id/args/content."""
+    fired = []
+    # Build the module's existing minimal run harness; set deps.post_tool_call = fired.append
+    # and deps.review_tool_calls to refuse one call and proceed another.
+    # Assert: exactly one firing, for the proceeded call, content == full result.
+```
+
+— then concretize it against the harness: if this module's fixtures drive `_run_one` directly, wire `post_tool_call` into its `LoopDeps`; if they go through `AgentService`, add the ctor param first and assert through one level. Do not leave the test as a sketch — write the real body using the fixtures you find.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Agents/test_run_hooks.py::TestPostToolDep Tests/Agents/test_agent_runtime_review_hook.py -v`
+Expected: FAIL — `post_tool_dep` missing.
+
+- [ ] **Step 3: Implement**
+
+`run_hooks.py` (method on `RunHooksEngine`):
+
+```python
+    def post_tool_dep(self, *, session_id: str) -> Callable[[str, str, dict, str, bool], None]:
+        def post_tool_call(tool_name: str, call_id: str, args: dict,
+                           content: str, ok: bool) -> None:
+            self.notify("PostToolUse", session_id=session_id,
+                        data={"tool_name": tool_name, "tool_args": args,
+                              "tool_result": _truncate(content),
+                              "is_error": not ok})
+        return post_tool_call
+```
+
+`agent_runtime.py` — in the `LoopDeps`/deps dataclass beside `run_skill_script`:
+
+```python
+    # run-hooks PostToolUse: fired at the dispatch capture point, ONLY for
+    # calls that actually dispatched (verdict == "proceed") — refusals fire
+    # nothing. Receives the still-UNCAPPED content; the engine truncates.
+    post_tool_call: Callable[[str, str, dict, str, bool], None] | None = None
+```
+
+In the dispatch loop, immediately after each `_emit_record(..., "tool_result", ...)` call (both the continuation-checkpoint branch — where the full text is `full_content` — and the plain branch — where `content` is still full), add:
+
+```python
+            if deps.post_tool_call is not None and verdict == "proceed":
+                try:
+                    deps.post_tool_call(call.name, call.call_id, call.args,
+                                        full_content, result.ok)
+                except Exception as exc:
+                    logger.warning("post_tool_call consumer raised (exception_type={})", type(exc).__name__)
+```
+
+(use `content` instead of `full_content` in the plain branch).
+
+`agent_service.py` — ctor param beside `run_skill_script_tool`:
+
+```python
+        post_tool_call: Callable[[str, str, dict, str, bool], None] | None = None,
+```
+
+storage beside `self._run_skill_script_tool = run_skill_script_tool`:
+
+```python
+        self._post_tool_call = post_tool_call
+```
+
+deps wiring beside `run_skill_script=self._run_skill_script_tool`:
+
+```python
+            post_tool_call=self._post_tool_call,
+```
+
+`console_agent_bridge.py` — at the `AgentService(` construction, add:
+
+```python
+            post_tool_call=(
+                engine.post_tool_dep(session_id=session_id)
+                if (engine := runtime.ensure_run_hooks()) is not None
+                else None
+            ),
+```
+
+adapting `runtime`/`session_id` to the names in scope at that construction site.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Agents/test_run_hooks.py Tests/Agents/test_agent_runtime_review_hook.py Tests/Agents/test_fleet_continuation.py -v`
+Expected: all PASS (`test_fleet_continuation.py` guards the deps shape changes).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Agents/agent_runtime.py tldw_chatbook/Agents/agent_service.py tldw_chatbook/Chat/console_agent_bridge.py Tests/Agents/test_run_hooks.py Tests/Agents/test_agent_runtime_review_hook.py
+git commit -m "feat(run-hooks): post_tool_call runtime dep fires PostToolUse at the capture point"
+```
+
+---
+
+### Task 6: PreToolUse wiring in the bridge
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (where the run's review callable is built from `build_tool_review_hook` — `rg -n "build_tool_review_hook|review_tool_calls=" tldw_chatbook/Chat/console_agent_bridge.py`)
+- Test: `Tests/Chat/test_console_local_review_hook.py` (append — it is the review-hook integration home)
+
+**Interfaces:**
+- Consumes: `ensure_run_hooks()` (Task 4), `wrap_review` (Task 3).
+- Produces: every run's `review_tool_calls` passes through `engine.wrap_review(...)` when hooks exist.
+
+- [ ] **Step 1: Write the failing test** (append to `Tests/Chat/test_console_local_review_hook.py`, reusing its `ConsoleChatController` fixtures)
+
+```python
+def test_pretooluse_hook_denies_before_permission_store(tmp_path):
+    """A configured exit-2 PreToolUse hook denies the matched call and the
+    approval round never carries it (deny-only, spec §5)."""
+    import sys as _sys
+    from tldw_chatbook.Agents.run_hooks import HookSpec, RunHooksConfig, RunHooksEngine
+
+    engine = RunHooksEngine(
+        lambda: RunHooksConfig(enabled=True, hooks=(
+            HookSpec("PreToolUse", (_sys.executable, "-c", "sys.exit(2)"), matcher="fs_*"),)),
+        lambda: str(tmp_path))
+    # Follow this module's existing pattern for building a controller + calls;
+    # wrap its review callable: wrapped = engine.wrap_review(inner, session_id=SESSION)
+    # Assert: fs_* call's verdict != "proceed"; non-matching call proceeds.
+```
+
+Concretize using the module's existing `build_combined_review_hook`/controller fixture pattern — write the real body; the assertion set is `verdicts["<fs tool>"] != "proceed"` and `verdicts["<other tool>"] == "proceed"`.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Chat/test_console_local_review_hook.py -k pretooluse -v`
+Expected: FAIL (test body asserts on wiring that does not exist yet — once concretized it fails because the bridge does not wrap).
+
+Note: this test exercises `wrap_review` directly (unit-level); the bridge wiring is asserted in Task 8's sweep.
+
+- [ ] **Step 3: Implement the bridge wiring**
+
+At the review-callable construction site in `console_agent_bridge.py`:
+
+```python
+        review_callable = build_tool_review_hook(...)  # existing call, unchanged
+        engine = runtime.ensure_run_hooks()
+        if engine is not None:
+            review_callable = engine.wrap_review(review_callable, session_id=session_id)
+```
+
+adapting variable names to the site (it may be an inline kwarg — in that case bind it to a local first, wrap, then pass).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Chat/test_console_local_review_hook.py Tests/Chat/test_console_provider_gateway.py Tests/Agents/test_agent_runtime_review_hook.py -v`
+Expected: all PASS (the gateway tests guard the review chain end to end).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_agent_bridge.py Tests/Chat/test_console_local_review_hook.py
+git commit -m "feat(run-hooks): bridge wraps the run review chain with PreToolUse hooks"
+```
+
+---
+
+### Task 7: UserPromptSubmit in the submit path
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/message_metadata.py` (beside `MESSAGE_ORIGIN_AGENT_WAKE` line 58 and `MESSAGE_ORIGINS` line 74)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (submit path; anchor: the wake-guarded `_record_prompt_history` call at ~line 3813–3817)
+- Test: `Tests/Chat/test_console_chat_controller.py` (append — the submit-path test home)
+
+**Interfaces:**
+- Consumes: `ensure_run_hooks()` (Task 4 — reach it via the controller's runtime reference; check how the controller accesses `ConsoleRuntime`), `fire_async` (Task 2), `ConsoleSubmitResult(accepted, should_clear_draft, visible_copy)`.
+- Produces: `MESSAGE_ORIGIN_HOOK = "hook"`; hooks block sends (refusal result + SYSTEM row) or inject context (SYSTEM row carrying hook origin, persisted, visible — never merged into the user's message).
+
+- [ ] **Step 1: Write the failing tests** (append to `Tests/Chat/test_console_chat_controller.py`, reusing its submit fixtures — read them first and reuse the existing draft/controller harness)
+
+```python
+class TestUserPromptSubmitHooks:
+    def test_block_rejects_send_without_assistant_row(self):
+        # engine configured with an exit-2 UserPromptSubmit hook; submit_draft
+        # returns accepted=False, should_clear_draft=False, reason in visible_copy;
+        # no ASSISTANT row appended.
+        ...
+
+    def test_stdout_injected_as_hook_origin_system_row(self):
+        # engine whose hook prints "ctx"; submit proceeds; a SYSTEM row with
+        # metadata origin == MESSAGE_ORIGIN_HOOK and content "ctx" exists,
+        # persisted, after the user row and before the assistant row.
+        ...
+
+    def test_wake_notice_fires_nothing(self):
+        # origin=AGENT_WAKE submit never invokes the engine (wake invariant).
+        ...
+
+    def test_hook_crash_send_proceeds(self):
+        # exit-1 hook: send proceeds, no SYSTEM row, warning logged.
+        ...
+```
+
+Write the four bodies against the module's existing submit harness (`rg -n "async def test.*submit" Tests/Chat/test_console_chat_controller.py | head` shows the pattern to copy); the engine is injected by patching the controller's runtime `ensure_run_hooks` to return a `RunHooksEngine` built over a temp config.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Chat/test_console_chat_controller.py -k UserPromptSubmitHooks -v`
+Expected: FAIL — constant missing / no firing.
+
+- [ ] **Step 3: Implement**
+
+`message_metadata.py`:
+
+```python
+MESSAGE_ORIGIN_HOOK = "hook"
+```
+
+and extend `MESSAGE_ORIGINS` to `frozenset({"", MESSAGE_ORIGIN_AGENT_WAKE, MESSAGE_ORIGIN_HOOK})` (grep for tests asserting that set's contents — `rg -n "MESSAGE_ORIGINS" Tests/` — and update them in the same commit).
+
+`console_chat_controller.py`, in `_submit_draft_inner` immediately AFTER the wake-guarded `_record_prompt_history` block (both share the manual-origin condition):
+
+```python
+        # Run hooks (spec 2026-09-11): manual-origin sends only — a wake
+        # notice is machine text and never fires UserPromptSubmit.
+        if origin is not ConsoleSubmissionOrigin.AGENT_WAKE:
+            hooks_engine = self._run_hooks_engine()  # returns None when unconfigured
+            if hooks_engine is not None:
+                outcome = await hooks_engine.fire_async(
+                    "UserPromptSubmit", session_id=session.id,
+                    data={"prompt": _truncate(clean_draft)})
+                if outcome.blocked:
+                    self.store.append_message(
+                        session.id, role=ConsoleMessageRole.SYSTEM,
+                        content=f"Send blocked by hook: {outcome.reason}",
+                        persist=self.store.persistence is not None,
+                        metadata=MessageMetadata(origin=MESSAGE_ORIGIN_HOOK))
+                    return ConsoleSubmitResult(accepted=False, should_clear_draft=False,
+                                               visible_copy=f"Blocked by hook: {outcome.reason}")
+                if outcome.context:
+                    self.store.append_message(
+                        session.id, role=ConsoleMessageRole.SYSTEM,
+                        content=outcome.context,
+                        persist=self.store.persistence is not None,
+                        metadata=MessageMetadata(origin=MESSAGE_ORIGIN_HOOK))
+```
+
+Add the small accessor on the controller (it must work viewless — headless wake shares this code path):
+
+```python
+    def _run_hooks_engine(self):
+        runtime = getattr(self, "_runtime_ref", None)
+        return runtime.ensure_run_hooks() if runtime is not None else None
+```
+
+— adapt `_runtime_ref` to how the controller actually reaches `ConsoleRuntime` (`rg -n "console_runtime|ensure_console_runtime" tldw_chatbook/Chat/console_chat_controller.py | head`); if it holds no reference today, thread one through its constructor the way other app-owned services reach it, keeping the parameter optional (default `None`) so existing tests construct unchanged.
+
+Note `MESSAGE_ORIGIN_HOOK` must be imported where `MESSAGE_ORIGIN_AGENT_WAKE` already is.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_headless_wake_invariants.py -v`
+Expected: all PASS (the headless-wake invariants guard the wake-never-fires rule).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/message_metadata.py tldw_chatbook/Chat/console_chat_controller.py Tests/Chat/test_console_chat_controller.py
+git commit -m "feat(run-hooks): UserPromptSubmit — block/inject on manual sends, wake exempt"
+```
+
+---
+
+### Task 8: Stop, SubagentStop, ApprovalRequested fire points
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` (approval round site — anchor: `request_mcp_approvals`, where `add_pending_round` registers the round before consulting the bridge slots, ~lines 4100–4140)
+- Modify: `tldw_chatbook/Chat/console_agent_bridge.py` (run terminal state — anchor: the once-guarded branches that invoke `notify_run_outcome`/`notify_run_failure`, `rg -n "notify_run_outcome|notify_run_failure" tldw_chatbook/Chat/console_agent_bridge.py tldw_chatbook/Chat/console_chat_controller.py`; child settle — the `on_child_settled=functools.partial(...)` at ~line 4211)
+- Test: `Tests/Agents/test_fleet_send_to_agent.py` (settle path), `Tests/Chat/test_console_fleet_wake.py` (headless), `Tests/Chat/test_console_local_review_hook.py` (approval path)
+
+**Interfaces:**
+- Consumes: `ensure_run_hooks()` (Task 4), `engine.notify` (Task 2).
+- Produces: complete six-event firing per the spec's event table.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `Tests/Chat/test_console_local_review_hook.py` (approval round):
+
+```python
+def test_approval_requested_fires_with_round_payload():
+    # Patch the controller's engine accessor with a recording fake;
+    # drive one ask-state call through request_mcp_approvals;
+    # assert engine.notify was called once with event="ApprovalRequested",
+    # data carrying the call name and session_active=True.
+```
+
+In `Tests/Agents/test_fleet_send_to_agent.py` (child settle):
+
+```python
+def test_subagent_stop_fires_on_child_settle():
+    # Recording fake engine on the bridge; drive a child run to settle;
+    # assert notify("SubagentStop", data={"child_run_id": ..., "status": ...}).
+```
+
+In `Tests/Chat/test_console_fleet_wake.py` (headless Stop):
+
+```python
+def test_stop_fires_for_wake_run_terminal_state():
+    # Recording fake engine; headless wake run reaches terminal state;
+    # assert notify("Stop", data={"status": ...}) fired despite no view.
+```
+
+Concretize all three against each module's existing fixtures (they exist precisely for these paths); each asserts a single `notify` call with the exact event name and payload keys.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `pytest Tests/Chat/test_console_local_review_hook.py Tests/Agents/test_fleet_send_to_agent.py Tests/Chat/test_console_fleet_wake.py -v`
+Expected: new tests FAIL (no firing yet).
+
+- [ ] **Step 3: Implement the three fire sites**
+
+Approval (controller, in `request_mcp_approvals`, immediately after the round is registered — after `add_pending_round`, before the bridge slots are consulted):
+
+```python
+            if (engine := self._run_hooks_engine()) is not None:
+                engine.notify("ApprovalRequested", session_id=session_id,
+                              data={"calls": [{"name": c.name} for c in pending_calls],
+                                    "session_active": True})
+```
+
+(adapt `pending_calls` to the local variable holding the round's `MCPPendingCall` list; the parked/background round site — the `park_pending_approval` consumer, ~line 4637's territory — fires the same event with `session_active=False`. Find it with `rg -n "park_pending_approval\\(" tldw_chatbook/Chat/console_chat_controller.py` and mirror.)
+
+Stop (bridge, beside BOTH once-guarded terminal branches that invoke `notify_run_outcome` / `notify_run_failure`):
+
+```python
+            if (engine := runtime.ensure_run_hooks()) is not None:
+                engine.notify("Stop", session_id=session_id,
+                              run_id=run_id,
+                              data={"status": "error" if failed else "completed"})
+```
+
+SubagentStop (bridge, in the `on_child_settled` wiring at ~4211 — wrap, don't replace, the existing partial):
+
+```python
+            _settled = functools.partial(
+                self._on_fleet_child_settled,
+                conversation_id, session_id, assistant_message_id,
+            )
+
+            def on_child_settled(child_run_id, status, *, _inner=_settled, _sid=session_id):
+                if (engine := runtime.ensure_run_hooks()) is not None:
+                    engine.notify("SubagentStop", session_id=_sid, run_id=child_run_id,
+                                  data={"child_run_id": child_run_id, "status": status})
+                _inner(child_run_id, status)
+```
+
+and pass `on_child_settled=on_child_settled` at the original site (adapt `runtime` to the bridge's runtime accessor).
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `pytest Tests/Chat/test_console_local_review_hook.py Tests/Agents/test_fleet_send_to_agent.py Tests/Chat/test_console_fleet_wake.py Tests/Chat/test_console_fleet_wake_safety.py Tests/Chat/test_fleet_settle_fanout.py -v`
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_controller.py tldw_chatbook/Chat/console_agent_bridge.py Tests/Chat/test_console_local_review_hook.py Tests/Agents/test_fleet_send_to_agent.py Tests/Chat/test_console_fleet_wake.py
+git commit -m "feat(run-hooks): Stop / SubagentStop / ApprovalRequested fire points"
+```
+
+---
+
+### Task 9: Docs + final integration sweep
+
+**Files:**
+- Modify: `Docs/User_Guide/console/agent-runs-and-tools.md` (new "Run hooks" section)
+- Modify: `CLAUDE.md` / `AGENTS.md` special-systems note (one paragraph beside the Tool Calling section)
+- Modify: `Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md` (status → Implemented, note the loguru execution-log mapping)
+- Test: no new tests — this task runs the accumulated targeted sweep
+
+**Interfaces:**
+- Consumes: everything above.
+- Produces: documentation; the ADR-check already exists (ADR-148, linked from spec and plan).
+
+- [ ] **Step 1: Write the user-guide section**
+
+In `Docs/User_Guide/console/agent-runs-and-tools.md`, add a section covering: the six events with one-line payload descriptions; the `[hooks]` config example copied verbatim from the spec's §6; the verdict rules table (deny-only, fail directions); the security notes (user-scope only, argv-only, timeouts, run-log visibility); and a pointer that a settings sub-screen lands in the next PR.
+
+- [ ] **Step 2: Add the one-paragraph special-systems note to `CLAUDE.md`/`AGENTS.md`**
+
+Beside the existing Tool Calling subsection:
+
+```markdown
+### Console Run Hooks
+- User-configured external commands at six lifecycle events (UserPromptSubmit, PreToolUse, PostToolUse, ApprovalRequested, Stop, SubagentStop); config: `[hooks]` in config.toml (ADR-148).
+- Deny-only: hooks can refuse tool calls but never bypass the permission store; PreToolUse fails closed, UserPromptSubmit fails open; argv-list commands only, process-group timeout kill.
+```
+
+- [ ] **Step 3: Run the accumulated targeted sweep**
+
+Run: `pytest Tests/Agents/test_run_hooks.py Tests/Agents/test_agent_runtime_review_hook.py Tests/Agents/test_fleet_continuation.py Tests/Agents/test_fleet_send_to_agent.py Tests/Chat/test_console_viewless_hooks.py Tests/Chat/test_console_local_review_hook.py Tests/Chat/test_console_chat_controller.py Tests/Chat/test_console_headless_wake_invariants.py Tests/Chat/test_console_fleet_wake.py Tests/Chat/test_console_fleet_wake_safety.py Tests/Chat/test_fleet_settle_fanout.py Tests/Chat/test_console_provider_gateway.py -v`
+Expected: all PASS. (Full suite only if the user asks — AGENTS.md rule.)
+
+- [ ] **Step 4: Update the spec status and Implementation Notes**
+
+Set the spec's Status line to `Implemented`. Then per AGENTS.md backlog flow: create the backlog task (`backlog task create "Console run hooks" ...`), mark ACs from the spec, add Implementation Notes, link ADR-148, set Done only when the DoD checklist is complete.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Docs/User_Guide/console/agent-runs-and-tools.md CLAUDE.md AGENTS.md Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
+git commit -m "docs(run-hooks): user guide + special-systems notes for Console run hooks"
+```
+
+---
+
+## Self-Review (performed after writing)
+
+1. **Spec coverage:** §3 events → Tasks 5–8 (all six wired); §4 execution model → Task 2; §5 verdict semantics → Tasks 2–3; §6 config → Tasks 1+4; §7 payload hygiene → Task 2 (envelope, truncation) with `_truncate` applied at payload build in fire sites; §8 wiring → Tasks 4–8; §9 error handling → Task 2 (`fire` never raises; fail directions); §10 testing → per-task tests + Task 9 sweep; §2 non-goals honored (no settings UI, no project scope, no rewriting).
+2. **Placeholder scan:** Tasks 4, 5, 6, 7, 8 contain "concretize against the module's fixtures" instructions — these name the exact file, anchor, and assertion set where the harness must be reused rather than reinvented; the engine-module code (the new logic) is fully specified. This is deliberate: reinventing those harnesses blind would drift from their fixture discipline.
+3. **Type consistency:** `HookSpec(event, command, matcher, timeout_s)`, `HookOutcome(blocked, reason, context)`, `wrap_review(inner, *, session_id)`, `post_tool_dep(*, session_id)`, `ensure_run_hooks() -> RunHooksEngine | None`, `fire(event, *, session_id, run_id=None, data=None)` used consistently across tasks.

--- a/Docs/superpowers/plans/2026-09-11-task-32481-console-persona-session-identity.md
+++ b/Docs/superpowers/plans/2026-09-11-task-32481-console-persona-session-identity.md
@@ -1,0 +1,2296 @@
+# Console Persona Session Identity Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Persona "Chat now" binds a persona-native Console session so the transcript label shows the persona's name instead of "Assistant", persona system prompts expand `{{user}}`/`{{char}}`-family macros dynamically, and resumed persona conversations re-resolve the name — full parity with character sessions, locally and against a server.
+
+**Architecture:** Extends the existing ADR-046 character identity machinery (stored projections, single-pass macro expansion, one shared presentation resolver) with a persona branch, per ADR-149. The session gains `assistant_name` + `persona_system_template` fields; no schema migration — the name is re-resolved from `assistant_id` at resume, and the trusted template rides the version-1 `console_roleplay_context` metadata envelope as an optional key.
+
+**Tech Stack:** Python 3.11+, Textual, SQLite (via `CharactersRAGDB`), pytest (+ pytest-asyncio).
+
+**Spec:** `Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md`
+**ADR:** `backlog/decisions/149-console-persona-session-identity.md`
+**Backlog task:** `backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md` (mark In Progress at start, Done at end; add Implementation Notes when done)
+
+## Global Constraints
+
+- **No database schema migration.** Conversations already persist `assistant_kind` / `assistant_id`; nothing else is added to the DB.
+- **Persona conversations remain authority-free** (ADR-037): never resolve or store `assistant_authority_id` for a persona session.
+- **Single-pass macro expansion** (ADR-046): all expansion goes through `expand_character_template`; never re-scan replacement values.
+- **Character behavior must not change**: existing tests in `Tests/Chat/test_console_roleplay_identity.py`, `Tests/Chat/test_console_chat_store.py`, and the character handoff tests in `Tests/UI/test_console_native_chat_flow.py` must stay green unmodified (except where a task below explicitly extends a test helper).
+- **One-name-set invariant**: at most one of `character_name` / `assistant_name` is non-blank on any session; every identity write enforces it.
+- Repo notes: the `timeout` shell command is unavailable; run targeted tests only (`pytest <file> -v`), never the full suite unless asked.
+- The `backlog` CLI is unavailable in this environment; update `backlog/tasks/task-32481 - ....md` by editing the file (status field, Implementation Notes section) if it remains unavailable at execution time.
+- **Spec deviation (§2), flagged for plan review:** the spec called for extracting "a shared fenced-fetch spine parameterized by a kind-specific fetch and a kind-specific seed." This plan extracts the security-critical half — the server capture/currency fence — as `_capture_server_handoff_context`, shared verbatim by both starters, but keeps two starter bodies. Rationale: the authority-resolver dance, greeting-matched duplicate detection, reaction clearing, and the seed call signatures are all genuinely kind-specific; a fully parameterized spine would thread ~6 injected seams through the exact fencing code the review finding was protecting. If the full spine is preferred, say so before execution and Task 5 will be restructured.
+
+---
+
+### Task 1: Session identity fields + presentation persona branch
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` — `ConsoleChatSession` (fields at lines 547–551), `create_session` (883–964), `presentation_context` (3313–3325)
+- Modify: `tldw_chatbook/Chat/console_roleplay_identity.py` — `ConsolePresentationContext` (118–126), `resolve_console_message_presentation` (141–217), new helper
+- Test: `Tests/Chat/test_console_roleplay_identity.py`, `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Consumes: nothing from other tasks.
+- Produces: session fields `assistant_name: str | None`, `persona_system_template: str | None`; `create_session(..., assistant_name=None, persona_system_template=None)`; `session_assistant_display_name(session: object) -> str | None`; `ConsolePresentationContext.assistant_name`; persona branch in `resolve_console_message_presentation`. Every later task relies on these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Chat/test_console_roleplay_identity.py`:
+
+```python
+def assistant_message(content: str) -> ConsoleChatMessage:
+    return ConsoleChatMessage(role=ConsoleMessageRole.ASSISTANT, content=content)
+
+
+def test_persona_session_labels_assistant_rows_with_persona_name():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(
+            assistant_kind="persona", assistant_name="Archivist"
+        ),
+    )
+    assert presentation.speaker_label == "Archivist"
+    assert presentation.speaker_tone == "assistant"
+    assert presentation.row_class == "console-transcript-message-role-assistant"
+
+
+def test_persona_session_without_name_falls_back_to_assistant():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(assistant_kind="persona", assistant_name="  "),
+    )
+    assert presentation.speaker_label == "Assistant"
+    assert presentation.speaker_tone == "assistant"
+
+
+def test_persona_name_never_gets_roleplay_character_styling():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(
+            assistant_kind="persona",
+            assistant_name="Archivist",
+            transcript_style=ConsoleTranscriptStyle.IMMERSIVE_RP,
+        ),
+    )
+    assert presentation.speaker_label == "Archivist"
+    assert presentation.speaker_tone == "assistant"
+    assert presentation.row_class == "console-transcript-message-role-assistant"
+
+
+def test_session_assistant_display_name_picks_per_kind():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Chat.console_roleplay_identity import (
+        session_assistant_display_name,
+    )
+
+    character = SimpleNamespace(
+        assistant_kind="character", character_name="Alraune", assistant_name=None
+    )
+    persona = SimpleNamespace(
+        assistant_kind="persona", character_name=None, assistant_name=" Archivist "
+    )
+    generic = SimpleNamespace(
+        assistant_kind="generic", character_name=None, assistant_name=None
+    )
+    assert session_assistant_display_name(character) == "Alraune"
+    assert session_assistant_display_name(persona) == "Archivist"
+    assert session_assistant_display_name(generic) is None
+```
+
+Append to `Tests/Chat/test_console_chat_store.py` (check the file's existing imports; it already imports `ConsoleChatStore`):
+
+```python
+def test_presentation_context_carries_persona_display_name():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    context = store.presentation_context(session.id, "")
+    assert context.assistant_kind == "persona"
+    assert context.assistant_name == "Archivist"
+    assert context.character_name is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_roleplay_identity.py Tests/Chat/test_console_chat_store.py -v -k "persona or display_name"`
+Expected: FAIL — `TypeError: ConsolePresentationContext() got an unexpected keyword argument 'assistant_name'` and `create_session() got an unexpected keyword argument 'assistant_name'`; `ImportError` for `session_assistant_display_name`.
+
+- [ ] **Step 3: Implement the session fields and store plumbing**
+
+In `tldw_chatbook/Chat/console_chat_store.py`, `ConsoleChatSession` (after the `character_name` field at line 547):
+
+```python
+    character_name: str | None = None
+    #: Persona-kind assistant display name (ADR-149). Set only when
+    #: ``assistant_kind == "persona"``; mutually exclusive with
+    #: ``character_name``. Never persisted on the conversation row --
+    #: re-resolved from ``assistant_id`` at resume.
+    assistant_name: str | None = None
+```
+
+and after `character_system_template` (line 551):
+
+```python
+    #: Trusted persona system-prompt source (ADR-149); materialized into
+    #: ``settings.system_prompt`` via the identity-template expander and
+    #: persisted as an optional key in the version-1 roleplay envelope.
+    persona_system_template: str | None = None
+```
+
+In `create_session` (883), add two keyword parameters after `character_name: str | None = None,`:
+
+```python
+        character_name: str | None = None,
+        assistant_name: str | None = None,
+        persona_system_template: str | None = None,
+```
+
+and pass them into the `ConsoleChatSession(...)` constructor after `character_name=character_name,`:
+
+```python
+            character_name=character_name,
+            assistant_name=assistant_name,
+            persona_system_template=persona_system_template,
+```
+
+In `presentation_context` (3313–3325), add one line:
+
+```python
+        return ConsolePresentationContext(
+            user_name=effective_user_display_name(
+                session.user_display_name_override, global_default
+            ),
+            assistant_kind=session.assistant_kind,
+            character_name=session.character_name,
+            assistant_name=session.assistant_name,
+            revision=session.identity_revision,
+        )
+```
+
+Do NOT change `restore_persisted_session`'s signature — hydration assigns persona fields post-restore (mirroring `character_system_template` at `console_conversation_hydration.py:438`).
+
+- [ ] **Step 4: Implement the identity-module changes**
+
+In `tldw_chatbook/Chat/console_roleplay_identity.py`:
+
+Add the field to `ConsolePresentationContext` (after `character_name`):
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConsolePresentationContext:
+    """Identity inputs used to project one Console transcript message."""
+
+    user_name: str = "User"
+    assistant_kind: str | None = "generic"
+    character_name: str | None = None
+    assistant_name: str | None = None
+    revision: int = 0
+    transcript_style: ConsoleTranscriptStyle = DEFAULT_CONSOLE_TRANSCRIPT_STYLE
+```
+
+Add the helper after `effective_user_display_name`:
+
+```python
+def session_assistant_display_name(session: object) -> str | None:
+    """Return the session's kind-appropriate assistant display name.
+
+    Character sessions read ``character_name``; persona sessions read
+    ``assistant_name`` (ADR-149); anything else has no bound identity.
+    Blank values are treated as absent.
+    """
+    kind = getattr(session, "assistant_kind", None)
+    if kind == "character":
+        value = getattr(session, "character_name", None)
+    elif kind == "persona":
+        value = getattr(session, "assistant_name", None)
+    else:
+        return None
+    text = value.strip() if isinstance(value, str) else ""
+    return text or None
+```
+
+In `resolve_console_message_presentation`, extend the name resolution block (lines 145–156):
+
+```python
+    raw_character_name = (
+        context.character_name.strip()
+        if isinstance(context.character_name, str)
+        else ""
+    )
+    raw_persona_name = (
+        context.assistant_name.strip()
+        if isinstance(context.assistant_name, str)
+        else ""
+    )
+    is_character_session = (
+        context.assistant_kind == "character" and bool(raw_character_name)
+    )
+    is_persona_session = (
+        context.assistant_kind == "persona" and bool(raw_persona_name)
+    )
+    character_display_name = sanitize_character_display_label(
+        raw_character_name,
+        max_characters=CHARACTER_SPEAKER_LABEL_MAX_CHARACTERS,
+    )
+    persona_display_name = sanitize_character_display_label(
+        raw_persona_name,
+        max_characters=CHARACTER_SPEAKER_LABEL_MAX_CHARACTERS,
+    )
+```
+
+and the ASSISTANT branch (lines 174–183):
+
+```python
+    elif message.role is ConsoleMessageRole.ASSISTANT:
+        if is_character_session:
+            speaker_label = character_display_name
+        elif is_persona_session:
+            speaker_label = persona_display_name
+        else:
+            speaker_label = "Assistant"
+        speaker_tone = "character" if is_character_session else "assistant"
+        row_class = None
+        if role_accents:
+            row_class = (
+                "console-transcript-message-roleplay-character"
+                if is_character_session
+                # Persona rows keep the standard assistant treatment:
+                # personas are not roleplay characters (ADR-149).
+                else "console-transcript-message-role-assistant"
+            )
+```
+
+(The greeting-template block below it stays gated on `is_character_session` — personas have no greeting templates.)
+
+Add one line to `expand_character_template`'s docstring:
+
+```python
+def expand_character_template(
+    source: str, *, user_name: str, character_name: str
+) -> str:
+    """Expand trusted character template aliases in one non-recursive pass.
+
+    This is the identity-template expander for both character and persona
+    sessions (ADR-149); ``character_name`` carries the persona name for
+    persona-kind content.
+    """
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_roleplay_identity.py Tests/Chat/test_console_chat_store.py -v`
+Expected: PASS, including all pre-existing tests (character branch unchanged).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_store.py tldw_chatbook/Chat/console_roleplay_identity.py Tests/Chat/test_console_roleplay_identity.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat: persona display identity on Console sessions + transcript persona branch (task-32481)"
+```
+
+---
+
+### Task 2: Roleplay envelope `persona_system_template` persistence
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_roleplay_metadata.py` (whole file is the envelope: dataclass, parse, merge)
+- Modify: `tldw_chatbook/Chat/chat_persistence_service.py` — `update_conversation_roleplay_context` (480–515)
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` — Protocol signature (365–372), `_persist_roleplay_context` (4101–4120), first-persist flush condition (5524–5527)
+- Test: `Tests/Chat/test_console_roleplay_metadata.py`, `Tests/Chat/test_chat_persistence_service.py`
+
+**Interfaces:**
+- Consumes: Task 1's `session.persona_system_template`.
+- Produces: `ConsoleRoleplayContext.persona_system_template: str | None = None`; `update_conversation_roleplay_context(..., persona_system_template: str | None)`; envelope key `persona_system_template` under `console_roleplay_context` version 1. Tasks 3 and 6 rely on these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Chat/test_console_roleplay_metadata.py` (it already imports `json`, `ConsoleRoleplayContext`, `merge_console_roleplay_context`, `parse_console_roleplay_context` — verify and extend imports as needed):
+
+```python
+def test_persona_template_round_trip_preserves_sibling_keys():
+    merged = merge_console_roleplay_context(
+        '{"unrelated": true}',
+        ConsoleRoleplayContext(persona_system_template="Guide {{user}}."),
+    )
+    decoded = json.loads(merged)
+    assert decoded["unrelated"] is True
+    owned = decoded["console_roleplay_context"]
+    assert owned["version"] == 1
+    assert "user_name_override" not in owned
+    assert "character_system_template" not in owned
+    assert owned["persona_system_template"] == "Guide {{user}}."
+    parsed = parse_console_roleplay_context(merged)
+    assert parsed.persona_system_template == "Guide {{user}}."
+
+
+def test_envelope_without_persona_key_parses_as_before():
+    merged = merge_console_roleplay_context(
+        None,
+        ConsoleRoleplayContext(
+            user_name_override="Rowan", character_system_template="Be {{char}}."
+        ),
+    )
+    parsed = parse_console_roleplay_context(merged)
+    assert parsed.user_name_override == "Rowan"
+    assert parsed.character_system_template == "Be {{char}}."
+    assert parsed.persona_system_template is None
+
+
+def test_blank_persona_template_fails_soft_and_all_empty_pops_envelope():
+    assert parse_console_roleplay_context(
+        '{"console_roleplay_context": '
+        '{"version": 1, "persona_system_template": "  "}}'
+    ) == ConsoleRoleplayContext()
+    merged = merge_console_roleplay_context(
+        '{"console_roleplay_context": '
+        '{"version": 1, "persona_system_template": "x"}}',
+        ConsoleRoleplayContext(),
+    )
+    assert json.loads(merged) == {}
+```
+
+Append to `Tests/Chat/test_chat_persistence_service.py`, inside `TestChatPersistenceService` (uses the file's `db_instance` fixture; `service.create_conversation` kwargs mirror its existing conversation-creation tests):
+
+```python
+    def test_roleplay_context_round_trips_persona_template(
+        self, db_instance: CharactersRAGDB
+    ):
+        service = ChatPersistenceService(db_instance)
+        conversation_id = service.create_conversation(
+            conversation_title="Chat with Archivist",
+            runtime_backend="local",
+            assistant_kind="persona",
+            assistant_id="local-persona-abc",
+        )
+        assert service.update_conversation_roleplay_context(
+            conversation_id=conversation_id,
+            user_name_override=None,
+            character_system_template=None,
+            persona_system_template="Guide {{user}}.",
+        )
+        record = db_instance.get_conversation_by_id(conversation_id)
+        owned = json.loads(record["metadata"])["console_roleplay_context"]
+        assert owned["version"] == 1
+        assert owned["persona_system_template"] == "Guide {{user}}."
+```
+
+(If `create_conversation`'s exact required kwargs differ, copy the call shape from a neighboring passing test in the same class and keep the identity kwargs above.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_roleplay_metadata.py -v -k persona` and `pytest Tests/Chat/test_chat_persistence_service.py -v -k persona_template`
+Expected: FAIL — `TypeError: ConsoleRoleplayContext() got an unexpected keyword argument 'persona_system_template'`; `TypeError` on the service kwarg.
+
+- [ ] **Step 3: Implement the envelope key**
+
+In `tldw_chatbook/Chat/console_roleplay_metadata.py`:
+
+```python
+@dataclass(frozen=True, slots=True)
+class ConsoleRoleplayContext:
+    """Trusted, optional roleplay context stored on a conversation."""
+
+    user_name_override: str | None = None
+    character_system_template: str | None = None
+    persona_system_template: str | None = None
+```
+
+In `parse_console_roleplay_context`, after the `character_system_template` validation block:
+
+```python
+    persona_system_template = owned_context.get("persona_system_template")
+    if persona_system_template is not None and (
+        not isinstance(persona_system_template, str)
+        or not persona_system_template.strip()
+    ):
+        return ConsoleRoleplayContext()
+
+    return ConsoleRoleplayContext(
+        user_name_override=user_name_override,
+        character_system_template=character_system_template,
+        persona_system_template=persona_system_template,
+    )
+```
+
+In `merge_console_roleplay_context`, after the `character_system_template` normalization:
+
+```python
+    persona_system_template = context.persona_system_template
+    if (
+        not isinstance(persona_system_template, str)
+        or not persona_system_template.strip()
+    ):
+        persona_system_template = None
+
+    if (
+        user_name_override is None
+        and character_system_template is None
+        and persona_system_template is None
+    ):
+        metadata.pop(ROLEPLAY_CONTEXT_METADATA_KEY, None)
+    else:
+        metadata[ROLEPLAY_CONTEXT_METADATA_KEY] = {
+            "version": ROLEPLAY_CONTEXT_VERSION,
+            **(
+                {"user_name_override": user_name_override}
+                if user_name_override is not None
+                else {}
+            ),
+            **(
+                {"character_system_template": character_system_template}
+                if character_system_template is not None
+                else {}
+            ),
+            **(
+                {"persona_system_template": persona_system_template}
+                if persona_system_template is not None
+                else {}
+            ),
+        }
+    return json.dumps(metadata, sort_keys=True)
+```
+
+(The version stays 1 — an optional key under per-key fail-soft parsing, per ADR-149.)
+
+- [ ] **Step 4: Plumb the persistence seam**
+
+In `tldw_chatbook/Chat/chat_persistence_service.py::update_conversation_roleplay_context`:
+
+```python
+    def update_conversation_roleplay_context(
+        self,
+        *,
+        conversation_id: str,
+        user_name_override: str | None,
+        character_system_template: str | None,
+        persona_system_template: str | None = None,
+    ) -> bool:
+```
+
+and pass it into the context constructor:
+
+```python
+            metadata = merge_console_roleplay_context(
+                record.get("metadata"),
+                ConsoleRoleplayContext(
+                    user_name_override=user_name_override,
+                    character_system_template=character_system_template,
+                    persona_system_template=persona_system_template,
+                ),
+            )
+```
+
+In `tldw_chatbook/Chat/console_chat_store.py`, Protocol method (365–372):
+
+```python
+    def update_conversation_roleplay_context(
+        self,
+        *,
+        conversation_id: str,
+        user_name_override: str | None,
+        character_system_template: str | None,
+        persona_system_template: str | None = None,
+    ) -> bool:
+        """Persist Console-owned roleplay identity context for a conversation."""
+```
+
+`_persist_roleplay_context` (4101–4120) — add one kwarg:
+
+```python
+                writer(
+                    conversation_id=session.persisted_conversation_id,
+                    user_name_override=session.user_display_name_override,
+                    character_system_template=session.character_system_template,
+                    persona_system_template=session.persona_system_template,
+                )
+```
+
+`persist_session_if_needed` first-persist flush condition (5524–5527):
+
+```python
+        if (
+            session.user_display_name_override is not None
+            or session.character_system_template is not None
+            or session.persona_system_template is not None
+        ) and not self._persist_roleplay_context(session):
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_roleplay_metadata.py Tests/Chat/test_chat_persistence_service.py Tests/Chat/test_console_chat_store.py -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_roleplay_metadata.py tldw_chatbook/Chat/chat_persistence_service.py tldw_chatbook/Chat/console_chat_store.py Tests/Chat/test_console_roleplay_metadata.py Tests/Chat/test_chat_persistence_service.py
+git commit -m "feat: persist persona system template in v1 roleplay envelope (task-32481)"
+```
+
+---
+
+### Task 3: Store persona identity operations
+
+**Files:**
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` — `_is_named_character_session` (3573–3579), `_roleplay_projection_is_stale` (3581–3610), `_materialize_roleplay_projections_live` (3626–3690), `seed_character_roleplay` (3395–3425), `swap_session_character_roleplay` (3427–3493), `set_session_character_name` (3533–3551)
+- Test: `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Consumes: Task 1 session fields; Task 2 `_persist_roleplay_context` plumbing.
+- Produces: `ConsoleChatStore._is_named_persona_session(session) -> bool`, `._is_named_identity_session(session) -> bool`, `._identity_display_name(session) -> str`, `._identity_system_template(session) -> str | None`; `seed_persona_roleplay(session_id, *, system_template: str, global_default: object) -> None`; `set_session_assistant_name(session_id, assistant_name: str | None, *, global_default: object) -> tuple[ConsoleChatSession, bool]`. Tasks 5 and 6 call these.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/Chat/test_console_chat_store.py`. Imports to add if missing: `from dataclasses import replace`, `from types import SimpleNamespace`, `from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings`.
+
+```python
+def _persona_settings() -> ConsoleSessionSettings:
+    return ConsoleSessionSettings(provider="anthropic", model="claude-3-haiku")
+
+
+def _persona_session(store: ConsoleChatStore) -> ConsoleChatSession:
+    return store.create_session(
+        title="Chat with Archivist",
+        settings=_persona_settings(),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+
+
+def test_named_identity_gates_separate_kinds():
+    persona = SimpleNamespace(
+        assistant_kind="persona", character_name=None, assistant_name="Archivist"
+    )
+    character = SimpleNamespace(
+        assistant_kind="character", character_name="Alraune", assistant_name=None
+    )
+    generic = SimpleNamespace(
+        assistant_kind="generic", character_name=None, assistant_name=None
+    )
+    assert ConsoleChatStore._is_named_persona_session(persona) is True
+    assert ConsoleChatStore._is_named_character_session(persona) is False
+    assert ConsoleChatStore._is_named_persona_session(character) is False
+    assert ConsoleChatStore._is_named_character_session(character) is True
+    assert ConsoleChatStore._is_named_identity_session(persona) is True
+    assert ConsoleChatStore._is_named_identity_session(character) is True
+    assert ConsoleChatStore._is_named_identity_session(generic) is False
+
+
+def test_persona_seed_expands_identity_macros_into_system_prompt():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="Guide {{user}} as {{persona}}.",
+        global_default="Rowan",
+    )
+    assert session.persona_system_template == "Guide {{user}} as {{persona}}."
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Guide Rowan as Archivist."
+    # Personas have no greeting: seeding never appends a message.
+    assert store.messages_for_session(session.id) == []
+
+
+def test_persona_seed_without_system_prompt_keeps_default_settings():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id, system_template="  ", global_default="Rowan"
+    )
+    assert session.persona_system_template is None
+    assert session.settings is not None
+    assert session.settings.system_prompt == _persona_settings().system_prompt
+    assert session.assistant_name == "Archivist"
+
+
+def test_persona_rename_rematerializes_projection():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="I am {{char}} for {{user}}.",
+        global_default="Rowan",
+    )
+    _session, persisted = store.set_session_assistant_name(
+        session.id, "Scribe", global_default="Rowan"
+    )
+    assert persisted is True
+    assert session.assistant_name == "Scribe"
+    assert session.settings is not None
+    assert session.settings.system_prompt == "I am Scribe for Rowan."
+
+
+def test_set_session_assistant_name_clears_character_name():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Alraune",
+        settings=_persona_settings(),
+        assistant_kind="character",
+        assistant_id="7",
+        character_id=7,
+        character_name="Alraune",
+    )
+    store.set_session_assistant_name(session.id, "Archivist", global_default="Rowan")
+    assert session.assistant_name == "Archivist"
+    assert session.character_name is None
+
+
+def test_character_swap_off_persona_session_clears_persona_identity():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id, system_template="Guide {{user}}.", global_default="Rowan"
+    )
+    # The screen sets kind/id fields before calling the store seam; mirror it.
+    session.assistant_kind = "character"
+    session.assistant_id = "7"
+    session.character_id = 7
+    _session, _greeting, persisted = store.swap_session_character_roleplay(
+        session.id,
+        character_name="Alraune",
+        system_template="Be {{char}}.",
+        greeting_template="",
+        global_default="Rowan",
+    )
+    assert persisted is True
+    assert session.character_name == "Alraune"
+    assert session.assistant_name is None
+    assert session.persona_system_template is None
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Be Alraune."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/Chat/test_console_chat_store.py -v -k "persona or named_identity or swap_off"`
+Expected: FAIL — `AttributeError` for `_is_named_persona_session` / `seed_persona_roleplay` / `set_session_assistant_name`.
+
+- [ ] **Step 3: Implement the gates and kind-aware accessors**
+
+In `console_chat_store.py`, after `_is_named_character_session` (3573–3579):
+
+```python
+    @staticmethod
+    def _is_named_persona_session(session: ConsoleChatSession) -> bool:
+        return (
+            session.assistant_kind == "persona"
+            and isinstance(session.assistant_name, str)
+            and bool(session.assistant_name.strip())
+        )
+
+    @classmethod
+    def _is_named_identity_session(cls, session: ConsoleChatSession) -> bool:
+        return cls._is_named_character_session(
+            session
+        ) or cls._is_named_persona_session(session)
+
+    @staticmethod
+    def _identity_system_template(session: ConsoleChatSession) -> str | None:
+        """Return the trusted template for the session's bound kind."""
+        if session.assistant_kind == "persona":
+            return session.persona_system_template
+        return session.character_system_template
+
+    @staticmethod
+    def _identity_display_name(session: ConsoleChatSession) -> str:
+        """Return the session's bound assistant display name, or ""."""
+        return (session_assistant_display_name(session) or "").strip()
+```
+
+Add the import at the top of the file, extending the existing identity import block (line 56 imports `expand_character_template` from the same module):
+
+```python
+from tldw_chatbook.Chat.console_roleplay_identity import (
+    session_assistant_display_name,
+)
+```
+
+- [ ] **Step 4: Generalize staleness and materialization**
+
+In `_roleplay_projection_is_stale` (3581–3610), change the gate and the two reads:
+
+```python
+    def _roleplay_projection_is_stale(
+        self, session: ConsoleChatSession, global_default: object
+    ) -> bool:
+        if not self._is_named_identity_session(session):
+            return False
+        context = self.presentation_context(session.id, global_default)
+        identity_name = self._identity_display_name(session)
+        template = self._identity_system_template(session)
+        if template and session.settings is not None:
+            if session.settings.system_prompt != expand_character_template(
+                template,
+                user_name=context.user_name,
+                character_name=identity_name,
+            ):
+                return True
+```
+
+(The greeting-provenance loop below stays exactly as-is: it keys on
+`template_kind == "character_greeting"`, which persona sessions never carry.)
+
+In `_materialize_roleplay_projections_live` (3626–3690), change the gate and reads the same way:
+
+```python
+        session = self._session_or_raise(session_id)
+        if not self._is_named_identity_session(session):
+            return None
+        context = self.presentation_context(session_id, global_default)
+        identity_name = self._identity_display_name(session)
+        template = self._identity_system_template(session)
+        system_prompt_write: _RoleplaySystemPromptWrite | None = None
+        message_writes: list[_RoleplayMessageProjectionWrite] = []
+        if template and session.settings is not None:
+            projected_system = expand_character_template(
+                template,
+                user_name=context.user_name,
+                character_name=identity_name,
+            )
+```
+
+(Everything below — the settings write, the greeting loop, the persistence
+plan — is unchanged; the greeting loop is inert for persona sessions.)
+
+- [ ] **Step 5: Implement `seed_persona_roleplay` and `set_session_assistant_name`; harden the swap**
+
+After `seed_character_roleplay` (ends ~3425):
+
+```python
+    def seed_persona_roleplay(
+        self,
+        session_id: str,
+        *,
+        system_template: str,
+        global_default: object,
+    ) -> None:
+        """Seed the trusted persona system source into a fresh session.
+
+        Persona profiles have no greeting field, so unlike
+        ``seed_character_roleplay`` this never appends a message.
+        """
+        session = self._session_or_raise(session_id)
+        source = (
+            system_template
+            if isinstance(system_template, str) and system_template.strip()
+            else None
+        )
+        source_changed = session.persona_system_template != source
+        session.persona_system_template = source
+        if source_changed:
+            self._bump_identity_revision(session_id)
+        context_persisted = self._persist_roleplay_context(session)
+        self._materialize_roleplay_projections(
+            session_id, global_default=global_default
+        )
+        if not context_persisted:
+            logger.warning("Failed to persist seeded Console persona context.")
+```
+
+After `set_session_character_name` (ends ~3551):
+
+```python
+    def set_session_assistant_name(
+        self,
+        session_id: str,
+        assistant_name: str | None,
+        *,
+        global_default: object,
+    ) -> tuple[ConsoleChatSession, bool]:
+        """Set persona identity through the projection revision seam.
+
+        Setting a non-blank persona name clears any character name, keeping
+        the one-name-set invariant (ADR-149).
+        """
+        session = self._session_or_raise(session_id)
+        normalized = assistant_name.strip() if isinstance(assistant_name, str) else ""
+        new_name = normalized or None
+        if session.assistant_name == new_name:
+            return session, True
+        session.assistant_name = new_name
+        if new_name is not None:
+            session.character_name = None
+        self._bump_identity_revision(session_id)
+        persisted = self._materialize_roleplay_projections(
+            session_id, global_default=global_default
+        )
+        return session, persisted
+```
+
+In `swap_session_character_roleplay` (3453–3471), extend `identity_changed` and clear persona fields:
+
+```python
+        identity_changed = (
+            session.character_name != new_name
+            or session.character_system_template != source
+            or session.assistant_name is not None
+            or session.persona_system_template is not None
+        )
+        source_changed = session.character_system_template != source
+        session.character_name = new_name
+        session.character_system_template = source
+        # One-name-set invariant (ADR-149): a character swap retires any
+        # persona identity bound to this session.
+        session.assistant_name = None
+        session.persona_system_template = None
+        if identity_changed:
+            self._bump_identity_revision(session_id)
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest Tests/Chat/test_console_chat_store.py -v`
+Expected: PASS, including all pre-existing store tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/Chat/console_chat_store.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat: persona identity operations in Console chat store (task-32481)"
+```
+
+---
+
+### Task 4: Persona handoff extraction + prompt seed
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py` — after `_character_session_identity_from_handoff` (304–348) and after `CharacterSessionPromptSeed`/`_character_session_prompt_seed` (351–429)
+- Test: `Tests/UI/test_console_native_chat_flow.py`
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (pure functions), though it is only reachable once Task 5 wires the starter.
+- Produces: `_persona_session_identity_from_handoff(payload: ChatHandoffPayload) -> tuple[str, str, str, str] | None` returning `(runtime_backend, persona_id, persona_name, assistant_id)`; `PersonaSessionPromptSeed(name: str, system_template: str, system_prompt: str)`; `_persona_session_prompt_seed(profile: Mapping, name_hint: str = "", *, user_name: str = "User") -> PersonaSessionPromptSeed`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_console_native_chat_flow.py`, next to the character handoff helpers (the file already imports `ChatHandoffPayload`):
+
+```python
+def _persona_start_handoff(
+    *,
+    runtime_backend: str = "local",
+    active_server_profile_id: str | None = None,
+    persona_id: object = "local-persona-abc",
+) -> ChatHandoffPayload:
+    return ChatHandoffPayload(
+        source="personas",
+        item_type="persona-card",
+        title="Archivist",
+        body="Persona summary",
+        runtime_backend=runtime_backend,
+        source_owner=runtime_backend,
+        source_selector_state=runtime_backend,
+        active_server_profile_id=active_server_profile_id,
+        metadata={
+            "intent": "start_chat",
+            "selected_kind": "persona",
+            "selected_record_id": persona_id,
+            "selected_name": "Archivist",
+            "selected_target_id": f"{runtime_backend}:persona:{persona_id}",
+            "backend": runtime_backend,
+        },
+    )
+
+
+def test_persona_handoff_accepts_exact_coherent_payload():
+    payload = _persona_start_handoff()
+    assert _persona_session_identity_from_handoff(payload) == (
+        "local",
+        "local-persona-abc",
+        "Archivist",
+        "local-persona-abc",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        pytest.param("item_type", "character-card", id="character-item-type"),
+        pytest.param("runtime_backend", "LOCAL", id="non-exact-runtime-source"),
+        pytest.param("source_owner", "server", id="contradictory-owner"),
+    ),
+)
+def test_persona_handoff_rejects_incoherent_envelope(field, value):
+    payload = replace(_persona_start_handoff(), **{field: value})
+    assert _persona_session_identity_from_handoff(payload) is None
+
+
+def test_persona_handoff_rejects_character_kind_and_target_mismatch():
+    character_payload = _character_start_handoff()
+    assert _persona_session_identity_from_handoff(character_payload) is None
+    mismatched = _persona_start_handoff()
+    mismatched.metadata["selected_target_id"] = "local:persona:someone-else"
+    assert _persona_session_identity_from_handoff(mismatched) is None
+
+
+def test_persona_handoff_preserves_opaque_string_id():
+    payload = _persona_start_handoff(persona_id="srv-persona-7")
+    payload.metadata["selected_target_id"] = "local:persona:srv-persona-7"
+    identity = _persona_session_identity_from_handoff(payload)
+    assert identity is not None
+    assert identity[1] == "srv-persona-7"  # never int-coerced
+
+
+def test_persona_seed_expands_user_and_persona_macros():
+    seed = _persona_session_prompt_seed(
+        {"id": "local-persona-abc", "name": "Archivist",
+         "system_prompt": "Guide {{user}} as {{persona}} ({{char}})."},
+        user_name="Rowan",
+    )
+    assert seed.name == "Archivist"
+    assert seed.system_template == "Guide {{user}} as {{persona}} ({{char}})."
+    assert seed.system_prompt == "Guide Rowan as Archivist (Archivist)."
+
+
+def test_persona_seed_without_system_prompt_stays_empty():
+    seed = _persona_session_prompt_seed(
+        {"id": "local-persona-abc", "name": "Archivist"}, user_name="Rowan"
+    )
+    assert seed.system_template == ""
+    assert seed.system_prompt == ""
+
+
+def test_persona_seed_uses_name_hint_and_stays_single_pass():
+    seed = _persona_session_prompt_seed(
+        {"id": "p1", "system_prompt": "Hi {{user}}"},
+        name_hint=" {{char}} ",
+        user_name="{{user}}",
+    )
+    # The hint is sanitized but never macro-expanded; the user name is
+    # substituted literally exactly once (ADR-046 single-pass rule).
+    assert seed.name == "{{char}}"
+    assert seed.system_prompt == "Hi {{user}}"
+```
+
+(`replace` is `dataclasses.replace` — `ChatHandoffPayload` is a frozen dataclass in these tests; if the file's existing reject tests mutate instead, mirror them. Add imports: `from tldw_chatbook.UI.Console_Modules.session import _persona_session_identity_from_handoff, _persona_session_prompt_seed` — place beside the file's existing private imports of that module.)
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "persona_handoff or persona_seed"`
+Expected: FAIL — `ImportError` on both names.
+
+- [ ] **Step 3: Implement the extractor and seed**
+
+In `tldw_chatbook/UI/Console_Modules/session.py`, after `_character_session_identity_from_handoff` (ends line 348):
+
+```python
+def _persona_session_identity_from_handoff(
+    payload: ChatHandoffPayload,
+) -> tuple[str, str, str, str] | None:
+    """Return persona session identity for Personas Start Chat handoffs.
+
+    Mirrors ``_character_session_identity_from_handoff`` with one deliberate
+    difference: persona IDs are opaque strings (``local-persona-<hex>``
+    locally, server IDs remotely), so no integer coercion or canonical
+    numeric check applies.
+
+    Returns:
+        A tuple of `(runtime_backend, persona_id, persona_name,
+        assistant_id)` when the payload is a source-aware Personas persona
+        Start Chat handoff; otherwise `None`.
+    """
+    metadata = payload.metadata
+    if not isinstance(metadata, Mapping):
+        return None
+    if (
+        payload.source != "personas"
+        or payload.item_type != "persona-card"
+        or metadata.get("intent") != "start_chat"
+        or metadata.get("selected_kind") != "persona"
+    ):
+        return None
+    runtime_backend = payload.runtime_backend
+    if runtime_backend not in {"local", "server"}:
+        return None
+    if (
+        payload.source_owner != runtime_backend
+        or payload.source_selector_state != runtime_backend
+        or metadata.get("backend") != runtime_backend
+    ):
+        return None
+
+    persona_id = str(metadata.get("selected_record_id") or "").strip()
+    if not persona_id:
+        return None
+    if (
+        metadata.get("selected_target_id")
+        != f"{runtime_backend}:persona:{persona_id}"
+    ):
+        return None
+
+    persona_name = str(metadata.get("selected_name") or payload.title or "").strip()
+    return runtime_backend, persona_id, persona_name, persona_id
+```
+
+After `_character_session_prompt_seed` (ends ~429). Check whether
+`sanitize_character_display_label` is already imported in this module
+(`character.py` imports it from `...UI.character_display_text`); if not, add
+it to the existing identity imports near line 164:
+
+```python
+@dataclass(frozen=True, slots=True)
+class PersonaSessionPromptSeed:
+    """Trusted persona source and its current safe projection."""
+
+    name: str
+    system_template: str
+    system_prompt: str
+
+
+def _persona_session_prompt_seed(
+    profile: Mapping[str, Any], name_hint: str = "", *, user_name: str = "User"
+) -> PersonaSessionPromptSeed:
+    """Return the trusted persona source and its safe projection.
+
+    Unlike character cards there is no multi-field join: a persona profile
+    contributes its ``system_prompt`` field verbatim as the trusted
+    template, and there is no greeting.
+    """
+    raw_name = str(profile.get("name") or "").strip() or str(name_hint or "").strip()
+    name = (
+        sanitize_character_display_label(raw_name, max_characters=180) or "Persona"
+    )
+    template = str(profile.get("system_prompt") or "")
+    system_prompt = (
+        expand_character_template(template, user_name=user_name, character_name=name)
+        if template.strip()
+        else ""
+    )
+    return PersonaSessionPromptSeed(
+        name=name, system_template=template, system_prompt=system_prompt
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "persona_handoff or persona_seed or character_start_handoff"`
+Expected: PASS, including the pre-existing character extraction tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/session.py Tests/UI/test_console_native_chat_flow.py
+git commit -m "feat: persona start-chat handoff extraction + prompt seed (task-32481)"
+```
+
+---
+
+### Task 5: Persona session starter + server-fence helper + repurpose persona branch
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py` — new `_capture_server_handoff_context` (before `_start_character_console_session`, ~2522), character starter server block (2549–2648), new `_start_persona_console_session` (after 2827)
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` — `_consume_pending_chat_handoff` (11253–11293)
+- Modify: `tldw_chatbook/Chat/console_chat_store.py` — `repurpose_pristine_session` (1015–1096)
+- Test: `Tests/UI/test_console_native_chat_flow.py`, `Tests/Chat/test_console_chat_store.py`
+
+**Interfaces:**
+- Consumes: Task 1 `create_session(..., assistant_name=...)`; Task 3 `seed_persona_roleplay`; Task 4 `_persona_session_identity_from_handoff` / `_persona_session_prompt_seed`.
+- Produces: `ConsoleSessionController._capture_server_handoff_context(payload) -> tuple[object, Callable[[], bool]] | None`; `ConsoleSessionController._start_persona_console_session(payload) -> bool`; `repurpose_pristine_session(..., character_name: str | None, assistant_name: str | None = None)` with a validated persona branch. Task 6's resume overlay relies on the same identity fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_console_native_chat_flow.py`, beside the character handoff helpers (`_persona_profile` near `_character_card` at 4405, the rest near `_character_handoff_runtime` at 4417):
+
+```python
+def _persona_profile() -> dict:
+    return {
+        "id": "local-persona-abc",
+        "name": "Archivist",
+        "system_prompt": "Guide {{user}} as {{persona}}.",
+    }
+
+
+def _persona_start_handoff(
+    *,
+    runtime_backend: str = "local",
+    active_server_profile_id: str | None = None,
+) -> ChatHandoffPayload:
+    return ChatHandoffPayload(
+        source="personas",
+        item_type="persona-card",
+        title="Archivist",
+        body="Persona summary",
+        runtime_backend=runtime_backend,
+        source_owner=runtime_backend,
+        source_selector_state=runtime_backend,
+        active_server_profile_id=active_server_profile_id,
+        metadata={
+            "intent": "start_chat",
+            "selected_kind": "persona",
+            "selected_record_id": "local-persona-abc",
+            "selected_name": "Archivist",
+            "selected_target_id": f"{runtime_backend}:persona:local-persona-abc",
+            "backend": runtime_backend,
+        },
+    )
+
+
+def _persona_handoff_runtime(
+    *,
+    active_server_id: str | None = None,
+    profile=_DEFAULT_HANDOFF_VALUE,
+) -> SimpleNamespace:
+    """Persona mirror of `_character_handoff_runtime` with sentinel seams."""
+    scoped_profile = _persona_profile() if profile is _DEFAULT_HANDOFF_VALUE else profile
+    scope_service = SimpleNamespace(
+        get_persona_profile=AsyncMock(return_value=scoped_profile),
+        # The persona flow must never touch the character fetch seam.
+        get_character=AsyncMock(side_effect=AssertionError("character seam touched")),
+    )
+    db = SimpleNamespace(
+        # Personas are authority-free: no local authority lookup either.
+        get_local_authority_id=Mock(return_value="local-authority"),
+    )
+    initial_capture = SimpleNamespace(account="A")
+    authority_context_state = {"current": initial_capture}
+    capture_context = Mock(
+        side_effect=lambda *, expected_server_id: authority_context_state["current"]
+    )
+    capture_is_current = Mock(
+        side_effect=lambda capture: capture is authority_context_state["current"]
+    )
+    resolver = AsyncMock(
+        side_effect=AssertionError("persona flow must not resolve authority")
+    )
+    app = SimpleNamespace(
+        app_config={},
+        active_server_id=active_server_id,
+        chachanotes_db=db,
+        character_persona_scope_service=scope_service,
+        server_context_provider=SimpleNamespace(
+            capture_character_authority_context=capture_context,
+            is_character_authority_context_current=capture_is_current,
+            resolve_character_authority_id=resolver,
+        ),
+    )
+    return SimpleNamespace(
+        app=app,
+        db=db,
+        scope_service=scope_service,
+        resolver=resolver,
+        authority_context_state=authority_context_state,
+    )
+```
+
+Tests:
+
+```python
+@pytest.mark.asyncio
+async def test_persona_start_chat_binds_local_persona_session(monkeypatch):
+    runtime = _persona_handoff_runtime()
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is True
+    session = store.session
+    assert session is not None
+    assert session.runtime_backend == "local"
+    assert session.assistant_kind == "persona"
+    assert session.assistant_id == "local-persona-abc"
+    # ADR-037: persona sessions never carry an authority id, local included.
+    assert session.assistant_authority_id is None
+    assert session.assistant_name == "Archivist"
+    assert session.character_name is None
+    assert session.character_ref() is None
+    assert session.persona_system_template == "Guide {{user}} as {{persona}}."
+    assert session.settings is not None
+    # app_config={} -> global display name falls back to "User".
+    assert session.settings.system_prompt == "Guide User as Archivist."
+    # Personas have no greeting: seeding appends no message.
+    assert store.messages == []
+    runtime.scope_service.get_persona_profile.assert_awaited_once_with(
+        "local-persona-abc", mode="local"
+    )
+    runtime.scope_service.get_character.assert_not_awaited()
+    runtime.resolver.assert_not_awaited()
+    runtime.db.get_local_authority_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_fails_closed_when_profile_missing(monkeypatch):
+    runtime = _persona_handoff_runtime(profile=None)
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is False
+    assert store.session is None
+    assert store.create_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_fails_closed_when_profile_fetch_raises(monkeypatch):
+    runtime = _persona_handoff_runtime()
+    runtime.scope_service.get_persona_profile.side_effect = RuntimeError("boom")
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is False
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_binds_server_persona_without_authority(monkeypatch):
+    runtime = _persona_handoff_runtime(active_server_id="server-1")
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff(
+            runtime_backend="server", active_server_profile_id="server-1"
+        )
+    )
+
+    assert started is True
+    session = store.session
+    assert session.runtime_backend == "server"
+    assert session.assistant_kind == "persona"
+    assert session.assistant_authority_id is None
+    runtime.resolver.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_server_fence_flip_mid_fetch_fails_closed(
+    monkeypatch,
+):
+    runtime = _persona_handoff_runtime(active_server_id="server-1")
+
+    async def flip_then_return(*_args, **_kwargs):
+        runtime.authority_context_state["current"] = SimpleNamespace(account="B")
+        return _persona_profile()
+
+    runtime.scope_service.get_persona_profile.side_effect = flip_then_return
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff(
+            runtime_backend="server", active_server_profile_id="server-1"
+        )
+    )
+
+    assert started is False
+    assert store.session is None
+    assert store.create_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_persona_payload_rejected_by_character_starter_accepted_by_persona_starter(
+    monkeypatch,
+):
+    runtime = _persona_handoff_runtime()
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+    payload = _persona_start_handoff()
+
+    assert await screen._session._start_character_console_session(payload) is False
+    assert await screen._session._start_persona_console_session(payload) is True
+```
+
+Append to `Tests/Chat/test_console_chat_store.py` (helpers `_pristine_defaults`/`_pristine_session` already exist at 33/37):
+
+```python
+def test_repurpose_pristine_session_accepts_persona_identity():
+    defaults = _pristine_defaults()
+    persona_settings = replace(
+        defaults, system_prompt="Guide User as Archivist.", character_label=""
+    )
+    store = ConsoleChatStore()
+    session = _pristine_session(store, defaults)
+
+    updated = store.repurpose_pristine_session(
+        session.id,
+        canonical_settings=defaults,
+        trusted_system_prompt="Guide User as Archivist.",
+        title="Chat with Archivist",
+        settings=persona_settings,
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_authority_id=None,
+        character_id=None,
+        character_name=None,
+        assistant_name="Archivist",
+    )
+
+    assert updated is session
+    assert updated.assistant_kind == "persona"
+    assert updated.assistant_id == "local-persona-abc"
+    assert updated.assistant_name == "Archivist"
+    assert updated.character_id is None
+    assert updated.character_name is None
+    assert updated.assistant_authority_id is None
+    assert updated.settings == persona_settings
+
+
+def test_repurpose_pristine_session_rejects_persona_authority():
+    defaults = _pristine_defaults()
+    store = ConsoleChatStore()
+    session = _pristine_session(store, defaults)
+    before = replace(session)
+
+    with pytest.raises(ValueError, match="authority-free"):
+        store.repurpose_pristine_session(
+            session.id,
+            canonical_settings=defaults,
+            trusted_system_prompt="Guide User.",
+            title="Chat with Archivist",
+            settings=replace(defaults, system_prompt="Guide User."),
+            runtime_backend="server",
+            assistant_kind="persona",
+            assistant_id="opaque-persona",
+            assistant_authority_id="server-user-v1:" + ("a" * 64),
+            character_id=None,
+            character_name=None,
+            assistant_name="Archivist",
+        )
+
+    assert store.sessions()[0] is session
+    assert session == before
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py Tests/Chat/test_console_chat_store.py -v -k "persona_start_chat or persona_payload_rejected or repurpose_pristine_session_accepts_persona or repurpose_pristine_session_rejects_persona"`
+Expected: FAIL — `AttributeError: 'ConsoleSessionController' object has no attribute '_start_persona_console_session'`; repurpose tests fail with `TypeError: unexpected keyword argument 'assistant_name'`.
+
+- [ ] **Step 3: Extract the server-fence helper and rewire the character starter**
+
+In `tldw_chatbook/UI/Console_Modules/session.py`, immediately before `_start_character_console_session`:
+
+```python
+    def _capture_server_handoff_context(
+        self, payload: ChatHandoffPayload
+    ) -> tuple[object, Callable[[], bool]] | None:
+        """Capture and fence the server authority context for a handoff.
+
+        Returns ``(capture, is_current)`` when the handoff's expected server
+        is still active and its context capture is current, else ``None``.
+        ``is_current()`` re-checks both conditions, so callers re-fence after
+        every suspension point by calling it again.
+        """
+        expected_server_id = payload.active_server_profile_id
+        if (
+            type(expected_server_id) is not str
+            or not expected_server_id
+            or expected_server_id != expected_server_id.strip()
+        ):
+            return None
+        if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+            return None
+        provider = getattr(self.app_instance, "server_context_provider", None)
+        capture_context = getattr(
+            provider, "capture_character_authority_context", None
+        )
+        context_is_current = getattr(
+            provider, "is_character_authority_context_current", None
+        )
+        if not callable(capture_context) or not callable(context_is_current):
+            return None
+        try:
+            capture = capture_context(expected_server_id=expected_server_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return None
+
+        def is_current() -> bool:
+            if (
+                getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
+                return False
+            try:
+                return context_is_current(capture) is True
+            except Exception:
+                return False
+
+        if not is_current():
+            return None
+        return capture, is_current
+```
+
+In `_start_character_console_session`, delete the closure defs at 2551–2560 (`server_context_capture`/`server_context_is_current` predeclarations and `exact_server_context_is_current`) and replace the server `else` branch (2581–2648) with:
+
+```python
+        else:
+            fenced = self._capture_server_handoff_context(payload)
+            if fenced is None:
+                return False
+            server_context_capture, exact_server_context_is_current = fenced
+            expected_server_id = payload.active_server_profile_id
+            assistant_authority_id = None
+            provider = getattr(self.app_instance, "server_context_provider", None)
+            resolver = getattr(provider, "resolve_character_authority_id", None)
+            if callable(resolver):
+                try:
+                    resolved_authority_id = await resolver(
+                        expected_server_id=expected_server_id,
+                        context_capture=server_context_capture,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    resolved_authority_id = None
+                if (
+                    type(resolved_authority_id) is str
+                    and _SERVER_CHARACTER_AUTHORITY_PATTERN.fullmatch(
+                        resolved_authority_id
+                    )
+                    is not None
+                ):
+                    assistant_authority_id = resolved_authority_id
+
+            # This is both the post-resolver fence and the immediately
+            # pre-card-fetch fence. No card from a newly active target may be
+            # used for the ID carried by the handoff.
+            if not exact_server_context_is_current():
+                return False
+            local_character_id = None
+```
+
+(`Callable` is already imported at line 124.) The helper's `is_current` now folds in the `active_server_id` check the old call sites did separately, so simplify the two later fences: at 2669–2676 and 2694–2699 replace the compound `not exact_server_context_is_current() or active_server_id != ...` with just `if not exact_server_context_is_current(): return False` (same conjunction). Keep the predeclarations `assistant_authority_id: str | None` / `local_character_id: int | None` at 2549–2550. The resolver call kwargs are unchanged, so the existing pin `resolve_captures == [initial_capture]` still holds.
+
+- [ ] **Step 4: Implement the persona starter and the consumption branch**
+
+In `session.py`, after `_start_character_console_session` (ends 2827):
+
+```python
+    async def _start_persona_console_session(
+        self, payload: ChatHandoffPayload
+    ) -> bool:
+        """Build a dedicated persona-bound session from a Personas handoff.
+
+        Mirrors ``_start_character_console_session`` minus greeting, local
+        numeric projection, and authority resolution: persona sessions stay
+        authority-free per ADR-037 (server personas get freshness fencing but
+        never an ``assistant_authority_id``).
+        """
+        identity = _persona_session_identity_from_handoff(payload)
+        if identity is None:
+            return False
+        runtime_backend, persona_id, name_hint, assistant_id = identity
+
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        get_persona_profile = getattr(scope_service, "get_persona_profile", None)
+        if not callable(get_persona_profile):
+            return False
+
+        context_is_current: Callable[[], bool] | None = None
+        if runtime_backend == "server":
+            fenced = self._capture_server_handoff_context(payload)
+            if fenced is None:
+                return False
+            _capture, context_is_current = fenced
+
+        try:
+            profile = await get_persona_profile(persona_id, mode=runtime_backend)
+            if hasattr(profile, "model_dump"):
+                profile = profile.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Start Chat: persona profile unavailable; staging context "
+                "instead (source={}, backend={}).",
+                payload.source,
+                runtime_backend,
+            )
+            return False
+        if not isinstance(profile, Mapping) or not profile:
+            return False
+        profile = dict(profile)
+        if str(profile.get("id") or "") != persona_id:
+            return False
+        if context_is_current is not None and not context_is_current():
+            return False
+
+        global_name = _console_global_user_display_name(
+            self._provider_readiness_app_config()
+        )
+        seed = _persona_session_prompt_seed(
+            profile, name_hint=str(name_hint or ""), user_name=global_name
+        )
+
+        store = self._ensure_console_chat_store()
+        canonical_defaults = self._default_console_session_settings()
+        settings = replace(
+            canonical_defaults,
+            system_prompt=seed.system_prompt or None,
+            character_label="",
+        )
+        if context_is_current is not None and not context_is_current():
+            return False
+        active = next(
+            (
+                candidate
+                for candidate in store.sessions()
+                if candidate.id == store.active_session_id
+            ),
+            None,
+        )
+        if (
+            active is not None
+            and active.settings is not None
+            and active.settings != canonical_defaults
+            and active.canonical_settings_baseline == active.settings
+        ):
+            try:
+                active = store.refresh_pristine_session_settings(
+                    active.id,
+                    prior_canonical_settings=active.settings,
+                    current_canonical_settings=canonical_defaults,
+                )
+            except ValueError:
+                pass
+        active_messages = (
+            store.messages_for_session(active.id) if active is not None else []
+        )
+        duplicate_handoff = bool(
+            active is not None
+            and active.settings == settings
+            and active.runtime_backend == runtime_backend
+            and active.assistant_kind == "persona"
+            and active.assistant_id == assistant_id
+            and active.assistant_name == seed.name
+            and active.persona_system_template == seed.system_template
+            and not active_messages
+        )
+        if duplicate_handoff:
+            session = active
+        else:
+            session = None
+            if active is not None and store.is_pristine_session(
+                active.id,
+                expected_settings=canonical_defaults,
+            ):
+                try:
+                    session = store.repurpose_pristine_session(
+                        active.id,
+                        canonical_settings=canonical_defaults,
+                        trusted_system_prompt=seed.system_prompt,
+                        title=f"Chat with {seed.name}",
+                        settings=settings,
+                        runtime_backend=runtime_backend,
+                        assistant_kind="persona",
+                        assistant_id=assistant_id,
+                        assistant_authority_id=None,
+                        character_id=None,
+                        character_name=None,
+                        assistant_name=seed.name,
+                    )
+                except ValueError:
+                    session = None
+            if session is None:
+                session = store.create_session(
+                    title=f"Chat with {seed.name}",
+                    workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+                    settings=settings,
+                    runtime_backend=runtime_backend,
+                    assistant_kind="persona",
+                    assistant_id=assistant_id,
+                    assistant_authority_id=None,
+                    assistant_name=seed.name,
+                )
+            try:
+                store.seed_persona_roleplay(
+                    session.id,
+                    system_template=seed.system_template,
+                    global_default=global_name,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Start Chat: persona roleplay template seed/persist failed; "
+                    "continuing (error_type={}).",
+                    type(exc).__name__,
+                )
+        store.switch_session(session.id)
+        if not duplicate_handoff:
+            # Same defensive cleanup as the server-character path: a persona
+            # session never keys reactions by actor, so clear wholesale.
+            self._clear_session_manual_reactions(session.id)
+        try:
+            await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
+        except asyncio.CancelledError:
+            # The durable commit boundary is above. Report success so the
+            # caller acknowledges this handoff instead of replaying it.
+            return True
+        except Exception:
+            # The persona session is already durably created above -- a
+            # UI-sync/focus failure here must not propagate, or the caller
+            # would never clear ``pending_chat_handoff`` and a later
+            # re-consume would build a SECOND durable persona session.
+            logger.opt(exception=True).warning(
+                "Start Chat: post-seed console sync/focus failed; persona "
+                "session was already created and the handoff is still "
+                "considered consumed."
+            )
+        return True
+```
+
+(`Mapping` is already imported at line 124; `_console_global_user_display_name`, `CONSOLE_GLOBAL_WORKSPACE_ID`, and `replace` are already used by the character starter in this module.)
+
+In `chat_screen.py` `_consume_pending_chat_handoff` (11253–11293), replace the comment block and staging call at 11267–11277:
+
+```python
+            # The native Console composes no legacy tab surface. Personas
+            # Start-Chat handoffs get a dedicated identity-bound session:
+            # character cards seed a greeting (task-427); persona cards bind
+            # name + system template without one (task-32481). Anything else
+            # -- or an identity session that failed to build -- stages into
+            # the Console live-work lane so the context lands in Staged
+            # Context instead of being dropped with a warning.
+            if await self._session._start_character_console_session(payload):
+                store.acknowledge(claim)
+                return
+            if await self._session._start_persona_console_session(payload):
+                store.acknowledge(claim)
+                return
+            self._stage_handoff_as_console_live_work(payload)
+            store.acknowledge(claim)
+```
+
+- [ ] **Step 5: Add the persona branch to `repurpose_pristine_session`**
+
+In `console_chat_store.py` (1015–1096): change the signature to `character_name: str | None` plus `assistant_name: str | None = None`; move the `trusted_system_prompt` non-empty check (1035–1036) into the character branch; widen the kind gate (1039–1040). The validation block becomes:
+
+```python
+        if type(trusted_system_prompt) is not str:
+            raise TypeError("Trusted roleplay system prompt must be text.")
+        if runtime_backend not in {"local", "server"}:
+            raise ValueError("Roleplay runtime backend must be local or server.")
+        if assistant_kind not in {"character", "persona"}:
+            raise ValueError("Repurposed sessions require named identity.")
+        if type(assistant_id) is not str or not assistant_id:
+            raise ValueError("Roleplay assistant id must be non-empty text.")
+        if assistant_authority_id is not None and (
+            type(assistant_authority_id) is not str or not assistant_authority_id
+        ):
+            raise ValueError("Roleplay authority id must be non-empty text or None.")
+        if assistant_kind == "character":
+            if not trusted_system_prompt.strip():
+                raise ValueError("Trusted roleplay system prompt must be non-empty text.")
+            if type(character_name) is not str or not character_name.strip():
+                raise ValueError("Roleplay character name must be non-empty text.")
+            if title != f"Chat with {character_name}":
+                raise ValueError("Roleplay title does not match the character identity.")
+            expected_roleplay_settings = replace(
+                canonical_settings,
+                system_prompt=trusted_system_prompt,
+                character_label=character_name,
+            )
+        else:
+            # Persona sessions remain authority-free (ADR-037) and never
+            # carry character identity. A blank template keeps the canonical
+            # default prompt (``None``), matching the persona seed contract.
+            if assistant_authority_id is not None:
+                raise ValueError("Persona sessions remain authority-free (ADR-037).")
+            if character_id is not None or character_name is not None:
+                raise ValueError("Persona sessions cannot carry character identity.")
+            if type(assistant_name) is not str or not assistant_name.strip():
+                raise ValueError("Persona name must be non-empty text.")
+            if title != f"Chat with {assistant_name}":
+                raise ValueError("Persona title does not match the persona identity.")
+            expected_roleplay_settings = replace(
+                canonical_settings,
+                system_prompt=trusted_system_prompt or None,
+                character_label="",
+            )
+        if settings != expected_roleplay_settings:
+            raise ValueError("Roleplay settings contain noncanonical changes.")
+        if runtime_backend == "local":
+            if assistant_kind == "character" and (
+                type(character_id) is not int
+                or character_id < 1
+                or assistant_id != str(character_id)
+            ):
+                raise ValueError("Local roleplay identity is inconsistent.")
+        elif character_id is not None:
+            raise ValueError("Server roleplay identity cannot carry a local id.")
+```
+
+At the end of the field assignments (after 1092), add:
+
+```python
+        session.assistant_name = assistant_name if assistant_kind == "persona" else None
+```
+
+(This also keeps the one-name invariant on the character path: repurposing a tab as a character clears any stale `assistant_name`.)
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py Tests/Chat/test_console_chat_store.py -v -k "persona_start_chat or persona_payload_rejected or repurpose_pristine_session"`
+Expected: PASS, including the pre-existing repurpose tests at 582/651/693/740/778.
+
+Regression for the fencing refactor (existing character server tests):
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "handoff"`
+Expected: PASS — the pre-existing `test_persona_start_chat_does_not_create_character_session` (5091) stays green (it calls the character starter directly).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/Chat/console_chat_store.py Tests/UI/test_console_native_chat_flow.py Tests/Chat/test_console_chat_store.py
+git commit -m "feat: persona console session starter + repurpose persona branch (task-32481)"
+```
+
+---
+
+### Task 6: Resume persona branch + wiring + hydration
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Screens/chat_screen.py` — new `_resolve_resumed_persona_name` after `_resolve_resumed_character_name` (7148–7171)
+- Modify: `tldw_chatbook/UI/Console_Modules/workspace.py` — ctor param (~164), stored fn (~236), property accessor (after 474), persona overlay branch in `_resume_console_workspace_conversation` (between 2468 and 2469)
+- Modify: `tldw_chatbook/UI/Console_Modules/wiring.py` — beside `resolve_resumed_character_name` (299–301)
+- Modify: `tldw_chatbook/Chat/console_conversation_hydration.py` — after line 438
+- Test: `Tests/UI/test_console_native_chat_flow.py`
+
+**Interfaces:**
+- Consumes: Task 2 envelope key `persona_system_template`; Task 5 bound persona sessions.
+- Produces: `ChatScreen._resolve_resumed_persona_name(persona_id, runtime_backend) -> str`; `ConsoleWorkspaceController` ctor kwarg `resolve_resumed_persona_name` + `_resolve_resumed_persona_name` property; persona overlay branch on resume; hydration restoring `session.persona_system_template`. Task 7's send path relies on both restored fields.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_console_native_chat_flow.py`, mirroring `test_console_resume_rehydrates_local_character_name_from_local_projection` (9096–9137):
+
+```python
+@pytest.mark.asyncio
+async def test_console_resume_rehydrates_persona_name_from_profile():
+    """A resumed persona session re-resolves its display name, both backends."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                    # No assistant_authority_id: personas are authority-free.
+                    # No character_id: personas carry no local projection.
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        name_lookup = AsyncMock(return_value="Archivist")
+        console._resolve_resumed_persona_name = name_lookup
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.runtime_backend == "local"
+        assert session.assistant_kind == "persona"
+        assert session.assistant_id == "local-persona-abc"
+        assert session.assistant_authority_id is None
+        assert session.assistant_name == "Archivist"
+        assert session.character_name is None
+        assert session.character_ref() is None
+        name_lookup.assert_awaited_once_with("local-persona-abc", "local")
+
+
+@pytest.mark.asyncio
+async def test_console_resume_persona_name_lookup_failure_stays_unlabeled():
+    """A failed profile lookup resumes the session without a persona name."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        console._resolve_resumed_persona_name = AsyncMock(return_value="")
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.assistant_kind == "persona"
+        assert session.assistant_name is None
+
+
+@pytest.mark.asyncio
+async def test_console_resume_restores_persona_system_template_from_metadata():
+    """The trusted persona template rides the roleplay metadata envelope."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                    "metadata": {
+                        "console_roleplay_context": {
+                            "version": 1,
+                            "persona_system_template": "Guide {{user}}.",
+                        },
+                    },
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        console._resolve_resumed_persona_name = AsyncMock(return_value="Archivist")
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.persona_system_template == "Guide {{user}}."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "resume_rehydrates_persona or resume_persona_name_lookup or restores_persona_system_template"`
+Expected: FAIL — `assistant_name is None` assertions fail (no persona overlay branch); the metadata test fails on `persona_system_template is None` (hydration does not restore it). The mock on `console._resolve_resumed_persona_name` is never awaited.
+
+- [ ] **Step 3: Implement the screen resolver**
+
+In `chat_screen.py`, immediately after `_resolve_resumed_character_name` (ends 7171):
+
+```python
+    async def _resolve_resumed_persona_name(
+        self, persona_id: str, runtime_backend: str
+    ) -> str:
+        """Return a resumed persona's display name from its profile, or ``""``.
+
+        Best-effort mirror of ``_resolve_resumed_character_name``: any
+        failure (missing scope service, missing profile, fetch error)
+        returns an empty string and the caller keeps the session unlabeled.
+        """
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        get_persona_profile = getattr(scope_service, "get_persona_profile", None)
+        if not callable(get_persona_profile):
+            return ""
+        try:
+            profile = await get_persona_profile(persona_id, mode=runtime_backend)
+            if hasattr(profile, "model_dump"):
+                profile = profile.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Resume: persona profile fetch failed; identity row falls back."
+            )
+            return ""
+        if not isinstance(profile, Mapping):
+            return ""
+        return str(profile.get("name") or "").strip()
+```
+
+(`Mapping` is already imported in `chat_screen.py` at line 3 — no import change needed.)
+
+- [ ] **Step 4: Implement the workspace overlay branch, ctor kwarg, and wiring**
+
+In `workspace.py`'s `_resume_console_workspace_conversation`, insert between the character branch (ends 2468) and the trailing `elif session.settings is not None:` (2469):
+
+```python
+        elif session.assistant_kind == "persona" and session.assistant_id:
+            # Persona sessions carry no local projection; the display name is
+            # re-resolved from the live profile on every resume (ADR-149),
+            # for local and server backends alike.
+            persona_name = await self._resolve_resumed_persona_name(
+                session.assistant_id, session.runtime_backend
+            )
+            session.assistant_name = persona_name or None
+            if persona_name:
+                # One-name invariant: a persona session never shows a stale
+                # character label.
+                session.character_name = None
+            if session.settings is not None:
+                session.settings = replace(session.settings, character_label="")
+```
+
+In the same file's constructor, add after the `wake_retry_poke` parameter (164):
+
+```python
+        resolve_resumed_persona_name: Callable[[str, str], Any] | None = None,
+```
+
+Store it beside line 236 (`self._resolve_resumed_character_name_fn = ...`):
+
+```python
+        self._resolve_resumed_persona_name_fn = resolve_resumed_persona_name
+```
+
+Add the accessor beside the `_resolve_resumed_character_name` property (473–475):
+
+```python
+    @property
+    def _resolve_resumed_persona_name(self) -> Any:
+        resolver = self._resolve_resumed_persona_name_fn
+        if resolver is None:
+            # Bare-controller/test construction: best-effort resume simply
+            # leaves the session unlabeled.
+            async def _unresolved(_persona_id: str, _runtime_backend: str) -> str:
+                return ""
+
+            return _unresolved
+        return resolver
+```
+
+In `wiring.py`, beside `resolve_resumed_character_name` (299–301):
+
+```python
+        resolve_resumed_persona_name=(
+            lambda persona_id, runtime_backend: screen._resolve_resumed_persona_name(
+                persona_id, runtime_backend
+            )
+        ),
+```
+
+In `console_conversation_hydration.py`, after line 438 (`session.character_system_template = ...`):
+
+```python
+    session.persona_system_template = roleplay_context.persona_system_template
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "resume"`
+Expected: PASS, including the pre-existing character resume tests (9096+).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tldw_chatbook/UI/Screens/chat_screen.py tldw_chatbook/UI/Console_Modules/workspace.py tldw_chatbook/UI/Console_Modules/wiring.py tldw_chatbook/Chat/console_conversation_hydration.py Tests/UI/test_console_native_chat_flow.py
+git commit -m "feat: persona name re-resolution + template restore on resume (task-32481)"
+```
+
+---
+
+### Task 7: Screen-state serialization + send-path persona branch
+
+**Files:**
+- Modify: `tldw_chatbook/UI/Console_Modules/session.py` — `_console_session_to_state` (3084–3125), `_console_session_from_state` (3127–3273)
+- Modify: `tldw_chatbook/Chat/console_chat_controller.py` — `_resolved_system_prompt` (12770–12796)
+- Test: `Tests/UI/test_console_native_chat_flow.py`, `Tests/Chat/test_console_provider_continuation.py`
+
+**Interfaces:**
+- Consumes: Task 1 session fields; Task 5/6 bound-and-restored persona identity.
+- Produces: `assistant_name` / `persona_system_template` keys in serialized screen state; kind-keyed one-name invariant on restore; persona branch in `_resolved_system_prompt`. Completes the feature.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `Tests/UI/test_console_native_chat_flow.py`, mirroring `test_native_console_state_round_trip_preserves_source_aware_character_identity` (10323–10375):
+
+```python
+def test_native_console_state_round_trip_preserves_persona_identity():
+    """Screen state keeps persona provenance and its trusted template."""
+    store = ConsoleChatStore()
+    session = ConsoleChatSession(
+        id="session-p",
+        title="Chat with Archivist",
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+        persona_system_template="Guide {{user}} as {{persona}}.",
+    )
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    payload = _console_snapshot_with_sessions(screen)
+    assert payload is not None
+    assert {
+        key: payload["sessions"][0][key]
+        for key in (
+            "runtime_backend",
+            "assistant_kind",
+            "assistant_id",
+            "assistant_name",
+            "persona_system_template",
+        )
+    } == {
+        "runtime_backend": "local",
+        "assistant_kind": "persona",
+        "assistant_id": "local-persona-abc",
+        "assistant_name": "Archivist",
+        "persona_system_template": "Guide {{user}} as {{persona}}.",
+    }
+
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+    _restore_console_snapshot_with_sessions(restored_screen, payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.runtime_backend == "local"
+    assert restored_session.assistant_kind == "persona"
+    assert restored_session.assistant_id == "local-persona-abc"
+    assert restored_session.assistant_name == "Archivist"
+    assert (
+        restored_session.persona_system_template
+        == "Guide {{user}} as {{persona}}."
+    )
+    assert restored_session.character_name is None
+    assert restored_session.character_ref() is None
+
+
+def test_native_console_state_restore_drops_stray_character_name_on_persona():
+    """A contradictory payload keeps only the kind-appropriate name."""
+    store = ConsoleChatStore()
+    session = ConsoleChatSession(
+        id="session-p",
+        title="Chat with Archivist",
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    payload = _console_snapshot_with_sessions(screen)
+    assert payload is not None
+    payload["sessions"][0]["character_name"] = "Stale Character"
+
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+    _restore_console_snapshot_with_sessions(restored_screen, payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.assistant_name == "Archivist"
+    assert restored_session.character_name is None
+```
+
+Append to `Tests/Chat/test_console_provider_continuation.py` (add `from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings` to the imports — not currently present; `ConsoleChatStore` and `ConsoleChatController` are already imported at 19–27):
+
+```python
+def test_resolved_system_prompt_re_expands_persona_template() -> None:
+    """The send path re-expands the trusted persona template per turn."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="Guide {{user}} as {{persona}}.",
+        global_default="Rowan",
+    )
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    # The bare controller is constructed without a `global_user_display_name`
+    # accessor, so the constructor default (`lambda: "User"`, line 1760)
+    # applies and the per-turn re-expansion uses "User" — not the seed-time
+    # "Rowan". This pins that send-time expansion always wins.
+    assert (
+        controller._resolved_system_prompt(session.id)
+        == "Guide User as Archivist."
+    )
+
+
+def test_resolved_system_prompt_leaves_generic_sessions_untouched() -> None:
+    """Non-identity sessions keep the controller's configured prompt."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+    )
+    controller = ConsoleChatController(
+        store=store, provider_gateway=object(), system_prompt="Base prompt."
+    )
+
+    assert controller._resolved_system_prompt(session.id) == "Base prompt."
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "round_trip_preserves_persona or stray_character_name"` and `pytest Tests/Chat/test_console_provider_continuation.py -v -k "resolved_system_prompt"`
+Expected: FAIL — serialized payload lacks `assistant_name`/`persona_system_template`; `_resolved_system_prompt` returns `None` for the persona session (character-only gate falls through to `self.system_prompt`, which defaults to `None`).
+
+- [ ] **Step 3: Serialize and restore the persona fields with the one-name invariant**
+
+In `_console_session_to_state` (session.py 3091–3125), add `"assistant_name": session.assistant_name` immediately after the `"character_name"` line (3113) and `"persona_system_template": session.persona_system_template` immediately after the `"character_system_template"` line (3115). Explicit field list — nothing else changes.
+
+In `_console_session_from_state` (3127–3273), after the `character_name` block (3238–3240):
+
+```python
+        raw_assistant_name = raw_session.get("assistant_name")
+        if raw_assistant_name is not None:
+            session_kwargs["assistant_name"] = str(raw_assistant_name)
+```
+
+After the `character_system_template` block (3249–3254):
+
+```python
+        raw_persona_system_template = raw_session.get("persona_system_template")
+        session_kwargs["persona_system_template"] = (
+            raw_persona_system_template
+            if isinstance(raw_persona_system_template, str)
+            else None
+        )
+```
+
+Immediately before `return ConsoleChatSession(**session_kwargs)` (3273):
+
+```python
+        # One-name invariant (ADR-149): a session shows exactly one identity
+        # label, keyed by kind. A contradictory payload keeps only the
+        # kind-appropriate field. Legacy payloads predate `assistant_name`,
+        # so the else-branch pop is a no-op for them.
+        if session_kwargs.get("assistant_kind") == "persona":
+            session_kwargs.pop("character_name", None)
+        else:
+            session_kwargs.pop("assistant_name", None)
+```
+
+- [ ] **Step 4: Add the persona branch to `_resolved_system_prompt`**
+
+In `console_chat_controller.py`, replace the body of `_resolved_system_prompt` (12770–12796) with a kind-keyed pick (behavior on the character path is unchanged):
+
+```python
+    def _resolved_system_prompt(self, session_id: str | None) -> str | None:
+        """Resolve the trusted identity system template for the session kind."""
+        if session_id is None:
+            return self.system_prompt
+        session = next(
+            (
+                candidate
+                for candidate in self.store.sessions()
+                if candidate.id == session_id
+            ),
+            None,
+        )
+        if session is None:
+            return self.system_prompt
+        if session.assistant_kind == "character":
+            name = session.character_name
+            template = session.character_system_template
+        elif session.assistant_kind == "persona":
+            name = session.assistant_name
+            template = session.persona_system_template
+        else:
+            return self.system_prompt
+        if (
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(template, str)
+            or not template.strip()
+        ):
+            return self.system_prompt
+        context = self._presentation_context_for(session_id)
+        return expand_character_template(
+            template,
+            user_name=context.user_name,
+            character_name=name.strip(),
+        )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py -v -k "round_trip or stray_character_name or state_restore"` and `pytest Tests/Chat/test_console_provider_continuation.py -v`
+Expected: PASS — new persona tests plus the pre-existing state round trips (10323, 10406) and the whole provider-continuation file (character `_resolved_system_prompt` behavior preserved; no pre-existing direct tests of it — these are the first).
+
+- [ ] **Step 6: Full feature sweep + task hygiene**
+
+Run the complete set of files this plan touches:
+
+Run: `pytest Tests/UI/test_console_native_chat_flow.py Tests/Chat/test_console_chat_store.py Tests/Chat/test_console_provider_continuation.py Tests/Chat/test_console_conversation_hydration.py Tests/Chat/test_console_roleplay_metadata.py -q`
+Expected: PASS.
+
+Then update the backlog task by hand (the `backlog` CLI is not installed here — edit `backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md` directly): mark every acceptance criterion `- [x]`, add the `## Implementation Notes` section (approach: persona branch on the ADR-046 identity machinery; authority-free per ADR-037; name re-resolved at resume; template in the version-1 envelope), and set `status: Done` in the frontmatter.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add tldw_chatbook/UI/Console_Modules/session.py tldw_chatbook/Chat/console_chat_controller.py Tests/UI/test_console_native_chat_flow.py Tests/Chat/test_console_provider_continuation.py "backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md"
+git commit -m "feat: persona identity in console screen state + send path (task-32481)"
+```
+
+---
+
+## Self-Review Notes
+
+Checks run against the approved spec before commit:
+
+- **Spec coverage:** §1 identity model → Task 1; gate hygiene (`_is_named_persona_session` / `_is_named_identity_session`) and swap hardening → Task 3; §2 handoff routing/creation → Tasks 4–5 (with the fenced-fetch deviation flagged in Global Constraints); §3 expansion at seed/send/identity-change → Tasks 3, 5, 7; `expand_character_template` docstring line → Task 1; §4 presentation → Task 1 (chip needs no change — verified `_build_console_control_state` already passes `assistant_name`); §5 persistence/resume → Tasks 2, 6; §6 error handling → Tasks 5–7; §7 testing matrix → per-task test steps. Resume server-mode parameter pinning is covered by the local assertion pattern only, matching the character suite's local-only resume coverage.
+- **Placeholder scan:** no TBD/TODO; every line reference and signature was verified against the working tree on 2026-09-11.
+- **Type/name consistency:** `assistant_name`, `persona_system_template`, `session_assistant_display_name`, `_is_named_identity_session`, `seed_persona_roleplay(session_id, *, system_template, global_default)`, `set_session_assistant_name`, `_persona_session_identity_from_handoff` (4-tuple), `PersonaSessionPromptSeed`, `_persona_session_prompt_seed(profile, name_hint=..., *, user_name=...)`, `_capture_server_handoff_context`, `_start_persona_console_session`, `_resolve_resumed_persona_name(persona_id, runtime_backend)`, `get_persona_profile(persona_id, mode=...)`, and `ConsoleRoleplayContext.persona_system_template` are spelled identically at every production and consumption site.
+

--- a/Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md
+++ b/Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md
@@ -1,0 +1,347 @@
+# Agent Chat Fork & Spawn — Design Spec
+
+Date: 2026-09-11
+Status: Approved design (pre-plan)
+Governance: ADR required (conversation-lineage semantics are a data-ownership
+decision; an agent-initiated, confirmation-gated chat-creation channel is a
+cross-module interface with a security policy). New ADR, not amending ADR-146.
+Backlog task to be created at plan time; follow-up task for sub-agent support
+already filed (`backlog/tasks/task-32480 - Extend-fork_chat-new_chat-tools-to-sub-agents.md`).
+
+```text
+ADR required: yes
+ADR path: backlog/decisions/NNN-agent-chat-fork-and-spawn.md (number assigned at plan time)
+Reason: first writer of the conversation-lineage columns (data ownership) plus a new
+agent-initiated UI-mutation channel gated by a confirmation policy (cross-module
+interface + security); fork copy semantics will be reused by the sub-agent and
+preset-routing follow-ups.
+```
+
+## Problem
+
+A Console agent can suggest parallel workstreams ("we could chase A, B, or C"),
+but the user must manually create each chat (Ctrl+T), re-title it, re-paste
+context, and re-state the goal. There is no agent-reachable way to prepare those
+chats, and no fork primitive at all: the `parent_conversation_id` /
+`forked_from_message_id` columns added in the V11→V12 migration "for
+conversation forking" (`DB/ChaChaNotes_DB.py:468-469`) have never been written
+by Console code, and `Chat/chat_persistence_service.py:333`
+`fork_conversation_into_workspace` is a misleading name — it links workspace
+membership for the *same* conversation and copies nothing.
+
+This spec adds two runtime tools, `fork_chat` and `new_chat`, that let the
+primary agent prepare follow-through chats for the user, always confirmed by
+default.
+
+## Locked decisions (from brainstorming)
+
+1. **Fork copies the active path as of the tool call.** Root → active leaf,
+   verbatim: roles, content, tool-call/result markers, tree parents remapped.
+   Mid-conversation forks compose with existing rewind (rewind first, then
+   fork). No agent-facing message-addressing scheme.
+2. **Agent-settable args: `title`, `opening_prompt`, `instructions`** — and
+   nothing else. No provider/preset/model args in v1 (deferred, decision 7).
+3. **Two runtime tools**, not one with a mode enum: `fork_chat` (copy path)
+   and `new_chat` (fresh chat). Distinct schemas, descriptions, and card
+   headers. Names deliberately avoid "spawn" (`spawn_subagent` exists).
+4. **The opening prompt is a draft, never sent.** It lands in the new chat's
+   composer via `set_session_draft` ("Open in Console" precedent). The user
+   reviews, edits, and sends. One approval covers one creation.
+5. **Confirmation: per-call card, Allow / Allow for this session / Deny**,
+   modeled on `request_skill_script_confirm` (`Chat/console_chat_controller.py:6253`).
+   Fail-closed on no-UI/cancel/timeout; parks a badge for background sessions.
+   Remember is per-tool and Console-session-scoped — no persisted bypass, so
+   every new conversation confirms by default.
+6. **Landing: background + toast.** The new chat is created in the same
+   workspace, not activated; a toast announces it by title; the user stays in
+   the current chat while the agent finishes its turn.
+7. **Provider/preset routing for new chats is out of scope for v1** and lands
+   as a dedicated integration PR after the agent provider-routing work
+   (presets + gated spawn overrides) merges to dev.
+
+## Goals
+
+* An agent can turn "here are three parallel workstreams" into three prepared
+  chats — titled, optionally forked from current context, each with a draft
+  opening prompt — in one turn, each behind an explicit user approval.
+* Fork semantics are exact and durable: verbatim active-path copy, lineage
+  columns written, divergence afterwards is total (new messages never appear
+  in the source and vice versa).
+* Confirmation is the default state; opt-out is bounded to the current
+  Console session and per tool.
+* Zero DB schema migration in either database.
+
+## Non-goals
+
+* Auto-sending the opening prompt, or the agent chatting in the new chat.
+* Agent-chosen fork points, batch-approval of multiple creations in one card,
+  full-tree copies (variants/inactive branches).
+* Provider/model/preset selection on the created chats (decision 7).
+* Sub-agent access to the tools — filed as `task-32480`.
+* Any change to rewind, branching, or workspace-membership semantics beyond
+  what creation needs.
+
+## Architecture
+
+Both tools follow the `install_skill` / `run_skill_script` **runtime-tool**
+pattern — not local/builtin catalog tools — because they need conversation
+context, a blocking confirm round-trip, and chat-store access from the agent's
+worker thread. Per tool:
+
+* `RUNTIME_TOOL_NAMES` entry (`Agents/agent_models.py:106`) and a
+  `ToolSchema` constant in `Agents/tool_catalog.py` (style of
+  `INSTALL_SKILL_TOOL_SCHEMA` :258). IDs: `runtime:fork_chat`,
+  `runtime:new_chat`. Descriptions document the confirm contract, the
+  draft-not-send behavior, the mid-turn snapshot boundary (see Fork
+  primitive), and guidance to create sparingly (one card per call; a turn
+  that needs three chats gets three sequential confirms).
+* Constructor-injected callable on `AgentService.__init__` (pattern:
+  `run_skill_script_tool`, `agent_service.py:1045`), threaded in from the
+  bridge's `run_reply` composition (`Chat/console_agent_bridge.py:3385-3433`,
+  closure pattern :3678-3865).
+* Schema pin in `_run_one`, gated on
+  `agent_kind == AGENT_KIND_PRIMARY and self._<callable> is not None`,
+  **appended after the run-log block (post-`agent_service.py:2597`)** so the
+  diff inside `agent_service.py` is new lines only — the in-flight
+  provider-routing PR rewrites the spawn closure (:3115-3442) and the
+  `runtime_schemas` block around :2513-2597.
+* Dispatch branch in `Agents/agent_runtime.py` `run_agent_loop` (spawn branch
+  :1450-1490 is the model; `LoopDeps` :327-476).
+
+Transcript rendering is free: the tools emit normal `STEP_TOOL_CALL` /
+`STEP_TOOL_RESULT` steps and render via `format_agent_step_marker`
+(`console_agent_bridge.py:865-913`) / `_append_marker` (:6180).
+
+## Tool contracts
+
+### `fork_chat`
+
+Args (all optional strings): `title`, `opening_prompt`, `instructions`.
+
+Behavior: snapshot the **active path of the running agent's own conversation**
+(not whatever session is visible on screen) and copy it verbatim into a new
+conversation:
+
+* Fields preserved per message: sender/role, content, `metadata_json`,
+  `usage_json`, `provider_continuation_json`, image fields, timestamps. IDs
+  regenerate; `parent_message_id` remaps old→new.
+* `parent_conversation_id` = source conversation id;
+  `forked_from_message_id` = source active-leaf message id.
+* Inherits from the source: workspace (`scope_type`/`workspace_id`),
+  assistant identity / character binding, system prompt, speech preferences.
+  `instructions`, when given, **replaces** the system prompt — except on
+  character-bound sources, where `instructions` is refused (see Errors): a
+  model-authored prompt must not silently override a persona.
+* Project-instruction bindings are **not** copied: the new chat starts with
+  its own default `ProjectInstructionControlState` (per-session binding is a
+  deliberate user act under ADR-069 governance).
+
+### `new_chat`
+
+Same args. Creates a fresh, empty conversation in the same workspace with
+Console defaults plus whatever the agent supplied. Never inherits another
+chat's identity or context.
+
+### Shared semantics
+
+* `title` defaults: `"Fork of <source title>"` / `"New Chat"`. Clamped and
+  sanitized (control chars stripped, length cap) via `input_validation`.
+* `opening_prompt` (max length capped, excess rejected with a clear error)
+  becomes the new session's composer draft via `set_session_draft`.
+* Result JSON to the agent: `{ok, title, conversation_id, workspace_id,
+  copied_messages (fork only), draft_set: true, note}` where `note` states
+  that the chat opened in the background and the user must send the draft
+  themselves.
+* Both tools may only run when the source session is durable. An ephemeral
+  source (`ConsoleChatSession.ephemeral`) is a tool error for `fork_chat`
+  (nothing persisted to copy); `new_chat` always creates a durable chat.
+
+### Mid-turn snapshot boundary
+
+The copy is taken at tool execution. Messages appended to the source after
+that point — including this tool call's own result marker and the remainder
+of the current assistant turn (the very reply suggesting the workstreams) —
+are **not** in the fork. This is deliberate and must be taught in the tool
+description: the agent carries workstream framing in `opening_prompt`, never
+relies on its in-flight reply being present in the copy.
+
+## Fork primitive
+
+New helper `fork_conversation_history` in `Chat/chat_conversation_service.py`
+(which already owns `create_conversation` :370; the name avoids collision
+with the misnomer `fork_conversation_into_workspace`):
+
+1. Read the source active path via the existing tree walk
+   (`Chat/chat_conversation_scope_service.get_conversation_tree` :364, the
+   same raised-caps read `Chat/console_conversation_hydration.py:250`
+   `load_console_conversation_tree` uses). **The read must be uncapped —
+   silent truncation of long chats is a bug, and a >cap-length fork is a
+   required test.**
+2. Create the target through `Chat/chat_persistence_service.create_conversation`
+   (:216) — carries title, workspace scope, identity, system prompt
+   (possibly overridden by `instructions`), speech prefs, metadata — with the
+   two lineage columns passed through (the service's `extra_fields`
+   passthrough already reaches `add_conversation`, `DB/ChaChaNotes_DB.py:7610`).
+3. Loop `db.add_message` (:9524) remapping parents, inside one transaction
+   (`db.transaction()`); chunked inserts so a large copy does not hold an
+   oversized single statement batch (FTS triggers fire per row; cost is
+   bounded and off the UI thread). Atomic: a mid-copy failure rolls back and
+   creates nothing.
+4. `set_conversation_active_leaf` (:9096) to the copied leaf.
+
+No schema migration: both lineage columns already exist (index included,
+:482) and are simply never written by the Console today.
+
+### Draft durability
+
+The composer draft is session state and would vanish on restart. To make the
+handoff durable, the creation writes the draft into the conversation's
+local-only metadata (key `console_agent_handoff`: `{draft, created_via,
+source_run_id}`), the same persistence philosophy as per-conversation
+project-instruction state (`set_conversation_console_project_context`,
+`DB/ChaChaNotes_DB.py:9165`). `restore_persisted_session`
+(`Chat/console_chat_store.py:1210`) rehydrates it into the session draft; it
+is consumed by ordinary composer semantics (sent, edited, or replaced).
+
+## Session creation & UI surfacing
+
+After an allow, on the agent worker thread: run the fork copy (fork_chat) or
+nothing (new_chat) — note `new_chat` also creates its conversation row
+immediately (not lazily) so both tools produce an equal, durable artifact.
+Then marshal to the UI thread (`app.call_from_thread`, pattern
+`UI/Console_Modules/agent.py:1121`):
+
+1. Build a **non-activated** session over the new conversation —
+   `restore_persisted_session` activates today, so it gains an
+   `activate=False` variant (`create_session` :883 already supports the
+   flag; `Chat/console_launch_wake.py:235` proves no-screen hydration).
+2. `set_session_draft(opening_prompt)`.
+3. Workspace listing: verify at implementation time whether the workspace
+   thread list keys off `conversations.scope_type/workspace_id` or
+   `workspace_registry` membership; if the latter, apply the same
+   membership link `fork_conversation_into_workspace` uses. The new chat
+   must actually appear in its workspace list — invisibility here would be
+   a silent failure.
+4. `_invalidate_console_persisted_rows_cache()` and
+   `run_worker(self._sync_native_console_chat_ui, exclusive=True,
+   group="console-sync")` (`UI/Screens/chat_screen.py:12159`).
+5. Toast: `app.notify` — "Forked chat created: <title>" / "New chat created:
+   <title>".
+
+The user is never switched away mid-turn (locked decision 6).
+
+## Confirmation flow
+
+Modeled on `request_skill_script_confirm` (`console_chat_controller.py:6253-6438`)
+with `resolve_pending_*` (:6472) and a `set_pending_*` card seam:
+
+* Card: verb header ("Fork this chat" / "Create new chat"), proposed title,
+  **full bodies** of `opening_prompt` and `instructions` (a model-authored
+  system prompt is a persistent injection surface and is always shown in
+  full on the card), fork summary (N messages from "<source title>"),
+  requesting run/agent identity.
+* Buttons: **Allow / Allow for this session / Deny**. Remember is per tool
+  name, scoped to the Console session (cleared when the session closes), and
+  covers only the confirm card — creation still executes fresh each call.
+* No UI / cancel / timeout / revoked round ⇒ deny-equivalent error result to
+  the agent. Parks a badge for background sessions (pattern:
+  `_park_console_approval`, `UI/Screens/chat_screen.py:16346`).
+* Honors the run-cancel signal and the approval kill-switch semantics like
+  the skill-script confirm does.
+* **Denial guard:** denials are counted per tool per run; after 2 denials,
+  further calls of that tool fail fast with a terminal error for the rest of
+  the run (no card). Deny results and tool descriptions both instruct the
+  model not to retry within the turn.
+
+Residual, accepted risk (documented in the ADR): with session-remember
+active, a later call's `instructions` payload is not card-reviewed; exposure
+is bounded to the Console session and the resulting system prompt remains
+visible/editable in the new chat's settings.
+
+## Error handling
+
+All errors surface as the tool's error result (never exceptions across the
+seam):
+
+* `source_not_persisted` — fork on an ephemeral session.
+* `empty_history` — fork of a conversation with zero messages ("use
+  new_chat").
+* `character_conflict` — `instructions` on a character-bound fork source.
+* `payload_too_large` — `opening_prompt`/`instructions` over the length cap.
+* `user_denied` / `confirm_timeout` / `run_cancelled` — fail-closed outcomes.
+* `denied_repeatedly` — terminal after the denial guard trips.
+* `copy_failed` — transaction rolled back; nothing created.
+
+## Sub-agent extension (deferred — task-32480)
+
+v1 pins both tools to `AGENT_KIND_PRIMARY`. Sub-agents are scoped to the
+parent conversation, so extending means: pin schemas for child kinds, fork
+from the parent conversation's active path, identify the requesting agent
+and parent run on the card, and scope denial/remember to the requesting run.
+
+## Provider/preset integration (deferred — decision 7)
+
+After the agent provider-routing PR merges to dev, a follow-up PR adds
+optional preset/provider selection to the created chats, reusing that work's
+`AgentDefinition` routing vocabulary and `SpawnTarget` resolution. The v1
+schemas intentionally omit those args so the later change is additive.
+
+## Testing
+
+* **Unit (fork helper):** active-path selection; parent remap; leaf set;
+  lineage columns written; field preservation (images, usage,
+  provider_continuation, metadata); TOOL-role markers copied; **>
+  read-cap message count copies without truncation**; mid-copy failure rolls
+  back atomically; ephemeral and empty-history refusal; character-bound
+  `instructions` refusal; `new_chat` immediate persistence.
+* **Unit (confirm):** allow / deny / remember-scoping (per tool, per
+  session) / no-UI fail-closed / cancel / deadline / park-for-background;
+  denial-guard terminal behavior.
+* **Integration:** bridge → controller → store end to end on a real
+  in-memory SQLite DB; schema pinned for primary runs and absent for
+  subagent kinds; dispatch branch reached; result JSON shape; STEP markers
+  render via `format_agent_step_marker`; workspace listing shows the new
+  chat (whichever listing mechanism step 3 of surfacing confirmed);
+  `activate=False` does not switch the active session.
+* **Draft durability:** conversation + `console_agent_handoff` metadata
+  survive a store rebuild; draft rehydrates into the composer.
+* **Live verification** (per `backlog/docs/lessons-live-verification.md`):
+  real app run — agent proposes two workstreams, forks one chat and creates
+  one fresh; confirm card, toast, switcher entries, drafts in composers;
+  send in the fork and verify the source chat does not receive it; restart
+  and verify both chats and drafts persist.
+
+## Expected touch list
+
+* New: `fork_conversation_history` in `Chat/chat_conversation_service.py`,
+  spec (this doc), ADR.
+* Modified: `Agents/agent_models.py` (two `RUNTIME_TOOL_NAMES` entries),
+  `Agents/tool_catalog.py` (two schema constants),
+  `Agents/agent_service.py` (two injected callables + post-:2597 pins — new
+  lines only), `Agents/agent_runtime.py` (dispatch branches),
+  `Chat/console_agent_bridge.py` (two closures in the `run_reply`
+  composition region — accepted overlap with the routing PR),
+  `Chat/console_chat_controller.py` (confirm rounds + resolvers + card
+  seam), `Chat/console_chat_store.py` (`restore_persisted_session`
+  `activate=False` variant, draft-rehydration hook),
+  `Chat/chat_persistence_service.py` (lineage passthrough), plus the
+  workspace-listing wiring whichever mechanism verification requires
+  (`UI/Console_Modules/workspace.py` if membership links are needed).
+* Docs: `Docs/User_Guide/console/agent-runs-and-tools.md`, a workstream
+  blurb in `Docs/User_Guide/console/`.
+* Tests: new `Tests/Chat/test_console_chat_fork_spawn.py` +
+  fork-helper unit tests alongside the conversation-service suite.
+
+## Rollout
+
+1. Plan time: create ADR (`backlog/decisions/NNN-agent-chat-fork-and-spawn.md`)
+   and the v1 backlog task; link both ways and to `task-32480`.
+2. Sequence against the provider-routing PR: implement on top of it (or
+   rebase before opening) — `agent_service.py`, `agent_runtime.py`, and
+   `console_agent_bridge.py` are shared files; our edits are additive but
+   the routing PR rewrites adjacent regions.
+3. Implement in order: fork helper → runtime-tool seam (schema + pin +
+   dispatch + injected callable) → confirm card & rounds → session
+   surfacing & draft durability → docs.
+4. Live verification before marking done; lessons doc updated only if the
+   task surfaces something generalizable.

--- a/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
+++ b/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
@@ -1,0 +1,238 @@
+# Agent Provider Routing — Design Spec
+
+Date: 2026-09-11
+Status: Approved design (pre-plan)
+Governance: ADR required (provider/runtime boundary + cross-module interface); Backlog task to be created at plan time.
+
+## Problem
+
+A Console agent run resolves exactly one `ConsoleProviderSelection` at send
+time (`build_console_provider_selection_from_settings`,
+`Chat/console_chat_controller.py:288`), and everything the run spawns inherits
+it. `AgentDefinition.model` (`Agents/agent_models.py:375`) can only swap the
+model *on the same provider endpoint*. There is no way for a master/control
+agent to run on one backend (e.g. Kimi API) while delegating implementation
+work to a child on another (e.g. a local qwen3.8-27B served via llama.cpp,
+ollama, or a `custom-ep:` registry entry from ADR-146 / PR #2617).
+
+## Locked decisions (from brainstorming)
+
+1. **Mechanism: presets primary, ad-hoc args as gated override.** Named agent
+   presets carry routing; `spawn_subagent` gains optional ad-hoc args honored
+   only under a user-controlled flag.
+2. **Default: explicit sub-agent default setting.** A new
+   `[agents] subagent_default_provider/model`; when unset, children inherit
+   the parent's selection (today's behavior).
+3. **Override scope: flag + allowlist.** Ad-hoc args require
+   `[agents] spawn_override_enabled = true` AND the requested provider must be
+   in `[agents] spawn_override_allowlist`. Presets are user-authored and
+   therefore unrestricted by the allowlist.
+
+## Goals
+
+- A master agent can spawn children onto a different provider+model than its
+  own, via named presets or (when enabled) ad-hoc args.
+- The user owns the routing table: presets, the sub-agent default, the
+  override flag, and the allowlist are all user-configured.
+- Cross-provider routing reuses the existing readiness/identity/execution
+  seams, including `custom-ep:` registry providers.
+- Routing decisions are loud, persisted, and visible — never silent fallbacks.
+
+## Non-goals
+
+- Per-preset sampling parameters (temperature, etc.). Children inherit the
+  parent's sampling params.
+- Named route registry as a separate config entity (rejected approach 2).
+- Policy-file rules engine (rejected approach 3).
+- Per-provider budget accounting; unpriced local models keep the existing
+  "unpriced keeps previous accounting" behavior
+  (`Agents/agent_service.py:_budget_weighted_tokens`).
+- Any change to how the top-level (session) provider+model is chosen.
+
+## Architecture
+
+New **pure** module `Agents/agent_routing.py` (preserving the rule that
+`agent_service.py` is the only impure Agents module). It owns:
+
+- Config-dataclass defaults for the new `[agents]` keys (mirroring how
+  `DEFAULT_MAX_LIVE_SUBAGENTS` etc. live in `agent_service.py`), so the
+  shipped `config.py` template keeps the keys commented out.
+- The resolver:
+
+```
+resolve_spawn_target(app_config, parent_selection, preset, override_args, agents_config)
+    → SpawnTarget | RoutingError
+```
+
+`SpawnTarget` carries `provider`, `model`, `base_url` (already resolved,
+including registry lookup for `custom-ep:` ids), plus a `source` tag
+(`override` / `preset` / `default` / `inherit`) for logging and persistence.
+
+### Resolution order
+
+Each level fills only blanks left by the levels above:
+
+1. **Ad-hoc spawn args** (`provider`, `model` from the spawn tool call).
+   Honored only when `spawn_override_enabled` is true; when `provider` is
+   given it must appear in `spawn_override_allowlist`. A model-only ad-hoc
+   arg swaps the model on whatever provider levels 2–4 resolve.
+2. **Preset routing fields** — the spawned `AgentDefinition`'s `provider`
+   and `model`.
+3. **Sub-agent default** — `[agents] subagent_default_provider` /
+   `subagent_default_model`.
+4. **Inherit parent** — the run's own `ConsoleProviderSelection`.
+
+The winner is validated through the existing seams:
+`resolve_console_provider_identities` (`Chat/console_provider_support.py`)
+for display/readiness/execution keys (custom-ep aware), then readiness
+(missing credential / no reachable endpoint → `RoutingError`), producing a
+full `ConsoleProviderSelection` for the child. Tool shaping needs no change:
+`provider_supports_native_tools` is already evaluated per run inside
+`_make_call_model` (`agent_service.py:1314,1565`). Unknown local models fall
+back to default token-window handling, same as any unlisted model today.
+
+`AgentService.spawn()` (`agent_service.py:3115`) calls the resolver **before**
+reserving fleet capacity; a `RoutingError` is returned to the master as the
+spawn tool's error result and no fleet slot is consumed.
+
+## Data model changes
+
+### `AgentDefinition` (`Agents/agent_models.py`)
+
+- New field `provider: str = ""`. Semantics of the existing `model` field
+  widen from "same endpoint only" to "model on the preset's provider".
+  `model` set **without** `provider` keeps today's exact same-endpoint
+  behavior — existing presets are unaffected.
+- No `base_url` field: built-in providers resolve URLs from `api_settings`;
+  additional local endpoints are `custom-ep:` registry entries (their
+  entries carry URL + credentials, ADR-146). Presets name the slug.
+- `validate_agent_definition` additionally checks `provider` is a known
+  built-in provider id or matches the `custom-ep:<slug>` form. Registry
+  existence is **not** checked at validation time (entries can be deleted
+  between authoring and spawn); that surfaces as a spawn-time
+  `RoutingError` instead.
+- The definition dict serialization (`agent_models.py:417`) gains `provider`.
+
+### Config `[agents]` (template at `config.py:3046`)
+
+New keys, shipped commented-out with defaults owned by
+`Agents/agent_routing.py`:
+
+- `subagent_default_provider` (string, empty = unset → inherit)
+- `subagent_default_model` (string, empty = provider's configured/default model)
+- `spawn_override_enabled` (bool, default false)
+- `spawn_override_allowlist` (list of provider ids, may include
+  `custom-ep:<slug>` entries; default empty)
+
+### Database (`DB/AgentRuns_DB.py`, `_CURRENT_SCHEMA_VERSION` 15 → 16)
+
+One version step adding:
+
+- `agent_definitions.provider TEXT NOT NULL DEFAULT ''`
+- `agent_runs` resolved-target snapshot columns (nullable):
+  `resolved_provider`, `resolved_model`, `resolved_base_url`
+
+### Resume / continuation semantics
+
+Today fleet continuation re-resolves the agent definition *by name*, so
+editing a preset between finish and resume would silently move the child to
+a different provider mid-conversation. Fix: the resolved target is persisted
+on the run row at spawn; continuation/resume reuses the persisted snapshot.
+Live re-resolution is the fallback only for legacy rows with NULL snapshot
+columns.
+
+## Spawn tool contract & master visibility
+
+- `spawn_subagent` gains optional string args `provider` and `model`.
+- The args are **omitted from the tool schema entirely** when
+  `spawn_override_enabled` is false — the model cannot attempt what is not
+  advertised. Schema construction (identity-path schema referenced at
+  `agent_service.py:1170`) becomes config-dependent.
+- When enabled, the schema description enumerates the allowlisted provider
+  ids with their configured models (from `api_settings` and registry cached
+  `CustomEndpointEntry.models`), so the master chooses real targets instead
+  of guessing.
+- Named-agent enumeration (existing) gains each preset's routing in its
+  description, e.g. "runs on custom-ep:qwen-local / qwen3.8-27b".
+
+## Security policy
+
+- Spawn args are model-generated and therefore untrusted: `provider` accepts
+  only a known built-in provider id or a `custom-ep:<slug>` matching the
+  registry slug pattern. **Ad-hoc args never carry URLs** — endpoints come
+  only from user-controlled config/registry, so a prompt-injected master
+  cannot point a child at an arbitrary endpoint to exfiltrate context.
+- The allowlist is the cost/injection guard for ad-hoc routing; presets are
+  trusted because the user authored them.
+- No credential material flows through the resolver's outputs beyond what
+  the existing gateway already handles; registry entries' `api_key` is
+  repr-excluded upstream (ADR-146).
+
+## Error handling
+
+`RoutingError` variants, always surfaced as the spawn tool's error result so
+the master can pick another target or ask the user:
+
+- `override_disabled` — ad-hoc args present while the flag is off
+  (defense-in-depth; the args are also absent from the schema).
+- `provider_not_allowlisted` — ad-hoc `provider` not in the allowlist.
+- `unknown_provider` — id matches no built-in provider.
+- `unknown_endpoint_slug` — `custom-ep:<slug>` not in the registry.
+- `provider_not_ready` — missing credential or no reachable endpoint.
+- `no_model_resolved` — fires only when routing selected a provider other
+  than plain inherit (levels 1–3) and every level left model blank and the
+  target provider has no configured/default model. The inherit path keeps
+  today's behavior exactly (a blank model means the endpoint's server-side
+  default, as now) and never raises this error.
+
+Each error names the failing level (override / preset / default). There is
+**no** automatic cross-provider fallback. The rail summary shows each
+child's resolved target (e.g. "qwen-local · qwen3.8-27b").
+
+## Settings UI
+
+`Widgets/settings_agents_panel.py` gains:
+
+- Per-preset `provider` / `model` pickers, fed by the same provider-option
+  builder as Console settings so `custom-ep:` entries appear with their
+  `display_name`.
+- Sub-agent default provider/model pickers.
+- `spawn_override_enabled` toggle and an allowlist multi-select.
+- Stale allowlist entries (deleted registry slugs) are flagged in the UI,
+  not silently dropped from config.
+
+## Testing
+
+- **Unit:** pure resolver matrix — every resolution level, blank-filling,
+  each `RoutingError` variant, custom-ep slug resolution, model-only ad-hoc
+  args.
+- **Integration:** spawn through `AgentService` with routed preset, with
+  sub-agent default, and with override on/off; assert the child's
+  `ConsoleProviderSelection`, the persisted snapshot columns, and that
+  refusals return an error result without consuming a fleet slot.
+- **Migration tests** for schema v16: column defaults, legacy rows unchanged.
+- **Backward-compat regression:** existing preset with `model` but no
+  `provider` keeps same-endpoint override behavior.
+- **Settings panel tests:** picker populations include custom-ep display
+  names; stale allowlist slug flagging.
+- **Live verification** (per `backlog/docs/lessons-live-verification.md`):
+  real local endpoint registered as `custom-ep:`, cheap cloud model as
+  master, one two-step delegation exercised end to end.
+
+## Expected touch list
+
+- New: `Agents/agent_routing.py`, spec/plan docs, ADR.
+- Modified: `Agents/agent_models.py`, `Agents/agent_service.py` (spawn hook,
+  schema gating), `DB/AgentRuns_DB.py` (v16 migration), `config.py`
+  (template comments), `Widgets/settings_agents_panel.py`,
+  `Chat/console_agent_bridge.py` (rail summary target display).
+- Tests: new `Tests/Agents/test_agent_routing.py` plus integration,
+  migration, and settings-panel coverage.
+
+## Rollout
+
+1. Create ADR in `backlog/decisions/` and Backlog task; link both ways.
+2. Implement per the writing-plans output (pure resolver first, then DB
+   migration, then spawn integration, then UI).
+3. Update `Docs/User_Guide/console/agent-runs-and-tools.md` with the new
+  `[agents]` keys and preset routing fields.

--- a/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
+++ b/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
@@ -2,7 +2,9 @@
 
 Date: 2026-09-11
 Status: Approved design (pre-plan)
-Governance: ADR required (provider/runtime boundary + cross-module interface); Backlog task to be created at plan time.
+Governance: ADR required (provider/runtime boundary + cross-module interface);
+the ADR also **amends ADR-146** (registry entries gain a `params` table —
+precedent: ADR-020 amends ADR-002). Backlog task to be created at plan time.
 
 ## Problem
 
@@ -22,31 +24,44 @@ ollama, or a `custom-ep:` registry entry from ADR-146 / PR #2617).
    only under a user-controlled flag.
 2. **Default: explicit sub-agent default setting.** A new
    `[agents] subagent_default_provider/model`; when unset, children inherit
-   the parent's selection (today's behavior).
+   the parent's provider+model (today's behavior).
 3. **Override scope: flag + allowlist.** Ad-hoc args require
    `[agents] spawn_override_enabled = true` AND the requested provider must be
    in `[agents] spawn_override_allowlist`. Presets are user-authored and
    therefore unrestricted by the allowlist.
+4. **Children never inherit the parent's sampling/API params.** A child's
+   params are built fresh for its resolved provider+model — uniform rule,
+   including the plain-inherit path (behavior change, see "Sampling / API
+   params").
+5. **Param ownership: endpoint defaults + preset overrides (D).** Registry
+   entries gain an optional `params` table (endpoint-owned tuning);
+   `AgentDefinition` presets gain optional `params` applied above everything
+   else (role-owned tuning).
 
 ## Goals
 
 - A master agent can spawn children onto a different provider+model than its
   own, via named presets or (when enabled) ad-hoc args.
-- The user owns the routing table: presets, the sub-agent default, the
-  override flag, and the allowlist are all user-configured.
+- The user owns the routing table and the params: presets, endpoint entries,
+  the sub-agent default, the override flag, and the allowlist are all
+  user-configured.
 - Cross-provider routing reuses the existing readiness/identity/execution
   seams, including `custom-ep:` registry providers.
 - Routing decisions are loud, persisted, and visible — never silent fallbacks.
 
 ## Non-goals
 
-- Per-preset sampling parameters (temperature, etc.). Children inherit the
-  parent's sampling params.
+- Ad-hoc sampling params in spawn tool args (params come only from
+  user-authored stores: presets, registry entries, config — never from
+  model-generated args).
 - Named route registry as a separate config entity (rejected approach 2).
 - Policy-file rules engine (rejected approach 3).
 - Per-provider budget accounting; unpriced local models keep the existing
   "unpriced keeps previous accounting" behavior
-  (`Agents/agent_service.py:_budget_weighted_tokens`).
+  (`Agents/agent_service.py:_budget_weighted_tokens`). Per-child pricing
+  attribution needs no work: that function already keys on each run's own
+  provider/model, so a local child is accounted as unpriced-local while a
+  cloud master bills at cloud rates.
 - Any change to how the top-level (session) provider+model is chosen.
 
 ## Architecture
@@ -65,10 +80,11 @@ resolve_spawn_target(app_config, parent_selection, preset, override_args, agents
 ```
 
 `SpawnTarget` carries `provider`, `model`, `base_url` (already resolved,
-including registry lookup for `custom-ep:` ids), plus a `source` tag
-(`override` / `preset` / `default` / `inherit`) for logging and persistence.
+including registry lookup for `custom-ep:` ids), the fully resolved sampling
+params (see below), plus a `source` tag (`override` / `preset` / `default` /
+`inherit`) for logging and persistence.
 
-### Resolution order
+### Resolution order (provider + model)
 
 Each level fills only blanks left by the levels above:
 
@@ -80,7 +96,8 @@ Each level fills only blanks left by the levels above:
    and `model`.
 3. **Sub-agent default** — `[agents] subagent_default_provider` /
    `subagent_default_model`.
-4. **Inherit parent** — the run's own `ConsoleProviderSelection`.
+4. **Inherit parent** — the parent's provider+model (NOT its params; see
+   below).
 
 The winner is validated through the existing seams:
 `resolve_console_provider_identities` (`Chat/console_provider_support.py`)
@@ -95,6 +112,41 @@ back to default token-window handling, same as any unlisted model today.
 reserving fleet capacity; a `RoutingError` is returned to the master as the
 spawn tool's error result and no fleet slot is consumed.
 
+### Sampling / API params
+
+A child **never** inherits sampling or API params (temperature, top_p, min_p,
+top_k, max_tokens, seed, presence/frequency penalty, reasoning/verbosity/
+thinking knobs, streaming) from the parent's `ConsoleProviderSelection`. Its
+params are built fresh for its resolved provider+model through the same
+layering a brand-new Console session to that provider would get
+(`build_default_console_session_settings`,
+`Chat/console_session_settings.py:509`), extended with the two new sources.
+Precedence, highest first:
+
+1. **Preset `params`** — only when the spawn names a preset that sets them.
+2. **Per-model profile** — `[api_settings.<provider>].model_defaults.<model>`.
+3. **Console saved defaults** — `[console.provider_defaults.<provider>]`.
+4. **Registry entry `params`** — `[custom_endpoints.<slug>.params]`, projected
+   into the provider-settings layer (custom-ep targets only; slots above the
+   global chat_defaults because endpoint-authored tuning is more specific
+   than global defaults).
+5. **Global `[chat_defaults]`**.
+6. **Raw `[api_settings.<provider>]` scalars**, then function fallbacks
+   (0.7 / 0.95 / …).
+
+This is a **uniform rule**: even a plain same-provider child gets fresh
+provider-default params rather than the parent's session-tweaked values.
+**Behavior change:** today a plain spawn inherits the session's live sampling
+params; after this change it gets the provider's configured defaults. Called
+out in the ADR and the user guide.
+
+The merged params pass through the same capability filtering as a fresh send
+(`model_capabilities`), so provider-specific knobs (e.g. a Kimi
+`reasoning_effort`) never leak onto a model that doesn't support them; a
+dropped knob is noted in the run log. Oversized `max_tokens` for a small
+local model is handled by the existing `repair_request_fits_model_window`
+path. Ad-hoc spawn args carry **no** params (see Security policy).
+
 ## Data model changes
 
 ### `AgentDefinition` (`Agents/agent_models.py`)
@@ -103,6 +155,9 @@ spawn tool's error result and no fleet slot is consumed.
   widen from "same endpoint only" to "model on the preset's provider".
   `model` set **without** `provider` keeps today's exact same-endpoint
   behavior — existing presets are unaffected.
+- New field `params`: optional mapping of sampling-param name → value.
+  Validated against the known param-name set (typo guard) with per-key type
+  checks; unknown keys are validation errors.
 - No `base_url` field: built-in providers resolve URLs from `api_settings`;
   additional local endpoints are `custom-ep:` registry entries (their
   entries carry URL + credentials, ADR-146). Presets name the slug.
@@ -111,7 +166,17 @@ spawn tool's error result and no fleet slot is consumed.
   existence is **not** checked at validation time (entries can be deleted
   between authoring and spawn); that surfaces as a spawn-time
   `RoutingError` instead.
-- The definition dict serialization (`agent_models.py:417`) gains `provider`.
+- The definition dict serialization (`agent_models.py:417`) gains `provider`
+  and `params`.
+
+### Registry entries (`Chat/custom_endpoint_registry.py`, amends ADR-146)
+
+- `CustomEndpointEntry` gains `params`: an optional mapping loaded from a
+  `[custom_endpoints.<slug>.params]` TOML sub-table; validated with the same
+  known-name/type rules as preset params. Secret-handling unchanged
+  (`api_key` stays repr-excluded; params hold no secrets by validation).
+- `build_entry_mutation` / `load_custom_endpoints` round-trip the table;
+  entries without it behave exactly as today.
 
 ### Config `[agents]` (template at `config.py:3046`)
 
@@ -129,21 +194,28 @@ New keys, shipped commented-out with defaults owned by
 One version step adding:
 
 - `agent_definitions.provider TEXT NOT NULL DEFAULT ''`
+- `agent_definitions.params_json TEXT NOT NULL DEFAULT '{}'`
 - `agent_runs` resolved-target snapshot columns (nullable):
-  `resolved_provider`, `resolved_model`, `resolved_base_url`
+  `resolved_provider`, `resolved_model`, `resolved_base_url`,
+  `resolved_params_json` — the full merged param set, so a resumed child is
+  stable even if the preset, the registry entry, or config defaults were
+  edited after the spawn.
 
 ### Resume / continuation semantics
 
 Today fleet continuation re-resolves the agent definition *by name*, so
 editing a preset between finish and resume would silently move the child to
-a different provider mid-conversation. Fix: the resolved target is persisted
-on the run row at spawn; continuation/resume reuses the persisted snapshot.
-Live re-resolution is the fallback only for legacy rows with NULL snapshot
-columns.
+a different provider mid-conversation. Fix: the resolved target — provider,
+model, base_url, and merged params — is persisted on the run row at spawn;
+continuation/resume reuses the persisted snapshot. Live re-resolution is the
+fallback only for legacy rows with NULL snapshot columns. (Note the intended
+consequence: editing a built-in provider's URL or an endpoint's params does
+not move an already-spawned child — snapshot semantics.)
 
 ## Spawn tool contract & master visibility
 
-- `spawn_subagent` gains optional string args `provider` and `model`.
+- `spawn_subagent` gains optional string args `provider` and `model` — and
+  nothing else; no params, no URLs.
 - The args are **omitted from the tool schema entirely** when
   `spawn_override_enabled` is false — the model cannot attempt what is not
   advertised. Schema construction (identity-path schema referenced at
@@ -159,9 +231,11 @@ columns.
 
 - Spawn args are model-generated and therefore untrusted: `provider` accepts
   only a known built-in provider id or a `custom-ep:<slug>` matching the
-  registry slug pattern. **Ad-hoc args never carry URLs** — endpoints come
-  only from user-controlled config/registry, so a prompt-injected master
-  cannot point a child at an arbitrary endpoint to exfiltrate context.
+  registry slug pattern. **Ad-hoc args never carry URLs or params** —
+  endpoints and sampling come only from user-controlled config/registry/
+  presets, so a prompt-injected master can neither point a child at an
+  arbitrary endpoint to exfiltrate context nor crank params (e.g. max
+  reasoning budget) on a paid provider.
 - The allowlist is the cost/injection guard for ad-hoc routing; presets are
   trusted because the user authored them.
 - No credential material flows through the resolver's outputs beyond what
@@ -195,44 +269,59 @@ child's resolved target (e.g. "qwen-local · qwen3.8-27b").
 
 - Per-preset `provider` / `model` pickers, fed by the same provider-option
   builder as Console settings so `custom-ep:` entries appear with their
-  `display_name`.
+  `display_name`, plus per-preset `params` editing (the known sampling keys).
 - Sub-agent default provider/model pickers.
 - `spawn_override_enabled` toggle and an allowlist multi-select.
 - Stale allowlist entries (deleted registry slugs) are flagged in the UI,
   not silently dropped from config.
+
+The endpoint editor (`Widgets/Console/console_endpoint_template_modal.py`)
+gains an optional `params` section for the same known sampling keys.
 
 ## Testing
 
 - **Unit:** pure resolver matrix — every resolution level, blank-filling,
   each `RoutingError` variant, custom-ep slug resolution, model-only ad-hoc
   args.
+- **Unit (params):** the six-layer precedence stack, incl. preset-over-entry
+  and entry-over-chat_defaults ordering; unknown/mistyped param keys rejected
+  for both presets and registry entries; capability filtering drops
+  unsupported knobs with a run-log note.
 - **Integration:** spawn through `AgentService` with routed preset, with
   sub-agent default, and with override on/off; assert the child's
-  `ConsoleProviderSelection`, the persisted snapshot columns, and that
-  refusals return an error result without consuming a fleet slot.
+  `ConsoleProviderSelection` (provider, model, base_url, **and merged
+  params**), the persisted snapshot columns, and that refusals return an
+  error result without consuming a fleet slot.
 - **Migration tests** for schema v16: column defaults, legacy rows unchanged.
 - **Backward-compat regression:** existing preset with `model` but no
-  `provider` keeps same-endpoint override behavior.
-- **Settings panel tests:** picker populations include custom-ep display
-  names; stale allowlist slug flagging.
+  `provider` keeps same-endpoint override behavior; registry entries without
+  `params` load unchanged.
+- **Settings panel/modal tests:** picker populations include custom-ep
+  display names; stale allowlist slug flagging; params editing round-trips.
 - **Live verification** (per `backlog/docs/lessons-live-verification.md`):
-  real local endpoint registered as `custom-ep:`, cheap cloud model as
-  master, one two-step delegation exercised end to end.
+  real local endpoint registered as `custom-ep:` with its own `params`,
+  cheap cloud model as master, one two-step delegation exercised end to end,
+  confirming in the run log that the child's request carried the endpoint's
+  params, not the master's.
 
 ## Expected touch list
 
 - New: `Agents/agent_routing.py`, spec/plan docs, ADR.
 - Modified: `Agents/agent_models.py`, `Agents/agent_service.py` (spawn hook,
   schema gating), `DB/AgentRuns_DB.py` (v16 migration), `config.py`
-  (template comments), `Widgets/settings_agents_panel.py`,
+  (template comments), `Chat/custom_endpoint_registry.py` (entry params),
+  `Widgets/settings_agents_panel.py`,
+  `Widgets/Console/console_endpoint_template_modal.py` (params editing),
   `Chat/console_agent_bridge.py` (rail summary target display).
 - Tests: new `Tests/Agents/test_agent_routing.py` plus integration,
-  migration, and settings-panel coverage.
+  migration, registry, and settings-panel coverage.
 
 ## Rollout
 
-1. Create ADR in `backlog/decisions/` and Backlog task; link both ways.
-2. Implement per the writing-plans output (pure resolver first, then DB
-   migration, then spawn integration, then UI).
+1. Create ADR in `backlog/decisions/` (amending ADR-146 for entry `params`)
+   and Backlog task; link both ways.
+2. Implement per the writing-plans output (pure resolver + params stack
+   first, then DB migration, then spawn integration, then UI).
 3. Update `Docs/User_Guide/console/agent-runs-and-tools.md` with the new
-  `[agents]` keys and preset routing fields.
+   `[agents]` keys, preset routing/params fields, and the plain-spawn
+   params behavior change.

--- a/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
+++ b/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
@@ -84,6 +84,14 @@ including registry lookup for `custom-ep:` ids), the fully resolved sampling
 params (see below), plus a `source` tag (`override` / `preset` / `default` /
 `inherit`) for logging and persistence.
 
+A second new pure module, `Chat/sampling_params.py`, owns the known
+sampling-param key set, the per-key value validator, and the layer-merge
+helpers (extracted from `build_default_console_session_settings`' private
+helpers). Both param validators (presets, registry entries) and the resolver
+share it, avoiding any new import edge between `Agents/` and the registry —
+whose relationship with `console_session_settings` is already a managed
+lazy-import cycle.
+
 ### Resolution order (provider + model)
 
 Each level fills only blanks left by the levels above:
@@ -92,6 +100,10 @@ Each level fills only blanks left by the levels above:
    Honored only when `spawn_override_enabled` is true; when `provider` is
    given it must appear in `spawn_override_allowlist`. A model-only ad-hoc
    arg swaps the model on whatever provider levels 2–4 resolve.
+   **Final-provider guard:** whenever ANY ad-hoc arg is present, the final
+   resolved provider must be allowlisted or equal to the parent's provider —
+   otherwise `provider_not_allowlisted`. (Closes the hole where a model-only
+   arg rides a paid `subagent_default_provider` the user never allowlisted.)
 2. **Preset routing fields** — the spawned `AgentDefinition`'s `provider`
    and `model`.
 3. **Sub-agent default** — `[agents] subagent_default_provider` /
@@ -116,16 +128,18 @@ spawn tool's error result and no fleet slot is consumed.
 
 A child **never** inherits sampling or API params (temperature, top_p, min_p,
 top_k, max_tokens, seed, presence/frequency penalty, reasoning/verbosity/
-thinking knobs, streaming) from the parent's `ConsoleProviderSelection`. Its
-params are built fresh for its resolved provider+model through the same
-layering a brand-new Console session to that provider would get
+thinking knobs) from the parent's `ConsoleProviderSelection`. Its params are
+built fresh for its resolved provider+model through the same layering a
+brand-new Console session to that provider would get
 (`build_default_console_session_settings`,
 `Chat/console_session_settings.py:509`), extended with the two new sources.
 Precedence, highest first:
 
 1. **Preset `params`** — only when the spawn names a preset that sets them.
 2. **Per-model profile** — `[api_settings.<provider>].model_defaults.<model>`.
-3. **Console saved defaults** — `[console.provider_defaults.<provider>]`.
+3. **Console saved defaults** — `[console.provider_defaults.<provider>]`
+   (empty for `custom-ep:` targets today: PR #2617 writes registry-provider
+   saves to `chat_defaults`; layers degrade gracefully when empty).
 4. **Registry entry `params`** — `[custom_endpoints.<slug>.params]`, projected
    into the provider-settings layer (custom-ep targets only; slots above the
    global chat_defaults because endpoint-authored tuning is more specific
@@ -134,18 +148,28 @@ Precedence, highest first:
 6. **Raw `[api_settings.<provider>]` scalars**, then function fallbacks
    (0.7 / 0.95 / …).
 
+The known-param set excludes transport-level keys (`streaming`): child runs
+keep the run loop's own streaming policy.
+
 This is a **uniform rule**: even a plain same-provider child gets fresh
 provider-default params rather than the parent's session-tweaked values.
 **Behavior change:** today a plain spawn inherits the session's live sampling
 params; after this change it gets the provider's configured defaults. Called
 out in the ADR and the user guide.
 
-The merged params pass through the same capability filtering as a fresh send
-(`model_capabilities`), so provider-specific knobs (e.g. a Kimi
-`reasoning_effort`) never leak onto a model that doesn't support them; a
-dropped knob is noted in the run log. Oversized `max_tokens` for a small
-local model is handled by the existing `repair_request_fits_model_window`
-path. Ad-hoc spawn args carry **no** params (see Security policy).
+The merged params get exactly the capability treatment a fresh send to that
+provider/model would get — the gateway already consults `model_capabilities`
+per send (`console_provider_gateway.py:1436-1449`; per-family predicates in
+`model_capabilities.py`), so provider-specific knobs (e.g. a Kimi
+`reasoning_effort`) never leak onto a model that doesn't support them, and no
+new filter layer is introduced. Oversized `max_tokens` for a small local
+model is handled by the existing `repair_request_fits_model_window` path.
+Ad-hoc spawn args carry **no** params (see Security policy).
+
+Implementation note: `build_default_console_session_settings`' source tuple
+and merge helpers (`_float_setting_from_sources` etc.) are private. The plan
+extracts them into `Chat/sampling_params.py` so the resolver composes the
+six layers while session defaults stay byte-identical.
 
 ## Data model changes
 
@@ -156,8 +180,8 @@ path. Ad-hoc spawn args carry **no** params (see Security policy).
   `model` set **without** `provider` keeps today's exact same-endpoint
   behavior — existing presets are unaffected.
 - New field `params`: optional mapping of sampling-param name → value.
-  Validated against the known param-name set (typo guard) with per-key type
-  checks; unknown keys are validation errors.
+  Validated via `Chat/sampling_params.py` (known-name typo guard + per-key
+  type checks); unknown keys are validation errors.
 - No `base_url` field: built-in providers resolve URLs from `api_settings`;
   additional local endpoints are `custom-ep:` registry entries (their
   entries carry URL + credentials, ADR-146). Presets name the slug.
@@ -173,8 +197,9 @@ path. Ad-hoc spawn args carry **no** params (see Security policy).
 
 - `CustomEndpointEntry` gains `params`: an optional mapping loaded from a
   `[custom_endpoints.<slug>.params]` TOML sub-table; validated with the same
-  known-name/type rules as preset params. Secret-handling unchanged
-  (`api_key` stays repr-excluded; params hold no secrets by validation).
+  `Chat/sampling_params.py` rules as preset params. Secret-handling
+  unchanged (`api_key` stays repr-excluded; params hold no secrets by
+  validation).
 - `build_entry_mutation` / `load_custom_endpoints` round-trip the table;
   entries without it behave exactly as today.
 
@@ -236,8 +261,10 @@ not move an already-spawned child — snapshot semantics.)
   presets, so a prompt-injected master can neither point a child at an
   arbitrary endpoint to exfiltrate context nor crank params (e.g. max
   reasoning budget) on a paid provider.
-- The allowlist is the cost/injection guard for ad-hoc routing; presets are
-  trusted because the user authored them.
+- The allowlist is the cost/injection guard for ad-hoc routing, strengthened
+  by the final-provider guard (resolution level 1): with ad-hoc args present,
+  the child lands only on an allowlisted provider or the parent's own.
+  Presets are trusted because the user authored them.
 - No credential material flows through the resolver's outputs beyond what
   the existing gateway already handles; registry entries' `api_key` is
   repr-excluded upstream (ADR-146).
@@ -249,7 +276,8 @@ the master can pick another target or ask the user:
 
 - `override_disabled` — ad-hoc args present while the flag is off
   (defense-in-depth; the args are also absent from the schema).
-- `provider_not_allowlisted` — ad-hoc `provider` not in the allowlist.
+- `provider_not_allowlisted` — ad-hoc `provider` not in the allowlist, or
+  final-provider guard tripped by a model-only ad-hoc arg.
 - `unknown_provider` — id matches no built-in provider.
 - `unknown_endpoint_slug` — `custom-ep:<slug>` not in the registry.
 - `provider_not_ready` — missing credential or no reachable endpoint.
@@ -282,11 +310,12 @@ gains an optional `params` section for the same known sampling keys.
 
 - **Unit:** pure resolver matrix — every resolution level, blank-filling,
   each `RoutingError` variant, custom-ep slug resolution, model-only ad-hoc
-  args.
+  args, and the final-provider guard (model-only ad-hoc onto a
+  non-allowlisted paid default is refused).
 - **Unit (params):** the six-layer precedence stack, incl. preset-over-entry
-  and entry-over-chat_defaults ordering; unknown/mistyped param keys rejected
-  for both presets and registry entries; capability filtering drops
-  unsupported knobs with a run-log note.
+  and entry-over-chat_defaults ordering; shared-validator typo/type
+  rejection for both presets and registry entries; `streaming` excluded
+  from the known set.
 - **Integration:** spawn through `AgentService` with routed preset, with
   sub-agent default, and with override on/off; assert the child's
   `ConsoleProviderSelection` (provider, model, base_url, **and merged
@@ -295,7 +324,9 @@ gains an optional `params` section for the same known sampling keys.
 - **Migration tests** for schema v16: column defaults, legacy rows unchanged.
 - **Backward-compat regression:** existing preset with `model` but no
   `provider` keeps same-endpoint override behavior; registry entries without
-  `params` load unchanged.
+  `params` load unchanged; session defaults from
+  `build_default_console_session_settings` are byte-identical before/after
+  the helper extraction.
 - **Settings panel/modal tests:** picker populations include custom-ep
   display names; stale allowlist slug flagging; params editing round-trips.
 - **Live verification** (per `backlog/docs/lessons-live-verification.md`):
@@ -306,11 +337,13 @@ gains an optional `params` section for the same known sampling keys.
 
 ## Expected touch list
 
-- New: `Agents/agent_routing.py`, spec/plan docs, ADR.
+- New: `Agents/agent_routing.py`, `Chat/sampling_params.py`, spec/plan docs,
+  ADR.
 - Modified: `Agents/agent_models.py`, `Agents/agent_service.py` (spawn hook,
   schema gating), `DB/AgentRuns_DB.py` (v16 migration), `config.py`
-  (template comments), `Chat/custom_endpoint_registry.py` (entry params),
-  `Widgets/settings_agents_panel.py`,
+  (template comments), `Chat/console_session_settings.py` (helper extraction
+  only — behavior-preserving), `Chat/custom_endpoint_registry.py` (entry
+  params), `Widgets/settings_agents_panel.py`,
   `Widgets/Console/console_endpoint_template_modal.py` (params editing),
   `Chat/console_agent_bridge.py` (rail summary target display).
 - Tests: new `Tests/Agents/test_agent_routing.py` plus integration,

--- a/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
+++ b/Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
@@ -4,7 +4,7 @@ Date: 2026-09-11
 Status: Approved design (pre-plan)
 Governance: ADR required (provider/runtime boundary + cross-module interface);
 the ADR also **amends ADR-146** (registry entries gain a `params` table —
-precedent: ADR-020 amends ADR-002). Backlog task to be created at plan time.
+precedent: ADR-020 amends ADR-002). ADR-147 written; Backlog TASK-32477.
 
 ## Problem
 
@@ -26,9 +26,12 @@ ollama, or a `custom-ep:` registry entry from ADR-146 / PR #2617).
    `[agents] subagent_default_provider/model`; when unset, children inherit
    the parent's provider+model (today's behavior).
 3. **Override scope: flag + allowlist.** Ad-hoc args require
-   `[agents] spawn_override_enabled = true` AND the requested provider must be
-   in `[agents] spawn_override_allowlist`. Presets are user-authored and
-   therefore unrestricted by the allowlist.
+   `[agents] spawn_override_enabled = true` AND the requested target must
+   match `[agents] spawn_override_allowlist`. Allowlist entries are either a
+   bare provider id (`llama_cpp`, `custom-ep:qwen-local`) or a
+   `provider/model-glob` form (`llama_cpp/qwen3.8-*`; fnmatch,
+   case-insensitive) that additionally constrains the model. Presets are
+   user-authored and therefore unrestricted by the allowlist.
 4. **Children never inherit the parent's sampling/API params.** A child's
    params are built fresh for its resolved provider+model — uniform rule,
    including the plain-inherit path (behavior change, see "Sampling / API
@@ -54,6 +57,14 @@ ollama, or a `custom-ep:` registry entry from ADR-146 / PR #2617).
 - Ad-hoc sampling params in spawn tool args (params come only from
   user-authored stores: presets, registry entries, config — never from
   model-generated args).
+- **Preset `fallback_models` chains** — user-configured ordered fallbacks for
+  retryable pre-tool-activity provider failures (pi-subagents
+  `fallbackModels` semantics). Valuable but a large surface (budgeting,
+  continuation, admission); deferred to follow-up TASK-32479.
+- **A thinking-level ceiling** (`subagent_max_thinking`): weak need here —
+  params are all user-authored, so there is little to guard against.
+- Provider-scoped role overrides (`agentOverridesByProvider`-style matrices):
+  the preset + default layers express the same intent without a matrix.
 - Named route registry as a separate config entity (rejected approach 2).
 - Policy-file rules engine (rejected approach 3).
 - Per-provider budget accounting; unpriced local models keep the existing
@@ -98,12 +109,15 @@ Each level fills only blanks left by the levels above:
 
 1. **Ad-hoc spawn args** (`provider`, `model` from the spawn tool call).
    Honored only when `spawn_override_enabled` is true; when `provider` is
-   given it must appear in `spawn_override_allowlist`. A model-only ad-hoc
-   arg swaps the model on whatever provider levels 2–4 resolve.
+   given, `provider/model` must match `spawn_override_allowlist` (bare
+   provider entries match any model; `provider/model-glob` entries match via
+   fnmatch, case-insensitive). A model-only ad-hoc arg swaps the model on
+   whatever provider levels 2–4 resolve.
    **Final-provider guard:** whenever ANY ad-hoc arg is present, the final
-   resolved provider must be allowlisted or equal to the parent's provider —
-   otherwise `provider_not_allowlisted`. (Closes the hole where a model-only
-   arg rides a paid `subagent_default_provider` the user never allowlisted.)
+   resolved `provider/model` must match the allowlist or the provider must
+   equal the parent's provider — otherwise `provider_not_allowlisted`.
+   (Closes the hole where a model-only arg rides a paid
+   `subagent_default_provider` the user never allowlisted.)
 2. **Preset routing fields** — the spawned `AgentDefinition`'s `provider`
    and `model`.
 3. **Sub-agent default** — `[agents] subagent_default_provider` /
@@ -114,8 +128,9 @@ Each level fills only blanks left by the levels above:
 The winner is validated through the existing seams:
 `resolve_console_provider_identities` (`Chat/console_provider_support.py`)
 for display/readiness/execution keys (custom-ep aware), then readiness
-(missing credential / no reachable endpoint → `RoutingError`), producing a
-full `ConsoleProviderSelection` for the child. Tool shaping needs no change:
+(`get_provider_readiness`, `Chat/provider_readiness.py:476` — missing
+credential / no reachable endpoint → `RoutingError`), producing a full
+`ConsoleProviderSelection` for the child. Tool shaping needs no change:
 `provider_supports_native_tools` is already evaluated per run inside
 `_make_call_model` (`agent_service.py:1314,1565`). Unknown local models fall
 back to default token-window handling, same as any unlisted model today.
@@ -140,10 +155,12 @@ Precedence, highest first:
 3. **Console saved defaults** — `[console.provider_defaults.<provider>]`
    (empty for `custom-ep:` targets today: PR #2617 writes registry-provider
    saves to `chat_defaults`; layers degrade gracefully when empty).
-4. **Registry entry `params`** — `[custom_endpoints.<slug>.params]`, projected
-   into the provider-settings layer (custom-ep targets only; slots above the
-   global chat_defaults because endpoint-authored tuning is more specific
-   than global defaults).
+4. **Registry entry `params`** — `[custom_endpoints.<slug>.params]`, fed to
+   `build_default_console_session_settings` via a new optional
+   `extra_sources` parameter slotting after saved_defaults and before
+   chat_defaults (custom-ep targets only; endpoint-authored tuning is more
+   specific than global defaults). Empty by default, so session defaults
+   stay byte-identical.
 5. **Global `[chat_defaults]`**.
 6. **Raw `[api_settings.<provider>]` scalars**, then function fallbacks
    (0.7 / 0.95 / …).
@@ -153,9 +170,10 @@ keep the run loop's own streaming policy.
 
 This is a **uniform rule**: even a plain same-provider child gets fresh
 provider-default params rather than the parent's session-tweaked values.
-**Behavior change:** today a plain spawn inherits the session's live sampling
-params; after this change it gets the provider's configured defaults. Called
-out in the ADR and the user guide.
+**Behavior change:** today a plain spawn sends no sampling kwargs at all and
+`chat_api_call` falls back to its own internal config resolution; after this
+change the child's params are resolved explicitly through the six-layer
+stack, logged, and snapshotted. Called out in the ADR and the user guide.
 
 The merged params get exactly the capability treatment a fresh send to that
 provider/model would get — the gateway already consults `model_capabilities`
@@ -167,9 +185,10 @@ model is handled by the existing `repair_request_fits_model_window` path.
 Ad-hoc spawn args carry **no** params (see Security policy).
 
 Implementation note: `build_default_console_session_settings`' source tuple
-and merge helpers (`_float_setting_from_sources` etc.) are private. The plan
-extracts them into `Chat/sampling_params.py` so the resolver composes the
-six layers while session defaults stay byte-identical.
+and merge helpers (`_float_setting_from_sources` etc.,
+`console_session_settings.py:1561-1640`) are private. The plan extracts them
+into `Chat/sampling_params.py` so the resolver composes the six layers while
+session defaults stay byte-identical.
 
 ## Data model changes
 
@@ -182,14 +201,17 @@ six layers while session defaults stay byte-identical.
 - New field `params`: optional mapping of sampling-param name → value.
   Validated via `Chat/sampling_params.py` (known-name typo guard + per-key
   type checks); unknown keys are validation errors.
+- `definition_fingerprint` extends to `provider` and `params` — both shape
+  what actually ran, and the fingerprint is that audit identity.
 - No `base_url` field: built-in providers resolve URLs from `api_settings`;
   additional local endpoints are `custom-ep:` registry entries (their
   entries carry URL + credentials, ADR-146). Presets name the slug.
 - `validate_agent_definition` additionally checks `provider` is a known
-  built-in provider id or matches the `custom-ep:<slug>` form. Registry
-  existence is **not** checked at validation time (entries can be deleted
-  between authoring and spawn); that surfaces as a spawn-time
-  `RoutingError` instead.
+  built-in provider id (`supported_console_provider_readiness_keys()`,
+  lazy-imported) or matches the `custom-ep:<slug>` form. Registry existence
+  is **not** checked at validation time (entries can be deleted between
+  authoring and spawn); that surfaces as a spawn-time `RoutingError`
+  instead.
 - The definition dict serialization (`agent_models.py:417`) gains `provider`
   and `params`.
 
@@ -211,8 +233,9 @@ New keys, shipped commented-out with defaults owned by
 - `subagent_default_provider` (string, empty = unset → inherit)
 - `subagent_default_model` (string, empty = provider's configured/default model)
 - `spawn_override_enabled` (bool, default false)
-- `spawn_override_allowlist` (list of provider ids, may include
-  `custom-ep:<slug>` entries; default empty)
+- `spawn_override_allowlist` (list of entries; each entry is a provider id —
+  including `custom-ep:<slug>` — optionally followed by `/` and a
+  case-insensitive model glob; default empty)
 
 ### Database (`DB/AgentRuns_DB.py`, `_CURRENT_SCHEMA_VERSION` 15 → 16)
 
@@ -243,8 +266,9 @@ not move an already-spawned child — snapshot semantics.)
   nothing else; no params, no URLs.
 - The args are **omitted from the tool schema entirely** when
   `spawn_override_enabled` is false — the model cannot attempt what is not
-  advertised. Schema construction (identity-path schema referenced at
-  `agent_service.py:1170`) becomes config-dependent.
+  advertised. Schema construction (`build_spawn_schema`,
+  `Agents/tool_catalog.py:86`; call site `agent_service.py:2514`) becomes
+  config-dependent.
 - When enabled, the schema description enumerates the allowlisted provider
   ids with their configured models (from `api_settings` and registry cached
   `CustomEndpointEntry.models`), so the master chooses real targets instead
@@ -261,9 +285,10 @@ not move an already-spawned child — snapshot semantics.)
   presets, so a prompt-injected master can neither point a child at an
   arbitrary endpoint to exfiltrate context nor crank params (e.g. max
   reasoning budget) on a paid provider.
-- The allowlist is the cost/injection guard for ad-hoc routing, strengthened
-  by the final-provider guard (resolution level 1): with ad-hoc args present,
-  the child lands only on an allowlisted provider or the parent's own.
+- The allowlist is the cost/injection guard for ad-hoc routing — bare
+  provider entries or `provider/model-glob` entries — strengthened by the
+  final-provider guard (resolution level 1): with ad-hoc args present, the
+  child lands only on an allowlisted target or the parent's own provider.
   Presets are trusted because the user authored them.
 - No credential material flows through the resolver's outputs beyond what
   the existing gateway already handles; registry entries' `api_key` is
@@ -276,8 +301,8 @@ the master can pick another target or ask the user:
 
 - `override_disabled` — ad-hoc args present while the flag is off
   (defense-in-depth; the args are also absent from the schema).
-- `provider_not_allowlisted` — ad-hoc `provider` not in the allowlist, or
-  final-provider guard tripped by a model-only ad-hoc arg.
+- `provider_not_allowlisted` — ad-hoc `provider/model` matches no allowlist
+  entry, or the final-provider guard tripped on a model-only ad-hoc arg.
 - `unknown_provider` — id matches no built-in provider.
 - `unknown_endpoint_slug` — `custom-ep:<slug>` not in the registry.
 - `provider_not_ready` — missing credential or no reachable endpoint.
@@ -299,9 +324,14 @@ child's resolved target (e.g. "qwen-local · qwen3.8-27b").
   builder as Console settings so `custom-ep:` entries appear with their
   `display_name`, plus per-preset `params` editing (the known sampling keys).
 - Sub-agent default provider/model pickers.
-- `spawn_override_enabled` toggle and an allowlist multi-select.
+- `spawn_override_enabled` toggle and an allowlist editor (one entry per
+  line, `provider` or `provider/model-glob`).
 - Stale allowlist entries (deleted registry slugs) are flagged in the UI,
   not silently dropped from config.
+- A **"Test routing" dry-run action**: runs `resolve_spawn_target` for every
+  enabled preset and the configured default against live config and reports
+  each target's resolved provider/model/params summary and readiness —
+  catches config rot (deleted slugs, expired keys) before a run does.
 
 The endpoint editor (`Widgets/Console/console_endpoint_template_modal.py`)
 gains an optional `params` section for the same known sampling keys.
@@ -310,8 +340,9 @@ gains an optional `params` section for the same known sampling keys.
 
 - **Unit:** pure resolver matrix — every resolution level, blank-filling,
   each `RoutingError` variant, custom-ep slug resolution, model-only ad-hoc
-  args, and the final-provider guard (model-only ad-hoc onto a
-  non-allowlisted paid default is refused).
+  args, the final-provider guard (model-only ad-hoc onto a non-allowlisted
+  paid default is refused), and allowlist glob matching (`provider`,
+  `provider/exact-model`, `provider/prefix-*`, case-insensitivity, no-match).
 - **Unit (params):** the six-layer precedence stack, incl. preset-over-entry
   and entry-over-chat_defaults ordering; shared-validator typo/type
   rejection for both presets and registry entries; `streaming` excluded
@@ -326,9 +357,10 @@ gains an optional `params` section for the same known sampling keys.
   `provider` keeps same-endpoint override behavior; registry entries without
   `params` load unchanged; session defaults from
   `build_default_console_session_settings` are byte-identical before/after
-  the helper extraction.
+  the helper extraction and the `extra_sources` addition.
 - **Settings panel/modal tests:** picker populations include custom-ep
-  display names; stale allowlist slug flagging; params editing round-trips.
+  display names; stale allowlist slug flagging; params editing round-trips;
+  "Test routing" reports ready and not-ready targets correctly.
 - **Live verification** (per `backlog/docs/lessons-live-verification.md`):
   real local endpoint registered as `custom-ep:` with its own `params`,
   cheap cloud model as master, one two-step delegation exercised end to end,
@@ -342,8 +374,8 @@ gains an optional `params` section for the same known sampling keys.
 - Modified: `Agents/agent_models.py`, `Agents/agent_service.py` (spawn hook,
   schema gating), `DB/AgentRuns_DB.py` (v16 migration), `config.py`
   (template comments), `Chat/console_session_settings.py` (helper extraction
-  only — behavior-preserving), `Chat/custom_endpoint_registry.py` (entry
-  params), `Widgets/settings_agents_panel.py`,
+  + `extra_sources` — behavior-preserving), `Chat/custom_endpoint_registry.py`
+  (entry params), `Widgets/settings_agents_panel.py`,
   `Widgets/Console/console_endpoint_template_modal.py` (params editing),
   `Chat/console_agent_bridge.py` (rail summary target display).
 - Tests: new `Tests/Agents/test_agent_routing.py` plus integration,
@@ -351,10 +383,13 @@ gains an optional `params` section for the same known sampling keys.
 
 ## Rollout
 
-1. Create ADR in `backlog/decisions/` (amending ADR-146 for entry `params`)
-   and Backlog task; link both ways.
-2. Implement per the writing-plans output (pure resolver + params stack
-   first, then DB migration, then spawn integration, then UI).
+1. ADR-147 and Backlog TASK-32477 created and linked both ways; fallback
+   chains filed as follow-up TASK-32479.
+2. Implement per this plan (pure resolver + params stack first, then DB
+   migration, then spawn integration, then UI).
 3. Update `Docs/User_Guide/console/agent-runs-and-tools.md` with the new
-   `[agents]` keys, preset routing/params fields, and the plain-spawn
-   params behavior change.
+   `[agents]` keys, preset routing/params fields, the plain-spawn params
+   behavior change, and a short "route by task shape" tiering guide (fast
+   workhorse for recon/mechanical edits, mid-tier for routine delegation,
+   deep-bounded for hard well-scoped tasks, intent-strong model for
+   ambiguous judgment work).

--- a/Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md
+++ b/Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md
@@ -361,4 +361,4 @@ re-materialization of a persona session on user-display-name change.
 
 - [ADR-037: Persona/User Profile separation and authority-scoped assistant identity](../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md)
 - [ADR-046: Human chat display identity and template provenance](../../backlog/decisions/046-roleplay-chat-display-identity-and-template-provenance.md)
-- ADR-149: Console persona session identity (to be created before implementation)
+- [ADR-149: Console persona sessions bind a kind-generic assistant display identity](../../backlog/decisions/149-console-persona-session-identity.md)

--- a/Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md
+++ b/Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md
@@ -1,0 +1,364 @@
+# Console Persona Session Identity Design
+
+Status: Approved design, pre-planning
+Date: 2026-09-11
+Extends: ADR-037, ADR-046
+ADR required: yes — `backlog/decisions/149-console-persona-session-identity.md` (to be created before implementation, linked from the Backlog task and implementation plan)
+
+## Summary
+
+A Personas-screen "Chat now" on a persona currently stages the card as
+context in a generic Console chat; the transcript keeps showing "Assistant"
+and no template macros expand. Character cards already bind a real session
+identity: the transcript shows the character's name and `{{user}}`-family
+macros expand dynamically. This design brings persona cards to parity: a
+persona "Chat now" creates a persona-bound native Console session whose
+transcript label is the persona's name, whose system prompt is materialized
+through the existing single-pass macro expander, and whose identity survives
+persistence and resume. The speaker label always reflects the session's
+current assistant identity, whatever its kind.
+
+## Context
+
+Current state, verified against the code:
+
+- The transcript speaker label is resolved in
+  `Chat/console_roleplay_identity.py::resolve_console_message_presentation`:
+  assistant rows show the character name only when
+  `assistant_kind == "character"` and `character_name` is non-blank;
+  otherwise the literal "Assistant".
+- Character sessions bind through
+  `UI/Console_Modules/session.py::_start_character_console_session` from a
+  Personas-screen handoff (`source="personas"`, `item_type="character-card"`,
+  `metadata.intent="start_chat"`, `metadata.selected_kind="character"`).
+  Persona handoffs (`item_type="persona-card"`, `selected_kind="persona"`)
+  fail that extraction and fall through to
+  `ChatScreen._stage_handoff_as_console_live_work`, which stages the card as
+  evidence with the suggested prompt "Respond as \<name\>." — no bound
+  identity, no macro expansion.
+- Macro expansion exists as
+  `Chat/console_roleplay_identity.py::expand_character_template`: one
+  non-recursive pass; `{{user}}` / `{{random_user}}` / `<USER>` map to the
+  effective user display name; `{{char}}` / `{{character}}` / `{{persona}}` /
+  `<CHAR>` map to the assistant-side name. Character sessions expand at seed,
+  re-expand per send (`console_chat_controller.py::_resolved_system_prompt`),
+  and re-materialize on identity change
+  (`console_chat_store.py::_materialize_roleplay_projections`, gated by
+  `_is_named_character_session` and fenced by `identity_revision`).
+- The effective user display name resolves per ADR-046: per-conversation
+  override -> `[chat_defaults].user_display_name` -> "User"
+  (`effective_user_display_name`).
+- Persona profiles (`CharacterPersonaScopeService.get_persona_profile`,
+  mode-routed local/server) carry `name`, `system_prompt` (optional),
+  `description`, `personality_traits`. They have no greeting field, so there
+  is no persona greeting seeding.
+- The conversations table persists `assistant_kind`, `assistant_id`,
+  `character_id`, and `assistant_authority_id`. There is no assistant-name
+  column; character names are re-resolved at resume from `character_id`
+  (`_resolve_resumed_character_name`).
+- The versioned `console_roleplay_context` metadata envelope
+  (`Chat/console_roleplay_metadata.py`, version 1) persists
+  `user_name_override` and `character_system_template` with per-key fail-soft
+  parsing.
+- The control chip already has a persona branch:
+  `resolve_assistant_identity_label` renders `Persona: <name>` when given
+  `assistant_kind="persona"` and an `assistant_name`
+  (`Chat/console_display_state.py`), and
+  `ChatScreen._build_console_control_state` already passes
+  `assistant_name=getattr(active_session, "assistant_name", None)` — always
+  `None` today because the field does not exist.
+- ADR-037 decides that persona and generic conversations remain
+  authority-free: persona sessions never store `assistant_authority_id`.
+- ADR-037's server "character authority" trio
+  (`capture_character_authority_context`,
+  `is_character_authority_context_current`,
+  `resolve_character_authority_id`) resolves a server-user authority
+  (`server-user-v1:<sha256>`) and is already reused by persona-adjacent code
+  (`personas_screen.py` TTS authority). The capture/is-current pair is
+  server-target freshness fencing and is kind-agnostic.
+
+## Goals
+
+- The Console transcript speaker label always reflects the session's current
+  assistant identity: character name for character sessions, persona name for
+  persona sessions, "Assistant" only when no identity is bound.
+- Persona "Chat now" from the Personas screen creates a persona-bound native
+  Console session, locally and against a connected server.
+- Persona system prompts expand `{{user}}`-family macros with the effective
+  user display name and `{{char}}`/`{{persona}}`-family macros with the
+  persona name, at seed, per send, and on identity change — identical to the
+  character behavior required by ADR-046.
+- Resumed persona conversations — including legacy persona conversations that
+  already persist `assistant_kind="persona"` — render the persona name.
+- No database schema migration.
+
+## Non-goals
+
+- The Console identity picker stays character-only. Personas cannot be picked
+  or swapped mid-chat from inside the Console; persona sessions originate
+  from the Personas screen. (Decided with the owner.)
+- No persona greeting seeding; persona profiles have no greeting field.
+- No persona avatar/rail art, buddy visuals, or TTS/voice changes.
+- The staged-context "Attach" intent is unchanged, and the handoff fallback
+  path continues to stage persona card bodies with raw, unexpanded macros —
+  staged context is evidence, not identity. This matches character fallback.
+- STTS window and TTS readback copy are separate surfaces and are unchanged.
+- Persona conversations remain authority-free per ADR-037; no
+  `assistant_authority_id` is resolved or stored for them.
+
+## Design
+
+### 1. Session identity model (storage approach B)
+
+`ConsoleChatSession` gains one nullable field:
+
+```python
+#: Persona-kind assistant display name. Set only when
+#: ``assistant_kind == "persona"``; mutually exclusive with
+#: ``character_name``.
+assistant_name: str | None = None
+```
+
+and one nullable trusted-template field:
+
+```python
+#: Trusted persona system-prompt source; materialized into
+#: ``settings.system_prompt`` via the identity-template expander.
+persona_system_template: str | None = None
+```
+
+Rules:
+
+- `assistant_kind == "character"`: display name in `character_name` (unchanged).
+- `assistant_kind == "persona"`: display name in `assistant_name`.
+- `generic`: neither.
+- Invariant: at most one of `character_name` / `assistant_name` is non-blank.
+  Every identity write enforces it: persona bind blanks `character_name`,
+  `_swap_console_session_character` blanks `assistant_name` and
+  `persona_system_template`, and resume-clear blanks in both directions.
+  `settings.character_label` is cleared on persona bind and persona resume so
+  the chip's character-first precedence can never show a stale character name
+  over a live persona.
+
+A single helper — `session_assistant_display_name(session)` in
+`Chat/console_roleplay_identity.py` — centralizes the kind-conditional pick
+so no other code branches on kind for the display name.
+
+Gate hygiene (review finding): `_is_named_character_session` stays
+character-only (it guards greeting-template re-expansion, which personas must
+never inherit). A new `_is_named_persona_session` covers the persona branch,
+and the shared materialization machinery uses a combined
+`_is_named_identity_session`.
+
+### 2. Handoff routing and session creation
+
+A new `_persona_session_identity_from_handoff` in
+`UI/Console_Modules/session.py` accepts exactly:
+
+- `payload.source == "personas"`
+- `payload.item_type == "persona-card"`
+- `metadata.intent == "start_chat"`
+- `metadata.selected_kind == "persona"`
+- `payload.runtime_backend in {"local", "server"}`
+- three-way backend consistency: `source_owner == source_selector_state ==
+  metadata.backend == runtime_backend`
+- `metadata.selected_target_id == f"{runtime_backend}:persona:{persona_id}"`
+
+It returns `(runtime_backend, persona_id, name_hint, assistant_id)`. Unlike
+the character extractor, `selected_record_id` stays an opaque string — no
+`int()` coercion, no `_canonical_character_id_text` (persona IDs are
+`local-persona-<hex>` or server opaque strings). Anything but a clean match
+returns `None`, and the handoff falls through to the existing staged-context
+path unchanged.
+
+`_consume_pending_chat_handoff` tries the character starter first, then the
+persona starter, then stages as live work — preserving today's fallback
+order and semantics for every other payload.
+
+Session creation reuses the character fencing spine rather than copying it
+(review finding): the ~150 lines of
+`_start_character_console_session` are mostly security-critical fencing. The
+implementation extracts a shared fenced-fetch spine parameterized by a
+kind-specific fetch and a kind-specific seed:
+
+- Local: fetch via
+  `character_persona_scope_service.get_persona_profile(persona_id,
+  mode="local")`.
+- Server: capture the authority context, verify currency, fetch via
+  `get_persona_profile(persona_id, mode="server")`, re-verify currency before
+  using the profile. Per ADR-037, personas do **not** resolve or store an
+  authority ID; `assistant_authority_id` stays `None`. Failed fencing or a
+  failed fetch returns `False` and the caller falls back to staged context
+  with a notification — the character path's existing contract.
+
+On success the new session is created with:
+
+- `assistant_kind="persona"`, `assistant_id=persona_id`
+- `assistant_name` = profile name through `sanitize_character_display_label`
+  (180-character cap, same as characters; persona names may be 200)
+- `character_id=None`, `character_name=None`, `assistant_authority_id=None`
+- `runtime_backend` from the handoff
+- title `Chat with <name>` (`derive_conversation_title` already produces
+  this for persona kind)
+- `settings.character_label` cleared; `settings.system_prompt` set to the
+  materialized projection when the persona has a system prompt
+
+Personas without a system prompt are fully valid: `persona_system_template`
+stays `None`, settings keep the Console default, every expansion point
+no-ops, and the session is still persona-bound — the name label works
+regardless.
+
+### 3. Template expansion
+
+All expansion runs through the existing `expand_character_template`, whose
+docstring gains one line declaring it the identity-template expander for both
+kinds (the name stays; seven callsites are not worth the churn). For persona
+sessions it is called with `character_name=<persona name>`, so
+`{{char}}`/`{{character}}`/`{{persona}}`/`<CHAR>` all map to the persona name
+and `{{user}}`/`{{random_user}}`/`<USER>` to the effective user display name.
+Expansion remains single-pass and non-recursive per ADR-046: a display name
+literally containing `{{user}}` renders literally.
+
+Three coordinated expansion points, mirroring characters:
+
+1. **Seed**: `persona_system_template` is stored as the trusted source;
+   `settings.system_prompt` receives the materialized projection.
+2. **Per send**: `console_chat_controller.py::_resolved_system_prompt` gains
+   a persona branch (today it gates character-only), re-expanding from the
+   trusted template so a display-name change lands on the next message even
+   before re-materialization runs.
+3. **Identity change**: the generalized staleness / re-materialization
+   machinery re-projects `settings.system_prompt` when the user display name
+   or persona name changes, bumping `identity_revision` so mounted
+   transcripts repaint. Editing template-derived content clears provenance,
+   per ADR-046's existing rule.
+
+### 4. Presentation
+
+`ConsolePresentationContext` gains `assistant_name: str | None = None`;
+`ConsoleChatStore.presentation_context()` passes the session's value
+through.
+
+`resolve_console_message_presentation` gains a persona branch:
+`assistant_kind == "persona"` with a non-blank sanitized `assistant_name`
+yields the persona name as `speaker_label`. Styling deliberately stays on the
+standard assistant treatment (`console-transcript-message-role-assistant`
+row class under role-accent styles, `"assistant"` speaker tone): personas are
+not roleplay characters, and the immersive-RP classes remain gated on the
+character branch. Because the label rides the presentation `revision_token`,
+every surface the shared resolver feeds — plain rows, Markdown rows,
+copy/export/save, model-context assembly (ADR-046) — picks up the persona
+name from one change.
+
+The control chip needs no change: it already receives
+`session.assistant_name` and renders `Persona: <name>` once the field exists.
+
+### 5. Persistence and resume
+
+No schema migration. `assistant_kind` and `assistant_id` already persist on
+the conversation row; the persona display name is **never** persisted — it is
+re-resolved at resume, exactly the character pattern
+(`_resolve_resumed_character_name`). This also means a persona renamed after
+binding shows its fresh name on next resume, same as characters.
+
+The one value that must persist is the trusted `persona_system_template`. It
+rides the existing `console_roleplay_context` metadata envelope as an
+**optional third key under version 1** — not a version bump. The envelope's
+parse is per-key fail-soft, so:
+
+- old builds read the envelope and simply never look at the new key
+  (backward compatible);
+- new builds reading an old envelope see the key absent (forward
+  compatible).
+
+A version bump was rejected: the strict `version == 1` check would make old
+builds drop the whole envelope including `user_name_override` — an unrelated
+regression. `ConsoleRoleplayContext` gains
+`persona_system_template: str | None = None`; serialization writes the key
+only when set and preserves sibling keys per ADR-046.
+
+Resume (`UI/Console_Modules/workspace.py::_resume_console_workspace_conversation`,
+which today handles character name resolution) gains a persona branch:
+
+- `assistant_kind == "persona"` -> resolve the name via
+  `get_persona_profile(assistant_id, mode=session.runtime_backend)`;
+  set `session.assistant_name` on success, clear it on failure;
+  clear `settings.character_label` either way (inherited settings must not
+  leak a different identity's label).
+- Hydration (`Chat/console_conversation_hydration.py`) additionally reads
+  `persona_system_template` from the parsed roleplay envelope onto the
+  session, then the existing staleness check re-materializes if the
+  projection drifted.
+
+Legacy persona conversations (persisted with `assistant_kind="persona"` by
+the pre-native-Console route) get the same branch, so they gain the persona
+label on resume with no migration.
+
+### 6. Error handling
+
+- Handoff fetch/fencing failure -> `False` -> staged-context fallback +
+  notification. Card content is never dropped.
+- Resume name-resolution failure (deleted persona, unreachable server) ->
+  `assistant_name=None` -> the transcript honestly falls back to
+  "Assistant"; the session stays fully usable.
+- Absent/corrupt template key -> envelope fail-soft -> the last materialized
+  `settings.system_prompt` keeps serving; no heuristic rewrite (ADR-046).
+- `_resolved_system_prompt`'s persona branch gates on non-blank name and
+  template, else returns the session prompt unchanged.
+- Every display-boundary name passes through
+  `sanitize_character_display_label`.
+
+### 7. Testing
+
+Unit tests (mirroring the existing character suites):
+
+- presentation resolver persona branch: label, assistant (not roleplay)
+  styling, revision-token contents;
+- handoff extraction: accepts a clean persona payload; rejects wrong kind,
+  backend mismatch, wrong `selected_target_id`; preserves the opaque string
+  ID;
+- seed expansion: `{{user}}` and `{{persona}}`/`{{char}}` both directions;
+  single-pass safety with a display name containing literal `{{user}}`;
+- persona without system prompt: bound session, no template, expansion
+  no-ops;
+- gate separation: `_is_named_character_session` unchanged for personas,
+  `_is_named_identity_session` true for both kinds;
+- swap invariant: character swap onto a persona session blanks
+  `assistant_name`/`persona_system_template` and vice versa;
+- envelope round-trip with and without the persona key; sibling keys
+  preserved;
+- resume name resolution: local hit, local miss, server-mode call
+  parameters.
+
+Store/controller level: handoff-to-persona-session end-to-end (transcript
+label, materialized system prompt, per-send re-expansion), and
+re-materialization of a persona session on user-display-name change.
+
+## Alternatives considered
+
+| Option | Why rejected |
+| --- | --- |
+| Overload `character_name` for personas (approach A) | The field would lie about its contents; every character-only reader (avatar, rail, chip, speech) would need an audit against persona leakage. |
+| Resolve the name live by ID at render (approach C) | Puts synchronous service lookups in the render path and breaks the deliberately pure presentation resolver; contradicts ADR-046's stored-projection model. |
+| Bump the roleplay envelope to version 2 | The strict version check would make old builds drop the whole envelope, including `user_name_override` — an unrelated regression. An optional v1 key is both backward and forward compatible. |
+| Re-fetch the persona's current system prompt at resume instead of persisting the template | Persona edits would silently rewrite existing chats, breaking snapshot parity with character sessions (ADR-046 source-and-projection). |
+| Resolve and store `assistant_authority_id` for server personas | Contradicts ADR-037: persona conversations remain authority-free. |
+| Add personas to the Console identity picker | Deferred with the owner; persona sessions originate from the Personas screen only. |
+
+## Consequences
+
+- Persona identity becomes a first-class native-Console session kind with
+  transcript labeling, chip labeling, and dynamic macro expansion.
+- The session dataclass grows two nullable fields; snapshots and screen-state
+  serialization carry them.
+- Legacy persona conversations improve on resume without migration.
+- Server persona binding reuses the existing freshness fencing but stores no
+  authority, keeping ADR-037's authority-free persona rule intact.
+- The handoff consumption order (character -> persona -> staged) preserves
+  every existing fallback behavior.
+
+## Links
+
+- [ADR-037: Persona/User Profile separation and authority-scoped assistant identity](../../backlog/decisions/037-roleplay-assistant-identity-and-persona-user-profile-separation.md)
+- [ADR-046: Human chat display identity and template provenance](../../backlog/decisions/046-roleplay-chat-display-identity-and-template-provenance.md)
+- ADR-149: Console persona session identity (to be created before implementation)

--- a/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
+++ b/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
@@ -32,8 +32,10 @@ v1 serves three purposes:
   the builtin tool gate. Hooks only add restrictions.
 - SessionStart/SessionEnd/PreCompact events (no clean, well-defined seam yet;
   sessions are lazily created and long-lived).
-- Settings-screen UI. Config-file only in v1; the F9 settings surface follows
-  later if the feature sticks.
+- Settings-screen UI. Config-file only in v1; a dedicated settings
+  sub-screen is **confirmed for the immediately following PR** (user
+  decision 2026-09-11) — this spec's config schema is the contract that
+  sub-screen will edit.
 - Shell command strings. Commands are argv lists only — no shell parsing, no
   injection surface.
 
@@ -236,5 +238,6 @@ patterns):
 ## 11. Future work (explicitly out of v1)
 
 Project-scope hooks behind a trust gate; decision-JSON input rewriting;
-SessionStart/SessionEnd; PreCompact (rewind/summarize seam); settings-screen
-surface; per-session hook overrides.
+SessionStart/SessionEnd; PreCompact (rewind/summarize seam); **dedicated
+settings sub-screen (confirmed follow-up PR, editing the config schema
+defined here)**; per-session hook overrides.

--- a/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
+++ b/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
@@ -1,0 +1,200 @@
+# Console Run Hooks — Design Spec
+
+Date: 2026-09-11
+Status: Draft — pending user review
+ADR: backlog/decisions/148-console-run-hooks.md
+Related: ADR-069 (untrusted project context), `Docs/superpowers/specs/2026-08-20-agents-md-support-design.md`
+
+## 1. Goal
+
+Give developers Claude Code–style lifecycle hooks in a Console chat session:
+user-configured external commands that run at defined points of a session/turn
+lifecycle, with a JSON protocol on stdin and exit-code semantics on stdout.
+
+v1 serves three purposes:
+
+1. **Guardrails** — inspect and deny tool calls before dispatch (`PreToolUse`).
+2. **Automation / notification** — react to lifecycle facts (approval waiting,
+   run finished, tool failed) with fire-and-forget commands.
+3. **Context injection** — add text context to a turn at submit time
+   (`UserPromptSubmit`).
+
+## 2. Non-goals (v1)
+
+- **Project-scoped hooks** (repo-shipped hook config like Claude Code's
+  `.claude/settings.json`). Deliberately excluded: ADR-069 treats
+  project-provided content as untrusted and it must never grant execution. A
+  project hooks file is a drive-by-execution vector. Revisit only behind an
+  explicit trust gate (future ADR).
+- **Tool-input rewriting** (`updatedInput` / decision-JSON mutation). Hooks may
+  deny, never rewrite.
+- **`allow` bypass.** A hook verdict can never skip the MCP permission store or
+  the builtin tool gate. Hooks only add restrictions.
+- SessionStart/SessionEnd/PreCompact events (no clean, well-defined seam yet;
+  sessions are lazily created and long-lived).
+- Settings-screen UI. Config-file only in v1; the F9 settings surface follows
+  later if the feature sticks.
+- Shell command strings. Commands are argv lists only — no shell parsing, no
+  injection surface.
+
+## 3. Event catalogue (6 events)
+
+| Event | Fires | Seam (existing code) | Blocking? |
+|---|---|---|---|
+| `UserPromptSubmit` | after submit gates, before turn compose; **manual-origin sends only** | controller submit path, beside the `prompt_history` slot write | yes (exit 2 rejects the send) |
+| `PreToolUse` | per tool-call batch, before permission review | wrapper around `build_tool_review_hook` verdict chain (`Chat/console_chat_controller.py`) | yes (exit 2 denies the batch) |
+| `PostToolUse` | after dispatch, at tool_result capture | bridge `on_step` consumer on `tool_result` records (no AgentService change) | no |
+| `ApprovalRequested` | when an approval round is armed | `set_pending_approval` / `park_pending_approval` bridge sites | no |
+| `Stop` | a session turn's run reaching terminal state | bridge run terminal-state path (active and non-active sessions) | no |
+| `SubagentStop` | a fleet child run settling | the `on_child_settled` wiring in `Chat/console_agent_bridge.py` | no |
+
+The **wake invariant** holds: wake notices are machine-origin, so
+`UserPromptSubmit` never fires for them (same rule the `prompt_history` slot
+already documents). `Stop`/`SubagentStop` fire for wake turns too — they report
+run outcomes, not user input.
+
+## 4. Execution model
+
+- **Engine module** `tldw_chatbook/Agents/run_hooks.py`: config parsing +
+  validation, payload assembly, subprocess execution, redaction/truncation,
+  logging. No UI imports; headless-testable.
+- **Process**: argv list, executed synchronously via `subprocess`
+  (**no shell**) — blocking events run inline in their calling context (submits
+  and run dispatch are already workers, never the UI thread); non-blocking
+  events run on the engine's executor (below).
+- **cwd**: the session's workspace root when one is bound, else the app cwd
+  (mirrors `[console] workspace_root` fallback semantics).
+- **stdin**: one JSON document — common envelope + event-specific `data`:
+
+```json
+{
+  "hook_event": "PreToolUse",
+  "session_id": "…",
+  "run_id": "…",
+  "timestamp": "2026-09-11T12:00:00+00:00",
+  "cwd": "/workspace/root",
+  "data": { "tool_name": "fs_write", "tool_args": { "path": "…" } }
+}
+```
+
+Event-specific `data` fields:
+
+- `UserPromptSubmit`: `{"prompt": "…truncated…"}`
+- `PreToolUse`: `{"tool_name": "fs_write", "tool_args": {…}}`
+- `PostToolUse`: `{"tool_name": …, "tool_args": {…}, "tool_result": "…truncated…", "is_error": bool}`
+- `ApprovalRequested`: `{"calls": [{"name": …, "args_summary": …}], "session_active": bool}`
+- `Stop`: `{"status": "completed|error|cancelled"}`
+- `SubagentStop`: `{"child_run_id": …, "status": …}`
+
+A single shared budget constant (default 4 000 chars) governs every truncation
+site: payload fields, hook stdout, and hook stderr.
+
+`PreToolUse` matching is **per tool call**: the engine fans a review batch out
+per call whose name matches the hook's glob, runs each matching hook once per
+call, and merges results into the existing per-call verdict dict. Calls a hook
+does not match are untouched.
+- **stdout/stderr**: captured (truncated to the shared budget) and written to
+  the run log (`search_run_log` surfaces it).
+- **Timeout**: per-hook `timeout_s`, default 10 s, hard-killed after.
+- **Concurrency**: blocking events (`UserPromptSubmit`, `PreToolUse`) run
+  sequentially inline in the calling context (already off the UI thread —
+  submits and run dispatch are workers). Non-blocking events are handed to a
+  single-worker executor inside the engine and never delay the turn; a full
+  executor queue drops the firing with a log line (hooks must not stall chat).
+
+## 5. Verdict semantics
+
+| Event | exit 0 | exit 2 | other non-zero / crash / timeout |
+|---|---|---|---|
+| `UserPromptSubmit` | stdout (≤ budget) is prepended as context for this turn | send rejected; reason surfaced to the user as a refusal | warning logged; send proceeds |
+| `PreToolUse` | no opinion; normal permission flow continues | deny; reason becomes the tool result the model sees | **deny — fail-closed** (repo convention) |
+| all others | stdout logged to run log | same as non-zero | logged, ignored |
+
+`PreToolUse` also accepts a JSON stdout body `{"decision": "deny", "reason":
+"…"}`. `{"decision": "allow"}` is parsed, ignored, and logged — the deny-only
+stance is enforced in the engine, not by hook authors.
+
+Matching: optional `matcher` is a glob against the tool name
+(`fs_*`, `mcp__github__*`). No matcher = fires for every call.
+
+## 6. Config surface
+
+`config.toml`, following the existing `[console]` section pattern in
+`config.py`:
+
+```toml
+[hooks]
+enabled = true          # master switch; false disables every firing
+
+[[hooks.hook]]
+event = "PreToolUse"    # one of the six names; unknown = validation error
+matcher = "fs_*"        # optional, tool-name glob
+command = ["/usr/local/bin/guard.sh", "--strict"]   # argv; required, non-empty
+timeout_s = 10          # optional, default 10
+```
+
+Validation is fail-loud at load: unknown event names, empty/non-list `command`,
+non-positive timeouts are config errors (logged, that hook disabled) — never
+silent no-ops.
+
+## 7. Payload hygiene
+
+- No secrets: payloads are built from session/run ids, tool names, args and
+  results only — never env, config values, or API keys.
+- Tool args and results are truncated to the payload budget before the child
+  sees them.
+- Hook processes inherit the user's privileges by design (that is what a hook
+  is); the spec's mitigations are scope (user-config only), deny-only verdicts,
+  timeouts, and full logging of every execution to the run log.
+
+## 8. Wiring (what changes where)
+
+No new `AgentService` constructor surface. All fire points are Console-layer,
+using seams that already exist:
+
+1. `Chat/console_chat_controller.py` — call `engine.fire(UserPromptSubmit)` in
+   the submit path beside the `prompt_history` write; wrap
+   `build_tool_review_hook`'s verdict callable so `PreToolUse` hooks run first
+   and can deny into the existing verdict mechanism.
+2. `Chat/console_agent_bridge.py` — in the `on_step` consumer, fire
+   `PostToolUse` for `tool_result` records; at the run terminal-state path fire
+   `Stop`; keep the `on_child_settled` partial and fire `SubagentStop` beside
+   it.
+3. Approval bridges (`set_pending_approval` / `park_pending_approval` sites) —
+   fire `ApprovalRequested`.
+4. `Agents/run_hooks.py` — new engine module (the only new file).
+5. `config.py` — parse/validate `[hooks]`.
+
+## 9. Error handling summary
+
+- Config invalid → that hook disabled + loud log at load.
+- PreToolUse crash/timeout → deny (fail-closed), logged.
+- Non-blocking event crash/timeout → logged, dropped.
+- Engine never raises into the turn path: every firing is wrapped; internal
+  errors degrade to "hook did not run" with the event's failure semantics.
+
+## 10. Testing plan
+
+Unit (`Tests/Agents/test_run_hooks.py`):
+- config parse/validation matrix (unknown event, bad matcher, empty command,
+  timeout bounds, master switch)
+- subprocess execution via stub `python -c` commands: exit 0/2, stdout capture,
+  timeout kill, truncation, redaction
+- deny-only enforcement (`allow` decision ignored)
+- executor drop semantics for non-blocking events
+
+Integration (mirroring `Tests/Chat/test_console_local_review_hook.py`
+patterns):
+- PreToolUse deny short-circuits before the permission store; allow does not
+  bypass it
+- PreToolUse fail-closed on crash/timeout
+- UserPromptSubmit: exit-2 rejection; stdout injection; wake notice fires
+  nothing
+- PostToolUse/Stop/SubagentStop/ApprovalRequested fire with correct payloads
+  from their seams (viewless wake path included)
+
+## 11. Future work (explicitly out of v1)
+
+Project-scope hooks behind a trust gate; decision-JSON input rewriting;
+SessionStart/SessionEnd; PreCompact (rewind/summarize seam); settings-screen
+surface; per-session hook overrides.

--- a/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
+++ b/Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md
@@ -43,7 +43,7 @@ v1 serves three purposes:
 |---|---|---|---|
 | `UserPromptSubmit` | after submit gates, before turn compose; **manual-origin sends only** | controller submit path, beside the `prompt_history` slot write | yes (exit 2 rejects the send) |
 | `PreToolUse` | per tool-call batch, before permission review | wrapper around `build_tool_review_hook` verdict chain (`Chat/console_chat_controller.py`) | yes (exit 2 denies the batch) |
-| `PostToolUse` | after dispatch, at tool_result capture | bridge `on_step` consumer on `tool_result` records (no AgentService change) | no |
+| `PostToolUse` | after dispatch, at the run-log capture point where the full result exists; **only for calls that actually dispatched** (verdict `proceed` — refusals fire nothing) | new optional `post_tool_call` dep on the runtime deps (same shape as `run_skill_script`), fired from `Agents/agent_runtime.py`'s dispatch loop; the step stream stays out of it — `AgentStep` results are capped to 2 000 chars and carry no args | no |
 | `ApprovalRequested` | when an approval round is armed | `set_pending_approval` / `park_pending_approval` bridge sites | no |
 | `Stop` | a session turn's run reaching terminal state | bridge run terminal-state path (active and non-active sessions) | no |
 | `SubagentStop` | a fleet child run settling | the `on_child_settled` wiring in `Chat/console_agent_bridge.py` | no |
@@ -58,10 +58,24 @@ run outcomes, not user input.
 - **Engine module** `tldw_chatbook/Agents/run_hooks.py`: config parsing +
   validation, payload assembly, subprocess execution, redaction/truncation,
   logging. No UI imports; headless-testable.
-- **Process**: argv list, executed synchronously via `subprocess`
-  (**no shell**) — blocking events run inline in their calling context (submits
-  and run dispatch are already workers, never the UI thread); non-blocking
-  events run on the engine's executor (below).
+- **Process**: argv list, **no shell**. The engine offers two entries over one
+  implementation: `fire()` (synchronous `subprocess`, for thread contexts —
+  the run/review chain executes in threads) and `fire_async()`
+  (`asyncio.to_thread` around `fire()`, for event-loop contexts).
+  **`UserPromptSubmit` must use `fire_async()`**: `submit_draft` is `async`
+  and runs on the event loop (its existing hooks fire synchronously "from
+  deep inside submit_draft"), so a blocking subprocess there would freeze
+  the TUI.
+- **Concurrency**: matching hooks for one firing run **concurrently** on a
+  bounded pool — worst-case wall time is the slowest hook, not the sum.
+  For blocking events the first deny wins and remaining results are
+  discarded. Non-blocking events are scheduled on a single-worker executor
+  and never delay the turn; a full queue drops the firing with a log line
+  (hooks must not stall chat).
+- **Timeout kill**: per-hook `timeout_s`, default 10 s. Hooks are started
+  with `start_new_session=True` and killed as a **process group**
+  (`os.killpg`) so the script's own children cannot survive the timeout;
+  Windows falls back to `taskkill /T`.
 - **cwd**: the session's workspace root when one is bound, else the app cwd
   (mirrors `[console] workspace_root` fallback semantics).
 - **stdin**: one JSON document — common envelope + event-specific `data`:
@@ -95,27 +109,30 @@ call, and merges results into the existing per-call verdict dict. Calls a hook
 does not match are untouched.
 - **stdout/stderr**: captured (truncated to the shared budget) and written to
   the run log (`search_run_log` surfaces it).
-- **Timeout**: per-hook `timeout_s`, default 10 s, hard-killed after.
-- **Concurrency**: blocking events (`UserPromptSubmit`, `PreToolUse`) run
-  sequentially inline in the calling context (already off the UI thread —
-  submits and run dispatch are workers). Non-blocking events are handed to a
-  single-worker executor inside the engine and never delay the turn; a full
-  executor queue drops the firing with a log line (hooks must not stall chat).
 
 ## 5. Verdict semantics
 
-| Event | exit 0 | exit 2 | other non-zero / crash / timeout |
+| Event | clean pass | explicit deny | anything else |
 |---|---|---|---|
-| `UserPromptSubmit` | stdout (≤ budget) is prepended as context for this turn | send rejected; reason surfaced to the user as a refusal | warning logged; send proceeds |
-| `PreToolUse` | no opinion; normal permission flow continues | deny; reason becomes the tool result the model sees | **deny — fail-closed** (repo convention) |
-| all others | stdout logged to run log | same as non-zero | logged, ignored |
+| `UserPromptSubmit` | exit 0, no JSON: stdout (≤ budget) is prepended as turn context | exit 2 or JSON `{"decision":"block"}`: send rejected; reason surfaced to the user as a refusal | other non-zero / crash / timeout: **warning logged, send proceeds** — a broken hook must not brick the composer |
+| `PreToolUse` | exit 0, no JSON: no opinion; normal permission flow continues | exit 2 or JSON `{"decision":"deny","reason":"…"}`: deny; reason becomes the tool result the model sees | **deny — fail-closed**, reason "hook `<name>` failed (exit/timeout)"; the failure is visible to model and run log, never silent |
+| all others | stdout logged to run log | n/a (no verdict semantics) | logged, ignored |
 
-`PreToolUse` also accepts a JSON stdout body `{"decision": "deny", "reason":
-"…"}`. `{"decision": "allow"}` is parsed, ignored, and logged — the deny-only
-stance is enforced in the engine, not by hook authors.
+Precedence rules for blocking events: stdout that parses as a JSON object with
+a `decision` key wins over the exit code (exit 2 is shorthand for the event's
+blocking decision — `deny` for `PreToolUse`, `block` for `UserPromptSubmit`);
+unparseable stdout with exit 0 is a clean pass with a warning;
+`{"decision":"allow"}` on `PreToolUse` is parsed, ignored, and logged — the
+deny-only stance is enforced in the engine, not by hook authors.
+
+Injected `UserPromptSubmit` context is model-visible text, so it is recorded
+in the run log as its own entry (source hook named) — auditable after the
+fact, never silently merged into the prompt.
 
 Matching: optional `matcher` is a glob against the tool name
-(`fs_*`, `mcp__github__*`). No matcher = fires for every call.
+(`fs_*`, `mcp__github__*`). No matcher = fires for every call. `matcher` is
+**only valid on `PreToolUse` / `PostToolUse`**; on any other event it is a
+config validation error (there is no tool name to match).
 
 ## 6. Config surface
 
@@ -133,9 +150,12 @@ command = ["/usr/local/bin/guard.sh", "--strict"]   # argv; required, non-empty
 timeout_s = 10          # optional, default 10
 ```
 
-Validation is fail-loud at load: unknown event names, empty/non-list `command`,
-non-positive timeouts are config errors (logged, that hook disabled) — never
-silent no-ops.
+Validation is fail-loud: unknown event names, `matcher` on a non-tool event,
+empty/non-list `command`, non-positive timeouts are config errors (logged,
+that hook disabled) — never silent no-ops. Config is re-parsed when the
+file's mtime changes (checked per fire, cached between), and the master
+`enabled` switch is read fresh per fire — both follow the kill-switch
+"read fresh per turn" precedent.
 
 ## 7. Payload hygiene
 
@@ -149,49 +169,69 @@ silent no-ops.
 
 ## 8. Wiring (what changes where)
 
-No new `AgentService` constructor surface. All fire points are Console-layer,
-using seams that already exist:
+The engine is a **`ConsoleRuntime`-owned singleton** (like the controller and
+store): one shared executor, survives view detach, reachable from headless
+wake runs. One new `AgentService` surface, mirroring an established dep:
 
-1. `Chat/console_chat_controller.py` — call `engine.fire(UserPromptSubmit)` in
-   the submit path beside the `prompt_history` write; wrap
-   `build_tool_review_hook`'s verdict callable so `PreToolUse` hooks run first
-   and can deny into the existing verdict mechanism.
-2. `Chat/console_agent_bridge.py` — in the `on_step` consumer, fire
-   `PostToolUse` for `tool_result` records; at the run terminal-state path fire
-   `Stop`; keep the `on_child_settled` partial and fire `SubagentStop` beside
-   it.
-3. Approval bridges (`set_pending_approval` / `park_pending_approval` sites) —
-   fire `ApprovalRequested`.
-4. `Agents/run_hooks.py` — new engine module (the only new file).
-5. `config.py` — parse/validate `[hooks]`.
+1. `Chat/console_chat_controller.py` — call `await engine.fire_async(...)`
+   (`UserPromptSubmit`) in the submit path beside the `prompt_history` write,
+   **past the gates, still on the event loop** — `fire_async` keeps the loop
+   free while hooks run; wrap `build_tool_review_hook`'s verdict callable so
+   `PreToolUse` hooks run first and can deny into the existing verdict
+   mechanism (that chain executes in a thread — plain `engine.fire`).
+2. `Agents/agent_runtime.py` + `Agents/agent_service.py` — a new optional
+   `post_tool_call` dep (the `run_skill_script` pattern: optional field,
+   guarded call at the site), fired at the dispatch-loop capture point where
+   the full, uncapped result exists, only when `verdict == "proceed"`.
+3. `Chat/console_agent_bridge.py` — at the run terminal-state path fire
+   `Stop`; keep the `on_child_settled` partial and fire `SubagentStop`
+   beside it; wire `post_tool_call` through to the service constructor.
+4. Approval bridges (`set_pending_approval` / `park_pending_approval` sites) —
+   fire `ApprovalRequested` (these can be UI-thread bridges; the engine's
+   executor keeps the subprocess off the UI thread).
+5. `Agents/run_hooks.py` — new engine module (the only new file).
+6. `config.py` — parse/validate `[hooks]`.
 
 ## 9. Error handling summary
 
-- Config invalid → that hook disabled + loud log at load.
-- PreToolUse crash/timeout → deny (fail-closed), logged.
+The fail direction is **per purpose**, not global: a guardrail failing must
+not open the gate; a convenience failing must not brick the composer.
+
+- Config invalid → that hook disabled + loud log.
+- `PreToolUse`: deny on crash/timeout/non-clean exit (fail-closed), with the
+  failure reason as the visible tool result.
+- `UserPromptSubmit`: crash/timeout/non-clean exit → warning logged, send
+  proceeds (fail-open); only an explicit deny blocks.
 - Non-blocking event crash/timeout → logged, dropped.
 - Engine never raises into the turn path: every firing is wrapped; internal
-  errors degrade to "hook did not run" with the event's failure semantics.
+  errors degrade to "hook did not run" with the event's failure semantics;
+  executor task failures are logged.
 
 ## 10. Testing plan
 
 Unit (`Tests/Agents/test_run_hooks.py`):
-- config parse/validation matrix (unknown event, bad matcher, empty command,
-  timeout bounds, master switch)
-- subprocess execution via stub `python -c` commands: exit 0/2, stdout capture,
-  timeout kill, truncation, redaction
+- config parse/validation matrix (unknown event, matcher on non-tool event,
+  bad glob, empty command, timeout bounds, master switch)
+- subprocess execution via stub `python -c` commands: exit 0/2, JSON-decision
+  precedence over exit code, stdout capture, timeout kill (process group —
+  the stub spawns a surviving child that must die), truncation, redaction
 - deny-only enforcement (`allow` decision ignored)
+- concurrent hooks: first-deny-wins, wall time ≈ slowest hook
 - executor drop semantics for non-blocking events
+- `fire_async` keeps a running event loop responsive while a hook sleeps
 
 Integration (mirroring `Tests/Chat/test_console_local_review_hook.py`
 patterns):
 - PreToolUse deny short-circuits before the permission store; allow does not
   bypass it
-- PreToolUse fail-closed on crash/timeout
-- UserPromptSubmit: exit-2 rejection; stdout injection; wake notice fires
-  nothing
-- PostToolUse/Stop/SubagentStop/ApprovalRequested fire with correct payloads
-  from their seams (viewless wake path included)
+- PreToolUse fail-closed on crash/timeout, reason visible in the tool result
+- UserPromptSubmit: exit-2 rejection; stdout injection (and its run-log
+  record); wake notice fires nothing; loop stays responsive during a slow
+  hook
+- PostToolUse fires with full (engine-truncated) args+result from the
+  runtime dep, and fires nothing for refused calls
+- Stop/SubagentStop/ApprovalRequested fire with correct payloads from their
+  seams (viewless wake path included)
 
 ## 11. Future work (explicitly out of v1)
 

--- a/Tests/Chat/test_chat_persistence_service.py
+++ b/Tests/Chat/test_chat_persistence_service.py
@@ -2414,6 +2414,27 @@ class TestChatPersistenceService:
         assert extra[0]["data"] == b"img-1"
         assert extra[0]["display_name"] == "b.jpg"
 
+    def test_roleplay_context_round_trips_persona_template(
+        self, db_instance: CharactersRAGDB
+    ):
+        service = ChatPersistenceService(db_instance)
+        conversation_id = service.create_conversation(
+            conversation_title="Chat with Archivist",
+            runtime_backend="local",
+            assistant_kind="persona",
+            assistant_id="local-persona-abc",
+        )
+        assert service.update_conversation_roleplay_context(
+            conversation_id=conversation_id,
+            user_name_override=None,
+            character_system_template=None,
+            persona_system_template="Guide {{user}}.",
+        )
+        record = db_instance.get_conversation_by_id(conversation_id)
+        owned = json.loads(record["metadata"])["console_roleplay_context"]
+        assert owned["version"] == 1
+        assert owned["persona_system_template"] == "Guide {{user}}."
+
 
 class _RoleplayConflictDB:
     """Small optimistic-lock seam whose first write preserves a sibling."""

--- a/Tests/Chat/test_console_appearance.py
+++ b/Tests/Chat/test_console_appearance.py
@@ -1,0 +1,251 @@
+"""Tests for Console conversation appearance metadata (task-31207).
+
+Mirrors the ``console_speech`` metadata contract tests: versioned,
+namespaced ``conversations.metadata`` JSON that fails closed on malformed
+input and merges without disturbing sibling keys.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from tldw_chatbook.Chat.console_appearance import (
+    CONSOLE_APPEARANCE_COLOR_HEXES,
+    CONSOLE_APPEARANCE_METADATA_KEY,
+    CONSOLE_APPEARANCE_PALETTE,
+    ConsoleConversationAppearance,
+    is_valid_console_appearance_color,
+    is_valid_console_appearance_icon,
+    merge_console_conversation_appearance,
+    parse_console_conversation_appearance,
+)
+from tldw_chatbook.Chat.console_glyphs import (
+    GLYPH_APPEARANCE_ASCII_SET,
+    GLYPH_APPEARANCE_ASCII_UNSET,
+)
+
+
+def _metadata_with(appearance: object, **siblings: object) -> str:
+    payload: dict[str, object] = {CONSOLE_APPEARANCE_METADATA_KEY: appearance}
+    payload.update(siblings)
+    return json.dumps(payload)
+
+
+class TestIconValidation:
+    def test_single_code_point_emoji_is_valid(self) -> None:
+        assert is_valid_console_appearance_icon("🧪")
+
+    def test_variation_selector_emoji_is_valid(self) -> None:
+        # "❤️" is U+2764 U+FE0F: one glyph plus a variation selector.
+        assert is_valid_console_appearance_icon("❤️")
+
+    def test_wide_emoji_pair_is_invalid(self) -> None:
+        assert not is_valid_console_appearance_icon("🧪🧪")
+
+    def test_ascii_pair_is_invalid(self) -> None:
+        assert not is_valid_console_appearance_icon("ab")
+
+    def test_zwj_family_is_invalid(self) -> None:
+        assert not is_valid_console_appearance_icon("👨‍👩‍👧")
+
+    def test_empty_and_non_string_are_invalid(self) -> None:
+        assert not is_valid_console_appearance_icon("")
+        assert not is_valid_console_appearance_icon(None)  # type: ignore[arg-type]
+        assert not is_valid_console_appearance_icon(7)  # type: ignore[arg-type]
+
+
+class TestColorValidation:
+    def test_six_digit_hex_is_valid(self) -> None:
+        assert "#f87171" in CONSOLE_APPEARANCE_COLOR_HEXES
+
+    def test_named_colors_are_invalid(self) -> None:
+        assert not is_valid_console_appearance_color("red")
+
+    def test_short_and_long_hex_are_invalid(self) -> None:
+        assert not is_valid_console_appearance_color("#f87")
+        assert not is_valid_console_appearance_color("#f871711")
+        assert not is_valid_console_appearance_color("f87171")
+
+    def test_non_string_is_invalid(self) -> None:
+        assert not is_valid_console_appearance_color(0xF87171)  # type: ignore[arg-type]
+
+    def test_palette_entries_are_unique_canonical_hex(self) -> None:
+        hexes = [value for _, value in CONSOLE_APPEARANCE_PALETTE]
+        assert len(hexes) == len(set(hexes))
+        assert set(hexes) == CONSOLE_APPEARANCE_COLOR_HEXES
+        assert len(hexes) >= 12
+        for label, value in CONSOLE_APPEARANCE_PALETTE:
+            assert isinstance(label, str) and label
+            assert is_valid_console_appearance_color(value)
+
+    def test_ascii_glyphs_are_pure_ascii(self) -> None:
+        assert GLYPH_APPEARANCE_ASCII_SET.isascii()
+        assert GLYPH_APPEARANCE_ASCII_UNSET.isascii()
+        assert GLYPH_APPEARANCE_ASCII_SET != GLYPH_APPEARANCE_ASCII_UNSET
+
+
+class TestDataclassValidation:
+    def test_defaults_are_unset(self) -> None:
+        appearance = ConsoleConversationAppearance()
+        assert appearance.icon is None
+        assert appearance.color is None
+
+    def test_invalid_icon_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ConsoleConversationAppearance(icon="nope")
+
+    def test_invalid_color_raises(self) -> None:
+        with pytest.raises(ValueError):
+            ConsoleConversationAppearance(color="blue")
+
+
+class TestParse:
+    def test_missing_metadata_fails_closed(self) -> None:
+        assert parse_console_conversation_appearance(None) == (
+            ConsoleConversationAppearance()
+        )
+        assert parse_console_conversation_appearance("") == (
+            ConsoleConversationAppearance()
+        )
+        assert parse_console_conversation_appearance("not json") == (
+            ConsoleConversationAppearance()
+        )
+        assert parse_console_conversation_appearance(json.dumps([])) == (
+            ConsoleConversationAppearance()
+        )
+
+    def test_missing_key_fails_closed(self) -> None:
+        metadata = json.dumps({"console_speech": {"paused": False}})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance()
+        )
+
+    def test_valid_payload_round_trips(self) -> None:
+        metadata = _metadata_with({"icon": "🧪", "color": "#f87171"})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance(icon="🧪", color="#f87171")
+        )
+
+    def test_unset_members_round_trip_as_none(self) -> None:
+        metadata = _metadata_with({"icon": None, "color": None})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance()
+        )
+
+    def test_icon_without_color_is_kept(self) -> None:
+        metadata = _metadata_with({"icon": "🧪", "color": None})
+        assert parse_console_conversation_appearance(metadata).icon == "🧪"
+
+    def test_unknown_keys_drop_the_whole_entry(self) -> None:
+        # Strict key set, like ``console_speech``: a payload from a newer
+        # shape must not be partially interpreted by this version.
+        metadata = _metadata_with({"icon": "🧪", "color": None, "scale": 2})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance()
+        )
+
+    def test_malformed_icon_is_sanitized_per_member(self) -> None:
+        # Per-member sanitization: a bad icon drops only the icon.
+        metadata = _metadata_with({"icon": "🧪🧪", "color": "#f87171"})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance(color="#f87171")
+        )
+
+    def test_malformed_color_is_sanitized_per_member(self) -> None:
+        metadata = _metadata_with({"icon": "🧪", "color": "cerulean"})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance(icon="🧪")
+        )
+
+    def test_non_object_entry_fails_closed(self) -> None:
+        metadata = _metadata_with(["🧪"])
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance()
+        )
+
+    def test_non_string_members_are_sanitized_per_member(self) -> None:
+        metadata = _metadata_with({"icon": 3, "color": "#f87171"})
+        assert parse_console_conversation_appearance(metadata) == (
+            ConsoleConversationAppearance(color="#f87171")
+        )
+
+
+class TestMerge:
+    def test_merge_replaces_only_the_appearance_key(self) -> None:
+        metadata = _metadata_with(
+            {"icon": "🧪", "color": None}, console_speech={"paused": True}
+        )
+        merged = merge_console_conversation_appearance(
+            metadata, ConsoleConversationAppearance(icon="🎨", color="#22d3ee")
+        )
+        assert merged["console_speech"] == {"paused": True}
+        assert merged[CONSOLE_APPEARANCE_METADATA_KEY] == {
+            "icon": "🎨",
+            "color": "#22d3ee",
+        }
+
+    def test_merge_clears_both_members(self) -> None:
+        metadata = _metadata_with({"icon": "🧪", "color": "#f87171"})
+        merged = merge_console_conversation_appearance(
+            metadata, ConsoleConversationAppearance()
+        )
+        assert merged[CONSOLE_APPEARANCE_METADATA_KEY] == {
+            "icon": None,
+            "color": None,
+        }
+
+    def test_merge_accepts_mapping_metadata(self) -> None:
+        merged = merge_console_conversation_appearance(
+            {"console_speech": {"paused": True}},
+            ConsoleConversationAppearance(icon="🧪"),
+        )
+        assert merged["console_speech"] == {"paused": True}
+        assert merged[CONSOLE_APPEARANCE_METADATA_KEY]["icon"] == "🧪"
+
+    def test_merge_rejects_non_appearance_objects(self) -> None:
+        with pytest.raises(TypeError):
+            merge_console_conversation_appearance("{}", {"icon": "🧪"})  # type: ignore[arg-type]
+
+    def test_merge_rejects_invalid_values(self) -> None:
+        with pytest.raises(ValueError):
+            merge_console_conversation_appearance(
+                "{}", ConsoleConversationAppearance(icon="bad", color=None)
+            )
+
+    def test_merge_result_is_json_serializable_and_stable(self) -> None:
+        merged = merge_console_conversation_appearance(
+            "{}", ConsoleConversationAppearance(icon="🧪", color="#f87171")
+        )
+        encoded = json.dumps(merged, sort_keys=True)
+        assert parse_console_conversation_appearance(encoded) == (
+            ConsoleConversationAppearance(icon="🧪", color="#f87171")
+        )
+
+
+class TestHexInputNormalization:
+    def test_optional_hash_and_case(self) -> None:
+        from tldw_chatbook.Chat.console_appearance import (
+            normalize_console_appearance_hex_input,
+        )
+
+        assert normalize_console_appearance_hex_input("c0ffee") == "#c0ffee"
+        assert normalize_console_appearance_hex_input("#C0FFEE") == "#c0ffee"
+        assert normalize_console_appearance_hex_input(" #f87171 ") == "#f87171"
+
+    def test_partial_and_junk_return_none(self) -> None:
+        from tldw_chatbook.Chat.console_appearance import (
+            normalize_console_appearance_hex_input,
+        )
+
+        assert normalize_console_appearance_hex_input("") is None
+        assert normalize_console_appearance_hex_input("#f87") is None
+        assert normalize_console_appearance_hex_input("#f871711") is None
+        assert normalize_console_appearance_hex_input("red") is None
+        assert normalize_console_appearance_hex_input("##f87171") is None
+        assert normalize_console_appearance_hex_input(31) is None  # type: ignore[arg-type]
+
+    def test_palette_extended_beyond_the_initial_set(self) -> None:
+        # task-31209: the shipped palette grew from 13 to 21 swatches.
+        assert len(CONSOLE_APPEARANCE_PALETTE) >= 21

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import FrozenInstanceError, replace
 from datetime import datetime
+from types import SimpleNamespace
 
 import pytest
 
@@ -5588,3 +5589,120 @@ def test_presentation_context_carries_persona_display_name():
     assert context.assistant_kind == "persona"
     assert context.assistant_name == "Archivist"
     assert context.character_name is None
+
+
+def _persona_settings() -> ConsoleSessionSettings:
+    return ConsoleSessionSettings(provider="anthropic", model="claude-3-haiku")
+
+
+def _persona_session(store: ConsoleChatStore) -> ConsoleChatSession:
+    return store.create_session(
+        title="Chat with Archivist",
+        settings=_persona_settings(),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+
+
+def test_named_identity_gates_separate_kinds():
+    persona = SimpleNamespace(
+        assistant_kind="persona", character_name=None, assistant_name="Archivist"
+    )
+    character = SimpleNamespace(
+        assistant_kind="character", character_name="Alraune", assistant_name=None
+    )
+    generic = SimpleNamespace(
+        assistant_kind="generic", character_name=None, assistant_name=None
+    )
+    assert ConsoleChatStore._is_named_persona_session(persona) is True
+    assert ConsoleChatStore._is_named_character_session(persona) is False
+    assert ConsoleChatStore._is_named_persona_session(character) is False
+    assert ConsoleChatStore._is_named_character_session(character) is True
+    assert ConsoleChatStore._is_named_identity_session(persona) is True
+    assert ConsoleChatStore._is_named_identity_session(character) is True
+    assert ConsoleChatStore._is_named_identity_session(generic) is False
+
+
+def test_persona_seed_expands_identity_macros_into_system_prompt():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="Guide {{user}} as {{persona}}.",
+        global_default="Rowan",
+    )
+    assert session.persona_system_template == "Guide {{user}} as {{persona}}."
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Guide Rowan as Archivist."
+    # Personas have no greeting: seeding never appends a message.
+    assert store.messages_for_session(session.id) == []
+
+
+def test_persona_seed_without_system_prompt_keeps_default_settings():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id, system_template="  ", global_default="Rowan"
+    )
+    assert session.persona_system_template is None
+    assert session.settings is not None
+    assert session.settings.system_prompt == _persona_settings().system_prompt
+    assert session.assistant_name == "Archivist"
+
+
+def test_persona_rename_rematerializes_projection():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="I am {{char}} for {{user}}.",
+        global_default="Rowan",
+    )
+    _session, persisted = store.set_session_assistant_name(
+        session.id, "Scribe", global_default="Rowan"
+    )
+    assert persisted is True
+    assert session.assistant_name == "Scribe"
+    assert session.settings is not None
+    assert session.settings.system_prompt == "I am Scribe for Rowan."
+
+
+def test_set_session_assistant_name_clears_character_name():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Alraune",
+        settings=_persona_settings(),
+        assistant_kind="character",
+        assistant_id="7",
+        character_id=7,
+        character_name="Alraune",
+    )
+    store.set_session_assistant_name(session.id, "Archivist", global_default="Rowan")
+    assert session.assistant_name == "Archivist"
+    assert session.character_name is None
+
+
+def test_character_swap_off_persona_session_clears_persona_identity():
+    store = ConsoleChatStore()
+    session = _persona_session(store)
+    store.seed_persona_roleplay(
+        session.id, system_template="Guide {{user}}.", global_default="Rowan"
+    )
+    # The screen sets kind/id fields before calling the store seam; mirror it.
+    session.assistant_kind = "character"
+    session.assistant_id = "7"
+    session.character_id = 7
+    _session, _greeting, persisted = store.swap_session_character_roleplay(
+        session.id,
+        character_name="Alraune",
+        system_template="Be {{char}}.",
+        greeting_template="",
+        global_default="Rowan",
+    )
+    assert persisted is True
+    assert session.character_name == "Alraune"
+    assert session.assistant_name is None
+    assert session.persona_system_template is None
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Be Alraune."

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -762,6 +762,65 @@ def test_repurpose_rejects_mismatched_roleplay_title_without_mutation():
     assert store.sessions() == [before]
 
 
+def test_repurpose_pristine_session_accepts_persona_identity():
+    defaults = _pristine_defaults()
+    persona_settings = replace(
+        defaults, system_prompt="Guide User as Archivist.", character_label=""
+    )
+    store = ConsoleChatStore()
+    session = _pristine_session(store, defaults)
+
+    updated = store.repurpose_pristine_session(
+        session.id,
+        canonical_settings=defaults,
+        trusted_system_prompt="Guide User as Archivist.",
+        title="Chat with Archivist",
+        settings=persona_settings,
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_authority_id=None,
+        character_id=None,
+        character_name=None,
+        assistant_name="Archivist",
+    )
+
+    assert updated is session
+    assert updated.assistant_kind == "persona"
+    assert updated.assistant_id == "local-persona-abc"
+    assert updated.assistant_name == "Archivist"
+    assert updated.character_id is None
+    assert updated.character_name is None
+    assert updated.assistant_authority_id is None
+    assert updated.settings == persona_settings
+
+
+def test_repurpose_pristine_session_rejects_persona_authority():
+    defaults = _pristine_defaults()
+    store = ConsoleChatStore()
+    session = _pristine_session(store, defaults)
+    before = replace(session)
+
+    with pytest.raises(ValueError, match="authority-free"):
+        store.repurpose_pristine_session(
+            session.id,
+            canonical_settings=defaults,
+            trusted_system_prompt="Guide User.",
+            title="Chat with Archivist",
+            settings=replace(defaults, system_prompt="Guide User."),
+            runtime_backend="server",
+            assistant_kind="persona",
+            assistant_id="opaque-persona",
+            assistant_authority_id="server-user-v1:" + ("a" * 64),
+            character_id=None,
+            character_name=None,
+            assistant_name="Archivist",
+        )
+
+    assert store.sessions()[0] is session
+    assert session == before
+
+
 def test_session_character_ref_projects_complete_local_and_server_identities():
     local = ConsoleChatSession(
         runtime_backend="local",

--- a/Tests/Chat/test_console_chat_store.py
+++ b/Tests/Chat/test_console_chat_store.py
@@ -5573,3 +5573,18 @@ def test_promotion_transaction_rolls_back_created_conversation_on_context_failur
 
     assert persistence.created_conversations == []
     assert session.ephemeral is True
+
+
+
+def test_presentation_context_carries_persona_display_name():
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    context = store.presentation_context(session.id, "")
+    assert context.assistant_kind == "persona"
+    assert context.assistant_name == "Archivist"
+    assert context.character_name is None

--- a/Tests/Chat/test_console_provider_continuation.py
+++ b/Tests/Chat/test_console_provider_continuation.py
@@ -25,6 +25,7 @@ from tldw_chatbook.Chat.console_chat_store import (
     ConsoleChatStore,
     ContinuationDurabilityResult,
 )
+from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
 from tldw_chatbook.Chat.provider_continuation import (
     ContinuationCall,
     ContinuationRound,
@@ -1228,3 +1229,48 @@ def test_ephemeral_event_writes_no_checkpoint_and_offers_no_recovery() -> None:
         )
     finally:
         database.close_connection()
+
+
+def test_resolved_system_prompt_re_expands_persona_template() -> None:
+    """The send path re-expands the trusted persona template per turn."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="Guide {{user}} as {{persona}}.",
+        global_default="Rowan",
+    )
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    # The bare controller is constructed without a `global_user_display_name`
+    # accessor, so the constructor default (`lambda: "User"`, line 1760)
+    # applies and the per-turn re-expansion uses "User" — not the seed-time
+    # "Rowan". This pins that send-time expansion always wins.
+    assert (
+        controller._resolved_system_prompt(session.id)
+        == "Guide User as Archivist."
+    )
+
+
+def test_resolved_system_prompt_leaves_generic_sessions_untouched() -> None:
+    """Non-identity sessions keep the controller's configured prompt."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+    )
+    controller = ConsoleChatController(
+        store=store, provider_gateway=object(), system_prompt="Base prompt."
+    )
+
+    assert controller._resolved_system_prompt(session.id) == "Base prompt."

--- a/Tests/Chat/test_console_provider_continuation.py
+++ b/Tests/Chat/test_console_provider_continuation.py
@@ -1274,3 +1274,105 @@ def test_resolved_system_prompt_leaves_generic_sessions_untouched() -> None:
     )
 
     assert controller._resolved_system_prompt(session.id) == "Base prompt."
+
+
+def test_provider_selection_re_expands_persona_template_per_send() -> None:
+    """Persona sends re-expand the trusted template with the CURRENT user name.
+
+    The seeded settings projection ("Guide Rowan as Archivist.") is stale by
+    construction: the bare controller's `global_user_display_name` default
+    resolves to "User", so the selection must carry the per-turn re-expansion
+    from `_resolved_system_prompt`, not the settings snapshot.
+    """
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    store.seed_persona_roleplay(
+        session.id,
+        system_template="Guide {{user}} as {{persona}}.",
+        global_default="Rowan",
+    )
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Guide Rowan as Archivist."
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    selection = controller._provider_selection_for_session(session.id)
+
+    assert selection.system_prompt == "Guide User as Archivist."
+
+
+def test_provider_selection_keeps_settings_prompt_for_template_less_persona() -> None:
+    """A persona session with no trusted template keeps the settings prompt."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Archivist",
+        settings=ConsoleSessionSettings(
+            provider="anthropic",
+            model="claude-3-haiku",
+            system_prompt="Custom persona prompt.",
+        ),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    selection = controller._provider_selection_for_session(session.id)
+
+    assert selection.system_prompt == "Custom persona prompt."
+
+
+def test_provider_selection_keeps_settings_prompt_for_name_failed_persona() -> None:
+    """A persona resume whose name resolution failed keeps the settings prompt."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat",
+        settings=ConsoleSessionSettings(
+            provider="anthropic",
+            model="claude-3-haiku",
+            system_prompt="Guide Rowan.",
+        ),
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name=None,
+        persona_system_template="Guide {{user}}.",
+    )
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    selection = controller._provider_selection_for_session(session.id)
+
+    assert selection.system_prompt == "Guide Rowan."
+
+
+def test_provider_selection_re_expands_character_template_per_send() -> None:
+    """Regression guard: the character path already re-expands per send."""
+    store = ConsoleChatStore()
+    session = store.create_session(
+        title="Chat with Alraune",
+        settings=ConsoleSessionSettings(
+            provider="anthropic", model="claude-3-haiku"
+        ),
+        assistant_kind="character",
+        assistant_id="local-character-alraune",
+        character_name="Alraune",
+    )
+    store.seed_character_roleplay(
+        session.id,
+        system_template="Be {{char}} for {{user}}.",
+        greeting_template="",
+        global_default="Rowan",
+    )
+    assert session.settings is not None
+    assert session.settings.system_prompt == "Be Alraune for Rowan."
+    controller = ConsoleChatController(store=store, provider_gateway=object())
+
+    selection = controller._provider_selection_for_session(session.id)
+
+    assert selection.system_prompt == "Be Alraune for User."

--- a/Tests/Chat/test_console_roleplay_identity.py
+++ b/Tests/Chat/test_console_roleplay_identity.py
@@ -256,3 +256,60 @@ def test_resolver_uses_the_current_variant_and_leaves_system_and_tool_content_li
     assert resolve_console_message_presentation(tool, context).content == (
         "{{character}}"
     )
+
+
+
+def test_persona_session_labels_assistant_rows_with_persona_name():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(
+            assistant_kind="persona", assistant_name="Archivist"
+        ),
+    )
+    assert presentation.speaker_label == "Archivist"
+    assert presentation.speaker_tone == "assistant"
+    assert presentation.row_class == "console-transcript-message-role-assistant"
+
+
+def test_persona_session_without_name_falls_back_to_assistant():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(assistant_kind="persona", assistant_name="  "),
+    )
+    assert presentation.speaker_label == "Assistant"
+    assert presentation.speaker_tone == "assistant"
+
+
+def test_persona_name_never_gets_roleplay_character_styling():
+    presentation = resolve_console_message_presentation(
+        assistant_message("Certainly."),
+        ConsolePresentationContext(
+            assistant_kind="persona",
+            assistant_name="Archivist",
+            transcript_style=ConsoleTranscriptStyle.IMMERSIVE_RP,
+        ),
+    )
+    assert presentation.speaker_label == "Archivist"
+    assert presentation.speaker_tone == "assistant"
+    assert presentation.row_class == "console-transcript-message-role-assistant"
+
+
+def test_session_assistant_display_name_picks_per_kind():
+    from types import SimpleNamespace
+
+    from tldw_chatbook.Chat.console_roleplay_identity import (
+        session_assistant_display_name,
+    )
+
+    character = SimpleNamespace(
+        assistant_kind="character", character_name="Alraune", assistant_name=None
+    )
+    persona = SimpleNamespace(
+        assistant_kind="persona", character_name=None, assistant_name=" Archivist "
+    )
+    generic = SimpleNamespace(
+        assistant_kind="generic", character_name=None, assistant_name=None
+    )
+    assert session_assistant_display_name(character) == "Alraune"
+    assert session_assistant_display_name(persona) == "Archivist"
+    assert session_assistant_display_name(generic) is None

--- a/Tests/Chat/test_console_roleplay_metadata.py
+++ b/Tests/Chat/test_console_roleplay_metadata.py
@@ -123,3 +123,45 @@ def test_merge_writes_only_nonblank_owned_fields():
             "character_system_template": "  Speak plainly.  ",
         }
     }
+
+
+def test_persona_template_round_trip_preserves_sibling_keys():
+    merged = merge_console_roleplay_context(
+        '{"unrelated": true}',
+        ConsoleRoleplayContext(persona_system_template="Guide {{user}}."),
+    )
+    decoded = json.loads(merged)
+    assert decoded["unrelated"] is True
+    owned = decoded["console_roleplay_context"]
+    assert owned["version"] == 1
+    assert "user_name_override" not in owned
+    assert "character_system_template" not in owned
+    assert owned["persona_system_template"] == "Guide {{user}}."
+    parsed = parse_console_roleplay_context(merged)
+    assert parsed.persona_system_template == "Guide {{user}}."
+
+
+def test_envelope_without_persona_key_parses_as_before():
+    merged = merge_console_roleplay_context(
+        None,
+        ConsoleRoleplayContext(
+            user_name_override="Rowan", character_system_template="Be {{char}}."
+        ),
+    )
+    parsed = parse_console_roleplay_context(merged)
+    assert parsed.user_name_override == "Rowan"
+    assert parsed.character_system_template == "Be {{char}}."
+    assert parsed.persona_system_template is None
+
+
+def test_blank_persona_template_fails_soft_and_all_empty_pops_envelope():
+    assert parse_console_roleplay_context(
+        '{"console_roleplay_context": '
+        '{"version": 1, "persona_system_template": "  "}}'
+    ) == ConsoleRoleplayContext()
+    merged = merge_console_roleplay_context(
+        '{"console_roleplay_context": '
+        '{"version": 1, "persona_system_template": "x"}}',
+        ConsoleRoleplayContext(),
+    )
+    assert json.loads(merged) == {}

--- a/Tests/UI/test_console_appearance_picker.py
+++ b/Tests/UI/test_console_appearance_picker.py
@@ -1,0 +1,401 @@
+"""Console conversation appearance picker contracts (task-31207)."""
+
+from __future__ import annotations
+
+import pytest
+from textual.app import App, ComposeResult
+
+import tldw_chatbook.Widgets.Console.console_appearance_picker_modal as modal_module
+from tldw_chatbook.Chat.console_appearance import ConsoleConversationAppearance
+from tldw_chatbook.Widgets.Console.console_appearance_picker_modal import (
+    EMOJI_SELECTED_CLASS,
+    SWATCH_SELECTED_CLASS,
+    ConsoleAppearancePickerModal,
+    filter_appearance_emojis,
+)
+from tldw_chatbook.Widgets.emoji_picker import EmojiButton
+
+_FAKE_CATALOG = (
+    {"char": "🧪", "name": "test tube", "category": "objects", "aliases": ["lab"]},
+    {"char": "🎨", "name": "art", "category": "objects", "aliases": ["paint"]},
+    {"char": "🚀", "name": "rocket", "category": "travel", "aliases": ["ship"]},
+)
+
+
+@pytest.fixture(autouse=True)
+def _sandbox_emoji_sources(monkeypatch):
+    """Pin the catalog and keep the picker off the real recents file."""
+    monkeypatch.setattr(
+        modal_module, "get_emoji_data", lambda: (_FAKE_CATALOG, {}, [])
+    )
+    monkeypatch.setattr(modal_module, "load_recent_emojis", lambda: [])
+    saved: list[str] = []
+    monkeypatch.setattr(modal_module, "save_recent_emoji", saved.append)
+    return saved
+
+
+def test_filter_matches_name_and_alias() -> None:
+    assert [e["char"] for e in filter_appearance_emojis(_FAKE_CATALOG, "")] == [
+        "🧪",
+        "🎨",
+        "🚀",
+    ]
+    assert [e["char"] for e in filter_appearance_emojis(_FAKE_CATALOG, "rocket")] == [
+        "🚀"
+    ]
+    assert [e["char"] for e in filter_appearance_emojis(_FAKE_CATALOG, "LAB")] == ["🧪"]
+    assert filter_appearance_emojis(_FAKE_CATALOG, "nope") == []
+
+
+def test_constructor_rejects_foreign_values() -> None:
+    modal = ConsoleAppearancePickerModal(
+        conversation_id="conv-1",
+        conversation_title="T",
+        icon="not one glyph",
+        color="cerulean",
+    )
+    assert modal._selected_icon is None
+    assert modal._selected_color is None
+
+
+class PickerHarness(App[None]):
+    def __init__(self, **kwargs) -> None:
+        super().__init__()
+        self._kwargs = kwargs
+        self.result: object = "not-dismissed"
+
+    def on_mount(self) -> None:
+        self.push_screen(
+            ConsoleAppearancePickerModal(**self._kwargs),
+            callback=self._record_result,
+        )
+
+    def _record_result(self, result: object) -> None:
+        self.result = result
+
+
+async def _current_appearance(modal: ConsoleAppearancePickerModal):
+    return ConsoleConversationAppearance(
+        icon=modal._selected_icon, color=modal._selected_color
+    )
+
+
+@pytest.mark.asyncio
+async def test_apply_commits_icon_and_color_and_saves_recents(
+    _sandbox_emoji_sources,
+) -> None:
+    harness = PickerHarness(
+        conversation_id="conv-1", conversation_title="Lab chat"
+    )
+    async with harness.run_test(size=(80, 30)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+
+        # Carried-in unset state: nothing highlighted, no selection.
+        assert await _current_appearance(modal) == ConsoleConversationAppearance()
+
+        # Pick the first emoji, then a color swatch, then Apply.
+        first_emoji = modal.query(EmojiButton).first()
+        first_emoji.press()
+        await pilot.pause()
+        swatches = [
+            button
+            for button in modal.query(".console-appearance-swatch")
+            if getattr(button, "hex_color", None) is not None
+        ]
+        swatches[0].press()
+        await pilot.pause()
+
+        assert first_emoji.has_class(EMOJI_SELECTED_CLASS)
+        assert swatches[0].has_class(SWATCH_SELECTED_CLASS)
+        assert await _current_appearance(modal) == ConsoleConversationAppearance(
+            icon="🧪", color=swatches[0].hex_color
+        )
+
+        modal.query_one("#console-appearance-picker-apply").press()
+        await pilot.pause()
+        assert harness.result == ConsoleConversationAppearance(
+            icon="🧪", color=swatches[0].hex_color
+        )
+        assert _sandbox_emoji_sources == ["🧪"]
+
+
+@pytest.mark.asyncio
+async def test_carried_in_appearance_is_preselected(_sandbox_emoji_sources) -> None:
+    harness = PickerHarness(
+        conversation_id="conv-1",
+        conversation_title="T",
+        icon="🚀",
+        color="#22d3ee",
+    )
+    async with harness.run_test(size=(80, 30)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+
+        assert await _current_appearance(modal) == ConsoleConversationAppearance(
+            icon="🚀", color="#22d3ee"
+        )
+        highlighted = [
+            button
+            for button in modal.query(EmojiButton)
+            if button.has_class(EMOJI_SELECTED_CLASS)
+        ]
+        assert [button.emoji_data["char"] for button in highlighted] == ["🚀"]
+        selected_swatch = [
+            button
+            for button in modal.query(".console-appearance-swatch")
+            if button.has_class(SWATCH_SELECTED_CLASS)
+        ]
+        assert [button.hex_color for button in selected_swatch] == ["#22d3ee"]
+
+
+@pytest.mark.asyncio
+async def test_clear_resets_to_unset(_sandbox_emoji_sources) -> None:
+    harness = PickerHarness(
+        conversation_id="conv-1",
+        conversation_title="T",
+        icon="🚀",
+        color="#22d3ee",
+    )
+    async with harness.run_test(size=(80, 30)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+
+        modal.query_one("#console-appearance-picker-clear").press()
+        await pilot.pause()
+        assert harness.result == ConsoleConversationAppearance()
+        assert _sandbox_emoji_sources == []
+
+
+@pytest.mark.asyncio
+async def test_filter_narrows_the_grid(_sandbox_emoji_sources) -> None:
+    harness = PickerHarness(conversation_id="conv-1", conversation_title="T")
+    async with harness.run_test(size=(80, 30)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+
+        filter_input = modal.query_one("#console-appearance-picker-filter")
+        filter_input.value = "rocket"
+        # Drive the debounced filter synchronously (the timer is 0.2s).
+        modal._cancel_filter_timer()
+        modal._apply_filter("rocket")
+        await pilot.pause()
+
+        chars = [
+            button.emoji_data["char"] for button in modal.query(EmojiButton)
+        ]
+        assert chars == ["🚀"]
+
+
+class SwitcherHarness(App[None]):
+    def __init__(self, rows) -> None:
+        super().__init__()
+        self._rows = rows
+
+    def on_mount(self) -> None:
+        from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+            ConsoleSessionSwitcherModal,
+        )
+
+        self.push_screen(ConsoleSessionSwitcherModal(rows=self._rows))
+
+
+@pytest.mark.asyncio
+async def test_switcher_row_shows_colored_icon_left_of_title() -> None:
+    """task-31208: the Ctrl+K switcher renders the appearance icon left of
+    the title, and rows without one are unchanged."""
+    from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+        _switcher_icon_prefix,
+    )
+    from tldw_chatbook.Workspaces.conversation_browser_state import (
+        ConsoleConversationBrowserInputRow,
+    )
+
+    def _switcher_row(key, title, *, icon="", color=""):
+        return ConsoleConversationBrowserInputRow(
+            row_key=key,
+            conversation_id=key,
+            native_session_id=None,
+            title=title,
+            scope_type="global",
+            workspace_id=None,
+            workspace_label="",
+            icon=icon,
+            color=color,
+        )
+
+    rows = (
+        _switcher_row("conv-icon", "Lab chat", icon="🧪", color="#f87171"),
+        _switcher_row("conv-plain", "Plain chat"),
+    )
+    harness = SwitcherHarness(rows)
+    async with harness.run_test(size=(80, 30)) as pilot:
+        await pilot.pause()
+        modal = harness.screen_stack[-1]
+        labels = {
+            button.id: str(button.label)
+            for button in modal.query(".console-switcher-result")
+        }
+        ordered = list(labels.values())
+        # dev's label shape is "<caret> <state column> <title>\n  <metadata>";
+        # the icon sits between the state column and the title.
+        lab = next(label for label in ordered if "🧪" in label)
+        plain = next(label for label in ordered if "Plain chat" in label)
+        assert "Lab chat" in lab
+        assert lab.index("🧪") < lab.index("Lab chat")
+        # The plain row carries no icon glyph at all.
+        assert "🧪" not in plain
+
+    # Pure prefix helper: unset rows contribute nothing.
+    from tldw_chatbook.Chat.console_switcher_state import ConsoleSwitcherEntry
+
+    plain_entry = ConsoleSwitcherEntry(
+        row_key="k",
+        title="t",
+        subtitle="",
+        native_session_id=None,
+        conversation_id="k",
+        scope_type="global",
+        workspace_id=None,
+        is_active=False,
+    )
+    assert _switcher_icon_prefix(plain_entry) == ""
+
+
+@pytest.mark.asyncio
+async def test_custom_hex_entry_applies_valid_color(_sandbox_emoji_sources) -> None:
+    """task-31209: typing a canonical hex (with or without '#') selects it;
+    junk input leaves the current selection untouched."""
+    harness = PickerHarness(
+        conversation_id="conv-1",
+        conversation_title="T",
+        color="#22d3ee",
+    )
+    async with harness.run_test(size=(80, 34)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+
+        hex_input = modal.query_one("#console-appearance-picker-hex")
+        # Carried-in color is prefilled.
+        assert hex_input.value == "#22d3ee"
+
+        hex_input.value = "c0ffee"
+        await pilot.pause()
+        assert modal._selected_color == "#c0ffee"
+
+        # Junk must not clobber the selection mid-typing.
+        hex_input.value = "not a color"
+        await pilot.pause()
+        assert modal._selected_color == "#c0ffee"
+
+        modal.query_one("#console-appearance-picker-apply").press()
+        await pilot.pause()
+        assert harness.result == ConsoleConversationAppearance(
+            icon=None, color="#c0ffee"
+        )
+
+
+@pytest.mark.asyncio
+async def test_unstorable_emoji_sequence_is_rejected_at_selection(
+    _sandbox_emoji_sources,
+) -> None:
+    """PR #2480 review (#5): a ZWJ-family catalog entry must be rejected at
+    selection time -- Apply must never raise or record a stray recent."""
+    harness = PickerHarness(conversation_id="conv-1", conversation_title="T")
+    async with harness.run_test(size=(80, 34)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+        notes: list[str] = []
+        modal.app.notify = lambda message, **kwargs: notes.append(str(message))
+
+        modal._select_icon("👨‍👩‍👧")
+        await pilot.pause()
+        assert modal._selected_icon is None
+        assert notes, "the rejection must be surfaced, not silent"
+
+        modal.query_one("#console-appearance-picker-apply").press()
+        await pilot.pause()
+        assert harness.result == ConsoleConversationAppearance()
+        assert _sandbox_emoji_sources == []
+
+
+@pytest.mark.asyncio
+async def test_preview_renders_color_not_markup_tags(_sandbox_emoji_sources) -> None:
+    """PR #2480 review (#6): the preview is markup=False, so the color
+    sample must arrive as styled content -- literal '[#...]' tags are the
+    bug."""
+    harness = PickerHarness(
+        conversation_id="conv-1",
+        conversation_title="[b]Bold[/b] chat",
+        icon="🧪",
+        color="#f87171",
+    )
+    async with harness.run_test(size=(80, 34)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+        preview_text = str(modal.query_one("#console-appearance-picker-preview").render())
+        assert "#f87171" in preview_text
+        # Only the color tag must not leak literally; a markup-bearing TITLE
+        # legitimately shows its literal brackets in this markup=False view.
+        assert "[#" not in preview_text
+
+
+@pytest.mark.asyncio
+async def test_swatch_press_updates_custom_color_field(
+    _sandbox_emoji_sources,
+) -> None:
+    """PR #2480 review (#9): the custom-color input must show what Apply
+    will persist after a palette/no-color swatch press."""
+    harness = PickerHarness(conversation_id="conv-1", conversation_title="T")
+    async with harness.run_test(size=(80, 34)) as pilot:
+        modal = harness.screen_stack[-1]
+        assert isinstance(modal, ConsoleAppearancePickerModal)
+        await pilot.pause()
+        hex_input = modal.query_one("#console-appearance-picker-hex")
+
+        swatches = [
+            button
+            for button in modal.query(".console-appearance-swatch")
+            if getattr(button, "hex_color", None) is not None
+        ]
+        swatches[0].press()
+        await pilot.pause()
+        assert hex_input.value == swatches[0].hex_color
+
+        modal.query_one("#console-appearance-swatch-none").press()
+        await pilot.pause()
+        assert hex_input.value == ""
+        assert modal._selected_color is None
+
+
+def test_switcher_prefix_renders_placeholder_for_color_only() -> None:
+    """PR #2480 review (#8): a color-only appearance keeps a visible marker
+    in the switcher via the placeholder glyph, matching the rail."""
+    from tldw_chatbook.Chat.console_glyphs import GLYPH_APPEARANCE_PLACEHOLDER
+    from tldw_chatbook.Chat.console_switcher_state import ConsoleSwitcherEntry
+    from tldw_chatbook.Widgets.Console.console_session_switcher_modal import (
+        _switcher_icon_prefix,
+    )
+
+    color_only = ConsoleSwitcherEntry(
+        row_key="k",
+        title="t",
+        subtitle="",
+        native_session_id=None,
+        conversation_id="k",
+        scope_type="global",
+        workspace_id=None,
+        is_active=False,
+        icon="",
+        color="#22d3ee",
+    )
+    prefix = _switcher_icon_prefix(color_only)
+    assert GLYPH_APPEARANCE_PLACEHOLDER in prefix
+    assert prefix.startswith("[#22d3ee]")

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -4437,6 +4437,14 @@ def _character_card() -> dict:
     }
 
 
+def _persona_profile() -> dict:
+    return {
+        "id": "local-persona-abc",
+        "name": "Archivist",
+        "system_prompt": "Guide {{user}} as {{persona}}.",
+    }
+
+
 _DEFAULT_HANDOFF_VALUE = object()
 
 
@@ -4499,6 +4507,53 @@ def _character_handoff_runtime(
         capture_context=capture_context,
         capture_is_current=capture_is_current,
         resolve_captures=resolve_captures,
+    )
+
+
+def _persona_handoff_runtime(
+    *,
+    active_server_id: str | None = None,
+    profile=_DEFAULT_HANDOFF_VALUE,
+) -> SimpleNamespace:
+    """Persona mirror of `_character_handoff_runtime` with sentinel seams."""
+    scoped_profile = _persona_profile() if profile is _DEFAULT_HANDOFF_VALUE else profile
+    scope_service = SimpleNamespace(
+        get_persona_profile=AsyncMock(return_value=scoped_profile),
+        # The persona flow must never touch the character fetch seam.
+        get_character=AsyncMock(side_effect=AssertionError("character seam touched")),
+    )
+    db = SimpleNamespace(
+        # Personas are authority-free: no local authority lookup either.
+        get_local_authority_id=Mock(return_value="local-authority"),
+    )
+    initial_capture = SimpleNamespace(account="A")
+    authority_context_state = {"current": initial_capture}
+    capture_context = Mock(
+        side_effect=lambda *, expected_server_id: authority_context_state["current"]
+    )
+    capture_is_current = Mock(
+        side_effect=lambda capture: capture is authority_context_state["current"]
+    )
+    resolver = AsyncMock(
+        side_effect=AssertionError("persona flow must not resolve authority")
+    )
+    app = SimpleNamespace(
+        app_config={},
+        active_server_id=active_server_id,
+        chachanotes_db=db,
+        character_persona_scope_service=scope_service,
+        server_context_provider=SimpleNamespace(
+            capture_character_authority_context=capture_context,
+            is_character_authority_context_current=capture_is_current,
+            resolve_character_authority_id=resolver,
+        ),
+    )
+    return SimpleNamespace(
+        app=app,
+        db=db,
+        scope_service=scope_service,
+        resolver=resolver,
+        authority_context_state=authority_context_state,
     )
 
 
@@ -5205,6 +5260,129 @@ async def test_persona_start_chat_does_not_create_character_session(monkeypatch)
     runtime.resolver.assert_not_awaited()
     runtime.scope_service.get_character.assert_not_awaited()
     assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_binds_local_persona_session(monkeypatch):
+    runtime = _persona_handoff_runtime()
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is True
+    session = store.session
+    assert session is not None
+    assert session.runtime_backend == "local"
+    assert session.assistant_kind == "persona"
+    assert session.assistant_id == "local-persona-abc"
+    # ADR-037: persona sessions never carry an authority id, local included.
+    assert session.assistant_authority_id is None
+    assert session.assistant_name == "Archivist"
+    assert session.character_name is None
+    assert session.character_ref() is None
+    assert session.persona_system_template == "Guide {{user}} as {{persona}}."
+    assert session.settings is not None
+    # app_config={} -> global display name falls back to "User".
+    assert session.settings.system_prompt == "Guide User as Archivist."
+    # Personas have no greeting: seeding appends no message.
+    assert store.messages == []
+    runtime.scope_service.get_persona_profile.assert_awaited_once_with(
+        "local-persona-abc", mode="local"
+    )
+    runtime.scope_service.get_character.assert_not_awaited()
+    runtime.resolver.assert_not_awaited()
+    runtime.db.get_local_authority_id.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_fails_closed_when_profile_missing(monkeypatch):
+    runtime = _persona_handoff_runtime(profile=None)
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is False
+    assert store.session is None
+    assert store.create_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_fails_closed_when_profile_fetch_raises(monkeypatch):
+    runtime = _persona_handoff_runtime()
+    runtime.scope_service.get_persona_profile.side_effect = RuntimeError("boom")
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff()
+    )
+
+    assert started is False
+    assert store.session is None
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_binds_server_persona_without_authority(monkeypatch):
+    runtime = _persona_handoff_runtime(active_server_id="server-1")
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff(
+            runtime_backend="server", active_server_profile_id="server-1"
+        )
+    )
+
+    assert started is True
+    session = store.session
+    assert session.runtime_backend == "server"
+    assert session.assistant_kind == "persona"
+    assert session.assistant_authority_id is None
+    runtime.resolver.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persona_start_chat_server_fence_flip_mid_fetch_fails_closed(
+    monkeypatch,
+):
+    runtime = _persona_handoff_runtime(active_server_id="server-1")
+
+    async def flip_then_return(*_args, **_kwargs):
+        runtime.authority_context_state["current"] = SimpleNamespace(account="B")
+        return _persona_profile()
+
+    runtime.scope_service.get_persona_profile.side_effect = flip_then_return
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+
+    started = await screen._session._start_persona_console_session(
+        _persona_start_handoff(
+            runtime_backend="server", active_server_profile_id="server-1"
+        )
+    )
+
+    assert started is False
+    assert store.session is None
+    assert store.create_kwargs is None
+
+
+@pytest.mark.asyncio
+async def test_persona_payload_rejected_by_character_starter_accepted_by_persona_starter(
+    monkeypatch,
+):
+    runtime = _persona_handoff_runtime()
+    store = _CharacterHandoffStore()
+    screen = _handoff_chat_screen(monkeypatch, runtime.app, store)
+    payload = _persona_start_handoff()
+
+    assert await screen._session._start_character_console_session(payload) is False
+    assert await screen._session._start_persona_console_session(payload) is True
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -12737,3 +12737,134 @@ async def test_console_routine_send_fires_no_success_toast():
 
     success_toasts = [m for m, severity in notifications if severity == "success"]
     assert success_toasts == []
+
+
+@pytest.mark.asyncio
+async def test_console_resume_rehydrates_persona_name_from_profile():
+    """A resumed persona session re-resolves its display name, both backends."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                    # No assistant_authority_id: personas are authority-free.
+                    # No character_id: personas carry no local projection.
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        name_lookup = AsyncMock(return_value="Archivist")
+        console._resolve_resumed_persona_name = name_lookup
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.runtime_backend == "local"
+        assert session.assistant_kind == "persona"
+        assert session.assistant_id == "local-persona-abc"
+        assert session.assistant_authority_id is None
+        assert session.assistant_name == "Archivist"
+        assert session.character_name is None
+        assert session.character_ref() is None
+        name_lookup.assert_awaited_once_with("local-persona-abc", "local")
+
+
+@pytest.mark.asyncio
+async def test_console_resume_persona_name_lookup_failure_stays_unlabeled():
+    """A failed profile lookup resumes the session without a persona name."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        console._resolve_resumed_persona_name = AsyncMock(return_value="")
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.assistant_kind == "persona"
+        assert session.assistant_name is None
+
+
+@pytest.mark.asyncio
+async def test_console_resume_restores_persona_system_template_from_metadata():
+    """The trusted persona template rides the roleplay metadata envelope."""
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app.chat_conversation_scope_service = StaticConversationTreeService(
+        {
+            "local-persona": {
+                "conversation": {
+                    "id": "local-persona",
+                    "title": "Chat with Archivist",
+                    "runtime_backend": "local",
+                    "assistant_kind": "persona",
+                    "assistant_id": "local-persona-abc",
+                    "metadata": {
+                        "console_roleplay_context": {
+                            "version": 1,
+                            "persona_system_template": "Guide {{user}}.",
+                        },
+                    },
+                },
+                "root_threads": [],
+            }
+        }
+    )
+    host = ConsoleHarness(app)
+
+    async with host.run_test(size=(160, 48)) as pilot:
+        console = host.screen_stack[-1]
+        await _wait_for_selector(console, pilot, "#console-native-transcript")
+        console._resolve_resumed_persona_name = AsyncMock(return_value="Archivist")
+
+        assert (
+            await console._workspace._resume_console_workspace_conversation(
+                "local-persona"
+            )
+            is True
+        )
+
+        store = console._ensure_console_chat_store()
+        session = store.switch_session(store.active_session_id)
+        assert session.persona_system_template == "Guide {{user}}."

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -10644,6 +10644,92 @@ def test_native_console_state_round_trip_preserves_source_aware_character_identi
     assert restored_session.character_ref() is not None
 
 
+def test_native_console_state_round_trip_preserves_persona_identity():
+    """Screen state keeps persona provenance and its trusted template."""
+    store = ConsoleChatStore()
+    session = ConsoleChatSession(
+        id="session-p",
+        title="Chat with Archivist",
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+        persona_system_template="Guide {{user}} as {{persona}}.",
+    )
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    payload = _console_snapshot_with_sessions(screen)
+    assert payload is not None
+    assert {
+        key: payload["sessions"][0][key]
+        for key in (
+            "runtime_backend",
+            "assistant_kind",
+            "assistant_id",
+            "assistant_name",
+            "persona_system_template",
+        )
+    } == {
+        "runtime_backend": "local",
+        "assistant_kind": "persona",
+        "assistant_id": "local-persona-abc",
+        "assistant_name": "Archivist",
+        "persona_system_template": "Guide {{user}} as {{persona}}.",
+    }
+
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+    _restore_console_snapshot_with_sessions(restored_screen, payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.runtime_backend == "local"
+    assert restored_session.assistant_kind == "persona"
+    assert restored_session.assistant_id == "local-persona-abc"
+    assert restored_session.assistant_name == "Archivist"
+    assert (
+        restored_session.persona_system_template
+        == "Guide {{user}} as {{persona}}."
+    )
+    assert restored_session.character_name is None
+    assert restored_session.character_ref() is None
+
+
+def test_native_console_state_restore_drops_stray_character_name_on_persona():
+    """A contradictory payload keeps only the kind-appropriate name."""
+    store = ConsoleChatStore()
+    session = ConsoleChatSession(
+        id="session-p",
+        title="Chat with Archivist",
+        runtime_backend="local",
+        assistant_kind="persona",
+        assistant_id="local-persona-abc",
+        assistant_name="Archivist",
+    )
+    store.restore_state(
+        sessions=[session],
+        messages_by_session={session.id: []},
+        active_session_id=session.id,
+    )
+    screen = _bare_console_screen(store)
+
+    payload = _console_snapshot_with_sessions(screen)
+    assert payload is not None
+    payload["sessions"][0]["character_name"] = "Stale Character"
+
+    restored_store = ConsoleChatStore()
+    restored_screen = _bare_console_screen(restored_store)
+    _restore_console_snapshot_with_sessions(restored_screen, payload)
+
+    restored_session = restored_store.sessions()[0]
+    assert restored_session.assistant_name == "Archivist"
+    assert restored_session.character_name is None
+
+
 def test_live_server_session_never_exposes_local_character_projection():
     """A stray server-side numeric ID cannot drive local rail/card state."""
     session = ConsoleChatSession(

--- a/Tests/UI/test_console_native_chat_flow.py
+++ b/Tests/UI/test_console_native_chat_flow.py
@@ -76,6 +76,7 @@ import tldw_chatbook.UI.Console_Modules.message as message_module
 import tldw_chatbook.UI.Console_Modules.session as session_module
 from tldw_chatbook.UI.Console_Modules.message import ConsoleMessageController
 from tldw_chatbook.UI.Console_Modules.session import ConsoleSessionController
+from tldw_chatbook.UI.Console_Modules.session import _persona_session_identity_from_handoff, _persona_session_prompt_seed
 from tldw_chatbook.UI.Console_Modules.workspace import ConsoleWorkspaceController
 from tldw_chatbook.UI.Screens.chat_screen_state import TaskResumeState
 from tldw_chatbook.UI.Screens.settings_config_models import SettingsCategoryId
@@ -4401,6 +4402,32 @@ def _character_start_handoff(
     )
 
 
+def _persona_start_handoff(
+    *,
+    runtime_backend: str = "local",
+    active_server_profile_id: str | None = None,
+    persona_id: object = "local-persona-abc",
+) -> ChatHandoffPayload:
+    return ChatHandoffPayload(
+        source="personas",
+        item_type="persona-card",
+        title="Archivist",
+        body="Persona summary",
+        runtime_backend=runtime_backend,
+        source_owner=runtime_backend,
+        source_selector_state=runtime_backend,
+        active_server_profile_id=active_server_profile_id,
+        metadata={
+            "intent": "start_chat",
+            "selected_kind": "persona",
+            "selected_record_id": persona_id,
+            "selected_name": "Archivist",
+            "selected_target_id": f"{runtime_backend}:persona:{persona_id}",
+            "backend": runtime_backend,
+        },
+    )
+
+
 def _character_card() -> dict:
     return {
         "id": 7,
@@ -4594,6 +4621,78 @@ def test_character_start_handoff_requires_matching_record_and_target_ids(
     payload.metadata["selected_target_id"] = target_id
 
     assert session_module._character_session_identity_from_handoff(payload) is None
+
+
+def test_persona_handoff_accepts_exact_coherent_payload():
+    payload = _persona_start_handoff()
+    assert _persona_session_identity_from_handoff(payload) == (
+        "local",
+        "local-persona-abc",
+        "Archivist",
+        "local-persona-abc",
+    )
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    (
+        pytest.param("item_type", "character-card", id="character-item-type"),
+        pytest.param("runtime_backend", "LOCAL", id="non-exact-runtime-source"),
+        pytest.param("source_owner", "server", id="contradictory-owner"),
+    ),
+)
+def test_persona_handoff_rejects_incoherent_envelope(field, value):
+    payload = _persona_start_handoff()
+    setattr(payload, field, value)
+
+    assert _persona_session_identity_from_handoff(payload) is None
+
+
+def test_persona_handoff_rejects_character_kind_and_target_mismatch():
+    character_payload = _character_start_handoff()
+    assert _persona_session_identity_from_handoff(character_payload) is None
+    mismatched = _persona_start_handoff()
+    mismatched.metadata["selected_target_id"] = "local:persona:someone-else"
+    assert _persona_session_identity_from_handoff(mismatched) is None
+
+
+def test_persona_handoff_preserves_opaque_string_id():
+    payload = _persona_start_handoff(persona_id="srv-persona-7")
+    payload.metadata["selected_target_id"] = "local:persona:srv-persona-7"
+    identity = _persona_session_identity_from_handoff(payload)
+    assert identity is not None
+    assert identity[1] == "srv-persona-7"  # never int-coerced
+
+
+def test_persona_seed_expands_user_and_persona_macros():
+    seed = _persona_session_prompt_seed(
+        {"id": "local-persona-abc", "name": "Archivist",
+         "system_prompt": "Guide {{user}} as {{persona}} ({{char}})."},
+        user_name="Rowan",
+    )
+    assert seed.name == "Archivist"
+    assert seed.system_template == "Guide {{user}} as {{persona}} ({{char}})."
+    assert seed.system_prompt == "Guide Rowan as Archivist (Archivist)."
+
+
+def test_persona_seed_without_system_prompt_stays_empty():
+    seed = _persona_session_prompt_seed(
+        {"id": "local-persona-abc", "name": "Archivist"}, user_name="Rowan"
+    )
+    assert seed.system_template == ""
+    assert seed.system_prompt == ""
+
+
+def test_persona_seed_uses_name_hint_and_stays_single_pass():
+    seed = _persona_session_prompt_seed(
+        {"id": "p1", "system_prompt": "Hi {{user}}"},
+        name_hint=" {{char}} ",
+        user_name="{{user}}",
+    )
+    # The hint is sanitized but never macro-expanded; the user name is
+    # substituted literally exactly once (ADR-046 single-pass rule).
+    assert seed.name == "{{char}}"
+    assert seed.system_prompt == "Hi {{user}}"
 
 
 @pytest.mark.asyncio

--- a/Tests/UI/test_console_session_settings.py
+++ b/Tests/UI/test_console_session_settings.py
@@ -6533,7 +6533,7 @@ def test_console_control_state_reads_persona_label_without_storing_it_on_session
     assert session.assistant_authority_id is None
     assert "assistant_kind" in session.__dataclass_fields__
     assert "assistant_id" in session.__dataclass_fields__
-    assert "assistant_name" not in session.__dataclass_fields__
+    assert session.assistant_name is None
 
 
 def test_console_saved_openai_with_key_shows_ready_readiness() -> None:

--- a/backlog/decisions/147-agent-provider-routing.md
+++ b/backlog/decisions/147-agent-provider-routing.md
@@ -1,0 +1,39 @@
+# ADR-147: Agent provider routing — preset routing, gated spawn overrides, child-owned params
+
+Status: Accepted
+Date: 2026-09-11
+Related Task: [TASK-32477](../tasks/task-32477%20-%20Agent-provider-routing-preset-routing-gated-spawn-overrides.md)
+Related Spec: [Agent provider routing design](../../Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md)
+Amends: [ADR-146](146-console-custom-endpoint-registry.md) (registry entries gain an optional `params` table)
+Follow-up: TASK-32479 (preset `fallback_models` chains — deferred)
+
+## Context
+
+A Console agent run resolves one provider+model at send time and everything it spawns inherits that identity: `AgentDefinition.model` could only swap the model on the *same* provider endpoint. Users running a strong cloud model alongside a cheap/local one (e.g. Kimi API as architect, a local qwen3.8-27B as implementer) could not have a master agent delegate onto the other backend. ADR-146's registry made endpoints first-class for Console sessions but said "sampling and generation settings are never copied; they remain governed by the existing per-provider defaults chain" — leaving registry endpoints without any endpoint-owned param store. Two further facts shaped the decision: the Agents runtime never plumbs session sampling params into runs at all (`AgentService.call_model` sends `self.chat_call(...)` with only `tools`/continuation kwargs, so params fall back to `chat_api_call`'s internal config resolution), and fleet continuation re-resolves the agent definition by name, so editing a preset between finish and resume would silently move a child mid-conversation. The pi-subagents project's models doc was consulted as prior art; its precedence chain (per-run override → role override → default → parent) converges with the one chosen here.
+
+## Decision
+
+- **Routing resolves through one pure resolver** (`Agents/agent_routing.py`), invoked by `AgentService.spawn()` before fleet reservation. Resolution order, each level filling only blanks left above: (1) ad-hoc spawn args — honored only when `[agents] spawn_override_enabled` and matching `spawn_override_allowlist`; (2) the named preset's `provider`/`model`; (3) `[agents] subagent_default_provider/model`; (4) inherit the parent's provider+model. A `RoutingError` is returned as the spawn tool's error result (`SpawnAdmissionRefusal`): no silent cross-provider fallback, no fleet slot consumed.
+- **Ad-hoc args carry identity only.** `spawn_subagent` gains optional `provider`/`model` string args — never URLs (endpoints come only from config/registry, blocking context exfiltration to an attacker endpoint) and never params. Allowlist entries are a bare provider id (`llama_cpp`, `custom-ep:qwen-local`) or a `provider/model-glob` form (`llama_cpp/qwen3.8-*`; fnmatch, case-insensitive). A final-provider guard applies whenever any ad-hoc arg is present: the resolved `provider/model` must match the allowlist or the provider must equal the parent's, so a model-only arg cannot ride a paid default the user never allowlisted. The args are omitted from the tool schema entirely when the override flag is off.
+- **`AgentDefinition` gains `provider` and `params`.** `model` without `provider` keeps the legacy same-endpoint semantics; existing presets are unchanged. `definition_fingerprint` extends to the new fields (they shape what ran).
+- **Children never inherit parent sampling/API params.** A child's params are built fresh for its resolved provider+model through a six-layer stack, highest first: preset `params` → `[api_settings.<provider>].model_defaults.<model>` → `[console.provider_defaults.<provider>]` → registry entry `params` → `[chat_defaults]` → `[api_settings.<provider>]` scalars → function fallbacks. Uniform rule, including plain spawns — a deliberate behavior change from today's implicit `chat_api_call` config fallback: child params become explicit, deterministic, and visible in the run log. The known-param set and validators live in a new pure `Chat/sampling_params.py` shared by presets, registry entries, and the resolver; transport-level keys (`streaming`) are excluded.
+- **Registry entries gain an optional `params` table** (`[custom_endpoints.<slug>.params]`), amending ADR-146's "template scope is limited to family/endpoint/model list": endpoint-owned tuning is more specific than global chat_defaults and slots above that layer, below Console per-provider saved defaults (delivered via an optional `extra_sources` parameter on `build_default_console_session_settings`, empty by default so session defaults stay byte-identical). Entries without `params` behave exactly as before.
+- **The resolved target is persisted on the run row** (`resolved_provider`, `resolved_model`, `resolved_base_url`, `resolved_params_json`, schema v16). Continuation/resume reuses the snapshot; only legacy NULL rows re-resolve live. Editing a preset, endpoint, or config default after a spawn never moves an already-spawned child.
+
+## Alternatives
+
+- **Named route registry** (a separate route entity presets reference) was rejected: it duplicates `api_settings`/registry knowledge and adds a config surface the scenario doesn't need.
+- **Policy-file rules engine** was rejected as speculative; the allowlist expresses the one rule users asked for and can grow into policy later.
+- **Preset `fallback_models` chains** (pi-subagents-style retryable-failure fallback, pre-tool-activity only) were deferred to TASK-32479, not rejected: the chain is user-authored so it does not violate the no-silent-fallback rule, but its interactions with budgeting, continuation, and admission are a design surface of their own.
+- **A thinking-level ceiling** (`subagent_max_thinking`, pi-subagents `maxThinking`) was rejected: params here are all user-authored, so there is little to guard against.
+- **Provider-scoped role override matrices** (pi-subagents `agentOverridesByProvider`) were rejected: preset + default layers express the same intent without a matrix.
+- **Inheriting parent params for same-provider children only** was rejected in favor of the uniform rule: a split rule is harder to reason about, and the runtime never delivered session params to runs anyway.
+- **Validating preset providers against the registry at authoring time** was rejected: entries can be deleted between authoring and spawn, so registry existence is a spawn-time `RoutingError`, not a validation error.
+- **Ad-hoc params in spawn args** was rejected: model-generated params on a paid provider are a cost/injection surface; params come only from user-authored stores.
+
+## Consequences
+
+- New `[agents]` keys ship commented-out with defaults owned in `Agents/agent_routing.py`: `subagent_default_provider`, `subagent_default_model`, `spawn_override_enabled` (false), `spawn_override_allowlist` ([]).
+- Tool shaping, capability filtering, and pricing attribution need no new code: `provider_supports_native_tools` runs per run, the gateway consults `model_capabilities` per send, and `_budget_weighted_tokens` keys on each run's own provider/model (local children account as unpriced-local).
+- Per-child rail summaries show the resolved target; routing failures name the failing level (override / preset / default).
+- Stale allowlist slugs (deleted registry entries) are flagged in Settings UI, never silently dropped; a "Test routing" dry-run action reports each preset/default target's resolved provider/model/params and readiness.

--- a/backlog/decisions/148-console-run-hooks.md
+++ b/backlog/decisions/148-console-run-hooks.md
@@ -1,0 +1,33 @@
+# ADR-148: Console run hooks — user-scope external command hooks on session lifecycle events
+
+Status: Proposed
+Date: 2026-09-11
+Related Spec: [Console run hooks design](../../Docs/superpowers/specs/2026-09-11-console-run-hooks-design.md)
+Related: [ADR-069](069-console-project-instruction-local-state-and-preflight.md) (untrusted project context never grants execution)
+
+## Context
+
+The Console had no Claude Code–style hook system: no user-configurable commands at lifecycle points, no `[hooks]` config surface, and the only seams were internal (`CONSOLE_VIEW_HOOK_SLOTS` view binding, `AgentService`'s `review_tool_calls`/`on_step`/`on_child_settled` callbacks). Developers integrating with a console chat session had no sanctioned way to gate tool calls, observe runs, or inject context. Meanwhile every Claude Code event already has a natural attach point in this codebase (review chain, per-step consumer, settle hooks, submit path, approval bridges), and the repo already has a trust-gated script-execution precedent (`run_skill_script`).
+
+## Decision
+
+- **Six v1 events**, Claude Code names where semantics match: `UserPromptSubmit` (manual-origin sends only — the wake invariant), `PreToolUse` (blocking), `PostToolUse`, `ApprovalRequested`, `Stop`, `SubagentStop` (all fire-and-forget).
+- **External commands, argv-only, no shell.** A new pure engine module `Agents/run_hooks.py` parses `[hooks]` config, builds JSON payloads, executes via subprocess with per-hook timeouts, truncates output, and logs every execution to the run log.
+- **Deny-only guardrails.** `PreToolUse` hooks can deny a call (which then flows through the existing verdict mechanism as the tool result); they can never allow-bypass the MCP permission store or the builtin gate. Crash/timeout on `PreToolUse` denies — fail-closed, per repo convention.
+- **User-scope config only** (`config.toml [hooks]` + `[[hooks.hook]]`). Project-shipped hook files are rejected for v1: ADR-069's rule that project context never grants execution applies squarely to repo-shipped commands that would run on clone.
+- **No new `AgentService` surface.** All fire points live in the Console layer (controller submit path and review-hook wrapper, bridge `on_step`/terminal-state/`on_child_settled` consumers, approval bridges), riding seams that already exist.
+
+## Alternatives
+
+- **In-process Python callback registry** was rejected: usable only by code shipped with the app, no parity with the Claude Code model users asked for, and it introduces a plugin-packaging surface this repo doesn't have.
+- **Event-bus taps (observability only)** was rejected: Textual message subscribers can observe but cannot gate or inject, which drops two of the three purposes.
+- **Full Claude Code parity in v1** (project scope, decision-JSON input rewriting, SessionStart/End/PreCompact) was rejected as scope creep: each deferred piece needs its own trust or seam design.
+- **Shell command strings** were rejected for argv lists: a shell string is an injection surface and adds quoting ambiguity for no capability gain.
+
+## Consequences
+
+- Hooks run with the user's privileges by design; the mitigations are scope (user config only), deny-only verdicts, timeouts, payload redaction/truncation, and full run-log visibility of every execution.
+- Invalid hook config fails loud at load (that hook disabled + logged), never a silent no-op.
+- Non-blocking events run on a single-worker executor inside the engine and are dropped (logged) under pressure — chat latency is never hostage to hook scripts.
+- `UserPromptSubmit` stdout injection gives hooks a turn-scoped context channel; the send can be rejected with exit 2, surfaced as a refusal.
+- Future project-scope hooks require a new ADR extending the ADR-069 trust gate; this ADR's deny-only and fail-closed rules are the floor any extension stands on.

--- a/backlog/decisions/148-console-run-hooks.md
+++ b/backlog/decisions/148-console-run-hooks.md
@@ -13,9 +13,10 @@ The Console had no Claude Code–style hook system: no user-configurable command
 
 - **Six v1 events**, Claude Code names where semantics match: `UserPromptSubmit` (manual-origin sends only — the wake invariant), `PreToolUse` (blocking), `PostToolUse`, `ApprovalRequested`, `Stop`, `SubagentStop` (all fire-and-forget).
 - **External commands, argv-only, no shell.** A new pure engine module `Agents/run_hooks.py` parses `[hooks]` config, builds JSON payloads, executes via subprocess with per-hook timeouts, truncates output, and logs every execution to the run log.
-- **Deny-only guardrails.** `PreToolUse` hooks can deny a call (which then flows through the existing verdict mechanism as the tool result); they can never allow-bypass the MCP permission store or the builtin gate. Crash/timeout on `PreToolUse` denies — fail-closed, per repo convention.
+- **Deny-only guardrails, failing per purpose.** `PreToolUse` hooks can deny a call (which then flows through the existing verdict mechanism as the tool result); they can never allow-bypass the MCP permission store or the builtin gate. `PreToolUse` denies on crash/timeout/unclean exit (fail-closed — a broken guardrail must not open the gate), while `UserPromptSubmit` fails open (a broken hook must not brick the composer); only an explicit deny blocks a send. stdout JSON decisions take precedence over exit-code shorthand.
 - **User-scope config only** (`config.toml [hooks]` + `[[hooks.hook]]`). Project-shipped hook files are rejected for v1: ADR-069's rule that project context never grants execution applies squarely to repo-shipped commands that would run on clone.
-- **No new `AgentService` surface.** All fire points live in the Console layer (controller submit path and review-hook wrapper, bridge `on_step`/terminal-state/`on_child_settled` consumers, approval bridges), riding seams that already exist.
+- **Minimal runtime surface.** One new optional dep `post_tool_call` on the agent runtime deps (the established `run_skill_script` pattern), fired at the dispatch-loop capture point where the uncapped result exists — the step stream cannot serve `PostToolUse` because `AgentStep` results are capped to 2 000 chars and carry no args. Everything else fires from Console-layer seams (controller submit path and review-hook wrapper, bridge terminal-state/`on_child_settled` consumers, approval bridges). The engine is a `ConsoleRuntime`-owned singleton so headless wake runs share it.
+- **Thread-model aware execution.** `submit_draft` is async on the event loop, so `UserPromptSubmit` hooks run via an async entry (`asyncio.to_thread`); the run/review chain executes in threads and uses the synchronous entry. Matching hooks run concurrently with first-deny-wins; timeouts kill the hook's whole process group (`start_new_session` + `killpg`; `taskkill /T` on Windows) so a timed-out script's children cannot survive.
 
 ## Alternatives
 
@@ -26,7 +27,7 @@ The Console had no Claude Code–style hook system: no user-configurable command
 
 ## Consequences
 
-- Hooks run with the user's privileges by design; the mitigations are scope (user config only), deny-only verdicts, timeouts, payload redaction/truncation, and full run-log visibility of every execution.
+- Hooks run with the user's privileges by design; the mitigations are scope (user config only), deny-only verdicts, timeouts with process-group kill, payload redaction/truncation, and full run-log visibility of every execution and every injected context block.
 - Invalid hook config fails loud at load (that hook disabled + logged), never a silent no-op.
 - Non-blocking events run on a single-worker executor inside the engine and are dropped (logged) under pressure — chat latency is never hostage to hook scripts.
 - `UserPromptSubmit` stdout injection gives hooks a turn-scoped context channel; the send can be rejected with exit 2, surfaced as a refusal.

--- a/backlog/decisions/149-console-persona-session-identity.md
+++ b/backlog/decisions/149-console-persona-session-identity.md
@@ -1,0 +1,103 @@
+# ADR-149: Console persona sessions bind a kind-generic assistant display identity
+
+Status: Accepted
+Date: 2026-09-11
+Related Spec: [Console Persona Session Identity Design](../../Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md)
+Extends: ADR-037, ADR-046
+
+## Decision
+
+A Personas-screen "Chat now" on a persona creates a persona-bound native
+Console session, paralleling character sessions. `ConsoleChatSession` gains
+two nullable fields — `assistant_name` (the persona-kind display name) and
+`persona_system_template` (the trusted system-prompt source) — rather than
+overloading the character fields. At most one of `character_name` /
+`assistant_name` is ever non-blank; every identity write (persona bind,
+character swap, resume-clear) blanks the other side, and
+`settings.character_label` is cleared whenever a persona identity applies.
+
+The transcript's shared presentation resolver gains a persona branch: a
+persona session with a non-blank `assistant_name` renders the persona name as
+the speaker label with the standard assistant styling; roleplay styling
+remains character-gated. Persona system prompts expand through the existing
+single-pass identity-template expander at seed, per send, and on identity
+change, per ADR-046's source-and-projection model. Personas have no greeting
+field, so no greeting is seeded.
+
+No database migration is introduced. The persona display name is never
+persisted; it is re-resolved at resume from the persisted `assistant_id` via
+the mode-routed persona service, mirroring character-name resolution and
+covering legacy persona conversations. The trusted template persists as one
+optional `persona_system_template` key under the existing version-1
+`console_roleplay_context` metadata envelope, whose per-key fail-soft parsing
+keeps old and new builds interoperable in both directions.
+
+Server persona handoffs reuse the existing server-target freshness fencing
+(capture context, verify currency, fetch, re-verify) but, per ADR-037,
+persona conversations remain authority-free: no authority ID is resolved or
+stored, and failed fencing or fetch falls back to the existing staged-context
+path. The Console identity picker remains character-only; persona sessions
+originate from the Personas screen.
+
+## Context
+
+Persona "Chat now" handoffs currently fail the character-only identity
+extraction and land as staged context in a generic chat, so the transcript
+shows "Assistant", no macros expand, and the persona is not the session's
+identity. The character machinery this mirrors — display labeling, macro
+expansion, re-materialization, template provenance — was built under ADR-046
+but is gated on `assistant_kind == "character"`. ADR-046 also centralizes
+label resolution in one presentation resolver, so one persona branch
+propagates to transcript rows, Markdown rows, copy/export/save surfaces, and
+model-context assembly. ADR-037 fixes personas as assistant-side profiles and
+rules their conversations authority-free, which this decision preserves while
+still supporting server-backed personas.
+
+## Alternatives Considered
+
+| Option | Why rejected |
+| --- | --- |
+| Overload `character_name` / `character_system_template` for personas | The fields would lie about their contents, and every character-only reader (avatar, rail, chip, speech) would need an audit against persona leakage. |
+| Resolve the display name live by ID at render time | Synchronous service lookups in the render path; breaks the deliberately pure presentation resolver and ADR-046's stored-projection model. |
+| Persist the persona name in a new conversations column | Unnecessary: the character pattern of re-resolving the name from the persisted ID at resume already works and avoids a schema migration. |
+| Persist the template under a version-2 roleplay envelope | The strict version check would make old builds drop the entire envelope, including `user_name_override`; an optional version-1 key is backward and forward compatible. |
+| Re-fetch the persona's current system prompt at resume | Persona edits would silently rewrite existing chats, breaking snapshot parity with character sessions. |
+| Resolve/store `assistant_authority_id` for server personas | Contradicts ADR-037's authority-free persona rule. |
+| Add personas to the Console identity picker | Deferred by owner decision; persona sessions originate from the Personas screen only. |
+
+## Consequences
+
+- Persona identity becomes a first-class native-Console session kind with
+  transcript labeling, control-chip labeling (the existing
+  `resolve_assistant_identity_label` persona branch lights up unchanged), and
+  dynamic macro expansion.
+- The session dataclass grows two nullable fields; session snapshots and
+  screen-state serialization carry them.
+- Legacy persona conversations gain the persona label on resume without
+  migration.
+- Character behavior is structurally unchanged: `_is_named_character_session`
+  stays character-only, shared materialization machinery uses a combined
+  named-identity gate, and the character handoff path is tried before the
+  persona path with the staged-context fallback preserved.
+- A persona renamed after binding shows its fresh name on next resume;
+  deleted or unreachable personas degrade honestly to "Assistant" while the
+  session stays usable.
+- The persona fallback path continues to stage card bodies with raw,
+  unexpanded macros; staged context is evidence, not identity.
+
+## Verification Consequences
+
+Unit tests cover the presentation persona branch, handoff extraction
+accept/reject, macro expansion both directions with single-pass safety,
+identity-gate separation, the one-name-set invariant on swap, envelope
+round-trip with and without the new key, and resume name resolution for
+local hit/miss and server mode. Store/controller-level tests cover
+handoff-to-persona-session end to end and re-materialization on
+user-display-name change. Only tests related to the changed files and
+behavior are part of the implementation gate.
+
+## Links
+
+- [Console Persona Session Identity Design](../../Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md)
+- [ADR-037: Persona/User Profile separation and authority-scoped assistant identity](037-roleplay-assistant-identity-and-persona-user-profile-separation.md)
+- [ADR-046: Human chat display identity and template provenance](046-roleplay-chat-display-identity-and-template-provenance.md)

--- a/backlog/decisions/150-agent-chat-fork-and-spawn.md
+++ b/backlog/decisions/150-agent-chat-fork-and-spawn.md
@@ -1,0 +1,115 @@
+# ADR-150: Agent chat fork & spawn — confirmation-gated workstream chats
+
+Status: Accepted
+Date: 2026-09-11
+Related Task: [TASK-32482](../tasks/task-32482%20-%20Agent-chat-fork-and-spawn-tools-fork_chat-new_chat.md)
+Related Spec: [Agent chat fork & spawn design](../../Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md)
+Coordinates with: [ADR-147](147-agent-provider-routing.md) (preset/provider args for created chats are a deferred follow-up PR); [ADR-069](069-console-project-instruction-local-state-and-preflight.md) (project-instruction bindings are never copied)
+Follow-ups: TASK-32480 (sub-agent access), preset/provider integration PR (after ADR-147 lands on dev)
+
+## Context
+
+A Console agent can propose parallel workstreams but the user performs all the
+follow-through manually: create tabs, re-title, re-paste context, re-state the
+goal. Two gaps block automating the preparation. First, there is no
+agent-reachable chat-creation path at all — the tool executors are
+deliberately dependency-light (no store, no UI access), and reaching the
+Console from the agent worker thread happens only through callables injected
+at `run_reply` composition (the `install_skill` / `run_skill_script` seam).
+Second, there is no fork primitive: the `parent_conversation_id` /
+`forked_from_message_id` columns added in the V11→V12 migration "for
+conversation forking" have never been written by Console code, and
+`fork_conversation_into_workspace` is a misnomer that links workspace
+membership for the same conversation without copying anything. Any
+agent-initiated creation is also a new mutation channel from model-generated
+input, so the confirmation policy is part of the architecture, not an
+afterthought.
+
+## Decision
+
+- **Two runtime tools on the injected-callable seam: `fork_chat` and
+  `new_chat`**, not local/builtin catalog tools. Both need conversation
+  context, a blocking confirm round-trip, and chat-store access from the
+  agent worker thread — exactly what the `run_skill_script` pattern provides.
+  Pinned for `AGENT_KIND_PRIMARY` runs only in v1; sub-agents are a follow-up
+  (TASK-32480). Names avoid "spawn" (`spawn_subagent` exists).
+- **Fork = verbatim active-path snapshot at tool execution.** Root → active
+  leaf of the running agent's own conversation: roles, content, tool markers,
+  parents remapped, full field preservation (images, usage,
+  provider-continuation JSON, metadata). Messages appended after the snapshot
+  — including the tool's own result marker and the rest of the in-flight turn
+  — are excluded, and the tool description teaches the agent to carry
+  workstream framing in `opening_prompt` instead. Mid-conversation forks
+  compose with existing rewind rather than inventing a message-addressing
+  scheme the model could not use reliably. The lineage columns are finally
+  written; no schema migration in either database.
+- **Args are `title`, `opening_prompt`, `instructions` — and nothing else.**
+  No provider/preset/model args in v1: those land in a dedicated integration
+  PR after ADR-147 merges to dev. `instructions` replace the source's system
+  prompt except on character-bound sources, which refuse them (a model-authored
+  prompt must not silently override a persona). Project-instruction bindings
+  are never copied — selecting a binding is a deliberate user act (ADR-069).
+- **The opening prompt is a draft, never sent.** It lands in the new chat's
+  composer via `set_session_draft`; the user reviews, edits, and sends. To
+  survive restarts, the draft is persisted in the conversation's local-only
+  metadata (`console_agent_handoff`) and rehydrated on session restore.
+- **Confirmation is a per-call card: Allow / Allow for this session / Deny**
+  on the `request_skill_script_confirm` pattern — fail-closed on no-UI,
+  cancel, or timeout; parks a badge for background sessions; full bodies of
+  `opening_prompt` and `instructions` always shown on the card (a
+  model-authored system prompt is a persistent injection surface). Remember is
+  per tool and Console-session-scoped: no persisted bypass, so every new
+  conversation confirms by default. A per-run denial guard makes the tool
+  terminal after two denials. Accepted residual risk, documented: a remembered
+  session skips card review of later `instructions` payloads; exposure is
+  bounded to the session and the prompt stays visible/editable in the new
+  chat's settings.
+- **Creation is durable, background, and never steals focus.** Both tools
+  persist the conversation row immediately (no lazy minting), create a
+  non-activated session in the same workspace, invalidate the persisted-rows
+  cache, trigger the console-sync worker, and announce with a toast. The
+  workspace listing mechanism (scope columns vs registry membership) is
+  verified during implementation so the chat is guaranteed visible.
+
+## Alternatives
+
+- **Local/builtin catalog tool** was rejected: the catalog executor is
+  dependency-light by design — no conversation context, no store access — and
+  permission-store gating (allow/ask/deny states) cannot render the
+  payload-review card these tools need.
+- **One `create_chat` tool with a mode enum** was rejected: two verbs get
+  distinct schemas, descriptions, and card headers, which is what teaches the
+  model when to use which; the wiring cost is two small copies of an existing
+  pattern.
+- **Agent-chosen fork points** (e.g. "fork from message N") were rejected: the
+  model has no usable message addressing in its context; rewind-then-fork
+  composes to the same outcome.
+- **Full-tree copies** (variants and inactive branches) were rejected: users
+  act on the path they can see; the heavier copy buys nothing for v1.
+- **Auto-sending the opening prompt** was rejected: the agent must not act as
+  the user; drafts keep one approval per creation and keep the user in the
+  send loop.
+- **Permission-store persisted allow** was rejected: it would remove by
+  configuration the default safety rail the requirement names; session-scoped
+  remember is the only opt-out.
+- **Batch approval of multiple creations in one card** was rejected as YAGNI:
+  sequential cards are correct, rare, and each approval stays atomic.
+
+## Consequences
+
+- `fork_conversation_history` (new, `Chat/chat_conversation_service.py`) is
+  the first Console writer of the lineage columns; the name avoids collision
+  with the `fork_conversation_into_workspace` misnomer. The copy must use the
+  raised-caps/uncapped tree read — silent truncation of long chats is a bug
+  and an over-cap fork is a tested case.
+- `restore_persisted_session` gains an `activate=False` variant
+  (`create_session` already supports the flag; no-screen hydration is proven
+  by `console_launch_wake`). Draft rehydration hooks into session restore.
+- Shared files with the ADR-147 PR (`agent_service.py` — additive pins after
+  the runtime-schema block, `agent_runtime.py`, `console_agent_bridge.py`):
+  implement on top of it or rebase before opening; the routing PR rewrites
+  adjacent regions.
+- No new config keys: confirmation defaults are the tools' built-in policy.
+- Docs: `agent-runs-and-tools.md` and a workstream blurb in the Console user
+  guide document both tools, the draft-not-send contract, and the mid-turn
+  snapshot boundary.

--- a/backlog/tasks/task-32477 - Agent-provider-routing-preset-routing-gated-spawn-overrides.md
+++ b/backlog/tasks/task-32477 - Agent-provider-routing-preset-routing-gated-spawn-overrides.md
@@ -1,0 +1,35 @@
+---
+id: TASK-32477
+title: 'Agent provider routing: preset routing + gated spawn overrides'
+status: To Do
+assignee: []
+created_date: '2026-09-12 00:57'
+updated_date: '2026-09-12 00:59'
+labels:
+  - agents
+  - console
+  - llm-routing
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a Console master/control agent spawn sub-agents onto a specific provider+model (incl. custom-ep: registry endpoints) or a user-configured sub-agent default, instead of always inheriting the parent's selection. Presets (AgentDefinition) carry provider/model/params routing; spawn_subagent gains provider/model ad-hoc args gated by [agents] spawn_override_enabled + spawn_override_allowlist with a final-provider guard; children never inherit parent sampling/API params (six-layer stack: preset > model profile > console.provider_defaults > registry entry params > chat_defaults > api_settings scalars); resolved target snapshot persisted on the run row for stable resume. Spec: Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Master can spawn a child onto a different provider+model via named preset; ad-hoc args honored only when enabled and allowlisted, else loud tool error
+- [ ] #2 Sub-agent default provider/model setting with inherit-parent fallback
+- [ ] #3 Children never inherit parent sampling params; preset/endpoint params precedence verified by tests
+- [ ] #4 Resolved target snapshot persisted; resume reuses snapshot
+- [ ] #5 Registry entries support optional params table (amends ADR-146)
+- [ ] #6 No silent cross-provider fallback; RoutingError variants surface as spawn tool errors
+<!-- AC:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+ADR: backlog/decisions/147-agent-provider-routing.md (amends ADR-146). Spec: Docs/superpowers/specs/2026-09-11-agent-provider-routing-design.md. Plan: Docs/superpowers/plans/2026-09-11-agent-provider-routing.md
+<!-- SECTION:NOTES:END -->

--- a/backlog/tasks/task-32479 - Preset-fallback_models-user-configured-fallback-chains-for-routed-sub-agents.md
+++ b/backlog/tasks/task-32479 - Preset-fallback_models-user-configured-fallback-chains-for-routed-sub-agents.md
@@ -1,0 +1,25 @@
+---
+id: TASK-32479
+title: 'Preset fallback_models: user-configured fallback chains for routed sub-agents'
+status: To Do
+assignee: []
+created_date: '2026-09-12 01:06'
+labels:
+  - agents
+  - console
+  - llm-routing
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Follow-up to TASK-32477 (agent provider routing, ADR-147). Let an AgentDefinition preset carry an ordered fallback_models list (provider/model entries) used when the primary target fails with a retryable provider error (rate-limit, overload, unavailable model, provider-reported timeout) BEFORE any tool activity. The chain is user-authored, so it does not violate the no-silent-fallback rule of ADR-147. Must define interaction with run budgeting, provider continuation, fleet admission, and the resolved-target snapshot; reference pi-subagents docs/models.md fallbackModels semantics as a starting point. Explicitly out of scope there: mid-run fallback after tool activity.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Preset schema gains validated fallback_models list
+- [ ] #2 Fallback triggers only on retryable pre-tool-activity provider failures
+- [ ] #3 Budget/continuation/snapshot interactions specified and tested
+<!-- AC:END -->

--- a/backlog/tasks/task-32480 - Extend-fork_chat-new_chat-tools-to-sub-agents.md
+++ b/backlog/tasks/task-32480 - Extend-fork_chat-new_chat-tools-to-sub-agents.md
@@ -1,0 +1,24 @@
+---
+id: TASK-32480
+title: Extend fork_chat/new_chat tools to sub-agents
+status: To Do
+assignee: []
+created_date: '2026-09-12 01:17'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+v1 pins fork_chat/new_chat runtime tools to primary agents only. Sub-agents (fleet children, skill spawns) are scoped to the parent conversation, so the same tools can let a delegated child open follow-up workstream chats for the user with the same confirmation gates. Build on the v1 spec: Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md (see Sub-agent extension section).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Sub-agent runs advertise fork_chat and new_chat schemas when injected
+- [ ] #2 Fork from a sub-agent copies the parent conversation's active path with lineage columns set
+- [ ] #3 Confirmation card identifies the requesting agent and parent run
+- [ ] #4 Denial and session-remember semantics scope to the requesting run
+- [ ] #5 Fleet-child fork and new_chat paths tested end to end
+<!-- AC:END -->

--- a/backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md
+++ b/backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md
@@ -1,0 +1,41 @@
+---
+id: TASK-32481
+title: 'Console persona session identity: label parity and dynamic identity macros'
+status: To Do
+assignee: []
+created_date: '2026-09-11'
+labels:
+  - console
+  - personas
+  - roleplay
+dependencies: []
+references:
+  - backlog/decisions/149-console-persona-session-identity.md
+  - >-
+    Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md
+  - >-
+    Docs/superpowers/plans/2026-09-11-task-32481-console-persona-session-identity.md
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+A Personas-screen "Chat now" on a persona currently stages the card as context
+in a generic Console chat: the transcript keeps showing "Assistant" and no
+template macros expand. Character cards already bind a real session identity
+with a named transcript label and dynamic macro expansion. This task brings
+persona cards to parity, locally and against a connected server, per the
+approved spec and ADR-149, so the Console speaker label always reflects the
+session's current assistant identity whatever its kind.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Persona "Chat now" (local and server backends) creates a persona-bound native Console session whose transcript labels assistant rows with the persona's name instead of "Assistant".
+- [ ] #2 Persona system-prompt macros (`{{user}}`/`{{random_user}}`/`<USER>` and `{{char}}`/`{{character}}`/`{{persona}}`/`<CHAR>`) expand with the effective user display name and persona name at session seed, per send, and after identity-name changes (single non-recursive pass, per ADR-046).
+- [ ] #3 Resumed persona conversations — including legacy ones persisted with `assistant_kind="persona"` — re-resolve the persona name from `assistant_id`; resolution failure degrades honestly to "Assistant".
+- [ ] #4 No database schema migration; the trusted persona system template persists as an optional `persona_system_template` key under the existing version-1 `console_roleplay_context` metadata envelope.
+- [ ] #5 Character behavior is unchanged; a character swap onto a persona session clears persona identity fields, and at most one of `character_name`/`assistant_name` is ever set.
+- [ ] #6 Persona sessions never store `assistant_authority_id` (ADR-037 authority-free rule); server persona fetches still use the existing target-freshness fencing.
+- [ ] #7 Targeted tests covering all changed behavior pass.
+<!-- AC:END -->

--- a/backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md
+++ b/backlog/tasks/task-32481 - Console-persona-session-identity-label-parity-and-dynamic-identity-macros.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-32481
 title: 'Console persona session identity: label parity and dynamic identity macros'
-status: To Do
+status: Done
 assignee: []
 created_date: '2026-09-11'
 labels:
@@ -31,11 +31,45 @@ session's current assistant identity whatever its kind.
 
 ## Acceptance Criteria
 <!-- AC:BEGIN -->
-- [ ] #1 Persona "Chat now" (local and server backends) creates a persona-bound native Console session whose transcript labels assistant rows with the persona's name instead of "Assistant".
-- [ ] #2 Persona system-prompt macros (`{{user}}`/`{{random_user}}`/`<USER>` and `{{char}}`/`{{character}}`/`{{persona}}`/`<CHAR>`) expand with the effective user display name and persona name at session seed, per send, and after identity-name changes (single non-recursive pass, per ADR-046).
-- [ ] #3 Resumed persona conversations — including legacy ones persisted with `assistant_kind="persona"` — re-resolve the persona name from `assistant_id`; resolution failure degrades honestly to "Assistant".
-- [ ] #4 No database schema migration; the trusted persona system template persists as an optional `persona_system_template` key under the existing version-1 `console_roleplay_context` metadata envelope.
-- [ ] #5 Character behavior is unchanged; a character swap onto a persona session clears persona identity fields, and at most one of `character_name`/`assistant_name` is ever set.
-- [ ] #6 Persona sessions never store `assistant_authority_id` (ADR-037 authority-free rule); server persona fetches still use the existing target-freshness fencing.
-- [ ] #7 Targeted tests covering all changed behavior pass.
+- [x] #1 Persona "Chat now" (local and server backends) creates a persona-bound native Console session whose transcript labels assistant rows with the persona's name instead of "Assistant".
+- [x] #2 Persona system-prompt macros (`{{user}}`/`{{random_user}}`/`<USER>` and `{{char}}`/`{{character}}`/`{{persona}}`/`<CHAR>`) expand with the effective user display name and persona name at session seed, per send, and after identity-name changes (single non-recursive pass, per ADR-046).
+- [x] #3 Resumed persona conversations — including legacy ones persisted with `assistant_kind="persona"` — re-resolve the persona name from `assistant_id`; resolution failure degrades honestly to "Assistant".
+- [x] #4 No database schema migration; the trusted persona system template persists as an optional `persona_system_template` key under the existing version-1 `console_roleplay_context` metadata envelope.
+- [x] #5 Character behavior is unchanged; a character swap onto a persona session clears persona identity fields, and at most one of `character_name`/`assistant_name` is ever set.
+- [x] #6 Persona sessions never store `assistant_authority_id` (ADR-037 authority-free rule); server persona fetches still use the existing target-freshness fencing.
+- [x] #7 Targeted tests covering all changed behavior pass.
 <!-- AC:END -->
+
+## Implementation Notes
+
+Implemented persona session identity for the native Console as a kind-keyed
+persona branch on the existing ADR-046 character-identity machinery, so
+persona cards reach label parity with character cards without a parallel
+stack.
+
+- **Approach:** `ConsoleChatSession` carries `assistant_name` /
+  `persona_system_template` alongside the character identity fields, with a
+  one-name invariant (at most one of `character_name` / `assistant_name` set,
+  keyed by `assistant_kind`) enforced on identity mutation and on
+  screen-state restore. Persona "Chat now" builds a persona-bound native
+  session through the same handoff/seed path as characters
+  (`seed_persona_roleplay`), and the send path re-expands the trusted
+  template per turn via the kind-keyed `_resolved_system_prompt` branch, so
+  macro expansion always uses the live user display name.
+- **Authority-free per ADR-037:** persona sessions never store
+  `assistant_authority_id`; server persona fetches reuse the existing
+  target-freshness fencing rather than a new authority channel.
+- **Resume:** the persona name is re-resolved from `assistant_id` at resume
+  (including legacy `assistant_kind="persona"` conversations); a failed
+  lookup degrades honestly to the generic "Assistant" label.
+- **Persistence:** no schema migration — the trusted persona template rides
+  as an optional `persona_system_template` key in the existing version-1
+  `console_roleplay_context` metadata envelope, and as a
+  `persona_system_template` field in serialized screen state.
+- **Modified files:** `Chat/console_chat_store.py` (session fields, persona
+  seed/swap/clear operations, envelope persistence),
+  `Chat/console_roleplay_identity.py` (shared expansion/presentation),
+  `Chat/console_chat_controller.py` (kind-keyed `_resolved_system_prompt`),
+  `UI/Console_Modules/session.py` (handoff starter, resume re-resolution,
+  screen-state round trip), plus targeted tests under `Tests/Chat/` and
+  `Tests/UI/`.

--- a/backlog/tasks/task-32482 - Agent-chat-fork-and-spawn-tools-fork_chat-new_chat.md
+++ b/backlog/tasks/task-32482 - Agent-chat-fork-and-spawn-tools-fork_chat-new_chat.md
@@ -1,0 +1,29 @@
+---
+id: TASK-32482
+title: Agent chat fork and spawn tools (fork_chat / new_chat)
+status: To Do
+assignee: []
+created_date: '2026-09-12 01:25'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+Let a Console agent prepare parallel-workstream chats for the user: fork_chat copies the current conversation's active path into a new chat (first-ever writer of the parent_conversation_id / forked_from_message_id lineage columns); new_chat creates a fresh chat. Both accept title / opening_prompt / instructions, require an explicit user approval per call by default (Allow / Allow-for-session / Deny, fail-closed, session-scoped remember), land the opening prompt as a composer draft the user sends, and open the chat in the background with a toast. Spec: Docs/superpowers/specs/2026-09-11-agent-chat-fork-spawn-design.md; ADR: backlog/decisions/150-agent-chat-fork-and-spawn.md; Plan: Docs/superpowers/plans/2026-09-11-agent-chat-fork-spawn.md; follow-ups: sub-agents (task-32480) and preset/provider args (post ADR-147 integration PR).
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [ ] #1 Agent can fork the current chat into a new one via a confirmed tool call (verbatim active-path copy with lineage columns set)
+- [ ] #2 Agent can create a fresh chat with title and instructions via a confirmed tool call
+- [ ] #3 Every creation requires explicit user approval by default with per-tool session-scoped remember and fail-closed behavior when no UI or on cancel or timeout
+- [ ] #4 Opening prompt lands as a composer draft the user sends and survives app restart via conversation metadata
+- [ ] #5 New chats appear in the same workspace without switching the active session and a toast announces them
+- [ ] #6 Forks of character-bound chats refuse agent instructions and ephemeral or empty sources return clear tool errors
+- [ ] #7 Tool schemas are advertised to primary agents only while sub-agent runs are unchanged
+- [ ] #8 Workspace listing shows created chats under whichever mechanism governs it
+- [ ] #9 Tests cover fork helper semantics (remap, lineage, atomicity, uncapped copy) and confirm rounds (allow, deny, remember, fail-closed, park)
+- [ ] #10 User docs updated for both tools
+<!-- AC:END -->

--- a/tldw_chatbook/Chat/chat_persistence_service.py
+++ b/tldw_chatbook/Chat/chat_persistence_service.py
@@ -483,6 +483,7 @@ class ChatPersistenceService:
         conversation_id: str,
         user_name_override: str | None,
         character_system_template: str | None,
+        persona_system_template: str | None = None,
     ) -> bool:
         """Merge Console-owned roleplay identity context with one retry.
 
@@ -500,6 +501,7 @@ class ChatPersistenceService:
                 ConsoleRoleplayContext(
                     user_name_override=user_name_override,
                     character_system_template=character_system_template,
+                    persona_system_template=persona_system_template,
                 ),
             )
             try:

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -8511,6 +8511,22 @@ class ConsoleChatController:
             selection = replace(
                 selection, system_prompt=self._resolved_system_prompt(session_id)
             )
+        elif (
+            session is not None
+            and self.store._is_named_persona_session(session)
+            and isinstance(session.persona_system_template, str)
+            and session.persona_system_template.strip()
+        ):
+            # Persona sessions always carry settings, so without this override
+            # their sends would reuse the settings' last materialized
+            # projection. Swap in the per-turn re-expansion -- but only under
+            # exactly the conditions where `_resolved_system_prompt` returns a
+            # fresh expansion (named persona + trusted template). A
+            # template-less persona, or a resume whose name resolution failed
+            # (assistant_name=None), keeps the settings-derived prompt.
+            selection = replace(
+                selection, system_prompt=self._resolved_system_prompt(session_id)
+            )
         return selection
 
     def resolve_turn_execution_context(

--- a/tldw_chatbook/Chat/console_chat_controller.py
+++ b/tldw_chatbook/Chat/console_chat_controller.py
@@ -12527,7 +12527,7 @@ class ConsoleChatController:
         return fallback
 
     def _resolved_system_prompt(self, session_id: str | None) -> str | None:
-        """Resolve a trusted character system template for the current identity."""
+        """Resolve the trusted identity system template for the session kind."""
         if session_id is None:
             return self.system_prompt
         session = next(
@@ -12538,20 +12538,28 @@ class ConsoleChatController:
             ),
             None,
         )
+        if session is None:
+            return self.system_prompt
+        if session.assistant_kind == "character":
+            name = session.character_name
+            template = session.character_system_template
+        elif session.assistant_kind == "persona":
+            name = session.assistant_name
+            template = session.persona_system_template
+        else:
+            return self.system_prompt
         if (
-            session is None
-            or session.assistant_kind != "character"
-            or not isinstance(session.character_name, str)
-            or not session.character_name.strip()
-            or not isinstance(session.character_system_template, str)
-            or not session.character_system_template.strip()
+            not isinstance(name, str)
+            or not name.strip()
+            or not isinstance(template, str)
+            or not template.strip()
         ):
             return self.system_prompt
         context = self._presentation_context_for(session_id)
         return expand_character_template(
-            session.character_system_template,
+            template,
             user_name=context.user_name,
-            character_name=session.character_name.strip(),
+            character_name=name.strip(),
         )
 
     def _leading_system_message(

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -1023,38 +1023,59 @@ class ConsoleChatStore:
         assistant_id: str,
         assistant_authority_id: str | None,
         character_id: int | None,
-        character_name: str,
+        character_name: str | None,
+        assistant_name: str | None = None,
     ) -> ConsoleChatSession:
         """Atomically replace an untouched initial tab with roleplay identity."""
         if not isinstance(canonical_settings, ConsoleSessionSettings):
             raise TypeError("canonical_settings must be ConsoleSessionSettings.")
         if not isinstance(settings, ConsoleSessionSettings):
             raise TypeError("settings must be ConsoleSessionSettings.")
-        if type(trusted_system_prompt) is not str or not trusted_system_prompt.strip():
-            raise ValueError("Trusted roleplay system prompt must be non-empty text.")
+        if type(trusted_system_prompt) is not str:
+            raise TypeError("Trusted roleplay system prompt must be text.")
         if runtime_backend not in {"local", "server"}:
             raise ValueError("Roleplay runtime backend must be local or server.")
-        if assistant_kind != "character":
-            raise ValueError("Repurposed sessions require character identity.")
+        if assistant_kind not in {"character", "persona"}:
+            raise ValueError("Repurposed sessions require named identity.")
         if type(assistant_id) is not str or not assistant_id:
             raise ValueError("Roleplay assistant id must be non-empty text.")
         if assistant_authority_id is not None and (
             type(assistant_authority_id) is not str or not assistant_authority_id
         ):
             raise ValueError("Roleplay authority id must be non-empty text or None.")
-        if type(character_name) is not str or not character_name.strip():
-            raise ValueError("Roleplay character name must be non-empty text.")
-        if title != f"Chat with {character_name}":
-            raise ValueError("Roleplay title does not match the character identity.")
-        expected_roleplay_settings = replace(
-            canonical_settings,
-            system_prompt=trusted_system_prompt,
-            character_label=character_name,
-        )
+        if assistant_kind == "character":
+            if not trusted_system_prompt.strip():
+                raise ValueError("Trusted roleplay system prompt must be non-empty text.")
+            if type(character_name) is not str or not character_name.strip():
+                raise ValueError("Roleplay character name must be non-empty text.")
+            if title != f"Chat with {character_name}":
+                raise ValueError("Roleplay title does not match the character identity.")
+            expected_roleplay_settings = replace(
+                canonical_settings,
+                system_prompt=trusted_system_prompt,
+                character_label=character_name,
+            )
+        else:
+            # Persona sessions remain authority-free (ADR-037) and never
+            # carry character identity. A blank template keeps the canonical
+            # default prompt (``None``), matching the persona seed contract.
+            if assistant_authority_id is not None:
+                raise ValueError("Persona sessions remain authority-free (ADR-037).")
+            if character_id is not None or character_name is not None:
+                raise ValueError("Persona sessions cannot carry character identity.")
+            if type(assistant_name) is not str or not assistant_name.strip():
+                raise ValueError("Persona name must be non-empty text.")
+            if title != f"Chat with {assistant_name}":
+                raise ValueError("Persona title does not match the persona identity.")
+            expected_roleplay_settings = replace(
+                canonical_settings,
+                system_prompt=trusted_system_prompt or None,
+                character_label="",
+            )
         if settings != expected_roleplay_settings:
             raise ValueError("Roleplay settings contain noncanonical changes.")
         if runtime_backend == "local":
-            if (
+            if assistant_kind == "character" and (
                 type(character_id) is not int
                 or character_id < 1
                 or assistant_id != str(character_id)
@@ -1088,6 +1109,7 @@ class ConsoleChatStore:
         session.assistant_authority_id = assistant_authority_id
         session.character_id = character_id
         session.character_name = character_name
+        session.assistant_name = assistant_name if assistant_kind == "persona" else None
         session.updated_at = proposed_updated_at
         session.identity_revision = proposed_identity_revision
         self._payload_revisions[session_id] = proposed_payload_revision

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -533,10 +533,19 @@ class ConsoleChatSession:
     #: IDs remain opaque in ``assistant_id`` and never populate this field.
     character_id: int | None = None
     character_name: str | None = None
+    #: Persona-kind assistant display name (ADR-149). Set only when
+    #: ``assistant_kind == "persona"``; mutually exclusive with
+    #: ``character_name``. Never persisted on the conversation row --
+    #: re-resolved from ``assistant_id`` at resume.
+    assistant_name: str | None = None
     #: Per-chat human label, independently persisted in conversation metadata.
     user_display_name_override: str | None = None
     #: Trusted character system source; materialized into ``settings.system_prompt``.
     character_system_template: str | None = None
+    #: Trusted persona system-prompt source (ADR-149); materialized into
+    #: ``settings.system_prompt`` via the identity-template expander and
+    #: persisted as an optional key in the version-1 roleplay envelope.
+    persona_system_template: str | None = None
     speech_preferences: ConsoleSpeechPreferences = field(
         default_factory=ConsoleSpeechPreferences
     )
@@ -880,6 +889,8 @@ class ConsoleChatStore:
         assistant_authority_id: str | None = None,
         character_id: int | None = None,
         character_name: str | None = None,
+        assistant_name: str | None = None,
+        persona_system_template: str | None = None,
         ephemeral: bool = False,
         activate: bool = True,
         project_instruction_state: ProjectInstructionControlState | None = None,
@@ -928,6 +939,8 @@ class ConsoleChatStore:
             assistant_authority_id=assistant_authority_id,
             character_id=character_id,
             character_name=character_name,
+            assistant_name=assistant_name,
+            persona_system_template=persona_system_template,
             ephemeral=ephemeral,
             project_instruction_state=(
                 project_instruction_state
@@ -3204,6 +3217,7 @@ class ConsoleChatStore:
             ),
             assistant_kind=session.assistant_kind,
             character_name=session.character_name,
+            assistant_name=session.assistant_name,
             revision=session.identity_revision,
         )
 

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -360,6 +360,7 @@ class ConsoleChatPersistence(Protocol):
         conversation_id: str,
         user_name_override: str | None,
         character_system_template: str | None,
+        persona_system_template: str | None = None,
     ) -> bool:
         """Persist Console-owned roleplay identity context for a conversation."""
 
@@ -4001,14 +4002,17 @@ class ConsoleChatStore:
         writer = getattr(self.persistence, "update_conversation_roleplay_context", None)
         if not callable(writer):
             return False
+        context_kwargs: dict[str, Any] = {
+            "conversation_id": session.persisted_conversation_id,
+            "user_name_override": session.user_display_name_override,
+            "character_system_template": session.character_system_template,
+        }
+        # Declare-to-receive: narrow persistence fakes written before this
+        # kwarg existed keep the original three-keyword call shape.
+        if self._persistence_accepts_kwarg(writer, "persona_system_template"):
+            context_kwargs["persona_system_template"] = session.persona_system_template
         try:
-            return bool(
-                writer(
-                    conversation_id=session.persisted_conversation_id,
-                    user_name_override=session.user_display_name_override,
-                    character_system_template=session.character_system_template,
-                )
-            )
+            return bool(writer(**context_kwargs))
         except Exception as exc:
             logger.warning(
                 "Failed to persist Console roleplay identity context (error_type={}).",
@@ -5362,6 +5366,7 @@ class ConsoleChatStore:
         if (
             session.user_display_name_override is not None
             or session.character_system_template is not None
+            or session.persona_system_template is not None
         ) and not self._persist_roleplay_context(session):
             logger.warning("Failed to flush Console roleplay context on first persist.")
             if strict_roleplay_context:

--- a/tldw_chatbook/Chat/console_chat_store.py
+++ b/tldw_chatbook/Chat/console_chat_store.py
@@ -52,6 +52,7 @@ from tldw_chatbook.Chat.console_roleplay_identity import (
     expand_character_template,
     normalize_chat_display_name,
     resolve_console_message_presentation,
+    session_assistant_display_name,
 )
 from tldw_chatbook.Chat.console_roleplay_metadata import ConsoleRoleplayContext
 from tldw_chatbook.Chat.console_session_settings import ConsoleSessionSettings
@@ -3322,6 +3323,35 @@ class ConsoleChatStore:
             source_changed=source_changed,
         )
 
+    def seed_persona_roleplay(
+        self,
+        session_id: str,
+        *,
+        system_template: str,
+        global_default: object,
+    ) -> None:
+        """Seed the trusted persona system source into a fresh session.
+
+        Persona profiles have no greeting field, so unlike
+        ``seed_character_roleplay`` this never appends a message.
+        """
+        session = self._session_or_raise(session_id)
+        source = (
+            system_template
+            if isinstance(system_template, str) and system_template.strip()
+            else None
+        )
+        source_changed = session.persona_system_template != source
+        session.persona_system_template = source
+        if source_changed:
+            self._bump_identity_revision(session_id)
+        context_persisted = self._persist_roleplay_context(session)
+        self._materialize_roleplay_projections(
+            session_id, global_default=global_default
+        )
+        if not context_persisted:
+            logger.warning("Failed to persist seeded Console persona context.")
+
     def swap_session_character_roleplay(
         self,
         session_id: str,
@@ -3361,10 +3391,16 @@ class ConsoleChatStore:
         identity_changed = (
             session.character_name != new_name
             or session.character_system_template != source
+            or session.assistant_name is not None
+            or session.persona_system_template is not None
         )
         source_changed = session.character_system_template != source
         session.character_name = new_name
         session.character_system_template = source
+        # One-name-set invariant (ADR-149): a character swap retires any
+        # persona identity bound to this session.
+        session.assistant_name = None
+        session.persona_system_template = None
         if identity_changed:
             self._bump_identity_revision(session_id)
 
@@ -3448,6 +3484,32 @@ class ConsoleChatStore:
         )
         return session, persisted
 
+    def set_session_assistant_name(
+        self,
+        session_id: str,
+        assistant_name: str | None,
+        *,
+        global_default: object,
+    ) -> tuple[ConsoleChatSession, bool]:
+        """Set persona identity through the projection revision seam.
+
+        Setting a non-blank persona name clears any character name, keeping
+        the one-name-set invariant (ADR-149).
+        """
+        session = self._session_or_raise(session_id)
+        normalized = assistant_name.strip() if isinstance(assistant_name, str) else ""
+        new_name = normalized or None
+        if session.assistant_name == new_name:
+            return session, True
+        session.assistant_name = new_name
+        if new_name is not None:
+            session.character_name = None
+        self._bump_identity_revision(session_id)
+        persisted = self._materialize_roleplay_projections(
+            session_id, global_default=global_default
+        )
+        return session, persisted
+
     def _bump_identity_revision(self, session_id: str) -> None:
         session = self._session_or_raise(session_id)
         session.identity_revision += 1
@@ -3476,19 +3538,45 @@ class ConsoleChatStore:
             and bool(session.character_name.strip())
         )
 
+    @staticmethod
+    def _is_named_persona_session(session: ConsoleChatSession) -> bool:
+        return (
+            session.assistant_kind == "persona"
+            and isinstance(session.assistant_name, str)
+            and bool(session.assistant_name.strip())
+        )
+
+    @classmethod
+    def _is_named_identity_session(cls, session: ConsoleChatSession) -> bool:
+        return cls._is_named_character_session(
+            session
+        ) or cls._is_named_persona_session(session)
+
+    @staticmethod
+    def _identity_system_template(session: ConsoleChatSession) -> str | None:
+        """Return the trusted template for the session's bound kind."""
+        if session.assistant_kind == "persona":
+            return session.persona_system_template
+        return session.character_system_template
+
+    @staticmethod
+    def _identity_display_name(session: ConsoleChatSession) -> str:
+        """Return the session's bound assistant display name, or ""."""
+        return (session_assistant_display_name(session) or "").strip()
+
     def _roleplay_projection_is_stale(
         self, session: ConsoleChatSession, global_default: object
     ) -> bool:
-        if not self._is_named_character_session(session):
+        if not self._is_named_identity_session(session):
             return False
         context = self.presentation_context(session.id, global_default)
-        character_name = (session.character_name or "").strip()
-        template = session.character_system_template
+        identity_name = self._identity_display_name(session)
+        template = self._identity_system_template(session)
         if template and session.settings is not None:
             if session.settings.system_prompt != expand_character_template(
                 template,
                 user_name=context.user_name,
-                character_name=character_name,
+                character_name=identity_name,
             ):
                 return True
         for message in self._nodes_by_session.get(session.id, {}).values():
@@ -3501,7 +3589,7 @@ class ConsoleChatStore:
                 != expand_character_template(
                     metadata.template_source,
                     user_name=context.user_name,
-                    character_name=character_name,
+                    character_name=identity_name,
                 )
             ):
                 return True
@@ -3530,17 +3618,18 @@ class ConsoleChatStore:
     ) -> ConsoleRoleplayProjectionPersistencePlan | None:
         """Update owner-thread state and return frozen durable call arguments."""
         session = self._session_or_raise(session_id)
-        if not self._is_named_character_session(session):
+        if not self._is_named_identity_session(session):
             return None
         context = self.presentation_context(session_id, global_default)
-        character_name = (session.character_name or "").strip()
+        identity_name = self._identity_display_name(session)
+        template = self._identity_system_template(session)
         system_prompt_write: _RoleplaySystemPromptWrite | None = None
         message_writes: list[_RoleplayMessageProjectionWrite] = []
-        if session.character_system_template and session.settings is not None:
+        if template and session.settings is not None:
             projected_system = expand_character_template(
-                session.character_system_template,
+                template,
                 user_name=context.user_name,
-                character_name=character_name,
+                character_name=identity_name,
             )
             if session.settings.system_prompt != projected_system:
                 prior_system_prompt = session.settings.system_prompt
@@ -3570,7 +3659,7 @@ class ConsoleChatStore:
             projected = expand_character_template(
                 metadata.template_source,
                 user_name=context.user_name,
-                character_name=character_name,
+                character_name=identity_name,
             )
             if message.content == projected and not force_persistence:
                 continue

--- a/tldw_chatbook/Chat/console_conversation_hydration.py
+++ b/tldw_chatbook/Chat/console_conversation_hydration.py
@@ -432,4 +432,5 @@ def hydrate_console_session(
     roleplay_context = parse_console_roleplay_context(conversation.get("metadata"))
     session.user_display_name_override = roleplay_context.user_name_override
     session.character_system_template = roleplay_context.character_system_template
+    session.persona_system_template = roleplay_context.persona_system_template
     return session

--- a/tldw_chatbook/Chat/console_roleplay_identity.py
+++ b/tldw_chatbook/Chat/console_roleplay_identity.py
@@ -98,6 +98,24 @@ def effective_user_display_name(override: object, global_default: object) -> str
     return normalize_chat_display_name(global_default, blank_means_none=False) or "User"
 
 
+def session_assistant_display_name(session: object) -> str | None:
+    """Return the session's kind-appropriate assistant display name.
+
+    Character sessions read ``character_name``; persona sessions read
+    ``assistant_name`` (ADR-149); anything else has no bound identity.
+    Blank values are treated as absent.
+    """
+    kind = getattr(session, "assistant_kind", None)
+    if kind == "character":
+        value = getattr(session, "character_name", None)
+    elif kind == "persona":
+        value = getattr(session, "assistant_name", None)
+    else:
+        return None
+    text = value.strip() if isinstance(value, str) else ""
+    return text or None
+
+
 _TEMPLATE_TOKEN_RE = re.compile(
     r"\{\{user\}\}|\{\{random_user\}\}|<USER>|"
     r"\{\{char\}\}|\{\{character\}\}|\{\{persona\}\}|<CHAR>"
@@ -108,7 +126,12 @@ _USER_TOKENS = frozenset({"{{user}}", "{{random_user}}", "<USER>"})
 def expand_character_template(
     source: str, *, user_name: str, character_name: str
 ) -> str:
-    """Expand trusted character template aliases in one non-recursive pass."""
+    """Expand trusted character template aliases in one non-recursive pass.
+
+    This is the identity-template expander for both character and persona
+    sessions (ADR-149); ``character_name`` carries the persona name for
+    persona-kind content.
+    """
     def replacement(match: re.Match[str]) -> str:
         return user_name if match.group(0) in _USER_TOKENS else character_name
 
@@ -122,6 +145,7 @@ class ConsolePresentationContext:
     user_name: str = "User"
     assistant_kind: str | None = "generic"
     character_name: str | None = None
+    assistant_name: str | None = None
     revision: int = 0
     transcript_style: ConsoleTranscriptStyle = DEFAULT_CONSOLE_TRANSCRIPT_STYLE
 
@@ -147,11 +171,23 @@ def resolve_console_message_presentation(
         if isinstance(context.character_name, str)
         else ""
     )
+    raw_persona_name = (
+        context.assistant_name.strip()
+        if isinstance(context.assistant_name, str)
+        else ""
+    )
     is_character_session = (
         context.assistant_kind == "character" and bool(raw_character_name)
     )
+    is_persona_session = (
+        context.assistant_kind == "persona" and bool(raw_persona_name)
+    )
     character_display_name = sanitize_character_display_label(
         raw_character_name,
+        max_characters=CHARACTER_SPEAKER_LABEL_MAX_CHARACTERS,
+    )
+    persona_display_name = sanitize_character_display_label(
+        raw_persona_name,
         max_characters=CHARACTER_SPEAKER_LABEL_MAX_CHARACTERS,
     )
     transcript_style = normalize_console_transcript_style(context.transcript_style)
@@ -172,13 +208,20 @@ def resolve_console_message_presentation(
                 else "console-transcript-message-role-user"
             )
     elif message.role is ConsoleMessageRole.ASSISTANT:
-        speaker_label = character_display_name if is_character_session else "Assistant"
+        if is_character_session:
+            speaker_label = character_display_name
+        elif is_persona_session:
+            speaker_label = persona_display_name
+        else:
+            speaker_label = "Assistant"
         speaker_tone = "character" if is_character_session else "assistant"
         row_class = None
         if role_accents:
             row_class = (
                 "console-transcript-message-roleplay-character"
                 if is_character_session
+                # Persona rows keep the standard assistant treatment:
+                # personas are not roleplay characters (ADR-149).
                 else "console-transcript-message-role-assistant"
             )
         metadata: MessageMetadata | None = message.metadata

--- a/tldw_chatbook/Chat/console_roleplay_metadata.py
+++ b/tldw_chatbook/Chat/console_roleplay_metadata.py
@@ -27,6 +27,7 @@ class ConsoleRoleplayContext:
 
     user_name_override: str | None = None
     character_system_template: str | None = None
+    persona_system_template: str | None = None
 
 
 def parse_console_roleplay_context(raw_metadata: object) -> ConsoleRoleplayContext:
@@ -57,9 +58,17 @@ def parse_console_roleplay_context(raw_metadata: object) -> ConsoleRoleplayConte
     ):
         return ConsoleRoleplayContext()
 
+    persona_system_template = owned_context.get("persona_system_template")
+    if persona_system_template is not None and (
+        not isinstance(persona_system_template, str)
+        or not persona_system_template.strip()
+    ):
+        return ConsoleRoleplayContext()
+
     return ConsoleRoleplayContext(
         user_name_override=user_name_override,
         character_system_template=character_system_template,
+        persona_system_template=persona_system_template,
     )
 
 
@@ -96,7 +105,18 @@ def merge_console_roleplay_context(
     ):
         character_system_template = None
 
-    if user_name_override is None and character_system_template is None:
+    persona_system_template = context.persona_system_template
+    if (
+        not isinstance(persona_system_template, str)
+        or not persona_system_template.strip()
+    ):
+        persona_system_template = None
+
+    if (
+        user_name_override is None
+        and character_system_template is None
+        and persona_system_template is None
+    ):
         metadata.pop(ROLEPLAY_CONTEXT_METADATA_KEY, None)
     else:
         metadata[ROLEPLAY_CONTEXT_METADATA_KEY] = {
@@ -109,6 +129,11 @@ def merge_console_roleplay_context(
             **(
                 {"character_system_template": character_system_template}
                 if character_system_template is not None
+                else {}
+            ),
+            **(
+                {"persona_system_template": persona_system_template}
+                if persona_system_template is not None
                 else {}
             ),
         }

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2190,6 +2190,56 @@ class ConsoleSessionController:
         )
         return True
 
+    def _capture_server_handoff_context(
+        self, payload: ChatHandoffPayload
+    ) -> tuple[object, Callable[[], bool]] | None:
+        """Capture and fence the server authority context for a handoff.
+
+        Returns ``(capture, is_current)`` when the handoff's expected server
+        is still active and its context capture is current, else ``None``.
+        ``is_current()`` re-checks both conditions, so callers re-fence after
+        every suspension point by calling it again.
+        """
+        expected_server_id = payload.active_server_profile_id
+        if (
+            type(expected_server_id) is not str
+            or not expected_server_id
+            or expected_server_id != expected_server_id.strip()
+        ):
+            return None
+        if getattr(self.app_instance, "active_server_id", None) != expected_server_id:
+            return None
+        provider = getattr(self.app_instance, "server_context_provider", None)
+        capture_context = getattr(
+            provider, "capture_character_authority_context", None
+        )
+        context_is_current = getattr(
+            provider, "is_character_authority_context_current", None
+        )
+        if not callable(capture_context) or not callable(context_is_current):
+            return None
+        try:
+            capture = capture_context(expected_server_id=expected_server_id)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            return None
+
+        def is_current() -> bool:
+            if (
+                getattr(self.app_instance, "active_server_id", None)
+                != expected_server_id
+            ):
+                return False
+            try:
+                return context_is_current(capture) is True
+            except Exception:
+                return False
+
+        if not is_current():
+            return None
+        return capture, is_current
+
     async def _start_character_console_session(
         self, payload: ChatHandoffPayload
     ) -> bool:
@@ -2219,16 +2269,6 @@ class ConsoleSessionController:
 
         assistant_authority_id: str | None
         local_character_id: int | None
-        server_context_capture: object | None = None
-        server_context_is_current: Callable[[object], bool] | None = None
-
-        def exact_server_context_is_current() -> bool:
-            if server_context_capture is None or server_context_is_current is None:
-                return False
-            try:
-                return server_context_is_current(server_context_capture) is True
-            except Exception:
-                return False
 
         if runtime_backend == "local":
             db = getattr(self.app_instance, "chachanotes_db", None)
@@ -2250,44 +2290,14 @@ class ConsoleSessionController:
             assistant_authority_id = local_authority_id
             local_character_id = character_id
         else:
+            fenced = self._capture_server_handoff_context(payload)
+            if fenced is None:
+                return False
+            server_context_capture, exact_server_context_is_current = fenced
             expected_server_id = payload.active_server_profile_id
-            if (
-                type(expected_server_id) is not str
-                or not expected_server_id
-                or expected_server_id != expected_server_id.strip()
-            ):
-                return False
-            if (
-                getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
-                return False
-
             assistant_authority_id = None
             provider = getattr(self.app_instance, "server_context_provider", None)
-            capture_context = getattr(
-                provider,
-                "capture_character_authority_context",
-                None,
-            )
-            server_context_is_current = getattr(
-                provider,
-                "is_character_authority_context_current",
-                None,
-            )
             resolver = getattr(provider, "resolve_character_authority_id", None)
-            if not callable(capture_context) or not callable(server_context_is_current):
-                return False
-            try:
-                server_context_capture = capture_context(
-                    expected_server_id=expected_server_id
-                )
-            except asyncio.CancelledError:
-                raise
-            except Exception:
-                return False
-            if not exact_server_context_is_current():
-                return False
             if callable(resolver):
                 try:
                     resolved_authority_id = await resolver(
@@ -2310,11 +2320,7 @@ class ConsoleSessionController:
             # This is both the post-resolver fence and the immediately
             # pre-card-fetch fence. No card from a newly active target may be
             # used for the ID carried by the handoff.
-            if (
-                not exact_server_context_is_current()
-                or getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
+            if not exact_server_context_is_current():
                 return False
             local_character_id = None
 
@@ -2338,12 +2344,7 @@ class ConsoleSessionController:
             return False
 
         if runtime_backend == "server":
-            expected_server_id = payload.active_server_profile_id
-            if (
-                not exact_server_context_is_current()
-                or getattr(self.app_instance, "active_server_id", None)
-                != expected_server_id
-            ):
+            if not exact_server_context_is_current():
                 return False
 
         global_name = _console_global_user_display_name(
@@ -2362,11 +2363,7 @@ class ConsoleSessionController:
             system_prompt=seed.system_prompt,
             character_label=seed.name,
         )
-        if runtime_backend == "server" and (
-            not exact_server_context_is_current()
-            or getattr(self.app_instance, "active_server_id", None)
-            != payload.active_server_profile_id
-        ):
+        if runtime_backend == "server" and not exact_server_context_is_current():
             return False
         active = next(
             (
@@ -2492,6 +2489,180 @@ class ConsoleSessionController:
             # character session.
             logger.opt(exception=True).warning(
                 "Start Chat: post-seed console sync/focus failed; character "
+                "session was already created and the handoff is still "
+                "considered consumed."
+            )
+        return True
+
+    async def _start_persona_console_session(
+        self, payload: ChatHandoffPayload
+    ) -> bool:
+        """Build a dedicated persona-bound session from a Personas handoff.
+
+        Mirrors ``_start_character_console_session`` minus greeting, local
+        numeric projection, and authority resolution: persona sessions stay
+        authority-free per ADR-037 (server personas get freshness fencing but
+        never an ``assistant_authority_id``).
+        """
+        identity = _persona_session_identity_from_handoff(payload)
+        if identity is None:
+            return False
+        runtime_backend, persona_id, name_hint, assistant_id = identity
+
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        get_persona_profile = getattr(scope_service, "get_persona_profile", None)
+        if not callable(get_persona_profile):
+            return False
+
+        context_is_current: Callable[[], bool] | None = None
+        if runtime_backend == "server":
+            fenced = self._capture_server_handoff_context(payload)
+            if fenced is None:
+                return False
+            _capture, context_is_current = fenced
+
+        try:
+            profile = await get_persona_profile(persona_id, mode=runtime_backend)
+            if hasattr(profile, "model_dump"):
+                profile = profile.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.warning(
+                "Start Chat: persona profile unavailable; staging context "
+                "instead (source={}, backend={}).",
+                payload.source,
+                runtime_backend,
+            )
+            return False
+        if not isinstance(profile, Mapping) or not profile:
+            return False
+        profile = dict(profile)
+        if str(profile.get("id") or "") != persona_id:
+            return False
+        if context_is_current is not None and not context_is_current():
+            return False
+
+        global_name = _console_global_user_display_name(
+            self._provider_readiness_app_config()
+        )
+        seed = _persona_session_prompt_seed(
+            profile, name_hint=str(name_hint or ""), user_name=global_name
+        )
+
+        store = self._ensure_console_chat_store()
+        canonical_defaults = self._default_console_session_settings()
+        settings = replace(
+            canonical_defaults,
+            system_prompt=seed.system_prompt or None,
+            character_label="",
+        )
+        if context_is_current is not None and not context_is_current():
+            return False
+        active = next(
+            (
+                candidate
+                for candidate in store.sessions()
+                if candidate.id == store.active_session_id
+            ),
+            None,
+        )
+        if (
+            active is not None
+            and active.settings is not None
+            and active.settings != canonical_defaults
+            and active.canonical_settings_baseline == active.settings
+        ):
+            try:
+                active = store.refresh_pristine_session_settings(
+                    active.id,
+                    prior_canonical_settings=active.settings,
+                    current_canonical_settings=canonical_defaults,
+                )
+            except ValueError:
+                pass
+        active_messages = (
+            store.messages_for_session(active.id) if active is not None else []
+        )
+        duplicate_handoff = bool(
+            active is not None
+            and active.settings == settings
+            and active.runtime_backend == runtime_backend
+            and active.assistant_kind == "persona"
+            and active.assistant_id == assistant_id
+            and active.assistant_name == seed.name
+            and active.persona_system_template == seed.system_template
+            and not active_messages
+        )
+        if duplicate_handoff:
+            session = active
+        else:
+            session = None
+            if active is not None and store.is_pristine_session(
+                active.id,
+                expected_settings=canonical_defaults,
+            ):
+                try:
+                    session = store.repurpose_pristine_session(
+                        active.id,
+                        canonical_settings=canonical_defaults,
+                        trusted_system_prompt=seed.system_prompt,
+                        title=f"Chat with {seed.name}",
+                        settings=settings,
+                        runtime_backend=runtime_backend,
+                        assistant_kind="persona",
+                        assistant_id=assistant_id,
+                        assistant_authority_id=None,
+                        character_id=None,
+                        character_name=None,
+                        assistant_name=seed.name,
+                    )
+                except ValueError:
+                    session = None
+            if session is None:
+                session = store.create_session(
+                    title=f"Chat with {seed.name}",
+                    workspace_id=CONSOLE_GLOBAL_WORKSPACE_ID,
+                    settings=settings,
+                    runtime_backend=runtime_backend,
+                    assistant_kind="persona",
+                    assistant_id=assistant_id,
+                    assistant_authority_id=None,
+                    assistant_name=seed.name,
+                )
+            try:
+                store.seed_persona_roleplay(
+                    session.id,
+                    system_template=seed.system_template,
+                    global_default=global_name,
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Start Chat: persona roleplay template seed/persist failed; "
+                    "continuing (error_type={}).",
+                    type(exc).__name__,
+                )
+        store.switch_session(session.id)
+        if not duplicate_handoff:
+            # Same defensive cleanup as the server-character path: a persona
+            # session never keys reactions by actor, so clear wholesale.
+            self._clear_session_manual_reactions(session.id)
+        try:
+            await self._sync_native_console_chat_ui()
+            self._focus_console_composer_if_needed(force=True)
+        except asyncio.CancelledError:
+            # The durable commit boundary is above. Report success so the
+            # caller acknowledges this handoff instead of replaying it.
+            return True
+        except Exception:
+            # The persona session is already durably created above -- a
+            # UI-sync/focus failure here must not propagate, or the caller
+            # would never clear ``pending_chat_handoff`` and a later
+            # re-consume would build a SECOND durable persona session.
+            logger.opt(exception=True).warning(
+                "Start Chat: post-seed console sync/focus failed; persona "
                 "session was already created and the handoff is still "
                 "considered consumed."
             )

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -2953,8 +2953,10 @@ class ConsoleSessionController:
             "assistant_authority_id": session.assistant_authority_id,
             "character_id": session.local_character_id(),
             "character_name": session.character_name,
+            "assistant_name": session.assistant_name,
             "user_display_name_override": session.user_display_name_override,
             "character_system_template": session.character_system_template,
+            "persona_system_template": session.persona_system_template,
             "identity_revision": session.identity_revision,
             # Temporary conversations: without this key a temporary chat
             # comes back as a persisting one after any screen navigation,
@@ -3080,6 +3082,9 @@ class ConsoleSessionController:
         raw_character_name = raw_session.get("character_name")
         if raw_character_name is not None:
             session_kwargs["character_name"] = str(raw_character_name)
+        raw_assistant_name = raw_session.get("assistant_name")
+        if raw_assistant_name is not None:
+            session_kwargs["assistant_name"] = str(raw_assistant_name)
         raw_user_display_name_override = raw_session.get("user_display_name_override")
         try:
             session_kwargs["user_display_name_override"] = normalize_chat_display_name(
@@ -3092,6 +3097,12 @@ class ConsoleSessionController:
         session_kwargs["character_system_template"] = (
             raw_character_system_template
             if isinstance(raw_character_system_template, str)
+            else None
+        )
+        raw_persona_system_template = raw_session.get("persona_system_template")
+        session_kwargs["persona_system_template"] = (
+            raw_persona_system_template
+            if isinstance(raw_persona_system_template, str)
             else None
         )
         raw_identity_revision = raw_session.get("identity_revision")
@@ -3112,6 +3123,14 @@ class ConsoleSessionController:
         session_kwargs["project_instruction_state"] = decode_project_context_json(
             encoded_project_state
         )
+        # One-name invariant (ADR-149): a session shows exactly one identity
+        # label, keyed by kind. A contradictory payload keeps only the
+        # kind-appropriate field. Legacy payloads predate `assistant_name`,
+        # so the else-branch pop is a no-op for them.
+        if session_kwargs.get("assistant_kind") == "persona":
+            session_kwargs.pop("character_name", None)
+        else:
+            session_kwargs.pop("assistant_name", None)
         return ConsoleChatSession(**session_kwargs)
 
     def _build_console_project_instruction_display_state(

--- a/tldw_chatbook/UI/Console_Modules/session.py
+++ b/tldw_chatbook/UI/Console_Modules/session.py
@@ -201,6 +201,7 @@ from ...Workspaces.display_state import (
     ConsoleWorkspaceContextState,
     ConsoleWorkspaceConversationRow,
 )
+from ..character_display_text import sanitize_character_display_label
 from .reaction_preview import ConsoleReactionPreviewCoordinator
 
 if TYPE_CHECKING:
@@ -323,6 +324,54 @@ def _character_session_identity_from_handoff(
     return runtime_backend, character_id, character_name, character_id_text
 
 
+def _persona_session_identity_from_handoff(
+    payload: ChatHandoffPayload,
+) -> tuple[str, str, str, str] | None:
+    """Return persona session identity for Personas Start Chat handoffs.
+
+    Mirrors ``_character_session_identity_from_handoff`` with one deliberate
+    difference: persona IDs are opaque strings (``local-persona-<hex>``
+    locally, server IDs remotely), so no integer coercion or canonical
+    numeric check applies.
+
+    Returns:
+        A tuple of `(runtime_backend, persona_id, persona_name,
+        assistant_id)` when the payload is a source-aware Personas persona
+        Start Chat handoff; otherwise `None`.
+    """
+    metadata = payload.metadata
+    if not isinstance(metadata, Mapping):
+        return None
+    if (
+        payload.source != "personas"
+        or payload.item_type != "persona-card"
+        or metadata.get("intent") != "start_chat"
+        or metadata.get("selected_kind") != "persona"
+    ):
+        return None
+    runtime_backend = payload.runtime_backend
+    if runtime_backend not in {"local", "server"}:
+        return None
+    if (
+        payload.source_owner != runtime_backend
+        or payload.source_selector_state != runtime_backend
+        or metadata.get("backend") != runtime_backend
+    ):
+        return None
+
+    persona_id = str(metadata.get("selected_record_id") or "").strip()
+    if not persona_id:
+        return None
+    if (
+        metadata.get("selected_target_id")
+        != f"{runtime_backend}:persona:{persona_id}"
+    ):
+        return None
+
+    persona_name = str(metadata.get("selected_name") or payload.title or "").strip()
+    return runtime_backend, persona_id, persona_name, persona_id
+
+
 @dataclass(frozen=True, slots=True)
 class CharacterSessionPromptSeed:
     """Trusted character sources and their current safe projections."""
@@ -403,6 +452,39 @@ def _character_session_prompt_seed(
             user_name=user_name,
             character_name=name,
         ),
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class PersonaSessionPromptSeed:
+    """Trusted persona source and its current safe projection."""
+
+    name: str
+    system_template: str
+    system_prompt: str
+
+
+def _persona_session_prompt_seed(
+    profile: Mapping[str, Any], name_hint: str = "", *, user_name: str = "User"
+) -> PersonaSessionPromptSeed:
+    """Return the trusted persona source and its safe projection.
+
+    Unlike character cards there is no multi-field join: a persona profile
+    contributes its ``system_prompt`` field verbatim as the trusted
+    template, and there is no greeting.
+    """
+    raw_name = str(profile.get("name") or "").strip() or str(name_hint or "").strip()
+    name = (
+        sanitize_character_display_label(raw_name, max_characters=180) or "Persona"
+    )
+    template = str(profile.get("system_prompt") or "")
+    system_prompt = (
+        expand_character_template(template, user_name=user_name, character_name=name)
+        if template.strip()
+        else ""
+    )
+    return PersonaSessionPromptSeed(
+        name=name, system_template=template, system_prompt=system_prompt
     )
 
 

--- a/tldw_chatbook/UI/Console_Modules/wiring.py
+++ b/tldw_chatbook/UI/Console_Modules/wiring.py
@@ -293,6 +293,11 @@ def build_console_controllers(
         resolve_resumed_character_name=(
             lambda character_id: screen._resolve_resumed_character_name(character_id)
         ),
+        resolve_resumed_persona_name=(
+            lambda persona_id, runtime_backend: screen._resolve_resumed_persona_name(
+                persona_id, runtime_backend
+            )
+        ),
         # Agent <-> workspace seam, same shape as the message seam above:
         # the resume flow's TOOL-marker re-derivation moved to
         # `ConsoleAgentController` (wave-4 task 3). This accessor already

--- a/tldw_chatbook/UI/Console_Modules/workspace.py
+++ b/tldw_chatbook/UI/Console_Modules/workspace.py
@@ -157,6 +157,7 @@ class ConsoleWorkspaceController:
         subagent_counts_for_rows: Callable[[Any, Iterable[Any]], dict[str, int]],
         conversation_browser_collapse_preferences: Callable[[], dict[str, bool]],
         wake_retry_poke: Callable[[], None] | None = None,
+        resolve_resumed_persona_name: Callable[[str, str], Any] | None = None,
     ) -> None:
         """Bind canonical Workspace state and its late-bound dependencies.
 
@@ -203,6 +204,9 @@ class ConsoleWorkspaceController:
             subagent_counts_for_rows: Compute sub-agent counts for browser rows.
             conversation_browser_collapse_preferences: Return collapse preferences.
             wake_retry_poke: Optionally request a staged-wake retry after resume.
+            resolve_resumed_persona_name: Optionally resolve a resumed persona's
+                display name from its live profile (bare-controller/test
+                construction leaves the session unlabeled).
         """
         self._screen = screen
         self.app_instance = app_instance
@@ -225,6 +229,7 @@ class ConsoleWorkspaceController:
             session_settings_for_resume_accessor
         )
         self._resolve_resumed_character_name_fn = resolve_resumed_character_name
+        self._resolve_resumed_persona_name_fn = resolve_resumed_persona_name
         self._inject_resume_agent_markers_accessor = (
             inject_resume_agent_markers_accessor
         )
@@ -463,6 +468,18 @@ class ConsoleWorkspaceController:
     @property
     def _resolve_resumed_character_name(self) -> Any:
         return self._resolve_resumed_character_name_fn
+
+    @property
+    def _resolve_resumed_persona_name(self) -> Any:
+        resolver = self._resolve_resumed_persona_name_fn
+        if resolver is None:
+            # Bare-controller/test construction: best-effort resume simply
+            # leaves the session unlabeled.
+            async def _unresolved(_persona_id: str, _runtime_backend: str) -> str:
+                return ""
+
+            return _unresolved
+        return resolver
 
     @property
     def _inject_resume_agent_markers(self) -> Any:
@@ -2215,6 +2232,20 @@ class ConsoleWorkspaceController:
                 session.settings = replace(
                     session.settings, character_label=character_name
                 )
+        elif session.assistant_kind == "persona" and session.assistant_id:
+            # Persona sessions carry no local projection; the display name is
+            # re-resolved from the live profile on every resume (ADR-149),
+            # for local and server backends alike.
+            persona_name = await self._resolve_resumed_persona_name(
+                session.assistant_id, session.runtime_backend
+            )
+            session.assistant_name = persona_name or None
+            if persona_name:
+                # One-name invariant: a persona session never shows a stale
+                # character label.
+                session.character_name = None
+            if session.settings is not None:
+                session.settings = replace(session.settings, character_label="")
         elif session.settings is not None:
             session.settings = replace(session.settings, character_label="")
         self._set_active_workspace_for_console_session(session.id)

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -9996,6 +9996,36 @@ class ChatScreen(BaseAppScreen):
             return ""
         return str(card.get("name") or "").strip()
 
+    async def _resolve_resumed_persona_name(
+        self, persona_id: str, runtime_backend: str
+    ) -> str:
+        """Return a resumed persona's display name from its profile, or ``""``.
+
+        Best-effort mirror of ``_resolve_resumed_character_name``: any
+        failure (missing scope service, missing profile, fetch error)
+        returns an empty string and the caller keeps the session unlabeled.
+        """
+        scope_service = getattr(
+            self.app_instance, "character_persona_scope_service", None
+        )
+        get_persona_profile = getattr(scope_service, "get_persona_profile", None)
+        if not callable(get_persona_profile):
+            return ""
+        try:
+            profile = await get_persona_profile(persona_id, mode=runtime_backend)
+            if hasattr(profile, "model_dump"):
+                profile = profile.model_dump(mode="json")
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.opt(exception=True).warning(
+                "Resume: persona profile fetch failed; identity row falls back."
+            )
+            return ""
+        if not isinstance(profile, Mapping):
+            return ""
+        return str(profile.get("name") or "").strip()
+
     def _set_console_conversation_row_loading(
         self, conversation_id: str, loading: bool
     ) -> None:

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -14271,14 +14271,17 @@ class ChatScreen(BaseAppScreen):
         try:
             payload = claim.value
 
-            # The native Console composes no legacy tab surface. A
-            # Personas Start-Chat character handoff gets a dedicated
-            # character-bound session with its greeting seeded
-            # (task-427); anything else -- or a character session that
-            # failed to build -- stages into the Console live-work lane
-            # so the context lands in Staged Context instead of being
-            # dropped with a warning.
+            # The native Console composes no legacy tab surface. Personas
+            # Start-Chat handoffs get a dedicated identity-bound session:
+            # character cards seed a greeting (task-427); persona cards bind
+            # name + system template without one (task-32481). Anything else
+            # -- or an identity session that failed to build -- stages into
+            # the Console live-work lane so the context lands in Staged
+            # Context instead of being dropped with a warning.
             if await self._session._start_character_console_session(payload):
+                store.acknowledge(claim)
+                return
+            if await self._session._start_persona_console_session(payload):
                 store.acknowledge(claim)
                 return
             self._stage_handoff_as_console_live_work(payload)

--- a/tldw_chatbook/Widgets/Console/console_appearance_picker_modal.py
+++ b/tldw_chatbook/Widgets/Console/console_appearance_picker_modal.py
@@ -1,0 +1,492 @@
+"""Console conversation appearance picker: icon + color (task-31207).
+
+Cursor-style customization: one modal picks a conversation's emoji icon
+(reusing the dormant ``Widgets/emoji_picker`` grid + recents store) and a
+palette color. The modal is result-driven like the workspace rename modal —
+``dismiss(ConsoleConversationAppearance)`` on Apply, an all-unset appearance
+on Clear, ``dismiss(None)`` on cancel — so the pushing controller owns the
+write path.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, ClassVar
+
+from textual import on
+from textual.app import ComposeResult
+from textual.containers import Horizontal, HorizontalScroll, Vertical
+from textual.css.query import NoMatches, QueryError
+from textual.screen import ModalScreen
+from textual.timer import Timer
+from textual.widgets import Button, Input, Static
+
+from tldw_chatbook.Chat.console_appearance import (
+    CONSOLE_APPEARANCE_PALETTE,
+    ConsoleConversationAppearance,
+    is_valid_console_appearance_color,
+    is_valid_console_appearance_icon,
+    normalize_console_appearance_hex_input,
+)
+from tldw_chatbook.Widgets.emoji_picker import (
+    EmojiButton,
+    EmojiGrid,
+    ProcessedEmoji,
+    get_emoji_data,
+    load_recent_emojis,
+    save_recent_emoji,
+)
+from tldw_chatbook.Widgets.modal_dismissal import SafeModalDismissMixin
+
+FILTER_INPUT_ID = "console-appearance-picker-filter"
+HEX_INPUT_ID = "console-appearance-picker-hex"
+GRID_ID = "console-appearance-picker-emoji"
+PREVIEW_ID = "console-appearance-picker-preview"
+COLORS_ID = "console-appearance-picker-colors"
+SWATCH_CLASS = "console-appearance-swatch"
+SWATCH_NONE_ID = "console-appearance-swatch-none"
+APPLY_ID = "console-appearance-picker-apply"
+CLEAR_ID = "console-appearance-picker-clear"
+CANCEL_ID = "console-appearance-picker-cancel"
+EMOJI_SELECTED_CLASS = "console-appearance-emoji-selected"
+SWATCH_SELECTED_CLASS = "console-appearance-swatch-selected"
+
+FILTER_DEBOUNCE_SECONDS = 0.2
+
+
+def filter_appearance_emojis(
+    emojis: Sequence[ProcessedEmoji], query: str
+) -> list[ProcessedEmoji]:
+    """Return emojis whose name or aliases contain the query.
+
+    Args:
+        emojis: Catalog entries to filter, in display order.
+        query: Case-insensitive substring; an empty or blank query returns
+            the input order unchanged (the grid's default population).
+
+    Returns:
+        The matching entries, in input order. Input is never mutated.
+    """
+    needle = str(query or "").strip().casefold()
+    if not needle:
+        return list(emojis)
+    matches: list[ProcessedEmoji] = []
+    for emoji in emojis:
+        if needle in str(emoji.get("name", "")).casefold():
+            matches.append(emoji)
+            continue
+        for alias in emoji.get("aliases", []) or []:
+            if needle in str(alias).casefold():
+                matches.append(emoji)
+                break
+    return matches
+
+
+def _default_emoji_sequence() -> list[ProcessedEmoji]:
+    """Recents first, then the full catalog, deduplicated."""
+    all_emojis, _, _ = get_emoji_data()
+    by_char = {str(emoji["char"]): emoji for emoji in all_emojis}
+    ordered: list[ProcessedEmoji] = []
+    for char in load_recent_emojis():
+        emoji = by_char.pop(char, None)
+        if emoji is not None:
+            ordered.append(emoji)
+    ordered.extend(by_char.values())
+    return ordered
+
+
+class ConsoleAppearancePickerModal(
+    SafeModalDismissMixin, ModalScreen[ConsoleConversationAppearance | None]
+):
+    """Pick one conversation's icon glyph and palette color."""
+
+    DEFAULT_CSS = """
+    ConsoleAppearancePickerModal {
+        align: center middle;
+    }
+
+    #console-appearance-picker-modal {
+        width: 64;
+        max-width: 100%;
+        height: 29;
+        max-height: 100%;
+        border: tall $accent;
+        background: $panel;
+        padding: 1 2;
+    }
+
+    #console-appearance-picker-filter {
+        width: 100%;
+        height: 3;
+    }
+
+    #console-appearance-picker-preview {
+        width: 100%;
+        height: 1;
+        color: $text-muted;
+    }
+
+    #console-appearance-picker-emoji {
+        width: 100%;
+        height: 1fr;
+        min-height: 6;
+        background: $surface-darken-1;
+    }
+
+    #console-appearance-picker-colors {
+        /* task-31209: a scrollable strip -- the 22-swatch palette (plus
+           "none") no longer fits one modal row, and shrinking swatches to
+           two cells left no content width under a selection border. */
+        width: 100%;
+        height: 3;
+        margin-top: 1;
+    }
+
+    #console-appearance-picker-hex {
+        width: 1fr;
+        height: 3;
+        margin-top: 1;
+    }
+
+    .console-appearance-swatch {
+        width: 3;
+        min-width: 3;
+        max-width: 3;
+        height: 3;
+        min-height: 3;
+        margin: 0;
+        padding: 0;
+        border: none;
+        text-align: center;
+        content-align: center middle;
+    }
+
+    .console-appearance-swatch-selected {
+        /* Background highlight, not a border: the 2-cell swatch has no room
+           for a 2-cell border (zero content width crashed cell chopping). */
+        background: $accent 25%;
+        text-style: bold;
+    }
+
+    #console-appearance-swatch-none {
+        width: 5;
+        min-width: 5;
+        max-width: 5;
+    }
+
+    .console-appearance-emoji-selected {
+        background: $accent 25%;
+        text-style: bold;
+    }
+
+    #console-appearance-picker-actions {
+        width: 100%;
+        height: 3;
+        margin-top: 1;
+    }
+
+    #console-appearance-picker-actions Button {
+        width: 1fr;
+        height: 3;
+        border: none;
+        margin: 0 1 0 0;
+    }
+
+    #console-appearance-picker-apply {
+        background: $primary;
+        color: $text;
+    }
+
+    #console-appearance-picker-clear,
+    #console-appearance-picker-cancel {
+        background: $surface;
+        color: $text;
+    }
+    """
+
+    BINDINGS: ClassVar = [("escape", "request_safe_cancel", "Cancel")]
+    SAFE_MODAL_CONTENT = "#console-appearance-picker-modal"
+
+    def __init__(
+        self,
+        *,
+        conversation_id: str,
+        conversation_title: str = "",
+        icon: str | None = None,
+        color: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.conversation_id = str(conversation_id or "")
+        self._conversation_title = str(conversation_title or "")
+        # Defensive re-validation: the row state is sanitized already, but a
+        # stale/foreign caller must not smuggle markup into the preview.
+        self._selected_icon: str | None = (
+            icon if icon and is_valid_console_appearance_icon(icon) else None
+        )
+        self._selected_color: str | None = (
+            color if color and is_valid_console_appearance_color(color) else None
+        )
+        self._all_emojis = _default_emoji_sequence()
+        self._filter_timer: Timer | None = None
+
+    def compose(self) -> ComposeResult:
+        with Vertical(id="console-appearance-picker-modal"):
+            yield Static("Customize conversation", classes="console-modal-header")
+            yield Static("", id=PREVIEW_ID, markup=False)
+            yield Input(
+                placeholder="Search icons by name…",
+                id=FILTER_INPUT_ID,
+            )
+            yield EmojiGrid(
+                self._all_emojis, id=GRID_ID, can_focus=False
+            )
+            with HorizontalScroll(id=COLORS_ID):
+                yield Button(
+                    "none",
+                    id=SWATCH_NONE_ID,
+                    classes=SWATCH_CLASS,
+                    compact=True,
+                )
+                for label, hex_color in CONSOLE_APPEARANCE_PALETTE:
+                    swatch = Button(
+                        _swatch_label(hex_color),
+                        id=f"console-appearance-swatch-"
+                        f"{label.lower().replace(' ', '-')}",
+                        classes=SWATCH_CLASS,
+                        compact=True,
+                        tooltip=label,
+                    )
+                    swatch.hex_color = hex_color  # type: ignore[attr-defined]
+                    yield swatch
+            yield Input(
+                placeholder="Or type a custom color, e.g. #c0ffee or c0ffee…",
+                id=HEX_INPUT_ID,
+            )
+            with Horizontal(id="console-appearance-picker-actions"):
+                yield Button("Apply", id=APPLY_ID, compact=True)
+                yield Button("Clear", id=CLEAR_ID, compact=True)
+                yield Button("Cancel", id=CANCEL_ID, compact=True)
+
+    async def on_mount(self) -> None:  # type: ignore[override]
+        # EmojiGrid populates itself from its constructor list on mount;
+        # highlight the carried-in selection on top of it.
+        self._sync_emoji_highlight()
+        self._sync_preview()
+        self._sync_swatch_highlight()
+        if self._selected_color is not None:
+            self.query_one(f"#{HEX_INPUT_ID}", Input).value = self._selected_color
+        self._focus_filter()
+
+    def on_unmount(self) -> None:
+        self._cancel_filter_timer()
+
+    @on(Input.Changed, f"#{FILTER_INPUT_ID}")
+    def _filter_changed(self, event: Input.Changed) -> None:
+        event.stop()
+        self._cancel_filter_timer()
+        query = event.value
+        self._filter_timer = self.set_timer(
+            FILTER_DEBOUNCE_SECONDS,
+            lambda: self._settle_filter(query),
+        )
+
+    @on(Input.Submitted, f"#{FILTER_INPUT_ID}")
+    def _filter_submitted(self, event: Input.Submitted) -> None:
+        event.stop()
+        self._cancel_filter_timer()
+        self._apply_filter(event.value)
+        # Enter commits the first match, the reaction picker's muscle memory.
+        grid = self._grid()
+        if grid is None:
+            return
+        try:
+            first = grid.query(EmojiButton).first()
+        except NoMatches:
+            return
+        char = str(
+            getattr(first, "emoji_data", {}).get("char", "") or ""
+        )
+        if char:
+            self._select_icon(char)
+
+    @on(Button.Pressed, ".emoji_button")
+    def _emoji_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        char = str(getattr(event.button, "emoji_data", {}).get("char", "") or "")
+        if char:
+            self._select_icon(char)
+
+    @on(Input.Changed, f"#{HEX_INPUT_ID}")
+    def _hex_changed(self, event: Input.Changed) -> None:
+        """Apply a valid custom hex color live; ignore anything else.
+
+        task-31209: a leading '#' is optional ("c0ffee" == "#c0ffee"); an
+        invalid or partial value never disturbs the current selection — the
+        "none" swatch is the explicit way to clear, so a mid-typing state
+        must not silently drop a chosen color.
+        """
+        event.stop()
+        normalized = normalize_console_appearance_hex_input(event.value)
+        if normalized is None:
+            return
+        self._selected_color = normalized
+        self._sync_preview()
+        self._sync_swatch_highlight()
+
+    @on(Button.Pressed, f".{SWATCH_CLASS}")
+    def _swatch_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        button = event.button
+        if button.id == SWATCH_NONE_ID:
+            self._selected_color = None
+        else:
+            hex_color = getattr(button, "hex_color", None)
+            self._selected_color = (
+                hex_color if hex_color and is_valid_console_appearance_color(hex_color) else None
+            )
+        self._sync_preview()
+        self._sync_swatch_highlight()
+        # PR #2480 review (#9): keep the custom-color field in step with the
+        # swatch selection so what it displays is what Apply persists. (The
+        # programmatic assignment re-fires `_hex_changed`, which is a no-op
+        # here: the normalized value is exactly `_selected_color`.)
+        try:
+            hex_input = self.query_one(f"#{HEX_INPUT_ID}", Input)
+        except (NoMatches, QueryError):
+            hex_input = None
+        if hex_input is not None:
+            hex_input.value = self._selected_color or ""
+        self._focus_filter()
+
+    @on(Button.Pressed, f"#{APPLY_ID}")
+    def _apply_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        icon = self._selected_icon
+        # PR #2480 review (#5): build the validating result BEFORE recording
+        # the recent-emoji side effect, so a rejected icon cannot leave a
+        # stray recents entry (selection-time rejection makes this belt and
+        # braces for foreign callers of `_select_icon`).
+        result = ConsoleConversationAppearance(
+            icon=icon, color=self._selected_color
+        )
+        if icon is not None:
+            save_recent_emoji(icon)
+        self.dismiss(result)
+
+    @on(Button.Pressed, f"#{CLEAR_ID}")
+    def _clear_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        self.dismiss(ConsoleConversationAppearance())
+
+    @on(Button.Pressed, f"#{CANCEL_ID}")
+    async def _cancel_pressed(self, event: Button.Pressed) -> None:
+        event.stop()
+        await self.request_safe_cancel(source="visible")
+
+    async def _perform_safe_cancel(self, *, source: str) -> None:
+        del source
+
+        async def cancel_filter_timer() -> None:
+            self._cancel_filter_timer()
+
+        await self.run_cancel_effect_once(cancel_filter_timer)
+        self.dismiss_safe_once(None)
+
+    def _grid(self) -> EmojiGrid | None:
+        try:
+            return self.query_one(f"#{GRID_ID}", EmojiGrid)
+        except (NoMatches, QueryError):
+            return None
+
+    def _apply_filter(self, query: str) -> None:
+        grid = self._grid()
+        if grid is None:
+            return
+        matches = filter_appearance_emojis(self._all_emojis, query)
+        grid.populate_grid(matches)
+        self._sync_emoji_highlight()
+        self._focus_filter()
+
+    def _settle_filter(self, query: str) -> None:
+        self._filter_timer = None
+        if not self.is_mounted:
+            return
+        self._apply_filter(query)
+
+    def _cancel_filter_timer(self) -> None:
+        if self._filter_timer is not None:
+            self._filter_timer.stop()
+            self._filter_timer = None
+
+    def _select_icon(self, char: str) -> None:
+        """Select one icon glyph, rejecting unstorable sequences (#5)."""
+        if not is_valid_console_appearance_icon(char):
+            # PR #2480 review (#5): the shared catalog includes ZWJ families
+            # and wide pairs the appearance contract cannot store; reject at
+            # selection so Apply never hits the dataclass's ValueError.
+            self.app.notify(
+                "That icon uses a sequence this app cannot store; pick a single emoji.",
+                severity="warning",
+            )
+            return
+        self._selected_icon = char
+        self._sync_emoji_highlight()
+        self._sync_preview()
+        self._focus_filter()
+
+    def _sync_emoji_highlight(self) -> None:
+        grid = self._grid()
+        if grid is None:
+            return
+        for button in grid.query(EmojiButton):
+            button.set_class(
+                str(button.emoji_data.get("char", "")) == self._selected_icon,
+                EMOJI_SELECTED_CLASS,
+            )
+
+    def _sync_swatch_highlight(self) -> None:
+        for button in self.query(f".{SWATCH_CLASS}"):
+            hex_color = getattr(button, "hex_color", None)
+            is_selected = (
+                self._selected_color is not None
+                and hex_color == self._selected_color
+            )
+            button.set_class(is_selected, SWATCH_SELECTED_CLASS)
+
+    def _sync_preview(self) -> None:
+        try:
+            preview = self.query_one(f"#{PREVIEW_ID}", Static)
+        except (NoMatches, QueryError):
+            return
+        # PR #2480 review (#6): the preview Static is markup=False, so a
+        # markup STRING would display literal tags. Build a styled Content
+        # instead -- styles render, and the title stays escaped text.
+        from textual.content import Content
+
+        icon = self._selected_icon or "·"
+        color = self._selected_color
+        title = self._conversation_title or "this conversation"
+        if color:
+            preview.update(
+                Content.assemble(
+                    (f"{icon} ", "dim"),
+                    (f"{title}  ", None),
+                    (color, color),
+                )
+            )
+        else:
+            preview.update(Content.assemble((f"{icon} ", "dim"), (f"{title}  no color", None)))
+
+    def _focus_filter(self) -> None:
+        try:
+            self.query_one(f"#{FILTER_INPUT_ID}", Input).focus()
+        except (NoMatches, QueryError):
+            return
+
+
+def _swatch_label(hex_color: str) -> Any:
+    """Return a colored square label for one swatch button."""
+    from textual.content import Content
+
+    return Content.from_markup(f"[{hex_color}]■[/]")


### PR DESCRIPTION
## Summary

Console persona session identity per ADR-149 (spec + ADR land in the base branch PR #2649): persona display identity on Console sessions with a transcript persona branch, identity operations in the Console chat store, persona identity in console screen state + send path, persona name re-resolution + template restore on resume, console session starter + start-chat handoff extraction with prompt seed, and per-send template re-expansion reaching provider selection. The persona system template is persisted in the v1 roleplay envelope.

- Task: TASK-32481 (status: Done)
- Design: ADR-149 + `Docs/superpowers/specs/2026-09-11-console-persona-session-identity-design.md` (lands via #2649)
- 11 commits; diff vs base = exactly this work

## Notes

- Also carries docs commit 91caf08be2 (fork_chat/new_chat implementation plan, ADR-150, TASK-32482 v1 task) — it was committed on this line; the fork/new_chat code itself ships separately as #2643.
- Base-branch test note: the appearance-picker collection defect was **fixed on the base branch** (fc9b300cbe, sync to dev's merged #2480 state). Two switcher tests still fail on-branch pending dev's switcher-modal rewrite (they pass on dev); two modal-inventory tests fail identically on origin/dev (pre-existing). See #2649 for the full breakdown. None of this is introduced by this branch.

Stacked on `feat/custom-endpoint-registry` (#2649); auto-retargets to `dev` when the base lands.
