### PR TITLE
fix(console): Speak-replies consent modal survives its own screen suspend

### DIFF
--- a/Tests/UI/test_console_auto_speak_wiring.py
+++ b/Tests/UI/test_console_auto_speak_wiring.py
@@ -912,3 +912,80 @@ async def test_modal_callback_scheduler_rejection_unwinds_modal() -> None:
 
     assert harness.session.speech_preferences.auto_speak is False
     assert len(harness.opened) == 1
+
+
+@pytest.mark.asyncio
+async def test_consent_survives_the_modal_push_suspend(monkeypatch):
+    """TASK-32509 (UAT-found): enabling Speak replies pushes the consent
+    modal over the Console, and the coordinator behind the switch was
+    being unmounted while its own modal was open -- Enable arrived dead,
+    consent was silently discarded, and the switch snapped back OFF. The
+    coordinator must survive its own consent modal."""
+    from Tests.UI.app_factory import _build_test_app
+    from Tests.UI.test_console_fleet_wake_hidden_screen import (
+        _mount_chat,
+    )
+    from Tests.UI.test_console_native_chat_flow import (
+        _configure_native_ready_console,
+    )
+    from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import ConsoleTTSDestination
+
+    destination = ConsoleTTSDestination(
+        fingerprint="sha256:" + "a" * 64,
+        provider_label="Test Provider",
+        sanitized_destination="https://t.example",
+        charges_may_apply=False,
+    )
+
+    class _StubHandler:
+        async def resolve_console_speech_destination(self, *_a, **_k):
+            return destination
+
+    async def _stub_ensure():
+        return _StubHandler()
+
+    app = _build_test_app()
+    _configure_native_ready_console(app)
+    app._ensure_tts_handler = _stub_ensure
+
+    async with app.run_test(size=(160, 48)) as pilot:
+        console = await _mount_chat(app, pilot)
+        store = console._ensure_console_chat_store()
+        session_id = store.active_session_id
+
+        from textual.widgets import Switch
+
+        speak = console.query_one("#console-auto-speak", Switch)
+        speak.value = True
+
+        modal = None
+        for _ in range(120):
+            await pilot.pause(0.25)
+            if type(app.screen).__name__ == "AutoSpeakConsentModal":
+                modal = app.screen
+                break
+        assert modal is not None, "consent modal never opened"
+
+        # The coordinator behind the switch must still be live while its
+        # own modal is open -- unmounted here means Enable arrives dead.
+        assert console._console_auto_speak._mounted is True, (
+            "auto-speak coordinator was unmounted while its consent modal "
+            "was open -- the Enable callback is tombstoned"
+        )
+
+        await pilot.click("#console-auto-speak-consent-confirm")
+        for _ in range(40):
+            await pilot.pause(0.25)
+            if type(app.screen).__name__ == "ChatScreen":
+                break
+
+        session = None
+        for _ in range(20):
+            await pilot.pause(0.25)
+            session = next((s for s in store.sessions() if s.id == session_id), None)
+            if session is not None and session.speech_preferences.auto_speak:
+                break
+        assert session is not None and session.speech_preferences.auto_speak is True, (
+            "consent was discarded after pressing Enable "
+            f"(prefs={getattr(session, 'speech_preferences', None)})"
+        )

--- a/Tests/UI/test_console_auto_speak_wiring.py
+++ b/Tests/UI/test_console_auto_speak_wiring.py
@@ -12,10 +12,10 @@ from tldw_chatbook.app import TldwCli
 from tldw_chatbook.Chat.console_chat_models import ConsoleMessageRole
 from tldw_chatbook.Chat.console_chat_store import ConsoleChatStore
 from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import (
+    ConsoleTTSDestination,
     TTSMessageSpeechRequestEvent,
 )
 from tldw_chatbook.UI.Console_Modules.wiring import build_console_controllers
-from tldw_chatbook.Event_Handlers.TTS_Events.tts_events import ConsoleTTSDestination
 from tldw_chatbook.Widgets.Console.console_auto_speak_consent import (
     AutoSpeakConsentModal,
     ConsoleAutoSpeakCoordinator,
@@ -952,6 +952,10 @@ async def test_consent_survives_the_modal_push_suspend(monkeypatch):
         console = await _mount_chat(app, pilot)
         store = console._ensure_console_chat_store()
         session_id = store.active_session_id
+        # Shared polling cadence for the modal-open, screen-return, and
+        # persistence waits below (PR #2656 Qodo #3) so the three loops'
+        # timing cannot drift apart.
+        _CONSENT_POLL_SECONDS = 0.25
 
         from textual.widgets import Switch
 
@@ -960,7 +964,7 @@ async def test_consent_survives_the_modal_push_suspend(monkeypatch):
 
         modal = None
         for _ in range(120):
-            await pilot.pause(0.25)
+            await pilot.pause(_CONSENT_POLL_SECONDS)
             if type(app.screen).__name__ == "AutoSpeakConsentModal":
                 modal = app.screen
                 break
@@ -975,13 +979,13 @@ async def test_consent_survives_the_modal_push_suspend(monkeypatch):
 
         await pilot.click("#console-auto-speak-consent-confirm")
         for _ in range(40):
-            await pilot.pause(0.25)
+            await pilot.pause(_CONSENT_POLL_SECONDS)
             if type(app.screen).__name__ == "ChatScreen":
                 break
 
         session = None
         for _ in range(20):
-            await pilot.pause(0.25)
+            await pilot.pause(_CONSENT_POLL_SECONDS)
             session = next((s for s in store.sessions() if s.id == session_id), None)
             if session is not None and session.speech_preferences.auto_speak:
                 break
@@ -989,3 +993,70 @@ async def test_consent_survives_the_modal_push_suspend(monkeypatch):
             "consent was discarded after pressing Enable "
             f"(prefs={getattr(session, 'speech_preferences', None)})"
         )
+
+
+class TestSuspendGuardUnit:
+    """PR #2656 Qodo #1/#4: isolated coverage of the suspend-path guard.
+
+    Three flag states matter: modal up with a live callback (suspend must
+    PRESERVE the coordinator), modal dismissed with the async finish work
+    still running (suspend must QUIESCE it -- the post-dismissal window),
+    and no modal at all (suspend must quiesce, the original TASK-31520
+    behavior).
+    """
+
+    def _bare_coordinator(self) -> ConsoleAutoSpeakCoordinator:
+        coordinator = object.__new__(ConsoleAutoSpeakCoordinator)
+        coordinator._mounted = True
+        coordinator._modal_open = False
+        coordinator._modal_callback_consumed = False
+        return coordinator
+
+    def test_pending_requires_open_modal_and_live_callback(self) -> None:
+        coordinator = self._bare_coordinator()
+        assert coordinator.modal_result_pending is False
+
+        coordinator._modal_open = True
+        assert coordinator.modal_result_pending is True
+
+        # The post-dismissal window: modal flag still up, callback already
+        # consumed by the async finish work.
+        coordinator._modal_callback_consumed = True
+        assert coordinator.modal_result_pending is False
+
+    @pytest.mark.asyncio
+    async def test_suspend_preserves_coordinator_only_while_result_pending(
+        self,
+    ) -> None:
+        from Tests.UI.app_factory import _build_test_app
+        from Tests.UI.test_console_fleet_wake_hidden_screen import _mount_chat
+
+        app = _build_test_app()
+        unmounted: list[bool] = []
+
+        class _StubCoordinator:
+            modal_result_pending = False
+
+            def unmount(self) -> None:
+                unmounted.append(True)
+
+        async with app.run_test(size=(160, 48)) as pilot:
+            console = await _mount_chat(app, pilot)
+            real = console._console_auto_speak
+            stub = _StubCoordinator()
+            console._console_auto_speak = stub
+            try:
+                # Modal result pending: suspend must NOT quiesce.
+                stub.modal_result_pending = True
+                console.on_screen_suspend()
+                assert unmounted == [], "suspend quiesced a mid-consent coordinator"
+
+                # No modal (or dismissed mid-finish): suspend must quiesce.
+                stub.modal_result_pending = False
+                console.on_screen_suspend()
+                assert unmounted == [True], (
+                    "suspend failed to quiesce the coordinator without a "
+                    "pending modal result"
+                )
+            finally:
+                console._console_auto_speak = real

--- a/backlog/tasks/task-32509 - Speak-replies-consent-modal-survives-its-own-screen-suspend.md
+++ b/backlog/tasks/task-32509 - Speak-replies-consent-modal-survives-its-own-screen-suspend.md
@@ -1,0 +1,37 @@
+---
+id: TASK-32509
+title: Speak-replies consent modal survives its own screen suspend
+status: Done
+assignee:
+  - '@robert'
+created_date: '2026-09-12 21:46'
+updated_date: '2026-09-12 21:46'
+labels: []
+dependencies: []
+---
+
+## Description
+
+<!-- SECTION:DESCRIPTION:BEGIN -->
+UAT on merged dev (PR #2638 follow-up) found the Speak-replies enable flow broken: pushing the destination-consent modal SUSPENDS the ChatScreen underneath, and on_screen_suspend unmounts the ConsoleAutoSpeakCoordinator -- whose unmount tombstones the pending modal callback. The user's Enable press arrives dead: consent is silently discarded and the switch snaps back OFF. Introduced by TASK-31520 (fed0b7257a) moving the coordinator unmount into the suspend path; invisible to the suite because the consent tests mock the modal opener without a real push. Live-verified repro and fix against a real app boot (Kokoro ONNX TTS, DeepSeek chat): consent persists, disposition computes SPEAK, Kokoro synthesizes WAV, and the streaming sink opens the real output device.
+<!-- SECTION:DESCRIPTION:END -->
+
+## Acceptance Criteria
+<!-- AC:BEGIN -->
+- [x] #1 Mounted test with a REAL pushed consent modal pins that the coordinator stays mounted while its modal is open and that Enable persists auto_speak
+- [x] #2 Verified by the test failing on dev HEAD and passing with the fix
+- [x] #3 Suspend quiesce still unmounts the coordinator when no consent modal is open (original TASK-31520 behavior preserved)
+- [x] #4 Existing consent/auto-speak suites stay green (43-file suite 44 passed; modal-dismissal failures identical to pristine dev)
+<!-- AC:END -->
+
+## Implementation Plan
+
+<!-- SECTION:PLAN:BEGIN -->
+1. RED: mounted test with real modal push (coordinator unmounted mid-consent on dev HEAD)\n2. Fix: modal_open property + suspend-path guard\n3. GREEN + auto-speak/fleet-wake/hands-free suites\n4. Live audible verification (consent persists, Kokoro WAV speaks through the sink)
+<!-- SECTION:PLAN:END -->
+
+## Implementation Notes
+
+<!-- SECTION:NOTES:BEGIN -->
+Fixed and live-verified; see Implementation Notes.
+<!-- SECTION:NOTES:END -->

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -23018,7 +23018,14 @@ class ChatScreen(BaseAppScreen):
             timer.stop()
         self._console_resume_handoff_timers = []
         self._message.invalidate_console_speech_context()
-        self._console_auto_speak.unmount()
+        # TASK-32509 (UAT-found): skip the coordinator quiesce while ITS OWN
+        # consent modal is the screen that suspended us -- unmount tombstones
+        # the pending modal callback, so the user's Enable press would arrive
+        # dead and the consent would be silently discarded (switch snaps
+        # back OFF). A consent modal keeps the console semi-visible; the
+        # disposition gating still refuses speech for hidden turns.
+        if not self._console_auto_speak.modal_open:
+            self._console_auto_speak.unmount()
         self._stop_console_transcript_sync_timer()
         self._fleet._stop_console_fleet_survivor_tick()
         self._stop_console_cost_ttl_timer()

--- a/tldw_chatbook/UI/Screens/chat_screen.py
+++ b/tldw_chatbook/UI/Screens/chat_screen.py
@@ -23024,7 +23024,11 @@ class ChatScreen(BaseAppScreen):
         # dead and the consent would be silently discarded (switch snaps
         # back OFF). A consent modal keeps the console semi-visible; the
         # disposition gating still refuses speech for hidden turns.
-        if not self._console_auto_speak.modal_open:
+        # PR #2656 Qodo #1: guard on a PENDING modal result, not bare modal
+        # visibility -- after dismissal the async finish work runs with the
+        # callback consumed, and a suspend in that window must quiesce the
+        # coordinator or the hidden screen stays subscribed forever.
+        if not self._console_auto_speak.modal_result_pending:
             self._console_auto_speak.unmount()
         self._stop_console_transcript_sync_timer()
         self._fleet._stop_console_fleet_survivor_tick()

--- a/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
+++ b/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
@@ -232,6 +232,18 @@ class ConsoleAutoSpeakCoordinator:
         self._modal_open = False
         self._modal_callback_consumed = True
 
+    @property
+    def modal_open(self) -> bool:
+        """Whether the destination-consent modal is currently open.
+
+        TASK-32509: pushing that modal SUSPENDS the ChatScreen underneath,
+        and `on_screen_suspend` quiesces this coordinator -- whose unmount
+        tombstones the pending modal callback, so the user's Enable press
+        arrives dead and consent is silently discarded. The suspend path
+        consults this property to leave a mid-consent coordinator mounted.
+        """
+        return self._modal_open
+
     def _schedule_work(
         self,
         coroutine: Coroutine[Any, Any, Any],

--- a/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
+++ b/tldw_chatbook/Widgets/Console/console_auto_speak_consent.py
@@ -233,16 +233,29 @@ class ConsoleAutoSpeakCoordinator:
         self._modal_callback_consumed = True
 
     @property
-    def modal_open(self) -> bool:
-        """Whether the destination-consent modal is currently open.
+    def modal_result_pending(self) -> bool:
+        """Whether a destination-consent modal is awaiting the user's choice.
 
         TASK-32509: pushing that modal SUSPENDS the ChatScreen underneath,
         and `on_screen_suspend` quiesces this coordinator -- whose unmount
         tombstones the pending modal callback, so the user's Enable press
         arrives dead and consent is silently discarded. The suspend path
         consults this property to leave a mid-consent coordinator mounted.
+
+        PR #2656 Qodo #1: True only while the modal is open AND its
+        dismiss callback has NOT fired. Once Enable/Cancel dismisses the
+        modal, the async finish work runs with the callback already
+        consumed -- a suspend in that window (e.g. the user navigates
+        away during the awaited destination re-resolution in `finish`)
+        must quiesce the coordinator like any other, or the hidden
+        screen's coordinator stays subscribed forever.
+
+        Returns:
+            True while the consent modal is up and its result callback is
+            still live; False otherwise (including the post-dismissal
+            async-finish window).
         """
-        return self._modal_open
+        return self._modal_open and not self._modal_callback_consumed
 
     def _schedule_work(
         self,


### PR DESCRIPTION
## Summary

Found during live UAT of #2638 on merged `dev`: **the Speak-replies enable flow is broken** — flipping the switch opens the destination-consent modal, but pressing **Enable** silently discards the consent and the switch snaps back OFF.

**Root cause:** pushing the consent modal *suspends* the ChatScreen underneath. TASK-31520 (`fed0b7257a`) moved the `ConsoleAutoSpeakCoordinator` unmount into `on_screen_suspend` for screen-instance reuse — and `unmount()` bumps `_modal_generation` and latches `_modal_callback_consumed`, tombstoning the pending modal callback. The suite never caught it because the consent tests mock `open_consent` without a real screen push, so no suspend ever fires.

Closes TASK-32509 (backlog task with full notes; ADR: not required — single-guard behavior fix).

## Fix

- `ConsoleAutoSpeakCoordinator.modal_open` property.
- `on_screen_suspend` skips the coordinator quiesce **while its consent modal is open** — the modal keeps the console semi-visible, and speech-disposition gating already refuses hidden turns. Real teardown (`on_unmount`) is unchanged, and the suspend quiesce still runs when no modal is open (original TASK-31520 behavior preserved).

## Test plan

- New mounted test `test_consent_survives_the_modal_push_suspend` with a **real pushed modal**: fails on dev HEAD (coordinator unmounted mid-consent), passes with the fix; asserts Enable persists `auto_speak` with the destination fingerprint.
- `test_console_auto_speak_wiring.py` 44/44 green; fleet-wake hidden-screen and hands-free wiring suites green; `test_console_modal_dismissal.py` failure set identical to pristine `origin/dev` (6 pre-existing, stash-compared).
- **Live audible verification** (real app boot, isolated profile, DeepSeek chat + Kokoro ONNX TTS): consent persists end-to-end, reply disposition computes SPEAK, Kokoro synthesizes WAV (353MB model auto-fetched), and `StreamingPcmSink.open()` plays it on the real output device — captured via playback-seam instrumentation, with no failure pause, escalation, or remedy toast.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Speak-replies enable flow so pressing Enable in the consent modal no longer discards the consent and snaps the switch back OFF. The screen suspend unmounted the auto-speak coordinator while its own consent modal was open, tombstoning the pending callback; the suspend path now skips unmounting while a modal result is pending, preserving real teardown and the original suspend behavior otherwise.

## Bug Fixes

- Adds `modal_result_pending` property (`modal_open` AND live callback) to `ConsoleAutoSpeakCoordinator`.
- `ChatScreen.on_screen_suspend` checks `modal_result_pending` before unmounting, so suspend still quiesces the coordinator after modal dismissal during async-finish work.
- Adds a mounted test with a real pushed consent modal (fails on dev HEAD, passes with the fix) plus isolated unit coverage of all guard flag states.

<sup>Written for commit 3b154b278ed7a1e3050ca34b176f7964cad68160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/rmusser01/tldw_chatbook/pull/2656?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

