### PR TITLE
docs(backlog): Qodo-round riders from the approval-card wave (32563, 32564; 32376 extended)

### DIFF
--- a/backlog/tasks/task-32376 - dev-red-test-fenced-nested-delivery-counts-exact-transformed-payload-before-mark-mock-lacks-reasoning-replay-kwarg.md
+++ b/backlog/tasks/task-32376 - dev-red-test-fenced-nested-delivery-counts-exact-transformed-payload-before-mark-mock-lacks-reasoning-replay-kwarg.md
@@ -17,6 +17,9 @@ Commit f043db12b77 on dev made `console_agent_bridge` pass `reasoning_replay=` t
 
 Source: approval-card / MCP-permissions fix wave 2026-09-10/11 (plan `Docs/superpowers/plans/2026-09-10-approval-card-fix-wave.md`, review snapshot `.impeccable/critique/2026-09-10T17-31-53Z__hatbook-widgets-chat-widgets-chat-approval-card-py.md`); rider recorded in the lane ledger, not fixed in the wave.
 
+
+Also red at the same untouched baseline in `Tests/Chat/test_console_agent_bridge.py` (found while stacking lane A on dev 0e62de41d4): `test_successful_tool_payload_collisions_stay_success_live_and_resumed[tool call denied…]` and `test_run_reply_forwards_review_tool_calls_hook_to_agent_service`.
+
 ## Acceptance Criteria
 
 - [ ] The test passes on dev without changing the source under test

--- a/backlog/tasks/task-32509 - raw-shell-tool-provider-reports-a-gate-error-as-permission-Off.md
+++ b/backlog/tasks/task-32509 - raw-shell-tool-provider-reports-a-gate-error-as-permission-Off.md
@@ -1,0 +1,24 @@
+---
+id: TASK-32509
+title: raw_shell_tool_provider reports a gate error as permission Off
+status: To Do
+assignee: []
+created_date: '2026-09-12 00:10'
+labels:
+  - console
+  - approvals
+dependencies: []
+priority: low
+---
+
+## Description
+
+`raw_shell_tool_provider` returns `RAW_SHELL_DENY_REFUSAL` when the permission *resolve* raises (around L483-484), not only when the resolver said deny. Since #2594 maps that constant to `blocked_off`, a resolver failure now renders `· blocked (Off)` in the transcript — a false configuration claim. The local provider has `LOCAL_GATE_ERROR_REFUSAL` for exactly this case.
+
+Source: Qodo review rounds on the approval-card fix-wave PRs #2586/#2594/#2597/#2600 (2026-09-11); recorded in the lane ledgers, not fixed in the wave.
+
+## Acceptance Criteria
+
+- [ ] A raw-shell permission-resolve failure returns a distinct gate-error refusal (mirroring `LOCAL_GATE_ERROR_REFUSAL`) and renders as the generic blocked word, never as `blocked (Off)`
+- [ ] The audit token for that path is `denied-unresolved`, not `denied-policy`
+- [ ] One test pins the raising-resolver path

--- a/backlog/tasks/task-32510 - Two-defaults-for-mcp-approval-timeout-seconds-controller-0-0-vs-service-120-0.md
+++ b/backlog/tasks/task-32510 - Two-defaults-for-mcp-approval-timeout-seconds-controller-0-0-vs-service-120-0.md
@@ -1,0 +1,24 @@
+---
+id: TASK-32510
+title: Two defaults for [mcp] approval_timeout_seconds: controller 0.0 vs service 120.0
+status: To Do
+assignee: []
+created_date: '2026-09-12 00:10'
+labels:
+  - mcp
+  - config
+dependencies: []
+priority: low
+---
+
+## Description
+
+The Console approval card resolves `[mcp] approval_timeout_seconds` through `ConsoleChatController._resolve_mcp_approval_timeout_seconds` with `_DEFAULT_MCP_APPROVAL_TIMEOUT_SECONDS = 0.0` (wait indefinitely; the `config.py` template documents 0 as the default), while `UnifiedMCPControlPlaneService.approval_timeout_seconds` and `live_server_request_wiring.py` fall back to 120.0 for the same key. Nothing injects the service value into the controller today, so the card waits indefinitely and external MCP-client waits auto-deny after 120 s — one key, two documented defaults. Surfaced by a Qodo finding on #2600 that read the service default as the card's.
+
+Source: Qodo review rounds on the approval-card fix-wave PRs #2586/#2594/#2597/#2600 (2026-09-11); recorded in the lane ledgers, not fixed in the wave.
+
+## Acceptance Criteria
+
+- [ ] One documented default for the key, or two clearly named keys/paths, decided and recorded in the config template comment
+- [ ] The service, the controller, and the live-server wiring agree with that decision
+- [ ] The user guide states the resulting behaviour for the approval card


### PR DESCRIPTION
Close-out riders from the Qodo review rounds on #2586 / #2594 / #2597 / #2600:

- **task-32563** — `raw_shell_tool_provider` returns `RAW_SHELL_DENY_REFUSAL` when the permission resolve *raises*, which #2594 now renders as `· blocked (Off)`; needs a gate-error refusal like `LOCAL_GATE_ERROR_REFUSAL`.
- **task-32564** — `[mcp] approval_timeout_seconds` has two defaults: the Console card path (controller, 0.0 = wait indefinitely, as the config template documents) and the service / live-server path (120.0). Surfaced by a Qodo finding on #2600 that read the service default as the card's.
- **task-32376** — two more dev-side reds in `Tests/Chat/test_console_agent_bridge.py` recorded alongside the `reasoning_replay` mock red.

Originally filed as 32509/32510; renumbered above the global max (32562) after dev minted its own task-32509 (landed-keeps-id rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)